### PR TITLE
Backport to 2.8: Update upload-pages-artifact to v3 (#3423)

### DIFF
--- a/.github/actions/docs-build/action.yml
+++ b/.github/actions/docs-build/action.yml
@@ -54,4 +54,4 @@ runs:
     # Upload docs as pages artifacts
     - name: Upload artifact
       if: ${{ inputs.upload_pages_artifact == 'true' }}
-      uses: actions/upload-pages-artifact@v2
+      uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
This fix is needed to keep the CI running on the 2.8 branch.