### PR TITLE
Removes deprecated `Agent*` alias templates in the public namespace

### DIFF
--- a/cub/cub/agent/agent_adjacent_difference.cuh
+++ b/cub/cub/agent/agent_adjacent_difference.cuh
@@ -258,22 +258,4 @@ struct AgentDifferenceInit
 } // namespace adjacent_difference
 } // namespace detail
 
-template <typename Policy,
-          typename InputIteratorT,
-          typename OutputIteratorT,
-          typename DifferenceOpT,
-          typename OffsetT,
-          typename InputT,
-          typename OutputT,
-          bool MayAlias,
-          bool ReadLeft>
-using AgentDifference CCCL_DEPRECATED_BECAUSE("This class is considered an implementation detail and the public "
-                                              "interface will be removed.") = detail::adjacent_difference::
-  AgentDifference<Policy, InputIteratorT, OutputIteratorT, DifferenceOpT, OffsetT, InputT, OutputT, MayAlias, ReadLeft>;
-
-template <typename InputIteratorT, typename InputT, typename OffsetT, bool ReadLeft>
-using AgentDifferenceInit CCCL_DEPRECATED_BECAUSE("This class is considered an implementation detail and the public "
-                                                  "interface will be removed.") =
-  detail::adjacent_difference::AgentDifferenceInit<InputIteratorT, InputT, OffsetT, ReadLeft>;
-
 CUB_NAMESPACE_END

--- a/cub/cub/agent/agent_histogram.cuh
+++ b/cub/cub/agent/agent_histogram.cuh
@@ -918,26 +918,4 @@ struct AgentHistogram
 } // namespace histogram
 } // namespace detail
 
-template <typename AgentHistogramPolicyT,
-          int PRIVATIZED_SMEM_BINS,
-          int NUM_CHANNELS,
-          int NUM_ACTIVE_CHANNELS,
-          typename SampleIteratorT,
-          typename CounterT,
-          typename PrivatizedDecodeOpT,
-          typename OutputDecodeOpT,
-          typename OffsetT>
-using AgentHistogram CCCL_DEPRECATED_BECAUSE("This class is considered an implementation detail and the public "
-                                             "interface will be removed.") =
-  detail::histogram::AgentHistogram<
-    AgentHistogramPolicyT,
-    PRIVATIZED_SMEM_BINS,
-    NUM_CHANNELS,
-    NUM_ACTIVE_CHANNELS,
-    SampleIteratorT,
-    CounterT,
-    PrivatizedDecodeOpT,
-    OutputDecodeOpT,
-    OffsetT>;
-
 CUB_NAMESPACE_END

--- a/cub/cub/agent/agent_merge_sort.cuh
+++ b/cub/cub/agent/agent_merge_sort.cuh
@@ -750,42 +750,4 @@ struct AgentMerge
 } // namespace merge_sort
 } // namespace detail
 
-template <typename Policy,
-          typename KeyInputIteratorT,
-          typename ValueInputIteratorT,
-          typename KeyIteratorT,
-          typename ValueIteratorT,
-          typename OffsetT,
-          typename CompareOpT,
-          typename KeyT,
-          typename ValueT>
-using AgentBlockSort CCCL_DEPRECATED_BECAUSE("This class is considered an implementation detail and the public "
-                                             "interface will be removed.") =
-  detail::merge_sort::AgentBlockSort<
-    Policy,
-    KeyInputIteratorT,
-    ValueInputIteratorT,
-    KeyIteratorT,
-    ValueIteratorT,
-    OffsetT,
-    CompareOpT,
-    KeyT,
-    ValueT>;
-
-template <typename KeyIteratorT, typename OffsetT, typename CompareOpT, typename KeyT>
-using AgentPartition CCCL_DEPRECATED_BECAUSE(
-  "This class is considered an implementation detail and the public interface will be "
-  "removed.") = detail::merge_sort::AgentPartition<KeyIteratorT, OffsetT, CompareOpT, KeyT>;
-
-template <typename Policy,
-          typename KeyIteratorT,
-          typename ValueIteratorT,
-          typename OffsetT,
-          typename CompareOpT,
-          typename KeyT,
-          typename ValueT>
-using AgentMerge CCCL_DEPRECATED_BECAUSE("This class is considered an implementation detail and the public interface "
-                                         "will be removed.") =
-  detail::merge_sort::AgentMerge<Policy, KeyIteratorT, ValueIteratorT, OffsetT, CompareOpT, KeyT, ValueT>;
-
 CUB_NAMESPACE_END

