### PR TITLE
add missing visibility annotations to ustdex types that have data members

### DIFF
--- a/cudax/include/cuda/experimental/__async/sender/basic_sender.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/basic_sender.cuh
@@ -75,7 +75,7 @@ struct receiver_defaults
 };
 
 template <class _Data, class _Rcvr>
-struct basic_receiver
+struct _CCCL_TYPE_VISIBILITY_DEFAULT basic_receiver
 {
   using receiver_concept = __async::receiver_t;
   using __rcvr_t         = typename _Data::receiver_tag;
@@ -212,10 +212,10 @@ _CUDAX_TRIVIAL_API auto __get_attrs(long, const _Data&, const _Sndrs&... __sndrs
 }
 
 template <class _Data, class... _Sndrs>
-struct basic_sender;
+struct _CCCL_TYPE_VISIBILITY_DEFAULT basic_sender;
 
 template <class _Data, class _Sndr>
-struct basic_sender<_Data, _Sndr>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT basic_sender<_Data, _Sndr>
 {
   using sender_concept = __async::sender_t;
   using __tag_t        = typename _Data::sender_tag;

--- a/cudax/include/cuda/experimental/__async/sender/conditional.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/conditional.cuh
@@ -135,7 +135,7 @@ struct __cond_t
   };
 
   template <class _Sndr, class _Pred, class _Then, class _Else>
-  struct __sndr_t;
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __sndr_t;
 
   template <class _Pred, class _Then, class _Else>
   struct __closure
@@ -174,7 +174,7 @@ struct __cond_t
 };
 
 template <class _Sndr, class _Pred, class _Then, class _Else>
