### PR TITLE
[STF] frozen_logical_data::get_access_mode()

### DIFF
--- a/cudax/include/cuda/experimental/__stf/internal/frozen_logical_data.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/frozen_logical_data.cuh
@@ -136,6 +136,11 @@ private:
       ld.set_automatic_unfreeze(fake_task, flag);
     }
 
+    access_mode get_access_mode() const
+    {
+      return m;
+    }
+
   private:
     logical_data<T> ld;
     access_mode m;
@@ -197,6 +202,12 @@ public:
     assert(pimpl);
     pimpl->set_automatic_unfreeze(flag);
     return *this;
+  }
+
+  access_mode get_access_mode() const
+  {
+    assert(pimpl);
+    return pimpl->get_access_mode();
   }
 
 private:

--- a/cudax/test/stf/freeze/freeze_rw.cu
+++ b/cudax/test/stf/freeze/freeze_rw.cu
@@ -56,6 +56,9 @@ int main()
   for (int k = 0; k < 4; k++)
   {
     auto fx = ctx.freeze(lX, access_mode::rw, data_place::current_device());
+
+    _CCCL_ASSERT(fx.get_access_mode() == access_mode::rw, "invalid access mode");
+
     auto dX = fx.get(data_place::current_device(), stream);
     mult<<<8, 4, 0, stream>>>(dX, 4);
     fx.unfreeze(stream);

--- a/docs/cudax/stf.rst
+++ b/docs/cudax/stf.rst
@@ -1853,6 +1853,9 @@ stream passed to ``freeze`` (for example, by using a blocking call such as
 depend on the completion of the work in the streams used for any preceding
 ``freeze`` and ``get`` calls.
 
+It is possible to retrieve the access mode used to freeze a logical data with
+the ``get_access_mode()`` method of the ``frozen_logical_data`` object.
+
 Logical token
 ^^^^^^^^^^^^^
 


### PR DESCRIPTION
Implement frozen_logical_data::get_access_mode to query the access mode used to freeze a logical data (and avoid storing this information separately)

## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes <!-- Link issue here -->

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
