### PR TITLE
Fix SM100 histogram tunings

### DIFF
--- a/cub/cub/device/dispatch/tuning/tuning_histogram.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_histogram.cuh
@@ -182,33 +182,35 @@ struct sm100_tuning<false, SampleT, 1, 1, counter_size::_4, primitive_sample::ye
 // template <class SampleT>
 // struct sm100_tuning<false, SampleT, 1, 1, counter_size::_4, primitive_sample::yes, sample_size::_2> {};
 
-template <class SampleT>
-struct sm100_tuning<false, SampleT, 1, 1, counter_size::_4, primitive_sample::yes, sample_size::_4>
-{
-  // ipt_9.tpb_1024.rle_1.ws_0.mem_1.ld_0.laid_1.vec_0 1.358537  1.001009  1.373329  2.614104
-  static constexpr int items                                     = 9;
-  static constexpr int threads                                   = 1024;
-  static constexpr bool rle_compress                             = true;
-  static constexpr bool work_stealing                            = false;
-  static constexpr BlockHistogramMemoryPreference mem_preference = SMEM;
-  static constexpr CacheLoadModifier load_modifier               = LOAD_DEFAULT;
-  static constexpr BlockLoadAlgorithm load_algorithm             = BLOCK_LOAD_WARP_TRANSPOSE;
-  static constexpr int vec_size                                  = 1 << 0;
-};
+// TODO(gonidelis): we found the below tuning but the verification benchmark showed regressions, so it's disabled
+// template <class SampleT>
+// struct sm100_tuning<false, SampleT, 1, 1, counter_size::_4, primitive_sample::yes, sample_size::_4>
+// {
+//   // ipt_9.tpb_1024.rle_1.ws_0.mem_1.ld_0.laid_1.vec_0 1.358537  1.001009  1.373329  2.614104
+//   static constexpr int items                                     = 9;
+//   static constexpr int threads                                   = 1024;
+//   static constexpr bool rle_compress                             = true;
+//   static constexpr bool work_stealing                            = false;
+//   static constexpr BlockHistogramMemoryPreference mem_preference = SMEM;
+//   static constexpr CacheLoadModifier load_modifier               = LOAD_DEFAULT;
+//   static constexpr BlockLoadAlgorithm load_algorithm             = BLOCK_LOAD_WARP_TRANSPOSE;
+//   static constexpr int vec_size                                  = 1 << 0;
+// };
 
-template <class SampleT>
-struct sm100_tuning<false, SampleT, 1, 1, counter_size::_4, primitive_sample::yes, sample_size::_8>
-{
-  // ipt_7.tpb_544.rle_1.ws_0.mem_1.ld_1.laid_0.vec_0 1.105331  0.934888  1.108557  1.391657
-  static constexpr int items                                     = 7;
-  static constexpr int threads                                   = 544;
-  static constexpr bool rle_compress                             = true;
-  static constexpr bool work_stealing                            = false;
-  static constexpr BlockHistogramMemoryPreference mem_preference = SMEM;
-  static constexpr CacheLoadModifier load_modifier               = LOAD_LDG;
-  static constexpr BlockLoadAlgorithm load_algorithm             = BLOCK_LOAD_DIRECT;
-  static constexpr int vec_size                                  = 1 << 0;
-};
+// TODO(gonidelis): we found the below tuning but the verification benchmark showed regressions, so it's disabled
+// template <class SampleT>
+// struct sm100_tuning<false, SampleT, 1, 1, counter_size::_4, primitive_sample::yes, sample_size::_8>
+// {
+//   // ipt_7.tpb_544.rle_1.ws_0.mem_1.ld_1.laid_0.vec_0 1.105331  0.934888  1.108557  1.391657
+//   static constexpr int items                                     = 7;
+//   static constexpr int threads                                   = 544;
+//   static constexpr bool rle_compress                             = true;
+//   static constexpr bool work_stealing                            = false;
+//   static constexpr BlockHistogramMemoryPreference mem_preference = SMEM;
+//   static constexpr CacheLoadModifier load_modifier               = LOAD_LDG;
+//   static constexpr BlockLoadAlgorithm load_algorithm             = BLOCK_LOAD_DIRECT;
+//   static constexpr int vec_size                                  = 1 << 0;
+// };
 
 // multi.even
 template <class SampleT>

