### PR TITLE
Fix typo in index.rst

### DIFF
--- a/docs/libcudacxx/index.rst
+++ b/docs/libcudacxx/index.rst
@@ -65,7 +65,7 @@ learning curve of learning CUDA. However, there are many aspects of writing high
 be expressed through purely Standard conforming APIs. For these cases, libcu++ also provides *extensions* of Standard
 Library utilities.
 
-For example, libcu++ extends ``atomic<T>`` and other synchornization primitives with the notion of a “thread scope”
+For example, libcu++ extends ``atomic<T>`` and other synchronization primitives with the notion of a “thread scope”
 that controls the strength of the memory fence.
 
 To use utilities that are extensions to Standard Library features, drop the ``std``:


### PR DESCRIPTION
## Description
 Spelling mistake in landing docs page for libcudacxx