### PR TITLE
Backport to 2.8: Deprecate CUB iterators existing in Thrust (#3304)

### DIFF
--- a/cub/benchmarks/bench/run_length_encode/encode.cu
+++ b/cub/benchmarks/bench/run_length_encode/encode.cu
@@ -27,6 +27,8 @@
 
 #include <cub/device/device_run_length_encode.cuh>
 
+#include <thrust/iterator/constant_iterator.h>
+
 #include <look_back_helper.cuh>
 #include <nvbench_helper.cuh>
 
@@ -74,7 +76,7 @@ static void rle(nvbench::state& state, nvbench::type_list<T, OffsetT>)
   using offset_t                   = OffsetT;
   using keys_input_it_t            = const T*;
   using unique_output_it_t         = T*;
-  using vals_input_it_t            = cub::ConstantInputIterator<offset_t, OffsetT>;
+  using vals_input_it_t            = thrust::constant_iterator<offset_t, OffsetT>;
   using aggregate_output_it_t      = offset_t*;
   using num_runs_output_iterator_t = offset_t*;
   using equality_op_t              = ::cuda::std::equal_to<>;

--- a/cub/cub/agent/agent_reduce_by_key.cuh
+++ b/cub/cub/agent/agent_reduce_by_key.cuh
@@ -49,7 +49,6 @@
 #include <cub/block/block_scan.cuh>
 #include <cub/block/block_store.cuh>
 #include <cub/iterator/cache_modified_input_iterator.cuh>
-#include <cub/iterator/constant_input_iterator.cuh>
 
 #include <cuda/std/type_traits>
 

--- a/cub/cub/agent/agent_rle.cuh
+++ b/cub/cub/agent/agent_rle.cuh
@@ -52,7 +52,6 @@
 #include <cub/block/block_store.cuh>
 #include <cub/grid/grid_queue.cuh>
 #include <cub/iterator/cache_modified_input_iterator.cuh>
-#include <cub/iterator/constant_input_iterator.cuh>
 
 #include <cuda/ptx>
 #include <cuda/std/type_traits>

--- a/cub/cub/agent/agent_segment_fixup.cuh
+++ b/cub/cub/agent/agent_segment_fixup.cuh
@@ -50,7 +50,6 @@
 #include <cub/block/block_scan.cuh>
 #include <cub/block/block_store.cuh>
 #include <cub/iterator/cache_modified_input_iterator.cuh>
-#include <cub/iterator/constant_input_iterator.cuh>
 
 #include <cuda/std/type_traits>
 

--- a/cub/cub/agent/agent_spmv_orig.cuh
+++ b/cub/cub/agent/agent_spmv_orig.cuh
@@ -386,7 +386,9 @@ struct CCCL_DEPRECATED_BECAUSE("Use the cuSPARSE library instead") AgentSpmv
     __syncthreads();
 
     // Search for the thread's starting coordinate within the merge tile
+    _CCCL_SUPPRESS_DEPRECATED_PUSH
     CountingInputIterator<OffsetT> tile_nonzero_indices(tile_start_coord.y);
+    _CCCL_SUPPRESS_DEPRECATED_POP
     CoordinateT thread_start_coord;
 
     MergePathSearch(
@@ -567,7 +569,9 @@ struct CCCL_DEPRECATED_BECAUSE("Use the cuSPARSE library instead") AgentSpmv
     __syncthreads();
 
     // Search for the thread's starting coordinate within the merge tile
+    _CCCL_SUPPRESS_DEPRECATED_PUSH
     CountingInputIterator<OffsetT> tile_nonzero_indices(tile_start_coord.y);
+    _CCCL_SUPPRESS_DEPRECATED_POP
     CoordinateT thread_start_coord;
 
     MergePathSearch(
@@ -701,7 +705,9 @@ struct CCCL_DEPRECATED_BECAUSE("Use the cuSPARSE library instead") AgentSpmv
         // Search our starting coordinates
         OffsetT diagonal = (tile_idx + threadIdx.x) * TILE_ITEMS;
         CoordinateT tile_coord;
+        _CCCL_SUPPRESS_DEPRECATED_PUSH
         CountingInputIterator<OffsetT> nonzero_indices(0);
+        _CCCL_SUPPRESS_DEPRECATED_POP
 
         // Search the merge path
         MergePathSearch(

--- a/cub/cub/device/device_run_length_encode.cuh
+++ b/cub/cub/device/device_run_length_encode.cuh
@@ -48,6 +48,7 @@
 #include <cub/device/dispatch/dispatch_reduce_by_key.cuh>
 #include <cub/device/dispatch/dispatch_rle.cuh>
 #include <cub/device/dispatch/tuning/tuning_run_length_encode.cuh>
+#include <cub/iterator/constant_input_iterator.cuh>
 
 #include <iterator>
 
@@ -199,7 +200,9 @@ struct DeviceRunLengthEncode
     using length_t = cub::detail::non_void_value_t<LengthsOutputIteratorT, offset_t>;
 
     // Generator type for providing 1s values for run-length reduction
+    _CCCL_SUPPRESS_DEPRECATED_PUSH
     using lengths_input_iterator_t = ConstantInputIterator<length_t, offset_t>;
+    _CCCL_SUPPRESS_DEPRECATED_POP
 
     using accum_t = ::cuda::std::__accumulator_t<reduction_op, length_t, length_t>;
 
@@ -207,6 +210,7 @@ struct DeviceRunLengthEncode
 
     using policy_t = detail::rle::encode::policy_hub<accum_t, key_t>;
 
+    _CCCL_SUPPRESS_DEPRECATED_PUSH
     return DispatchReduceByKey<
       InputIteratorT,
       UniqueOutputIteratorT,
@@ -228,6 +232,7 @@ struct DeviceRunLengthEncode
                           reduction_op(),
                           num_items,
                           stream);
+    _CCCL_SUPPRESS_DEPRECATED_POP
   }
 
 #ifndef _CCCL_DOXYGEN_INVOKED // Do not document

--- a/cub/cub/device/dispatch/dispatch_spmv_orig.cuh
+++ b/cub/cub/device/dispatch/dispatch_spmv_orig.cuh
@@ -157,7 +157,9 @@ CUB_DETAIL_KERNEL_ATTRIBUTES void DeviceSpmvSearchKernel(
   {
     OffsetT diagonal = (tile_idx * TILE_ITEMS);
     CoordinateT tile_coordinate;
+    _CCCL_SUPPRESS_DEPRECATED_PUSH
     CountingInputIterator<OffsetT> nonzero_indices(0);
+    _CCCL_SUPPRESS_DEPRECATED_POP
 
     // Search the merge path
     MergePathSearch(

--- a/cub/cub/device/dispatch/dispatch_streaming_reduce.cuh
+++ b/cub/cub/device/dispatch/dispatch_streaming_reduce.cuh
@@ -13,10 +13,6 @@
 #  pragma system_header
 #endif // no system header
 
-_CCCL_SUPPRESS_DEPRECATED_PUSH
-#include <cuda/std/functional>
-_CCCL_SUPPRESS_DEPRECATED_POP
-
 #include <cub/device/dispatch/dispatch_reduce.cuh>
 #include <cub/iterator/arg_index_input_iterator.cuh>
 #include <cub/iterator/constant_input_iterator.cuh>
@@ -24,10 +20,13 @@ _CCCL_SUPPRESS_DEPRECATED_POP
 #include <thrust/iterator/iterator_adaptor.h>
 #include <thrust/iterator/tabulate_output_iterator.h>
 
+#include <cuda/std/functional>
 #include <cuda/std/type_traits>
 
 #ifndef _CCCL_DOXYGEN_INVOKED // Do not document
 
+// suppress deprecation warnings for ConstantInputIterator
+_CCCL_SUPPRESS_DEPRECATED_PUSH
 CUB_NAMESPACE_BEGIN
 
 namespace detail
@@ -192,6 +191,12 @@ template <typename InputIteratorT,
             detail::reduce::policy_hub<KeyValuePair<PerPartitionOffsetT, InitT>, PerPartitionOffsetT, ReductionOpT>>
 struct dispatch_streaming_arg_reduce_t
 {
+#  if _CCCL_COMPILER(NVHPC)
+  // NVHPC fails to suppress a deprecation when the alias is inside the function below, so we put it here and span a
+  // deprecation suppression region across the entire file as well
+  using constant_offset_it_t = ConstantInputIterator<GlobalOffsetT>;
+#  endif // _CCCL_COMPILER(NVHPC)
+
   // Internal dispatch routine for computing a device-wide argument extremum, like `ArgMin` and `ArgMax`
   //
   // @param[in] d_temp_storage
@@ -231,7 +236,11 @@ struct dispatch_streaming_arg_reduce_t
     cudaStream_t stream)
   {
     // Constant iterator to provide the offset of the current partition for the user-provided input iterator
+#  if !_CCCL_COMPILER(NVHPC)
+    _CCCL_SUPPRESS_DEPRECATED_PUSH
     using constant_offset_it_t = ConstantInputIterator<GlobalOffsetT>;
+    _CCCL_SUPPRESS_DEPRECATED_POP
+#  endif
 
     // Wrapped input iterator to produce index-value tuples, i.e., <PerPartitionOffsetT, InputT>-tuples
     // We make sure to offset the user-provided input iterator by the current partition's offset
@@ -376,7 +385,7 @@ struct dispatch_streaming_arg_reduce_t
 
 } // namespace reduce
 } // namespace detail
-
+_CCCL_SUPPRESS_DEPRECATED_POP
 CUB_NAMESPACE_END
 
 #endif // !_CCCL_DOXYGEN_INVOKED

--- a/cub/cub/iterator/constant_input_iterator.cuh
+++ b/cub/cub/iterator/constant_input_iterator.cuh
@@ -87,7 +87,13 @@ CUB_NAMESPACE_BEGIN
  *   The difference type of this iterator (Default: @p ptrdiff_t)
  */
 template <typename ValueType, typename OffsetT = ptrdiff_t>
-class ConstantInputIterator
+class
+#ifndef __CUDA_ARCH__
+  // Avoid generating a deprecation warning from length_encode.compute_xx.cpp1.ii, which is compiled by cicc for which
+  // we cannot suppress the warning
+  CCCL_DEPRECATED_BECAUSE("Use thrust::constant_iterator instead")
+#endif
+    ConstantInputIterator
 {
 public:
   // Required iterator traits
@@ -216,11 +222,13 @@ public:
   }
 
   /// ostream operator
+  _CCCL_SUPPRESS_DEPRECATED_PUSH
   friend std::ostream& operator<<(std::ostream& os, const self_type& itr)
   {
     os << "[" << itr.val << "," << itr.offset << "]";
     return os;
   }
+  _CCCL_SUPPRESS_DEPRECATED_POP
 };
 
 CUB_NAMESPACE_END

--- a/cub/cub/iterator/counting_input_iterator.cuh
+++ b/cub/cub/iterator/counting_input_iterator.cuh
@@ -90,7 +90,7 @@ CUB_NAMESPACE_BEGIN
  *   The difference type of this iterator (Default: @p ptrdiff_t)
  */
 template <typename ValueType, typename OffsetT = ptrdiff_t>
-class CountingInputIterator
+class CCCL_DEPRECATED_BECAUSE("Use thrust::counting_iterator instead") CountingInputIterator
 {
 public:
   // Required iterator traits
@@ -218,11 +218,13 @@ public:
 
   /// ostream operator
 #if !_CCCL_COMPILER(NVRTC)
+  _CCCL_SUPPRESS_DEPRECATED_PUSH
   friend std::ostream& operator<<(std::ostream& os, const self_type& itr)
   {
     os << "[" << itr.val << "]";
     return os;
   }
+  _CCCL_SUPPRESS_DEPRECATED_POP
 #endif // !_CCCL_COMPILER(NVRTC)
 };
 

--- a/cub/cub/iterator/discard_output_iterator.cuh
+++ b/cub/cub/iterator/discard_output_iterator.cuh
@@ -54,7 +54,7 @@ CUB_NAMESPACE_BEGIN
  * @brief A discard iterator
  */
 template <typename OffsetT = ptrdiff_t>
-class DiscardOutputIterator
+class CCCL_DEPRECATED_BECAUSE("Use thrust::discard_iterator instead") DiscardOutputIterator
 {
 public:
   // Required iterator traits
@@ -191,11 +191,13 @@ public:
   }
 
   /// ostream operator
+  _CCCL_SUPPRESS_DEPRECATED_PUSH
   friend std::ostream& operator<<(std::ostream& os, const self_type& itr)
   {
     os << "[" << itr.offset << "]";
     return os;
   }
+  _CCCL_SUPPRESS_DEPRECATED_POP
 };
 
 CUB_NAMESPACE_END

--- a/cub/cub/iterator/transform_input_iterator.cuh
+++ b/cub/cub/iterator/transform_input_iterator.cuh
@@ -110,7 +110,7 @@ CUB_NAMESPACE_BEGIN
  *   The difference type of this iterator (Default: @p ptrdiff_t)
  */
 template <typename ValueType, typename ConversionOp, typename InputIteratorT, typename OffsetT = ptrdiff_t>
-class TransformInputIterator
+class CCCL_DEPRECATED_BECAUSE("Use thrust::transform_iterator instead") TransformInputIterator
 {
 public:
   // Required iterator traits
@@ -233,10 +233,12 @@ public:
   }
 
   /// ostream operator
+  _CCCL_SUPPRESS_DEPRECATED_PUSH
   friend std::ostream& operator<<(std::ostream& os, const self_type& /* itr */)
   {
     return os;
   }
+  _CCCL_SUPPRESS_DEPRECATED_POP
 };
 
 CUB_NAMESPACE_END

--- a/cub/test/catch2_test_block_run_length_decode.cu
+++ b/cub/test/catch2_test_block_run_length_decode.cu
@@ -29,9 +29,10 @@
 #include <cub/block/block_run_length_decode.cuh>
 #include <cub/block/block_store.cuh>
 #include <cub/device/device_scan.cuh>
-#include <cub/iterator/counting_input_iterator.cuh>
 #include <cub/iterator/transform_input_iterator.cuh>
 #include <cub/util_allocator.cuh>
+
+#include <thrust/iterator/counting_iterator.h>
 
 #include <cuda/std/type_traits>
 
@@ -332,11 +333,11 @@ void TestAlgorithmSpecialisation()
 
   using RunItemT      = float;
   using RunLengthT    = uint32_t;
-  using ItemItT       = cub::CountingInputIterator<RunItemT>;
-  using RunLengthsItT = cub::TransformInputIterator<RunLengthT, ModOp, cub::CountingInputIterator<RunLengthT>>;
+  using ItemItT       = thrust::counting_iterator<RunItemT>;
+  using RunLengthsItT = thrust::transform_iterator<ModOp, thrust::counting_iterator<RunLengthT>>;
 
   ItemItT d_unique_items(1000U);
-  RunLengthsItT d_run_lengths(cub::CountingInputIterator<RunLengthT>(0), ModOp{});
+  RunLengthsItT d_run_lengths(thrust::counting_iterator<RunLengthT>(0), ModOp{});
 
   constexpr uint32_t num_runs   = 10000;
   constexpr uint32_t num_blocks = (num_runs + (RUNS_PER_BLOCK - 1U)) / RUNS_PER_BLOCK;

--- a/cub/test/catch2_test_block_store.cu
+++ b/cub/test/catch2_test_block_store.cu
@@ -27,7 +27,6 @@
 
 #include <cub/block/block_store.cuh>
 #include <cub/iterator/cache_modified_output_iterator.cuh>
-#include <cub/iterator/discard_output_iterator.cuh>
 #include <cub/util_allocator.cuh>
 #include <cub/util_arch.cuh>
 

--- a/cub/test/catch2_test_device_for.cu
+++ b/cub/test/catch2_test_device_for.cu
@@ -29,11 +29,11 @@
 // above header needs to be included first
 
 #include <cub/device/device_for.cuh>
-#include <cub/iterator/counting_input_iterator.cuh>
 
 #include <thrust/count.h>
 #include <thrust/detail/raw_pointer_cast.h>
 #include <thrust/equal.h>
+#include <thrust/iterator/counting_iterator.h>
 #include <thrust/sequence.h>
 
 #include "catch2_test_launch_helper.h"
@@ -260,7 +260,7 @@ C2H_TEST("Device for each works with counting iterator", "[for][device]")
       max_items,
     }));
 