--- a/cub/cub/device/dispatch/tuning/tuning_histogram.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_histogram.cuh
@@ -138,7 +138,7 @@ struct sm100_tuning;
 
 // even
 template <class SampleT>
-struct sm100_tuning<1, SampleT, 1, 1, counter_size::_4, primitive_sample::yes, sample_size::_1>
+struct sm100_tuning<true, SampleT, 1, 1, counter_size::_4, primitive_sample::yes, sample_size::_1>
 {
   // ipt_12.tpb_928.rle_0.ws_0.mem_1.ld_2.laid_0.vec_2 1.033332  0.940517  1.031835  1.195876
   static constexpr int items                                     = 12;
@@ -153,19 +153,19 @@ struct sm100_tuning<1, SampleT, 1, 1, counter_size::_4, primitive_sample::yes, s
 
 // same as SM90
 // template <class SampleT>
-// struct sm100_tuning<1, SampleT, 1, 1, counter_size::_4, primitive_sample::yes, sample_size::_2> {};
+// struct sm100_tuning<true, SampleT, 1, 1, counter_size::_4, primitive_sample::yes, sample_size::_2> {};
 
 // same as SM90
 // template <class SampleT>
-// struct sm100_tuning<1, SampleT, 1, 1, counter_size::_4, primitive_sample::yes, sample_size::_4> {};
+// struct sm100_tuning<true, SampleT, 1, 1, counter_size::_4, primitive_sample::yes, sample_size::_4> {};
 
 // same as SM90
 // template <class SampleT>
-// struct sm100_tuning<1, SampleT, 1, 1, counter_size::_4, primitive_sample::yes, sample_size::_8> {};
+// struct sm100_tuning<true, SampleT, 1, 1, counter_size::_4, primitive_sample::yes, sample_size::_8> {};
 
 // range
 template <class SampleT>
-struct sm100_tuning<0, SampleT, 1, 1, counter_size::_4, primitive_sample::yes, sample_size::_1>
+struct sm100_tuning<false, SampleT, 1, 1, counter_size::_4, primitive_sample::yes, sample_size::_1>
 {
   // ipt_12.tpb_448.rle_0.ws_0.mem_1.ld_1.laid_0.vec_2 1.078987  0.985542  1.085118  1.175637
   static constexpr int items                                     = 12;
@@ -180,10 +180,10 @@ struct sm100_tuning<0, SampleT, 1, 1, counter_size::_4, primitive_sample::yes, s
 
 // same as SM90
 // template <class SampleT>
-// struct sm100_tuning<0, SampleT, 1, 1, counter_size::_4, primitive_sample::yes, sample_size::_2> {};
+// struct sm100_tuning<false, SampleT, 1, 1, counter_size::_4, primitive_sample::yes, sample_size::_2> {};
 
 template <class SampleT>
-struct sm100_tuning<0, SampleT, 1, 1, counter_size::_4, primitive_sample::yes, sample_size::_4>
+struct sm100_tuning<false, SampleT, 1, 1, counter_size::_4, primitive_sample::yes, sample_size::_4>
 {
   // ipt_9.tpb_1024.rle_1.ws_0.mem_1.ld_0.laid_1.vec_0 1.358537  1.001009  1.373329  2.614104
   static constexpr int items                                     = 9;
@@ -197,7 +197,7 @@ struct sm100_tuning<0, SampleT, 1, 1, counter_size::_4, primitive_sample::yes, s
 };
 
 template <class SampleT>
-struct sm100_tuning<0, SampleT, 1, 1, counter_size::_4, primitive_sample::yes, sample_size::_8>
+struct sm100_tuning<false, SampleT, 1, 1, counter_size::_4, primitive_sample::yes, sample_size::_8>
 {
   // ipt_7.tpb_544.rle_1.ws_0.mem_1.ld_1.laid_0.vec_0 1.105331  0.934888  1.108557  1.391657
   static constexpr int items                                     = 7;
@@ -212,7 +212,7 @@ struct sm100_tuning<0, SampleT, 1, 1, counter_size::_4, primitive_sample::yes, s
 
 // multi.even
 template <class SampleT>
-struct sm100_tuning<1, SampleT, 4, 3, counter_size::_4, primitive_sample::yes, sample_size::_1>
+struct sm100_tuning<true, SampleT, 4, 3, counter_size::_4, primitive_sample::yes, sample_size::_1>
 {
   // ipt_9.tpb_1024.rle_0.ws_0.mem_1.ld_1.laid_1.vec_0 1.629591  0.997416  1.570900  2.772504
   static constexpr int items                                     = 9;
@@ -227,19 +227,19 @@ struct sm100_tuning<1, SampleT, 4, 3, counter_size::_4, primitive_sample::yes, s
 
 // same as SM90
 // template <class SampleT>
-// struct sm100_tuning<1, SampleT, 4, 3, counter_size::_4, primitive_sample::yes, sample_size::_2> {};
+// struct sm100_tuning<true, SampleT, 4, 3, counter_size::_4, primitive_sample::yes, sample_size::_2> {};
 
 // same as SM90
 // template <class SampleT>
-// struct sm100_tuning<1, SampleT, 4, 3, counter_size::_4, primitive_sample::yes, sample_size::_4> {};
+// struct sm100_tuning<true, SampleT, 4, 3, counter_size::_4, primitive_sample::yes, sample_size::_4> {};
 
 // same as SM90
 // template <class SampleT>
-// struct sm100_tuning<1, SampleT, 4, 3, counter_size::_4, primitive_sample::yes, sample_size::_8> {};
+// struct sm100_tuning<true, SampleT, 4, 3, counter_size::_4, primitive_sample::yes, sample_size::_8> {};
 
 // multi.range
 template <class SampleT>
-struct sm100_tuning<0, SampleT, 4, 3, counter_size::_4, primitive_sample::yes, sample_size::_1>
+struct sm100_tuning<false, SampleT, 4, 3, counter_size::_4, primitive_sample::yes, sample_size::_1>
 {
   // ipt_7.tpb_160.rle_0.ws_0.mem_1.ld_1.laid_1.vec_1 1.210837  0.99556  1.189049  1.939584
   static constexpr int items                                     = 7;
@@ -254,15 +254,15 @@ struct sm100_tuning<0, SampleT, 4, 3, counter_size::_4, primitive_sample::yes, s
 
 // same as SM90
 // template <class SampleT>
-// struct sm100_tuning<0, SampleT, 4, 3, counter_size::_4, primitive_sample::yes, sample_size::_2> {};
+// struct sm100_tuning<false, SampleT, 4, 3, counter_size::_4, primitive_sample::yes, sample_size::_2> {};
 
 // same as SM90
 // template <class SampleT>
-// struct sm100_tuning<0, SampleT, 4, 3, counter_size::_4, primitive_sample::yes, sample_size::_4> {};
+// struct sm100_tuning<false, SampleT, 4, 3, counter_size::_4, primitive_sample::yes, sample_size::_4> {};
 
 // same as SM90
 // template <class SampleT>
-// struct sm100_tuning<0, SampleT, 4, 3, counter_size::_4, primitive_sample::yes, sample_size::_8> {};
+// struct sm100_tuning<false, SampleT, 4, 3, counter_size::_4, primitive_sample::yes, sample_size::_8> {};
 
 template <class SampleT, class CounterT, int NumChannels, int NumActiveChannels, bool IsEven>
 struct policy_hub

--- a/cub/cub/device/dispatch/tuning/tuning_histogram.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_histogram.cuh
@@ -225,15 +225,15 @@ struct sm100_tuning<1, SampleT, 4, 3, counter_size::_4, primitive_sample::yes, s
   static constexpr int vec_size                                  = 1 << 0;
 };
 
-// same as base
+// same as SM90
 // template <class SampleT>
 // struct sm100_tuning<1, SampleT, 4, 3, counter_size::_4, primitive_sample::yes, sample_size::_2> {};
 
-// same as base
+// same as SM90
 // template <class SampleT>
 // struct sm100_tuning<1, SampleT, 4, 3, counter_size::_4, primitive_sample::yes, sample_size::_4> {};
 
-// same as base
+// same as SM90
 // template <class SampleT>
 // struct sm100_tuning<1, SampleT, 4, 3, counter_size::_4, primitive_sample::yes, sample_size::_8> {};
 
@@ -252,23 +252,17 @@ struct sm100_tuning<0, SampleT, 4, 3, counter_size::_4, primitive_sample::yes, s
   static constexpr int vec_size                                  = 1 << 1;
 };
 
-// same as base
-template <class SampleT>
-struct sm100_tuning<0, SampleT, 4, 3, counter_size::_4, primitive_sample::yes, sample_size::_2>
-    : sm90_tuning<SampleT, 1, 1, counter_size::_4, primitive_sample::yes, sample_size::_2>
-{};
+// same as SM90
+// template <class SampleT>
+// struct sm100_tuning<0, SampleT, 4, 3, counter_size::_4, primitive_sample::yes, sample_size::_2> {};
 
-// same as base
-template <class SampleT>
-struct sm100_tuning<0, SampleT, 4, 3, counter_size::_4, primitive_sample::yes, sample_size::_4>
-    : sm90_tuning<SampleT, 1, 1, counter_size::_4, primitive_sample::yes, sample_size::_4>
-{};
+// same as SM90
+// template <class SampleT>
+// struct sm100_tuning<0, SampleT, 4, 3, counter_size::_4, primitive_sample::yes, sample_size::_4> {};
 
-// same as base
-template <class SampleT>
-struct sm100_tuning<0, SampleT, 4, 3, counter_size::_4, primitive_sample::yes, sample_size::_8>
-    : sm90_tuning<SampleT, 1, 1, counter_size::_4, primitive_sample::yes, sample_size::_8>
-{};
+// same as SM90
+// template <class SampleT>
+// struct sm100_tuning<0, SampleT, 4, 3, counter_size::_4, primitive_sample::yes, sample_size::_8> {};
 
 template <class SampleT, class CounterT, int NumChannels, int NumActiveChannels, bool IsEven>
 struct policy_hub

--- a/cub/cub/device/dispatch/tuning/tuning_histogram.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_histogram.cuh
@@ -151,17 +151,7 @@ struct sm100_tuning<true, SampleT, 1, 1, counter_size::_4, primitive_sample::yes
   static constexpr int vec_size                                  = 1 << 2;
 };
 
-// same as SM90
-// template <class SampleT>
-// struct sm100_tuning<true, SampleT, 1, 1, counter_size::_4, primitive_sample::yes, sample_size::_2> {};
-
-// same as SM90
-// template <class SampleT>
-// struct sm100_tuning<true, SampleT, 1, 1, counter_size::_4, primitive_sample::yes, sample_size::_4> {};
-
-// same as SM90
-// template <class SampleT>
-// struct sm100_tuning<true, SampleT, 1, 1, counter_size::_4, primitive_sample::yes, sample_size::_8> {};
+// sample_size 2/4/8 showed no benefit over SM90 during verification benchmarks
 
 // range
 template <class SampleT>
@@ -178,93 +168,9 @@ struct sm100_tuning<false, SampleT, 1, 1, counter_size::_4, primitive_sample::ye
   static constexpr int vec_size                                  = 1 << 2;
 };
 
-// same as SM90
-// template <class SampleT>
-// struct sm100_tuning<false, SampleT, 1, 1, counter_size::_4, primitive_sample::yes, sample_size::_2> {};
+// sample_size 2/4/8 showed no benefit over SM90 during verification benchmarks
 
-// TODO(gonidelis): we found the below tuning but the verification benchmark showed regressions, so it's disabled
-// template <class SampleT>
-// struct sm100_tuning<false, SampleT, 1, 1, counter_size::_4, primitive_sample::yes, sample_size::_4>
-// {
-//   // ipt_9.tpb_1024.rle_1.ws_0.mem_1.ld_0.laid_1.vec_0 1.358537  1.001009  1.373329  2.614104
-//   static constexpr int items                                     = 9;
-//   static constexpr int threads                                   = 1024;
-//   static constexpr bool rle_compress                             = true;
-//   static constexpr bool work_stealing                            = false;
-//   static constexpr BlockHistogramMemoryPreference mem_preference = SMEM;
-//   static constexpr CacheLoadModifier load_modifier               = LOAD_DEFAULT;
-//   static constexpr BlockLoadAlgorithm load_algorithm             = BLOCK_LOAD_WARP_TRANSPOSE;
-//   static constexpr int vec_size                                  = 1 << 0;
-// };
-
-// TODO(gonidelis): we found the below tuning but the verification benchmark showed regressions, so it's disabled
-// template <class SampleT>
-// struct sm100_tuning<false, SampleT, 1, 1, counter_size::_4, primitive_sample::yes, sample_size::_8>
-// {
-//   // ipt_7.tpb_544.rle_1.ws_0.mem_1.ld_1.laid_0.vec_0 1.105331  0.934888  1.108557  1.391657
-//   static constexpr int items                                     = 7;
-//   static constexpr int threads                                   = 544;
-//   static constexpr bool rle_compress                             = true;
-//   static constexpr bool work_stealing                            = false;
-//   static constexpr BlockHistogramMemoryPreference mem_preference = SMEM;
-//   static constexpr CacheLoadModifier load_modifier               = LOAD_LDG;
-//   static constexpr BlockLoadAlgorithm load_algorithm             = BLOCK_LOAD_DIRECT;
-//   static constexpr int vec_size                                  = 1 << 0;
-// };
-
-// multi.even
-template <class SampleT>
-struct sm100_tuning<true, SampleT, 4, 3, counter_size::_4, primitive_sample::yes, sample_size::_1>
-{
-  // ipt_9.tpb_1024.rle_0.ws_0.mem_1.ld_1.laid_1.vec_0 1.629591  0.997416  1.570900  2.772504
-  static constexpr int items                                     = 9;
-  static constexpr int threads                                   = 1024;
-  static constexpr bool rle_compress                             = false;
-  static constexpr bool work_stealing                            = false;
-  static constexpr BlockHistogramMemoryPreference mem_preference = SMEM;
-  static constexpr CacheLoadModifier load_modifier               = LOAD_LDG;
-  static constexpr BlockLoadAlgorithm load_algorithm             = BLOCK_LOAD_WARP_TRANSPOSE;
-  static constexpr int vec_size                                  = 1 << 0;
-};
-
-// same as SM90
-// template <class SampleT>
-// struct sm100_tuning<true, SampleT, 4, 3, counter_size::_4, primitive_sample::yes, sample_size::_2> {};
-
-// same as SM90
-// template <class SampleT>
-// struct sm100_tuning<true, SampleT, 4, 3, counter_size::_4, primitive_sample::yes, sample_size::_4> {};
-
-// same as SM90
-// template <class SampleT>
-// struct sm100_tuning<true, SampleT, 4, 3, counter_size::_4, primitive_sample::yes, sample_size::_8> {};
-
-// multi.range
-template <class SampleT>
-struct sm100_tuning<false, SampleT, 4, 3, counter_size::_4, primitive_sample::yes, sample_size::_1>
-{
-  // ipt_7.tpb_160.rle_0.ws_0.mem_1.ld_1.laid_1.vec_1 1.210837  0.99556  1.189049  1.939584
-  static constexpr int items                                     = 7;
-  static constexpr int threads                                   = 160;
-  static constexpr bool rle_compress                             = false;
-  static constexpr bool work_stealing                            = false;
-  static constexpr BlockHistogramMemoryPreference mem_preference = SMEM;
-  static constexpr CacheLoadModifier load_modifier               = LOAD_LDG;
-  static constexpr BlockLoadAlgorithm load_algorithm             = BLOCK_LOAD_WARP_TRANSPOSE;
-  static constexpr int vec_size                                  = 1 << 1;
-};
-
-// same as SM90
-// template <class SampleT>
-// struct sm100_tuning<false, SampleT, 4, 3, counter_size::_4, primitive_sample::yes, sample_size::_2> {};
-
-// same as SM90
-// template <class SampleT>
-// struct sm100_tuning<false, SampleT, 4, 3, counter_size::_4, primitive_sample::yes, sample_size::_4> {};
-
-// same as SM90
-// template <class SampleT>
-// struct sm100_tuning<false, SampleT, 4, 3, counter_size::_4, primitive_sample::yes, sample_size::_8> {};
+// multi.even and multi.range: none of the found tunings surpassed the SM90 tuning during verification benchmarks
 
 template <class SampleT, class CounterT, int NumChannels, int NumActiveChannels, bool IsEven>
 struct policy_hub

--- a/cub/cub/device/dispatch/tuning/tuning_histogram.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_histogram.cuh
@@ -148,7 +148,7 @@ struct sm100_tuning<1, SampleT, 1, 1, counter_size::_4, primitive_sample::yes, s
   static constexpr BlockHistogramMemoryPreference mem_preference = SMEM;
   static constexpr CacheLoadModifier load_modifier               = LOAD_CA;
   static constexpr BlockLoadAlgorithm load_algorithm             = BLOCK_LOAD_DIRECT;
-  static constexpr int tune_vec_size                             = 1 << 2;
+  static constexpr int vec_size                                  = 1 << 2;
 };
 
 // same as base
