### PR TITLE
Nightly fixes

### DIFF
--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -87,8 +87,8 @@ workflows:
     - {jobs: ['build'], project: 'cudax', ctk: ['12.0', 'curr'], std: 'all', cxx: ['gcc9', 'gcc10', 'gcc11']}
     - {jobs: ['build'], project: 'cudax', ctk: [        'curr'], std: 'all', cxx: ['clang14', 'clang15', 'clang16', 'clang17']}
     - {jobs: ['build'], project: 'cudax', ctk: [        '12.5'], std: 'all', cxx: ['nvhpc']}
-    - {jobs: ['build'], project: 'cudax', ctk: ['12.0',       ], std: 'all', cxx: ['msvc14.39']}
-    - {jobs: ['build'], project: 'cudax', ctk: [        'curr'], std: 'all', cxx: ['msvc2022']}
+    - {jobs: ['build'], project: 'cudax', ctk: ['12.0',       ], std: '20',  cxx: ['msvc14.39']}
+    - {jobs: ['build'], project: 'cudax', ctk: [        'curr'], std: '20',  cxx: ['msvc2022']}
     - {jobs: ['build'], project: 'cudax', ctk: ['12.0'        ], std: 'all', cxx: ['gcc12'], sm: "90"}
     - {jobs: ['build'], project: 'cudax', ctk: [        'curr'], std: 'all', cxx: ['gcc13'], sm: "90a"}
     - {jobs: ['build'], project: 'cudax', ctk: [        'curr'], std: 'all', cxx: ['gcc13', 'clang16'], cpu: 'arm64'}

--- a/cub/test/catch2_test_block_load.cu
+++ b/cub/test/catch2_test_block_load.cu
@@ -179,6 +179,8 @@ C2H_TEST("Block load works with even odd sizes",
     d_input, thrust::raw_pointer_cast(d_input.data()));
 }
 