-  const auto it = cub::CountingInputIterator<int>{0};
+  const auto it = thrust::counting_iterator<int>{0};
   c2h::device_vector<int> counts(num_items);
   device_for_each(it, it + num_items, incrementer_t{thrust::raw_pointer_cast(counts.data())});
 

--- a/cub/test/catch2_test_device_for_copy.cu
+++ b/cub/test/catch2_test_device_for_copy.cu
@@ -29,10 +29,10 @@
 // above header needs to be included first
 
 #include <cub/device/device_for.cuh>
-#include <cub/iterator/counting_input_iterator.cuh>
 
 #include <thrust/count.h>
 #include <thrust/detail/raw_pointer_cast.h>
+#include <thrust/iterator/counting_iterator.h>
 #include <thrust/sequence.h>
 
 #include "catch2_test_launch_helper.h"
@@ -200,7 +200,7 @@ C2H_TEST("Device for each works with counting iterator", "[for][device]")
       max_items,
     }));
 
-  const auto it = cub::CountingInputIterator<int>{0};
+  const auto it = thrust::counting_iterator<int>{0};
   c2h::device_vector<int> counts(num_items);
   device_for_each_copy(it, it + num_items, incrementer_t{thrust::raw_pointer_cast(counts.data())});
 

--- a/cub/test/catch2_test_device_histogram.cu
+++ b/cub/test/catch2_test_device_histogram.cu
@@ -27,7 +27,8 @@
  ******************************************************************************/
 
 #include <cub/device/device_histogram.cuh>
