### PR TITLE
Backport to 2.8: Deprecate thrust event, future and more (#3457)

### DIFF
--- a/thrust/testing/allocator_aware_policies.cu
+++ b/thrust/testing/allocator_aware_policies.cu
@@ -1,3 +1,8 @@
+#include <cuda/__cccl_config>
+
+// need to suppress deprecation warnings for execute_with_allocator_and_dependencies here and inside type traits
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+
 #include <thrust/detail/seq.h>
 #include <thrust/system/cpp/detail/par.h>
 #include <thrust/system/omp/detail/par.h>
@@ -118,3 +123,5 @@ SimpleUnitTest<TestAllocatorAttachment,
                                    omp_par_info,
                                    tbb_par_info>>
   TestAllocatorAttachmentInstance;
+
+_CCCL_SUPPRESS_DEPRECATED_POP

--- a/thrust/testing/async/exclusive_scan/counting_iterator.cu
+++ b/thrust/testing/async/exclusive_scan/counting_iterator.cu
@@ -1,3 +1,7 @@
+#include <cuda/__cccl_config>
+
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+
 #include <thrust/detail/config.h>
 
 #if _CCCL_STD_VER >= 2014
@@ -40,3 +44,5 @@ struct test_counting_iterator
 DECLARE_GENERIC_SIZED_UNITTEST_WITH_TYPES(test_counting_iterator, UnsignedIntegralTypes);
 
 #endif // C++14
+
+_CCCL_SUPPRESS_DEPRECATED_POP

--- a/thrust/testing/async/exclusive_scan/counting_iterator.cu
+++ b/thrust/testing/async/exclusive_scan/counting_iterator.cu
@@ -45,4 +45,7 @@ DECLARE_GENERIC_SIZED_UNITTEST_WITH_TYPES(test_counting_iterator, UnsignedIntegr
 
 #endif // C++14
 
+// we need to leak the suppression on clang to suppresses warnings from the cudafe1.stub.c file
+#if !_CCCL_COMPILER(CLANG)
 _CCCL_SUPPRESS_DEPRECATED_POP
+#endif

--- a/thrust/testing/async/exclusive_scan/counting_iterator.cu
+++ b/thrust/testing/async/exclusive_scan/counting_iterator.cu
@@ -45,7 +45,7 @@ DECLARE_GENERIC_SIZED_UNITTEST_WITH_TYPES(test_counting_iterator, UnsignedIntegr
 
 #endif // C++14
 
-// we need to leak the suppression on clang to suppresses warnings from the cudafe1.stub.c file
-#if !_CCCL_COMPILER(CLANG)
+// we need to leak the suppression on clang/MSVC to suppresses warnings from the cudafe1.stub.c file
+#if !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)
 _CCCL_SUPPRESS_DEPRECATED_POP
-#endif
+#endif // !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)

--- a/thrust/testing/async/exclusive_scan/counting_iterator.cu
+++ b/thrust/testing/async/exclusive_scan/counting_iterator.cu
@@ -46,6 +46,6 @@ DECLARE_GENERIC_SIZED_UNITTEST_WITH_TYPES(test_counting_iterator, UnsignedIntegr
 #endif // C++14
 
 // we need to leak the suppression on clang/MSVC to suppresses warnings from the cudafe1.stub.c file
-#if !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)
+#if !_CCCL_COMPILER(CLANG) && !_CCCL_COMPILER(MSVC)
 _CCCL_SUPPRESS_DEPRECATED_POP
-#endif // !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)
+#endif // !_CCCL_COMPILER(CLANG) && !_CCCL_COMPILER(MSVC)

--- a/thrust/testing/async/exclusive_scan/discard_output.cu
+++ b/thrust/testing/async/exclusive_scan/discard_output.cu
@@ -1,3 +1,7 @@
+#include <cuda/__cccl_config>
+
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+
 #include <thrust/detail/config.h>
 
 #if _CCCL_STD_VER >= 2014
@@ -37,3 +41,5 @@ struct test_discard
 DECLARE_GENERIC_SIZED_UNITTEST_WITH_TYPES(test_discard, NumericTypes);
 
 #endif // C++14
+
+_CCCL_SUPPRESS_DEPRECATED_POP

--- a/thrust/testing/async/exclusive_scan/discard_output.cu
+++ b/thrust/testing/async/exclusive_scan/discard_output.cu
@@ -42,7 +42,7 @@ DECLARE_GENERIC_SIZED_UNITTEST_WITH_TYPES(test_discard, NumericTypes);
 
 #endif // C++14
 
-// we need to leak the suppression on clang to suppresses warnings from the cudafe1.stub.c file
-#if !_CCCL_COMPILER(CLANG)
+// we need to leak the suppression on clang/MSVC to suppresses warnings from the cudafe1.stub.c file
+#if !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)
 _CCCL_SUPPRESS_DEPRECATED_POP
-#endif
+#endif // !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)

--- a/thrust/testing/async/exclusive_scan/discard_output.cu
+++ b/thrust/testing/async/exclusive_scan/discard_output.cu
@@ -42,4 +42,7 @@ DECLARE_GENERIC_SIZED_UNITTEST_WITH_TYPES(test_discard, NumericTypes);
 
 #endif // C++14
 
+// we need to leak the suppression on clang to suppresses warnings from the cudafe1.stub.c file
+#if !_CCCL_COMPILER(CLANG)
 _CCCL_SUPPRESS_DEPRECATED_POP
+#endif

--- a/thrust/testing/async/exclusive_scan/discard_output.cu
+++ b/thrust/testing/async/exclusive_scan/discard_output.cu
@@ -43,6 +43,6 @@ DECLARE_GENERIC_SIZED_UNITTEST_WITH_TYPES(test_discard, NumericTypes);
 #endif // C++14
 
 // we need to leak the suppression on clang/MSVC to suppresses warnings from the cudafe1.stub.c file
-#if !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)
+#if !_CCCL_COMPILER(CLANG) && !_CCCL_COMPILER(MSVC)
 _CCCL_SUPPRESS_DEPRECATED_POP
-#endif // !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)
+#endif // !_CCCL_COMPILER(CLANG) && !_CCCL_COMPILER(MSVC)

--- a/thrust/testing/async/exclusive_scan/large_indices.cu
+++ b/thrust/testing/async/exclusive_scan/large_indices.cu
@@ -1,3 +1,7 @@
+#include <cuda/__cccl_config>
+
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+
 #include <thrust/detail/config.h>
 
 #if _CCCL_STD_VER >= 2014
@@ -237,3 +241,5 @@ void test_large_indices_custom_scan_op()
 DECLARE_UNITTEST(test_large_indices_custom_scan_op);
 
 #endif // C++14
+
+_CCCL_SUPPRESS_DEPRECATED_POP

--- a/thrust/testing/async/exclusive_scan/large_indices.cu
+++ b/thrust/testing/async/exclusive_scan/large_indices.cu
@@ -243,6 +243,6 @@ DECLARE_UNITTEST(test_large_indices_custom_scan_op);
 #endif // C++14
 
 // we need to leak the suppression on clang/MSVC to suppresses warnings from the cudafe1.stub.c file
-#if !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)
+#if !_CCCL_COMPILER(CLANG) && !_CCCL_COMPILER(MSVC)
 _CCCL_SUPPRESS_DEPRECATED_POP
-#endif // !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)
+#endif // !_CCCL_COMPILER(CLANG) && !_CCCL_COMPILER(MSVC)

--- a/thrust/testing/async/exclusive_scan/large_indices.cu
+++ b/thrust/testing/async/exclusive_scan/large_indices.cu
@@ -242,4 +242,7 @@ DECLARE_UNITTEST(test_large_indices_custom_scan_op);
 
 #endif // C++14
 
+// we need to leak the suppression on clang to suppresses warnings from the cudafe1.stub.c file
+#if !_CCCL_COMPILER(CLANG)
 _CCCL_SUPPRESS_DEPRECATED_POP
+#endif

--- a/thrust/testing/async/exclusive_scan/large_indices.cu
+++ b/thrust/testing/async/exclusive_scan/large_indices.cu
@@ -242,7 +242,7 @@ DECLARE_UNITTEST(test_large_indices_custom_scan_op);
 
 #endif // C++14
 
-// we need to leak the suppression on clang to suppresses warnings from the cudafe1.stub.c file
-#if !_CCCL_COMPILER(CLANG)
+// we need to leak the suppression on clang/MSVC to suppresses warnings from the cudafe1.stub.c file
+#if !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)
 _CCCL_SUPPRESS_DEPRECATED_POP
-#endif
+#endif // !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)

--- a/thrust/testing/async/exclusive_scan/large_types.cu
+++ b/thrust/testing/async/exclusive_scan/large_types.cu
@@ -1,3 +1,7 @@
+#include <cuda/__cccl_config>
+
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+
 #include <thrust/detail/config.h>
 
 #if _CCCL_STD_VER >= 2014
@@ -52,3 +56,5 @@ struct test_large_types
 DECLARE_UNITTEST(test_large_types);
 
 #endif // C++14
+
+_CCCL_SUPPRESS_DEPRECATED_POP

--- a/thrust/testing/async/exclusive_scan/large_types.cu
+++ b/thrust/testing/async/exclusive_scan/large_types.cu
@@ -57,4 +57,7 @@ DECLARE_UNITTEST(test_large_types);
 
 #endif // C++14
 
+// we need to leak the suppression on clang to suppresses warnings from the cudafe1.stub.c file
+#if !_CCCL_COMPILER(CLANG)
 _CCCL_SUPPRESS_DEPRECATED_POP
+#endif

--- a/thrust/testing/async/exclusive_scan/large_types.cu
+++ b/thrust/testing/async/exclusive_scan/large_types.cu
@@ -58,6 +58,6 @@ DECLARE_UNITTEST(test_large_types);
 #endif // C++14
 
 // we need to leak the suppression on clang/MSVC to suppresses warnings from the cudafe1.stub.c file
-#if !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)
+#if !_CCCL_COMPILER(CLANG) && !_CCCL_COMPILER(MSVC)
 _CCCL_SUPPRESS_DEPRECATED_POP
-#endif // !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)
+#endif // !_CCCL_COMPILER(CLANG) && !_CCCL_COMPILER(MSVC)

--- a/thrust/testing/async/exclusive_scan/large_types.cu
+++ b/thrust/testing/async/exclusive_scan/large_types.cu
@@ -57,7 +57,7 @@ DECLARE_UNITTEST(test_large_types);
 
 #endif // C++14
 
-// we need to leak the suppression on clang to suppresses warnings from the cudafe1.stub.c file
-#if !_CCCL_COMPILER(CLANG)
+// we need to leak the suppression on clang/MSVC to suppresses warnings from the cudafe1.stub.c file
+#if !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)
 _CCCL_SUPPRESS_DEPRECATED_POP
-#endif
+#endif // !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)

--- a/thrust/testing/async/exclusive_scan/mixed_types.cu
+++ b/thrust/testing/async/exclusive_scan/mixed_types.cu
@@ -1,3 +1,7 @@
+#include <cuda/__cccl_config>
+
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+
 #include <thrust/detail/config.h>
 
 #if _CCCL_STD_VER >= 2014
@@ -115,3 +119,5 @@ void test_scan_mixed_types(size_t num_values)
 DECLARE_SIZED_UNITTEST(test_scan_mixed_types);
 
 #endif // C++14
+
+_CCCL_SUPPRESS_DEPRECATED_POP

--- a/thrust/testing/async/exclusive_scan/mixed_types.cu
+++ b/thrust/testing/async/exclusive_scan/mixed_types.cu
@@ -121,6 +121,6 @@ DECLARE_SIZED_UNITTEST(test_scan_mixed_types);
 #endif // C++14
 
 // we need to leak the suppression on clang/MSVC to suppresses warnings from the cudafe1.stub.c file
-#if !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)
+#if !_CCCL_COMPILER(CLANG) && !_CCCL_COMPILER(MSVC)
 _CCCL_SUPPRESS_DEPRECATED_POP
-#endif // !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)
+#endif // !_CCCL_COMPILER(CLANG) && !_CCCL_COMPILER(MSVC)

--- a/thrust/testing/async/exclusive_scan/mixed_types.cu
+++ b/thrust/testing/async/exclusive_scan/mixed_types.cu
@@ -120,7 +120,7 @@ DECLARE_SIZED_UNITTEST(test_scan_mixed_types);
 
 #endif // C++14
 
-// we need to leak the suppression on clang to suppresses warnings from the cudafe1.stub.c file
-#if !_CCCL_COMPILER(CLANG)
+// we need to leak the suppression on clang/MSVC to suppresses warnings from the cudafe1.stub.c file
+#if !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)
 _CCCL_SUPPRESS_DEPRECATED_POP
-#endif
+#endif // !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)

--- a/thrust/testing/async/exclusive_scan/mixed_types.cu
+++ b/thrust/testing/async/exclusive_scan/mixed_types.cu
@@ -120,4 +120,7 @@ DECLARE_SIZED_UNITTEST(test_scan_mixed_types);
 
 #endif // C++14
 
+// we need to leak the suppression on clang to suppresses warnings from the cudafe1.stub.c file
+#if !_CCCL_COMPILER(CLANG)
 _CCCL_SUPPRESS_DEPRECATED_POP
+#endif

--- a/thrust/testing/async/exclusive_scan/simple.cu
+++ b/thrust/testing/async/exclusive_scan/simple.cu
@@ -1,3 +1,7 @@
+#include <cuda/__cccl_config>
+
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+
 #include <thrust/detail/config.h>
 
 #if _CCCL_STD_VER >= 2014
@@ -65,3 +69,5 @@ struct test_simple_in_place
 DECLARE_GENERIC_SIZED_UNITTEST_WITH_TYPES(test_simple_in_place, NumericTypes);
 
 #endif // C++14
+
+_CCCL_SUPPRESS_DEPRECATED_POP

--- a/thrust/testing/async/exclusive_scan/simple.cu
+++ b/thrust/testing/async/exclusive_scan/simple.cu
@@ -71,6 +71,6 @@ DECLARE_GENERIC_SIZED_UNITTEST_WITH_TYPES(test_simple_in_place, NumericTypes);
 #endif // C++14
 
 // we need to leak the suppression on clang/MSVC to suppresses warnings from the cudafe1.stub.c file
-#if !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)
+#if !_CCCL_COMPILER(CLANG) && !_CCCL_COMPILER(MSVC)
 _CCCL_SUPPRESS_DEPRECATED_POP
-#endif // !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)
+#endif // !_CCCL_COMPILER(CLANG) && !_CCCL_COMPILER(MSVC)

--- a/thrust/testing/async/exclusive_scan/simple.cu
+++ b/thrust/testing/async/exclusive_scan/simple.cu
@@ -70,4 +70,7 @@ DECLARE_GENERIC_SIZED_UNITTEST_WITH_TYPES(test_simple_in_place, NumericTypes);
 
 #endif // C++14
 
+// we need to leak the suppression on clang to suppresses warnings from the cudafe1.stub.c file
+#if !_CCCL_COMPILER(CLANG)
 _CCCL_SUPPRESS_DEPRECATED_POP
+#endif

--- a/thrust/testing/async/exclusive_scan/simple.cu
+++ b/thrust/testing/async/exclusive_scan/simple.cu
@@ -70,7 +70,7 @@ DECLARE_GENERIC_SIZED_UNITTEST_WITH_TYPES(test_simple_in_place, NumericTypes);
 
 #endif // C++14
 
-// we need to leak the suppression on clang to suppresses warnings from the cudafe1.stub.c file
-#if !_CCCL_COMPILER(CLANG)
+// we need to leak the suppression on clang/MSVC to suppresses warnings from the cudafe1.stub.c file
+#if !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)
 _CCCL_SUPPRESS_DEPRECATED_POP
-#endif
+#endif // !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)

--- a/thrust/testing/async/exclusive_scan/stateful_operator.cu
+++ b/thrust/testing/async/exclusive_scan/stateful_operator.cu
@@ -1,3 +1,7 @@
+#include <cuda/__cccl_config>
+
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+
 #include <thrust/detail/config.h>
 
 #if _CCCL_STD_VER >= 2014
@@ -62,3 +66,5 @@ struct test_stateful_operator
 DECLARE_GENERIC_SIZED_UNITTEST_WITH_TYPES(test_stateful_operator, NumericTypes);
 
 #endif // C++14
+
+_CCCL_SUPPRESS_DEPRECATED_POP

--- a/thrust/testing/async/exclusive_scan/stateful_operator.cu
+++ b/thrust/testing/async/exclusive_scan/stateful_operator.cu
@@ -68,6 +68,6 @@ DECLARE_GENERIC_SIZED_UNITTEST_WITH_TYPES(test_stateful_operator, NumericTypes);
 #endif // C++14
 
 // we need to leak the suppression on clang/MSVC to suppresses warnings from the cudafe1.stub.c file
-#if !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)
+#if !_CCCL_COMPILER(CLANG) && !_CCCL_COMPILER(MSVC)
 _CCCL_SUPPRESS_DEPRECATED_POP
-#endif // !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)
+#endif // !_CCCL_COMPILER(CLANG) && !_CCCL_COMPILER(MSVC)

--- a/thrust/testing/async/exclusive_scan/stateful_operator.cu
+++ b/thrust/testing/async/exclusive_scan/stateful_operator.cu
@@ -67,7 +67,7 @@ DECLARE_GENERIC_SIZED_UNITTEST_WITH_TYPES(test_stateful_operator, NumericTypes);
 
 #endif // C++14
 
-// we need to leak the suppression on clang to suppresses warnings from the cudafe1.stub.c file
-#if !_CCCL_COMPILER(CLANG)
+// we need to leak the suppression on clang/MSVC to suppresses warnings from the cudafe1.stub.c file
+#if !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)
 _CCCL_SUPPRESS_DEPRECATED_POP
-#endif
+#endif // !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)

--- a/thrust/testing/async/exclusive_scan/stateful_operator.cu
+++ b/thrust/testing/async/exclusive_scan/stateful_operator.cu
@@ -67,4 +67,7 @@ DECLARE_GENERIC_SIZED_UNITTEST_WITH_TYPES(test_stateful_operator, NumericTypes);
 
 #endif // C++14
 
+// we need to leak the suppression on clang to suppresses warnings from the cudafe1.stub.c file
+#if !_CCCL_COMPILER(CLANG)
 _CCCL_SUPPRESS_DEPRECATED_POP
+#endif

--- a/thrust/testing/async/exclusive_scan/using_vs_adl.cu
+++ b/thrust/testing/async/exclusive_scan/using_vs_adl.cu
@@ -1,3 +1,7 @@
+#include <cuda/__cccl_config>
+
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+
 #include <thrust/detail/config.h>
 
 #if _CCCL_STD_VER >= 2014
@@ -168,3 +172,5 @@ void test_using_cpo()
 DECLARE_UNITTEST(test_using_cpo);
 
 #endif // C++14
+
+_CCCL_SUPPRESS_DEPRECATED_POP

--- a/thrust/testing/async/exclusive_scan/using_vs_adl.cu
+++ b/thrust/testing/async/exclusive_scan/using_vs_adl.cu
@@ -174,6 +174,6 @@ DECLARE_UNITTEST(test_using_cpo);
 #endif // C++14
 
 // we need to leak the suppression on clang/MSVC to suppresses warnings from the cudafe1.stub.c file
-#if !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)
+#if !_CCCL_COMPILER(CLANG) && !_CCCL_COMPILER(MSVC)
 _CCCL_SUPPRESS_DEPRECATED_POP
-#endif // !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)
+#endif // !_CCCL_COMPILER(CLANG) && !_CCCL_COMPILER(MSVC)

--- a/thrust/testing/async/exclusive_scan/using_vs_adl.cu
+++ b/thrust/testing/async/exclusive_scan/using_vs_adl.cu
@@ -173,7 +173,7 @@ DECLARE_UNITTEST(test_using_cpo);
 
 #endif // C++14
 
-// we need to leak the suppression on clang to suppresses warnings from the cudafe1.stub.c file
-#if !_CCCL_COMPILER(CLANG)
+// we need to leak the suppression on clang/MSVC to suppresses warnings from the cudafe1.stub.c file
+#if !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)
 _CCCL_SUPPRESS_DEPRECATED_POP
-#endif
+#endif // !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)

--- a/thrust/testing/async/exclusive_scan/using_vs_adl.cu
+++ b/thrust/testing/async/exclusive_scan/using_vs_adl.cu
@@ -173,4 +173,7 @@ DECLARE_UNITTEST(test_using_cpo);
 
 #endif // C++14
 
+// we need to leak the suppression on clang to suppresses warnings from the cudafe1.stub.c file
+#if !_CCCL_COMPILER(CLANG)
 _CCCL_SUPPRESS_DEPRECATED_POP
+#endif

--- a/thrust/testing/async/inclusive_scan/counting_iterator.cu
+++ b/thrust/testing/async/inclusive_scan/counting_iterator.cu
@@ -1,3 +1,7 @@
+#include <cuda/__cccl_config>
+
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+
 #include <thrust/detail/config.h>
 
 #if _CCCL_STD_VER >= 2014
@@ -39,3 +43,5 @@ struct test_counting_iterator
 DECLARE_GENERIC_SIZED_UNITTEST_WITH_TYPES(test_counting_iterator, UnsignedIntegralTypes);
 
 #endif // C++14
+
+_CCCL_SUPPRESS_DEPRECATED_POP

--- a/thrust/testing/async/inclusive_scan/counting_iterator.cu
+++ b/thrust/testing/async/inclusive_scan/counting_iterator.cu
@@ -44,7 +44,7 @@ DECLARE_GENERIC_SIZED_UNITTEST_WITH_TYPES(test_counting_iterator, UnsignedIntegr
 
 #endif // C++14
 
-// we need to leak the suppression on clang to suppresses warnings from the cudafe1.stub.c file
-#if !_CCCL_COMPILER(CLANG)
+// we need to leak the suppression on clang/MSVC to suppresses warnings from the cudafe1.stub.c file
+#if !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)
 _CCCL_SUPPRESS_DEPRECATED_POP
-#endif
+#endif // !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)

--- a/thrust/testing/async/inclusive_scan/counting_iterator.cu
+++ b/thrust/testing/async/inclusive_scan/counting_iterator.cu
@@ -44,4 +44,7 @@ DECLARE_GENERIC_SIZED_UNITTEST_WITH_TYPES(test_counting_iterator, UnsignedIntegr
 
 #endif // C++14
 
+// we need to leak the suppression on clang to suppresses warnings from the cudafe1.stub.c file
+#if !_CCCL_COMPILER(CLANG)
 _CCCL_SUPPRESS_DEPRECATED_POP
+#endif

--- a/thrust/testing/async/inclusive_scan/counting_iterator.cu
+++ b/thrust/testing/async/inclusive_scan/counting_iterator.cu
@@ -45,6 +45,6 @@ DECLARE_GENERIC_SIZED_UNITTEST_WITH_TYPES(test_counting_iterator, UnsignedIntegr
 #endif // C++14
 
 // we need to leak the suppression on clang/MSVC to suppresses warnings from the cudafe1.stub.c file
-#if !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)
+#if !_CCCL_COMPILER(CLANG) && !_CCCL_COMPILER(MSVC)
 _CCCL_SUPPRESS_DEPRECATED_POP
-#endif // !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)
+#endif // !_CCCL_COMPILER(CLANG) && !_CCCL_COMPILER(MSVC)

--- a/thrust/testing/async/inclusive_scan/discard_output.cu
+++ b/thrust/testing/async/inclusive_scan/discard_output.cu
@@ -1,3 +1,7 @@
+#include <cuda/__cccl_config>
+
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+
 #include <thrust/detail/config.h>
 
 #if _CCCL_STD_VER >= 2014
@@ -35,3 +39,5 @@ struct test_discard
 DECLARE_GENERIC_SIZED_UNITTEST_WITH_TYPES(test_discard, NumericTypes);
 
 #endif // C++14
+
+_CCCL_SUPPRESS_DEPRECATED_POP

--- a/thrust/testing/async/inclusive_scan/discard_output.cu
+++ b/thrust/testing/async/inclusive_scan/discard_output.cu
@@ -40,7 +40,7 @@ DECLARE_GENERIC_SIZED_UNITTEST_WITH_TYPES(test_discard, NumericTypes);
 
 #endif // C++14
 
-// we need to leak the suppression on clang to suppresses warnings from the cudafe1.stub.c file
-#if !_CCCL_COMPILER(CLANG)
+// we need to leak the suppression on clang/MSVC to suppresses warnings from the cudafe1.stub.c file
+#if !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)
 _CCCL_SUPPRESS_DEPRECATED_POP
-#endif
+#endif // !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)

--- a/thrust/testing/async/inclusive_scan/discard_output.cu
+++ b/thrust/testing/async/inclusive_scan/discard_output.cu
@@ -41,6 +41,6 @@ DECLARE_GENERIC_SIZED_UNITTEST_WITH_TYPES(test_discard, NumericTypes);
 #endif // C++14
 
 // we need to leak the suppression on clang/MSVC to suppresses warnings from the cudafe1.stub.c file
-#if !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)
+#if !_CCCL_COMPILER(CLANG) && !_CCCL_COMPILER(MSVC)
 _CCCL_SUPPRESS_DEPRECATED_POP
-#endif // !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)
+#endif // !_CCCL_COMPILER(CLANG) && !_CCCL_COMPILER(MSVC)

--- a/thrust/testing/async/inclusive_scan/discard_output.cu
+++ b/thrust/testing/async/inclusive_scan/discard_output.cu
@@ -40,4 +40,7 @@ DECLARE_GENERIC_SIZED_UNITTEST_WITH_TYPES(test_discard, NumericTypes);
 
 #endif // C++14
 
+// we need to leak the suppression on clang to suppresses warnings from the cudafe1.stub.c file
+#if !_CCCL_COMPILER(CLANG)
 _CCCL_SUPPRESS_DEPRECATED_POP
+#endif

--- a/thrust/testing/async/inclusive_scan/large_indices.cu
+++ b/thrust/testing/async/inclusive_scan/large_indices.cu
@@ -1,3 +1,7 @@
+#include <cuda/__cccl_config>
+
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+
 #include <thrust/detail/config.h>
 
 #if _CCCL_STD_VER >= 2014
@@ -232,3 +236,5 @@ void test_large_indices_custom_scan_op()
 DECLARE_UNITTEST(test_large_indices_custom_scan_op);
 
 #endif // C++14
+
+_CCCL_SUPPRESS_DEPRECATED_POP

--- a/thrust/testing/async/inclusive_scan/large_indices.cu
+++ b/thrust/testing/async/inclusive_scan/large_indices.cu
@@ -237,7 +237,7 @@ DECLARE_UNITTEST(test_large_indices_custom_scan_op);
 
 #endif // C++14
 
-// we need to leak the suppression on clang to suppresses warnings from the cudafe1.stub.c file
-#if !_CCCL_COMPILER(CLANG)
+// we need to leak the suppression on clang/MSVC to suppresses warnings from the cudafe1.stub.c file
+#if !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)
 _CCCL_SUPPRESS_DEPRECATED_POP
-#endif
+#endif // !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)

--- a/thrust/testing/async/inclusive_scan/large_indices.cu
+++ b/thrust/testing/async/inclusive_scan/large_indices.cu
@@ -238,6 +238,6 @@ DECLARE_UNITTEST(test_large_indices_custom_scan_op);
 #endif // C++14
 
 // we need to leak the suppression on clang/MSVC to suppresses warnings from the cudafe1.stub.c file
-#if !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)
+#if !_CCCL_COMPILER(CLANG) && !_CCCL_COMPILER(MSVC)
 _CCCL_SUPPRESS_DEPRECATED_POP
-#endif // !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)
+#endif // !_CCCL_COMPILER(CLANG) && !_CCCL_COMPILER(MSVC)

--- a/thrust/testing/async/inclusive_scan/large_indices.cu
+++ b/thrust/testing/async/inclusive_scan/large_indices.cu
@@ -237,4 +237,7 @@ DECLARE_UNITTEST(test_large_indices_custom_scan_op);
 
 #endif // C++14
 
+// we need to leak the suppression on clang to suppresses warnings from the cudafe1.stub.c file
+#if !_CCCL_COMPILER(CLANG)
 _CCCL_SUPPRESS_DEPRECATED_POP
+#endif

--- a/thrust/testing/async/inclusive_scan/large_types.cu
+++ b/thrust/testing/async/inclusive_scan/large_types.cu
@@ -1,3 +1,7 @@
+#include <cuda/__cccl_config>
+
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+
 #include <thrust/detail/config.h>
 
 #if _CCCL_STD_VER >= 2014
@@ -52,3 +56,5 @@ struct test_large_types
 DECLARE_UNITTEST(test_large_types);
 
 #endif // C++14
+
+_CCCL_SUPPRESS_DEPRECATED_POP

--- a/thrust/testing/async/inclusive_scan/large_types.cu
+++ b/thrust/testing/async/inclusive_scan/large_types.cu
@@ -57,4 +57,7 @@ DECLARE_UNITTEST(test_large_types);
 
 #endif // C++14
 
+// we need to leak the suppression on clang to suppresses warnings from the cudafe1.stub.c file
+#if !_CCCL_COMPILER(CLANG)
 _CCCL_SUPPRESS_DEPRECATED_POP
+#endif

--- a/thrust/testing/async/inclusive_scan/large_types.cu
+++ b/thrust/testing/async/inclusive_scan/large_types.cu
@@ -58,6 +58,6 @@ DECLARE_UNITTEST(test_large_types);
 #endif // C++14
 
 // we need to leak the suppression on clang/MSVC to suppresses warnings from the cudafe1.stub.c file
-#if !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)
+#if !_CCCL_COMPILER(CLANG) && !_CCCL_COMPILER(MSVC)
 _CCCL_SUPPRESS_DEPRECATED_POP
-#endif // !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)
+#endif // !_CCCL_COMPILER(CLANG) && !_CCCL_COMPILER(MSVC)

--- a/thrust/testing/async/inclusive_scan/large_types.cu
+++ b/thrust/testing/async/inclusive_scan/large_types.cu
@@ -57,7 +57,7 @@ DECLARE_UNITTEST(test_large_types);
 
 #endif // C++14
 
-// we need to leak the suppression on clang to suppresses warnings from the cudafe1.stub.c file
-#if !_CCCL_COMPILER(CLANG)
+// we need to leak the suppression on clang/MSVC to suppresses warnings from the cudafe1.stub.c file
+#if !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)
 _CCCL_SUPPRESS_DEPRECATED_POP
-#endif
+#endif // !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)

--- a/thrust/testing/async/inclusive_scan/mixed_types.cu
+++ b/thrust/testing/async/inclusive_scan/mixed_types.cu
@@ -1,3 +1,7 @@
+#include <cuda/__cccl_config>
+
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+
 #include <thrust/detail/config.h>
 
 #if _CCCL_STD_VER >= 2014
@@ -106,3 +110,5 @@ void test_scan_mixed_types(size_t num_values)
 DECLARE_SIZED_UNITTEST(test_scan_mixed_types);
 
 #endif // C++14
+
+_CCCL_SUPPRESS_DEPRECATED_POP

--- a/thrust/testing/async/inclusive_scan/mixed_types.cu
+++ b/thrust/testing/async/inclusive_scan/mixed_types.cu
@@ -111,7 +111,7 @@ DECLARE_SIZED_UNITTEST(test_scan_mixed_types);
 
 #endif // C++14
 
-// we need to leak the suppression on clang to suppresses warnings from the cudafe1.stub.c file
-#if !_CCCL_COMPILER(CLANG)
+// we need to leak the suppression on clang/MSVC to suppresses warnings from the cudafe1.stub.c file
+#if !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)
 _CCCL_SUPPRESS_DEPRECATED_POP
-#endif
+#endif // !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)

--- a/thrust/testing/async/inclusive_scan/mixed_types.cu
+++ b/thrust/testing/async/inclusive_scan/mixed_types.cu
@@ -111,4 +111,7 @@ DECLARE_SIZED_UNITTEST(test_scan_mixed_types);
 
 #endif // C++14
 
+// we need to leak the suppression on clang to suppresses warnings from the cudafe1.stub.c file
+#if !_CCCL_COMPILER(CLANG)
 _CCCL_SUPPRESS_DEPRECATED_POP
+#endif

--- a/thrust/testing/async/inclusive_scan/mixed_types.cu
+++ b/thrust/testing/async/inclusive_scan/mixed_types.cu
@@ -112,6 +112,6 @@ DECLARE_SIZED_UNITTEST(test_scan_mixed_types);
 #endif // C++14
 
 // we need to leak the suppression on clang/MSVC to suppresses warnings from the cudafe1.stub.c file
-#if !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)
+#if !_CCCL_COMPILER(CLANG) && !_CCCL_COMPILER(MSVC)
 _CCCL_SUPPRESS_DEPRECATED_POP
-#endif // !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)
+#endif // !_CCCL_COMPILER(CLANG) && !_CCCL_COMPILER(MSVC)

--- a/thrust/testing/async/inclusive_scan/simple.cu
+++ b/thrust/testing/async/inclusive_scan/simple.cu
@@ -1,3 +1,7 @@
+#include <cuda/__cccl_config>
+
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+
 #include <thrust/detail/config.h>
 
 #if _CCCL_STD_VER >= 2014
@@ -90,3 +94,5 @@ struct test_simple_in_place
 DECLARE_GENERIC_SIZED_UNITTEST_WITH_TYPES(test_simple_in_place, NumericTypes);
 
 #endif // C++14
+
+_CCCL_SUPPRESS_DEPRECATED_POP

--- a/thrust/testing/async/inclusive_scan/simple.cu
+++ b/thrust/testing/async/inclusive_scan/simple.cu
@@ -95,4 +95,7 @@ DECLARE_GENERIC_SIZED_UNITTEST_WITH_TYPES(test_simple_in_place, NumericTypes);
 
 #endif // C++14
 
+// we need to leak the suppression on clang to suppresses warnings from the cudafe1.stub.c file
+#if !_CCCL_COMPILER(CLANG)
 _CCCL_SUPPRESS_DEPRECATED_POP
+#endif

--- a/thrust/testing/async/inclusive_scan/simple.cu
+++ b/thrust/testing/async/inclusive_scan/simple.cu
@@ -95,7 +95,7 @@ DECLARE_GENERIC_SIZED_UNITTEST_WITH_TYPES(test_simple_in_place, NumericTypes);
 
 #endif // C++14
 
-// we need to leak the suppression on clang to suppresses warnings from the cudafe1.stub.c file
-#if !_CCCL_COMPILER(CLANG)
+// we need to leak the suppression on clang/MSVC to suppresses warnings from the cudafe1.stub.c file
+#if !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)
 _CCCL_SUPPRESS_DEPRECATED_POP
-#endif
+#endif // !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)

--- a/thrust/testing/async/inclusive_scan/simple.cu
+++ b/thrust/testing/async/inclusive_scan/simple.cu
@@ -96,6 +96,6 @@ DECLARE_GENERIC_SIZED_UNITTEST_WITH_TYPES(test_simple_in_place, NumericTypes);
 #endif // C++14
 
 // we need to leak the suppression on clang/MSVC to suppresses warnings from the cudafe1.stub.c file
-#if !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)
+#if !_CCCL_COMPILER(CLANG) && !_CCCL_COMPILER(MSVC)
 _CCCL_SUPPRESS_DEPRECATED_POP
-#endif // !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)
+#endif // !_CCCL_COMPILER(CLANG) && !_CCCL_COMPILER(MSVC)

--- a/thrust/testing/async/inclusive_scan/stateful_operator.cu
+++ b/thrust/testing/async/inclusive_scan/stateful_operator.cu
@@ -1,3 +1,7 @@
+#include <cuda/__cccl_config>
+
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+
 #include <thrust/detail/config.h>
 
 #if _CCCL_STD_VER >= 2014
@@ -62,3 +66,5 @@ struct test_stateful_operator
 DECLARE_GENERIC_SIZED_UNITTEST_WITH_TYPES(test_stateful_operator, NumericTypes);
 
 #endif // C++14
+
+_CCCL_SUPPRESS_DEPRECATED_POP

--- a/thrust/testing/async/inclusive_scan/stateful_operator.cu
+++ b/thrust/testing/async/inclusive_scan/stateful_operator.cu
@@ -68,6 +68,6 @@ DECLARE_GENERIC_SIZED_UNITTEST_WITH_TYPES(test_stateful_operator, NumericTypes);
 #endif // C++14
 
 // we need to leak the suppression on clang/MSVC to suppresses warnings from the cudafe1.stub.c file
-#if !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)
+#if !_CCCL_COMPILER(CLANG) && !_CCCL_COMPILER(MSVC)
 _CCCL_SUPPRESS_DEPRECATED_POP
-#endif // !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)
+#endif // !_CCCL_COMPILER(CLANG) && !_CCCL_COMPILER(MSVC)

--- a/thrust/testing/async/inclusive_scan/stateful_operator.cu
+++ b/thrust/testing/async/inclusive_scan/stateful_operator.cu
@@ -67,7 +67,7 @@ DECLARE_GENERIC_SIZED_UNITTEST_WITH_TYPES(test_stateful_operator, NumericTypes);
 
 #endif // C++14
 
-// we need to leak the suppression on clang to suppresses warnings from the cudafe1.stub.c file
-#if !_CCCL_COMPILER(CLANG)
+// we need to leak the suppression on clang/MSVC to suppresses warnings from the cudafe1.stub.c file
+#if !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)
 _CCCL_SUPPRESS_DEPRECATED_POP
-#endif
+#endif // !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)

--- a/thrust/testing/async/inclusive_scan/stateful_operator.cu
+++ b/thrust/testing/async/inclusive_scan/stateful_operator.cu
@@ -67,4 +67,7 @@ DECLARE_GENERIC_SIZED_UNITTEST_WITH_TYPES(test_stateful_operator, NumericTypes);
 
 #endif // C++14
 
+// we need to leak the suppression on clang to suppresses warnings from the cudafe1.stub.c file
+#if !_CCCL_COMPILER(CLANG)
 _CCCL_SUPPRESS_DEPRECATED_POP
+#endif

--- a/thrust/testing/async/inclusive_scan/using_vs_adl.cu
+++ b/thrust/testing/async/inclusive_scan/using_vs_adl.cu
@@ -1,3 +1,7 @@
+#include <cuda/__cccl_config>
+
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+
 #include <thrust/detail/config.h>
 
 #if _CCCL_STD_VER >= 2014
@@ -166,3 +170,5 @@ void test_using_cpo()
 DECLARE_UNITTEST(test_using_cpo);
 
 #endif // C++14
+
+_CCCL_SUPPRESS_DEPRECATED_POP

--- a/thrust/testing/async/inclusive_scan/using_vs_adl.cu
+++ b/thrust/testing/async/inclusive_scan/using_vs_adl.cu
@@ -171,4 +171,7 @@ DECLARE_UNITTEST(test_using_cpo);
 
 #endif // C++14
 
+// we need to leak the suppression on clang to suppresses warnings from the cudafe1.stub.c file
+#if !_CCCL_COMPILER(CLANG)
 _CCCL_SUPPRESS_DEPRECATED_POP
+#endif

--- a/thrust/testing/async/inclusive_scan/using_vs_adl.cu
+++ b/thrust/testing/async/inclusive_scan/using_vs_adl.cu
@@ -171,7 +171,7 @@ DECLARE_UNITTEST(test_using_cpo);
 
 #endif // C++14
 
-// we need to leak the suppression on clang to suppresses warnings from the cudafe1.stub.c file
-#if !_CCCL_COMPILER(CLANG)
+// we need to leak the suppression on clang/MSVC to suppresses warnings from the cudafe1.stub.c file
+#if !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)
 _CCCL_SUPPRESS_DEPRECATED_POP
-#endif
+#endif // !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)

--- a/thrust/testing/async/inclusive_scan/using_vs_adl.cu
+++ b/thrust/testing/async/inclusive_scan/using_vs_adl.cu
@@ -172,6 +172,6 @@ DECLARE_UNITTEST(test_using_cpo);
 #endif // C++14
 
 // we need to leak the suppression on clang/MSVC to suppresses warnings from the cudafe1.stub.c file
-#if !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)
+#if !_CCCL_COMPILER(CLANG) && !_CCCL_COMPILER(MSVC)
 _CCCL_SUPPRESS_DEPRECATED_POP
-#endif // !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)
+#endif // !_CCCL_COMPILER(CLANG) && !_CCCL_COMPILER(MSVC)

--- a/thrust/testing/async_copy.cu
+++ b/thrust/testing/async_copy.cu
@@ -1,3 +1,8 @@
+#include <cuda/__cccl_config>
+
+// need to suppress deprecation warnings inside a lot of thrust headers
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+
 #include <thrust/detail/config.h>
 
 #if _CCCL_STD_VER >= 2014
@@ -9,8 +14,6 @@
 
 #  include <unittest/unittest.h>
 #  include <unittest/util_async.h>
-
-_CCCL_SUPPRESS_DEPRECATED_PUSH
 
 #  define DEFINE_ASYNC_COPY_CALLABLE(name, ...)                                               \
     struct THRUST_PP_CAT2(name, _fn)                                                          \
@@ -321,3 +324,5 @@ DECLARE_GENERIC_SIZED_UNITTEST_WITH_TYPES(test_async_copy_after, BuiltinNumericT
 // Can't do this today because we can't do cross-system with explicit policies.
 
 #endif
+
+_CCCL_SUPPRESS_DEPRECATED_POP

--- a/thrust/testing/async_copy.cu
+++ b/thrust/testing/async_copy.cu
@@ -325,7 +325,7 @@ DECLARE_GENERIC_SIZED_UNITTEST_WITH_TYPES(test_async_copy_after, BuiltinNumericT
 
 #endif
 
-// we need to leak the suppression on clang to suppresses warnings from the cudafe1.stub.c file
-#if !_CCCL_COMPILER(CLANG)
+// we need to leak the suppression on clang/MSVC to suppresses warnings from the cudafe1.stub.c file
+#if !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)
 _CCCL_SUPPRESS_DEPRECATED_POP
-#endif
+#endif // !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)

--- a/thrust/testing/async_copy.cu
+++ b/thrust/testing/async_copy.cu
@@ -326,6 +326,6 @@ DECLARE_GENERIC_SIZED_UNITTEST_WITH_TYPES(test_async_copy_after, BuiltinNumericT
 #endif
 
 // we need to leak the suppression on clang/MSVC to suppresses warnings from the cudafe1.stub.c file
-#if !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)
+#if !_CCCL_COMPILER(CLANG) && !_CCCL_COMPILER(MSVC)
 _CCCL_SUPPRESS_DEPRECATED_POP
-#endif // !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)
+#endif // !_CCCL_COMPILER(CLANG) && !_CCCL_COMPILER(MSVC)

--- a/thrust/testing/async_copy.cu
+++ b/thrust/testing/async_copy.cu
@@ -325,4 +325,7 @@ DECLARE_GENERIC_SIZED_UNITTEST_WITH_TYPES(test_async_copy_after, BuiltinNumericT
 
 #endif
 
+// we need to leak the suppression on clang to suppresses warnings from the cudafe1.stub.c file
+#if !_CCCL_COMPILER(CLANG)
 _CCCL_SUPPRESS_DEPRECATED_POP
+#endif

--- a/thrust/testing/async_reduce.cu
+++ b/thrust/testing/async_reduce.cu
@@ -1,5 +1,10 @@
 #define THRUST_ENABLE_FUTURE_RAW_DATA_MEMBER
 
+#include <cuda/__cccl_config>
+
+// need to suppress deprecation warnings inside several thrust headers
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+
 #include <thrust/detail/config.h>
 
 #if _CCCL_STD_VER >= 2014
@@ -11,8 +16,6 @@
 
 #  include <unittest/unittest.h>
 #  include <unittest/util_async.h>
-
-_CCCL_SUPPRESS_DEPRECATED_PUSH
 
 template <typename T>
 struct custom_plus
@@ -541,16 +544,12 @@ struct test_async_reduce_using
     // When you import the customization points into the global namespace,
     // they should be selected instead of the synchronous algorithms.
     {
-      _CCCL_SUPPRESS_DEPRECATED_PUSH
       using namespace thrust::async;
       f0a = reduce(d0a.begin(), d0a.end());
-      _CCCL_SUPPRESS_DEPRECATED_POP
     }
     {
-      _CCCL_SUPPRESS_DEPRECATED_PUSH
       using thrust::async::reduce;
       f0b = reduce(d0b.begin(), d0b.end());
-      _CCCL_SUPPRESS_DEPRECATED_POP
     }
 
     // ADL should find the synchronous algorithms.
@@ -884,3 +883,5 @@ struct test_async_reduce_bug1886
 DECLARE_UNITTEST(test_async_reduce_bug1886);
 
 #endif
+
+_CCCL_SUPPRESS_DEPRECATED_POP

--- a/thrust/testing/async_reduce.cu
+++ b/thrust/testing/async_reduce.cu
@@ -884,7 +884,7 @@ DECLARE_UNITTEST(test_async_reduce_bug1886);
 
 #endif
 
-// we need to leak the suppression on clang to suppresses warnings from the cudafe1.stub.c file
-#if !_CCCL_COMPILER(CLANG)
+// we need to leak the suppression on clang/MSVC to suppresses warnings from the cudafe1.stub.c file
+#if !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)
 _CCCL_SUPPRESS_DEPRECATED_POP
-#endif
+#endif // !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)

--- a/thrust/testing/async_reduce.cu
+++ b/thrust/testing/async_reduce.cu
@@ -884,4 +884,7 @@ DECLARE_UNITTEST(test_async_reduce_bug1886);
 
 #endif
 
+// we need to leak the suppression on clang to suppresses warnings from the cudafe1.stub.c file
+#if !_CCCL_COMPILER(CLANG)
 _CCCL_SUPPRESS_DEPRECATED_POP
+#endif

--- a/thrust/testing/async_reduce.cu
+++ b/thrust/testing/async_reduce.cu
@@ -885,6 +885,6 @@ DECLARE_UNITTEST(test_async_reduce_bug1886);
 #endif
 
 // we need to leak the suppression on clang/MSVC to suppresses warnings from the cudafe1.stub.c file
-#if !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)
+#if !_CCCL_COMPILER(CLANG) && !_CCCL_COMPILER(MSVC)
 _CCCL_SUPPRESS_DEPRECATED_POP
-#endif // !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)
+#endif // !_CCCL_COMPILER(CLANG) && !_CCCL_COMPILER(MSVC)

--- a/thrust/testing/async_sort.cu
+++ b/thrust/testing/async_sort.cu
@@ -1,3 +1,8 @@
+#include <cuda/__cccl_config>
+
+// need to suppress deprecation warnings inside a lot of thrust headers
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+
 #include <thrust/detail/config.h>
 
 // Disabled on MSVC && NVCC < 11.1 for GH issue #1098.
@@ -14,8 +19,6 @@
 #  include <thrust/host_vector.h>
 
 #  include <unittest/unittest.h>
-
-_CCCL_SUPPRESS_DEPRECATED_PUSH
 
 enum wait_policy
 {
@@ -177,3 +180,5 @@ DECLARE_GENERIC_SIZED_UNITTEST_WITH_TYPES_AND_NAME(
 // TODO: Test future return type.
 
 #endif
+
+_CCCL_SUPPRESS_DEPRECATED_POP

--- a/thrust/testing/async_sort.cu
+++ b/thrust/testing/async_sort.cu
@@ -181,7 +181,7 @@ DECLARE_GENERIC_SIZED_UNITTEST_WITH_TYPES_AND_NAME(
 
 #endif
 
-// we need to leak the suppression on clang to suppresses warnings from the cudafe1.stub.c file
-#if !_CCCL_COMPILER(CLANG)
+// we need to leak the suppression on clang/MSVC to suppresses warnings from the cudafe1.stub.c file
+#if !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)
 _CCCL_SUPPRESS_DEPRECATED_POP
-#endif
+#endif // !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)

--- a/thrust/testing/async_sort.cu
+++ b/thrust/testing/async_sort.cu
@@ -182,6 +182,6 @@ DECLARE_GENERIC_SIZED_UNITTEST_WITH_TYPES_AND_NAME(
 #endif
 
 // we need to leak the suppression on clang/MSVC to suppresses warnings from the cudafe1.stub.c file
-#if !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)
+#if !_CCCL_COMPILER(CLANG) && !_CCCL_COMPILER(MSVC)
 _CCCL_SUPPRESS_DEPRECATED_POP
-#endif // !_CCCL_COMPILER(CLANG) || !_CCCL_COMPILER(MSVC)
+#endif // !_CCCL_COMPILER(CLANG) && !_CCCL_COMPILER(MSVC)

--- a/thrust/testing/async_sort.cu
+++ b/thrust/testing/async_sort.cu
@@ -181,4 +181,7 @@ DECLARE_GENERIC_SIZED_UNITTEST_WITH_TYPES_AND_NAME(
 
 #endif
 
+// we need to leak the suppression on clang to suppresses warnings from the cudafe1.stub.c file
+#if !_CCCL_COMPILER(CLANG)
 _CCCL_SUPPRESS_DEPRECATED_POP
+#endif

--- a/thrust/testing/dependencies_aware_policies.cu
+++ b/thrust/testing/dependencies_aware_policies.cu
@@ -1,3 +1,8 @@
+#include <cuda/__cccl_config>
+
+// need to suppress deprecation warnings for execute_with_allocator_and_dependencies inside type traits
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+
 #include <thrust/detail/config.h>
 
 #include <thrust/detail/seq.h>
@@ -113,3 +118,5 @@ SimpleUnitTest<TestDependencyAttachment,
 #endif
                  >>
   TestDependencyAttachmentInstance;
+
+_CCCL_SUPPRESS_DEPRECATED_POP

--- a/thrust/testing/event.cu
+++ b/thrust/testing/event.cu
@@ -7,6 +7,10 @@
 #  include <unittest/unittest.h>
 #  include <unittest/util_async.h>
 
+// note: there is no matching _CCCL_SUPPRESS_DEPRECATED_POP, so the warning suppression leaks into more content of the
+// generated cudafe1.stub.c file.
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+
 ///////////////////////////////////////////////////////////////////////////////
 
 _CCCL_HOST void test_event_default_constructed()

--- a/thrust/testing/future.cu
+++ b/thrust/testing/future.cu
@@ -7,6 +7,10 @@
 #  include <unittest/unittest.h>
 #  include <unittest/util_async.h>
 
+// note: there is no matching _CCCL_SUPPRESS_DEPRECATED_POP, so the warning suppression leaks into more content of the
+// generated cudafe1.stub.c file.
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+
 struct mock
 {};
 

--- a/thrust/thrust/async/copy.h
+++ b/thrust/thrust/async/copy.h
@@ -51,6 +51,7 @@ namespace async
 namespace unimplemented
 {
 
+_CCCL_SUPPRESS_DEPRECATED_PUSH
 template <typename FromPolicy, typename ToPolicy, typename ForwardIt, typename Sentinel, typename OutputIt>
 CCCL_DEPRECATED _CCCL_HOST event<FromPolicy> async_copy(
   thrust::execution_policy<FromPolicy>& from_exec,
@@ -63,6 +64,7 @@ CCCL_DEPRECATED _CCCL_HOST event<FromPolicy> async_copy(
                            "this algorithm is not implemented for the specified system");
   return {};
 }
+_CCCL_SUPPRESS_DEPRECATED_POP
 
 } // namespace unimplemented
 

--- a/thrust/thrust/async/for_each.h
+++ b/thrust/thrust/async/for_each.h
@@ -51,6 +51,7 @@ namespace async
 namespace unimplemented
 {
 
+_CCCL_SUPPRESS_DEPRECATED_PUSH
 template <typename DerivedPolicy, typename ForwardIt, typename Sentinel, typename UnaryFunction>
 CCCL_DEPRECATED _CCCL_HOST event<DerivedPolicy>
 async_for_each(thrust::execution_policy<DerivedPolicy>&, ForwardIt, Sentinel, UnaryFunction)
@@ -59,6 +60,7 @@ async_for_each(thrust::execution_policy<DerivedPolicy>&, ForwardIt, Sentinel, Un
                            "this algorithm is not implemented for the specified system");
   return {};
 }
+_CCCL_SUPPRESS_DEPRECATED_POP
 
 } // namespace unimplemented
 

--- a/thrust/thrust/async/reduce.h
+++ b/thrust/thrust/async/reduce.h
@@ -53,6 +53,7 @@ namespace async
 namespace unimplemented
 {
 
+_CCCL_SUPPRESS_DEPRECATED_PUSH
 template <typename DerivedPolicy, typename ForwardIt, typename Sentinel, typename T, typename BinaryOp>
 CCCL_DEPRECATED _CCCL_HOST future<DerivedPolicy, T>
 async_reduce(thrust::execution_policy<DerivedPolicy>&, ForwardIt, Sentinel, T, BinaryOp)
@@ -61,6 +62,7 @@ async_reduce(thrust::execution_policy<DerivedPolicy>&, ForwardIt, Sentinel, T, B
                            "this algorithm is not implemented for the specified system");
   return {};
 }
+_CCCL_SUPPRESS_DEPRECATED_POP
 
 } // namespace unimplemented
 
@@ -176,6 +178,7 @@ _CCCL_GLOBAL_CONSTANT reduce_detail::reduce_fn reduce{};
 namespace unimplemented
 {
 
+_CCCL_SUPPRESS_DEPRECATED_PUSH
 template <typename DerivedPolicy, typename ForwardIt, typename Sentinel, typename OutputIt, typename T, typename BinaryOp>
 CCCL_DEPRECATED _CCCL_HOST event<DerivedPolicy>
 async_reduce_into(thrust::execution_policy<DerivedPolicy>&, ForwardIt, Sentinel, OutputIt, T, BinaryOp)
@@ -184,6 +187,7 @@ async_reduce_into(thrust::execution_policy<DerivedPolicy>&, ForwardIt, Sentinel,
                            "this algorithm is not implemented for the specified system");
   return {};
 }
+_CCCL_SUPPRESS_DEPRECATED_POP
 
 } // namespace unimplemented
 

--- a/thrust/thrust/async/scan.h
+++ b/thrust/thrust/async/scan.h
@@ -52,6 +52,7 @@ namespace async
 namespace unimplemented
 {
 
+_CCCL_SUPPRESS_DEPRECATED_PUSH
 template <typename DerivedPolicy, typename ForwardIt, typename Sentinel, typename OutputIt, typename BinaryOp>
 CCCL_DEPRECATED event<DerivedPolicy>
 async_inclusive_scan(thrust::execution_policy<DerivedPolicy>&, ForwardIt, Sentinel, OutputIt, BinaryOp)
@@ -74,6 +75,7 @@ CCCL_DEPRECATED event<DerivedPolicy> async_exclusive_scan(
                            "this algorithm is not implemented for the specified system");
   return {};
 }
+_CCCL_SUPPRESS_DEPRECATED_POP
 
 } // namespace unimplemented
 

--- a/thrust/thrust/async/sort.h
+++ b/thrust/thrust/async/sort.h
@@ -53,6 +53,7 @@ namespace async
 namespace unimplemented
 {
 
+_CCCL_SUPPRESS_DEPRECATED_PUSH
 template <typename DerivedPolicy, typename ForwardIt, typename Sentinel, typename StrictWeakOrdering>
 CCCL_DEPRECATED _CCCL_HOST event<DerivedPolicy>
 async_stable_sort(thrust::execution_policy<DerivedPolicy>&, ForwardIt, Sentinel, StrictWeakOrdering)
@@ -61,6 +62,7 @@ async_stable_sort(thrust::execution_policy<DerivedPolicy>&, ForwardIt, Sentinel,
                            "this algorithm is not implemented for the specified system");
   return {};
 }
+_CCCL_SUPPRESS_DEPRECATED_POP
 
 } // namespace unimplemented
 
@@ -164,12 +166,14 @@ _CCCL_GLOBAL_CONSTANT stable_sort_detail::stable_sort_fn stable_sort{};
 namespace fallback
 {
 
+_CCCL_SUPPRESS_DEPRECATED_PUSH
 template <typename DerivedPolicy, typename ForwardIt, typename Sentinel, typename StrictWeakOrdering>
 CCCL_DEPRECATED _CCCL_HOST event<DerivedPolicy>
 async_sort(thrust::execution_policy<DerivedPolicy>& exec, ForwardIt&& first, Sentinel&& last, StrictWeakOrdering&& comp)
 {
   return async_stable_sort(thrust::detail::derived_cast(exec), THRUST_FWD(first), THRUST_FWD(last), THRUST_FWD(comp));
 }
+_CCCL_SUPPRESS_DEPRECATED_POP
 
 } // namespace fallback
 

--- a/thrust/thrust/async/transform.h
+++ b/thrust/thrust/async/transform.h
@@ -51,6 +51,7 @@ namespace async
 namespace unimplemented
 {
 
+_CCCL_SUPPRESS_DEPRECATED_PUSH
 template <typename DerivedPolicy, typename ForwardIt, typename Sentinel, typename OutputIt, typename UnaryOperation>
 CCCL_DEPRECATED _CCCL_HOST event<DerivedPolicy> async_transform(
   thrust::execution_policy<DerivedPolicy>& exec, ForwardIt first, Sentinel last, OutputIt output, UnaryOperation op)
@@ -59,6 +60,7 @@ CCCL_DEPRECATED _CCCL_HOST event<DerivedPolicy> async_transform(
                            "this algorithm is not implemented for the specified system");
   return {};
 }
+_CCCL_SUPPRESS_DEPRECATED_POP
 
 } // namespace unimplemented
 

--- a/thrust/thrust/detail/dependencies_aware_execution_policy.h
+++ b/thrust/thrust/detail/dependencies_aware_execution_policy.h
@@ -29,13 +29,14 @@
 
 #include <tuple>
 
+_CCCL_SUPPRESS_DEPRECATED_PUSH
 THRUST_NAMESPACE_BEGIN
 
 namespace detail
 {
 
 template <template <typename> class ExecutionPolicyCRTPBase>
-struct dependencies_aware_execution_policy
+struct CCCL_DEPRECATED dependencies_aware_execution_policy
 {
   template <typename... Dependencies>
   _CCCL_HOST thrust::detail::execute_with_dependencies<ExecutionPolicyCRTPBase, Dependencies...>
@@ -80,4 +81,5 @@ struct dependencies_aware_execution_policy
 
 } // namespace detail
 
+_CCCL_SUPPRESS_DEPRECATED_POP
 THRUST_NAMESPACE_END

--- a/thrust/thrust/detail/execute_with_allocator.h
+++ b/thrust/thrust/detail/execute_with_allocator.h
@@ -75,8 +75,9 @@ _CCCL_HOST void return_temporary_buffer(
   alloc_traits::deallocate(system.get_allocator(), to_ptr, num_elements);
 }
 
+_CCCL_SUPPRESS_DEPRECATED_PUSH
 template <typename T, template <typename> class BaseSystem, typename Allocator, typename... Dependencies>
-_CCCL_HOST thrust::pair<T*, std::ptrdiff_t> get_temporary_buffer(
+CCCL_DEPRECATED _CCCL_HOST thrust::pair<T*, std::ptrdiff_t> get_temporary_buffer(
   thrust::detail::execute_with_allocator_and_dependencies<Allocator, BaseSystem, Dependencies...>& system,
   std::ptrdiff_t n)
 {
@@ -114,6 +115,7 @@ _CCCL_HOST void return_temporary_buffer(
   pointer to_ptr = thrust::reinterpret_pointer_cast<pointer>(p);
   alloc_traits::deallocate(system.get_allocator(), to_ptr, num_elements);
 }
+_CCCL_SUPPRESS_DEPRECATED_POP
 
 } // namespace detail
 

--- a/thrust/thrust/detail/execute_with_allocator_fwd.h
+++ b/thrust/thrust/detail/execute_with_allocator_fwd.h
@@ -33,9 +33,9 @@ THRUST_NAMESPACE_BEGIN
 
 namespace detail
 {
-
-template <typename Allocator, template <typename> class BaseSystem>
-struct execute_with_allocator : BaseSystem<execute_with_allocator<Allocator, BaseSystem>>
+_CCCL_SUPPRESS_DEPRECATED_PUSH // because of execute_with_allocator_and_dependencies
+  template <typename Allocator, template <typename> class BaseSystem>
+  struct execute_with_allocator : BaseSystem<execute_with_allocator<Allocator, BaseSystem>>
 {
 private:
   using super_t = BaseSystem<execute_with_allocator<Allocator, BaseSystem>>;
@@ -59,46 +59,47 @@ public:
   }
 
   template <typename... Dependencies>
-  _CCCL_HOST execute_with_allocator_and_dependencies<Allocator, BaseSystem, Dependencies...>
+  CCCL_DEPRECATED _CCCL_HOST execute_with_allocator_and_dependencies<Allocator, BaseSystem, Dependencies...>
   after(Dependencies&&... dependencies) const
   {
     return {alloc, capture_as_dependency(THRUST_FWD(dependencies))...};
   }
 
   template <typename... Dependencies>
-  _CCCL_HOST execute_with_allocator_and_dependencies<Allocator, BaseSystem, Dependencies...>
+  CCCL_DEPRECATED _CCCL_HOST execute_with_allocator_and_dependencies<Allocator, BaseSystem, Dependencies...>
   after(std::tuple<Dependencies...>& dependencies) const
   {
     return {alloc, capture_as_dependency(dependencies)};
   }
   template <typename... Dependencies>
-  _CCCL_HOST execute_with_allocator_and_dependencies<Allocator, BaseSystem, Dependencies...>
+  CCCL_DEPRECATED _CCCL_HOST execute_with_allocator_and_dependencies<Allocator, BaseSystem, Dependencies...>
   after(std::tuple<Dependencies...>&& dependencies) const
   {
     return {alloc, capture_as_dependency(std::move(dependencies))};
   }
 
   template <typename... Dependencies>
-  _CCCL_HOST execute_with_allocator_and_dependencies<Allocator, BaseSystem, Dependencies...>
+  CCCL_DEPRECATED _CCCL_HOST execute_with_allocator_and_dependencies<Allocator, BaseSystem, Dependencies...>
   rebind_after(Dependencies&&... dependencies) const
   {
     return {alloc, capture_as_dependency(THRUST_FWD(dependencies))...};
   }
 
   template <typename... Dependencies>
-  _CCCL_HOST execute_with_allocator_and_dependencies<Allocator, BaseSystem, Dependencies...>
+  CCCL_DEPRECATED _CCCL_HOST execute_with_allocator_and_dependencies<Allocator, BaseSystem, Dependencies...>
   rebind_after(std::tuple<Dependencies...>& dependencies) const
   {
     return {alloc, capture_as_dependency(dependencies)};
   }
   template <typename... Dependencies>
-  _CCCL_HOST execute_with_allocator_and_dependencies<Allocator, BaseSystem, Dependencies...>
+  CCCL_DEPRECATED _CCCL_HOST execute_with_allocator_and_dependencies<Allocator, BaseSystem, Dependencies...>
   rebind_after(std::tuple<Dependencies...>&& dependencies) const
   {
     return {alloc, capture_as_dependency(std::move(dependencies))};
   }
 };
 
+_CCCL_SUPPRESS_DEPRECATED_POP
 } // namespace detail
 
 THRUST_NAMESPACE_END

--- a/thrust/thrust/detail/execute_with_dependencies.h
+++ b/thrust/thrust/detail/execute_with_dependencies.h
@@ -32,12 +32,13 @@
 #include <tuple>
 #include <type_traits>
 
+_CCCL_SUPPRESS_DEPRECATED_PUSH
 THRUST_NAMESPACE_BEGIN
 
 namespace detail
 {
 
-struct capture_as_dependency_fn
+struct CCCL_DEPRECATED capture_as_dependency_fn
 {
   template <typename Dependency>
   auto operator()(Dependency&& dependency) const THRUST_DECLTYPE_RETURNS(capture_as_dependency(THRUST_FWD(dependency)))
@@ -45,14 +46,15 @@ struct capture_as_dependency_fn
 
 // Default implementation: universal forwarding.
 template <typename Dependency>
-auto capture_as_dependency(Dependency&& dependency) THRUST_DECLTYPE_RETURNS(THRUST_FWD(dependency))
+CCCL_DEPRECATED auto capture_as_dependency(Dependency&& dependency) THRUST_DECLTYPE_RETURNS(THRUST_FWD(dependency))
 
-  template <typename... Dependencies>
-  auto capture_as_dependency(std::tuple<Dependencies...>& dependencies)
+  _CCCL_SUPPRESS_DEPRECATED_PUSH template <typename... Dependencies>
+  CCCL_DEPRECATED auto capture_as_dependency(std::tuple<Dependencies...>& dependencies)
     THRUST_DECLTYPE_RETURNS(tuple_for_each(THRUST_FWD(dependencies), capture_as_dependency_fn{}))
+      _CCCL_SUPPRESS_DEPRECATED_POP
 
-      template <template <typename> class BaseSystem, typename... Dependencies>
-      struct execute_with_dependencies : BaseSystem<execute_with_dependencies<BaseSystem, Dependencies...>>
+  template <template <typename> class BaseSystem, typename... Dependencies>
+  struct CCCL_DEPRECATED execute_with_dependencies : BaseSystem<execute_with_dependencies<BaseSystem, Dependencies...>>
 {
 private:
   using super_t = BaseSystem<execute_with_dependencies<BaseSystem, Dependencies...>>;
@@ -115,7 +117,7 @@ public:
 };
 
 template <typename Allocator, template <typename> class BaseSystem, typename... Dependencies>
-struct execute_with_allocator_and_dependencies
+struct CCCL_DEPRECATED execute_with_allocator_and_dependencies
     : BaseSystem<execute_with_allocator_and_dependencies<Allocator, BaseSystem, Dependencies...>>
 {
 private:
@@ -186,37 +188,38 @@ public:
 };
 
 template <template <typename> class BaseSystem, typename... Dependencies>
-_CCCL_HOST std::tuple<::cuda::std::remove_cvref_t<Dependencies>...>
+CCCL_DEPRECATED _CCCL_HOST std::tuple<::cuda::std::remove_cvref_t<Dependencies>...>
 extract_dependencies(thrust::detail::execute_with_dependencies<BaseSystem, Dependencies...>&& system)
 {
   return std::move(system).extract_dependencies();
 }
 template <template <typename> class BaseSystem, typename... Dependencies>
-_CCCL_HOST std::tuple<::cuda::std::remove_cvref_t<Dependencies>...>
+CCCL_DEPRECATED _CCCL_HOST std::tuple<::cuda::std::remove_cvref_t<Dependencies>...>
 extract_dependencies(thrust::detail::execute_with_dependencies<BaseSystem, Dependencies...>& system)
 {
   return std::move(system).extract_dependencies();
 }
 
 template <typename Allocator, template <typename> class BaseSystem, typename... Dependencies>
-_CCCL_HOST std::tuple<::cuda::std::remove_cvref_t<Dependencies>...> extract_dependencies(
+CCCL_DEPRECATED _CCCL_HOST std::tuple<::cuda::std::remove_cvref_t<Dependencies>...> extract_dependencies(
   thrust::detail::execute_with_allocator_and_dependencies<Allocator, BaseSystem, Dependencies...>&& system)
 {
   return std::move(system).extract_dependencies();
 }
 template <typename Allocator, template <typename> class BaseSystem, typename... Dependencies>
-_CCCL_HOST std::tuple<::cuda::std::remove_cvref_t<Dependencies>...> extract_dependencies(
+CCCL_DEPRECATED _CCCL_HOST std::tuple<::cuda::std::remove_cvref_t<Dependencies>...> extract_dependencies(
   thrust::detail::execute_with_allocator_and_dependencies<Allocator, BaseSystem, Dependencies...>& system)
 {
   return std::move(system).extract_dependencies();
 }
 
 template <typename System>
-_CCCL_HOST std::tuple<> extract_dependencies(System&&)
+CCCL_DEPRECATED _CCCL_HOST std::tuple<> extract_dependencies(System&&)
 {
   return std::tuple<>{};
 }
 
 } // namespace detail
 
+_CCCL_SUPPRESS_DEPRECATED_POP
 THRUST_NAMESPACE_END

--- a/thrust/thrust/future.h
+++ b/thrust/thrust/future.h
@@ -62,6 +62,7 @@
 #  include __THRUST_DEVICE_SYSTEM_FUTURE_HEADER
 #  undef __THRUST_DEVICE_SYSTEM_FUTURE_HEADER
 
+_CCCL_SUPPRESS_DEPRECATED_PUSH
 THRUST_NAMESPACE_BEGIN
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -76,16 +77,16 @@ THRUST_NAMESPACE_BEGIN
 namespace unimplemented
 {
 
-struct no_unique_eager_event_type_found
+struct CCCL_DEPRECATED no_unique_eager_event_type_found
 {};
 
-inline _CCCL_HOST no_unique_eager_event_type_found unique_eager_event_type(...) noexcept;
+CCCL_DEPRECATED _CCCL_HOST inline no_unique_eager_event_type_found unique_eager_event_type(...) noexcept;
 
-struct no_unique_eager_future_type_found
+struct CCCL_DEPRECATED no_unique_eager_future_type_found
 {};
 
 template <typename T>
-_CCCL_HOST no_unique_eager_future_type_found unique_eager_future_type(...) noexcept;
+CCCL_DEPRECATED _CCCL_HOST no_unique_eager_future_type_found unique_eager_future_type(...) noexcept;
 
 } // namespace unimplemented
 
@@ -95,7 +96,7 @@ namespace unique_eager_event_type_detail
 using unimplemented::unique_eager_event_type;
 
 template <typename System>
-using select = decltype(unique_eager_event_type(std::declval<System>()));
+using select CCCL_DEPRECATED = decltype(unique_eager_event_type(std::declval<System>()));
 
 } // namespace unique_eager_event_type_detail
 
@@ -105,25 +106,25 @@ namespace unique_eager_future_type_detail
 using unimplemented::unique_eager_future_type;
 
 template <typename System, typename T>
-using select = decltype(unique_eager_future_type<T>(std::declval<System>()));
+using select CCCL_DEPRECATED = decltype(unique_eager_future_type<T>(std::declval<System>()));
 
 } // namespace unique_eager_future_type_detail
 
 ///////////////////////////////////////////////////////////////////////////////
 
 template <typename System>
-using unique_eager_event = unique_eager_event_type_detail::select<System>;
+using unique_eager_event CCCL_DEPRECATED = unique_eager_event_type_detail::select<System>;
 
 template <typename System>
-using event = unique_eager_event<System>;
+using event CCCL_DEPRECATED = unique_eager_event<System>;
 
 ///////////////////////////////////////////////////////////////////////////////
 
 template <typename System, typename T>
-using unique_eager_future = unique_eager_future_type_detail::select<System, T>;
+using unique_eager_future CCCL_DEPRECATED = unique_eager_future_type_detail::select<System, T>;
 
 template <typename System, typename T>
-using future = unique_eager_future<System, T>;
+using future CCCL_DEPRECATED = unique_eager_future<System, T>;
 
 /*
 ///////////////////////////////////////////////////////////////////////////////
@@ -145,25 +146,29 @@ using host_future = host_unique_eager_future<T>;
 
 ///////////////////////////////////////////////////////////////////////////////
 
-using device_unique_eager_event =
+using device_unique_eager_event CCCL_DEPRECATED =
   unique_eager_event_type_detail::select<thrust::system::__THRUST_DEVICE_SYSTEM_NAMESPACE::tag>;
 
-using device_event = device_unique_eager_event;
+using device_event CCCL_DEPRECATED = device_unique_eager_event;
 
 ///////////////////////////////////////////////////////////////////////////////
 
 template <typename T>
-using device_unique_eager_future =
+using device_unique_eager_future CCCL_DEPRECATED =
   unique_eager_future_type_detail::select<thrust::system::__THRUST_DEVICE_SYSTEM_NAMESPACE::tag, T>;
 
 template <typename T>
-using device_future = device_unique_eager_future<T>;
+using device_future CCCL_DEPRECATED = device_unique_eager_future<T>;
 
 ///////////////////////////////////////////////////////////////////////////////
 
-struct new_stream_t final
+struct CCCL_DEPRECATED new_stream_t final
 {};
 
+#  ifndef CCCL_HEADER_MACRO_CHECK
+// when building header tests, we get a deprecation warning from cudafe1.stub.c if we deprecate a global variable
+CCCL_DEPRECATED
+#  endif
 _CCCL_GLOBAL_CONSTANT new_stream_t new_stream{};
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -172,6 +177,7 @@ using thrust::system::__THRUST_DEVICE_SYSTEM_NAMESPACE::when_all;
 
 ///////////////////////////////////////////////////////////////////////////////
 
+_CCCL_SUPPRESS_DEPRECATED_POP
 THRUST_NAMESPACE_END
 
 #endif

--- a/thrust/thrust/system/cuda/detail/async/copy.h
+++ b/thrust/thrust/system/cuda/detail/async/copy.h
@@ -61,6 +61,7 @@
 
 #    include <type_traits>
 
+_CCCL_SUPPRESS_DEPRECATED_PUSH
 THRUST_NAMESPACE_BEGIN
 
 namespace system
@@ -355,6 +356,7 @@ auto async_copy(thrust::cuda::execution_policy<FromPolicy>& from_exec,
 
 } // namespace cuda_cub
 
+_CCCL_SUPPRESS_DEPRECATED_POP
 THRUST_NAMESPACE_END
 
 #  endif // _CCCL_CUDA_COMPILER

--- a/thrust/thrust/system/cuda/detail/async/customization.h
+++ b/thrust/thrust/system/cuda/detail/async/customization.h
@@ -31,6 +31,8 @@
 
 #include <thrust/detail/config.h>
 
+#include "cuda/std/__cccl/diagnostic.h"
+
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
@@ -86,10 +88,10 @@ auto get_async_device_allocator(thrust::detail::execution_policy_base<DerivedPol
     auto get_async_device_allocator(thrust::detail::execute_with_allocator<Allocator, BaseSystem>& exec)
       THRUST_RETURNS(exec.get_allocator())
 
-        template <typename Allocator, template <typename> class BaseSystem>
-        auto get_async_device_allocator(
-          thrust::detail::execute_with_allocator_and_dependencies<Allocator, BaseSystem>& exec)
-          THRUST_RETURNS(exec.get_allocator())
+        _CCCL_SUPPRESS_DEPRECATED_PUSH template <typename Allocator, template <typename> class BaseSystem>
+        CCCL_DEPRECATED
+  auto get_async_device_allocator(thrust::detail::execute_with_allocator_and_dependencies<Allocator, BaseSystem>& exec)
+    THRUST_RETURNS(exec.get_allocator()) _CCCL_SUPPRESS_DEPRECATED_POP
 
   ///////////////////////////////////////////////////////////////////////////////
 

--- a/thrust/thrust/system/cuda/detail/async/exclusive_scan.h
+++ b/thrust/thrust/system/cuda/detail/async/exclusive_scan.h
@@ -56,6 +56,7 @@
 
 // TODO specialize for thrust::plus to use e.g. ExclusiveSum instead of ExcScan
 
+_CCCL_SUPPRESS_DEPRECATED_PUSH
 THRUST_NAMESPACE_BEGIN
 namespace system
 {
@@ -157,6 +158,7 @@ auto async_exclusive_scan(
 
 } // namespace cuda_cub
 
+_CCCL_SUPPRESS_DEPRECATED_POP
 THRUST_NAMESPACE_END
 
 #  endif // _CCCL_CUDA_COMPILER

--- a/thrust/thrust/system/cuda/detail/async/for_each.h
+++ b/thrust/thrust/system/cuda/detail/async/for_each.h
@@ -56,6 +56,7 @@
 
 #    include <type_traits>
 
+_CCCL_SUPPRESS_DEPRECATED_PUSH
 THRUST_NAMESPACE_BEGIN
 
 namespace system
@@ -127,6 +128,7 @@ auto async_for_each(execution_policy<DerivedPolicy>& policy, ForwardIt first, Se
 
 } // namespace cuda_cub
 
+_CCCL_SUPPRESS_DEPRECATED_POP
 THRUST_NAMESPACE_END
 
 #  endif // _CCCL_CUDA_COMPILER

--- a/thrust/thrust/system/cuda/detail/async/inclusive_scan.h
+++ b/thrust/thrust/system/cuda/detail/async/inclusive_scan.h
@@ -56,6 +56,7 @@
 
 // TODO specialize for thrust::plus to use e.g. InclusiveSum instead of IncScan
 
+_CCCL_SUPPRESS_DEPRECATED_PUSH
 THRUST_NAMESPACE_BEGIN
 namespace system
 {
@@ -244,6 +245,7 @@ auto async_inclusive_scan(
 
 } // namespace cuda_cub
 
+_CCCL_SUPPRESS_DEPRECATED_POP
 THRUST_NAMESPACE_END
 
 #  endif // _CCCL_CUDA_COMPILER

--- a/thrust/thrust/system/cuda/detail/async/reduce.h
+++ b/thrust/thrust/system/cuda/detail/async/reduce.h
@@ -58,6 +58,7 @@
 
 #    include <type_traits>
 
+_CCCL_SUPPRESS_DEPRECATED_PUSH
 THRUST_NAMESPACE_BEGIN
 
 namespace system
@@ -227,6 +228,7 @@ auto async_reduce_into(
 
 } // namespace cuda_cub
 
+_CCCL_SUPPRESS_DEPRECATED_POP
 THRUST_NAMESPACE_END
 
 #  endif // _CCCL_CUDA_COMPILER

--- a/thrust/thrust/system/cuda/detail/async/sort.h
+++ b/thrust/thrust/system/cuda/detail/async/sort.h
@@ -61,6 +61,7 @@
 
 #    include <type_traits>
 
+_CCCL_SUPPRESS_DEPRECATED_PUSH
 THRUST_NAMESPACE_BEGIN
 
 namespace system
@@ -319,6 +320,7 @@ auto async_stable_sort(execution_policy<DerivedPolicy>& policy, ForwardIt first,
 
 } // namespace cuda_cub
 
+_CCCL_SUPPRESS_DEPRECATED_POP
 THRUST_NAMESPACE_END
 
 #  endif // _CCCL_CUDA_COMPILER

--- a/thrust/thrust/system/cuda/detail/async/transform.h
+++ b/thrust/thrust/system/cuda/detail/async/transform.h
@@ -57,6 +57,7 @@
 
 #    include <type_traits>
 
+_CCCL_SUPPRESS_DEPRECATED_PUSH
 THRUST_NAMESPACE_BEGIN
 
 namespace system
@@ -132,6 +133,7 @@ auto async_transform(
 
 } // namespace cuda_cub
 
+_CCCL_SUPPRESS_DEPRECATED_POP
 THRUST_NAMESPACE_END
 
 #  endif // _CCCL_CUDA_COMPILER

--- a/thrust/thrust/system/cuda/detail/execution_policy.h
+++ b/thrust/thrust/system/cuda/detail/execution_policy.h
@@ -61,11 +61,13 @@ struct execution_policy<tag> : thrust::execution_policy<tag>
   using tag_type = tag;
 };
 
+_CCCL_SUPPRESS_DEPRECATED_PUSH
 struct tag
     : execution_policy<tag>
     , thrust::detail::allocator_aware_execution_policy<cuda_cub::execution_policy>
     , thrust::detail::dependencies_aware_execution_policy<cuda_cub::execution_policy>
 {};
+_CCCL_SUPPRESS_DEPRECATED_POP
 
 template <class Derived>
 struct execution_policy : thrust::execution_policy<Derived>

--- a/thrust/thrust/system/cuda/detail/future.inl
+++ b/thrust/thrust/system/cuda/detail/future.inl
@@ -41,10 +41,11 @@
 
 #  include <type_traits>
 
+_CCCL_SUPPRESS_DEPRECATED_PUSH
 THRUST_NAMESPACE_BEGIN
 
 // Forward declaration.
-struct new_stream_t;
+struct CCCL_DEPRECATED new_stream_t;
 
 namespace system
 {
@@ -326,17 +327,17 @@ template <typename X, typename Y, typename Deleter>
 _CCCL_HOST optional<unique_stream> try_acquire_stream(int device, std::unique_ptr<Y, Deleter>&) noexcept;
 
 // Precondition: `device` is the current CUDA device.
-inline _CCCL_HOST optional<unique_stream> try_acquire_stream(int, unique_stream& stream) noexcept;
+_CCCL_HOST inline optional<unique_stream> try_acquire_stream(int, unique_stream& stream) noexcept;
 
 // Precondition: `device` is the current CUDA device.
-inline _CCCL_HOST optional<unique_stream> try_acquire_stream(int device, ready_event&) noexcept;
+_CCCL_HOST inline optional<unique_stream> try_acquire_stream(int device, ready_event&) noexcept;
 
 // Precondition: `device` is the current CUDA device.
 template <typename X>
-inline _CCCL_HOST optional<unique_stream> try_acquire_stream(int device, ready_future<X>&) noexcept;
+_CCCL_HOST inline optional<unique_stream> try_acquire_stream(int device, ready_future<X>&) noexcept;
 
 // Precondition: `device` is the current CUDA device.
-inline _CCCL_HOST optional<unique_stream> try_acquire_stream(int device, unique_eager_event& parent) noexcept;
+_CCCL_HOST inline optional<unique_stream> try_acquire_stream(int device, unique_eager_event& parent) noexcept;
 
 // Precondition: `device` is the current CUDA device.
 template <typename X>
@@ -578,7 +579,7 @@ public:
 
 } // namespace detail
 
-struct ready_event final
+struct CCCL_DEPRECATED ready_event final
 {
   ready_event() = default;
 
@@ -598,7 +599,7 @@ struct ready_event final
 };
 
 template <typename T>
-struct ready_future final
+struct CCCL_DEPRECATED ready_future final
 {
   using value_type        = T;
   using raw_const_pointer = T const*;
@@ -650,7 +651,7 @@ public:
 #  endif
 };
 
-struct unique_eager_event final
+struct CCCL_DEPRECATED unique_eager_event final
 {
 protected:
   int device_ = 0;
@@ -759,7 +760,7 @@ public:
 };
 
 template <typename T>
-struct unique_eager_future final
+struct CCCL_DEPRECATED unique_eager_future final
 {
   THRUST_STATIC_ASSERT_MSG((!std::is_same<T, ::cuda::std::remove_cvref_t<void>>::value),
                            "`thrust::event` should be used to express valueless futures");
@@ -934,12 +935,12 @@ _CCCL_SUPPRESS_DEPRECATED_PUSH // for thrust::optional
   return {};
 }
 
-inline _CCCL_HOST optional<unique_stream> try_acquire_stream(int, unique_stream& stream) noexcept
+_CCCL_HOST inline optional<unique_stream> try_acquire_stream(int, unique_stream& stream) noexcept
 {
   return {std::move(stream)};
 }
 
-inline _CCCL_HOST optional<unique_stream> try_acquire_stream(int, ready_event&) noexcept
+_CCCL_HOST inline optional<unique_stream> try_acquire_stream(int, ready_event&) noexcept
 {
   // There's no stream to acquire!
   return {};
@@ -1025,18 +1026,18 @@ template <typename X, typename Deleter>
 _CCCL_HOST void create_dependency(unique_stream&, std::unique_ptr<X, Deleter>&) noexcept
 {}
 
-inline _CCCL_HOST void create_dependency(unique_stream&, ready_event&) noexcept {}
+_CCCL_HOST inline void create_dependency(unique_stream&, ready_event&) noexcept {}
 
 template <typename T>
 _CCCL_HOST void create_dependency(unique_stream&, ready_future<T>&) noexcept
 {}
 
-inline _CCCL_HOST void create_dependency(unique_stream& child, unique_stream& parent)
+_CCCL_HOST inline void create_dependency(unique_stream& child, unique_stream& parent)
 {
   child.depend_on(parent);
 }
 
-inline _CCCL_HOST void create_dependency(unique_stream& child, unique_eager_event& parent)
+_CCCL_HOST inline void create_dependency(unique_stream& child, unique_eager_event& parent)
 {
   child.depend_on(parent.stream());
 }
@@ -1209,7 +1210,7 @@ make_dependent_future(ComputeContent&& cc, std::tuple<Dependencies...>&& deps)
 ///////////////////////////////////////////////////////////////////////////////
 
 template <typename... Events>
-_CCCL_HOST unique_eager_event when_all(Events&&... evs)
+CCCL_DEPRECATED _CCCL_HOST unique_eager_event when_all(Events&&... evs)
 // TODO: Constrain to events, futures, and maybe streams (currently allows keep
 // alives).
 {
@@ -1217,17 +1218,18 @@ _CCCL_HOST unique_eager_event when_all(Events&&... evs)
 }
 
 // ADL hook for transparent `.after` move support.
-inline _CCCL_HOST auto capture_as_dependency(unique_eager_event& dependency)
+CCCL_DEPRECATED _CCCL_HOST inline auto capture_as_dependency(unique_eager_event& dependency)
   THRUST_DECLTYPE_RETURNS(std::move(dependency))
 
   // ADL hook for transparent `.after` move support.
   template <typename X>
-  _CCCL_HOST auto capture_as_dependency(unique_eager_future<X>& dependency)
+  CCCL_DEPRECATED _CCCL_HOST auto capture_as_dependency(unique_eager_future<X>& dependency)
     THRUST_DECLTYPE_RETURNS(std::move(dependency))
 
 } // namespace cuda
 } // namespace system
 
+_CCCL_SUPPRESS_DEPRECATED_POP
 THRUST_NAMESPACE_END
 
 #endif // C++14

--- a/thrust/thrust/system/cuda/detail/par.h
+++ b/thrust/thrust/system/cuda/detail/par.h
@@ -120,6 +120,7 @@ struct execute_on_stream_nosync : execute_on_stream_nosync_base<execute_on_strea
       : base_t(stream) {};
 };
 
+_CCCL_SUPPRESS_DEPRECATED_PUSH
 struct par_t
     : execution_policy<par_t>
     , thrust::detail::allocator_aware_execution_policy<execute_on_stream_base>
@@ -138,7 +139,9 @@ struct par_t
     return execute_on_stream(stream);
   }
 };
+_CCCL_SUPPRESS_DEPRECATED_POP
 
+_CCCL_SUPPRESS_DEPRECATED_PUSH
 struct par_nosync_t
     : execution_policy<par_nosync_t>
     , thrust::detail::allocator_aware_execution_policy<execute_on_stream_nosync_base>
@@ -165,6 +168,7 @@ private:
     return false;
   }
 };
+_CCCL_SUPPRESS_DEPRECATED_POP
 
 _CCCL_GLOBAL_CONSTANT par_t par;
 

--- a/thrust/thrust/system/cuda/future.h
+++ b/thrust/thrust/system/cuda/future.h
@@ -62,6 +62,7 @@ using thrust::system::cuda::when_all;
 
 } // namespace cuda
 
+_CCCL_SUPPRESS_DEPRECATED_PUSH
 template <typename DerivedPolicy>
 _CCCL_HOST thrust::cuda::unique_eager_event
 unique_eager_event_type(thrust::cuda::execution_policy<DerivedPolicy> const&) noexcept;
@@ -69,6 +70,7 @@ unique_eager_event_type(thrust::cuda::execution_policy<DerivedPolicy> const&) no
 template <typename T, typename DerivedPolicy>
 _CCCL_HOST thrust::cuda::unique_eager_future<T>
 unique_eager_future_type(thrust::cuda::execution_policy<DerivedPolicy> const&) noexcept;
+_CCCL_SUPPRESS_DEPRECATED_POP
 
 THRUST_NAMESPACE_END
 


### PR DESCRIPTION
Deprecate:
* detail::dependencies_aware_execution_policy
* detail::execute_with_allocator_and_dependencies
* detail::execute_with_dependencies
* [device_]unique_eager_event
* [device_]event
* [device_]unique_eager_future
* [device_]future
* new_stream[_t]
* when_all

And many utility entities around those