### PR TITLE
Add Python wrappers for c.parallel scan API

### DIFF
--- a/python/cuda_parallel/cuda/parallel/experimental/_bindings.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/_bindings.py
@@ -11,8 +11,6 @@ from typing import List
 
 from cuda.cccl import get_include_paths  # type: ignore[import-not-found]
 
-from . import _cccl as cccl
-
 
 @lru_cache()
 def get_bindings() -> ctypes.CDLL:
@@ -32,19 +30,6 @@ def get_bindings() -> ctypes.CDLL:
         else:
             raise RuntimeError(f"Unable to locate {so_path}")
     _bindings = ctypes.CDLL(str(cccl_c_path))
-    _bindings.cccl_device_reduce.restype = ctypes.c_int
-    _bindings.cccl_device_reduce.argtypes = [
-        cccl.DeviceReduceBuildResult,
-        ctypes.c_void_p,
-        ctypes.POINTER(ctypes.c_ulonglong),
-        cccl.Iterator,
-        cccl.Iterator,
-        ctypes.c_ulonglong,
-        cccl.Op,
-        cccl.Value,
-        ctypes.c_void_p,
-    ]
-    _bindings.cccl_device_reduce_cleanup.restype = ctypes.c_int
     return _bindings
 
 

--- a/python/cuda_parallel/cuda/parallel/experimental/_caching.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/_caching.py
@@ -49,10 +49,12 @@ class CachableFunction:
 
     def __init__(self, func):
         self._func = func
+
+        closure = func.__closure__ if func.__closure__ is not None else []
         self._identity = (
-            self._func.__code__.co_code,
-            self._func.__code__.co_consts,
-            self._func.__closure__,
+            func.__code__.co_code,
+            func.__code__.co_consts,
+            tuple(cell.cell_contents for cell in closure),
         )
 
     def __eq__(self, other):

--- a/python/cuda_parallel/cuda/parallel/experimental/_cccl.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/_cccl.py
@@ -93,6 +93,21 @@ class DeviceReduceBuildResult(ctypes.Structure):
     ]
 
 
+# MUST match `cccl_device_scan_build_result_t` in c/include/cccl/c/scan.h
+class DeviceScanBuildResult(ctypes.Structure):
+    _fields_ = [
+        ("cc", ctypes.c_int),
+        ("cubin", ctypes.c_void_p),
+        ("cubin_size", ctypes.c_size_t),
+        ("library", ctypes.c_void_p),
+        ("accumulator_type", TypeInfo),
+        ("init_kernel", ctypes.c_void_p),
+        ("scan_kernel", ctypes.c_void_p),
+        ("description_bytes_per_tile", ctypes.c_size_t),
+        ("payload_bytes_per_tile", ctypes.c_size_t),
+    ]
+
+
 # MUST match `cccl_value_t` in c/include/cccl/c/types.h
 class Value(ctypes.Structure):
     _fields_ = [("type", TypeInfo), ("state", ctypes.c_void_p)]

--- a/python/cuda_parallel/cuda/parallel/experimental/algorithms/__init__.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/algorithms/__init__.py
@@ -4,3 +4,4 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from .reduce import reduce_into as reduce_into
+from .scan import scan as scan

--- a/python/cuda_parallel/cuda/parallel/experimental/algorithms/reduce.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/algorithms/reduce.py
@@ -99,14 +99,14 @@ class _Reduce:
 
         error = self.bindings.cccl_device_reduce(
             self.build_result,
-            d_temp_storage,
+            ctypes.c_void_p(d_temp_storage),
             ctypes.byref(temp_storage_bytes),
             self.d_in_cccl,
             self.d_out_cccl,
             ctypes.c_ulonglong(num_items),
             self.op_wrapper,
             self.h_init_cccl,
-            stream_handle,
+            ctypes.c_void_p(stream_handle),
         )
 
         if error != enums.CUDA_SUCCESS:

--- a/python/cuda_parallel/cuda/parallel/experimental/algorithms/reduce.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/algorithms/reduce.py
@@ -145,10 +145,10 @@ def reduce_into(
     op: Callable,
     h_init: np.ndarray,
 ):
-    """Computes a device-wide reduction using the specified binary ``op`` functor and initial value ``init``.
+    """Computes a device-wide reduction using the specified binary ``op`` and initial value ``init``.
 
     Example:
-        The code snippet below demonstrates the usage of the ``reduce_into`` API:
+        Below, ``reduce_into`` is used to compute the minimum value of a sequence of integers.
 
         .. literalinclude:: ../../python/cuda_parallel/tests/test_reduce_api.py
             :language: python