--- a/cub/cub/agent/agent_radix_sort_downsweep.cuh
+++ b/cub/cub/agent/agent_radix_sort_downsweep.cuh
@@ -765,15 +765,4 @@ struct AgentRadixSortDownsweep
 } // namespace radix_sort
 } // namespace detail
 
-template <typename AgentRadixSortDownsweepPolicy,
-          bool IS_DESCENDING,
-          typename KeyT,
-          typename ValueT,
-          typename OffsetT,
-          typename DecomposerT = detail::identity_decomposer_t>
-using AgentRadixSortDownsweep CCCL_DEPRECATED_BECAUSE(
-  "This class is considered an implementation detail and the public "
-  "interface will be removed.") = detail::radix_sort::
-  AgentRadixSortDownsweep<AgentRadixSortDownsweepPolicy, IS_DESCENDING, KeyT, ValueT, OffsetT, DecomposerT>;
-
 CUB_NAMESPACE_END

--- a/cub/cub/agent/agent_radix_sort_histogram.cuh
+++ b/cub/cub/agent/agent_radix_sort_histogram.cuh
@@ -283,14 +283,4 @@ struct AgentRadixSortHistogram
 } // namespace radix_sort
 } // namespace detail
 
-template <typename AgentRadixSortHistogramPolicy,
-          bool IS_DESCENDING,
-          typename KeyT,
-          typename OffsetT,
-          typename DecomposerT = detail::identity_decomposer_t>
-using AgentRadixSortHistogram CCCL_DEPRECATED_BECAUSE(
-  "This class is considered an implementation detail and the public "
-  "interface will be removed.") =
-  detail::radix_sort::AgentRadixSortHistogram<AgentRadixSortHistogramPolicy, IS_DESCENDING, KeyT, OffsetT, DecomposerT>;
-
 CUB_NAMESPACE_END

--- a/cub/cub/agent/agent_radix_sort_onesweep.cuh
+++ b/cub/cub/agent/agent_radix_sort_onesweep.cuh
@@ -696,15 +696,4 @@ struct AgentRadixSortOnesweep
 } // namespace radix_sort
 } // namespace detail
 
-template <typename AgentRadixSortOnesweepPolicy,
-          bool IS_DESCENDING,
-          typename KeyT,
-          typename ValueT,
-          typename OffsetT,
-          typename PortionOffsetT,
-          typename DecomposerT = detail::identity_decomposer_t>
-using AgentRadixSortOnesweep CCCL_DEPRECATED_BECAUSE("This class is considered an implementation detail and the public "
-                                                     "interface will be removed.") = detail::radix_sort::
-  AgentRadixSortOnesweep<AgentRadixSortOnesweepPolicy, IS_DESCENDING, KeyT, ValueT, OffsetT, PortionOffsetT, DecomposerT>;
-
 CUB_NAMESPACE_END

--- a/cub/cub/agent/agent_radix_sort_upsweep.cuh
+++ b/cub/cub/agent/agent_radix_sort_upsweep.cuh
@@ -553,12 +553,4 @@ struct AgentRadixSortUpsweep
 } // namespace radix_sort
 } // namespace detail
 
-template <typename AgentRadixSortUpsweepPolicy,
-          typename KeyT,
-          typename OffsetT,
-          typename DecomposerT = detail::identity_decomposer_t>
-using AgentRadixSortUpsweep CCCL_DEPRECATED_BECAUSE("This class is considered an implementation detail and the public "
-                                                    "interface will be removed.") =
-  detail::radix_sort::AgentRadixSortUpsweep<AgentRadixSortUpsweepPolicy, KeyT, OffsetT, DecomposerT>;
-
 CUB_NAMESPACE_END

