### PR TITLE
Move `ForceInclusive` parameter of `DispatchScan` before policy

### DIFF
--- a/cub/cub/device/device_scan.cuh
+++ b/cub/cub/device/device_scan.cuh
@@ -1165,8 +1165,6 @@ struct DeviceScan
       detail::InputValue<InitValueT>,
       OffsetT,
       AccumT,
-      detail::scan::
-        policy_hub<detail::value_t<InputIteratorT>, detail::value_t<OutputIteratorT>, AccumT, OffsetT, ScanOpT>,
       ForceInclusive::Yes>::Dispatch(d_temp_storage,
                                      temp_storage_bytes,
                                      d_in,

--- a/cub/cub/device/dispatch/dispatch_scan.cuh
+++ b/cub/cub/device/dispatch/dispatch_scan.cuh
@@ -139,23 +139,23 @@ template <
   typename ScanOpT,
   typename InitValueT,
   typename OffsetT,
-  typename AccumT = ::cuda::std::__accumulator_t<ScanOpT,
-                                                 cub::detail::value_t<InputIteratorT>,
-                                                 ::cuda::std::_If<::cuda::std::is_same_v<InitValueT, NullType>,
-                                                                  cub::detail::value_t<InputIteratorT>,
-                                                                  typename InitValueT::value_type>>,
+  typename AccumT                 = ::cuda::std::__accumulator_t<ScanOpT,
+                                                                 cub::detail::value_t<InputIteratorT>,
+                                                                 ::cuda::std::_If<::cuda::std::is_same_v<InitValueT, NullType>,
+                                                                                  cub::detail::value_t<InputIteratorT>,
+                                                                                  typename InitValueT::value_type>>,
+  ForceInclusive EnforceInclusive = ForceInclusive::No,
   typename PolicyHub =
     detail::scan::policy_hub<detail::value_t<InputIteratorT>, detail::value_t<OutputIteratorT>, AccumT, OffsetT, ScanOpT>,
-  ForceInclusive EnforceInclusive = ForceInclusive::No,
-  typename KernelSource           = detail::scan::DeviceScanKernelSource<
-              typename PolicyHub::MaxPolicy,
-              InputIteratorT,
-              OutputIteratorT,
-              ScanOpT,
-              InitValueT,
-              OffsetT,
-              AccumT,
-              EnforceInclusive>,
+  typename KernelSource = detail::scan::DeviceScanKernelSource<
+    typename PolicyHub::MaxPolicy,
+    InputIteratorT,
+    OutputIteratorT,
+    ScanOpT,
+    InitValueT,
+    OffsetT,
+    AccumT,
+    EnforceInclusive>,
   typename KernelLauncherFactory = detail::TripleChevronFactory>
 struct DispatchScan
 {

--- a/thrust/thrust/system/cuda/detail/async/inclusive_scan.h
+++ b/thrust/thrust/system/cuda/detail/async/inclusive_scan.h
@@ -135,26 +135,10 @@ unique_eager_event async_inclusive_scan_n(
   using AccumT      = typename ::cuda::std::
     __accumulator_t<BinaryOp, typename ::cuda::std::iterator_traits<ForwardIt>::value_type, InitialValueType>;
 
-  using Dispatch32 = cub::DispatchScan<
-    ForwardIt,
-    OutputIt,
-    BinaryOp,
-    InputValueT,
-    std::int32_t,
-    AccumT,
-    cub::detail::scan::
-      policy_hub<cub::detail::value_t<ForwardIt>, cub::detail::value_t<OutputIt>, AccumT, std::int32_t, BinaryOp>,
-    cub::ForceInclusive::Yes>;
-  using Dispatch64 = cub::DispatchScan<
-    ForwardIt,
-    OutputIt,
-    BinaryOp,
-    InputValueT,
-    std::int64_t,
-    AccumT,
-    cub::detail::scan::
-      policy_hub<cub::detail::value_t<ForwardIt>, cub::detail::value_t<OutputIt>, AccumT, std::int64_t, BinaryOp>,
-    cub::ForceInclusive::Yes>;
+  using Dispatch32 =
+    cub::DispatchScan<ForwardIt, OutputIt, BinaryOp, InputValueT, std::int32_t, AccumT, cub::ForceInclusive::Yes>;
+  using Dispatch64 =
+    cub::DispatchScan<ForwardIt, OutputIt, BinaryOp, InputValueT, std::int64_t, AccumT, cub::ForceInclusive::Yes>;
 
   InputValueT init_value(init);
 

--- a/thrust/thrust/system/cuda/detail/scan.h
+++ b/thrust/thrust/system/cuda/detail/scan.h
@@ -119,29 +119,14 @@ _CCCL_HOST_DEVICE OutputIt inclusive_scan_n_impl(
   InitValueT init,
   ScanOp scan_op)
 {
-  using InputValueT  = cub::detail::InputValue<InitValueT>;
-  using ValueT       = cub::detail::value_t<InputIt>;
-  using OutputValueT = cub::detail::value_t<OutputIt>;
-  using AccumT       = ::cuda::std::__accumulator_t<ScanOp, ValueT, InitValueT>;
+  using InputValueT = cub::detail::InputValue<InitValueT>;
+  using ValueT      = cub::detail::value_t<InputIt>;
+  using AccumT      = ::cuda::std::__accumulator_t<ScanOp, ValueT, InitValueT>;
 
   using Dispatch32 =
-    cub::DispatchScan<InputIt,
-                      OutputIt,
-                      ScanOp,
-                      InputValueT,
-                      std::uint32_t,
-                      AccumT,
-                      cub::detail::scan::policy_hub<ValueT, OutputValueT, AccumT, std::int32_t, ScanOp>,
-                      cub::ForceInclusive::Yes>;
+    cub::DispatchScan<InputIt, OutputIt, ScanOp, InputValueT, std::uint32_t, AccumT, cub::ForceInclusive::Yes>;
   using Dispatch64 =
-    cub::DispatchScan<InputIt,
-                      OutputIt,
-                      ScanOp,
-                      InputValueT,
-                      std::uint64_t,
-                      AccumT,
-                      cub::detail::scan::policy_hub<ValueT, OutputValueT, AccumT, std::int64_t, ScanOp>,
-                      cub::ForceInclusive::Yes>;
+    cub::DispatchScan<InputIt, OutputIt, ScanOp, InputValueT, std::uint64_t, AccumT, cub::ForceInclusive::Yes>;
 
   cudaStream_t stream = thrust::cuda_cub::stream(policy);
   cudaError_t status;


### PR DESCRIPTION
This is a cleanup with causes a breaking change since it changes the signature of `DispatchScan`.