### PR TITLE
Clarify scan benchmarks

### DIFF
--- a/cub/benchmarks/bench/scan/exclusive/custom.cu
+++ b/cub/benchmarks/bench/scan/exclusive/custom.cu
@@ -25,6 +25,12 @@
  *
  ******************************************************************************/
 
+// This benchmark uses a custom operation, max_t, which is not known to CUB, so no operator specific optimizations and
+// tunings are performed.
+
+// Because CUB cannot detect this operator, we cannot add any tunings based on the results of this benchmark. Its main
+// use is to detect regressions.
+
 // %RANGE% TUNE_ITEMS ipt 7:24:1
 // %RANGE% TUNE_THREADS tpb 128:1024:32
 // %RANGE% TUNE_MAGIC_NS ns 0:2048:4

--- a/cub/benchmarks/bench/scan/exclusive/sum.cu
+++ b/cub/benchmarks/bench/scan/exclusive/sum.cu
@@ -25,6 +25,8 @@
  *
  ******************************************************************************/
 
+// Tuning parameters found for signed integer types apply equally for unsigned integer types
+
 #include <nvbench_helper.cuh>
 
 // %RANGE% TUNE_ITEMS ipt 7:24:1


### PR DESCRIPTION
Similarly as for the reduce benchmark in #3401, let's perform a similar renaming and clarification of the scan benchmark:

* Rename max.cu to custom.cu, since it uses a custom operator that CUB does not recognize so we cannot tune for it.