@@ -181,7 +181,7 @@ struct sm100_tuning<0, SampleT, 1, 1, counter_size::_4, primitive_sample::yes, s
   static constexpr BlockHistogramMemoryPreference mem_preference = SMEM;
   static constexpr CacheLoadModifier load_modifier               = LOAD_LDG;
   static constexpr BlockLoadAlgorithm load_algorithm             = BLOCK_LOAD_DIRECT;
-  static constexpr int tune_vec_size                             = 1 << 2;
+  static constexpr int vec_size                                  = 1 << 2;
 };
 
 // same as base
@@ -201,7 +201,7 @@ struct sm100_tuning<0, SampleT, 1, 1, counter_size::_4, primitive_sample::yes, s
   static constexpr BlockHistogramMemoryPreference mem_preference = SMEM;
   static constexpr CacheLoadModifier load_modifier               = LOAD_DEFAULT;
   static constexpr BlockLoadAlgorithm load_algorithm             = BLOCK_LOAD_WARP_TRANSPOSE;
-  static constexpr int tune_vec_size                             = 1 << 0;
+  static constexpr int vec_size                                  = 1 << 0;
 };
 
 template <class SampleT>
@@ -215,7 +215,7 @@ struct sm100_tuning<0, SampleT, 1, 1, counter_size::_4, primitive_sample::yes, s
   static constexpr BlockHistogramMemoryPreference mem_preference = SMEM;
   static constexpr CacheLoadModifier load_modifier               = LOAD_LDG;
   static constexpr BlockLoadAlgorithm load_algorithm             = BLOCK_LOAD_DIRECT;
