### PR TITLE
Move `zip_iterator` to internally use `cuda::std::tuple`

### DIFF
--- a/thrust/thrust/iterator/detail/zip_iterator.inl
+++ b/thrust/thrust/iterator/detail/zip_iterator.inl
@@ -91,15 +91,15 @@ zip_iterator<IteratorTuple>::distance_to(const zip_iterator<OtherIteratorTuple>&
 } // end zip_iterator::distance_to()
 
 template <typename... Iterators>
-_CCCL_HOST_DEVICE zip_iterator<thrust::tuple<Iterators...>> make_zip_iterator(thrust::tuple<Iterators...> t)
+_CCCL_HOST_DEVICE zip_iterator<_CUDA_VSTD::tuple<Iterators...>> make_zip_iterator(_CUDA_VSTD::tuple<Iterators...> t)
 {
-  return zip_iterator<thrust::tuple<Iterators...>>(t);
+  return zip_iterator<_CUDA_VSTD::tuple<Iterators...>>(t);
 } // end make_zip_iterator()
 
 template <typename... Iterators>
-_CCCL_HOST_DEVICE zip_iterator<thrust::tuple<Iterators...>> make_zip_iterator(Iterators... its)
+_CCCL_HOST_DEVICE zip_iterator<_CUDA_VSTD::tuple<Iterators...>> make_zip_iterator(Iterators... its)
 {
-  return make_zip_iterator(thrust::make_tuple(its...));
+  return make_zip_iterator(_CUDA_VSTD::make_tuple(its...));
 } // end make_zip_iterator()
 
 THRUST_NAMESPACE_END

--- a/thrust/thrust/iterator/zip_iterator.h
+++ b/thrust/thrust/iterator/zip_iterator.h
@@ -43,6 +43,8 @@
 #include <thrust/iterator/detail/zip_iterator_base.h>
 #include <thrust/iterator/iterator_facade.h>
 
+#include <cuda/std/tuple>
+
 THRUST_NAMESPACE_BEGIN
 
 /*! \addtogroup iterators
@@ -215,7 +217,8 @@ private:
  *  \see zip_iterator
  */
 template <typename... Iterators>
-inline _CCCL_HOST_DEVICE zip_iterator<thrust::tuple<Iterators...>> make_zip_iterator(thrust::tuple<Iterators...> t);
+inline _CCCL_HOST_DEVICE zip_iterator<_CUDA_VSTD::tuple<Iterators...>>
+make_zip_iterator(_CUDA_VSTD::tuple<Iterators...> t);
 
 /*! \p make_zip_iterator creates a \p zip_iterator from
  *  iterators.
@@ -226,7 +229,7 @@ inline _CCCL_HOST_DEVICE zip_iterator<thrust::tuple<Iterators...>> make_zip_iter
  *  \see zip_iterator
  */
 template <typename... Iterators>
-inline _CCCL_HOST_DEVICE zip_iterator<thrust::tuple<Iterators...>> make_zip_iterator(Iterators... its);
+inline _CCCL_HOST_DEVICE zip_iterator<_CUDA_VSTD::tuple<Iterators...>> make_zip_iterator(Iterators... its);
 
 /*! \} // end fancyiterators
  */


### PR DESCRIPTION
We want to get rid of the former and passing in a `cuda::std::tuple` into `thrust::make_zip_iterator` has surprising results.