-#include <cub/iterator/counting_input_iterator.cuh>
+
+#include <thrust/iterator/counting_iterator.h>
 
 #include <cuda/std/__algorithm_>
 #include <cuda/std/array>
@@ -495,7 +496,7 @@ C2H_TEST("DeviceHistogram::HistogramEven sample iterator", "[histogram_even][dev
   const auto lower_level = caller_vector<int>{0, -10, cs::numeric_limits<int>::lowest()};
   const auto upper_level = caller_vector<int>{total_values, 10, cs::numeric_limits<int>::max()};
 
-  auto sample_iterator = cub::CountingInputIterator<sample_t>(0);
+  auto sample_iterator = thrust::counting_iterator<sample_t>(0);
 
   // Channel #0: 0, 4,  8, 12
   // Channel #1: 1, 5,  9, 13
@@ -584,7 +585,7 @@ C2H_TEST_LIST("DeviceHistogram::HistogramEven bin computation does not overflow"
   constexpr sample_t lower_level = 0;
   constexpr sample_t upper_level = cs::numeric_limits<sample_t>::max();
   constexpr auto num_samples     = 1000;
-  auto d_samples                 = cub::CountingInputIterator<sample_t>{0UL};
+  auto d_samples                 = thrust::counting_iterator<sample_t>{0UL};
   auto d_histo_out               = c2h::device_vector<counter_t>(1024);
   const auto num_bins            = GENERATE(1, 2);
 

--- a/cub/test/catch2_test_device_reduce.cu
+++ b/cub/test/catch2_test_device_reduce.cu
@@ -39,6 +39,10 @@
 #include <c2h/custom_type.h>
 #include <c2h/extended_types.h>
 
+// need to suppress deprecation warnings for ConstantInputIterator in the cudafe1.stub.c file, so there is no matching
+// _CCCL_SUPPRESS_DEPRECATED_POP at the end of this file
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+
 DECLARE_LAUNCH_WRAPPER(cub::DeviceReduce::Reduce, device_reduce);
 DECLARE_LAUNCH_WRAPPER(cub::DeviceReduce::Sum, device_sum);
 DECLARE_LAUNCH_WRAPPER(cub::DeviceReduce::Min, device_min);

--- a/cub/test/catch2_test_device_reduce.cuh
+++ b/cub/test/catch2_test_device_reduce.cuh
@@ -203,11 +203,11 @@ inline __half* unwrap_it(half_t* it)
 }
 
 template <class OffsetT>
-inline cub::ConstantInputIterator<__half, OffsetT> unwrap_it(cub::ConstantInputIterator<half_t, OffsetT> it)
+inline thrust::constant_iterator<__half, OffsetT> unwrap_it(thrust::constant_iterator<half_t, OffsetT> it)
 {
   half_t wrapped_val = *it;
   __half val         = wrapped_val.operator __half();
-  return cub::ConstantInputIterator<__half, OffsetT>(val);
+  return thrust::constant_iterator<__half, OffsetT>(val);
 }
 #endif
 
@@ -218,11 +218,11 @@ inline __nv_bfloat16* unwrap_it(bfloat16_t* it)
 }
 
 template <class OffsetT>
