### PR TITLE
This improves the detection logic for `__cccl_ptx_isa` for clang-cuda

### DIFF
--- a/libcudacxx/include/cuda/std/__cccl/ptx_isa.h
+++ b/libcudacxx/include/cuda/std/__cccl/ptx_isa.h
@@ -34,29 +34,59 @@
 // PTX ISA 8.7 is available from CUDA 12.8
 // The first define is for future major versions of CUDACC.
 // We make sure that these get the highest known PTX ISA version.
+// For clang cuda check https://github.com/llvm/llvm-project/blob/release/XX.x/clang/lib/Driver/ToolChains/Cuda.cpp
+// getNVPTXTargetFeatures
 #if _CCCL_CUDACC_AT_LEAST(13, 0)
 #  define __cccl_ptx_isa 870ULL
 // PTX ISA 8.7 is available from CUDA 12.8, driver r570
-#elif _CCCL_CUDACC_AT_LEAST(12, 8)
+#elif _CCCL_CUDACC_AT_LEAST(12, 8) && !_CCCL_CUDA_COMPILER(CLANG, <, 20)
 #  define __cccl_ptx_isa 870ULL
 // PTX ISA 8.5 is available from CUDA 12.5, driver r555
-#elif _CCCL_CUDACC_AT_LEAST(12, 5)
+#elif _CCCL_CUDACC_AT_LEAST(12, 5) && !_CCCL_CUDA_COMPILER(CLANG, <, 19)
 #  define __cccl_ptx_isa 850ULL
 // PTX ISA 8.4 is available from CUDA 12.4, driver r550
-#elif _CCCL_CUDACC_AT_LEAST(12, 4)
+#elif _CCCL_CUDACC_AT_LEAST(12, 4) && !_CCCL_CUDA_COMPILER(CLANG, <, 19)
 #  define __cccl_ptx_isa 840ULL
 // PTX ISA 8.3 is available from CUDA 12.3, driver r545
-#elif _CCCL_CUDACC_AT_LEAST(12, 3)
+#elif _CCCL_CUDACC_AT_LEAST(12, 3) && !_CCCL_CUDA_COMPILER(CLANG, <, 18)
 #  define __cccl_ptx_isa 830ULL
 // PTX ISA 8.2 is available from CUDA 12.2, driver r535
-#elif _CCCL_CUDACC_AT_LEAST(12, 2)
+#elif _CCCL_CUDACC_AT_LEAST(12, 2) && !_CCCL_CUDA_COMPILER(CLANG, <, 18)
 #  define __cccl_ptx_isa 820ULL
 // PTX ISA 8.1 is available from CUDA 12.1, driver r530
-#elif _CCCL_CUDACC_AT_LEAST(12, 1)
+#elif _CCCL_CUDACC_AT_LEAST(12, 1) && !_CCCL_CUDA_COMPILER(CLANG, <, 17)
 #  define __cccl_ptx_isa 810ULL
 // PTX ISA 8.0 is available from CUDA 12.0, driver r525
-#elif _CCCL_CUDACC_AT_LEAST(12, 0)
+#elif _CCCL_CUDACC_AT_LEAST(12, 0) && !_CCCL_CUDA_COMPILER(CLANG, <, 17)
 #  define __cccl_ptx_isa 800ULL
+// PTX ISA 7.8 is available from CUDA 11.8, driver r520
+#elif _CCCL_CUDACC_AT_LEAST(11, 8) && !_CCCL_CUDA_COMPILER(CLANG, <, 16)
+#  define __cccl_ptx_isa 780ULL
+// PTX ISA 7.7 is available from CUDA 11.7, driver r515
+#elif _CCCL_CUDACC_AT_LEAST(11, 7) && !_CCCL_CUDA_COMPILER(CLANG, <, 16)
+#  define __cccl_ptx_isa 770ULL
+// PTX ISA 7.6 is available from CUDA 11.6, driver r510
+#elif _CCCL_CUDACC_AT_LEAST(11, 6) && !_CCCL_CUDA_COMPILER(CLANG, <, 16)
+#  define __cccl_ptx_isa 760ULL
+// PTX ISA 7.5 is available from CUDA 11.5, driver r495
+#elif _CCCL_CUDACC_AT_LEAST(11, 5) && !_CCCL_CUDA_COMPILER(CLANG, <, 14)
+#  define __cccl_ptx_isa 750ULL
+// PTX ISA 7.4 is available from CUDA 11.4, driver r470
+#elif _CCCL_CUDACC_AT_LEAST(11, 4) && !_CCCL_CUDA_COMPILER(CLANG, <, 14)
+#  define __cccl_ptx_isa 740ULL
+// PTX ISA 7.3 is available from CUDA 11.3, driver r465
+#elif _CCCL_CUDACC_AT_LEAST(11, 3) && !_CCCL_CUDA_COMPILER(CLANG, <, 14)
+#  define __cccl_ptx_isa 730ULL
+// PTX ISA 7.2 is available from CUDA 11.2, driver r460
+#elif _CCCL_CUDACC_AT_LEAST(11, 2) && !_CCCL_CUDA_COMPILER(CLANG, <, 13)
+#  define __cccl_ptx_isa 720ULL
+// PTX ISA 7.1 is available from CUDA 11.1, driver r455
+#elif _CCCL_CUDACC_AT_LEAST(11, 1) && !_CCCL_CUDA_COMPILER(CLANG, <, 13)
+#  define __cccl_ptx_isa 710ULL
+// PTX ISA 7.0 is available from CUDA 11.0, driver r445
+#elif _CCCL_CUDACC_AT_LEAST(11, 0) && !_CCCL_CUDA_COMPILER(CLANG, <, 12)
+#  define __cccl_ptx_isa 700ULL
+// Fallback case. Define the ISA version to be zero. This ensures that the macro is always defined.
 #else
 #  define __cccl_ptx_isa 0ULL
 #endif


### PR DESCRIPTION
We can actually check in the release branch of the respective release, whether clang-cuda marks a given PTX ISA as supported.

I went through all the relevant releases down to ptx 7.0 because we do select some code paths based on that

Fixes #3633