@@ -157,9 +157,9 @@ def reduce_into(
             :end-before: example-end reduce-min
 
     Args:
-        d_in: CUDA device array storing the input sequence of data items
-        d_out: CUDA device array storing the output aggregate
-        op: Binary reduction
+        d_in: Device array or iterator containing the input sequence of data items
+        d_out: Device array (of size 1) that will store the result of the reduction
+        op: Callable representing the binary operator to apply
         init: Numpy array storing initial value of the reduction
 
     Returns:

--- a/python/cuda_parallel/cuda/parallel/experimental/algorithms/scan.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/algorithms/scan.py
@@ -142,4 +142,24 @@ def scan(
     op: Callable,
     h_init: np.ndarray,
 ):
+    """Computes a device-wide scan using the specified binary ``op`` and initial value ``init``.
+
+    Example:
+        Below, ``scan`` is used to compute an exclusive scan of a sequence of integers.
+
+        .. literalinclude:: ../../python/cuda_parallel/tests/test_scan_api.py
+          :language: python
+          :dedent:
+          :start-after: example-begin scan-max
+          :end-before: example-end scan-max
+
+    Args:
+        d_in: Device array or iterator containing the input sequence of data items
+        d_out: Device array that will store the result of the scan
+        op: Callable representing the binary operator to apply
+        init: Numpy array storing initial value of the scan
+
+    Returns:
+        A callable object that can be used to perform the scan
+    """
     return _Scan(d_in, d_out, op, h_init)

--- a/python/cuda_parallel/cuda/parallel/experimental/algorithms/scan.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/algorithms/scan.py
@@ -1,0 +1,145 @@
+# Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from __future__ import annotations  # TODO: required for Python 3.7 docs env
+
+import ctypes
+from typing import Callable
+
+import numba
+import numpy as np
+from numba import cuda
+from numba.cuda.cudadrv import enums
+
+from .. import _cccl as cccl
+from .._bindings import get_bindings, get_paths
+from .._caching import CachableFunction, cache_with_key
+from .._utils import protocols
+from ..iterators._iterators import IteratorBase
+from ..typing import DeviceArrayLike, GpuStruct
+
+
+class _Scan:
+    # TODO: constructor shouldn't require concrete `d_in`, `d_out`:
+    def __init__(
+        self,
+        d_in: DeviceArrayLike | IteratorBase,
+        d_out: DeviceArrayLike | IteratorBase,
+        op: Callable,
+        h_init: np.ndarray | GpuStruct,
+    ):
+        # Referenced from __del__:
+        self.build_result = None
+
+        self.d_in_cccl = cccl.to_cccl_iter(d_in)
+        self.d_out_cccl = cccl.to_cccl_iter(d_out)
+        self.h_init_cccl = cccl.to_cccl_value(h_init)
+        cc_major, cc_minor = cuda.get_current_device().compute_capability
+        cub_path, thrust_path, libcudacxx_path, cuda_include_path = get_paths()
+        if isinstance(h_init, np.ndarray):
+            value_type = numba.from_dtype(h_init.dtype)
+        else:
+            value_type = numba.typeof(h_init)
+        sig = (value_type, value_type)
+        self.op_wrapper = cccl.to_cccl_op(op, sig)
+        self.build_result = cccl.DeviceScanBuildResult()
+        self.bindings = get_bindings()
+        error = self.bindings.cccl_device_scan_build(
+            ctypes.byref(self.build_result),
+            self.d_in_cccl,
+            self.d_out_cccl,
+            self.op_wrapper,
+            cccl.to_cccl_value(h_init),
+            cc_major,
+            cc_minor,
+            ctypes.c_char_p(cub_path),
+            ctypes.c_char_p(thrust_path),
+            ctypes.c_char_p(libcudacxx_path),
+            ctypes.c_char_p(cuda_include_path),
+        )
+        if error != enums.CUDA_SUCCESS:
+            raise ValueError("Error building scan")
+
+    def __call__(
+        self,
+        temp_storage,
+        d_in,
+        d_out,
+        num_items: int,
+        h_init: np.ndarray | GpuStruct,
+        stream=None,
+    ):
+        if self.d_in_cccl.type.value == cccl.IteratorKind.POINTER:
+            self.d_in_cccl.state = protocols.get_data_pointer(d_in)
+        else:
+            self.d_in_cccl.state = d_in.state
+
+        if self.d_out_cccl.type.value == cccl.IteratorKind.POINTER:
+            self.d_out_cccl.state = protocols.get_data_pointer(d_out)
+        else:
+            self.d_out_cccl.state = d_out.state
+
+        self.h_init_cccl.state = h_init.__array_interface__["data"][0]
+
+        stream_handle = protocols.validate_and_get_stream(stream)
+
+        if temp_storage is None:
+            temp_storage_bytes = ctypes.c_size_t()
+            d_temp_storage = None
+        else:
+            temp_storage_bytes = ctypes.c_size_t(temp_storage.nbytes)
+            d_temp_storage = protocols.get_data_pointer(temp_storage)
+
+        error = self.bindings.cccl_device_scan(
+            self.build_result,
+            ctypes.c_void_p(d_temp_storage),
+            ctypes.byref(temp_storage_bytes),
+            self.d_in_cccl,
+            self.d_out_cccl,
+            ctypes.c_ulonglong(num_items),
+            self.op_wrapper,
+            self.h_init_cccl,
+            ctypes.c_void_p(stream_handle),
+        )
+
+        if error != enums.CUDA_SUCCESS:
+            raise ValueError("Error reducing")
+
+        return temp_storage_bytes.value
+
+    def __del__(self):
+        if self.build_result is None:
+            return
+        bindings = get_bindings()
+        bindings.cccl_device_scan_cleanup(ctypes.byref(self.build_result))
+
+
+def make_cache_key(
+    d_in: DeviceArrayLike | IteratorBase,
+    d_out: DeviceArrayLike | IteratorBase,
+    op: Callable,
+    h_init: np.ndarray,
+):
+    d_in_key = (
+        d_in.kind if isinstance(d_in, IteratorBase) else protocols.get_dtype(d_in)
+    )
+    d_out_key = (
+        d_out.kind if isinstance(d_out, IteratorBase) else protocols.get_dtype(d_out)
+    )
+    op_key = CachableFunction(op)
+    h_init_key = h_init.dtype
+    return (d_in_key, d_out_key, op_key, h_init_key)
+
+
+# TODO Figure out `sum` without operator and initial value
+# TODO Accept stream
+@cache_with_key(make_cache_key)
+def scan(
+    d_in: DeviceArrayLike | IteratorBase,
+    d_out: DeviceArrayLike | IteratorBase,
+    op: Callable,
+    h_init: np.ndarray,
+):
+    return _Scan(d_in, d_out, op, h_init)

--- a/python/cuda_parallel/tests/conftest.py
+++ b/python/cuda_parallel/tests/conftest.py
@@ -1,0 +1,59 @@
+import cupy as cp
+import numpy as np
+import pytest
+
+
+# Define a pytest fixture that returns random arrays with different dtypes
+@pytest.fixture(
+    params=[
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.float32,
+        np.float64,
+        np.complex128,
+    ]
+)
+def input_array(request):
+    dtype = request.param
+
+    # Generate random values based on the dtype
+    if np.issubdtype(dtype, np.integer):
+        # For integer types, use np.random.randint for random integers
+        array = cp.random.randint(low=0, high=10, size=1000, dtype=dtype)
+    elif np.issubdtype(dtype, np.floating):
+        # For floating-point types, use np.random.random and cast to the required dtype
+        array = cp.random.random(1000).astype(dtype)
+    elif np.issubdtype(dtype, np.complexfloating):
+        # For complex types, generate random real and imaginary parts
+        real_part = cp.random.random(1000)
+        imag_part = cp.random.random(1000)
+        array = (real_part + 1j * imag_part).astype(dtype)
+
+    return array
+
+
+class Stream:
+    """
+    Simple cupy stream wrapper that implements the __cuda_stream__ protocol.
+    """
+
+    def __init__(self, cp_stream):
+        self.cp_stream = cp_stream
+
+    def __cuda_stream__(self):
+        return (0, self.cp_stream.ptr)
+
+    @property
+    def ptr(self):
+        return self.cp_stream.ptr
+
+
+@pytest.fixture(scope="function")
+def cuda_stream() -> Stream:
+    return Stream(cp.cuda.Stream())

--- a/python/cuda_parallel/tests/test_scan.py
+++ b/python/cuda_parallel/tests/test_scan.py
@@ -1,0 +1,115 @@
+# Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+
+import cupy as cp
+import numba.cuda
+import numba.types
+import numpy as np
+
+import cuda.parallel.experimental.algorithms as algorithms
+import cuda.parallel.experimental.iterators as iterators
+from cuda.parallel.experimental.struct import gpu_struct
+
+
+def exclusive_scan_host(h_input: np.ndarray, op, h_init):
+    result = h_input.copy()
+    result[0] = h_init[0]
+    for i in range(1, len(result)):
+        result[i] = op(result[i - 1], h_input[i - 1])
+    return result
+
+
+def exclusive_scan_device(d_input, d_output, num_items, op, h_init, stream=None):
+    scan = algorithms.scan(d_input, d_output, op, h_init)
+    temp_storage_size = scan(None, d_input, d_output, num_items, h_init, stream=stream)
+    d_temp_storage = numba.cuda.device_array(
+        temp_storage_size, dtype=np.uint8, stream=stream.ptr if stream else 0
+    )
+    scan(d_temp_storage, d_input, d_output, num_items, h_init, stream=stream)
+
+
+def test_scan_array_input(input_array):
+    def op(a, b):
+        return a + b
+
+    d_input = input_array
+    dtype = d_input.dtype
+    h_init = np.array([42], dtype=dtype)
+    d_output = cp.empty(len(d_input), dtype=dtype)
+
+    exclusive_scan_device(d_input, d_output, len(d_input), op, h_init)
+
+    got = d_output.get()
+    expected = exclusive_scan_host(d_input.get(), op, h_init)
+
+    np.testing.assert_allclose(expected, got, rtol=1e-5)
+
+
+def test_scan_iterator_input():
+    def op(a, b):
+        return a + b
+
+    d_input = iterators.CountingIterator(np.int32(1))
+    num_items = 1024
+    dtype = np.dtype("int32")
+    h_init = np.array([42], dtype=dtype)
+    d_output = cp.empty(num_items, dtype=dtype)
+
+    exclusive_scan_device(d_input, d_output, num_items, op, h_init)
+
+    got = d_output.get()
+    expected = exclusive_scan_host(np.arange(1, num_items + 1, dtype=dtype), op, h_init)
+
+    np.testing.assert_allclose(expected, got, rtol=1e-5)
+
+
+def test_scan_struct_type():
+    @gpu_struct
+    class XY:
+        x: np.int32
+        y: np.int32
+
+    def op(a, b):
+        return XY(a.x + b.x, a.y + b.y)
+
+    d_input = cp.random.randint(0, 256, (10, 2), dtype=np.int32).view(XY.dtype)
+    d_output = cp.empty_like(d_input)
+
+    h_init = XY(0, 0)
+
+    exclusive_scan_device(d_input, d_output, len(d_input), op, h_init)
+
+    got = d_output.get()
+    expected_x = exclusive_scan_host(
+        d_input.get()["x"], lambda a, b: a + b, np.asarray([h_init.x])
+    )
+    expected_y = exclusive_scan_host(
+        d_input.get()["y"], lambda a, b: a + b, np.asarray([h_init.y])
+    )
+
+    np.testing.assert_allclose(expected_x, got["x"], rtol=1e-5)
+    np.testing.assert_allclose(expected_y, got["y"], rtol=1e-5)
+
+
+def test_scan_with_stream(cuda_stream):
+    def op(a, b):
+        return a + b
+
+    cp_stream = cp.cuda.ExternalStream(cuda_stream.ptr)
+
+    with cp_stream:
+        d_input = cp.random.randint(0, 256, 1024, dtype=np.int32)
+        d_output = cp.empty_like(d_input)
+
+    h_init = np.array([42], dtype=np.int32)
+
+    exclusive_scan_device(
+        d_input, d_output, len(d_input), op, h_init, stream=cuda_stream
+    )
+
+    got = d_output.get()
+    expected = exclusive_scan_host(d_input.get(), op, h_init)
+
+    np.testing.assert_allclose(expected, got, rtol=1e-5)

--- a/python/cuda_parallel/tests/test_scan_api.py
+++ b/python/cuda_parallel/tests/test_scan_api.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+
+def test_scan_max():
+    # example-begin scan-max
+    import cupy as cp
+    import numpy as np
+
+    import cuda.parallel.experimental.algorithms as algorithms
+
+    def max_op(a, b):
+        return max(a, b)
+
+    h_init = np.array([1], dtype="int32")
+    d_input = cp.array([-5, 0, 2, -3, 2, 4, 0, -1, 2, 8], dtype="int32")
+    d_output = cp.empty_like(d_input, dtype="int32")
+
+    # Instantiate scan for the given operator and initial value
+    scanner = algorithms.scan(d_output, d_output, max_op, h_init)
+
+    # Determine temporary device storage requirements
+    temp_storage_size = scanner(None, d_input, d_output, d_input.size, h_init)
+
+    # Allocate temporary storage
+    d_temp_storage = cp.empty(temp_storage_size, dtype=np.uint8)
+
+    # Run reduction
+    scanner(d_temp_storage, d_input, d_output, d_input.size, h_init)
+
+    # Check the result is correct
+    expected = np.asarray([1, 1, 1, 2, 2, 2, 4, 4, 4, 4])
+    np.testing.assert_equal(d_output.get(), expected)
+    # example-end scan-max


### PR DESCRIPTION
## Description

Closes https://github.com/NVIDIA/cccl/issues/3458

Adds Python wrappers for the c.parallel scan API. Note to reviewers: it might be eaier to review this PR by commit.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