-  static constexpr int tune_vec_size                             = 1 << 0;
+  static constexpr int vec_size                                  = 1 << 0;
 };
 
 // multi.even
@@ -230,7 +230,7 @@ struct sm100_tuning<1, SampleT, 4, 3, counter_size::_4, primitive_sample::yes, s
   static constexpr BlockHistogramMemoryPreference mem_preference = SMEM;
   static constexpr CacheLoadModifier load_modifier               = LOAD_LDG;
   static constexpr BlockLoadAlgorithm load_algorithm             = BLOCK_LOAD_WARP_TRANSPOSE;
-  static constexpr int tune_vec_size                             = 1 << 0;
+  static constexpr int vec_size                                  = 1 << 0;
 };
 
 // same as base
@@ -263,7 +263,7 @@ struct sm100_tuning<0, SampleT, 4, 3, counter_size::_4, primitive_sample::yes, s
   static constexpr BlockHistogramMemoryPreference mem_preference = SMEM;
   static constexpr CacheLoadModifier load_modifier               = LOAD_LDG;
   static constexpr BlockLoadAlgorithm load_algorithm             = BLOCK_LOAD_WARP_TRANSPOSE;
-  static constexpr int tune_vec_size                             = 1 << 1;
+  static constexpr int vec_size                                  = 1 << 1;
 };
 
 // same as base