-cub::ConstantInputIterator<__nv_bfloat16, OffsetT> inline unwrap_it(cub::ConstantInputIterator<bfloat16_t, OffsetT> it)
+thrust::constant_iterator<__nv_bfloat16, OffsetT> inline unwrap_it(thrust::constant_iterator<bfloat16_t, OffsetT> it)
 {
   bfloat16_t wrapped_val = *it;
   __nv_bfloat16 val      = wrapped_val.operator __nv_bfloat16();
-  return cub::ConstantInputIterator<__nv_bfloat16, OffsetT>(val);
+  return thrust::constant_iterator<__nv_bfloat16, OffsetT>(val);
 }
 #endif
 

--- a/cub/test/catch2_test_device_reduce_fp_inf.cu
+++ b/cub/test/catch2_test_device_reduce_fp_inf.cu
@@ -45,6 +45,9 @@ DECLARE_LAUNCH_WRAPPER(cub::DeviceReduce::ArgMin, device_arg_min_old);
 DECLARE_LAUNCH_WRAPPER(cub::DeviceReduce::ArgMax, device_arg_max_old);
 _CCCL_SUPPRESS_DEPRECATED_POP
 
+// suppress deprecation of ConstantInputIterator in cudafe1.stub.c file
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+
 // %PARAM% TEST_LAUNCH lid 0:1
 
 C2H_TEST("Device reduce arg{min,max} works with inf items", "[reduce][device]")

