### PR TITLE
Unifies workload generation for`DeviceMerge` benchmarks

### DIFF
--- a/cub/benchmarks/bench/merge/keys.cu
+++ b/cub/benchmarks/bench/merge/keys.cu
@@ -3,11 +3,7 @@
 
 #include <cub/device/device_merge.cuh>
 
-#include <thrust/copy.h>
-#include <thrust/count.h>
 #include <thrust/detail/raw_pointer_cast.h>
-#include <thrust/iterator/tabulate_output_iterator.h>
-#include <thrust/sort.h>
 
 #include <cuda/std/utility>
 
@@ -46,67 +42,11 @@ void keys(nvbench::state& state, nvbench::type_list<KeyT, OffsetT>)
   const auto elements       = static_cast<std::size_t>(state.get_int64("Elements{io}"));
   const bit_entropy entropy = str_to_entropy(state.get_string("Entropy"));
 
-  // We generate data distributions in the range [0, 255], which, with lower entropy, get skewed towards 0.
-  // We use this to generate increasingly large *consecutive* segments of data that are getting selected from the lhs
-  thrust::device_vector<uint8_t> rnd_selector_val = generate(elements, entropy);
-  uint8_t threshold                               = 128;
-  select_if_less_than_t select_lhs_op{false, threshold};
-  select_if_less_than_t select_rhs_op{true, threshold};
+  const auto num_items_lhs  = elements / 2;
+  const auto num_items_rhs  = elements - num_items_lhs;
+  auto [keys_lhs, keys_rhs] = generate_lhs_rhs<KeyT>(num_items_lhs, num_items_rhs, entropy);
 
-  // The following algorithm only works under the precondition that there's at least 50% of the data in the lhs
-  // If that's not the case, we simply swap the logic for selecting into lhs and rhs
-  const auto num_items_selected_into_lhs =
-    static_cast<offset_t>(thrust::count_if(rnd_selector_val.begin(), rnd_selector_val.end(), select_lhs_op));
-  if (num_items_selected_into_lhs < elements / 2)
-  {
-    using ::cuda::std::swap;
-    swap(select_lhs_op, select_rhs_op);
-  }
-
-  // We want lhs and rhs to be of equal size. We also want to have skewed distributions, such that we put different
-  // workloads on the binary search part. For this reason, we identify the index from the input, referred to as pivot
-  // point, after which the lhs is "full". We compose the rhs by selecting all items up to the pivot point that were not
-  // selected for lhs and *all* items after the pivot point.
-  constexpr std::size_t num_pivot_points = 1;
-  thrust::device_vector<offset_t> pivot_point(num_pivot_points);
-  const auto num_items_lhs = elements / 2;
-  const auto num_items_rhs = elements - num_items_lhs;
-  auto counting_it         = thrust::make_counting_iterator(offset_t{0});
-  thrust::copy_if(
-    counting_it,
-    counting_it + elements,
-    rnd_selector_val.begin(),
-    thrust::make_tabulate_output_iterator(write_pivot_point_t<offset_t>{
-      static_cast<offset_t>(num_items_lhs), thrust::raw_pointer_cast(pivot_point.data())}),
-    select_lhs_op);
-
-  thrust::device_vector<key_t> keys_lhs(num_items_lhs);
-  thrust::device_vector<key_t> keys_rhs(num_items_rhs);
-  thrust::device_vector<key_t> keys_out(elements);
-
-  // Generate increasing input range to sample from
-  thrust::device_vector<key_t> increasing_input = generate(elements);
-  thrust::sort(increasing_input.begin(), increasing_input.end());
-
-  // Select lhs from input up to pivot point
-  offset_t pivot_point_val = pivot_point[0];
-  auto const end_lhs       = thrust::copy_if(
-    increasing_input.cbegin(),
-    increasing_input.cbegin() + pivot_point_val,
-    rnd_selector_val.cbegin(),
-    keys_lhs.begin(),
-    select_lhs_op);
-
-  // Select rhs items from input up to pivot point
-  auto const end_rhs = thrust::copy_if(
-    increasing_input.cbegin(),
-    increasing_input.cbegin() + pivot_point_val,
-    rnd_selector_val.cbegin(),
-    keys_rhs.begin(),
-    select_rhs_op);
-  // From pivot point copy all remaining items to rhs
-  thrust::copy(increasing_input.cbegin() + pivot_point_val, increasing_input.cbegin() + elements, end_rhs);
-
+  thrust::device_vector<KeyT> keys_out(elements);
   key_t* d_keys_lhs = thrust::raw_pointer_cast(keys_lhs.data());
   key_t* d_keys_rhs = thrust::raw_pointer_cast(keys_rhs.data());
   key_t* d_keys_out = thrust::raw_pointer_cast(keys_out.data());

