### PR TITLE
Tune select/partition on items per thread

### DIFF
--- a/cub/benchmarks/bench/partition/flagged.cu
+++ b/cub/benchmarks/bench/partition/flagged.cu
@@ -61,14 +61,9 @@ struct policy_hub_t
 {
   struct policy_t : cub::ChainedPolicy<300, policy_t, policy_t>
   {
-    static constexpr int NOMINAL_4B_ITEMS_PER_THREAD = TUNE_ITEMS_PER_THREAD;
-
-    static constexpr int ITEMS_PER_THREAD =
-      _CUDA_VSTD::clamp(NOMINAL_4B_ITEMS_PER_THREAD * 4 / sizeof(InputT), 1, NOMINAL_4B_ITEMS_PER_THREAD);
-
     using SelectIfPolicyT =
       cub::AgentSelectIfPolicy<TUNE_THREADS_PER_BLOCK,
-                               ITEMS_PER_THREAD,
+                               TUNE_ITEMS_PER_THREAD,
                                TUNE_LOAD_ALGORITHM,
                                TUNE_LOAD_MODIFIER,
                                cub::BLOCK_SCAN_WARP_SCANS,

--- a/cub/benchmarks/bench/partition/if.cu
+++ b/cub/benchmarks/bench/partition/if.cu
@@ -61,14 +61,9 @@ struct policy_hub_t
 {
   struct policy_t : cub::ChainedPolicy<300, policy_t, policy_t>
   {
-    static constexpr int NOMINAL_4B_ITEMS_PER_THREAD = TUNE_ITEMS_PER_THREAD;
-
-    static constexpr int ITEMS_PER_THREAD =
-      _CUDA_VSTD::clamp(NOMINAL_4B_ITEMS_PER_THREAD * 4 / sizeof(InputT), 1, NOMINAL_4B_ITEMS_PER_THREAD);
-
     using SelectIfPolicyT =
       cub::AgentSelectIfPolicy<TUNE_THREADS_PER_BLOCK,
-                               ITEMS_PER_THREAD,
+                               TUNE_ITEMS_PER_THREAD,
                                TUNE_LOAD_ALGORITHM,
                                TUNE_LOAD_MODIFIER,
                                cub::BLOCK_SCAN_WARP_SCANS,

--- a/cub/benchmarks/bench/select/flagged.cu
+++ b/cub/benchmarks/bench/select/flagged.cu
@@ -60,14 +60,9 @@ struct policy_hub_t
 {
   struct policy_t : cub::ChainedPolicy<300, policy_t, policy_t>
   {
-    static constexpr int NOMINAL_4B_ITEMS_PER_THREAD = TUNE_ITEMS_PER_THREAD;
-
-    static constexpr int ITEMS_PER_THREAD =
-      _CUDA_VSTD::clamp(NOMINAL_4B_ITEMS_PER_THREAD * 4 / sizeof(InputT), 1, NOMINAL_4B_ITEMS_PER_THREAD);
-
     using SelectIfPolicyT =
       cub::AgentSelectIfPolicy<TUNE_THREADS_PER_BLOCK,
-                               ITEMS_PER_THREAD,
+                               TUNE_ITEMS_PER_THREAD,
                                TUNE_LOAD_ALGORITHM,
                                TUNE_LOAD_MODIFIER,
                                cub::BLOCK_SCAN_WARP_SCANS,

--- a/cub/benchmarks/bench/select/if.cu
+++ b/cub/benchmarks/bench/select/if.cu
@@ -62,14 +62,9 @@ struct policy_hub_t
 {
   struct policy_t : cub::ChainedPolicy<300, policy_t, policy_t>
   {
-    static constexpr int NOMINAL_4B_ITEMS_PER_THREAD = TUNE_ITEMS_PER_THREAD;
-
-    static constexpr int ITEMS_PER_THREAD =
-      _CUDA_VSTD::clamp(NOMINAL_4B_ITEMS_PER_THREAD * 4 / sizeof(InputT), 1, NOMINAL_4B_ITEMS_PER_THREAD);
-
     using SelectIfPolicyT =
       cub::AgentSelectIfPolicy<TUNE_THREADS_PER_BLOCK,
-                               ITEMS_PER_THREAD,
+                               TUNE_ITEMS_PER_THREAD,
                                TUNE_LOAD_ALGORITHM,
                                TUNE_LOAD_MODIFIER,
                                cub::BLOCK_SCAN_WARP_SCANS,

--- a/cub/benchmarks/bench/select/unique.cu
+++ b/cub/benchmarks/bench/select/unique.cu
@@ -36,14 +36,9 @@ struct policy_hub_t
 {
   struct policy_t : cub::ChainedPolicy<300, policy_t, policy_t>
   {
-    static constexpr int NOMINAL_4B_ITEMS_PER_THREAD = TUNE_ITEMS_PER_THREAD;
-
-    static constexpr int ITEMS_PER_THREAD = _CUDA_VSTD::min(
-      NOMINAL_4B_ITEMS_PER_THREAD, _CUDA_VSTD::max(1, (NOMINAL_4B_ITEMS_PER_THREAD * 4 / sizeof(InputT))));
-
     using SelectIfPolicyT =
       cub::AgentSelectIfPolicy<TUNE_THREADS_PER_BLOCK,
-                               ITEMS_PER_THREAD,
+                               TUNE_ITEMS_PER_THREAD,
                                TUNE_LOAD_ALGORITHM,
                                TUNE_LOAD_MODIFIER,
                                cub::BLOCK_SCAN_WARP_SCANS,


### PR DESCRIPTION
Instead of nominal 4b items per thread, which caused confusion when creating tuning policies later.