### PR TITLE
Simplify `cuda::std::{min,max}`

### DIFF
--- a/libcudacxx/include/cuda/std/__algorithm/max.h
+++ b/libcudacxx/include/cuda/std/__algorithm/max.h
@@ -38,7 +38,7 @@ _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr const _Tp& max(const _Tp& __
 template <class _Tp>
 _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr const _Tp& max(const _Tp& __a, const _Tp& __b)
 {
-  return _CUDA_VSTD::max(__a, __b, __less{});
+  return __a < __b ? __b : __a;
 }
 
 template <class _Tp, class _Compare>

--- a/libcudacxx/include/cuda/std/__algorithm/min.h
+++ b/libcudacxx/include/cuda/std/__algorithm/min.h
@@ -38,7 +38,7 @@ _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr const _Tp& min(const _Tp& __
 template <class _Tp>
 _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr const _Tp& min(const _Tp& __a, const _Tp& __b)
 {
-  return _CUDA_VSTD::min(__a, __b, __less{});
+  return __b < __a ? __b : __a;
 }
 
 template <class _Tp, class _Compare>


### PR DESCRIPTION
They are so simple, that we should not instantiate another function and use a function object
