### PR TITLE
Fix cub trait deprecations

### DIFF
--- a/cub/cub/util_type.cuh
+++ b/cub/cub/util_type.cuh
@@ -794,7 +794,7 @@ struct BinaryOpHasIdxParam<T,
 /**
  * \brief Basic type traits categories
  */
-enum CCCL_DEPRECATED_BECAUSE("Use <cuda/std/type_traits> instead") Category
+enum Category
 {
   NOT_A_NUMBER,
   SIGNED_INTEGER,
@@ -828,7 +828,7 @@ struct BaseTraits<UNSIGNED_INTEGER, true, false, _UnsignedBits, T>
   static constexpr UnsignedBits LOWEST_KEY                                                         = UnsignedBits(0);
   static constexpr UnsignedBits MAX_KEY                                                            = UnsignedBits(-1);
   CCCL_DEPRECATED_BECAUSE("Use <cuda/std/type_traits> instead") static constexpr bool PRIMITIVE    = true;
-  static constexpr bool NULL_TYPE                                                                  = false;
+  CCCL_DEPRECATED static constexpr bool NULL_TYPE                                                  = false;
 
   static _CCCL_HOST_DEVICE _CCCL_FORCEINLINE UnsignedBits TwiddleIn(UnsignedBits key)
   {


### PR DESCRIPTION
* Add a missing deprecated
* Undeprecate `Category` to allow users to use `BaseTraits<Category, ...>` as base class when specializing `NumericTraits`. See examples uses here: https://github.com/search?type=code&q=cub%3A%3ABaseTraits%3C. 

E.g.: Users do for a custom type `nbla::HalfCuda`:
```c++
template <>
struct cub::NumericTraits<nbla::HalfCuda>
    : cub::BaseTraits<FLOATING_POINT, true, false, unsigned short,
                      nbla::HalfCuda> {};
```