### PR TITLE
cuda.parallel: invoke pytest directly rather than via `python -m pytest`

### DIFF
--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -25,7 +25,7 @@ for module in cuda_parallel cuda_cooperative; do
   begin_group "⚙️ ${module} site-packages"
   pip freeze
   end_group "⚙️ ${module} site-packages"
-  run_command "🚀  Pytest ${module}" python -m pytest -v ./tests
+  run_command "🚀  Pytest ${module}" pytest -v ./tests
   deactivate
 
   popd >/dev/null


### PR DESCRIPTION
## Description

### The problem

Recent `cuda.parallel` tests on CI have been failing:

- [Example 1](https://github.com/NVIDIA/cccl/actions/runs/12948642312/job/36117745144?pr=3521)
- [Example 2](https://github.com/NVIDIA/cccl/actions/runs/12947692645/job/36114833885?pr=3519)

<details>
<summary> Click to see what the failure looks like </summary>

```python
_________________________________ ERROR collecting tests/test_reduce.py _________________________________
ImportError while importing test module '/home/coder/cccl/python/cuda_parallel/tests/test_reduce.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/lib/python3.10/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/test_reduce.py:13: in <module>
    import cuda.parallel.experimental.algorithms as algorithms
cuda/parallel/experimental/algorithms/__init__.py:6: in <module>
    from .reduce import reduce_into as reduce_into
cuda/parallel/experimental/algorithms/reduce.py:17: in <module>
    from .._bindings import get_bindings, get_paths
cuda/parallel/experimental/_bindings.py:10: in <module>
    from cuda.cccl import get_include_paths  # type: ignore[import-not-found]
E   ModuleNotFoundError: No module named 'cuda.cccl'
```
</details>

### Why is this happening?

In [`test_python.sh`](https://github.com/NVIDIA/cccl/blob/d119489ffe2bca061ab3dab45b15fc7d85617f2b/ci/test_python.sh#L28), we invoke `pytest` as follows:

```
run_command "🚀  Pytest ${module}" python -m pytest -v ./tests
```

Note that the working directory for the invocation above is [`cuda_parallel`](https://github.com/NVIDIA/cccl/tree/main/python/cuda_parallel) directory, which contains a subdirectory named `cuda`. 

According to the [`pytest` docs](https://docs.pytest.org/en/7.1.x/explanation/pythonpath.html#invoking-pytest-versus-python-m-pytest), invoking `pytest` in this way adds the working directory (`cuda_parallel`) to the `sys.path`. This means that imports of subpackages like `cuda.cccl` will be attempted from the `cuda_parallel` directory, rather than the site-packages (which is where `cuda.cccl` lives). This is the problem - `cuda_parallel/cuda` doesn't contain the `cccl` subpackage.

### How to fix it?

There are a few possible solutions here:

1. Invoke `pytest` directly rather than via `python -m pytest`. This explicitly does not add the current working directory to the Python search path. 
2. Invoke `pytest` (in whatever way) from a directory other than `cuda_parallel` - e.g., `cd .. && python -m pytest cuda_parallel/tests`. This way imports of `cuda.cccl` will still be resolved from the site-packages directory.
3. Reorganize to [src layout rather than flat layout.](https://packaging.python.org/en/latest/discussions/src-layout-vs-flat-layout/#src-layout-vs-flat-layout). This way the `cuda_parallel` directory will not contain a `cuda` subdirectory.

I felt (1) was the simplest solution. I believe that `cuda.core` also needed to recently make a similar change.

FYI: @rwgk @leofang 

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
