### PR TITLE
Internalize cub::PolicyWrapper

### DIFF
--- a/cub/cub/device/dispatch/tuning/tuning_scan.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan.cuh
@@ -248,7 +248,7 @@ struct ScanPolicyWrapper<StaticPolicyT, ::cuda::std::void_t<decltype(StaticPolic
 
   CUB_RUNTIME_FUNCTION static constexpr PolicyWrapper<typename StaticPolicyT::ScanPolicyT> Scan()
   {
-    return MakePolicyWrapper(typename StaticPolicyT::ScanPolicyT());
+    return cub::detail::MakePolicyWrapper(typename StaticPolicyT::ScanPolicyT());
   }
 
   CUB_RUNTIME_FUNCTION constexpr CacheLoadModifier LoadModifier()

--- a/cub/cub/util_macro.cuh
+++ b/cub/cub/util_macro.cuh
@@ -111,10 +111,10 @@ _CCCL_DIAG_SUPPRESS_NVHPC(attribute_requires_external_linkage)
 #endif
 
 #ifndef CUB_DEFINE_SUB_POLICY_GETTER
-#  define CUB_DEFINE_SUB_POLICY_GETTER(name)                                                         \
-    CUB_RUNTIME_FUNCTION static constexpr PolicyWrapper<typename StaticPolicyT::name##Policy> name() \
-    {                                                                                                \
-      return MakePolicyWrapper(typename StaticPolicyT::name##Policy());                              \
+#  define CUB_DEFINE_SUB_POLICY_GETTER(name)                                                                 \
+    CUB_RUNTIME_FUNCTION static constexpr detail::PolicyWrapper<typename StaticPolicyT::name##Policy> name() \
+    {                                                                                                        \
+      return detail::MakePolicyWrapper(typename StaticPolicyT::name##Policy());                              \
     }
 #endif
 


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/cccl/issues/3680

## Description

Deprecate and move into the detail namespace `MakePolicyWrapper` and `PolicyWrapper`.
Can be backported to 2.8