### PR TITLE
Add b200 tunings for radix_sort.keys

### DIFF
--- a/cub/cub/device/dispatch/tuning/tuning_radix_sort.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_radix_sort.cuh
@@ -50,7 +50,7 @@ namespace detail
 {
 namespace radix
 {
-// default
+// sm90 default
 template <std::size_t KeySize, std::size_t ValueSize, std::size_t OffsetSize>
 struct sm90_small_key_tuning
 {
@@ -89,6 +89,60 @@ template <> struct sm90_small_key_tuning<2,  8, 4> { static constexpr int thread
 template <> struct sm90_small_key_tuning<2,  8, 8> { static constexpr int threads = 512; static constexpr int items = 23; };
 template <> struct sm90_small_key_tuning<2, 16, 4> { static constexpr int threads = 512; static constexpr int items = 21; };
 template <> struct sm90_small_key_tuning<2, 16, 8> { static constexpr int threads = 576; static constexpr int items = 22; };
+// clang-format on
+
+// sm100 default
+template <typename ValueT, std::size_t KeySize, std::size_t ValueSize, std::size_t OffsetSize>
+struct sm100_small_key_tuning : sm90_small_key_tuning<KeySize, ValueSize, OffsetSize>
+{};
+
+// clang-format off
+
+// keys
+
+// same as previous tuning
+template <typename ValueT> struct sm100_small_key_tuning<ValueT, 1,  0, 4> : sm90_small_key_tuning<1, 0, 4> {};
+
+// ipt_20.tpb_512 1.013282  0.967525  1.015764  1.047982
+// todo(@gonidelis): insignificant performance gain, need more runs.
+template <typename ValueT> struct sm100_small_key_tuning<ValueT, 2,  0, 4> { static constexpr int threads = 512; static constexpr int items = 20; };
+
+// ipt_21.tpb_512 1.002873  0.994608  1.004196  1.019301
+// todo(@gonidelis): insignificant performance gain, need more runs.
+template <typename ValueT> struct sm100_small_key_tuning<ValueT, 4,  0, 4> { static constexpr int threads = 512; static constexpr int items = 21; };
+
+// ipt_14.tpb_320 1.256020  1.000000  1.228182  1.486711
+template <typename ValueT> struct sm100_small_key_tuning<ValueT, 8,  0, 4> { static constexpr int threads = 320; static constexpr int items = 14; };
+
+// same as previous tuning
+template <typename ValueT> struct sm100_small_key_tuning<ValueT, 16,  0, 4> : sm90_small_key_tuning<16, 0, 4> {};
+
+// ipt_20.tpb_512 1.089698  0.979276  1.079822  1.199378
+template <> struct sm100_small_key_tuning<float, 4,  0, 4> { static constexpr int threads = 512; static constexpr int items = 20; };
+
+// ipt_18.tpb_288 1.049258  0.985085  1.042400  1.107771
+template <> struct sm100_small_key_tuning<double, 8,  0, 4> { static constexpr int threads = 288; static constexpr int items = 18; };
+
+// same as previous tuning
+template <typename ValueT> struct sm100_small_key_tuning<ValueT, 1,  0, 8> : sm90_small_key_tuning<1, 0, 8> {};
+
+// ipt_20.tpb_384 1.038445  1.015608  1.037620  1.068105
+template <typename ValueT> struct sm100_small_key_tuning<ValueT, 2,  0, 8> { static constexpr int threads = 384; static constexpr int items = 20; };
+
+// same as previous tuning
+template <typename ValueT> struct sm100_small_key_tuning<ValueT, 4,  0, 8> : sm90_small_key_tuning<4, 0, 8> {};
+
+// ipt_18.tpb_320 1.248354  1.000000  1.220666  1.446929
+template <typename ValueT> struct sm100_small_key_tuning<ValueT, 8,  0, 8> { static constexpr int threads = 320; static constexpr int items = 18; };
+
+// same as previous tuning
+template <typename ValueT> struct sm100_small_key_tuning<ValueT, 16,  0, 8> : sm90_small_key_tuning<16, 0, 8> {};
+
+// ipt_20.tpb_512 1.021557  0.981437  1.018920  1.039977
+template <> struct sm100_small_key_tuning<float, 4,  0, 8> { static constexpr int threads = 512; static constexpr int items = 20; };
+
+// ipt_21.tpb_256 1.068590  0.986635  1.059704  1.144921
+template <> struct sm100_small_key_tuning<double, 8,  0, 8> { static constexpr int threads = 256; static constexpr int items = 21; };
 // clang-format on
 
 /**
@@ -800,7 +854,130 @@ struct policy_hub
       SEGMENTED_RADIX_BITS - 1>;
   };
 
-  using MaxPolicy = Policy900;
+  // todo(@gonidelis): refactor this as to not duplicate SM90.
+  struct Policy1000 : ChainedPolicy<1000, Policy1000, Policy900>
+  {
+    static constexpr bool ONESWEEP           = true;
+    static constexpr int ONESWEEP_RADIX_BITS = 8;
+
+    using HistogramPolicy    = AgentRadixSortHistogramPolicy<128, 16, 1, KeyT, ONESWEEP_RADIX_BITS>;
+    using ExclusiveSumPolicy = AgentRadixSortExclusiveSumPolicy<256, ONESWEEP_RADIX_BITS>;
+
+  private:
+    static constexpr int PRIMARY_RADIX_BITS     = (sizeof(KeyT) > 1) ? 7 : 5;
+    static constexpr int SINGLE_TILE_RADIX_BITS = (sizeof(KeyT) > 1) ? 6 : 5;
+    static constexpr int SEGMENTED_RADIX_BITS   = (sizeof(KeyT) > 1) ? 6 : 5;
+    static constexpr int OFFSET_64BIT           = sizeof(OffsetT) == 8 ? 1 : 0;
+    static constexpr int FLOAT_KEYS             = ::cuda::std::is_same<KeyT, float>::value ? 1 : 0;
+
+    using OnesweepPolicyKey32 = AgentRadixSortOnesweepPolicy<
+      384,
+      KEYS_ONLY ? 20 - OFFSET_64BIT - FLOAT_KEYS
+                : (sizeof(ValueT) < 8 ? (OFFSET_64BIT ? 17 : 23) : (OFFSET_64BIT ? 29 : 30)),
+      DominantT,
+      1,
+      RADIX_RANK_MATCH_EARLY_COUNTS_ANY,
+      BLOCK_SCAN_RAKING_MEMOIZE,
+      RADIX_SORT_STORE_DIRECT,
+      ONESWEEP_RADIX_BITS>;
+
+    using OnesweepPolicyKey64 = AgentRadixSortOnesweepPolicy<
+      384,
+      sizeof(ValueT) < 8 ? 30 : 24,
+      DominantT,
+      1,
+      RADIX_RANK_MATCH_EARLY_COUNTS_ANY,
+      BLOCK_SCAN_RAKING_MEMOIZE,
+      RADIX_SORT_STORE_DIRECT,
+      ONESWEEP_RADIX_BITS>;
+
+    using OnesweepLargeKeyPolicy = ::cuda::std::_If<sizeof(KeyT) == 4, OnesweepPolicyKey32, OnesweepPolicyKey64>;
+
+    using OnesweepSmallKeyPolicySizes =
+      sm100_small_key_tuning<ValueT, sizeof(KeyT), KEYS_ONLY ? 0 : sizeof(ValueT), sizeof(OffsetT)>;
+
+    using OnesweepSmallKeyPolicy = AgentRadixSortOnesweepPolicy<
+      OnesweepSmallKeyPolicySizes::threads,
+      OnesweepSmallKeyPolicySizes::items,
+      DominantT,
+      1,
+      RADIX_RANK_MATCH_EARLY_COUNTS_ANY,
+      BLOCK_SCAN_RAKING_MEMOIZE,
+      RADIX_SORT_STORE_DIRECT,
+      8>;
+
+  public:
+    using OnesweepPolicy = ::cuda::std::_If<sizeof(KeyT) < 4, OnesweepSmallKeyPolicy, OnesweepLargeKeyPolicy>;
+
+    // The Scan, Downsweep and Upsweep policies are never run on SM90, but we have to include them to prevent a
+    // compilation error: When we compile e.g. for SM70 **and** SM90, the host compiler will reach calls to those
+    // kernels, and instantiate them for MaxPolicy (which is Policy900) on the host, which will reach into the policies
+    // below to set the launch bounds. The device compiler pass will also compile all kernels for SM70 **and** SM90,
+    // even though only the Onesweep kernel is used on SM90.
+    using ScanPolicy =
+      AgentScanPolicy<512,
+                      23,
+                      OffsetT,
+                      BLOCK_LOAD_WARP_TRANSPOSE,
+                      LOAD_DEFAULT,
+                      BLOCK_STORE_WARP_TRANSPOSE,
+                      BLOCK_SCAN_RAKING_MEMOIZE>;
+
+    using DownsweepPolicy = AgentRadixSortDownsweepPolicy<
+      512,
+      23,
+      DominantT,
+      BLOCK_LOAD_TRANSPOSE,
+      LOAD_DEFAULT,
+      RADIX_RANK_MATCH,
+      BLOCK_SCAN_WARP_SCANS,
+      PRIMARY_RADIX_BITS>;
+
+    using AltDownsweepPolicy = AgentRadixSortDownsweepPolicy<
+      (sizeof(KeyT) > 1) ? 256 : 128,
+      47,
+      DominantT,
+      BLOCK_LOAD_TRANSPOSE,
+      LOAD_DEFAULT,
+      RADIX_RANK_MEMOIZE,
+      BLOCK_SCAN_WARP_SCANS,
+      PRIMARY_RADIX_BITS - 1>;
+
+    using UpsweepPolicy    = AgentRadixSortUpsweepPolicy<256, 23, DominantT, LOAD_DEFAULT, PRIMARY_RADIX_BITS>;
+    using AltUpsweepPolicy = AgentRadixSortUpsweepPolicy<256, 47, DominantT, LOAD_DEFAULT, PRIMARY_RADIX_BITS - 1>;
+
+    using SingleTilePolicy = AgentRadixSortDownsweepPolicy<
+      256,
+      19,
+      DominantT,
+      BLOCK_LOAD_DIRECT,
+      LOAD_LDG,
+      RADIX_RANK_MEMOIZE,
+      BLOCK_SCAN_WARP_SCANS,
+      SINGLE_TILE_RADIX_BITS>;
+
+    using SegmentedPolicy = AgentRadixSortDownsweepPolicy<
+      192,
+      39,
+      DominantT,
+      BLOCK_LOAD_TRANSPOSE,
+      LOAD_DEFAULT,
+      RADIX_RANK_MEMOIZE,
+      BLOCK_SCAN_WARP_SCANS,
+      SEGMENTED_RADIX_BITS>;
+
+    using AltSegmentedPolicy = AgentRadixSortDownsweepPolicy<
+      384,
+      11,
+      DominantT,
+      BLOCK_LOAD_TRANSPOSE,
+      LOAD_DEFAULT,
+      RADIX_RANK_MEMOIZE,
+      BLOCK_SCAN_WARP_SCANS,
+      SEGMENTED_RADIX_BITS - 1>;
+  };
+
+  using MaxPolicy = Policy1000;
 };
 
 } // namespace radix


### PR DESCRIPTION
Benchmark `main` vs. this PR on B200:

```
|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |  Entropy  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |        Diff |   %Diff |  Status  |
|---------|---------------|----------------|-----------|------------|-------------|------------|-------------|-------------|---------|----------|
|   I8    |      I32      |      2^16      |     1     |  29.703 us |       3.34% |  29.690 us |       3.07% |   -0.012 us |  -0.04% |   SAME   |
|   I8    |      I32      |      2^20      |     1     |  37.131 us |       2.06% |  37.431 us |       2.39% |    0.300 us |   0.81% |   SAME   |
|   I8    |      I32      |      2^24      |     1     | 125.236 us |       1.18% | 125.268 us |       1.05% |    0.032 us |   0.03% |   SAME   |
|   I8    |      I32      |      2^28      |     1     |   1.313 ms |       0.34% |   1.313 ms |       0.23% |   -0.056 us |  -0.00% |   SAME   |
|   I8    |      I32      |      2^16      |   0.544   |  30.981 us |       4.27% |  31.080 us |       4.26% |    0.099 us |   0.32% |   SAME   |
|   I8    |      I32      |      2^20      |   0.544   |  38.347 us |       3.17% |  38.302 us |       3.20% |   -0.045 us |  -0.12% |   SAME   |
|   I8    |      I32      |      2^24      |   0.544   | 128.380 us |       1.31% | 128.470 us |       1.23% |    0.089 us |   0.07% |   SAME   |
|   I8    |      I32      |      2^28      |   0.544   |   1.331 ms |       0.24% |   1.332 ms |       0.24% |    0.795 us |   0.06% |   SAME   |
|   I8    |      I32      |      2^16      |   0.201   |  30.493 us |       3.77% |  30.384 us |       3.71% |   -0.109 us |  -0.36% |   SAME   |
|   I8    |      I32      |      2^20      |   0.201   |  36.381 us |       2.83% |  36.410 us |       2.90% |    0.029 us |   0.08% |   SAME   |
|   I8    |      I32      |      2^24      |   0.201   | 120.419 us |       1.08% | 120.381 us |       1.04% |   -0.038 us |  -0.03% |   SAME   |
|   I8    |      I32      |      2^28      |   0.201   |   1.255 ms |       0.35% |   1.255 ms |       0.33% |    0.228 us |   0.02% |   SAME   |
|   I8    |      I64      |      2^16      |     1     |  30.192 us |       3.85% |  30.284 us |       4.10% |    0.092 us |   0.30% |   SAME   |
|   I8    |      I64      |      2^20      |     1     |  37.734 us |       2.06% |  37.718 us |       2.00% |   -0.016 us |  -0.04% |   SAME   |
|   I8    |      I64      |      2^24      |     1     | 121.794 us |       0.76% | 121.915 us |       0.72% |    0.121 us |   0.10% |   SAME   |
|   I8    |      I64      |      2^28      |     1     |   1.323 ms |       0.25% |   1.323 ms |       0.26% |    0.112 us |   0.01% |   SAME   |
|   I8    |      I64      |      2^16      |   0.544   |  30.221 us |       3.87% |  30.213 us |       3.76% |   -0.008 us |  -0.03% |   SAME   |
|   I8    |      I64      |      2^20      |   0.544   |  38.073 us |       2.74% |  38.049 us |       2.79% |   -0.023 us |  -0.06% |   SAME   |
|   I8    |      I64      |      2^24      |   0.544   | 123.909 us |       1.07% | 123.906 us |       1.06% |   -0.003 us |  -0.00% |   SAME   |
|   I8    |      I64      |      2^28      |   0.544   |   1.342 ms |       0.26% |   1.342 ms |       0.26% |    0.293 us |   0.02% |   SAME   |
|   I8    |      I64      |      2^16      |   0.201   |  29.828 us |       3.18% |  29.791 us |       3.14% |   -0.038 us |  -0.13% |   SAME   |
|   I8    |      I64      |      2^20      |   0.201   |  36.729 us |       3.22% |  36.898 us |       3.45% |    0.169 us |   0.46% |   SAME   |
|   I8    |      I64      |      2^24      |   0.201   | 116.701 us |       1.09% | 116.717 us |       1.11% |    0.016 us |   0.01% |   SAME   |
|   I8    |      I64      |      2^28      |   0.201   |   1.263 ms |       0.47% |   1.263 ms |       0.48% |    0.433 us |   0.03% |   SAME   |
|   I16   |      I32      |      2^16      |     1     |  46.312 us |       1.67% |  46.440 us |       1.91% |    0.128 us |   0.28% |   SAME   |
|   I16   |      I32      |      2^20      |     1     |  58.665 us |       1.55% |  57.305 us |       2.02% |   -1.361 us |  -2.32% |   FAST   |
|   I16   |      I32      |      2^24      |     1     | 214.122 us |       0.28% | 212.096 us |       0.25% |   -2.026 us |  -0.95% |   FAST   |
|   I16   |      I32      |      2^28      |     1     |   2.590 ms |       0.07% |   2.543 ms |       0.10% |  -46.739 us |  -1.80% |   FAST   |
|   I16   |      I32      |      2^16      |   0.544   |  46.111 us |       1.33% |  46.072 us |       1.40% |   -0.039 us |  -0.08% |   SAME   |
|   I16   |      I32      |      2^20      |   0.544   |  60.360 us |       1.29% |  58.758 us |       1.67% |   -1.601 us |  -2.65% |   FAST   |
|   I16   |      I32      |      2^24      |   0.544   | 218.858 us |       0.60% | 216.667 us |       0.53% |   -2.191 us |  -1.00% |   FAST   |
|   I16   |      I32      |      2^28      |   0.544   |   2.643 ms |       0.08% |   2.598 ms |       0.10% |  -45.112 us |  -1.71% |   FAST   |
|   I16   |      I32      |      2^16      |   0.201   |  46.046 us |       1.46% |  45.983 us |       1.51% |   -0.063 us |  -0.14% |   SAME   |
|   I16   |      I32      |      2^20      |   0.201   |  56.392 us |       1.18% |  56.520 us |       1.23% |    0.128 us |   0.23% |   SAME   |
|   I16   |      I32      |      2^24      |   0.201   | 205.208 us |       0.68% | 202.913 us |       0.53% |   -2.295 us |  -1.12% |   FAST   |
|   I16   |      I32      |      2^28      |   0.201   |   2.474 ms |       0.11% |   2.426 ms |       0.14% |  -48.148 us |  -1.95% |   FAST   |
|   I16   |      I64      |      2^16      |     1     |  45.956 us |       1.40% |  45.609 us |       2.16% |   -0.346 us |  -0.75% |   SAME   |
|   I16   |      I64      |      2^20      |     1     |  58.744 us |       1.94% |  56.827 us |       1.49% |   -1.916 us |  -3.26% |   FAST   |
|   I16   |      I64      |      2^24      |     1     | 213.755 us |       0.46% | 207.097 us |       0.55% |   -6.658 us |  -3.11% |   FAST   |
|   I16   |      I64      |      2^28      |     1     |   2.611 ms |       0.24% |   2.469 ms |       0.20% | -141.897 us |  -5.43% |   FAST   |
|   I16   |      I64      |      2^16      |   0.544   |  45.960 us |       1.43% |  45.668 us |       2.11% |   -0.292 us |  -0.64% |   SAME   |
|   I16   |      I64      |      2^20      |   0.544   |  59.277 us |       2.12% |  57.677 us |       1.90% |   -1.600 us |  -2.70% |   FAST   |
|   I16   |      I64      |      2^24      |   0.544   | 216.178 us |       0.29% | 208.850 us |       0.54% |   -7.328 us |  -3.39% |   FAST   |
|   I16   |      I64      |      2^28      |   0.544   |   2.666 ms |       0.24% |   2.525 ms |       0.17% | -140.690 us |  -5.28% |   FAST   |
|   I16   |      I64      |      2^16      |   0.201   |  46.014 us |       1.30% |  46.025 us |       1.51% |    0.011 us |   0.02% |   SAME   |
|   I16   |      I64      |      2^20      |   0.201   |  57.305 us |       1.97% |  56.581 us |       0.99% |   -0.723 us |  -1.26% |   FAST   |
|   I16   |      I64      |      2^24      |   0.201   | 204.013 us |       0.38% | 199.969 us |       0.36% |   -4.044 us |  -1.98% |   FAST   |
|   I16   |      I64      |      2^28      |   0.201   |   2.498 ms |       0.32% |   2.366 ms |       0.18% | -131.878 us |  -5.28% |   FAST   |
|   I32   |      I32      |      2^16      |     1     |  75.642 us |       0.99% |  75.400 us |       1.08% |   -0.242 us |  -0.32% |   SAME   |
|   I32   |      I32      |      2^20      |     1     |  96.329 us |       1.08% |  96.170 us |       1.10% |   -0.159 us |  -0.17% |   SAME   |
|   I32   |      I32      |      2^24      |     1     | 391.202 us |       0.40% | 390.648 us |       0.39% |   -0.554 us |  -0.14% |   SAME   |
|   I32   |      I32      |      2^28      |     1     |   4.930 ms |       0.13% |   4.928 ms |       0.13% |   -2.159 us |  -0.04% |   SAME   |
|   I32   |      I32      |      2^16      |   0.544   |  75.750 us |       0.83% |  75.629 us |       0.85% |   -0.120 us |  -0.16% |   SAME   |
|   I32   |      I32      |      2^20      |   0.544   |  96.528 us |       0.81% |  96.477 us |       0.88% |   -0.051 us |  -0.05% |   SAME   |
|   I32   |      I32      |      2^24      |   0.544   | 397.930 us |       0.30% | 396.348 us |       0.35% |   -1.582 us |  -0.40% |   FAST   |
|   I32   |      I32      |      2^28      |   0.544   |   5.080 ms |       0.08% |   5.079 ms |       0.08% |   -0.970 us |  -0.02% |   SAME   |
|   I32   |      I32      |      2^16      |   0.201   |  75.733 us |       0.87% |  75.481 us |       1.04% |   -0.252 us |  -0.33% |   SAME   |
|   I32   |      I32      |      2^20      |   0.201   |  94.477 us |       0.94% |  94.311 us |       0.96% |   -0.166 us |  -0.18% |   SAME   |
|   I32   |      I32      |      2^24      |   0.201   | 379.625 us |       0.41% | 378.190 us |       0.37% |   -1.435 us |  -0.38% |   FAST   |
|   I32   |      I32      |      2^28      |   0.201   |   4.730 ms |       0.07% |   4.729 ms |       0.06% |   -0.784 us |  -0.02% |   SAME   |
|   I32   |      I64      |      2^16      |     1     |  77.417 us |       1.03% |  77.530 us |       1.00% |    0.113 us |   0.15% |   SAME   |
|   I32   |      I64      |      2^20      |     1     |  97.949 us |       0.98% |  97.926 us |       0.90% |   -0.023 us |  -0.02% |   SAME   |
|   I32   |      I64      |      2^24      |     1     | 412.331 us |       0.41% | 412.399 us |       0.39% |    0.068 us |   0.02% |   SAME   |
|   I32   |      I64      |      2^28      |     1     |   5.096 ms |       0.06% |   5.096 ms |       0.06% |    0.388 us |   0.01% |   SAME   |
|   I32   |      I64      |      2^16      |   0.544   |  77.560 us |       0.91% |  77.509 us |       0.94% |   -0.051 us |  -0.07% |   SAME   |
|   I32   |      I64      |      2^20      |   0.544   |  97.864 us |       1.03% |  97.927 us |       0.99% |    0.062 us |   0.06% |   SAME   |
|   I32   |      I64      |      2^24      |   0.544   | 419.451 us |       0.36% | 419.405 us |       0.36% |   -0.046 us |  -0.01% |   SAME   |
|   I32   |      I64      |      2^28      |   0.544   |   5.234 ms |       0.14% |   5.235 ms |       0.13% |    0.813 us |   0.02% |   SAME   |
|   I32   |      I64      |      2^16      |   0.201   |  77.441 us |       1.02% |  77.517 us |       1.12% |    0.077 us |   0.10% |   SAME   |
|   I32   |      I64      |      2^20      |   0.201   |  95.870 us |       0.97% |  95.935 us |       0.94% |    0.066 us |   0.07% |   SAME   |
|   I32   |      I64      |      2^24      |   0.201   | 393.673 us |       0.44% | 393.643 us |       0.50% |   -0.030 us |  -0.01% |   SAME   |
|   I32   |      I64      |      2^28      |   0.201   |   4.891 ms |       0.10% |   4.891 ms |       0.10% |   -0.040 us |  -0.00% |   SAME   |
|   I64   |      I32      |      2^16      |     1     | 132.681 us |       0.62% | 132.636 us |       0.56% |   -0.046 us |  -0.03% |   SAME   |
|   I64   |      I32      |      2^20      |     1     | 201.175 us |       0.65% | 201.243 us |       0.64% |    0.069 us |   0.03% |   SAME   |
|   I64   |      I32      |      2^24      |     1     |   1.436 ms |       0.19% |   1.436 ms |       0.20% |    0.140 us |   0.01% |   SAME   |
|   I64   |      I32      |      2^28      |     1     |  21.058 ms |       0.21% |  21.059 ms |       0.19% |    1.666 us |   0.01% |   SAME   |
|   I64   |      I32      |      2^16      |   0.544   | 132.686 us |       0.57% | 132.718 us |       0.56% |    0.032 us |   0.02% |   SAME   |
|   I64   |      I32      |      2^20      |   0.544   | 201.310 us |       0.54% | 201.339 us |       0.53% |    0.028 us |   0.01% |   SAME   |
|   I64   |      I32      |      2^24      |   0.544   |   1.439 ms |       0.16% |   1.439 ms |       0.18% |    0.164 us |   0.01% |   SAME   |
|   I64   |      I32      |      2^28      |   0.544   |  21.052 ms |       0.19% |  21.053 ms |       0.19% |    1.300 us |   0.01% |   SAME   |
|   I64   |      I32      |      2^16      |   0.201   | 132.669 us |       0.52% | 132.674 us |       0.48% |    0.005 us |   0.00% |   SAME   |
|   I64   |      I32      |      2^20      |   0.201   | 191.218 us |       0.75% | 191.281 us |       0.79% |    0.063 us |   0.03% |   SAME   |
|   I64   |      I32      |      2^24      |   0.201   |   1.388 ms |       0.19% |   1.388 ms |       0.20% |    0.141 us |   0.01% |   SAME   |
|   I64   |      I32      |      2^28      |   0.201   |  20.278 ms |       0.20% |  20.277 ms |       0.19% |   -0.735 us |  -0.00% |   SAME   |
|   I64   |      I64      |      2^16      |     1     | 132.863 us |       0.71% | 132.874 us |       0.73% |    0.011 us |   0.01% |   SAME   |
|   I64   |      I64      |      2^20      |     1     | 201.017 us |       0.67% | 201.006 us |       0.75% |   -0.011 us |  -0.01% |   SAME   |
|   I64   |      I64      |      2^24      |     1     |   1.447 ms |       0.21% |   1.447 ms |       0.22% |    0.130 us |   0.01% |   SAME   |
|   I64   |      I64      |      2^28      |     1     |  21.101 ms |       0.22% |  21.102 ms |       0.23% |    1.142 us |   0.01% |   SAME   |
|   I64   |      I64      |      2^16      |   0.544   | 132.891 us |       0.70% | 132.932 us |       0.75% |    0.040 us |   0.03% |   SAME   |
|   I64   |      I64      |      2^20      |   0.544   | 196.661 us |       1.07% | 196.835 us |       1.02% |    0.174 us |   0.09% |   SAME   |
|   I64   |      I64      |      2^24      |   0.544   |   1.446 ms |       0.20% |   1.446 ms |       0.20% |   -0.073 us |  -0.01% |   SAME   |
|   I64   |      I64      |      2^28      |   0.544   |  21.056 ms |       0.21% |  21.060 ms |       0.21% |    3.834 us |   0.02% |   SAME   |
|   I64   |      I64      |      2^16      |   0.201   | 131.976 us |       1.23% | 132.045 us |       1.18% |    0.069 us |   0.05% |   SAME   |
|   I64   |      I64      |      2^20      |   0.201   | 192.171 us |       0.44% | 192.209 us |       0.53% |    0.038 us |   0.02% |   SAME   |
|   I64   |      I64      |      2^24      |   0.201   |   1.392 ms |       0.19% |   1.392 ms |       0.19% |   -0.126 us |  -0.01% |   SAME   |
|   I64   |      I64      |      2^28      |   0.201   |  20.282 ms |       0.22% |  20.286 ms |       0.21% |    4.303 us |   0.02% |   SAME   |
|  I128   |      I32      |      2^16      |     1     | 232.949 us |       0.33% | 233.017 us |       0.37% |    0.068 us |   0.03% |   SAME   |
|  I128   |      I32      |      2^20      |     1     | 417.677 us |       0.50% | 417.830 us |       0.50% |    0.153 us |   0.04% |   SAME   |
|  I128   |      I32      |      2^24      |     1     |   3.519 ms |       0.10% |   3.518 ms |       0.10% |   -0.914 us |  -0.03% |   SAME   |
|  I128   |      I32      |      2^28      |     1     |  52.798 ms |       0.06% |  52.798 ms |       0.06% |    0.034 us |   0.00% |   SAME   |
|  I128   |      I32      |      2^16      |   0.544   | 232.315 us |       0.59% | 232.411 us |       0.58% |    0.096 us |   0.04% |   SAME   |
|  I128   |      I32      |      2^20      |   0.544   | 414.293 us |       0.68% | 413.570 us |       0.72% |   -0.724 us |  -0.17% |   SAME   |
|  I128   |      I32      |      2^24      |   0.544   |   3.498 ms |       0.10% |   3.498 ms |       0.09% |    0.207 us |   0.01% |   SAME   |
|  I128   |      I32      |      2^28      |   0.544   |  52.422 ms |       0.07% |  52.420 ms |       0.07% |   -1.940 us |  -0.00% |   SAME   |
|  I128   |      I32      |      2^16      |   0.201   | 226.398 us |       0.71% | 226.915 us |       0.74% |    0.517 us |   0.23% |   SAME   |
|  I128   |      I32      |      2^20      |   0.201   | 404.492 us |       0.49% | 404.626 us |       0.47% |    0.134 us |   0.03% |   SAME   |
|  I128   |      I32      |      2^24      |   0.201   |   3.453 ms |       0.09% |   3.454 ms |       0.10% |    0.584 us |   0.02% |   SAME   |
|  I128   |      I32      |      2^28      |   0.201   |  51.580 ms |       0.07% |  51.584 ms |       0.07% |    3.683 us |   0.01% |   SAME   |
|  I128   |      I64      |      2^16      |     1     | 235.025 us |       0.29% | 235.055 us |       0.29% |    0.030 us |   0.01% |   SAME   |
|  I128   |      I64      |      2^20      |     1     | 419.965 us |       0.44% | 419.949 us |       0.45% |   -0.016 us |  -0.00% |   SAME   |
|  I128   |      I64      |      2^24      |     1     |   3.542 ms |       0.10% |   3.542 ms |       0.10% |    0.082 us |   0.00% |   SAME   |
|  I128   |      I64      |      2^28      |     1     |  53.789 ms |       0.03% |  53.787 ms |       0.03% |   -2.392 us |  -0.00% |   SAME   |
|  I128   |      I64      |      2^16      |   0.544   | 229.653 us |       0.79% | 229.695 us |       0.81% |    0.042 us |   0.02% |   SAME   |
|  I128   |      I64      |      2^20      |   0.544   | 415.631 us |       0.60% | 415.655 us |       0.60% |    0.024 us |   0.01% |   SAME   |
|  I128   |      I64      |      2^24      |   0.544   |   3.524 ms |       0.10% |   3.524 ms |       0.11% |    0.131 us |   0.00% |   SAME   |
|  I128   |      I64      |      2^28      |   0.544   |  53.426 ms |       0.03% |  53.426 ms |       0.03% |   -0.185 us |  -0.00% |   SAME   |
|  I128   |      I64      |      2^16      |   0.201   | 228.221 us |       0.72% | 228.090 us |       0.67% |   -0.131 us |  -0.06% |   SAME   |
|  I128   |      I64      |      2^20      |   0.201   | 407.765 us |       0.59% | 407.945 us |       0.59% |    0.180 us |   0.04% |   SAME   |
|  I128   |      I64      |      2^24      |   0.201   |   3.479 ms |       0.10% |   3.479 ms |       0.11% |   -0.279 us |  -0.01% |   SAME   |
|  I128   |      I64      |      2^28      |   0.201   |  52.644 ms |       0.03% |  52.643 ms |       0.03% |   -0.230 us |  -0.00% |   SAME   |
|   F32   |      I32      |      2^16      |     1     |  75.701 us |       0.90% |  75.631 us |       0.97% |   -0.070 us |  -0.09% |   SAME   |
|   F32   |      I32      |      2^20      |     1     |  96.970 us |       1.30% |  96.882 us |       1.25% |   -0.088 us |  -0.09% |   SAME   |
|   F32   |      I32      |      2^24      |     1     | 453.461 us |       0.35% | 453.339 us |       0.34% |   -0.122 us |  -0.03% |   SAME   |
|   F32   |      I32      |      2^28      |     1     |   6.094 ms |       0.08% |   6.092 ms |       0.05% |   -1.215 us |  -0.02% |   SAME   |
|   F32   |      I32      |      2^16      |   0.544   |  75.754 us |       0.79% |  75.605 us |       0.88% |   -0.149 us |  -0.20% |   SAME   |
|   F32   |      I32      |      2^20      |   0.544   |  98.296 us |       0.77% |  98.173 us |       0.79% |   -0.123 us |  -0.13% |   SAME   |
|   F32   |      I32      |      2^24      |   0.544   | 459.983 us |       0.32% | 459.924 us |       0.38% |   -0.059 us |  -0.01% |   SAME   |
|   F32   |      I32      |      2^28      |   0.544   |   6.175 ms |       0.05% |   6.174 ms |       0.05% |   -0.807 us |  -0.01% |   SAME   |
|   F32   |      I32      |      2^16      |   0.201   |  75.654 us |       0.88% |  75.564 us |       0.85% |   -0.090 us |  -0.12% |   SAME   |
|   F32   |      I32      |      2^20      |   0.201   |  95.550 us |       1.29% |  95.572 us |       1.26% |    0.022 us |   0.02% |   SAME   |
|   F32   |      I32      |      2^24      |   0.201   | 444.787 us |       0.28% | 444.535 us |       0.27% |   -0.252 us |  -0.06% |   SAME   |
|   F32   |      I32      |      2^28      |   0.201   |   5.953 ms |       0.06% |   5.953 ms |       0.06% |   -0.712 us |  -0.01% |   SAME   |
|   F32   |      I64      |      2^16      |     1     |  77.634 us |       0.92% |  77.619 us |       0.93% |   -0.016 us |  -0.02% |   SAME   |
|   F32   |      I64      |      2^20      |     1     |  99.362 us |       1.94% |  99.547 us |       1.79% |    0.185 us |   0.19% |   SAME   |
|   F32   |      I64      |      2^24      |     1     | 411.097 us |       0.33% | 411.121 us |       0.30% |    0.023 us |   0.01% |   SAME   |
|   F32   |      I64      |      2^28      |     1     |   5.304 ms |       0.09% |   5.301 ms |       0.09% |   -3.046 us |  -0.06% |   SAME   |
|   F32   |      I64      |      2^16      |   0.544   |  77.542 us |       0.96% |  77.579 us |       1.01% |    0.037 us |   0.05% |   SAME   |
|   F32   |      I64      |      2^20      |   0.544   | 100.032 us |       1.58% | 100.021 us |       1.59% |   -0.011 us |  -0.01% |   SAME   |
|   F32   |      I64      |      2^24      |   0.544   | 415.910 us |       0.38% | 416.315 us |       0.40% |    0.405 us |   0.10% |   SAME   |
|   F32   |      I64      |      2^28      |   0.544   |   5.387 ms |       0.08% |   5.387 ms |       0.08% |   -0.034 us |  -0.00% |   SAME   |
|   F32   |      I64      |      2^16      |   0.201   |  77.639 us |       0.88% |  77.592 us |       0.91% |   -0.047 us |  -0.06% |   SAME   |
|   F32   |      I64      |      2^20      |   0.201   |  97.700 us |       1.44% |  97.872 us |       1.46% |    0.172 us |   0.18% |   SAME   |
|   F32   |      I64      |      2^24      |   0.201   | 403.122 us |       0.42% | 403.242 us |       0.42% |    0.120 us |   0.03% |   SAME   |
|   F32   |      I64      |      2^28      |   0.201   |   5.156 ms |       0.07% |   5.156 ms |       0.08% |   -0.096 us |  -0.00% |   SAME   |
|   F64   |      I32      |      2^16      |     1     | 132.969 us |       0.76% | 132.878 us |       0.69% |   -0.091 us |  -0.07% |   SAME   |
|   F64   |      I32      |      2^20      |     1     | 187.147 us |       0.84% | 187.345 us |       0.78% |    0.198 us |   0.11% |   SAME   |
|   F64   |      I32      |      2^24      |     1     |   1.080 ms |       0.24% |   1.080 ms |       0.24% |   -0.120 us |  -0.01% |   SAME   |
|   F64   |      I32      |      2^28      |     1     |  15.304 ms |       0.04% |  15.304 ms |       0.04% |   -0.170 us |  -0.00% |   SAME   |
|   F64   |      I32      |      2^16      |   0.544   | 133.276 us |       0.89% | 133.243 us |       0.90% |   -0.033 us |  -0.02% |   SAME   |
|   F64   |      I32      |      2^20      |   0.544   | 188.065 us |       0.52% | 188.050 us |       0.49% |   -0.016 us |  -0.01% |   SAME   |
|   F64   |      I32      |      2^24      |   0.544   |   1.098 ms |       0.22% |   1.098 ms |       0.21% |   -0.038 us |  -0.00% |   SAME   |
|   F64   |      I32      |      2^28      |   0.544   |  15.546 ms |       0.03% |  15.546 ms |       0.03% |   -0.106 us |  -0.00% |   SAME   |
|   F64   |      I32      |      2^16      |   0.201   | 133.841 us |       1.06% | 133.845 us |       1.05% |    0.004 us |   0.00% |   SAME   |
|   F64   |      I32      |      2^20      |   0.201   | 185.998 us |       0.49% | 185.935 us |       0.48% |   -0.064 us |  -0.03% |   SAME   |
|   F64   |      I32      |      2^24      |   0.201   |   1.065 ms |       0.26% |   1.066 ms |       0.24% |    0.266 us |   0.02% |   SAME   |
|   F64   |      I32      |      2^28      |   0.201   |  14.988 ms |       0.05% |  14.987 ms |       0.05% |   -0.355 us |  -0.00% |   SAME   |
|   F64   |      I64      |      2^16      |     1     | 132.892 us |       0.70% | 132.869 us |       0.70% |   -0.023 us |  -0.02% |   SAME   |
|   F64   |      I64      |      2^20      |     1     | 188.002 us |       0.84% | 187.904 us |       0.82% |   -0.099 us |  -0.05% |   SAME   |
|   F64   |      I64      |      2^24      |     1     |   1.068 ms |       0.18% |   1.067 ms |       0.18% |   -0.339 us |  -0.03% |   SAME   |
|   F64   |      I64      |      2^28      |     1     |  15.256 ms |       0.04% |  15.255 ms |       0.04% |   -0.374 us |  -0.00% |   SAME   |
|   F64   |      I64      |      2^16      |   0.544   | 132.988 us |       0.72% | 133.034 us |       0.75% |    0.045 us |   0.03% |   SAME   |
|   F64   |      I64      |      2^20      |   0.544   | 188.109 us |       0.52% | 188.125 us |       0.52% |    0.016 us |   0.01% |   SAME   |
|   F64   |      I64      |      2^24      |   0.544   |   1.086 ms |       0.16% |   1.086 ms |       0.17% |   -0.098 us |  -0.01% |   SAME   |
|   F64   |      I64      |      2^28      |   0.544   |  15.489 ms |       0.04% |  15.489 ms |       0.04% |   -0.872 us |  -0.01% |   SAME   |
|   F64   |      I64      |      2^16      |   0.201   | 132.560 us |       0.57% | 132.919 us |       0.69% |    0.360 us |   0.27% |   SAME   |
|   F64   |      I64      |      2^20      |   0.201   | 185.739 us |       0.53% | 186.010 us |       0.57% |    0.270 us |   0.15% |   SAME   |
|   F64   |      I64      |      2^24      |   0.201   |   1.053 ms |       0.22% |   1.053 ms |       0.21% |    0.546 us |   0.05% |   SAME   |
|   F64   |      I64      |      2^28      |   0.201   |  14.912 ms |       0.11% |  14.912 ms |       0.10% |   -0.210 us |  -0.00% |   SAME   |
```