--- a/cub/test/catch2_test_device_reduce_large_offsets.cu
+++ b/cub/test/catch2_test_device_reduce_large_offsets.cu
@@ -24,6 +24,9 @@ DECLARE_LAUNCH_WRAPPER(cub::DeviceReduce::ArgMin, device_arg_min);
 DECLARE_LAUNCH_WRAPPER(cub::DeviceReduce::Max, device_max);
 DECLARE_LAUNCH_WRAPPER(cub::DeviceReduce::ArgMax, device_arg_max);
 
+// suppress deprecation of ConstantInputIterator in cudafe1.stub.c file
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+
 // %PARAM% TEST_LAUNCH lid 0:1:2
 
 // List of offset types to test

--- a/cub/test/catch2_test_device_run_length_encode.cu
+++ b/cub/test/catch2_test_device_run_length_encode.cu
@@ -25,6 +25,13 @@
  *
  ******************************************************************************/
 
+#include <cuda/__cccl_config>
+
+#if _CCCL_COMPILER(NVHPC)
+// to suppress warnings for CountingInputIterator
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+#endif // _CCCL_COMPILER(NVHPC)
+
 #include "insert_nested_NVTX_range_guard.h"
 // above header needs to be included first
 
@@ -42,6 +49,9 @@
 #include <c2h/catch2_test_helper.h>
 
 DECLARE_LAUNCH_WRAPPER(cub::DeviceRunLengthEncode::Encode, run_length_encode);
