### PR TITLE
Fix python editable builds

### DIFF
--- a/python/cuda_parallel/cuda/parallel/experimental/_bindings.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/_bindings.py
@@ -20,15 +20,18 @@ def get_bindings() -> ctypes.CDLL:
     # can move this to a module-level import.
     from importlib.resources import as_file, files
 
+    so_path = "cccl/libcccl.c.parallel.so"
     with as_file(files("cuda.parallel.experimental")) as f:
-        cccl_c_path = str(f / "cccl" / "libcccl.c.parallel.so")
-    if not Path(cccl_c_path).exists():
-        for p in sys.path:
-            gl = Path(p).glob("cuda/parallel/experimental/cccl/libcccl.c.parallel.so")
-            for f in gl:
-                cccl_c_path = str(f)
+        cccl_c_path = f / so_path
+    if not cccl_c_path.exists():
+        # This may be needed to support editable builds (see PR #3762).
+        for sp in sys.path:
+            cccl_c_path = Path(sp).resolve() / "cuda/parallel/experimental" / so_path
+            if cccl_c_path.exists():
                 break
-    _bindings = ctypes.CDLL(cccl_c_path)
+        else:
+            raise RuntimeError(f"Unable to locate {so_path}")
+    _bindings = ctypes.CDLL(str(cccl_c_path))
     _bindings.cccl_device_reduce.restype = ctypes.c_int
     _bindings.cccl_device_reduce.argtypes = [
         cccl.DeviceReduceBuildResult,

--- a/python/cuda_parallel/cuda/parallel/experimental/_bindings.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/_bindings.py
@@ -4,7 +4,9 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import ctypes
+import sys
 from functools import lru_cache
+from pathlib import Path
 from typing import List
 
 from cuda.cccl import get_include_paths  # type: ignore[import-not-found]
@@ -20,6 +22,12 @@ def get_bindings() -> ctypes.CDLL:
 
     with as_file(files("cuda.parallel.experimental")) as f:
         cccl_c_path = str(f / "cccl" / "libcccl.c.parallel.so")
+    if not Path(cccl_c_path).exists():
+        for p in sys.path:
+            gl = Path(p).glob("cuda/parallel/experimental/cccl/libcccl.c.parallel.so")
+            for f in gl:
+                cccl_c_path = str(f)
+                break
     _bindings = ctypes.CDLL(cccl_c_path)
     _bindings.cccl_device_reduce.restype = ctypes.c_int
     _bindings.cccl_device_reduce.argtypes = [


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes gh-3761

<!-- Provide a standalone description of changes in this PR. -->

This PR modifies getter functions in `cuda_cccl` and `cuda_parallel` to search for artifacts in `sys.path` if the folder found by `importlib.resources` does not contain it.

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [x] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
