### PR TITLE
Deprecate `cub::RegBoundScaling` and `cub::MemBoundScaling`

### DIFF
--- a/cub/benchmarks/bench/scan/exclusive/base.cuh
+++ b/cub/benchmarks/bench/scan/exclusive/base.cuh
@@ -64,7 +64,8 @@ struct policy_hub_t
                          LOAD_ALGORITHM,
                          LOAD_MODIFIER,
                          STORE_ALGORITHM,
-                         SCAN_ALGORITHM delay_constructor_t>;
+                         SCAN_ALGORITHM,
+                         delay_constructor_t>;
 
   struct policy_t : cub::ChainedPolicy<300, policy_t, policy_t>
   {

--- a/cub/benchmarks/bench/scan/exclusive/base.cuh
+++ b/cub/benchmarks/bench/scan/exclusive/base.cuh
@@ -57,15 +57,16 @@ struct policy_hub_t
             cub::CacheLoadModifier LOAD_MODIFIER,
             cub::BlockStoreAlgorithm STORE_ALGORITHM,
             cub::BlockScanAlgorithm SCAN_ALGORITHM>
-  using agent_policy_t =
-    cub::AgentScanPolicy<NOMINAL_BLOCK_THREADS_4B,
-                         NOMINAL_ITEMS_PER_THREAD_4B,
-                         ComputeT,
-                         LOAD_ALGORITHM,
-                         LOAD_MODIFIER,
-                         STORE_ALGORITHM,
-                         SCAN_ALGORITHM,
-                         delay_constructor_t>;
+  using agent_policy_t = cub::AgentScanPolicy<
+    NOMINAL_BLOCK_THREADS_4B,
+    NOMINAL_ITEMS_PER_THREAD_4B,
+    ComputeT,
+    LOAD_ALGORITHM,
+    LOAD_MODIFIER,
+    STORE_ALGORITHM,
+    SCAN_ALGORITHM,
+    cub::detail::MemBoundScaling<NOMINAL_BLOCK_THREADS_4B, NOMINAL_ITEMS_PER_THREAD_4B, ComputeT>,
+    delay_constructor_t>;
 
   struct policy_t : cub::ChainedPolicy<300, policy_t, policy_t>
   {

--- a/cub/benchmarks/bench/scan/exclusive/base.cuh
+++ b/cub/benchmarks/bench/scan/exclusive/base.cuh
@@ -57,16 +57,14 @@ struct policy_hub_t
             cub::CacheLoadModifier LOAD_MODIFIER,
             cub::BlockStoreAlgorithm STORE_ALGORITHM,
             cub::BlockScanAlgorithm SCAN_ALGORITHM>
-  using agent_policy_t = cub::AgentScanPolicy<
-    NOMINAL_BLOCK_THREADS_4B,
-    NOMINAL_ITEMS_PER_THREAD_4B,
-    ComputeT,
-    LOAD_ALGORITHM,
-    LOAD_MODIFIER,
-    STORE_ALGORITHM,
-    SCAN_ALGORITHM,
-    cub::MemBoundScaling<NOMINAL_BLOCK_THREADS_4B, NOMINAL_ITEMS_PER_THREAD_4B, ComputeT>,
-    delay_constructor_t>;
+  using agent_policy_t =
+    cub::AgentScanPolicy<NOMINAL_BLOCK_THREADS_4B,
+                         NOMINAL_ITEMS_PER_THREAD_4B,
+                         ComputeT,
+                         LOAD_ALGORITHM,
+                         LOAD_MODIFIER,
+                         STORE_ALGORITHM,
+                         SCAN_ALGORITHM delay_constructor_t>;
 
   struct policy_t : cub::ChainedPolicy<300, policy_t, policy_t>
   {

--- a/cub/cub/agent/agent_radix_sort_downsweep.cuh
+++ b/cub/cub/agent/agent_radix_sort_downsweep.cuh
@@ -90,16 +90,17 @@ CUB_NAMESPACE_BEGIN
  * @tparam _RADIX_BITS
  *   The number of radix bits, i.e., log2(bins)
  */
-template <int NOMINAL_BLOCK_THREADS_4B,
-          int NOMINAL_ITEMS_PER_THREAD_4B,
-          typename ComputeT,
-          BlockLoadAlgorithm _LOAD_ALGORITHM,
-          CacheLoadModifier _LOAD_MODIFIER,
-          RadixRankAlgorithm _RANK_ALGORITHM,
-          BlockScanAlgorithm _SCAN_ALGORITHM,
-          int _RADIX_BITS>
-struct AgentRadixSortDownsweepPolicy
-    : detail::RegBoundScaling<NOMINAL_BLOCK_THREADS_4B, NOMINAL_ITEMS_PER_THREAD_4B, ComputeT>
+template <
+  int NOMINAL_BLOCK_THREADS_4B,
+  int NOMINAL_ITEMS_PER_THREAD_4B,
+  typename ComputeT,
+  BlockLoadAlgorithm _LOAD_ALGORITHM,
+  CacheLoadModifier _LOAD_MODIFIER,
+  RadixRankAlgorithm _RANK_ALGORITHM,
+  BlockScanAlgorithm _SCAN_ALGORITHM,
+  int _RADIX_BITS,
+  typename ScalingType = detail::RegBoundScaling<NOMINAL_BLOCK_THREADS_4B, NOMINAL_ITEMS_PER_THREAD_4B, ComputeT>>
+struct AgentRadixSortDownsweepPolicy : ScalingType
 {
   enum
   {

--- a/cub/cub/agent/agent_radix_sort_downsweep.cuh
+++ b/cub/cub/agent/agent_radix_sort_downsweep.cuh
@@ -97,9 +97,9 @@ template <int NOMINAL_BLOCK_THREADS_4B,
           CacheLoadModifier _LOAD_MODIFIER,
           RadixRankAlgorithm _RANK_ALGORITHM,
           BlockScanAlgorithm _SCAN_ALGORITHM,
-          int _RADIX_BITS,
-          typename ScalingType = RegBoundScaling<NOMINAL_BLOCK_THREADS_4B, NOMINAL_ITEMS_PER_THREAD_4B, ComputeT>>
-struct AgentRadixSortDownsweepPolicy : ScalingType
+          int _RADIX_BITS>
+struct AgentRadixSortDownsweepPolicy
+    : detail::RegBoundScaling<NOMINAL_BLOCK_THREADS_4B, NOMINAL_ITEMS_PER_THREAD_4B, ComputeT>
 {
   enum
   {

--- a/cub/cub/agent/agent_radix_sort_onesweep.cuh
+++ b/cub/cub/agent/agent_radix_sort_onesweep.cuh
@@ -83,9 +83,9 @@ template <int NOMINAL_BLOCK_THREADS_4B,
           RadixRankAlgorithm _RANK_ALGORITHM,
           BlockScanAlgorithm _SCAN_ALGORITHM,
           RadixSortStoreAlgorithm _STORE_ALGORITHM,
-          int _RADIX_BITS,
-          typename ScalingType = RegBoundScaling<NOMINAL_BLOCK_THREADS_4B, NOMINAL_ITEMS_PER_THREAD_4B, ComputeT>>
-struct AgentRadixSortOnesweepPolicy : ScalingType
+          int _RADIX_BITS>
+struct AgentRadixSortOnesweepPolicy
+    : detail::RegBoundScaling<NOMINAL_BLOCK_THREADS_4B, NOMINAL_ITEMS_PER_THREAD_4B, ComputeT>
 {
   enum
   {

--- a/cub/cub/agent/agent_radix_sort_onesweep.cuh
+++ b/cub/cub/agent/agent_radix_sort_onesweep.cuh
@@ -72,20 +72,21 @@ enum RadixSortStoreAlgorithm
   RADIX_SORT_STORE_ALIGNED
 };
 
-template <int NOMINAL_BLOCK_THREADS_4B,
-          int NOMINAL_ITEMS_PER_THREAD_4B,
-          typename ComputeT,
-          /** \brief Number of private histograms to use in the ranker;
-              ignored if the ranking algorithm is not one of RADIX_RANK_MATCH_EARLY_COUNTS_* */
-          int _RANK_NUM_PARTS,
-          /** \brief Ranking algorithm used in the onesweep kernel. Only algorithms that
-            support warp-strided key arrangement and count callbacks are supported. */
-          RadixRankAlgorithm _RANK_ALGORITHM,
-          BlockScanAlgorithm _SCAN_ALGORITHM,
-          RadixSortStoreAlgorithm _STORE_ALGORITHM,
-          int _RADIX_BITS>
-struct AgentRadixSortOnesweepPolicy
-    : detail::RegBoundScaling<NOMINAL_BLOCK_THREADS_4B, NOMINAL_ITEMS_PER_THREAD_4B, ComputeT>
+template <
+  int NOMINAL_BLOCK_THREADS_4B,
+  int NOMINAL_ITEMS_PER_THREAD_4B,
+  typename ComputeT,
+  /** \brief Number of private histograms to use in the ranker;
+      ignored if the ranking algorithm is not one of RADIX_RANK_MATCH_EARLY_COUNTS_* */
+  int _RANK_NUM_PARTS,
+  /** \brief Ranking algorithm used in the onesweep kernel. Only algorithms that
+    support warp-strided key arrangement and count callbacks are supported. */
+  RadixRankAlgorithm _RANK_ALGORITHM,
+  BlockScanAlgorithm _SCAN_ALGORITHM,
+  RadixSortStoreAlgorithm _STORE_ALGORITHM,
+  int _RADIX_BITS,
+  typename ScalingType = detail::RegBoundScaling<NOMINAL_BLOCK_THREADS_4B, NOMINAL_ITEMS_PER_THREAD_4B, ComputeT>>
+struct AgentRadixSortOnesweepPolicy : ScalingType
 {
   enum
   {

--- a/cub/cub/agent/agent_radix_sort_upsweep.cuh
+++ b/cub/cub/agent/agent_radix_sort_upsweep.cuh
@@ -82,9 +82,9 @@ template <int NOMINAL_BLOCK_THREADS_4B,
           int NOMINAL_ITEMS_PER_THREAD_4B,
           typename ComputeT,
           CacheLoadModifier _LOAD_MODIFIER,
-          int _RADIX_BITS,
-          typename ScalingType = RegBoundScaling<NOMINAL_BLOCK_THREADS_4B, NOMINAL_ITEMS_PER_THREAD_4B, ComputeT>>
-struct AgentRadixSortUpsweepPolicy : ScalingType
+          int _RADIX_BITS>
+struct AgentRadixSortUpsweepPolicy
+    : detail::RegBoundScaling<NOMINAL_BLOCK_THREADS_4B, NOMINAL_ITEMS_PER_THREAD_4B, ComputeT>
 {
   enum
   {

--- a/cub/cub/agent/agent_radix_sort_upsweep.cuh
+++ b/cub/cub/agent/agent_radix_sort_upsweep.cuh
@@ -78,13 +78,14 @@ CUB_NAMESPACE_BEGIN
  * @tparam _RADIX_BITS
  *   The number of radix bits, i.e., log2(bins)
  */
-template <int NOMINAL_BLOCK_THREADS_4B,
-          int NOMINAL_ITEMS_PER_THREAD_4B,
-          typename ComputeT,
-          CacheLoadModifier _LOAD_MODIFIER,
-          int _RADIX_BITS>
-struct AgentRadixSortUpsweepPolicy
-    : detail::RegBoundScaling<NOMINAL_BLOCK_THREADS_4B, NOMINAL_ITEMS_PER_THREAD_4B, ComputeT>
+template <
+  int NOMINAL_BLOCK_THREADS_4B,
+  int NOMINAL_ITEMS_PER_THREAD_4B,
+  typename ComputeT,
+  CacheLoadModifier _LOAD_MODIFIER,
+  int _RADIX_BITS,
+  typename ScalingType = detail::RegBoundScaling<NOMINAL_BLOCK_THREADS_4B, NOMINAL_ITEMS_PER_THREAD_4B, ComputeT>>
+struct AgentRadixSortUpsweepPolicy : ScalingType
 {
   enum
   {

--- a/cub/cub/agent/agent_reduce.cuh
+++ b/cub/cub/agent/agent_reduce.cuh
@@ -72,13 +72,15 @@ CUB_NAMESPACE_BEGIN
  * @tparam _BLOCK_ALGORITHM Cooperative block-wide reduction algorithm to use
  * @tparam _LOAD_MODIFIER Cache load modifier for reading input elements
  */
-template <int NOMINAL_BLOCK_THREADS_4B,
-          int NOMINAL_ITEMS_PER_THREAD_4B,
-          typename ComputeT,
-          int _VECTOR_LOAD_LENGTH,
-          BlockReduceAlgorithm _BLOCK_ALGORITHM,
-          CacheLoadModifier _LOAD_MODIFIER>
-struct AgentReducePolicy : detail::MemBoundScaling<NOMINAL_BLOCK_THREADS_4B, NOMINAL_ITEMS_PER_THREAD_4B, ComputeT>
+template <
+  int NOMINAL_BLOCK_THREADS_4B,
+  int NOMINAL_ITEMS_PER_THREAD_4B,
+  typename ComputeT,
+  int _VECTOR_LOAD_LENGTH,
+  BlockReduceAlgorithm _BLOCK_ALGORITHM,
+  CacheLoadModifier _LOAD_MODIFIER,
+  typename ScalingType = detail::MemBoundScaling<NOMINAL_BLOCK_THREADS_4B, NOMINAL_ITEMS_PER_THREAD_4B, ComputeT>>
+struct AgentReducePolicy : ScalingType
 {
   /// Number of items per vectorized load
   static constexpr int VECTOR_LOAD_LENGTH = _VECTOR_LOAD_LENGTH;

--- a/cub/cub/agent/agent_reduce.cuh
+++ b/cub/cub/agent/agent_reduce.cuh
@@ -77,9 +77,8 @@ template <int NOMINAL_BLOCK_THREADS_4B,
           typename ComputeT,
           int _VECTOR_LOAD_LENGTH,
           BlockReduceAlgorithm _BLOCK_ALGORITHM,
-          CacheLoadModifier _LOAD_MODIFIER,
-          typename ScalingType = MemBoundScaling<NOMINAL_BLOCK_THREADS_4B, NOMINAL_ITEMS_PER_THREAD_4B, ComputeT>>
-struct AgentReducePolicy : ScalingType
+          CacheLoadModifier _LOAD_MODIFIER>
+struct AgentReducePolicy : detail::MemBoundScaling<NOMINAL_BLOCK_THREADS_4B, NOMINAL_ITEMS_PER_THREAD_4B, ComputeT>
 {
   /// Number of items per vectorized load
   static constexpr int VECTOR_LOAD_LENGTH = _VECTOR_LOAD_LENGTH;

--- a/cub/cub/agent/agent_scan.cuh
+++ b/cub/cub/agent/agent_scan.cuh
@@ -93,9 +93,8 @@ template <int NOMINAL_BLOCK_THREADS_4B,
           CacheLoadModifier _LOAD_MODIFIER,
           BlockStoreAlgorithm _STORE_ALGORITHM,
           BlockScanAlgorithm _SCAN_ALGORITHM,
-          typename ScalingType       = MemBoundScaling<NOMINAL_BLOCK_THREADS_4B, NOMINAL_ITEMS_PER_THREAD_4B, ComputeT>,
           typename DelayConstructorT = detail::default_delay_constructor_t<ComputeT>>
-struct AgentScanPolicy : ScalingType
+struct AgentScanPolicy : detail::MemBoundScaling<NOMINAL_BLOCK_THREADS_4B, NOMINAL_ITEMS_PER_THREAD_4B, ComputeT>
 {
   static constexpr BlockLoadAlgorithm LOAD_ALGORITHM   = _LOAD_ALGORITHM;
   static constexpr CacheLoadModifier LOAD_MODIFIER     = _LOAD_MODIFIER;

--- a/cub/cub/agent/agent_scan.cuh
+++ b/cub/cub/agent/agent_scan.cuh
@@ -86,15 +86,17 @@ CUB_NAMESPACE_BEGIN
  *   Implementation detail, do not specify directly, requirements on the
  *   content of this type are subject to breaking change.
  */
-template <int NOMINAL_BLOCK_THREADS_4B,
-          int NOMINAL_ITEMS_PER_THREAD_4B,
-          typename ComputeT,
-          BlockLoadAlgorithm _LOAD_ALGORITHM,
-          CacheLoadModifier _LOAD_MODIFIER,
-          BlockStoreAlgorithm _STORE_ALGORITHM,
-          BlockScanAlgorithm _SCAN_ALGORITHM,
-          typename DelayConstructorT = detail::default_delay_constructor_t<ComputeT>>
-struct AgentScanPolicy : detail::MemBoundScaling<NOMINAL_BLOCK_THREADS_4B, NOMINAL_ITEMS_PER_THREAD_4B, ComputeT>
+template <
+  int NOMINAL_BLOCK_THREADS_4B,
+  int NOMINAL_ITEMS_PER_THREAD_4B,
+  typename ComputeT,
+  BlockLoadAlgorithm _LOAD_ALGORITHM,
+  CacheLoadModifier _LOAD_MODIFIER,
+  BlockStoreAlgorithm _STORE_ALGORITHM,
+  BlockScanAlgorithm _SCAN_ALGORITHM,
+  typename ScalingType       = detail::MemBoundScaling<NOMINAL_BLOCK_THREADS_4B, NOMINAL_ITEMS_PER_THREAD_4B, ComputeT>,
+  typename DelayConstructorT = detail::default_delay_constructor_t<ComputeT>>
+struct AgentScanPolicy : ScalingType
 {
   static constexpr BlockLoadAlgorithm LOAD_ALGORITHM   = _LOAD_ALGORITHM;
   static constexpr CacheLoadModifier LOAD_MODIFIER     = _LOAD_MODIFIER;

--- a/cub/cub/device/dispatch/tuning/tuning_scan.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan.cuh
@@ -307,6 +307,7 @@ struct policy_hub
                        LOAD_DEFAULT,
                        Tuning::store_algorithm,
                        BLOCK_SCAN_WARP_SCANS,
+                       cub::detail::MemBoundScaling<Tuning::threads, Tuning::items, AccumT>,
                        typename Tuning::delay_constructor>;
   template <typename Tuning>
   static auto select_agent_policy(long) -> typename DefaultPolicy::ScanPolicyT;

--- a/cub/cub/device/dispatch/tuning/tuning_scan.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan.cuh
@@ -307,7 +307,6 @@ struct policy_hub
                        LOAD_DEFAULT,
                        Tuning::store_algorithm,
                        BLOCK_SCAN_WARP_SCANS,
-                       MemBoundScaling<Tuning::threads, Tuning::items, AccumT>,
                        typename Tuning::delay_constructor>;
   template <typename Tuning>
   static auto select_agent_policy(long) -> typename DefaultPolicy::ScanPolicyT;

--- a/cub/cub/util_arch.cuh
+++ b/cub/cub/util_arch.cuh
@@ -35,8 +35,6 @@
 
 #include <cub/config.cuh>
 
-#include "cuda/std/__cccl/deprecated.h"
-
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)

--- a/cub/cub/util_arch.cuh
+++ b/cub/cub/util_arch.cuh
@@ -35,6 +35,8 @@
 
 #include <cub/config.cuh>
 
+#include "cuda/std/__cccl/deprecated.h"
+
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
@@ -115,7 +117,6 @@ namespace detail
 // The maximum amount of static shared memory available per thread block
 // Note that in contrast to dynamic shared memory, static shared memory is still limited to 48 KB
 static constexpr ::cuda::std::size_t max_smem_per_block = 48 * 1024;
-} // namespace detail
 
 template <int Nominal4ByteBlockThreads, int Nominal4ByteItemsPerThread, typename T>
 struct RegBoundScaling
@@ -136,6 +137,16 @@ struct MemBoundScaling
     Nominal4ByteBlockThreads,
     ::cuda::ceil_div(int{detail::max_smem_per_block} / (int{sizeof(T)} * ITEMS_PER_THREAD), 32) * 32);
 };
+
+} // namespace detail
+
+template <int Nominal4ByteBlockThreads, int Nominal4ByteItemsPerThread, typename T>
+using RegBoundScaling CCCL_DEPRECATED_BECAUSE("Internal implementation detail") =
+  detail::RegBoundScaling<Nominal4ByteBlockThreads, Nominal4ByteItemsPerThread, T>;
+
+template <int Nominal4ByteBlockThreads, int Nominal4ByteItemsPerThread, typename T>
+using MemBoundScaling CCCL_DEPRECATED_BECAUSE("Internal implementation detail") =
+  detail::RegBoundScaling<Nominal4ByteBlockThreads, Nominal4ByteItemsPerThread, T>;
 
 #endif // Do not document
 


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/cccl/issues/3663

## Description

Deprecate and move into detail namespace `cub::RegBoundScaling` and `cub::MemBoundScaling`

1. Deprecate `cub::RegBoundScaling` and `cub::MemBoundScaling`
2. Forward them to `cub::detail` namespace implementation

To backport to 2.8