### PR TITLE
Minor fix for a regressing tuning in reduce.by_key

### DIFF
--- a/cub/cub/device/dispatch/tuning/tuning_reduce_by_key.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_reduce_by_key.cuh
@@ -717,6 +717,12 @@ struct sm100_tuning<KeyT, AccumT, primitive_op::yes, primitive_key::yes, primiti
   static constexpr CacheLoadModifier load_modifier   = LOAD_DEFAULT;
 };
 
+// I16, F32, I32 regresses, default it back.
+template <class KeyT>
+struct sm100_tuning<KeyT, float, primitive_op::yes, primitive_key::yes, primitive_accum::yes, key_size::_2, accum_size::_4>
+    : sm90_tuning<KeyT, float, primitive_op::yes, primitive_key::yes, primitive_accum::yes, key_size::_4, accum_size::_1>
+{};
+
 // todo(gonidelis): Add tunings for I128.
 // template <class KeyT, class AccumT>
 // struct sm100_tuning<KeyT, AccumT, primitive_op::yes, primitive_key::yes, primitive_accum::no, key_size::_2,

--- a/cub/cub/device/dispatch/tuning/tuning_reduce_by_key.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_reduce_by_key.cuh
@@ -720,7 +720,6 @@ struct sm100_tuning<KeyT, AccumT, primitive_op::yes, primitive_key::yes, primiti
 // I16, F32, I32 regresses, default it back.
 template <class KeyT>
 struct sm100_tuning<KeyT, float, primitive_op::yes, primitive_key::yes, primitive_accum::yes, key_size::_2, accum_size::_4>
-    : sm90_tuning<KeyT, float, primitive_op::yes, primitive_key::yes, primitive_accum::yes, key_size::_4, accum_size::_1>
 {};
 
 // todo(gonidelis): Add tunings for I128.


### PR DESCRIPTION
This workload regresses and needs to be defaulted back