--- a/cub/cub/device/dispatch/tuning/tuning_histogram.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_histogram.cuh
@@ -151,23 +151,17 @@ struct sm100_tuning<1, SampleT, 1, 1, counter_size::_4, primitive_sample::yes, s
   static constexpr int vec_size                                  = 1 << 2;
 };
 
-// same as base
-template <class SampleT>
-struct sm100_tuning<1, SampleT, 1, 1, counter_size::_4, primitive_sample::yes, sample_size::_2>
-    : sm90_tuning<SampleT, 1, 1, counter_size::_4, primitive_sample::yes, sample_size::_2>
-{};
+// same as SM90
+// template <class SampleT>
+// struct sm100_tuning<1, SampleT, 1, 1, counter_size::_4, primitive_sample::yes, sample_size::_2> {};
 
-// same as base
-template <class SampleT>
-struct sm100_tuning<1, SampleT, 1, 1, counter_size::_4, primitive_sample::yes, sample_size::_4>
-    : sm90_tuning<SampleT, 1, 1, counter_size::_4, primitive_sample::yes, sample_size::_4>
-{};
+// same as SM90
+// template <class SampleT>
+// struct sm100_tuning<1, SampleT, 1, 1, counter_size::_4, primitive_sample::yes, sample_size::_4> {};
 
