### PR TITLE
Replace raw arm64/x86_64 macros

### DIFF
--- a/libcudacxx/include/cuda/std/__atomic/platform/msvc_to_builtins.h
+++ b/libcudacxx/include/cuda/std/__atomic/platform/msvc_to_builtins.h
@@ -38,10 +38,10 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 #  define _LIBCUDACXX_COMPILER_BARRIER() _ReadWriteBarrier()
 
-#  if defined(_M_ARM) || defined(_M_ARM64)
+#  if _CCCL_ARCH(ARM64)
 #    define _LIBCUDACXX_MEMORY_BARRIER()             __dmb(0xB) // inner shared data memory barrier
 #    define _LIBCUDACXX_COMPILER_OR_MEMORY_BARRIER() _LIBCUDACXX_MEMORY_BARRIER()
-#  elif defined(_M_IX86) || defined(_M_X64)
+#  elif _CCCL_ARCH(X86_64)
 #    define _LIBCUDACXX_MEMORY_BARRIER()             __faststorefence()
 // x86/x64 hardware only emits memory barriers inside _Interlocked intrinsics
 #    define _LIBCUDACXX_COMPILER_OR_MEMORY_BARRIER() _LIBCUDACXX_COMPILER_BARRIER()

--- a/libcudacxx/include/cuda/std/__functional/hash.h
+++ b/libcudacxx/include/cuda/std/__functional/hash.h
@@ -592,7 +592,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT hash<long double> : public __scalar_hash<lo
     __u.__s.__d = 0;
     __u.__t     = __v;
     return __u.__s.__a ^ __u.__s.__b ^ __u.__s.__c ^ __u.__s.__d;
-#  elif defined(__x86_64__)
+#  elif _CCCL_ARCH(X86_64)
     // Zero out padding bits
     union
     {

--- a/libcudacxx/include/cuda/std/__functional/hash.h
+++ b/libcudacxx/include/cuda/std/__functional/hash.h
@@ -592,7 +592,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT hash<long double> : public __scalar_hash<lo
     __u.__s.__d = 0;
     __u.__t     = __v;
     return __u.__s.__a ^ __u.__s.__b ^ __u.__s.__c ^ __u.__s.__d;
-#  elif _CCCL_ARCH(X86_64)
+#  elif _CCCL_ARCH(X86_64) && _CCCL_OS(LINUX)
     // Zero out padding bits
     union
     {

--- a/libcudacxx/include/cuda/std/__thread/threading_support.h
+++ b/libcudacxx/include/cuda/std/__thread/threading_support.h
@@ -44,13 +44,13 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 #  define _LIBCUDACXX_POLLING_COUNT 16
 
-#  if defined(__aarch64__)
+#  if _CCCL_ARCH(ARM64)
 #    define __LIBCUDACXX_ASM_THREAD_YIELD (asm volatile("yield" :: :);)
-#  elif defined(__x86_64__)
+#  elif _CCCL_ARCH(X86_64)
 #    define __LIBCUDACXX_ASM_THREAD_YIELD (asm volatile("pause" :: :);)
-#  else // ^^^ __x86_64__ ^^^ / vvv !__x86_64__ vvv
+#  else // ^^^  _CCCL_ARCH(X86_64) ^^^ / vvv ! _CCCL_ARCH(X86_64) vvv
 #    define __LIBCUDACXX_ASM_THREAD_YIELD (;)
-#  endif // !__x86_64__
+#  endif // ! _CCCL_ARCH(X86_64)
 
 _LIBCUDACXX_HIDE_FROM_ABI void __cccl_thread_yield_processor()
 {

--- a/libcudacxx/include/cuda/std/__thread/threading_support.h
+++ b/libcudacxx/include/cuda/std/__thread/threading_support.h
@@ -44,9 +44,9 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 #  define _LIBCUDACXX_POLLING_COUNT 16
 
-#  if _CCCL_ARCH(ARM64)
+#  if _CCCL_ARCH(ARM64) && _CCCL_OS(LINUX)
 #    define __LIBCUDACXX_ASM_THREAD_YIELD (asm volatile("yield" :: :);)
-#  elif _CCCL_ARCH(X86_64)
+#  elif _CCCL_ARCH(X86_64) && _CCCL_OS(LINUX)
 #    define __LIBCUDACXX_ASM_THREAD_YIELD (asm volatile("pause" :: :);)
 #  else // ^^^  _CCCL_ARCH(X86_64) ^^^ / vvv ! _CCCL_ARCH(X86_64) vvv
 #    define __LIBCUDACXX_ASM_THREAD_YIELD (;)

--- a/libcudacxx/include/cuda/std/__thread/threading_support_win32.h
+++ b/libcudacxx/include/cuda/std/__thread/threading_support_win32.h
@@ -37,7 +37,7 @@ using __cccl_mutex_t = void*;
 
 #  if defined(_M_IX86) || defined(__i386__) || defined(_M_ARM) || defined(__arm__)
 using __cccl_recursive_mutex_t = void* [6];
-#  elif defined(_M_AMD64) || defined(__x86_64__) || defined(_M_ARM64) || defined(__aarch64__)
+#  elif _CCCL_ARCH(ARM64) || _CCCL_ARCH(X86_64)
 using __cccl_recursive_mutex_t = void* [5];
 #  else
 #    error Unsupported architecture


### PR DESCRIPTION
## Description

Replace raw macros  `_M_ARM64`, `__x86_64__`, etc. with `_CCCL_ARCH(ARM64)`, `_CCCL_ARCH(X86_64)`