### PR TITLE
Fix the vectorized loading of BlockLoad

### DIFF
--- a/cub/cub/block/block_load.cuh
+++ b/cub/cub/block/block_load.cuh
@@ -207,12 +207,12 @@ InternalLoadDirectBlockedVectorized(int linear_tid, const T* block_src_ptr, T (&
   constexpr int vector_size        = (total_words % 4 == 0) ? 4 : (total_words % 2 == 0) ? 2 : 1;
   constexpr int vectors_per_thread = total_words / vector_size;
 
-  // Add the alignment check to ensure the vectorized loading can proceed.
-  if (reinterpret_cast<uintptr_t>(block_src_ptr) % (vector_size << 2) == 0)
-  {
-    // Load into an array of vectors in thread-blocked order
-    using vector_t = typename CubVector<device_word_t, vector_size>::Type;
+  // Load into an array of vectors in thread-blocked order
+  using vector_t = typename CubVector<device_word_t, vector_size>::Type;
 
+  // Add the alignment check to ensure the vectorized loading can proceed.
+  if (reinterpret_cast<uintptr_t>(block_src_ptr) % (sizeof(vector_t)) == 0)
+  {
     vector_t vec_items[vectors_per_thread];
     // Load into an array of vectors in thread-blocked order
     const vector_t* vec_ptr = reinterpret_cast<const vector_t*>(block_src_ptr) + linear_tid * vectors_per_thread;

--- a/cub/cub/block/block_load.cuh
+++ b/cub/cub/block/block_load.cuh
@@ -211,7 +211,7 @@ InternalLoadDirectBlockedVectorized(int linear_tid, const T* block_src_ptr, T (&
   using vector_t = typename CubVector<device_word_t, vector_size>::Type;
 
   // Add the alignment check to ensure the vectorized loading can proceed.
-  if (reinterpret_cast<uintptr_t>(block_src_ptr) % (sizeof(vector_t)) == 0)
+  if (reinterpret_cast<uintptr_t>(block_src_ptr) % (alignof(vector_t)) == 0)
   {
     vector_t vec_items[vectors_per_thread];
     // Load into an array of vectors in thread-blocked order

--- a/cub/cub/block/block_load.cuh
+++ b/cub/cub/block/block_load.cuh
@@ -206,22 +206,33 @@ InternalLoadDirectBlockedVectorized(int linear_tid, const T* block_src_ptr, T (&
   _CCCL_DIAG_POP
   constexpr int vector_size        = (total_words % 4 == 0) ? 4 : (total_words % 2 == 0) ? 2 : 1;
   constexpr int vectors_per_thread = total_words / vector_size;
-  using vector_t                   = typename CubVector<device_word_t, vector_size>::Type;
 
-  // Load into an array of vectors in thread-blocked order
-  vector_t vec_items[vectors_per_thread];
-  const vector_t* vec_ptr = reinterpret_cast<const vector_t*>(block_src_ptr) + linear_tid * vectors_per_thread;
-#  pragma unroll
-  for (int i = 0; i < vectors_per_thread; i++)
+  // Add the alignment check to ensure the vectorized loading can proceed.
+  if (reinterpret_cast<uintptr_t>(block_src_ptr) % (vector_size << 2) == 0)
   {
-    vec_items[i] = ThreadLoad<MODIFIER>(vec_ptr + i);
-  }
+    // Load into an array of vectors in thread-blocked order
+    using vector_t = typename CubVector<device_word_t, vector_size>::Type;
+
+    vector_t vec_items[vectors_per_thread];
+    // Load into an array of vectors in thread-blocked order
+    const vector_t* vec_ptr = reinterpret_cast<const vector_t*>(block_src_ptr) + linear_tid * vectors_per_thread;
+
+#  pragma unroll
+    for (int i = 0; i < vectors_per_thread; i++)
+    {
+      vec_items[i] = ThreadLoad<MODIFIER>(vec_ptr + i);
+    }
 
 // Copy to destination
 #  pragma unroll
-  for (int i = 0; i < ITEMS_PER_THREAD; i++)
+    for (int i = 0; i < ITEMS_PER_THREAD; i++)
+    {
+      dst_items[i] = *(reinterpret_cast<T*>(vec_items) + i);
+    }
+  }
+  else
   {
-    dst_items[i] = *(reinterpret_cast<T*>(vec_items) + i);
+    LoadDirectBlocked(linear_tid, block_src_ptr, dst_items);
   }
 }
 
@@ -876,8 +887,12 @@ class BlockLoad
     {}
 
     // attempts vectorization (pointer)
-    template <typename>
     _CCCL_DEVICE _CCCL_FORCEINLINE void Load(const T* block_ptr, T (&dst_items)[ITEMS_PER_THREAD])
+    {
+      InternalLoadDirectBlockedVectorized<LOAD_DEFAULT>(linear_tid, block_ptr, dst_items);
+    }
+
+    _CCCL_DEVICE _CCCL_FORCEINLINE void Load(T* block_ptr, T (&dst_items)[ITEMS_PER_THREAD])
     {
       InternalLoadDirectBlockedVectorized<LOAD_DEFAULT>(linear_tid, block_ptr, dst_items);
     }
@@ -886,18 +901,7 @@ class BlockLoad
     template <typename RandomAccessIterator>
     _CCCL_DEVICE _CCCL_FORCEINLINE void Load(RandomAccessIterator block_src_it, T (&dst_items)[ITEMS_PER_THREAD])
     {
-      constexpr bool is_pointer_to_type =
-        ::cuda::std::is_pointer_v<RandomAccessIterator>
-        && ::cuda::std::is_same_v<std::remove_cv_t<::cuda::std::remove_pointer_t<RandomAccessIterator>>, T>;
-
-      if (is_pointer_to_type)
-      {
-        InternalLoadDirectBlockedVectorized<LOAD_DEFAULT>(linear_tid, block_src_it, dst_items);
-      }
-      else
-      {
-        LoadDirectBlocked(linear_tid, block_src_it, dst_items);
-      }
+      LoadDirectBlocked(linear_tid, block_src_it, dst_items);
     }
 
     // attempts vectorization (cache modified iterator)

--- a/cub/cub/block/block_load.cuh
+++ b/cub/cub/block/block_load.cuh
@@ -891,7 +891,11 @@ class BlockLoad
     {
       InternalLoadDirectBlockedVectorized<LOAD_DEFAULT>(linear_tid, block_ptr, dst_items);
     }
-
+    // NOTE: This function is necessary for pointers to non-const types.
+    // The core reason is that the compiler will not deduce 'T*' to 'const T*' automatically.
+    // Otherwise, when the pointer type is 'T*', the compiler will prefer the overloaded version
+    // Load(RandomAccessIterator...) over Load(const T*...), which means it will never perform vectorized loading for
+    // pointers to non-const types.
     _CCCL_DEVICE _CCCL_FORCEINLINE void Load(T* block_ptr, T (&dst_items)[ITEMS_PER_THREAD])
     {
       InternalLoadDirectBlockedVectorized<LOAD_DEFAULT>(linear_tid, block_ptr, dst_items);

--- a/cub/cub/block/block_load.cuh
+++ b/cub/cub/block/block_load.cuh
@@ -886,7 +886,18 @@ class BlockLoad
     template <typename RandomAccessIterator>
     _CCCL_DEVICE _CCCL_FORCEINLINE void Load(RandomAccessIterator block_src_it, T (&dst_items)[ITEMS_PER_THREAD])
     {
-      LoadDirectBlocked(linear_tid, block_src_it, dst_items);
+      constexpr bool is_pointer_to_type =
+        ::cuda::std::is_pointer_v<RandomAccessIterator>
+        && ::cuda::std::is_same_v<std::remove_cv_t<::cuda::std::remove_pointer_t<RandomAccessIterator>>, T>;
+
+      if (is_pointer_to_type)
+      {
+        InternalLoadDirectBlockedVectorized<LOAD_DEFAULT>(linear_tid, block_src_it, dst_items);
+      }
+      else
+      {
+        LoadDirectBlocked(linear_tid, block_src_it, dst_items);
+      }
     }
 
     // attempts vectorization (cache modified iterator)

--- a/cub/test/catch2_test_block_load.cu
+++ b/cub/test/catch2_test_block_load.cu
@@ -135,9 +135,6 @@ using odd_load_algorithm =
                       cub::BlockLoadAlgorithm::BLOCK_LOAD_VECTORIZE,
                       cub::BlockLoadAlgorithm::BLOCK_LOAD_TRANSPOSE>;
 
-#if IPT == 1
-using is_const_or_not = c2h::enum_type_list<bool, true, false>;
-#endif
 template <class TestType>
 struct params_t
 {
@@ -225,11 +222,10 @@ C2H_TEST("Block load works with caching iterators", "[load][block]", items_per_t
 #if IPT == 1
 C2H_TEST("Vectorized block load with const and non-const datatype and different alignment cases",
          "[load][block]",
-         is_const_or_not)
+         c2h::type_list<const int*, int*>)
 {
-  constexpr bool is_const_input_ptr = c2h::get<0, TestType>::value;
-  using type                        = int;
-  using input_ptr_type              = std::conditional_t<is_const_input_ptr, const int*, int*>;
+  using type           = int;
+  using input_ptr_type = c2h::get<0, TestType>;
 
   const int offset_for_elements                           = GENERATE_COPY(0, 1, 2, 3, 4);
   constexpr int items_per_thread                          = 4;


### PR DESCRIPTION
## Description

Partially addresses https://github.com/NVIDIA/cccl/issues/431
What is remaining from https://github.com/NVIDIA/cccl/issues/431 after this PR is applying the same logic to `WARP_LOAD_VECTORIZE`.

Hi @elstehle elias and @bernhardmgruber, 

### Background:
We (Elias and I) are working on adding a parallel top-k algorithm into CUB. In this work, we are trying to load data using `Blockloading (BLOCK_LOAD_VECTORIZE)`. However, we found that the data loading used the instruction LDG instead of LDG128.   This PR is intended to fix this issue. 


### Description
To show this bug, I wrote a standalone [unit test code in this repo](https://github.com/ChristinaZ/unitTestVectorizedLoading/tree/main).  

1. To run this unit test, you first need to modify the cccl directory `CCCL_DIR` in Makefile. Then run `make` to compile.

2.  Then we can get related PTX instructions with `cuobjdump --dump-ptx ./benchmark | grep ld`
```
christinaz@****:/****/unitTestVectorizedLoading$ cuobjdump --dump-ptx ./benchmark | grep ld.global
ld.global.f32 %f1, [%rd8];
ld.global.f32 %f2, [%rd8+4];
ld.global.f32 %f3, [%rd8+8];
ld.global.f32 %f4, [%rd8+12];
```
We can find that it failed to perform vectorized loading. In this repo, we use the template parameter `InputIterator` for the input. Its value is actually `float*`. So it should be able to perform vectorized loading. 

3. We provide this fix, which checks the data type manually with the following code:
```
    template <typename RandomAccessIterator>
    _CCCL_DEVICE _CCCL_FORCEINLINE void Load(RandomAccessIterator block_src_it, T (&dst_items)[ITEMS_PER_THREAD])
    {
      constexpr bool is_pointer_to_type =
        ::cuda::std::is_pointer_v<RandomAccessIterator>
        && ::cuda::std::is_same_v<std::remove_cv_t<::cuda::std::remove_pointer_t<RandomAccessIterator>>, T>;

      if (is_pointer_to_type)
      {
        InternalLoadDirectBlockedVectorized<LOAD_DEFAULT>(linear_tid, block_src_it, dst_items);
      }
      else
      {
        LoadDirectBlocked(linear_tid, block_src_it, dst_items);
      }
    }
```

4. After this modification, rerun the command `cuobjdump --dump-ptx ./benchmark | grep ld`, we can get the following result:
```
christinaz@***:/****/unitTestVectorizedLoading$ cuobjdump --dump-ptx ./benchmark | grep ld.global
ld.global.v4.f32 {%f1, %f2, %f3, %f4}, [%rd7];
```

We can see that after the modification, we can use the vectorized loading successfully.


## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.

## Related issue
https://github.com/NVIDIA/cccl/issues/431 