+
+// suppress deprecation of ConstantInputIterator in cudafe1.stub.c file
+_CCCL_SUPPRESS_DEPRECATED_PUSH
 
 // %PARAM% TEST_LAUNCH lid 0:1:2
 
@@ -264,3 +274,7 @@ C2H_TEST("DeviceRunLengthEncode::Encode can handle leading NaN", "[device][run_l
   REQUIRE(out_counts == reference_counts);
   REQUIRE(out_num_runs == reference_num_runs);
 }
+
+#if _CCCL_COMPILER(NVHPC)
+_CCCL_SUPPRESS_DEPRECATED_POP
+#endif // _CCCL_COMPILER(NVHPC)

--- a/cub/test/catch2_test_iterator.cu
+++ b/cub/test/catch2_test_iterator.cu
@@ -26,6 +26,14 @@
  *
  ******************************************************************************/
 
+#include <cuda/__cccl_config>
+
+// with NVHPC we get deprecation warnings originating from instantiations from cudafe1.stub.c, so we have to bulk
+// suppress all deprecation warnings in this file (without a matching pop)
+#if _CCCL_COMPILER(NVHPC)
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+#endif
+
 #include <cub/iterator/arg_index_input_iterator.cuh>
 #include <cub/iterator/cache_modified_input_iterator.cuh>
 #include <cub/iterator/constant_input_iterator.cuh>
@@ -91,8 +99,10 @@ __global__ void test_iterator_kernel(InputIteratorT d_in, T* d_out, InputIterato
   d_itrs[1] = d_in; // Iterator at offset 0
 }
 
+_CCCL_SUPPRESS_DEPRECATED_PUSH
 template <typename InputIteratorT, typename T>
-void test_iterator(InputIteratorT d_in, const c2h::host_vector<T>& h_reference)
+void test_iterator(InputIteratorT d_in, const c2h::host_vector<T>& h_reference) //
+  _CCCL_SUPPRESS_DEPRECATED_POP
 {
   c2h::device_vector<T> d_out(h_reference.size());
   c2h::device_vector<InputIteratorT> d_itrs(2, d_in); // TODO(bgruber): using a raw allocation halves the compile time
@@ -113,7 +123,9 @@ C2H_TEST("Test constant iterator", "[iterator]", scalar_types)
   using T                = c2h::get<0, TestType>;
   const T base           = static_cast<T>(GENERATE(0, 99));
   const auto h_reference = c2h::host_vector<T>{base, base, base, base, base, base, base, base};
+  _CCCL_SUPPRESS_DEPRECATED_PUSH
   test_iterator(cub::ConstantInputIterator<T>(base), h_reference);
+  _CCCL_SUPPRESS_DEPRECATED_POP
 }
 
 C2H_TEST("Test counting iterator", "[iterator]", scalar_types)
@@ -129,7 +141,9 @@ C2H_TEST("Test counting iterator", "[iterator]", scalar_types)
     static_cast<T>(base + 21),
     static_cast<T>(base + 11),
     static_cast<T>(base + 0)};
+  _CCCL_SUPPRESS_DEPRECATED_PUSH
   test_iterator(cub::CountingInputIterator<T>(base), h_reference);
+  _CCCL_SUPPRESS_DEPRECATED_POP
 }
 
 using cache_modifiers =
@@ -187,9 +201,11 @@ C2H_TEST("Test transform iterator", "[iterator]", types)
     op(h_data[21]),
     op(h_data[11]),
     op(h_data[0])};
