### PR TITLE
Fix devcontainers' `initializeCommand`

### DIFF
--- a/.devcontainer/cuda12.0-gcc10/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc10/devcontainer.json
@@ -33,12 +33,12 @@
     "vscode": {
       "extensions": [
         "llvm-vs-code-extensions.vscode-clangd",
-        "xaver.clang-format",
+        "seaube.clangformat",
         "nvidia.nsight-vscode-edition",
         "ms-vscode.cmake-tools"
       ],
       "settings": {
-        "editor.defaultFormatter": "xaver.clang-format",
+        "editor.defaultFormatter": "seaube.clangformat",
         "editor.formatOnSave": true,
         "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [

--- a/.devcontainer/cuda12.0-gcc10/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc10/devcontainer.json
@@ -7,8 +7,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build;",
-    "if [[ -n ${WSLENV+set} ]]; then docker volume create cccl-build; else docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; else docker volume create cccl-build; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",

--- a/.devcontainer/cuda12.0-gcc11/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc11/devcontainer.json
@@ -33,12 +33,12 @@
     "vscode": {
       "extensions": [
         "llvm-vs-code-extensions.vscode-clangd",
-        "xaver.clang-format",
+        "seaube.clangformat",
         "nvidia.nsight-vscode-edition",
         "ms-vscode.cmake-tools"
       ],
       "settings": {
-        "editor.defaultFormatter": "xaver.clang-format",
+        "editor.defaultFormatter": "seaube.clangformat",
         "editor.formatOnSave": true,
         "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [

--- a/.devcontainer/cuda12.0-gcc11/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc11/devcontainer.json
@@ -7,8 +7,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build;",
-    "if [[ -n ${WSLENV+set} ]]; then docker volume create cccl-build; else docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; else docker volume create cccl-build; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",

--- a/.devcontainer/cuda12.0-gcc12/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc12/devcontainer.json
@@ -33,12 +33,12 @@
     "vscode": {
       "extensions": [
         "llvm-vs-code-extensions.vscode-clangd",
-        "xaver.clang-format",
+        "seaube.clangformat",
         "nvidia.nsight-vscode-edition",
         "ms-vscode.cmake-tools"
       ],
       "settings": {
-        "editor.defaultFormatter": "xaver.clang-format",
+        "editor.defaultFormatter": "seaube.clangformat",
         "editor.formatOnSave": true,
         "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [

--- a/.devcontainer/cuda12.0-gcc12/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc12/devcontainer.json
@@ -7,8 +7,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build;",
-    "if [[ -n ${WSLENV+set} ]]; then docker volume create cccl-build; else docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; else docker volume create cccl-build; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",

--- a/.devcontainer/cuda12.0-gcc7/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc7/devcontainer.json
@@ -33,12 +33,12 @@
     "vscode": {
       "extensions": [
         "llvm-vs-code-extensions.vscode-clangd",
-        "xaver.clang-format",
+        "seaube.clangformat",
         "nvidia.nsight-vscode-edition",
         "ms-vscode.cmake-tools"
       ],
       "settings": {
-        "editor.defaultFormatter": "xaver.clang-format",
+        "editor.defaultFormatter": "seaube.clangformat",
         "editor.formatOnSave": true,
         "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [

--- a/.devcontainer/cuda12.0-gcc7/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc7/devcontainer.json
@@ -7,8 +7,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build;",
-    "if [[ -n ${WSLENV+set} ]]; then docker volume create cccl-build; else docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; else docker volume create cccl-build; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",

--- a/.devcontainer/cuda12.0-gcc8/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc8/devcontainer.json
@@ -33,12 +33,12 @@
     "vscode": {
       "extensions": [
         "llvm-vs-code-extensions.vscode-clangd",
-        "xaver.clang-format",
+        "seaube.clangformat",
         "nvidia.nsight-vscode-edition",
         "ms-vscode.cmake-tools"
       ],
       "settings": {
-        "editor.defaultFormatter": "xaver.clang-format",
+        "editor.defaultFormatter": "seaube.clangformat",
         "editor.formatOnSave": true,
         "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [

--- a/.devcontainer/cuda12.0-gcc8/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc8/devcontainer.json
@@ -7,8 +7,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build;",
-    "if [[ -n ${WSLENV+set} ]]; then docker volume create cccl-build; else docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; else docker volume create cccl-build; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",

--- a/.devcontainer/cuda12.0-gcc9/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc9/devcontainer.json
@@ -33,12 +33,12 @@
     "vscode": {
       "extensions": [
         "llvm-vs-code-extensions.vscode-clangd",
-        "xaver.clang-format",
+        "seaube.clangformat",
         "nvidia.nsight-vscode-edition",
         "ms-vscode.cmake-tools"
       ],
       "settings": {
-        "editor.defaultFormatter": "xaver.clang-format",
+        "editor.defaultFormatter": "seaube.clangformat",
         "editor.formatOnSave": true,
         "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [

--- a/.devcontainer/cuda12.0-gcc9/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc9/devcontainer.json
@@ -7,8 +7,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build;",
-    "if [[ -n ${WSLENV+set} ]]; then docker volume create cccl-build; else docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; else docker volume create cccl-build; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",

--- a/.devcontainer/cuda12.0-llvm14/devcontainer.json
+++ b/.devcontainer/cuda12.0-llvm14/devcontainer.json
@@ -33,12 +33,12 @@
     "vscode": {
       "extensions": [
         "llvm-vs-code-extensions.vscode-clangd",
-        "xaver.clang-format",
+        "seaube.clangformat",
         "nvidia.nsight-vscode-edition",
         "ms-vscode.cmake-tools"
       ],
       "settings": {
-        "editor.defaultFormatter": "xaver.clang-format",
+        "editor.defaultFormatter": "seaube.clangformat",
         "editor.formatOnSave": true,
         "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [

--- a/.devcontainer/cuda12.0-llvm14/devcontainer.json
+++ b/.devcontainer/cuda12.0-llvm14/devcontainer.json
@@ -7,8 +7,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build;",
-    "if [[ -n ${WSLENV+set} ]]; then docker volume create cccl-build; else docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; else docker volume create cccl-build; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",

--- a/.devcontainer/cuda12.5-nvhpc24.7/devcontainer.json
+++ b/.devcontainer/cuda12.5-nvhpc24.7/devcontainer.json
@@ -33,12 +33,12 @@
     "vscode": {
       "extensions": [
         "llvm-vs-code-extensions.vscode-clangd",
-        "xaver.clang-format",
+        "seaube.clangformat",
         "nvidia.nsight-vscode-edition",
         "ms-vscode.cmake-tools"
       ],
       "settings": {
-        "editor.defaultFormatter": "xaver.clang-format",
+        "editor.defaultFormatter": "seaube.clangformat",
         "editor.formatOnSave": true,
         "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [

--- a/.devcontainer/cuda12.5-nvhpc24.7/devcontainer.json
+++ b/.devcontainer/cuda12.5-nvhpc24.7/devcontainer.json
@@ -7,8 +7,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build;",
-    "if [[ -n ${WSLENV+set} ]]; then docker volume create cccl-build; else docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; else docker volume create cccl-build; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",

--- a/.devcontainer/cuda12.8-gcc10/devcontainer.json
+++ b/.devcontainer/cuda12.8-gcc10/devcontainer.json
@@ -33,12 +33,12 @@
     "vscode": {
       "extensions": [
         "llvm-vs-code-extensions.vscode-clangd",
-        "xaver.clang-format",
+        "seaube.clangformat",
         "nvidia.nsight-vscode-edition",
         "ms-vscode.cmake-tools"
       ],
       "settings": {
-        "editor.defaultFormatter": "xaver.clang-format",
+        "editor.defaultFormatter": "seaube.clangformat",
         "editor.formatOnSave": true,
         "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [

--- a/.devcontainer/cuda12.8-gcc10/devcontainer.json
+++ b/.devcontainer/cuda12.8-gcc10/devcontainer.json
@@ -7,8 +7,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build;",
-    "if [[ -n ${WSLENV+set} ]]; then docker volume create cccl-build; else docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; else docker volume create cccl-build; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",

--- a/.devcontainer/cuda12.8-gcc11/devcontainer.json
+++ b/.devcontainer/cuda12.8-gcc11/devcontainer.json
@@ -33,12 +33,12 @@
     "vscode": {
       "extensions": [
         "llvm-vs-code-extensions.vscode-clangd",
-        "xaver.clang-format",
+        "seaube.clangformat",
         "nvidia.nsight-vscode-edition",
         "ms-vscode.cmake-tools"
       ],
       "settings": {
-        "editor.defaultFormatter": "xaver.clang-format",
+        "editor.defaultFormatter": "seaube.clangformat",
         "editor.formatOnSave": true,
         "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [

--- a/.devcontainer/cuda12.8-gcc11/devcontainer.json
+++ b/.devcontainer/cuda12.8-gcc11/devcontainer.json
@@ -7,8 +7,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build;",
-    "if [[ -n ${WSLENV+set} ]]; then docker volume create cccl-build; else docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; else docker volume create cccl-build; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",

--- a/.devcontainer/cuda12.8-gcc12/devcontainer.json
+++ b/.devcontainer/cuda12.8-gcc12/devcontainer.json
@@ -33,12 +33,12 @@
     "vscode": {
       "extensions": [
         "llvm-vs-code-extensions.vscode-clangd",
-        "xaver.clang-format",
+        "seaube.clangformat",
         "nvidia.nsight-vscode-edition",
         "ms-vscode.cmake-tools"
       ],
       "settings": {
-        "editor.defaultFormatter": "xaver.clang-format",
+        "editor.defaultFormatter": "seaube.clangformat",
         "editor.formatOnSave": true,
         "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [

--- a/.devcontainer/cuda12.8-gcc12/devcontainer.json
+++ b/.devcontainer/cuda12.8-gcc12/devcontainer.json
@@ -7,8 +7,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build;",
-    "if [[ -n ${WSLENV+set} ]]; then docker volume create cccl-build; else docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; else docker volume create cccl-build; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",

--- a/.devcontainer/cuda12.8-gcc13/devcontainer.json
+++ b/.devcontainer/cuda12.8-gcc13/devcontainer.json
@@ -33,12 +33,12 @@
     "vscode": {
       "extensions": [
         "llvm-vs-code-extensions.vscode-clangd",
-        "xaver.clang-format",
+        "seaube.clangformat",
         "nvidia.nsight-vscode-edition",
         "ms-vscode.cmake-tools"
       ],
       "settings": {
-        "editor.defaultFormatter": "xaver.clang-format",
+        "editor.defaultFormatter": "seaube.clangformat",
         "editor.formatOnSave": true,
         "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [

--- a/.devcontainer/cuda12.8-gcc13/devcontainer.json
+++ b/.devcontainer/cuda12.8-gcc13/devcontainer.json
@@ -7,8 +7,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build;",
-    "if [[ -n ${WSLENV+set} ]]; then docker volume create cccl-build; else docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; else docker volume create cccl-build; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",

--- a/.devcontainer/cuda12.8-gcc7/devcontainer.json
+++ b/.devcontainer/cuda12.8-gcc7/devcontainer.json
@@ -33,12 +33,12 @@
     "vscode": {
       "extensions": [
         "llvm-vs-code-extensions.vscode-clangd",
-        "xaver.clang-format",
+        "seaube.clangformat",
         "nvidia.nsight-vscode-edition",
         "ms-vscode.cmake-tools"
       ],
       "settings": {
-        "editor.defaultFormatter": "xaver.clang-format",
+        "editor.defaultFormatter": "seaube.clangformat",
         "editor.formatOnSave": true,
         "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [

--- a/.devcontainer/cuda12.8-gcc7/devcontainer.json
+++ b/.devcontainer/cuda12.8-gcc7/devcontainer.json
@@ -7,8 +7,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build;",
-    "if [[ -n ${WSLENV+set} ]]; then docker volume create cccl-build; else docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; else docker volume create cccl-build; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",

--- a/.devcontainer/cuda12.8-gcc8/devcontainer.json
+++ b/.devcontainer/cuda12.8-gcc8/devcontainer.json
@@ -33,12 +33,12 @@
     "vscode": {
       "extensions": [
         "llvm-vs-code-extensions.vscode-clangd",
-        "xaver.clang-format",
+        "seaube.clangformat",
         "nvidia.nsight-vscode-edition",
         "ms-vscode.cmake-tools"
       ],
       "settings": {
-        "editor.defaultFormatter": "xaver.clang-format",
+        "editor.defaultFormatter": "seaube.clangformat",
         "editor.formatOnSave": true,
         "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [

--- a/.devcontainer/cuda12.8-gcc8/devcontainer.json
+++ b/.devcontainer/cuda12.8-gcc8/devcontainer.json
@@ -7,8 +7,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build;",
-    "if [[ -n ${WSLENV+set} ]]; then docker volume create cccl-build; else docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; else docker volume create cccl-build; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",

--- a/.devcontainer/cuda12.8-gcc9/devcontainer.json
+++ b/.devcontainer/cuda12.8-gcc9/devcontainer.json
@@ -33,12 +33,12 @@
     "vscode": {
       "extensions": [
         "llvm-vs-code-extensions.vscode-clangd",
-        "xaver.clang-format",
+        "seaube.clangformat",
         "nvidia.nsight-vscode-edition",
         "ms-vscode.cmake-tools"
       ],
       "settings": {
-        "editor.defaultFormatter": "xaver.clang-format",
+        "editor.defaultFormatter": "seaube.clangformat",
         "editor.formatOnSave": true,
         "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [

--- a/.devcontainer/cuda12.8-gcc9/devcontainer.json
+++ b/.devcontainer/cuda12.8-gcc9/devcontainer.json
@@ -7,8 +7,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build;",
-    "if [[ -n ${WSLENV+set} ]]; then docker volume create cccl-build; else docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; else docker volume create cccl-build; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",

--- a/.devcontainer/cuda12.8-llvm14/devcontainer.json
+++ b/.devcontainer/cuda12.8-llvm14/devcontainer.json
@@ -33,12 +33,12 @@
     "vscode": {
       "extensions": [
         "llvm-vs-code-extensions.vscode-clangd",
-        "xaver.clang-format",
+        "seaube.clangformat",
         "nvidia.nsight-vscode-edition",
         "ms-vscode.cmake-tools"
       ],
       "settings": {
-        "editor.defaultFormatter": "xaver.clang-format",
+        "editor.defaultFormatter": "seaube.clangformat",
         "editor.formatOnSave": true,
         "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [

--- a/.devcontainer/cuda12.8-llvm14/devcontainer.json
+++ b/.devcontainer/cuda12.8-llvm14/devcontainer.json
@@ -7,8 +7,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build;",
-    "if [[ -n ${WSLENV+set} ]]; then docker volume create cccl-build; else docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; else docker volume create cccl-build; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",

--- a/.devcontainer/cuda12.8-llvm15/devcontainer.json
+++ b/.devcontainer/cuda12.8-llvm15/devcontainer.json
@@ -33,12 +33,12 @@
     "vscode": {
       "extensions": [
         "llvm-vs-code-extensions.vscode-clangd",
-        "xaver.clang-format",
+        "seaube.clangformat",
         "nvidia.nsight-vscode-edition",
         "ms-vscode.cmake-tools"
       ],
       "settings": {
-        "editor.defaultFormatter": "xaver.clang-format",
+        "editor.defaultFormatter": "seaube.clangformat",
         "editor.formatOnSave": true,
         "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [

--- a/.devcontainer/cuda12.8-llvm15/devcontainer.json
+++ b/.devcontainer/cuda12.8-llvm15/devcontainer.json
@@ -7,8 +7,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build;",
-    "if [[ -n ${WSLENV+set} ]]; then docker volume create cccl-build; else docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; else docker volume create cccl-build; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",

--- a/.devcontainer/cuda12.8-llvm16/devcontainer.json
+++ b/.devcontainer/cuda12.8-llvm16/devcontainer.json
@@ -33,12 +33,12 @@
     "vscode": {
       "extensions": [
         "llvm-vs-code-extensions.vscode-clangd",
-        "xaver.clang-format",
+        "seaube.clangformat",
         "nvidia.nsight-vscode-edition",
         "ms-vscode.cmake-tools"
       ],
       "settings": {
-        "editor.defaultFormatter": "xaver.clang-format",
+        "editor.defaultFormatter": "seaube.clangformat",
         "editor.formatOnSave": true,
         "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [

--- a/.devcontainer/cuda12.8-llvm16/devcontainer.json
+++ b/.devcontainer/cuda12.8-llvm16/devcontainer.json
@@ -7,8 +7,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build;",
-    "if [[ -n ${WSLENV+set} ]]; then docker volume create cccl-build; else docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; else docker volume create cccl-build; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",

--- a/.devcontainer/cuda12.8-llvm17/devcontainer.json
+++ b/.devcontainer/cuda12.8-llvm17/devcontainer.json
@@ -33,12 +33,12 @@
     "vscode": {
       "extensions": [
         "llvm-vs-code-extensions.vscode-clangd",
-        "xaver.clang-format",
+        "seaube.clangformat",
         "nvidia.nsight-vscode-edition",
         "ms-vscode.cmake-tools"
       ],
       "settings": {
-        "editor.defaultFormatter": "xaver.clang-format",
+        "editor.defaultFormatter": "seaube.clangformat",
         "editor.formatOnSave": true,
         "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [

--- a/.devcontainer/cuda12.8-llvm17/devcontainer.json
+++ b/.devcontainer/cuda12.8-llvm17/devcontainer.json
@@ -7,8 +7,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build;",
-    "if [[ -n ${WSLENV+set} ]]; then docker volume create cccl-build; else docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; else docker volume create cccl-build; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",

--- a/.devcontainer/cuda12.8-llvm18/devcontainer.json
+++ b/.devcontainer/cuda12.8-llvm18/devcontainer.json
@@ -7,8 +7,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build;",
-    "if [[ -n ${WSLENV+set} ]]; then docker volume create cccl-build; else docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; else docker volume create cccl-build; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",

--- a/.devcontainer/cuda12.8-llvm18/devcontainer.json
+++ b/.devcontainer/cuda12.8-llvm18/devcontainer.json
@@ -34,12 +34,12 @@
     "vscode": {
       "extensions": [
         "llvm-vs-code-extensions.vscode-clangd",
-        "xaver.clang-format",
+        "seaube.clangformat",
         "nvidia.nsight-vscode-edition",
         "ms-vscode.cmake-tools"
       ],
       "settings": {
-        "editor.defaultFormatter": "xaver.clang-format",
+        "editor.defaultFormatter": "seaube.clangformat",
         "editor.formatOnSave": true,
         "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [

--- a/.devcontainer/cuda12.8ext-gcc13/devcontainer.json
+++ b/.devcontainer/cuda12.8ext-gcc13/devcontainer.json
@@ -33,12 +33,12 @@
     "vscode": {
       "extensions": [
         "llvm-vs-code-extensions.vscode-clangd",
-        "xaver.clang-format",
+        "seaube.clangformat",
         "nvidia.nsight-vscode-edition",
         "ms-vscode.cmake-tools"
       ],
       "settings": {
-        "editor.defaultFormatter": "xaver.clang-format",
+        "editor.defaultFormatter": "seaube.clangformat",
         "editor.formatOnSave": true,
         "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [

--- a/.devcontainer/cuda12.8ext-gcc13/devcontainer.json
+++ b/.devcontainer/cuda12.8ext-gcc13/devcontainer.json
@@ -7,8 +7,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build;",
-    "if [[ -n ${WSLENV+set} ]]; then docker volume create cccl-build; else docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; else docker volume create cccl-build; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -33,12 +33,12 @@
     "vscode": {
       "extensions": [
         "llvm-vs-code-extensions.vscode-clangd",
-        "xaver.clang-format",
+        "seaube.clangformat",
         "nvidia.nsight-vscode-edition",
         "ms-vscode.cmake-tools"
       ],
       "settings": {
-        "editor.defaultFormatter": "xaver.clang-format",
+        "editor.defaultFormatter": "seaube.clangformat",
         "editor.formatOnSave": true,
         "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,8 +7,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build;",
-    "if [[ -n ${WSLENV+set} ]]; then docker volume create cccl-build; else docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; else docker volume create cccl-build; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",

--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -42,7 +42,7 @@ workflows:
     # verify-codegen:
     - {jobs: ['verify_codegen'], project: 'libcudacxx'}
     # cudax has different CTK reqs:
-    - {jobs: ['build'], project: 'cudax', ctk: ['12.0'], std: 20,    cxx: ['msvc14.36']}
+    - {jobs: ['build'], project: 'cudax', ctk: ['12.0'], std: 20,    cxx: ['msvc14.39']}
     - {jobs: ['build'], project: 'cudax', ctk: ['curr'], std: 20,    cxx: ['gcc10', 'gcc11', 'gcc12']}
     - {jobs: ['build'], project: 'cudax', ctk: ['curr'], std: 20,    cxx: ['clang14', 'clang15', 'clang16', 'clang17']}
     - {jobs: ['build'], project: 'cudax', ctk: ['12.5'], std: 'all', cxx: ['nvhpc']}
@@ -87,7 +87,7 @@ workflows:
     - {jobs: ['build'], project: 'cudax', ctk: ['12.0', 'curr'], std: 'all', cxx: ['gcc9', 'gcc10', 'gcc11']}
     - {jobs: ['build'], project: 'cudax', ctk: [        'curr'], std: 'all', cxx: ['clang14', 'clang15', 'clang16', 'clang17']}
     - {jobs: ['build'], project: 'cudax', ctk: [        '12.5'], std: 'all', cxx: ['nvhpc']}
-    - {jobs: ['build'], project: 'cudax', ctk: ['12.0',       ], std: 'all', cxx: ['msvc14.36']}
+    - {jobs: ['build'], project: 'cudax', ctk: ['12.0',       ], std: 'all', cxx: ['msvc14.39']}
     - {jobs: ['build'], project: 'cudax', ctk: [        'curr'], std: 'all', cxx: ['msvc2022']}
     - {jobs: ['build'], project: 'cudax', ctk: ['12.0'        ], std: 'all', cxx: ['gcc12'], sm: "90"}
     - {jobs: ['build'], project: 'cudax', ctk: [        'curr'], std: 'all', cxx: ['gcc13'], sm: "90a"}
@@ -99,7 +99,7 @@ workflows:
   # Any generated jobs that match the entries in `exclude` will be removed from the final matrix for all workflows.
   exclude:
     # GPU runners are not available on Windows.
-    - {jobs: ['test', 'test_gpu', 'test_nolid', 'test_lid0', 'test_lid1', 'test_lid2'], cxx: ['msvc2019', 'msvc14.36', 'msvc2022']}
+    - {jobs: ['test', 'test_gpu', 'test_nolid', 'test_lid0', 'test_lid1', 'test_lid2'], cxx: ['msvc2019', 'msvc14.39', 'msvc2022']}
 
 
 #############################################################################################
@@ -153,8 +153,8 @@ host_compilers:
     exe: cl
     versions:
       14.29: { stds: [ 17,   ], aka: '2019' }
-      14.36: { stds: [ 17, 20]              }
-      14.39: { stds: [ 17, 20], aka: '2022' }
+      14.39: { stds: [ 17, 20]              }
+      14.42: { stds: [ 17, 20], aka: '2022' }
   nvhpc:
     name: 'NVHPC'
     container_tag: 'nvhpc'


### PR DESCRIPTION
## Description

`initializeCommand` should not pass two arguments to `bash -c`.

The array syntax treats each element as a separate argument, and `bash -c` only executes the first argument in Linux. Maybe gitbash on Windows executes more, but this is why the docker volume isn't created in Linux or CI.

This PR also switches from [`xaver.clang-format`](https://github.com/xaverh/vscode-clang-format) to [`seaube.clangformat`](https://github.com/seaube/vscode-clang-format), because the former hasn't been released in 5 years. `xaver.clang-format` does not [account for](https://github.com/xaverh/vscode-clang-format/pull/131) vscode-clangd's language identifier switch from `cuda` to `cuda-cpp`, whereas `seaube.clangformat` does.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
