### PR TITLE
Fix transform iterator for non-copy-constructible types

### DIFF
--- a/thrust/testing/cuda/transform_iterator.cmake
+++ b/thrust/testing/cuda/transform_iterator.cmake
@@ -1,0 +1,12 @@
+target_compile_options(${test_target} PRIVATE $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>: --extended-lambda>)
+
+# this check is actually not correct, because we must check the host compiler, not the CXX compiler.
+# We rely on that those are usually the same ;)
+if ("Clang" STREQUAL "${CMAKE_CXX_COMPILER_ID}" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 13)
+    # When clang >= 13 is used as host compiler, we get the following warning:
+    #   nvcc_internal_extended_lambda_implementation:312:22: error: definition of implicit copy constructor for '__nv_hdl_wrapper_t<false, true, false, __nv_dl_tag<void (*)(), &TestAddressStabilityLambda, 2>, int (const int &)>' is deprecated because it has a user-declared copy assignment operator [-Werror,-Wdeprecated-copy]
+    #   312 | __nv_hdl_wrapper_t & operator=(const __nv_hdl_wrapper_t &in) = delete;
+    #   |                      ^
+    # Let's suppress it until NVBug 4980157 is resolved.
+    target_compile_options(${test_target} PRIVATE $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>: -Wno-deprecated-copy>)
+endif ()

--- a/thrust/testing/cuda/transform_iterator.cu
+++ b/thrust/testing/cuda/transform_iterator.cu
@@ -1,18 +1,19 @@
+#include <thrust/device_vector.h>
+#include <thrust/host_vector.h>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/logical.h>
 
 #include <unittest/unittest.h>
 
 // see also: https://github.com/NVIDIA/cccl/issues/3541
-template <class Vector>
 void TestTransformWithLambda()
 {
-  using T = typename Vector::value_type;
-  Vector A{1, 2, 3, 4, 5, 6, 7};
-  const auto result = thrust::any_of(A.begin(), A.end(), [] __host__ __device__(T v) {
-    return v < 4;
-  });
-  ASSERT_EQUAL(result, true);
+  auto l = [] __host__ __device__(int v) { return v < 4; };
+  thrust::host_vector<int> A{1, 2, 3, 4, 5, 6, 7};
+  ASSERT_EQUAL(thrust::any_of(A.begin(), A.end(), l), true);
+
+  thrust::device_vector<int> B{1, 2, 3, 4, 5, 6, 7};
+  ASSERT_EQUAL(thrust::any_of(B.begin(), B.end(), l), true);
 }
 
-DECLARE_INTEGRAL_VECTOR_UNITTEST(TestTransformWithLambda);
+DECLARE_UNITTEST(TestTransformWithLambda);

--- a/thrust/testing/cuda/transform_iterator.cu
+++ b/thrust/testing/cuda/transform_iterator.cu
@@ -1,0 +1,18 @@
+#include <thrust/iterator/transform_iterator.h>
+#include <thrust/logical.h>
+
+#include <unittest/unittest.h>
+
+// see also: https://github.com/NVIDIA/cccl/issues/3541
+template <class Vector>
+void TestTransformWithLambda()
+{
+  using T = typename Vector::value_type;
+  Vector A{1, 2, 3, 4, 5, 6, 7};
+  const auto result = thrust::any_of(A.begin(), A.end(), [] __host__ __device__(T v) {
+    return v < 4;
+  });
+  ASSERT_EQUAL(result, true);
+}
+
+DECLARE_INTEGRAL_VECTOR_UNITTEST(TestTransformWithLambda);

--- a/thrust/testing/transform_iterator.cu
+++ b/thrust/testing/transform_iterator.cu
@@ -2,6 +2,7 @@
 #include <thrust/functional.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
+#include <thrust/logical.h>
 #include <thrust/reduce.h>
 #include <thrust/sequence.h>
 


### PR DESCRIPTION
Pulled out from #3503 and added a test.

Fixes: #3541