-// same as base
-template <class SampleT>
-struct sm100_tuning<1, SampleT, 1, 1, counter_size::_4, primitive_sample::yes, sample_size::_8>
-    : sm90_tuning<SampleT, 1, 1, counter_size::_4, primitive_sample::yes, sample_size::_8>
-{};
+// same as SM90
+// template <class SampleT>
+// struct sm100_tuning<1, SampleT, 1, 1, counter_size::_4, primitive_sample::yes, sample_size::_8> {};
 
 // range
 template <class SampleT>
@@ -184,11 +178,9 @@ struct sm100_tuning<0, SampleT, 1, 1, counter_size::_4, primitive_sample::yes, s
   static constexpr int vec_size                                  = 1 << 2;
 };
 
-// same as base
-template <class SampleT>
-struct sm100_tuning<0, SampleT, 1, 1, counter_size::_4, primitive_sample::yes, sample_size::_2>
-    : sm90_tuning<SampleT, 1, 1, counter_size::_4, primitive_sample::yes, sample_size::_2>
-{};
+// same as SM90
+// template <class SampleT>
+// struct sm100_tuning<0, SampleT, 1, 1, counter_size::_4, primitive_sample::yes, sample_size::_2> {};
 
 template <class SampleT>
 struct sm100_tuning<0, SampleT, 1, 1, counter_size::_4, primitive_sample::yes, sample_size::_4>