--- a/cub/cub/agent/agent_reduce.cuh
+++ b/cub/cub/agent/agent_reduce.cuh
@@ -457,15 +457,4 @@ private:
 } // namespace reduce
 } // namespace detail
 
-template <typename AgentReducePolicy,
-          typename InputIteratorT,
-          typename OutputIteratorT,
-          typename OffsetT,
-          typename ReductionOp,
-          typename AccumT,
-          typename TransformOp = ::cuda::std::__identity>
-using AgentReduce CCCL_DEPRECATED_BECAUSE("This class is considered an implementation detail and the public interface "
-                                          "will be removed.") = detail::reduce::
-  AgentReduce<AgentReducePolicy, InputIteratorT, OutputIteratorT, OffsetT, ReductionOp, AccumT, TransformOp>;
-
 CUB_NAMESPACE_END

--- a/cub/cub/agent/agent_reduce_by_key.cuh
+++ b/cub/cub/agent/agent_reduce_by_key.cuh
@@ -701,28 +701,4 @@ struct AgentReduceByKey
 } // namespace reduce
 } // namespace detail
 
-template <typename AgentReduceByKeyPolicyT,
-          typename KeysInputIteratorT,
-          typename UniqueOutputIteratorT,
-          typename ValuesInputIteratorT,
-          typename AggregatesOutputIteratorT,
-          typename NumRunsOutputIteratorT,
-          typename EqualityOpT,
-          typename ReductionOpT,
-          typename OffsetT,
-          typename AccumT>
-using AgentReduceByKey CCCL_DEPRECATED_BECAUSE("This class is considered an implementation detail and the public "
-                                               "interface will be removed.") =
-  detail::reduce::AgentReduceByKey<
-    AgentReduceByKeyPolicyT,
-    KeysInputIteratorT,
-    UniqueOutputIteratorT,
-    ValuesInputIteratorT,
-    AggregatesOutputIteratorT,
-    NumRunsOutputIteratorT,
-    EqualityOpT,
-    ReductionOpT,
-    OffsetT,
-    AccumT>;
-
 CUB_NAMESPACE_END

--- a/cub/cub/agent/agent_rle.cuh
+++ b/cub/cub/agent/agent_rle.cuh
@@ -997,14 +997,4 @@ struct AgentRle
 } // namespace rle
 } // namespace detail
 
-template <typename AgentRlePolicyT,
-          typename InputIteratorT,
-          typename OffsetsOutputIteratorT,
-          typename LengthsOutputIteratorT,
-          typename EqualityOpT,
-          typename OffsetT>
-using AgentRle CCCL_DEPRECATED_BECAUSE("This class is considered an implementation detail and the public interface "
-                                       "will be removed.") = detail::rle::
-  AgentRle<AgentRlePolicyT, InputIteratorT, OffsetsOutputIteratorT, LengthsOutputIteratorT, EqualityOpT, OffsetT>;
-
 CUB_NAMESPACE_END

--- a/cub/cub/agent/agent_scan.cuh
+++ b/cub/cub/agent/agent_scan.cuh
@@ -597,16 +597,4 @@ struct AgentScan
 } // namespace scan
 } // namespace detail
 
-template <typename AgentScanPolicyT,
-          typename InputIteratorT,
-          typename OutputIteratorT,
-          typename ScanOpT,
-          typename InitValueT,
-          typename OffsetT,
-          typename AccumT,
-          bool ForceInclusive = false>
-using AgentScan CCCL_DEPRECATED_BECAUSE("This class is considered an implementation detail and the public interface "
-                                        "will be removed.") = detail::scan::
-  AgentScan<AgentScanPolicyT, InputIteratorT, OutputIteratorT, ScanOpT, InitValueT, OffsetT, AccumT, ForceInclusive>;
-
 CUB_NAMESPACE_END