+  _CCCL_SUPPRESS_DEPRECATED_PUSH
   test_iterator(cub::TransformInputIterator<T, transform_op_t<T>, const T*>(
                   const_cast<const T*>(const_cast<const T*>(thrust::raw_pointer_cast(d_data.data()))), op),
                 h_reference);
+  _CCCL_SUPPRESS_DEPRECATED_POP
 }
 
 C2H_TEST("Test tex-obj texture iterator", "[iterator]", types)
@@ -233,7 +249,9 @@ C2H_TEST("Test texture transform iterator", "[iterator]", types)
   TextureIterator d_tex_itr;
   CubDebugExit(
     d_tex_itr.BindTexture(const_cast<const T*>(thrust::raw_pointer_cast(d_data.data())), sizeof(T) * TEST_VALUES));
+  _CCCL_SUPPRESS_DEPRECATED_PUSH
   cub::TransformInputIterator<T, transform_op_t<T>, TextureIterator> xform_itr(d_tex_itr, op);
+  _CCCL_SUPPRESS_DEPRECATED_POP
   test_iterator(xform_itr, h_reference);
   CubDebugExit(d_tex_itr.UnbindTexture());
 }

--- a/cub/test/catch2_test_iterator.cu
+++ b/cub/test/catch2_test_iterator.cu
@@ -28,11 +28,8 @@
 
 #include <cuda/__cccl_config>
 
-// with NVHPC we get deprecation warnings originating from instantiations from cudafe1.stub.c, so we have to bulk
-// suppress all deprecation warnings in this file (without a matching pop)
-#if _CCCL_COMPILER(NVHPC)
+// we get deprecation warnings from all kinds of places (including  cudafe1.stub.c)), so just bulk suppress them
 _CCCL_SUPPRESS_DEPRECATED_PUSH
-#endif
 
 #include <cub/iterator/arg_index_input_iterator.cuh>
 #include <cub/iterator/cache_modified_input_iterator.cuh>
@@ -99,10 +96,8 @@ __global__ void test_iterator_kernel(InputIteratorT d_in, T* d_out, InputIterato
   d_itrs[1] = d_in; // Iterator at offset 0
 }
 
-_CCCL_SUPPRESS_DEPRECATED_PUSH
 template <typename InputIteratorT, typename T>
-void test_iterator(InputIteratorT d_in, const c2h::host_vector<T>& h_reference) //
-  _CCCL_SUPPRESS_DEPRECATED_POP
+void test_iterator(InputIteratorT d_in, const c2h::host_vector<T>& h_reference)
 {
   c2h::device_vector<T> d_out(h_reference.size());
   c2h::device_vector<InputIteratorT> d_itrs(2, d_in); // TODO(bgruber): using a raw allocation halves the compile time
@@ -123,9 +118,7 @@ C2H_TEST("Test constant iterator", "[iterator]", scalar_types)
   using T                = c2h::get<0, TestType>;
   const T base           = static_cast<T>(GENERATE(0, 99));
   const auto h_reference = c2h::host_vector<T>{base, base, base, base, base, base, base, base};
-  _CCCL_SUPPRESS_DEPRECATED_PUSH
   test_iterator(cub::ConstantInputIterator<T>(base), h_reference);
-  _CCCL_SUPPRESS_DEPRECATED_POP
 }
 
 C2H_TEST("Test counting iterator", "[iterator]", scalar_types)
@@ -141,9 +134,7 @@ C2H_TEST("Test counting iterator", "[iterator]", scalar_types)
     static_cast<T>(base + 21),
     static_cast<T>(base + 11),
     static_cast<T>(base + 0)};
-  _CCCL_SUPPRESS_DEPRECATED_PUSH
   test_iterator(cub::CountingInputIterator<T>(base), h_reference);
-  _CCCL_SUPPRESS_DEPRECATED_POP
 }
 
 using cache_modifiers =
@@ -201,11 +192,9 @@ C2H_TEST("Test transform iterator", "[iterator]", types)
     op(h_data[21]),
     op(h_data[11]),
     op(h_data[0])};
-  _CCCL_SUPPRESS_DEPRECATED_PUSH
   test_iterator(cub::TransformInputIterator<T, transform_op_t<T>, const T*>(
                   const_cast<const T*>(const_cast<const T*>(thrust::raw_pointer_cast(d_data.data()))), op),
                 h_reference);
-  _CCCL_SUPPRESS_DEPRECATED_POP
 }
 
 C2H_TEST("Test tex-obj texture iterator", "[iterator]", types)
@@ -249,9 +238,7 @@ C2H_TEST("Test texture transform iterator", "[iterator]", types)
   TextureIterator d_tex_itr;
   CubDebugExit(
     d_tex_itr.BindTexture(const_cast<const T*>(thrust::raw_pointer_cast(d_data.data())), sizeof(T) * TEST_VALUES));
