### PR TITLE
Fix issues with nvrtc compilation

### DIFF
--- a/cub/cub/util_cpp_dialect.cuh
+++ b/cub/cub/util_cpp_dialect.cuh
@@ -51,7 +51,7 @@
 #  define CUB_CPP_DIALECT _CCCL_STD_VER
 
 // Define CUB_COMPILER_DEPRECATION macro:
-#  if _CCCL_COMPILER(MSVC)
+#  if _CCCL_COMPILER(MSVC) || _CCCL_COMPILER(NVRTC)
 #    define CUB_COMP_DEPR_IMPL(msg) _CCCL_PRAGMA(message(__FILE__ ":" _CCCL_TO_STRING(__LINE__) ": warning: " #msg))
 #  else // clang / gcc:
 #    define CUB_COMP_DEPR_IMPL(msg) _CCCL_PRAGMA(GCC warning #msg)

--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -884,6 +884,10 @@
 #  define _CCCL_BUILTIN_REMOVE_REFERENCE_T(...) __remove_reference_t(__VA_ARGS__)
 #endif // _CCCL_HAS_BUILTIN(__remove_reference_t)
 
+#if _CCCL_COMPILER(NVRTC, <, 12, 4) // NVRTC below 12.4 fails to properly compile cuda::std::move with that
+#  undef _CCCL_BUILTIN_REMOVE_REFERENCE_T
+#endif // _CCCL_COMPILER(NVRTC, <, 12, 4)
+
 #if _CCCL_HAS_BUILTIN(__remove_volatile) && _CCCL_CUDA_COMPILER(CLANG)
 #  define _CCCL_BUILTIN_REMOVE_VOLATILE(...) __remove_volatile(__VA_ARGS__)
 #endif // _CCCL_HAS_BUILTIN(__remove_volatile)

--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -870,6 +870,10 @@
 #  define _CCCL_BUILTIN_REMOVE_CVREF(...) __remove_cvref(__VA_ARGS__)
 #endif // _CCCL_HAS_BUILTIN(__remove_cvref)
 
+#if _CCCL_COMPILER(NVRTC, <, 12, 4) // NVRTC below 12.4 fails to properly compile that builtin
+#  undef _CCCL_BUILTIN_REMOVE_CVREF
+#endif // _CCCL_COMPILER(NVRTC, <, 12, 4)
+
 #if _CCCL_HAS_BUILTIN(__remove_extent) && _CCCL_CUDA_COMPILER(CLANG)
 #  define _CCCL_BUILTIN_REMOVE_EXTENT(...) __remove_extent(__VA_ARGS__)
 #endif // _CCCL_HAS_BUILTIN(__remove_extent)

--- a/libcudacxx/include/cuda/std/__internal/cpp_dialect.h
+++ b/libcudacxx/include/cuda/std/__internal/cpp_dialect.h
@@ -21,7 +21,7 @@
 #endif // no system header
 
 // Define LIBCUDACXX_COMPILER_DEPRECATION macro:
-#if _CCCL_COMPILER(MSVC)
+#if _CCCL_COMPILER(MSVC) || _CCCL_COMPILER(NVRTC)
 #  define LIBCUDACXX_COMP_DEPR_IMPL(msg) \
     _CCCL_PRAGMA(message(__FILE__ ":" _CCCL_TO_STRING(__LINE__) ": warning: " #msg))
 #else // ^^^ _CCCL_COMPILER(MSVC) ^^^ / vvv !_CCCL_COMPILER(MSVC) vvv

--- a/thrust/thrust/detail/config/cpp_dialect.h
+++ b/thrust/thrust/detail/config/cpp_dialect.h
@@ -41,7 +41,7 @@
 #define THRUST_CPP_DIALECT _CCCL_STD_VER
 
 // Define THRUST_COMPILER_DEPRECATION macro:
-#if _CCCL_COMPILER(MSVC)
+#if _CCCL_COMPILER(MSVC) || _CCCL_COMPILER(NVRTC)
 #  define THRUST_COMP_DEPR_IMPL(msg) _CCCL_PRAGMA(message(__FILE__ ":" _CCCL_TO_STRING(__LINE__) ": warning: " #msg))
 #else // clang / gcc:
 #  define THRUST_COMP_DEPR_IMPL(msg) _CCCL_PRAGMA(GCC warning #msg)


### PR DESCRIPTION
Disable use of builtin `__remove_reference_t` for nvrtc below 12.4
NVRTC does not support it properly, so remove it to unblock cuPy

Also nvrtc uses the msvc like `#pragma message` rather than `#pragma GCC warning`