@@ -234,22 +226,16 @@ struct sm100_tuning<1, SampleT, 4, 3, counter_size::_4, primitive_sample::yes, s
 };
 
 // same as base
-template <class SampleT>
-struct sm100_tuning<1, SampleT, 4, 3, counter_size::_4, primitive_sample::yes, sample_size::_2>
-    : sm90_tuning<SampleT, 1, 1, counter_size::_4, primitive_sample::yes, sample_size::_2>
-{};
+// template <class SampleT>
+// struct sm100_tuning<1, SampleT, 4, 3, counter_size::_4, primitive_sample::yes, sample_size::_2> {};
 
 // same as base
-template <class SampleT>
-struct sm100_tuning<1, SampleT, 4, 3, counter_size::_4, primitive_sample::yes, sample_size::_4>
-    : sm90_tuning<SampleT, 1, 1, counter_size::_4, primitive_sample::yes, sample_size::_4>
-{};
+// template <class SampleT>
+// struct sm100_tuning<1, SampleT, 4, 3, counter_size::_4, primitive_sample::yes, sample_size::_4> {};
 
 // same as base
-template <class SampleT>
-struct sm100_tuning<1, SampleT, 4, 3, counter_size::_4, primitive_sample::yes, sample_size::_8>
-    : sm90_tuning<SampleT, 1, 1, counter_size::_4, primitive_sample::yes, sample_size::_8>
-{};
+// template <class SampleT>
+// struct sm100_tuning<1, SampleT, 4, 3, counter_size::_4, primitive_sample::yes, sample_size::_8> {};
 
 // multi.range
 template <class SampleT>


### PR DESCRIPTION
The tuning data member names did not match the one used when selecting tunings, so all SM100 tunings were SFINAE-ed out.

- [x] SASS diff for SM100 on `cub.bench.radix_sort.pairs.base` is empty (no side effect)
- [x] SASS diff for SM100 on `cub.bench.histogram.even.base` contains instruction changes (tunings have effect)
- [x] Perf diff between before https://github.com/NVIDIA/cccl/pull/3616 got merged and this PR.
- [ ] Perf diff for multi histograms