### PR TITLE
Modernize MSVC 2005/nvcc workaround

### DIFF
--- a/thrust/thrust/system/cuda/detail/get_value.h
+++ b/thrust/thrust/system/cuda/detail/get_value.h
@@ -38,51 +38,27 @@
 THRUST_NAMESPACE_BEGIN
 namespace cuda_cub
 {
-
-namespace
-{
-
 template <typename DerivedPolicy, typename Pointer>
-inline _CCCL_HOST_DEVICE typename thrust::iterator_value<Pointer>::type
-get_value_msvc2005_war(execution_policy<DerivedPolicy>& exec, Pointer ptr)
+_CCCL_HOST_DEVICE iterator_value_t<Pointer> get_value(execution_policy<DerivedPolicy>& exec, Pointer ptr)
 {
-  using result_type = typename thrust::iterator_value<Pointer>::type;
-
-  // XXX war nvbugs/881631
-  struct war_nvbugs_881631
+  // Because of https://docs.nvidia.com/cuda/cuda-c-programming-guide/#cuda-arch point 2., if a call from a __host__
+  // __device__ function leads to the template instantiation of a __global__ function, then this instantiation needs to
+  // happen regardless of whether __CUDA_ARCH__ is defined. Therefore, we make the host path visible outside the
+  // NV_IF_TARGET switch. See also NVBug 881631.
+  struct HostPath
   {
-    _CCCL_HOST inline static result_type host_path(execution_policy<DerivedPolicy>& exec, Pointer ptr)
+    _CCCL_HOST auto operator()(execution_policy<DerivedPolicy>& exec, Pointer ptr)
     {
-      // when called from host code, implement with assign_value
-      // note that this requires a type with default constructor
-      result_type result;
-
-      thrust::host_system_tag host_tag;
-      cross_system<thrust::host_system_tag, DerivedPolicy> systems(host_tag, exec);
+      // implemented with assign_value, which requires a type with a default constructor
+      iterator_value_t<Pointer> result;
+      host_system_tag host_tag;
+      cross_system<host_system_tag, DerivedPolicy> systems(host_tag, exec);
       assign_value(systems, &result, ptr);
-
       return result;
     }
-
-    _CCCL_DEVICE inline static result_type device_path(execution_policy<DerivedPolicy>&, Pointer ptr)
-    {
-      // when called from device code, just do simple deref
-      return *thrust::raw_pointer_cast(ptr);
-    }
   };
-
-  NV_IF_TARGET(
-    NV_IS_HOST, (return war_nvbugs_881631::host_path(exec, ptr);), (return war_nvbugs_881631::device_path(exec, ptr);))
-} // end get_value_msvc2005_war()
-} // namespace
-
-template <typename DerivedPolicy, typename Pointer>
-inline _CCCL_HOST_DEVICE typename thrust::iterator_value<Pointer>::type
-get_value(execution_policy<DerivedPolicy>& exec, Pointer ptr)
-{
-  return get_value_msvc2005_war(exec, ptr);
-} // end get_value()
-
+  NV_IF_TARGET(NV_IS_DEVICE, return *thrust::raw_pointer_cast(ptr);, (return HostPath{}(exec, ptr);))
+}
 } // namespace cuda_cub
 THRUST_NAMESPACE_END
 


### PR DESCRIPTION
I removed this workaround while trying to address #3591. It can avoid some corner cases.