-  _CCCL_SUPPRESS_DEPRECATED_PUSH
   cub::TransformInputIterator<T, transform_op_t<T>, TextureIterator> xform_itr(d_tex_itr, op);
-  _CCCL_SUPPRESS_DEPRECATED_POP
   test_iterator(xform_itr, h_reference);
   CubDebugExit(d_tex_itr.UnbindTexture());
 }

--- a/cub/test/catch2_test_util_type.cu
+++ b/cub/test/catch2_test_util_type.cu
@@ -35,6 +35,7 @@
 
 C2H_TEST("Tests non_void_value_t", "[util][type]")
 {
+  _CCCL_SUPPRESS_DEPRECATED_PUSH
   using fallback_t        = float;
   using void_fancy_it     = cub::DiscardOutputIterator<std::size_t>;
   using non_void_fancy_it = cub::CountingInputIterator<int>;
@@ -60,6 +61,7 @@ C2H_TEST("Tests non_void_value_t", "[util][type]")
   // works for a fancy iterator that has int as value type
   STATIC_REQUIRE(::cuda::std::is_same<int, //
                                       cub::detail::non_void_value_t<non_void_fancy_it, fallback_t>>::value);
+  _CCCL_SUPPRESS_DEPRECATED_POP
 }
 
 CUB_DEFINE_DETECT_NESTED_TYPE(cat_detect, cat);

--- a/cub/test/test_device_batch_memcpy.cu
+++ b/cub/test/test_device_batch_memcpy.cu
@@ -26,10 +26,10 @@
  ******************************************************************************/
 
 #include <cub/device/device_memcpy.cuh>
-#include <cub/iterator/transform_input_iterator.cuh>
 #include <cub/util_ptx.cuh>
 
 #include <thrust/fill.h>
+#include <thrust/iterator/transform_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/logical.h>
 #include <thrust/sequence.h>
@@ -283,12 +283,12 @@ void RunTest(BufferOffsetT num_buffers,
 
     // Prepare d_buffer_srcs
     OffsetToPtrOp<SrcPtrT> src_transform_op{static_cast<SrcPtrT>(thrust::raw_pointer_cast(d_in.data()))};
-    cub::TransformInputIterator<SrcPtrT, OffsetToPtrOp<SrcPtrT>, ByteOffsetT*> d_buffer_srcs(
+    thrust::transform_iterator<OffsetToPtrOp<SrcPtrT>, ByteOffsetT*> d_buffer_srcs(
       thrust::raw_pointer_cast(d_buffer_src_offsets.data()), src_transform_op);
 
     // Prepare d_buffer_dsts
     OffsetToPtrOp<DstPtrT> dst_transform_op{static_cast<DstPtrT>(thrust::raw_pointer_cast(d_out.data()))};
-    cub::TransformInputIterator<DstPtrT, OffsetToPtrOp<DstPtrT>, ByteOffsetT*> d_buffer_dsts(
+    thrust::transform_iterator<OffsetToPtrOp<DstPtrT>, ByteOffsetT*> d_buffer_dsts(
       thrust::raw_pointer_cast(d_buffer_dst_offsets.data()), dst_transform_op);
 
     // Get temporary storage requirements

--- a/cub/test/test_util.h
+++ b/cub/test/test_util.h
@@ -35,7 +35,6 @@
 #  include <sys/resource.h>
 #endif
 
-#include <cub/iterator/discard_output_iterator.cuh>
 #include <cub/util_debug.cuh>
 #include <cub/util_device.cuh>
 #include <cub/util_macro.cuh>
@@ -43,6 +42,8 @@
 #include <cub/util_namespace.cuh>
 #include <cub/util_ptx.cuh>
 #include <cub/util_type.cuh>
+
+#include <thrust/iterator/discard_iterator.h>
 
 #include <cfloat>
 #include <cmath>
@@ -1234,7 +1235,7 @@ inline int CompareDeviceResults(
 template <typename S, typename OffsetT>
 int CompareDeviceResults(
   S* /*h_reference*/,
-  CUB_NS_QUALIFIER::DiscardOutputIterator<OffsetT> /*d_data*/,
+  THRUST_NS_QUALIFIER::discard_iterator<OffsetT> /*d_data*/,
   std::size_t /*num_items*/,
   bool /*verbose*/      = true,
   bool /*display_data*/ = false)


### PR DESCRIPTION
We keep CUB iterators inside the CUB implementation headers, because some of those are exposed to NVRTC which cannot compile Thrust iterators yet.