--- a/cub/benchmarks/bench/merge/merge_common.cuh
+++ b/cub/benchmarks/bench/merge/merge_common.cuh
@@ -1,6 +1,16 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
+#pragma once
+
+#include <thrust/copy.h>
+#include <thrust/count.h>
+#include <thrust/device_vector.h>
+#include <thrust/iterator/tabulate_output_iterator.h>
+#include <thrust/sort.h>
+
+#include <nvbench_helper.cuh>
+
 #if !TUNE_BASE
 #  define TUNE_THREADS_PER_BLOCK (1 << TUNE_THREADS_PER_BLOCK_POW2)
 #  if TUNE_TRANSPOSE == 0
@@ -61,3 +71,68 @@ struct write_pivot_point_t
     }
   }
 };
+
+template <typename KeyT>
+std::pair<thrust::device_vector<KeyT>, thrust::device_vector<KeyT>>
+generate_lhs_rhs(std::size_t num_items_lhs, std::size_t num_items_rhs, bit_entropy entropy)
+{
+  using offset_t = std::size_t;
+
+  const auto elements = num_items_lhs + num_items_rhs;
+
+  // We generate data distributions in the range [0, 255], which, with lower entropy, get skewed towards 0.
+  // We use this to generate increasingly large *consecutive* segments of data that are getting selected from the lhs
+  thrust::device_vector<uint8_t> rnd_selector_val = generate(elements, entropy);
+  uint8_t threshold                               = 128;
+  select_if_less_than_t select_lhs_op{false, threshold};
+  select_if_less_than_t select_rhs_op{true, threshold};
+
+  // The following algorithm only works under the precondition that there's at least 50% of the data in the lhs
+  // If that's not the case, we simply swap the logic for selecting into lhs and rhs
+  const auto num_items_selected_into_lhs =
+    static_cast<offset_t>(thrust::count_if(rnd_selector_val.begin(), rnd_selector_val.end(), select_lhs_op));
+  if (num_items_selected_into_lhs < num_items_lhs)
+  {
+    using ::cuda::std::swap;
+    swap(select_lhs_op, select_rhs_op);
+  }
+
+  // We want lhs and rhs to be of equal size. We also want to have skewed distributions, such that we put different
+  // workloads on the binary search part. For this reason, we identify the index from the input, referred to as pivot
+  // point, after which the lhs is "full". We compose the rhs by selecting all items up to the pivot point that were not
+  // selected for lhs and *all* items after the pivot point.
+  constexpr std::size_t num_pivot_points = 1;
+  thrust::device_vector<offset_t> pivot_point(num_pivot_points);
+  auto counting_it = thrust::make_counting_iterator(offset_t{0});
+  thrust::copy_if(
+    counting_it,
+    counting_it + elements,
+    rnd_selector_val.begin(),
+    thrust::make_tabulate_output_iterator(write_pivot_point_t<offset_t>{
+      static_cast<offset_t>(num_items_lhs), thrust::raw_pointer_cast(pivot_point.data())}),
+    select_lhs_op);
+
+  thrust::device_vector<KeyT> keys_lhs(num_items_lhs);
+  thrust::device_vector<KeyT> keys_rhs(num_items_rhs);
+
+  thrust::device_vector<KeyT> increasing_input = generate(elements);
+  thrust::sort(increasing_input.begin(), increasing_input.end());
+
+  offset_t pivot_point_val = pivot_point[0];
+  auto const end_lhs       = thrust::copy_if(
+    increasing_input.cbegin(),
+    increasing_input.cbegin() + pivot_point_val,
+    rnd_selector_val.cbegin(),
+    keys_lhs.begin(),
+    select_lhs_op);
+
+  auto const end_rhs = thrust::copy_if(
+    increasing_input.cbegin(),
+    increasing_input.cbegin() + pivot_point_val,
+    rnd_selector_val.cbegin(),
+    keys_rhs.begin(),
+    select_rhs_op);
+  thrust::copy(increasing_input.cbegin() + pivot_point_val, increasing_input.cbegin() + elements, end_rhs);
+
+  return {keys_lhs, keys_rhs};
+}

--- a/cub/benchmarks/bench/merge/pairs.cu
+++ b/cub/benchmarks/bench/merge/pairs.cu
@@ -3,11 +3,7 @@
 
 #include <cub/device/device_merge.cuh>
 
-#include <thrust/copy.h>
-#include <thrust/count.h>
 #include <thrust/detail/raw_pointer_cast.h>
