### PR TITLE
Remove unsupported CPU architecture paths (32-bit)

### DIFF
--- a/libcudacxx/include/cuda/std/__functional/hash.h
+++ b/libcudacxx/include/cuda/std/__functional/hash.h
@@ -573,26 +573,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT hash<long double> : public __scalar_hash<lo
     {
       return 0;
     }
-#  if defined(__i386__) || (defined(__x86_64__) && defined(__ILP32__))
-    // Zero out padding bits
-    union
-    {
-      long double __t;
-      struct
-      {
-        size_t __a;
-        size_t __b;
-        size_t __c;
-        size_t __d;
-      } __s;
-    } __u;
-    __u.__s.__a = 0;
-    __u.__s.__b = 0;
-    __u.__s.__c = 0;
-    __u.__s.__d = 0;
-    __u.__t     = __v;
-    return __u.__s.__a ^ __u.__s.__b ^ __u.__s.__c ^ __u.__s.__d;
-#  elif _CCCL_ARCH(X86_64) && _CCCL_OS(LINUX)
+#  if _CCCL_ARCH(X86_64) && _CCCL_OS(LINUX)
     // Zero out padding bits
     union
     {

--- a/libcudacxx/include/cuda/std/__thread/threading_support_win32.h
+++ b/libcudacxx/include/cuda/std/__thread/threading_support_win32.h
@@ -35,9 +35,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 using __cccl_mutex_t = void*;
 #  define _LIBCUDACXX_MUTEX_INITIALIZER 0
 
-#  if defined(_M_IX86) || defined(__i386__) || defined(_M_ARM) || defined(__arm__)
-using __cccl_recursive_mutex_t = void* [6];
-#  elif _CCCL_ARCH(ARM64) || _CCCL_ARCH(X86_64)
+#  if _CCCL_ARCH(ARM64) || _CCCL_ARCH(X86_64)
 using __cccl_recursive_mutex_t = void* [5];
 #  else
 #    error Unsupported architecture

--- a/libcudacxx/include/cuda/std/limits
+++ b/libcudacxx/include/cuda/std/limits
@@ -259,7 +259,7 @@ public:
   static constexpr bool is_bounded = true;
   static constexpr bool is_modulo  = !is_signed;
 
-#if defined(__i386__) || defined(__x86_64__) || defined(__pnacl__) || defined(__wasm__)
+#if (_CCCL_ARCH(X86_64) && _CCCL_OS(LINUX)) || defined(__pnacl__) || defined(__wasm__)
   static constexpr bool traps = true;
 #else
   static constexpr bool traps = false;

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/traps.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/traps.pass.cpp
@@ -14,7 +14,7 @@
 
 #include "test_macros.h"
 
-#if defined(__i386__) || defined(__x86_64__) || defined(__pnacl__) || defined(__wasm__)
+#if (_CCCL_ARCH(X86_64) && _CCCL_OS(LINUX)) || defined(__pnacl__) || defined(__wasm__)
 static const bool integral_types_trap = true;
 #else
 static const bool integral_types_trap = false;

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/traps.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/traps.pass.cpp
@@ -14,7 +14,7 @@
 
 #include "test_macros.h"
 
-#if (_CCCL_ARCH(X86_64) && _CCCL_OS(LINUX)) || defined(__pnacl__) || defined(__wasm__)
+#if _CCCL_ARCH(X86_64) && _CCCL_OS(LINUX)
 static const bool integral_types_trap = true;
 #else
 static const bool integral_types_trap = false;


### PR DESCRIPTION
Remove paths related to `__i386__`, `_M_IX86`, `_M_ARM`, `__arm__`