### PR TITLE
Drop cugraph-gnn from rapids CI

### DIFF
--- a/.github/workflows/build-rapids.yml
+++ b/.github/workflows/build-rapids.yml
@@ -38,7 +38,7 @@ jobs:
         include:
           - { cuda: '12.5', libs: 'rmm kvikio cudf cudf_kafka cuspatial' }
           - { cuda: '12.5', libs: 'rmm ucxx raft cuvs cumlprims_mg cuml' }
-          - { cuda: '12.5', libs: 'rmm ucxx raft cugraph cugraph-gnn'    }
+          - { cuda: '12.5', libs: 'rmm ucxx raft cugraph'                }
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
It does not build because of a missing script so lets wait until it is usable

> /ci.sh: line 40: configure-cugraph-gnn-cpp: command not found