-#include <thrust/iterator/tabulate_output_iterator.h>
-#include <thrust/sort.h>
 
 #include <cuda/std/utility>
 
@@ -46,69 +42,15 @@ void pairs(nvbench::state& state, nvbench::type_list<KeyT, ValueT, OffsetT>)
   const auto elements       = static_cast<std::size_t>(state.get_int64("Elements{io}"));
   const bit_entropy entropy = str_to_entropy(state.get_string("Entropy"));
 
-  // We generate data distributions in the range [0, 255] that, with lower entropy, get skewed towards 0.
-  // We use this to generate increasingly large *consecutive* segments of data that are getting selected from the lhs
-  thrust::device_vector<uint8_t> rnd_selector_val = generate(elements, entropy);
-  uint8_t threshold                               = 128;
-  select_if_less_than_t select_lhs_op{false, threshold};
-  select_if_less_than_t select_rhs_op{true, threshold};
-
-  // The following algorithm only works under the precondition that there's at least 50% of the data in the lhs
-  // If that's not the case, we simply swap the logic for selecting into lhs and rhs
-  const auto num_items_selected_into_lhs =
-    static_cast<offset_t>(thrust::count_if(rnd_selector_val.begin(), rnd_selector_val.end(), select_lhs_op));
-  if (num_items_selected_into_lhs < elements / 2)
-  {
-    using ::cuda::std::swap;
-    swap(select_lhs_op, select_rhs_op);
-  }
-
-  // We want lhs and rhs to be of equal size. We also want to have skewed distributions, such that we put different
-  // workloads on the binary search part. For this reason, we identify the index from the input, referred to as pivot
-  // point, after which the lhs is "full". We compose the rhs by selecting all items up to the pivot point that were not
-  // selected for lhs and *all* items after the pivot point.
-  constexpr std::size_t num_pivot_points = 1;
-  thrust::device_vector<offset_t> pivot_point(num_pivot_points);
   const auto num_items_lhs = elements / 2;
   const auto num_items_rhs = elements - num_items_lhs;
-  auto counting_it         = thrust::make_counting_iterator(offset_t{0});
-  thrust::copy_if(
-    counting_it,
-    counting_it + elements,
-    rnd_selector_val.begin(),
-    thrust::make_tabulate_output_iterator(write_pivot_point_t<offset_t>{
-      static_cast<offset_t>(num_items_lhs), thrust::raw_pointer_cast(pivot_point.data())}),
-    select_lhs_op);
 
-  thrust::device_vector<key_t> keys_lhs(num_items_lhs);
-  thrust::device_vector<key_t> keys_rhs(num_items_rhs);
   thrust::device_vector<key_t> keys_out(elements);
   thrust::device_vector<value_t> values_lhs(num_items_lhs);
   thrust::device_vector<value_t> values_rhs(num_items_rhs);
   thrust::device_vector<value_t> values_out(elements);
 
-  // Generate increasing input range to sample from
-  thrust::device_vector<key_t> increasing_input = generate(elements);
-  thrust::sort(increasing_input.begin(), increasing_input.end());
-
-  // Select lhs from input up to pivot point
-  offset_t pivot_point_val = pivot_point[0];
-  auto const end_lhs       = thrust::copy_if(
-    increasing_input.cbegin(),
-    increasing_input.cbegin() + pivot_point_val,
-    rnd_selector_val.cbegin(),
-    keys_lhs.begin(),
-    select_lhs_op);
-
-  // Select rhs items from input up to pivot point
-  auto const end_rhs = thrust::copy_if(
-    increasing_input.cbegin(),
-    increasing_input.cbegin() + pivot_point_val,
-    rnd_selector_val.cbegin(),
-    keys_rhs.begin(),
-    select_rhs_op);
-  // From pivot point copy all remaining items to rhs
-  thrust::copy(increasing_input.cbegin() + pivot_point_val, increasing_input.cbegin() + elements, end_rhs);
+  auto [keys_lhs, keys_rhs] = generate_lhs_rhs<KeyT>(num_items_lhs, num_items_rhs, entropy);
 
   key_t* d_keys_lhs     = thrust::raw_pointer_cast(keys_lhs.data());
   key_t* d_keys_rhs     = thrust::raw_pointer_cast(keys_rhs.data());


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
PR https://github.com/NVIDIA/cccl/pull/3529 has added benchmarks for `DeviceMerge`. During that PR, @gevtushenko noted the potential for unifying the workload generation between benchmarks for merging keys and merging key-value pairs. 

This PR unifies the workload generation across the two files.  <!-- Link issue here -->