### PR TITLE
work around erroneous "undefined in device code" error in `basic_any`

### DIFF
--- a/cudax/include/cuda/experimental/__utility/basic_any/virtual_functions.cuh
+++ b/cudax/include/cuda/experimental/__utility/basic_any/virtual_functions.cuh
@@ -64,8 +64,8 @@ _CUDAX_TRIVIAL_API auto __c_style_cast(_Src* __ptr) noexcept -> _DstPtr
 }
 
 template <class _Tp, auto _Fn, class _Ret, bool _IsConst, bool _IsNothrow, class... _Args>
-_CCCL_NODISCARD _CUDAX_API auto __override_fn_([[maybe_unused]] _CUDA_VSTD::__maybe_const<_IsConst, void>* __pv,
-                                               [[maybe_unused]] _Args... __args) noexcept(_IsNothrow) -> _Ret
+_CCCL_NODISCARD _CUDAX_HOST_API auto __override_fn_([[maybe_unused]] _CUDA_VSTD::__maybe_const<_IsConst, void>* __pv,
+                                                    [[maybe_unused]] _Args... __args) noexcept(_IsNothrow) -> _Ret
 {
   using __value_type _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::__maybe_const<_IsConst, _Tp>;
 


### PR DESCRIPTION
## Description

this PR addresses an issue in \`basic_any\` that was causing nvcc to erroneously think that certain host-only entities were needed in device code, leading to an error.

the code was using the value of a host-only member function pointer in a host-only `constexpr` function. something about how this function was getting used in some code i was working on made nvcc think the member function was also needed on device. i have not been able to isolate the source of the problem, so i can't provide a test case for it, unfortunately.

this PR changes the `constexpr` function to a type computation, with the member function pointer as a NTTP. that seems to mollify nvcc.
