### PR TITLE
Disable `[[no_unique_address]]` for MSVC

### DIFF
--- a/libcudacxx/include/cuda/std/__cccl/attributes.h
+++ b/libcudacxx/include/cuda/std/__cccl/attributes.h
@@ -77,13 +77,8 @@
 #  define _CCCL_NODEBUG_ALIAS
 #endif // !_CCCL_CUDA_COMPILER(CLANG)
 
-#if _CCCL_HAS_CPP_ATTRIBUTE(msvc::no_unique_address)
-// MSVC implements [[no_unique_address]] as a silent no-op currently.
-// (If/when MSVC breaks its C++ ABI, it will be changed to work as intended.)
-// However, MSVC implements [[msvc::no_unique_address]] which does what
-// [[no_unique_address]] is supposed to do, in general.
-#  define _CCCL_NO_UNIQUE_ADDRESS [[msvc::no_unique_address]]
-#elif _CCCL_HAS_CPP_ATTRIBUTE(no_unique_address) < 201803L
+#if _CCCL_COMPILER(MSVC) || _CCCL_HAS_CPP_ATTRIBUTE(no_unique_address) < 201803L
+// MSVC implementation has lead to multiple issues with silent runtime corruption when passing data into kernels
 #  define _CCCL_HAS_NO_ATTRIBUTE_NO_UNIQUE_ADDRESS
 #  define _CCCL_NO_UNIQUE_ADDRESS
 #elif _CCCL_HAS_CPP_ATTRIBUTE(no_unique_address)


### PR DESCRIPTION
We had another report of silent data corruption when passing an object that utilizes `[[no_unique_address]]` into a kernel.

Disable it until MSVC properly implements the attribute

Fixes [BUG]: Struct of cuda:std::dextents causing data corruption on MSVC #3694
