### PR TITLE
assorted bug fixes for the std::execution implementation in cudax

### DIFF
--- a/cudax/include/cuda/experimental/__async/sender/env.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/env.cuh
@@ -76,6 +76,9 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT prop
   prop& operator=(const prop&) = delete;
 };
 
+template <class _Query, class _Value>
+prop(_Query, _Value) -> prop<_Query, _Value>;
+
 template <class... _Envs>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT env
 {

--- a/cudax/include/cuda/experimental/__async/sender/meta.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/meta.cuh
@@ -59,6 +59,8 @@ struct _IN_ALGORITHM;
 
 struct _WHAT;
 
+struct _WHY;
+
 struct _WITH_FUNCTION;
 
 struct _WITH_SENDER;

--- a/cudax/include/cuda/experimental/__async/sender/rcvr_with_env.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/rcvr_with_env.cuh
@@ -134,6 +134,10 @@ struct __rcvr_with_env_t<_Rcvr*, _Env>
   _Rcvr* __rcvr_;
   _Env __env_;
 };
+
+template <class _Rcvr, class _Env>
+__rcvr_with_env_t(_Rcvr, _Env) -> __rcvr_with_env_t<_Rcvr, _Env>;
+
 } // namespace cuda::experimental::__async
 
 #include <cuda/experimental/__async/sender/epilogue.cuh>

--- a/cudax/include/cuda/experimental/__async/sender/utility.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/utility.cuh
@@ -21,6 +21,8 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/std/__tuple_dir/ignore.h>
+#include <cuda/std/__type_traits/decay.h>
 #include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/initializer_list>
 
@@ -34,11 +36,7 @@ namespace cuda::experimental::__async
 {
 _CCCL_GLOBAL_CONSTANT size_t __npos = static_cast<size_t>(-1);
 
-struct __ignore
-{
-  template <class... _As>
-  _CUDAX_API constexpr __ignore(_As&&...) noexcept {};
-};
+using __ignore _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::__ignore_t; // NOLINT: misc-unused-using-decls
 
 using _CUDA_VSTD::__undefined; // NOLINT: misc-unused-using-decls
 
@@ -116,7 +114,7 @@ _CUDAX_API constexpr void __swap(_Ty& __left, _Ty& __right) noexcept
 }
 
 template <class _Ty>
-_CUDAX_API constexpr _Ty __decay_copy(_Ty&& __ty) noexcept(__nothrow_decay_copyable<_Ty>)
+_CUDAX_API constexpr _CUDA_VSTD::decay_t<_Ty> __decay_copy(_Ty&& __ty) noexcept(__nothrow_decay_copyable<_Ty>)
 {
   return static_cast<_Ty&&>(__ty);
 }

--- a/cudax/include/cuda/experimental/__async/sender/write_env.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/write_env.cuh
@@ -50,7 +50,7 @@ private:
     connect_result_t<_Sndr, __rcvr_with_env_t<_Rcvr, _Env>*> __opstate_;
 
     _CUDAX_API explicit __opstate_t(_Sndr&& __sndr, _Env __env, _Rcvr __rcvr)
-        : __env_rcvr_(static_cast<_Env&&>(__env), static_cast<_Rcvr&&>(__rcvr))
+        : __env_rcvr_{static_cast<_Rcvr&&>(__rcvr), static_cast<_Env&&>(__env)}
         , __opstate_(__async::connect(static_cast<_Sndr&&>(__sndr), &__env_rcvr_))
     {}
 


### PR DESCRIPTION
## Description

assorted fixes for ustdex issues i found while doing some prototyping the cudax async model. this PR fixes:

* missing deduction guides for `prop` and `__rcvr_with_env_t`
* bad diagnostics from `sync_wait` for senders that fail type-checking
* lack of `sync_wait` overload that takes an environment
* `__decay_copy` isn't decaying lvalues
* needless duplication of `cuda::std::__ignore_t`
* reversed args when constructing the operation state of `write_env` 