+// WAR bug in vec type handling in NVCC 12.0 + GCC 11.4 + C++20
+#if !(_CCCL_CUDA_COMPILER(NVCC, ==, 12, 0) && _CCCL_COMPILER(GCC, ==, 11, 4) && _CCCL_STD_VER == 2020)
 C2H_TEST(
   "Block load works with even vector types", "[load][block]", vec_types, items_per_thread, a_block_size, load_algorithm)
 {
@@ -190,6 +192,7 @@ C2H_TEST(
   test_block_load<params::items_per_thread, params::threads_in_block, params::load_algorithm>(
     d_input, thrust::raw_pointer_cast(d_input.data()));
 }
+#endif // !(NVCC 12.0 and GCC 11.4 and C++20)
 
 C2H_TEST("Block load works with custom types", "[load][block]", items_per_thread, load_algorithm)
 {

--- a/cub/test/catch2_test_block_store.cu
+++ b/cub/test/catch2_test_block_store.cu
@@ -206,6 +206,8 @@ C2H_TEST("Block store works with even odd sizes",
   REQUIRE(d_input == d_output);
 }
 
+// WAR bug in vec type handling in NVCC 12.0 + GCC 11.4 + C++20
+#if !(_CCCL_CUDA_COMPILER(NVCC, ==, 12, 0) && _CCCL_COMPILER(GCC, ==, 11, 4) && _CCCL_STD_VER == 2020)
 C2H_TEST("Block store works with even vector types",
          "[store][block]",
          vec_types,
@@ -228,6 +230,7 @@ C2H_TEST("Block store works with even vector types",
 
   REQUIRE(d_input == d_output);
 }
+#endif // !(NVCC 12.0 and GCC 11.4 and C++20)
 
 C2H_TEST("Block store works with custom types", "[store][block]", items_per_thread, store_algorithm)
 {

--- a/cub/test/catch2_test_device_partition_flagged.cu
+++ b/cub/test/catch2_test_device_partition_flagged.cu
@@ -87,12 +87,22 @@ using all_types =
                  std::uint32_t,
                  std::uint64_t,
                  ulonglong2,
+// WAR bug in vec type handling in NVCC 12.0 + GCC 11.4 + C++20
+#if !(_CCCL_CUDA_COMPILER(NVCC, ==, 12, 0) && _CCCL_COMPILER(GCC, ==, 11, 4) && _CCCL_STD_VER == 2020)
                  ulonglong4,
+#endif // !(NVCC 12.0 and GCC 11.4 and C++20)
                  int,
                  long2,
                  c2h::custom_type_t<c2h::equal_comparable_t>>;
 
-using types = c2h::type_list<std::uint8_t, std::uint32_t, ulonglong4, c2h::custom_type_t<c2h::equal_comparable_t>>;
+using types =
+  c2h::type_list<std::uint8_t,
+                 std::uint32_t,
+// WAR bug in vec type handling in NVCC 12.0 + GCC 11.4 + C++20
+#if !(_CCCL_CUDA_COMPILER(NVCC, ==, 12, 0) && _CCCL_COMPILER(GCC, ==, 11, 4) && _CCCL_STD_VER == 2020)
+                 ulonglong4,
+#endif // !(NVCC 12.0 and GCC 11.4 and C++20)
+                 c2h::custom_type_t<c2h::equal_comparable_t>>;
 
 // List of offset types to be used for testing large number of items
 using offset_types = c2h::type_list<std::int32_t, std::uint32_t, std::uint64_t>;

--- a/cub/test/catch2_test_device_partition_if.cu
+++ b/cub/test/catch2_test_device_partition_if.cu
@@ -76,13 +76,22 @@ using all_types =
                  std::uint32_t,
                  std::uint64_t,
                  ulonglong2,
+// WAR bug in vec type handling in NVCC 12.0 + GCC 11.4 + C++20
+#if !(_CCCL_CUDA_COMPILER(NVCC, ==, 12, 0) && _CCCL_COMPILER(GCC, ==, 11, 4) && _CCCL_STD_VER == 2020)
                  ulonglong4,
+#endif // !(NVCC 12.0 and GCC 11.4 and C++20)
                  int,
                  long2,
                  c2h::custom_type_t<c2h::less_comparable_t, c2h::equal_comparable_t>>;
 
-using types = c2h::
-  type_list<std::uint8_t, std::uint32_t, ulonglong4, c2h::custom_type_t<c2h::less_comparable_t, c2h::equal_comparable_t>>;
+using types =
+  c2h::type_list<std::uint8_t,
+                 std::uint32_t,
+// WAR bug in vec type handling in NVCC 12.0 + GCC 11.4 + C++20
+#if !(_CCCL_CUDA_COMPILER(NVCC, ==, 12, 0) && _CCCL_COMPILER(GCC, ==, 11, 4) && _CCCL_STD_VER == 2020)
+                 ulonglong4,
+#endif // !(NVCC 12.0 and GCC 11.4 and C++20)
+                 c2h::custom_type_t<c2h::less_comparable_t, c2h::equal_comparable_t>>;
 
 // List of offset types to be used for testing large number of items
 using offset_types = c2h::type_list<std::int32_t, std::uint32_t, std::uint64_t>;

--- a/cub/test/catch2_test_device_select_flagged.cu
+++ b/cub/test/catch2_test_device_select_flagged.cu
@@ -79,12 +79,22 @@ using all_types =
                  std::uint32_t,
                  std::uint64_t,
                  ulonglong2,
+// WAR bug in vec type handling in NVCC 12.0 + GCC 11.4 + C++20
+#if !(_CCCL_CUDA_COMPILER(NVCC, ==, 12, 0) && _CCCL_COMPILER(GCC, ==, 11, 4) && _CCCL_STD_VER == 2020)
                  ulonglong4,
+#endif // !(NVCC 12.0 and GCC 11.4 and C++20)
                  int,
                  long2,
                  c2h::custom_type_t<c2h::equal_comparable_t>>;
 
-using types = c2h::type_list<std::uint8_t, std::uint32_t, ulonglong4, c2h::custom_type_t<c2h::equal_comparable_t>>;
+using types =
+  c2h::type_list<std::uint8_t,
+                 std::uint32_t,
+// WAR bug in vec type handling in NVCC 12.0 + GCC 11.4 + C++20
+#if !(_CCCL_CUDA_COMPILER(NVCC, ==, 12, 0) && _CCCL_COMPILER(GCC, ==, 11, 4) && _CCCL_STD_VER == 2020)
+                 ulonglong4,
+#endif // !(NVCC 12.0 and GCC 11.4 and C++20)
+                 c2h::custom_type_t<c2h::equal_comparable_t>>;
 
 C2H_TEST("DeviceSelect::Flagged can run with empty input", "[device][select_flagged]", types)
 {

--- a/cub/test/catch2_test_device_select_flagged_if.cu
+++ b/cub/test/catch2_test_device_select_flagged_if.cu
@@ -121,9 +121,27 @@ struct always_true_t
 };
 
 using all_types =
-  c2h::type_list<std::uint8_t, std::uint16_t, std::uint32_t, std::uint64_t, ulonglong2, ulonglong4, int, long2, custom_t>;
+  c2h::type_list<std::uint8_t,
+                 std::uint16_t,
+                 std::uint32_t,
+                 std::uint64_t,
+                 ulonglong2,
+// WAR bug in vec type handling in NVCC 12.0 + GCC 11.4 + C++20
+#if !(_CCCL_CUDA_COMPILER(NVCC, ==, 12, 0) && _CCCL_COMPILER(GCC, ==, 11, 4) && _CCCL_STD_VER == 2020)
+                 ulonglong4,
+#endif // !(NVCC 12.0 and GCC 11.4 and C++20)
+                 int,
+                 long2,
+                 custom_t>;
 
-using types = c2h::type_list<std::uint8_t, std::uint32_t, ulonglong4, custom_t>;
+using types =
+  c2h::type_list<std::uint8_t,
+                 std::uint32_t,
+// WAR bug in vec type handling in NVCC 12.0 + GCC 11.4 + C++20
+#if !(_CCCL_CUDA_COMPILER(NVCC, ==, 12, 0) && _CCCL_COMPILER(GCC, ==, 11, 4) && _CCCL_STD_VER == 2020)
+                 ulonglong4,
+#endif // !(NVCC 12.0 and GCC 11.4 and C++20)
+                 custom_t>;
 
 using flag_types = c2h::type_list<std::uint8_t, std::uint64_t, custom_t>;
 

--- a/cub/test/catch2_test_device_select_if.cu
+++ b/cub/test/catch2_test_device_select_if.cu
@@ -83,13 +83,22 @@ using all_types =
                  std::uint32_t,
                  std::uint64_t,
                  ulonglong2,
+// WAR bug in vec type handling in NVCC 12.0 + GCC 11.4 + C++20
+#if !(_CCCL_CUDA_COMPILER(NVCC, ==, 12, 0) && _CCCL_COMPILER(GCC, ==, 11, 4) && _CCCL_STD_VER == 2020)
                  ulonglong4,
+#endif // !(NVCC 12.0 and GCC 11.4 and C++20)
                  int,
                  long2,
                  c2h::custom_type_t<c2h::less_comparable_t, c2h::equal_comparable_t>>;
 
-using types = c2h::
-  type_list<std::uint8_t, std::uint32_t, ulonglong4, c2h::custom_type_t<c2h::less_comparable_t, c2h::equal_comparable_t>>;
+using types =
+  c2h::type_list<std::uint8_t,
+                 std::uint32_t,
+// WAR bug in vec type handling in NVCC 12.0 + GCC 11.4 + C++20
+#if !(_CCCL_CUDA_COMPILER(NVCC, ==, 12, 0) && _CCCL_COMPILER(GCC, ==, 11, 4) && _CCCL_STD_VER == 2020)
+                 ulonglong4,
+#endif // !(NVCC 12.0 and GCC 11.4 and C++20)
+                 c2h::custom_type_t<c2h::less_comparable_t, c2h::equal_comparable_t>>;
 
 C2H_TEST("DeviceSelect::If can run with empty input", "[device][select_if]", types)
 {

--- a/cub/test/catch2_test_warp_exchange_smem.cu
+++ b/cub/test/catch2_test_warp_exchange_smem.cu
@@ -34,9 +34,14 @@ using inout_types =
   c2h::type_list<c2h::pair<std::uint16_t, std::int64_t>,
                  c2h::pair<std::uint16_t, std::uint32_t>,
                  c2h::pair<std::int32_t, std::int32_t>,
-                 c2h::pair<std::int64_t, std::int64_t>,
+                 c2h::pair<std::int64_t, std::int64_t>
+// WAR bug in vec type handling in NVCC 12.0 + GCC 11.4 + C++20
+#if !(_CCCL_CUDA_COMPILER(NVCC, ==, 12, 0) && _CCCL_COMPILER(GCC, ==, 11, 4) && _CCCL_STD_VER == 2020)
+                 ,
                  c2h::pair<uchar3, uchar3>,
-                 c2h::pair<ulonglong4, ulonglong4>>;
+                 c2h::pair<ulonglong4, ulonglong4>
+#endif // !(NVCC 12.0 and GCC 11.4 and C++20)
+                 >;
 
 using logical_warp_threads = c2h::enum_type_list<int, 4, 16, 32>;
 using items_per_thread     = c2h::enum_type_list<int, 1, 4, 7>;


### PR DESCRIPTION
WAR a compiler bug affecting CUB builds, update nightly matrix to remove invalid combination.