-struct __cond_t::__sndr_t
+struct _CCCL_TYPE_VISIBILITY_DEFAULT __cond_t::__sndr_t
 {
   __cond_t __tag_;
   __cond_t::__data<_Pred, _Then, _Else> __data_;

--- a/cudax/include/cuda/experimental/__async/sender/continue_on.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/continue_on.cuh
@@ -65,7 +65,7 @@ private:
                               completion_signatures<set_error_t(__decay_t<_Error>), set_error_t(::std::exception_ptr)>>;
 
   template <class _Rcvr, class _Result>
-  struct __rcvr_t
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __rcvr_t
   {
     using receiver_concept = receiver_t;
     _Rcvr __rcvr_;
@@ -127,7 +127,7 @@ private:
   };
 
   template <class _Rcvr, class _CvSndr, class _Sch>
-  struct __opstate_t
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __opstate_t
   {
     _CUDAX_API friend auto get_env(const __opstate_t* __self) noexcept -> env_of_t<_Rcvr>
     {
@@ -197,7 +197,7 @@ private:
   };
 
   template <class _Sndr, class _Sch>
-  struct __sndr_t;
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __sndr_t;
 
   template <class _Sch>
   struct __closure_t;
@@ -211,7 +211,7 @@ public:
 };
 
 template <class _Sch>
-struct continue_on_t::__closure_t
+struct _CCCL_TYPE_VISIBILITY_DEFAULT continue_on_t::__closure_t
 {
   _Sch __sch;
 
@@ -223,7 +223,7 @@ struct continue_on_t::__closure_t
 };
 
 template <class _Sndr, class _Sch>
-struct continue_on_t::__sndr_t
+struct _CCCL_TYPE_VISIBILITY_DEFAULT continue_on_t::__sndr_t
 {
   using sender_concept = sender_t;
   _CCCL_NO_UNIQUE_ADDRESS continue_on_t __tag;

--- a/cudax/include/cuda/experimental/__async/sender/env.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/env.cuh
@@ -63,7 +63,7 @@ template <class _Ty>
 using __unwrap_reference_t = decltype(__unwrap_ref<_Ty>);
 
 template <class _Query, class _Value>
-struct prop
+struct _CCCL_TYPE_VISIBILITY_DEFAULT prop
 {
   _CCCL_NO_UNIQUE_ADDRESS _Query __query;
   _CCCL_NO_UNIQUE_ADDRESS _Value __value;
@@ -77,7 +77,7 @@ struct prop
 };
 
 template <class... _Envs>
-struct env
+struct _CCCL_TYPE_VISIBILITY_DEFAULT env
 {
   __tuple<_Envs...> __envs_;
 
@@ -108,7 +108,7 @@ struct env
 
 // partial specialization for two environments
 template <class _Env0, class _Env1>
-struct env<_Env0, _Env1>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT env<_Env0, _Env1>
 {
   _CCCL_NO_UNIQUE_ADDRESS _Env0 __env0_;
   _CCCL_NO_UNIQUE_ADDRESS _Env1 __env1_;

--- a/cudax/include/cuda/experimental/__async/sender/just.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/just.cuh
@@ -61,7 +61,7 @@ private:
   using _SetTag  = decltype(__detail::__set_tag<_Disposition>());
 
   template <class _Rcvr, class... _Ts>
-  struct __opstate_t
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __opstate_t
   {
     using operation_state_concept = operation_state_t;
     using completion_signatures   = __async::completion_signatures<_SetTag(_Ts...)>;
@@ -85,7 +85,7 @@ private:
   };
 
   template <class... _Ts>
-  struct __sndr_t
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __sndr_t
   {
     using sender_concept        = sender_t;
     using completion_signatures = __async::completion_signatures<_SetTag(_Ts...)>;

--- a/cudax/include/cuda/experimental/__async/sender/just_from.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/just_from.cuh
@@ -112,7 +112,7 @@ private:
   };
 
   template <class _Fn>
-  struct __sndr_t
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __sndr_t
   {
     using sender_concept = sender_t;
 

--- a/cudax/include/cuda/experimental/__async/sender/let_value.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/let_value.cuh
@@ -146,7 +146,7 @@ private:
   /// @tparam _Rcvr The receiver connected to the `let_(value|error|stopped)`
   /// sender.
   template <class _Rcvr, class _CvSndr, class _Fn>
-  struct __opstate_t
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __opstate_t
   {
     _CUDAX_API friend env_of_t<_Rcvr> get_env(const __opstate_t* __self) noexcept
     {
@@ -235,7 +235,7 @@ private:
   /// @tparam _Fn The function to be called when the predecessor sender
   /// completes.
   template <class _Sndr, class _Fn>
-  struct __sndr_t
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __sndr_t
   {
     using sender_concept = sender_t;
     _CCCL_NO_UNIQUE_ADDRESS _LetTag __tag_;

--- a/cudax/include/cuda/experimental/__async/sender/read_env.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/read_env.cuh
@@ -61,7 +61,7 @@ private:
   };
 
   template <class _Rcvr, class _Query>
-  struct __opstate_t
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __opstate_t
   {
     using operation_state_concept = operation_state_t;
     using completion_signatures   = //
@@ -107,7 +107,7 @@ private:
 
   // This makes read_env a dependent sender:
   template <class _Query>
-  struct __opstate_t<receiver_archetype, _Query>
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __opstate_t<receiver_archetype, _Query>
   {
     using operation_state_concept = operation_state_t;
     using completion_signatures   = dependent_completions;
@@ -116,7 +116,7 @@ private:
   };
 
   template <class _Query>
-  struct __sndr_t;
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __sndr_t;
 
 public:
   /// @brief Returns a sender that, when connected to a receiver and started,
@@ -127,7 +127,7 @@ public:
 };
 
 template <class _Query>
-struct read_env_t::__sndr_t
+struct _CCCL_TYPE_VISIBILITY_DEFAULT read_env_t::__sndr_t
 {
   using sender_concept = sender_t;
   _CCCL_NO_UNIQUE_ADDRESS read_env_t __tag;

--- a/cudax/include/cuda/experimental/__async/sender/sequence.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/sequence.cuh
@@ -43,7 +43,7 @@ struct __seq
   };
 
   template <class _Zip>
-  struct __opstate
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __opstate
   {
     using operation_state_concept = operation_state_t;
 
@@ -99,14 +99,14 @@ struct __seq
   };
 
   template <class _Sndr1, class _Sndr2>
-  struct __sndr_t;
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __sndr_t;
 
   template <class _Sndr1, class _Sndr2>
   _CUDAX_API auto operator()(_Sndr1 __sndr1, _Sndr2 __sndr2) const -> __sndr_t<_Sndr1, _Sndr2>;
 };
 
 template <class _Sndr1, class _Sndr2>
-struct __seq::__sndr_t
+struct _CCCL_TYPE_VISIBILITY_DEFAULT __seq::__sndr_t
 {
   using sender_concept = sender_t;
   using __sndr1_t      = _Sndr1;

--- a/cudax/include/cuda/experimental/__async/sender/start_detached.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/start_detached.cuh
@@ -40,7 +40,7 @@ private:
   struct __opstate_base_t : __immovable
   {};
 
-  struct __rcvr_t
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __rcvr_t
   {
     using receiver_concept = receiver_t;
 
@@ -66,7 +66,7 @@ private:
   };
 
   template <class _Sndr>
-  struct __opstate_t : __opstate_base_t
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __opstate_t : __opstate_base_t
   {
     using operation_state_concept = operation_state_t;
     using completion_signatures   = __async::completion_signatures_of_t<_Sndr, __rcvr_t>;

--- a/cudax/include/cuda/experimental/__async/sender/start_on.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/start_on.cuh
@@ -52,7 +52,7 @@ private:
 #endif // !_CCCL_CUDA_COMPILER(NVCC)
 
   template <class _Rcvr, class _Sch, class _CvSndr>
-  struct __opstate_t
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __opstate_t
   {
     _CUDAX_API friend env_of_t<_Rcvr> get_env(const __opstate_t* __self) noexcept
     {
@@ -103,7 +103,7 @@ private:
   };
 
   template <class _Sch, class _Sndr>
-  struct __sndr_t;
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __sndr_t;
 
 public:
   template <class _Sch, class _Sndr>
@@ -112,7 +112,7 @@ public:
 } start_on{};
 
 template <class _Sch, class _Sndr>
-struct start_on_t::__sndr_t
+struct _CCCL_TYPE_VISIBILITY_DEFAULT start_on_t::__sndr_t
 {
   using sender_concept = sender_t;
   _CCCL_NO_UNIQUE_ADDRESS start_on_t __tag_;

--- a/cudax/include/cuda/experimental/__async/sender/sync_wait.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/sync_wait.cuh
@@ -67,7 +67,7 @@ private:
   template <class _Sndr>
   struct __state_t
   {
-    struct __rcvr_t
+    struct _CCCL_TYPE_VISIBILITY_DEFAULT __rcvr_t
     {
       using receiver_concept = receiver_t;
       __state_t* __state_;

--- a/cudax/include/cuda/experimental/__async/sender/then.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/then.cuh
@@ -126,7 +126,7 @@ private:
                                    __type_try_quote<__concat_completion_signatures>::__call>;
 
   template <class _Rcvr, class _CvSndr, class _Fn>
-  struct __opstate_t
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __opstate_t
   {
     _CUDAX_API friend env_of_t<_Rcvr> get_env(const __opstate_t* __self) noexcept
     {
@@ -213,7 +213,7 @@ private:
   };
 
   template <class _Fn, class _Sndr>
-  struct __sndr_t
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __sndr_t
   {
     using sender_concept = sender_t;
     _CCCL_NO_UNIQUE_ADDRESS _UponTag __tag_;

--- a/cudax/include/cuda/experimental/__async/sender/thread_context.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/thread_context.cuh
@@ -33,7 +33,7 @@
 
 namespace cuda::experimental::__async
 {
-struct thread_context
+struct _CCCL_TYPE_VISIBILITY_DEFAULT thread_context
 {
   thread_context() noexcept
       : __thrd_{[this] {

--- a/cudax/include/cuda/experimental/__async/sender/when_all.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/when_all.cuh
@@ -53,10 +53,10 @@ template <class>
 struct __env_t;
 
 template <class, size_t>
-struct __rcvr_t;
+struct _CCCL_TYPE_VISIBILITY_DEFAULT __rcvr_t;
 
 template <class, class, class>
-struct __opstate_t;
+struct _CCCL_TYPE_VISIBILITY_DEFAULT __opstate_t;
 
 using __tombstone = _ERROR<_WHERE(_IN_ALGORITHM, when_all_t), _WHAT(_SENDER_HAS_TOO_MANY_SUCCESS_COMPLETIONS)>;
 
@@ -322,7 +322,7 @@ struct __env_t
 };
 
 template <class _StateZip, size_t _Index>
-struct __rcvr_t
+struct _CCCL_TYPE_VISIBILITY_DEFAULT __rcvr_t
 {
   using receiver_concept = receiver_t;
   using __state_t        = __unzip<_StateZip>;
@@ -524,7 +524,7 @@ struct __state_t<_Rcvr, _CvFn, __tupl<_CUDA_VSTD::index_sequence<_Idx...>, _Sndr
 
 /// The operation state for when_all
 template <class _Rcvr, class _CvFn, size_t... _Idx, class... _Sndrs>
-struct __opstate_t<_Rcvr, _CvFn, __tupl<_CUDA_VSTD::index_sequence<_Idx...>, _Sndrs...>>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT __opstate_t<_Rcvr, _CvFn, __tupl<_CUDA_VSTD::index_sequence<_Idx...>, _Sndrs...>>
 {
   using operation_state_concept = operation_state_t;
   using __sndrs_t               = _CUDA_VSTD::__type_call<_CvFn, __tuple<_Sndrs...>>;
@@ -605,7 +605,7 @@ struct __opstate_t<_Rcvr, _CvFn, __tupl<_CUDA_VSTD::index_sequence<_Idx...>, _Sn
 };
 
 template <class... _Sndrs>
-struct __sndr_t;
+struct _CCCL_TYPE_VISIBILITY_DEFAULT __sndr_t;
 } // namespace __when_all
 
 struct when_all_t
@@ -616,7 +616,7 @@ struct when_all_t
 
 // The sender for when_all
 template <class... _Sndrs>
-struct __when_all::__sndr_t
+struct _CCCL_TYPE_VISIBILITY_DEFAULT __when_all::__sndr_t
 {
   using sender_concept = sender_t;
   using __sndrs_t      = __tuple<_Sndrs...>;

--- a/cudax/include/cuda/experimental/__async/sender/write_env.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/write_env.cuh
@@ -41,7 +41,7 @@ private:
 #endif // !_CCCL_CUDA_COMPILER(NVCC)
 
   template <class _Rcvr, class _Sndr, class _Env>
-  struct __opstate_t
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __opstate_t
   {
     using operation_state_concept = operation_state_t;
     using completion_signatures   = completion_signatures_of_t<_Sndr, __rcvr_with_env_t<_Rcvr, _Env>*>;
@@ -63,7 +63,7 @@ private:
   };
 
   template <class _Sndr, class _Env>
-  struct __sndr_t;
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __sndr_t;
 
 public:
   /// @brief Wraps one sender in another that modifies the execution
@@ -74,7 +74,7 @@ public:
 };
 
 template <class _Sndr, class _Env>
-struct write_env_t::__sndr_t
+struct _CCCL_TYPE_VISIBILITY_DEFAULT write_env_t::__sndr_t
 {
   using sender_concept = sender_t;
   _CCCL_NO_UNIQUE_ADDRESS write_env_t __tag_;


### PR DESCRIPTION
## Description

This should fix the build break seen by @alliepiper on #3544 and unblock the switch to use CTK 12.8 in CI

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
