### PR TITLE
Fixes value type of `thrust::tabulate_output_iterator`

### DIFF
--- a/thrust/thrust/iterator/detail/tabulate_output_iterator.inl
+++ b/thrust/thrust/iterator/detail/tabulate_output_iterator.inl
@@ -53,7 +53,7 @@ template <typename BinaryFunction, typename System, typename DifferenceT>
 using tabulate_output_iterator_base =
   thrust::iterator_adaptor<tabulate_output_iterator<BinaryFunction, System, DifferenceT>,
                            counting_iterator<DifferenceT>,
-                           thrust::use_default,
+                           void,
                            System,
                            thrust::use_default,
                            tabulate_output_iterator_proxy<BinaryFunction, DifferenceT>>;


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
The value type of `thrust::tabulate_output_iterator` should be void.  <!-- Link issue here -->
Otherwise, this may lead to issues for algorithms that query the return type of the output iterator, e.g., to infer the accumulator type, like `cub::DeviceSegmentedReduce` does.