--- a/cub/cub/agent/agent_scan_by_key.cuh
+++ b/cub/cub/agent/agent_scan_by_key.cuh
@@ -472,26 +472,4 @@ struct AgentScanByKey
 } // namespace scan_by_key
 } // namespace detail
 
-template <typename AgentScanByKeyPolicyT,
-          typename KeysInputIteratorT,
-          typename ValuesInputIteratorT,
-          typename ValuesOutputIteratorT,
-          typename EqualityOp,
-          typename ScanOpT,
-          typename InitValueT,
-          typename OffsetT,
-          typename AccumT>
-using AgentScanByKey CCCL_DEPRECATED_BECAUSE("This class is considered an implementation detail and the public "
-                                             "interface will be removed.") =
-  detail::scan_by_key::AgentScanByKey<
-    AgentScanByKeyPolicyT,
-    KeysInputIteratorT,
-    ValuesInputIteratorT,
-    ValuesOutputIteratorT,
-    EqualityOp,
-    ScanOpT,
-    InitValueT,
-    OffsetT,
-    AccumT>;
-
 CUB_NAMESPACE_END

--- a/cub/cub/agent/agent_segmented_radix_sort.cuh
+++ b/cub/cub/agent/agent_segmented_radix_sort.cuh
@@ -289,15 +289,4 @@ struct AgentSegmentedRadixSort
 } // namespace radix_sort
 } // namespace detail
 
-template <bool IS_DESCENDING,
-          typename SegmentedPolicyT,
-          typename KeyT,
-          typename ValueT,
-          typename OffsetT,
-          typename DecomposerT = detail::identity_decomposer_t>
-using AgentSegmentedRadixSort CCCL_DEPRECATED_BECAUSE(
-  "This class is considered an implementation detail and the public "
-  "interface will be removed.") =
-  detail::radix_sort::AgentSegmentedRadixSort<IS_DESCENDING, SegmentedPolicyT, KeyT, ValueT, OffsetT, DecomposerT>;
-
 CUB_NAMESPACE_END

--- a/cub/cub/agent/agent_sub_warp_merge_sort.cuh
+++ b/cub/cub/agent/agent_sub_warp_merge_sort.cuh
@@ -339,9 +339,4 @@ private:
 } // namespace sub_warp_merge_sort
 } // namespace detail
 
-template <bool IS_DESCENDING, typename PolicyT, typename KeyT, typename ValueT, typename OffsetT>
-using AgentSubWarpSort CCCL_DEPRECATED_BECAUSE("This class is considered an implementation detail and the public "
-                                               "interface will be removed.") =
-  detail::sub_warp_merge_sort::AgentSubWarpSort<IS_DESCENDING, PolicyT, KeyT, ValueT, OffsetT>;
-
 CUB_NAMESPACE_END

--- a/cub/cub/agent/agent_unique_by_key.cuh
+++ b/cub/cub/agent/agent_unique_by_key.cuh
@@ -613,22 +613,4 @@ struct AgentUniqueByKey
 } // namespace unique_by_key
 } // namespace detail
 
-template <typename AgentUniqueByKeyPolicyT,
-          typename KeyInputIteratorT,
-          typename ValueInputIteratorT,
-          typename KeyOutputIteratorT,
-          typename ValueOutputIteratorT,
-          typename EqualityOpT,
-          typename OffsetT>
-using AgentUniqueByKey CCCL_DEPRECATED_BECAUSE("This class is considered an implementation detail and the public "
-                                               "interface will be removed.") =
-  detail::unique_by_key::AgentUniqueByKey<
-    AgentUniqueByKeyPolicyT,
-    KeyInputIteratorT,
-    ValueInputIteratorT,
-    KeyOutputIteratorT,
-    ValueOutputIteratorT,
-    EqualityOpT,
-    OffsetT>;
-
 CUB_NAMESPACE_END


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
Closes https://github.com/NVIDIA/cccl/issues/3467 <!-- Link issue here -->