### PR TITLE
Remove cugraph-ops from RAPIDS 25.04 builds.

### DIFF
--- a/.github/workflows/build-rapids.yml
+++ b/.github/workflows/build-rapids.yml
@@ -36,9 +36,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { cuda: '12.5', libs: 'rmm kvikio cudf cudf_kafka cuspatial'         }
-          - { cuda: '12.5', libs: 'rmm ucxx raft cuvs cumlprims_mg cuml'         }
-          - { cuda: '12.5', libs: 'rmm ucxx raft cugraph-ops cugraph cugraph-gnn'}
+          - { cuda: '12.5', libs: 'rmm kvikio cudf cudf_kafka cuspatial' }
+          - { cuda: '12.5', libs: 'rmm ucxx raft cuvs cumlprims_mg cuml' }
+          - { cuda: '12.5', libs: 'rmm ucxx raft cugraph cugraph-gnn'    }
     permissions:
       id-token: write
       contents: read
@@ -63,7 +63,6 @@ jobs:
           # RAPIDS_cmake_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-25.04"}'
           # RAPIDS_cudf_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-25.04"}'
           # RAPIDS_cudf_kafka_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-25.04"}'
-          # RAPIDS_cugraph_ops_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-25.04"}'
           # RAPIDS_cugraph_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-25.04"}'
           # RAPIDS_cugraph_gnn_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-25.04"}'
           # RAPIDS_cuml_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-25.04"}'

--- a/.github/workflows/build-rapids.yml
+++ b/.github/workflows/build-rapids.yml
@@ -79,7 +79,6 @@ jobs:
           # Start the ssh-agent and add the repo deploy keys
           if ! pgrep ssh-agent >/dev/null 2>&1; then eval "$(ssh-agent -s)"; fi
           ssh-add - <<< '${{ secrets.RAPIDSAI_CUMLPRIMS_DEPLOY_KEY }}'
-          ssh-add - <<< '${{ secrets.RAPIDSAI_CUGRAPH_OPS_DEPLOY_KEY }}'
           devcontainer-utils-init-ssh-deploy-keys || true
           exec "$@"
           EOF

--- a/ci/rapids/cuda12.5-conda/devcontainer.json
+++ b/ci/rapids/cuda12.5-conda/devcontainer.json
@@ -36,7 +36,6 @@
     "RAPIDS_cuvs_GIT_REPO": "${localEnv:RAPIDS_cuvs_GIT_REPO}",
     "RAPIDS_cumlprims_mg_GIT_REPO": "${localEnv:RAPIDS_cumlprims_mg_GIT_REPO}",
     "RAPIDS_cuml_GIT_REPO": "${localEnv:RAPIDS_cuml_GIT_REPO}",
-    "RAPIDS_cugraph_ops_GIT_REPO": "${localEnv:RAPIDS_cugraph_ops_GIT_REPO}",
     "RAPIDS_cugraph_GIT_REPO": "${localEnv:RAPIDS_cugraph_GIT_REPO}",
     "RAPIDS_cugraph_gnn_GIT_REPO": "${localEnv:RAPIDS_cugraph_gnn_GIT_REPO}",
     "RAPIDS_cuspatial_GIT_REPO": "${localEnv:RAPIDS_cuspatial_GIT_REPO}"


### PR DESCRIPTION
## Description
`cugraph-ops` is no longer needed in RAPIDS 25.02 and has been archived.

## Checklist
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
