### PR TITLE
Move Dispatcher policy hub parameters to the back

### DIFF
--- a/c/parallel/src/reduce.cu
+++ b/c/parallel/src/reduce.cu
@@ -411,7 +411,7 @@ extern "C" CCCL_C_API CUresult cccl_device_reduce(
                         indirect_arg_t,
                         void,
                         ::cuda::std::__identity,
-                        reduce::dynamic_reduce_policy_t<&get_policy>,
+                        reduce::dynamic_reduce_policy_t<&reduce::get_policy>,
                         reduce::reduce_kernel_source,
                         cub::detail::CudaDriverLauncherFactory>::
       Dispatch(

--- a/c/parallel/src/reduce.cu
+++ b/c/parallel/src/reduce.cu
@@ -410,8 +410,8 @@ extern "C" CCCL_C_API CUresult cccl_device_reduce(
                         indirect_arg_t,
                         indirect_arg_t,
                         void,
-                        reduce::dynamic_reduce_policy_t<&reduce::get_policy>,
                         ::cuda::std::__identity,
+                        reduce::dynamic_reduce_policy_t<&get_policy>,
                         reduce::reduce_kernel_source,
                         cub::detail::CudaDriverLauncherFactory>::
       Dispatch(

--- a/cub/benchmarks/bench/copy/memcpy.cu
+++ b/cub/benchmarks/bench/copy/memcpy.cu
@@ -184,20 +184,18 @@ void copy(nvbench::state& state,
   using buffer_offset_t    = std::uint32_t;
   using block_offset_t     = std::uint32_t;
 
-#if !TUNE_BASE
-  using policy_t = policy_hub_t;
-#else
-  using policy_t = cub::detail::batch_memcpy::policy_hub<buffer_offset_t, block_offset_t>;
-#endif
-
   using dispatch_t = cub::detail::DispatchBatchMemcpy<
     input_buffer_it_t,
     output_buffer_it_t,
     buffer_size_it_t,
     buffer_offset_t,
     block_offset_t,
-    policy_t,
-    cub::CopyAlg::Memcpy>;
+    cub::CopyAlg::Memcpy
+#if !TUNE_BASE
+    ,
+    policy_hub_t
+#endif
+    >;
 
   thrust::device_vector<T> input_buffer = generate(elements);
   thrust::device_vector<T> output_buffer(elements);

--- a/cub/benchmarks/bench/radix_sort/keys.cu
+++ b/cub/benchmarks/bench/radix_sort/keys.cu
@@ -146,7 +146,7 @@ void radix_sort_keys(std::integral_constant<bool, true>, nvbench::state& state, 
     cub::DispatchRadixSort<sort_order,
                            key_t,
                            value_t,
-                           offset_t,
+                           offset_t
 #if !TUNE_BASE
                            ,
                            policy_hub_t<key_t, value_t, offset_t>

--- a/cub/benchmarks/bench/radix_sort/keys.cu
+++ b/cub/benchmarks/bench/radix_sort/keys.cu
@@ -142,12 +142,16 @@ void radix_sort_keys(std::integral_constant<bool, true>, nvbench::state& state, 
   using offset_t = cub::detail::choose_offset_t<OffsetT>;
 
   using key_t = T;
+  using dispatch_t =
+    cub::DispatchRadixSort<sort_order,
+                           key_t,
+                           value_t,
+                           offset_t,
 #if !TUNE_BASE
-  using policy_t   = policy_hub_t<key_t, value_t, offset_t>;
-  using dispatch_t = cub::DispatchRadixSort<sort_order, key_t, value_t, offset_t, policy_t>;
-#else // TUNE_BASE
-  using dispatch_t = cub::DispatchRadixSort<sort_order, key_t, value_t, offset_t>;
+                           ,
+                           policy_hub_t<key_t, value_t, offset_t>
 #endif // TUNE_BASE
+                           >;
 
   constexpr int begin_bit = 0;
   constexpr int end_bit   = sizeof(key_t) * 8;

--- a/cub/benchmarks/bench/radix_sort/pairs.cu
+++ b/cub/benchmarks/bench/radix_sort/pairs.cu
@@ -146,7 +146,7 @@ void radix_sort_values(
     cub::DispatchRadixSort<sort_order,
                            key_t,
                            value_t,
-                           offset_t,
+                           offset_t
 #if !TUNE_BASE
                            ,
                            policy_hub_t<key_t, value_t, offset_t>

--- a/cub/benchmarks/bench/radix_sort/pairs.cu
+++ b/cub/benchmarks/bench/radix_sort/pairs.cu
@@ -142,12 +142,16 @@ void radix_sort_values(
 
   using key_t   = KeyT;
   using value_t = ValueT;
+  using dispatch_t =
+    cub::DispatchRadixSort<sort_order,
+                           key_t,
+                           value_t,
+                           offset_t,
 #if !TUNE_BASE
-  using policy_t   = policy_hub_t<key_t, value_t, offset_t>;
-  using dispatch_t = cub::DispatchRadixSort<sort_order, key_t, value_t, offset_t, policy_t>;
-#else // TUNE_BASE
-  using dispatch_t = cub::DispatchRadixSort<sort_order, key_t, value_t, offset_t>;
+                           ,
+                           policy_hub_t<key_t, value_t, offset_t>
 #endif // TUNE_BASE
+                           >;
 
   constexpr int begin_bit = 0;
   constexpr int end_bit   = sizeof(key_t) * 8;

--- a/cub/benchmarks/bench/reduce/base.cuh
+++ b/cub/benchmarks/bench/reduce/base.cuh
@@ -69,12 +69,18 @@ void reduce(nvbench::state& state, nvbench::type_list<T, OffsetT>)
   using offset_t    = cub::detail::choose_offset_t<OffsetT>;
   using output_t    = T;
   using init_t      = T;
+  using dispatch_t  = cub::DispatchReduce<
+     input_it_t,
+     output_it_t,
+     offset_t,
+     op_t,
+     init_t,
+     accum_t
 #if !TUNE_BASE
-  using policy_t   = policy_hub_t<accum_t, offset_t>;
-  using dispatch_t = cub::DispatchReduce<input_it_t, output_it_t, offset_t, op_t, init_t, accum_t, policy_t>;
-#else // TUNE_BASE
-  using dispatch_t = cub::DispatchReduce<input_it_t, output_it_t, offset_t, op_t, init_t, accum_t>;
+    ,
+    policy_hub_t<accum_t, offset_t>
 #endif // TUNE_BASE
+    >;
 
   // Retrieve axis parameters
   const auto elements         = static_cast<std::size_t>(state.get_int64("Elements{io}"));

--- a/cub/benchmarks/bench/transform_reduce/sum.cu
+++ b/cub/benchmarks/bench/transform_reduce/sum.cu
@@ -89,12 +89,18 @@ void reduce(nvbench::state& state, nvbench::type_list<T, OffsetT>)
   using reduction_op_t = ::cuda::std::plus<>;
   using transform_op_t = square_t<T>;
 
+  using dispatch_t = cub::DispatchReduce<
+    input_it_t,
+    output_it_t,
+    offset_t,
+    reduction_op_t,
+    init_t,
+    accum_t
 #  if !TUNE_BASE
-  using policy_t   = policy_hub_t<accum_t, offset_t>;
-  using dispatch_t = cub::DispatchReduce<input_it_t, output_it_t, offset_t, reduction_op_t, init_t, accum_t, policy_t>;
-#  else // TUNE_BASE
-  using dispatch_t = cub::DispatchReduce<input_it_t, output_it_t, offset_t, reduction_op_t, init_t, accum_t>;
+    ,
+    policy_hub_t<accum_t, offset_t>
 #  endif // TUNE_BASE
+    >;
 
   // Retrieve axis parameters
   const auto elements         = static_cast<std::size_t>(state.get_int64("Elements{io}"));

--- a/cub/cub/device/device_copy.cuh
+++ b/cub/cub/device/device_copy.cuh
@@ -183,14 +183,8 @@ struct DeviceCopy
     // IDIV_CEIL(num_ranges, 64)
     using BlockOffsetT = uint32_t;
 
-    return detail::DispatchBatchMemcpy<
-      InputIt,
-      OutputIt,
-      SizeIteratorT,
-      RangeOffsetT,
-      BlockOffsetT,
-      detail::batch_memcpy::policy_hub<RangeOffsetT, BlockOffsetT>,
-      CopyAlg::Copy>::Dispatch(d_temp_storage, temp_storage_bytes, input_it, output_it, sizes, num_ranges, stream);
+    return detail::DispatchBatchMemcpy<InputIt, OutputIt, SizeIteratorT, RangeOffsetT, BlockOffsetT, CopyAlg::Copy>::
+      Dispatch(d_temp_storage, temp_storage_bytes, input_it, output_it, sizes, num_ranges, stream);
   }
 };
 

--- a/cub/cub/device/device_memcpy.cuh
+++ b/cub/cub/device/device_memcpy.cuh
@@ -190,20 +190,10 @@ struct DeviceMemcpy
     // IDIV_CEIL(num_buffers, 64)
     using BlockOffsetT = uint32_t;
 
-    return detail::DispatchBatchMemcpy<
-      InputBufferIt,
-      OutputBufferIt,
-      BufferSizeIteratorT,
-      BufferOffsetT,
-      BlockOffsetT,
-      detail::batch_memcpy::policy_hub<BufferOffsetT, BlockOffsetT>,
-      CopyAlg::Memcpy>::Dispatch(d_temp_storage,
-                                 temp_storage_bytes,
-                                 input_buffer_it,
-                                 output_buffer_it,
-                                 buffer_sizes,
-                                 num_buffers,
-                                 stream);
+    return detail::
+      DispatchBatchMemcpy<InputBufferIt, OutputBufferIt, BufferSizeIteratorT, BufferOffsetT, BlockOffsetT, CopyAlg::Memcpy>::
+        Dispatch(
+          d_temp_storage, temp_storage_bytes, input_buffer_it, output_buffer_it, buffer_sizes, num_buffers, stream);
   }
 };
 

--- a/cub/cub/device/device_radix_sort.cuh
+++ b/cub/cub/device/device_radix_sort.cuh
@@ -151,18 +151,17 @@ private:
     int end_bit,
     cudaStream_t stream)
   {
-    return DispatchRadixSort<Order, KeyT, ValueT, OffsetT, detail::radix::policy_hub<KeyT, ValueT, OffsetT>, DecomposerT>::
-      Dispatch(
-        d_temp_storage,
-        temp_storage_bytes,
-        d_keys,
-        d_values,
-        static_cast<OffsetT>(num_items),
-        begin_bit,
-        end_bit,
-        is_overwrite_okay,
-        stream,
-        decomposer);
+    return DispatchRadixSort<Order, KeyT, ValueT, OffsetT, DecomposerT>::Dispatch(
+      d_temp_storage,
+      temp_storage_bytes,
+      d_keys,
+      d_values,
+      static_cast<OffsetT>(num_items),
+      begin_bit,
+      end_bit,
+      is_overwrite_okay,
+      stream,
+      decomposer);
   }
 
   template <SortOrder Order, typename KeyT, typename ValueT, typename NumItemsT, typename DecomposerT>

--- a/cub/cub/device/dispatch/dispatch_batch_memcpy.cuh
+++ b/cub/cub/device/dispatch/dispatch_batch_memcpy.cuh
@@ -297,8 +297,8 @@ template <typename InputBufferIt,
           typename BufferSizeIteratorT,
           typename BufferOffsetT,
           typename BlockOffsetT,
-          typename PolicyHub = batch_memcpy::policy_hub<BufferOffsetT, BlockOffsetT>,
-          CopyAlg MemcpyOpt  = CopyAlg::Memcpy>
+          CopyAlg MemcpyOpt  = CopyAlg::Memcpy,
+          typename PolicyHub = batch_memcpy::policy_hub<BufferOffsetT, BlockOffsetT>>
 struct DispatchBatchMemcpy
 {
   //------------------------------------------------------------------------------

--- a/cub/cub/device/dispatch/dispatch_radix_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_radix_sort.cuh
@@ -872,8 +872,8 @@ template <SortOrder Order,
           typename KeyT,
           typename ValueT,
           typename OffsetT,
-          typename PolicyHub   = detail::radix::policy_hub<KeyT, ValueT, OffsetT>,
-          typename DecomposerT = detail::identity_decomposer_t>
+          typename DecomposerT = detail::identity_decomposer_t,
+          typename PolicyHub   = detail::radix::policy_hub<KeyT, ValueT, OffsetT>>
 struct DispatchRadixSort
 {
   //------------------------------------------------------------------------------

--- a/cub/cub/device/dispatch/dispatch_reduce.cuh
+++ b/cub/cub/device/dispatch/dispatch_reduce.cuh
@@ -137,10 +137,10 @@ template <typename InputIteratorT,
           typename OutputIteratorT,
           typename OffsetT,
           typename ReductionOpT,
-          typename InitT     = cub::detail::non_void_value_t<OutputIteratorT, cub::detail::value_t<InputIteratorT>>,
-          typename AccumT    = ::cuda::std::__accumulator_t<ReductionOpT, cub::detail::value_t<InputIteratorT>, InitT>,
-          typename PolicyHub = detail::reduce::policy_hub<AccumT, OffsetT, ReductionOpT>,
+          typename InitT  = cub::detail::non_void_value_t<OutputIteratorT, cub::detail::value_t<InputIteratorT>>,
+          typename AccumT = ::cuda::std::__accumulator_t<ReductionOpT, cub::detail::value_t<InputIteratorT>, InitT>,
           typename TransformOpT = ::cuda::std::__identity,
+          typename PolicyHub    = detail::reduce::policy_hub<AccumT, OffsetT, ReductionOpT>,
           typename KernelSource = detail::reduce::DeviceReduceKernelSource<
             typename PolicyHub::MaxPolicy,
             InputIteratorT,
@@ -593,8 +593,8 @@ using DispatchTransformReduce =
                  ReductionOpT,
                  InitT,
                  AccumT,
-                 PolicyHub,
                  TransformOpT,
+                 PolicyHub,
                  KernelSource,
                  KernelLauncherFactory>;
 

--- a/cub/cub/device/dispatch/dispatch_streaming_reduce.cuh
+++ b/cub/cub/device/dispatch/dispatch_streaming_reduce.cuh
@@ -264,6 +264,7 @@ struct dispatch_streaming_arg_reduce_t
                      ReductionOpT,
                      empty_problem_init_t,
                      per_partition_accum_t,
+                     ::cuda::std::__identity,
                      PolicyChainT>;
 
     // The current partition's input iterator is an ArgIndex iterator that generates indices relative to the beginning


### PR DESCRIPTION
This PR moves the policy hub template parameter after all meaningful other template parameters (but before any customizations for the C/Python API). This allows to omit specifying the policy hub in some template instantiations.

- [x] Merge before: #3739