### PR TITLE
Remove cuda/__init__.py in `cuda-parallel` package

### DIFF
--- a/python/cuda_parallel/README.md
+++ b/python/cuda_parallel/README.md
@@ -7,7 +7,7 @@ Please visit the documentation here: https://nvidia.github.io/cccl/python.html.
 ## Local development
 
 ```bash
-pip3 install -e ../cuda_cccl
-pip3 install -e .[test]
+pip3 install ../cuda_cccl
+pip3 install -e .[test] -v
 pytest -v ./tests/
 ```

--- a/python/cuda_parallel/README.md
+++ b/python/cuda_parallel/README.md
@@ -8,6 +8,6 @@ Please visit the documentation here: https://nvidia.github.io/cccl/python.html.
 
 ```bash
 pip3 install ../cuda_cccl
-pip3 install -e .[test] -v
+pip3 install .[test] -v
 pytest -v ./tests/
 ```

--- a/python/cuda_parallel/cuda/parallel/__init__.py
+++ b/python/cuda_parallel/cuda/parallel/__init__.py
@@ -2,6 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from cuda.parallel._version import __version__
+from ._version import __version__
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Description

This PR removes `cuda/__init__.py` within the `cuda_parallel` project. Without this, attempting to import other packages within the `cuda` namespace package will fail, e.g., `cuda.core` or `cuda.cccl`.

Secondly, it updates the install instructions to clarify that we cannot install `cuda_cccl` in editable mode. This is because `scikit-build-core` does not correctly handle editable installs. In particular, it places the CCCL headers in `site-packages`, rather than to the project directory, even in editable mode. Thus, the headers will no longer be found in `cuda_cccl.get_include_paths()`.

For similar reasons, `-e` cannot be used for `cuda_parallel` either.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
