### PR TITLE
Replace pre-c++17 traits with modern ones in CUB

### DIFF
--- a/cub/benchmarks/bench/radix_sort/keys.cu
+++ b/cub/benchmarks/bench/radix_sort/keys.cu
@@ -48,7 +48,7 @@ constexpr bool is_overwrite_ok      = false;
 template <typename KeyT, typename ValueT, typename OffsetT>
 struct policy_hub_t
 {
-  static constexpr bool KEYS_ONLY = std::is_same<ValueT, cub::NullType>::value;
+  static constexpr bool KEYS_ONLY = std::is_same_v<ValueT, cub::NullType>;
 
   using DominantT = ::cuda::std::_If<(sizeof(ValueT) > sizeof(KeyT)), ValueT, KeyT>;
 

--- a/cub/benchmarks/bench/radix_sort/pairs.cu
+++ b/cub/benchmarks/bench/radix_sort/pairs.cu
@@ -46,7 +46,7 @@ constexpr bool is_overwrite_ok      = false;
 template <typename KeyT, typename ValueT, typename OffsetT>
 struct policy_hub_t
 {
-  static constexpr bool KEYS_ONLY = std::is_same<ValueT, cub::NullType>::value;
+  static constexpr bool KEYS_ONLY = std::is_same_v<ValueT, cub::NullType>;
 
   using DominantT = ::cuda::std::_If<(sizeof(ValueT) > sizeof(KeyT)), ValueT, KeyT>;
 

--- a/cub/benchmarks/bench/reduce/arg_extrema.cu
+++ b/cub/benchmarks/bench/reduce/arg_extrema.cu
@@ -57,7 +57,7 @@ struct policy_hub_t
     // Type used for the final result
     using output_tuple_t = cub::KeyValuePair<global_offset_t, T>;
 
-    auto const init = ::cuda::std::is_same<OpT, cub::ArgMin>::value ? cub::Traits<T>::Max() : cub::Traits<T>::Lowest();
+    auto const init = ::cuda::std::is_same_v<OpT, cub::ArgMin> ? cub::Traits<T>::Max() : cub::Traits<T>::Lowest();
 
 #if !TUNE_BASE
     using policy_t   = policy_hub_t<output_tuple_t, per_partition_offset_t>;

--- a/cub/benchmarks/bench/transform/common.h
+++ b/cub/benchmarks/bench/transform/common.h
@@ -106,10 +106,10 @@ struct narrowing_error : std::runtime_error
 
 // from C++ GSL
 // implementation insipired by: https://github.com/microsoft/GSL/blob/main/include/gsl/narrow
-template <typename DstT, typename SrcT, ::cuda::std::enable_if_t<::cuda::std::is_arithmetic<SrcT>::value, int> = 0>
+template <typename DstT, typename SrcT, ::cuda::std::enable_if_t<::cuda::std::is_arithmetic_v<SrcT>, int> = 0>
 constexpr DstT narrow(SrcT value)
 {
-  constexpr bool is_different_signedness = ::cuda::std::is_signed<SrcT>::value != ::cuda::std::is_signed<DstT>::value;
+  constexpr bool is_different_signedness = ::cuda::std::is_signed_v<SrcT> != ::cuda::std::is_signed_v<DstT>;
   const auto converted                   = static_cast<DstT>(value);
   if (static_cast<SrcT>(converted) != value || (is_different_signedness && ((converted < DstT{}) != (value < SrcT{}))))
   {

--- a/cub/cub/agent/agent_batch_memcpy.cuh
+++ b/cub/cub/agent/agent_batch_memcpy.cuh
@@ -300,7 +300,7 @@ template <bool IsMemcpy,
           typename InputBufferT,
           typename OutputBufferT,
           typename OffsetT,
-          typename ::cuda::std::enable_if<IsMemcpy, int>::type = 0>
+          ::cuda::std::enable_if_t<IsMemcpy, int> = 0>
 _CCCL_DEVICE _CCCL_FORCEINLINE void
 copy_items(InputBufferT input_buffer, OutputBufferT output_buffer, OffsetT num_bytes, OffsetT offset = 0)
 {
@@ -316,7 +316,7 @@ template <bool IsMemcpy,
           typename InputBufferT,
           typename OutputBufferT,
           typename OffsetT,
-          typename ::cuda::std::enable_if<!IsMemcpy, int>::type = 0>
+          ::cuda::std::enable_if_t<!IsMemcpy, int> = 0>
 _CCCL_DEVICE _CCCL_FORCEINLINE void
 copy_items(InputBufferT input_buffer, OutputBufferT output_buffer, OffsetT num_items, OffsetT offset = 0)
 {
@@ -328,41 +328,25 @@ copy_items(InputBufferT input_buffer, OutputBufferT output_buffer, OffsetT num_i
   }
 }
 
-template <bool IsMemcpy,
-          typename AliasT,
-          typename InputIt,
-          typename OffsetT,
-          typename ::cuda::std::enable_if<IsMemcpy, int>::type = 0>
+template <bool IsMemcpy, typename AliasT, typename InputIt, typename OffsetT, ::cuda::std::enable_if_t<IsMemcpy, int> = 0>
 _CCCL_DEVICE _CCCL_FORCEINLINE AliasT read_item(InputIt buffer_src, OffsetT offset)
 {
   return *(reinterpret_cast<const AliasT*>(buffer_src) + offset);
 }
 
-template <bool IsMemcpy,
-          typename AliasT,
-          typename InputIt,
-          typename OffsetT,
-          typename ::cuda::std::enable_if<!IsMemcpy, int>::type = 0>
+template <bool IsMemcpy, typename AliasT, typename InputIt, typename OffsetT, ::cuda::std::enable_if_t<!IsMemcpy, int> = 0>
 _CCCL_DEVICE _CCCL_FORCEINLINE AliasT read_item(InputIt buffer_src, OffsetT offset)
 {
   return *(buffer_src + offset);
 }
 
-template <bool IsMemcpy,
-          typename AliasT,
-          typename OutputIt,
-          typename OffsetT,
-          typename ::cuda::std::enable_if<IsMemcpy, int>::type = 0>
+template <bool IsMemcpy, typename AliasT, typename OutputIt, typename OffsetT, ::cuda::std::enable_if_t<IsMemcpy, int> = 0>
 _CCCL_DEVICE _CCCL_FORCEINLINE void write_item(OutputIt buffer_dst, OffsetT offset, AliasT value)
 {
   *(reinterpret_cast<AliasT*>(buffer_dst) + offset) = value;
 }
 
-template <bool IsMemcpy,
-          typename AliasT,
-          typename OutputIt,
-          typename OffsetT,
-          typename ::cuda::std::enable_if<!IsMemcpy, int>::type = 0>
+template <bool IsMemcpy, typename AliasT, typename OutputIt, typename OffsetT, ::cuda::std::enable_if_t<!IsMemcpy, int> = 0>
 _CCCL_DEVICE _CCCL_FORCEINLINE void write_item(OutputIt buffer_dst, OffsetT offset, AliasT value)
 {
   *(buffer_dst + offset) = value;

--- a/cub/cub/agent/agent_histogram.cuh
+++ b/cub/cub/agent/agent_histogram.cuh
@@ -222,7 +222,7 @@ struct AgentHistogram
   // Wrap the native input pointer with CacheModifiedInputIterator
   // or directly use the supplied input iterator type
   using WrappedSampleIteratorT =
-    ::cuda::std::_If<::cuda::std::is_pointer<SampleIteratorT>::value,
+    ::cuda::std::_If<::cuda::std::is_pointer_v<SampleIteratorT>,
                      CacheModifiedInputIterator<LOAD_MODIFIER, SampleT, OffsetT>,
                      SampleIteratorT>;
 

--- a/cub/cub/agent/agent_merge.cuh
+++ b/cub/cub/agent/agent_merge.cuh
@@ -172,7 +172,7 @@ struct agent_t
     }
 
     // if items are provided, merge them
-    static constexpr bool have_items = !::cuda::std::is_same<item_type, NullType>::value;
+    static constexpr bool have_items = !::cuda::std::is_same_v<item_type, NullType>;
     _CCCL_IF_CONSTEXPR (have_items)
     {
       item_type items_loc[items_per_thread];

--- a/cub/cub/agent/agent_radix_sort_downsweep.cuh
+++ b/cub/cub/agent/agent_radix_sort_downsweep.cuh
@@ -178,7 +178,7 @@ struct AgentRadixSortDownsweep
     TILE_ITEMS       = BLOCK_THREADS * ITEMS_PER_THREAD,
 
     RADIX_DIGITS      = 1 << RADIX_BITS,
-    KEYS_ONLY         = ::cuda::std::is_same<ValueT, NullType>::value,
+    KEYS_ONLY         = ::cuda::std::is_same_v<ValueT, NullType>,
     LOAD_WARP_STRIPED = RANK_ALGORITHM == RADIX_RANK_MATCH || RANK_ALGORITHM == RADIX_RANK_MATCH_EARLY_COUNTS_ANY
                      || RANK_ALGORITHM == RADIX_RANK_MATCH_EARLY_COUNTS_ATOMIC_OR,
   };

--- a/cub/cub/agent/agent_radix_sort_onesweep.cuh
+++ b/cub/cub/agent/agent_radix_sort_onesweep.cuh
@@ -116,7 +116,7 @@ struct AgentRadixSortOnesweep
   enum
   {
     ITEMS_PER_THREAD      = AgentRadixSortOnesweepPolicy::ITEMS_PER_THREAD,
-    KEYS_ONLY             = ::cuda::std::is_same<ValueT, NullType>::value,
+    KEYS_ONLY             = ::cuda::std::is_same_v<ValueT, NullType>,
     BLOCK_THREADS         = AgentRadixSortOnesweepPolicy::BLOCK_THREADS,
     RANK_NUM_PARTS        = AgentRadixSortOnesweepPolicy::RANK_NUM_PARTS,
     TILE_ITEMS            = BLOCK_THREADS * ITEMS_PER_THREAD,

--- a/cub/cub/agent/agent_reduce.cuh
+++ b/cub/cub/agent/agent_reduce.cuh
@@ -151,7 +151,7 @@ struct AgentReduce
   // Wrap the native input pointer with CacheModifiedInputIterator
   // or directly use the supplied input iterator type
   using WrappedInputIteratorT =
-    ::cuda::std::_If<::cuda::std::is_pointer<InputIteratorT>::value,
+    ::cuda::std::_If<::cuda::std::is_pointer_v<InputIteratorT>,
                      CacheModifiedInputIterator<AgentReducePolicy::LOAD_MODIFIER, InputT, OffsetT>,
                      InputIteratorT>;
 
@@ -165,7 +165,7 @@ struct AgentReduce
   // pointer to a primitive type
   static constexpr bool ATTEMPT_VECTORIZATION =
     (VECTOR_LOAD_LENGTH > 1) && (ITEMS_PER_THREAD % VECTOR_LOAD_LENGTH == 0)
-    && (::cuda::std::is_pointer<InputIteratorT>::value) && is_primitive<InputT>::value;
+    && (::cuda::std::is_pointer_v<InputIteratorT>) && is_primitive<InputT>::value;
 
   static constexpr CacheLoadModifier LOAD_MODIFIER = AgentReducePolicy::LOAD_MODIFIER;
 

--- a/cub/cub/agent/agent_reduce_by_key.cuh
+++ b/cub/cub/agent/agent_reduce_by_key.cuh
@@ -228,14 +228,14 @@ struct AgentReduceByKey
   // Whether or not the scan operation has a zero-valued identity value (true
   // if we're performing addition on a primitive type)
   static constexpr int HAS_IDENTITY_ZERO =
-    (::cuda::std::is_same<ReductionOpT, ::cuda::std::plus<>>::value) && (is_primitive<AccumT>::value);
+    (::cuda::std::is_same_v<ReductionOpT, ::cuda::std::plus<>>) && (is_primitive<AccumT>::value);
 
   // Cache-modified Input iterator wrapper type (for applying cache modifier)
   // for keys Wrap the native input pointer with
   // CacheModifiedValuesInputIterator or directly use the supplied input
   // iterator type
   using WrappedKeysInputIteratorT =
-    ::cuda::std::_If<::cuda::std::is_pointer<KeysInputIteratorT>::value,
+    ::cuda::std::_If<::cuda::std::is_pointer_v<KeysInputIteratorT>,
                      CacheModifiedInputIterator<AgentReduceByKeyPolicyT::LOAD_MODIFIER, KeyInputT, OffsetT>,
                      KeysInputIteratorT>;
 
@@ -244,7 +244,7 @@ struct AgentReduceByKey
   // CacheModifiedValuesInputIterator or directly use the supplied input
   // iterator type
   using WrappedValuesInputIteratorT =
-    ::cuda::std::_If<::cuda::std::is_pointer<ValuesInputIteratorT>::value,
+    ::cuda::std::_If<::cuda::std::is_pointer_v<ValuesInputIteratorT>,
                      CacheModifiedInputIterator<AgentReduceByKeyPolicyT::LOAD_MODIFIER, ValueInputT, OffsetT>,
                      ValuesInputIteratorT>;
 
@@ -253,7 +253,7 @@ struct AgentReduceByKey
   // CacheModifiedValuesInputIterator or directly use the supplied input
   // iterator type
   using WrappedFixupInputIteratorT =
-    ::cuda::std::_If<::cuda::std::is_pointer<AggregatesOutputIteratorT>::value,
+    ::cuda::std::_If<::cuda::std::is_pointer_v<AggregatesOutputIteratorT>,
                      CacheModifiedInputIterator<AgentReduceByKeyPolicyT::LOAD_MODIFIER, ValueInputT, OffsetT>,
                      AggregatesOutputIteratorT>;
 

--- a/cub/cub/agent/agent_rle.cuh
+++ b/cub/cub/agent/agent_rle.cuh
@@ -238,7 +238,7 @@ struct AgentRle
   // Wrap the native input pointer with CacheModifiedVLengthnputIterator
   // Directly use the supplied input iterator type
   using WrappedInputIteratorT =
-    ::cuda::std::_If<::cuda::std::is_pointer<InputIteratorT>::value,
+    ::cuda::std::_If<::cuda::std::is_pointer_v<InputIteratorT>,
                      CacheModifiedInputIterator<AgentRlePolicyT::LOAD_MODIFIER, T, OffsetT>,
                      InputIteratorT>;
 

--- a/cub/cub/agent/agent_scan.cuh
+++ b/cub/cub/agent/agent_scan.cuh
@@ -166,7 +166,7 @@ struct AgentScan
   // Wrap the native input pointer with CacheModifiedInputIterator
   // or directly use the supplied input iterator type
   using WrappedInputIteratorT =
-    ::cuda::std::_If<::cuda::std::is_pointer<InputIteratorT>::value,
+    ::cuda::std::_If<::cuda::std::is_pointer_v<InputIteratorT>,
                      CacheModifiedInputIterator<AgentScanPolicyT::LOAD_MODIFIER, InputT, OffsetT>,
                      InputIteratorT>;
 
@@ -174,7 +174,7 @@ struct AgentScan
   enum
   {
     // Inclusive scan if no init_value type is provided
-    HAS_INIT     = !::cuda::std::is_same<InitValueT, NullType>::value,
+    HAS_INIT     = !::cuda::std::is_same_v<InitValueT, NullType>,
     IS_INCLUSIVE = ForceInclusive || !HAS_INIT, // We are relying on either initial value not being `NullType`
                                                 // or the ForceInclusive tag to be true for inclusive scan
                                                 // to get picked up.

--- a/cub/cub/agent/agent_scan_by_key.cuh
+++ b/cub/cub/agent/agent_scan_by_key.cuh
@@ -154,18 +154,18 @@ struct AgentScanByKey
 
   // Constants
   // Inclusive scan if no init_value type is provided
-  static constexpr int IS_INCLUSIVE     = ::cuda::std::is_same<InitValueT, NullType>::value;
+  static constexpr int IS_INCLUSIVE     = ::cuda::std::is_same_v<InitValueT, NullType>;
   static constexpr int BLOCK_THREADS    = AgentScanByKeyPolicyT::BLOCK_THREADS;
   static constexpr int ITEMS_PER_THREAD = AgentScanByKeyPolicyT::ITEMS_PER_THREAD;
   static constexpr int ITEMS_PER_TILE   = BLOCK_THREADS * ITEMS_PER_THREAD;
 
   using WrappedKeysInputIteratorT =
-    ::cuda::std::_If<::cuda::std::is_pointer<KeysInputIteratorT>::value,
+    ::cuda::std::_If<::cuda::std::is_pointer_v<KeysInputIteratorT>,
                      CacheModifiedInputIterator<AgentScanByKeyPolicyT::LOAD_MODIFIER, KeyT, OffsetT>,
                      KeysInputIteratorT>;
 
   using WrappedValuesInputIteratorT =
-    ::cuda::std::_If<::cuda::std::is_pointer<ValuesInputIteratorT>::value,
+    ::cuda::std::_If<::cuda::std::is_pointer_v<ValuesInputIteratorT>,
                      CacheModifiedInputIterator<AgentScanByKeyPolicyT::LOAD_MODIFIER, InputT, OffsetT>,
                      ValuesInputIteratorT>;
 
@@ -299,7 +299,7 @@ struct AgentScanByKey
     }
   }
 
-  template <bool IsNull                                         = ::cuda::std::is_same<InitValueT, NullType>::value,
+  template <bool IsNull                                         = ::cuda::std::is_same_v<InitValueT, NullType>,
             typename ::cuda::std::enable_if<!IsNull, int>::type = 0>
   _CCCL_DEVICE _CCCL_FORCEINLINE void
   AddInitToScan(AccumT (&items)[ITEMS_PER_THREAD], OffsetT (&flags)[ITEMS_PER_THREAD])
@@ -311,7 +311,7 @@ struct AgentScanByKey
     }
   }
 
-  template <bool IsNull                                        = ::cuda::std::is_same<InitValueT, NullType>::value,
+  template <bool IsNull                                        = ::cuda::std::is_same_v<InitValueT, NullType>,
             typename ::cuda::std::enable_if<IsNull, int>::type = 0>
   _CCCL_DEVICE _CCCL_FORCEINLINE void
   AddInitToScan(AccumT (& /*items*/)[ITEMS_PER_THREAD], OffsetT (& /*flags*/)[ITEMS_PER_THREAD])

--- a/cub/cub/agent/agent_scan_by_key.cuh
+++ b/cub/cub/agent/agent_scan_by_key.cuh
@@ -299,8 +299,7 @@ struct AgentScanByKey
     }
   }
 
-  template <bool IsNull                                         = ::cuda::std::is_same_v<InitValueT, NullType>,
-            typename ::cuda::std::enable_if<!IsNull, int>::type = 0>
+  template <bool IsNull = ::cuda::std::is_same_v<InitValueT, NullType>, ::cuda::std::enable_if_t<!IsNull, int> = 0>
   _CCCL_DEVICE _CCCL_FORCEINLINE void
   AddInitToScan(AccumT (&items)[ITEMS_PER_THREAD], OffsetT (&flags)[ITEMS_PER_THREAD])
   {
@@ -311,8 +310,7 @@ struct AgentScanByKey
     }
   }
 
-  template <bool IsNull                                        = ::cuda::std::is_same_v<InitValueT, NullType>,
-            typename ::cuda::std::enable_if<IsNull, int>::type = 0>
+  template <bool IsNull = ::cuda::std::is_same_v<InitValueT, NullType>, ::cuda::std::enable_if_t<IsNull, int> = 0>
   _CCCL_DEVICE _CCCL_FORCEINLINE void
   AddInitToScan(AccumT (& /*items*/)[ITEMS_PER_THREAD], OffsetT (& /*flags*/)[ITEMS_PER_THREAD])
   {}

--- a/cub/cub/agent/agent_segmented_radix_sort.cuh
+++ b/cub/cub/agent/agent_segmented_radix_sort.cuh
@@ -83,7 +83,7 @@ struct AgentSegmentedRadixSort
   static constexpr int BLOCK_THREADS    = SegmentedPolicyT::BLOCK_THREADS;
   static constexpr int RADIX_BITS       = SegmentedPolicyT::RADIX_BITS;
   static constexpr int RADIX_DIGITS     = 1 << RADIX_BITS;
-  static constexpr int KEYS_ONLY        = ::cuda::std::is_same<ValueT, NullType>::value;
+  static constexpr int KEYS_ONLY        = ::cuda::std::is_same_v<ValueT, NullType>;
 
   using traits           = radix::traits_t<KeyT>;
   using bit_ordered_type = typename traits::bit_ordered_type;

--- a/cub/cub/agent/agent_select_if.cuh
+++ b/cub/cub/agent/agent_select_if.cuh
@@ -246,8 +246,8 @@ struct AgentSelectIf
   static constexpr ::cuda::std::int32_t TILE_ITEMS       = BLOCK_THREADS * ITEMS_PER_THREAD;
   static constexpr bool TWO_PHASE_SCATTER                = (ITEMS_PER_THREAD > 1);
 
-  static constexpr bool has_select_op       = (!::cuda::std::is_same<SelectOpT, NullType>::value);
-  static constexpr bool has_flags_it        = (!::cuda::std::is_same<FlagT, NullType>::value);
+  static constexpr bool has_select_op       = (!::cuda::std::is_same_v<SelectOpT, NullType>);
+  static constexpr bool has_flags_it        = (!::cuda::std::is_same_v<FlagT, NullType>);
   static constexpr bool use_stencil_with_op = has_select_op && has_flags_it;
   static constexpr auto SELECT_METHOD =
     use_stencil_with_op ? USE_STENCIL_WITH_OP
@@ -259,7 +259,7 @@ struct AgentSelectIf
   // Wrap the native input pointer with CacheModifiedValuesInputIterator
   // or directly use the supplied input iterator type
   using WrappedInputIteratorT =
-    ::cuda::std::_If<::cuda::std::is_pointer<InputIteratorT>::value,
+    ::cuda::std::_If<::cuda::std::is_pointer_v<InputIteratorT>,
                      CacheModifiedInputIterator<AgentSelectIfPolicyT::LOAD_MODIFIER, InputT, OffsetT>,
                      InputIteratorT>;
 
@@ -267,7 +267,7 @@ struct AgentSelectIf
   // Wrap the native input pointer with CacheModifiedValuesInputIterator
   // or directly use the supplied input iterator type
   using WrappedFlagsInputIteratorT =
-    ::cuda::std::_If<::cuda::std::is_pointer<FlagsInputIteratorT>::value,
+    ::cuda::std::_If<::cuda::std::is_pointer_v<FlagsInputIteratorT>,
                      CacheModifiedInputIterator<AgentSelectIfPolicyT::LOAD_MODIFIER, FlagT, OffsetT>,
                      FlagsInputIteratorT>;
 

--- a/cub/cub/agent/agent_sub_warp_merge_sort.cuh
+++ b/cub/cub/agent/agent_sub_warp_merge_sort.cuh
@@ -179,7 +179,7 @@ class AgentSubWarpSort
   }
 
 public:
-  static constexpr bool KEYS_ONLY = ::cuda::std::is_same<ValueT, cub::NullType>::value;
+  static constexpr bool KEYS_ONLY = ::cuda::std::is_same_v<ValueT, cub::NullType>;
 
   using WarpMergeSortT = WarpMergeSort<KeyT, PolicyT::ITEMS_PER_THREAD, PolicyT::WARP_THREADS, ValueT>;
 

--- a/cub/cub/agent/agent_three_way_partition.cuh
+++ b/cub/cub/agent/agent_three_way_partition.cuh
@@ -113,7 +113,7 @@ struct accumulator_pack_base_t
 };
 
 template <class OffsetT>
-struct accumulator_pack_base_t<OffsetT, typename ::cuda::std::enable_if<sizeof(OffsetT) == 4>::type>
+struct accumulator_pack_base_t<OffsetT, ::cuda::std::enable_if_t<sizeof(OffsetT) == 4>>
 {
   using pack_t = uint64_t;
 

--- a/cub/cub/agent/agent_three_way_partition.cuh
+++ b/cub/cub/agent/agent_three_way_partition.cuh
@@ -194,7 +194,7 @@ struct AgentThreeWayPartition
   static constexpr int TILE_ITEMS       = BLOCK_THREADS * ITEMS_PER_THREAD;
 
   using WrappedInputIteratorT =
-    ::cuda::std::_If<::cuda::std::is_pointer<InputIteratorT>::value,
+    ::cuda::std::_If<::cuda::std::is_pointer_v<InputIteratorT>,
                      cub::CacheModifiedInputIterator<PolicyT::LOAD_MODIFIER, InputT, OffsetT>,
                      InputIteratorT>;
 

--- a/cub/cub/agent/agent_unique_by_key.cuh
+++ b/cub/cub/agent/agent_unique_by_key.cuh
@@ -152,7 +152,7 @@ struct AgentUniqueByKey
 
   // Cache-modified Input iterator wrapper type (for applying cache modifier) for keys
   using WrappedKeyInputIteratorT = typename ::cuda::std::conditional<
-    ::cuda::std::is_pointer<KeyInputIteratorT>::value,
+    ::cuda::std::is_pointer_v<KeyInputIteratorT>,
     CacheModifiedInputIterator<AgentUniqueByKeyPolicyT::LOAD_MODIFIER, KeyT, OffsetT>, // Wrap the native input pointer
                                                                                        // with
                                                                                        // CacheModifiedValuesInputIterator
@@ -160,7 +160,7 @@ struct AgentUniqueByKey
 
   // Cache-modified Input iterator wrapper type (for applying cache modifier) for values
   using WrappedValueInputIteratorT = typename ::cuda::std::conditional<
-    ::cuda::std::is_pointer<ValueInputIteratorT>::value,
+    ::cuda::std::is_pointer_v<ValueInputIteratorT>,
     CacheModifiedInputIterator<AgentUniqueByKeyPolicyT::LOAD_MODIFIER, ValueT, OffsetT>, // Wrap the native input
                                                                                          // pointer with
                                                                                          // CacheModifiedValuesInputIterator

--- a/cub/cub/agent/agent_unique_by_key.cuh
+++ b/cub/cub/agent/agent_unique_by_key.cuh
@@ -151,20 +151,20 @@ struct AgentUniqueByKey
   };
 
   // Cache-modified Input iterator wrapper type (for applying cache modifier) for keys
-  using WrappedKeyInputIteratorT = typename ::cuda::std::conditional<
+  using WrappedKeyInputIteratorT = ::cuda::std::conditional_t<
     ::cuda::std::is_pointer_v<KeyInputIteratorT>,
     CacheModifiedInputIterator<AgentUniqueByKeyPolicyT::LOAD_MODIFIER, KeyT, OffsetT>, // Wrap the native input pointer
                                                                                        // with
                                                                                        // CacheModifiedValuesInputIterator
-    KeyInputIteratorT>::type; // Directly use the supplied input iterator type
+    KeyInputIteratorT>; // Directly use the supplied input iterator type
 
   // Cache-modified Input iterator wrapper type (for applying cache modifier) for values
-  using WrappedValueInputIteratorT = typename ::cuda::std::conditional<
+  using WrappedValueInputIteratorT = ::cuda::std::conditional_t<
     ::cuda::std::is_pointer_v<ValueInputIteratorT>,
     CacheModifiedInputIterator<AgentUniqueByKeyPolicyT::LOAD_MODIFIER, ValueT, OffsetT>, // Wrap the native input
                                                                                          // pointer with
                                                                                          // CacheModifiedValuesInputIterator
-    ValueInputIteratorT>::type; // Directly use the supplied input iterator type
+    ValueInputIteratorT>; // Directly use the supplied input iterator type
 
   // Parameterized BlockLoad type for input data
   using BlockLoadKeys = BlockLoad<KeyT, BLOCK_THREADS, ITEMS_PER_THREAD, AgentUniqueByKeyPolicyT::LOAD_ALGORITHM>;

--- a/cub/cub/agent/single_pass_scan_operators.cuh
+++ b/cub/cub/agent/single_pass_scan_operators.cuh
@@ -652,28 +652,28 @@ struct ScanTileState<T, true>
 
 private:
   template <MemoryOrder Order>
-  _CCCL_DEVICE _CCCL_FORCEINLINE typename ::cuda::std::enable_if<(Order == MemoryOrder::relaxed), void>::type
+  _CCCL_DEVICE _CCCL_FORCEINLINE ::cuda::std::enable_if_t<(Order == MemoryOrder::relaxed), void>
   StoreStatus(TxnWord* ptr, TxnWord alias)
   {
     detail::store_relaxed(ptr, alias);
   }
 
   template <MemoryOrder Order>
-  _CCCL_DEVICE _CCCL_FORCEINLINE typename ::cuda::std::enable_if<(Order == MemoryOrder::acquire_release), void>::type
+  _CCCL_DEVICE _CCCL_FORCEINLINE ::cuda::std::enable_if_t<(Order == MemoryOrder::acquire_release), void>
   StoreStatus(TxnWord* ptr, TxnWord alias)
   {
     detail::store_release(ptr, alias);
   }
 
   template <MemoryOrder Order>
-  _CCCL_DEVICE _CCCL_FORCEINLINE typename ::cuda::std::enable_if<(Order == MemoryOrder::relaxed), TxnWord>::type
+  _CCCL_DEVICE _CCCL_FORCEINLINE ::cuda::std::enable_if_t<(Order == MemoryOrder::relaxed), TxnWord>
   LoadStatus(TxnWord* ptr)
   {
     return detail::load_relaxed(ptr);
   }
 
   template <MemoryOrder Order>
-  _CCCL_DEVICE _CCCL_FORCEINLINE typename ::cuda::std::enable_if<(Order == MemoryOrder::acquire_release), TxnWord>::type
+  _CCCL_DEVICE _CCCL_FORCEINLINE ::cuda::std::enable_if_t<(Order == MemoryOrder::acquire_release), TxnWord>
   LoadStatus(TxnWord* ptr)
   {
     // For pre-volta we hoist the memory barrier to outside the loop, i.e., after reading a valid state
@@ -681,12 +681,12 @@ private:
   }
 
   template <MemoryOrder Order>
-  _CCCL_DEVICE _CCCL_FORCEINLINE typename ::cuda::std::enable_if<(Order == MemoryOrder::relaxed), void>::type
+  _CCCL_DEVICE _CCCL_FORCEINLINE ::cuda::std::enable_if_t<(Order == MemoryOrder::relaxed), void>
   ThreadfenceForLoadAcqPreVolta()
   {}
 
   template <MemoryOrder Order>
-  _CCCL_DEVICE _CCCL_FORCEINLINE typename ::cuda::std::enable_if<(Order == MemoryOrder::acquire_release), void>::type
+  _CCCL_DEVICE _CCCL_FORCEINLINE ::cuda::std::enable_if_t<(Order == MemoryOrder::acquire_release), void>
   ThreadfenceForLoadAcqPreVolta()
   {
     NV_IF_TARGET(NV_PROVIDES_SM_70, (), (__threadfence();));

--- a/cub/cub/block/block_merge_sort.cuh
+++ b/cub/cub/block/block_merge_sort.cuh
@@ -175,7 +175,7 @@ private:
   static constexpr int ITEMS_PER_TILE = ITEMS_PER_THREAD * NUM_THREADS;
 
   // Whether or not there are values to be trucked along with keys
-  static constexpr bool KEYS_ONLY = ::cuda::std::is_same<ValueT, NullType>::value;
+  static constexpr bool KEYS_ONLY = ::cuda::std::is_same_v<ValueT, NullType>;
 
 #ifndef _CCCL_DOXYGEN_INVOKED // Do not document
   /// Shared memory type required by this thread block

--- a/cub/cub/block/block_radix_rank.cuh
+++ b/cub/cub/block/block_radix_rank.cuh
@@ -779,7 +779,7 @@ public:
     }
 
     __syncthreads();
-    if (!::cuda::std::is_same<CountsCallback, BlockRadixRankEmptyCallback<BINS_TRACKED_PER_THREAD>>::value)
+    if (!::cuda::std::is_same_v<CountsCallback, BlockRadixRankEmptyCallback<BINS_TRACKED_PER_THREAD>>)
     {
       CallBack<KEYS_PER_THREAD>(callback);
     }

--- a/cub/cub/block/block_radix_sort.cuh
+++ b/cub/cub/block/block_radix_sort.cuh
@@ -694,8 +694,8 @@ public:
   //!   comparison (e.g., `(sizeof(float) + sizeof(long long int)) * 8`)
   template <class DecomposerT>
   _CCCL_DEVICE _CCCL_FORCEINLINE //
-  typename ::cuda::std::enable_if< //
-    !::cuda::std::is_convertible_v<DecomposerT, int>>::type
+  ::cuda::std::enable_if_t< //
+    !::cuda::std::is_convertible_v<DecomposerT, int>>
   Sort(KeyT (&keys)[ITEMS_PER_THREAD], DecomposerT decomposer, int begin_bit, int end_bit)
   {
     NullType values[ITEMS_PER_THREAD];
@@ -754,8 +754,8 @@ public:
   //!   modify members of the key.
   template <class DecomposerT>
   _CCCL_DEVICE _CCCL_FORCEINLINE //
-  typename ::cuda::std::enable_if< //
-    !::cuda::std::is_convertible_v<DecomposerT, int>>::type
+  ::cuda::std::enable_if_t< //
+    !::cuda::std::is_convertible_v<DecomposerT, int>>
   Sort(KeyT (&keys)[ITEMS_PER_THREAD], DecomposerT decomposer)
   {
     Sort(keys, decomposer, 0, detail::radix::traits_t<KeyT>::default_end_bit(decomposer));
@@ -895,8 +895,8 @@ public:
   //!   comparison (e.g., `(sizeof(float) + sizeof(long long int)) * 8`)
   template <class DecomposerT>
   _CCCL_DEVICE _CCCL_FORCEINLINE //
-  typename ::cuda::std::enable_if< //
-    !::cuda::std::is_convertible_v<DecomposerT, int>>::type
+  ::cuda::std::enable_if_t< //
+    !::cuda::std::is_convertible_v<DecomposerT, int>>
   Sort(KeyT (&keys)[ITEMS_PER_THREAD],
        ValueT (&values)[ITEMS_PER_THREAD],
        DecomposerT decomposer,
@@ -965,8 +965,8 @@ public:
   //!   modify members of the key.
   template <class DecomposerT>
   _CCCL_DEVICE _CCCL_FORCEINLINE //
-  typename ::cuda::std::enable_if< //
-    !::cuda::std::is_convertible_v<DecomposerT, int>>::type
+  ::cuda::std::enable_if_t< //
+    !::cuda::std::is_convertible_v<DecomposerT, int>>
   Sort(KeyT (&keys)[ITEMS_PER_THREAD], ValueT (&values)[ITEMS_PER_THREAD], DecomposerT decomposer)
   {
     Sort(keys, values, decomposer, 0, detail::radix::traits_t<KeyT>::default_end_bit(decomposer));
@@ -1086,8 +1086,8 @@ public:
   //!   comparison (e.g., `(sizeof(float) + sizeof(long long int)) * 8`)
   template <class DecomposerT>
   _CCCL_DEVICE _CCCL_FORCEINLINE //
-  typename ::cuda::std::enable_if< //
-    !::cuda::std::is_convertible_v<DecomposerT, int>>::type
+  ::cuda::std::enable_if_t< //
+    !::cuda::std::is_convertible_v<DecomposerT, int>>
   SortDescending(KeyT (&keys)[ITEMS_PER_THREAD], DecomposerT decomposer, int begin_bit, int end_bit)
   {
     NullType values[ITEMS_PER_THREAD];
@@ -1146,8 +1146,8 @@ public:
   //!   modify members of the key.
   template <class DecomposerT>
   _CCCL_DEVICE _CCCL_FORCEINLINE //
-  typename ::cuda::std::enable_if< //
-    !::cuda::std::is_convertible_v<DecomposerT, int>>::type
+  ::cuda::std::enable_if_t< //
+    !::cuda::std::is_convertible_v<DecomposerT, int>>
   SortDescending(KeyT (&keys)[ITEMS_PER_THREAD], DecomposerT decomposer)
   {
     NullType values[ITEMS_PER_THREAD];
@@ -1294,8 +1294,8 @@ public:
   //!   comparison (e.g., `(sizeof(float) + sizeof(long long int)) * 8`)
   template <class DecomposerT>
   _CCCL_DEVICE _CCCL_FORCEINLINE //
-  typename ::cuda::std::enable_if< //
-    !::cuda::std::is_convertible_v<DecomposerT, int>>::type
+  ::cuda::std::enable_if_t< //
+    !::cuda::std::is_convertible_v<DecomposerT, int>>
   SortDescending(KeyT (&keys)[ITEMS_PER_THREAD],
                  ValueT (&values)[ITEMS_PER_THREAD],
                  DecomposerT decomposer,
@@ -1364,8 +1364,8 @@ public:
   //!   modify members of the key.
   template <class DecomposerT>
   _CCCL_DEVICE _CCCL_FORCEINLINE //
-  typename ::cuda::std::enable_if< //
-    !::cuda::std::is_convertible_v<DecomposerT, int>>::type
+  ::cuda::std::enable_if_t< //
+    !::cuda::std::is_convertible_v<DecomposerT, int>>
   SortDescending(KeyT (&keys)[ITEMS_PER_THREAD], ValueT (&values)[ITEMS_PER_THREAD], DecomposerT decomposer)
   {
     SortBlocked(
@@ -1498,8 +1498,8 @@ public:
   //!   comparison (e.g., `(sizeof(float) + sizeof(long long int)) * 8`)
   template <class DecomposerT>
   _CCCL_DEVICE _CCCL_FORCEINLINE //
-  typename ::cuda::std::enable_if< //
-    !::cuda::std::is_convertible_v<DecomposerT, int>>::type
+  ::cuda::std::enable_if_t< //
+    !::cuda::std::is_convertible_v<DecomposerT, int>>
   SortBlockedToStriped(KeyT (&keys)[ITEMS_PER_THREAD], DecomposerT decomposer, int begin_bit, int end_bit)
   {
     NullType values[ITEMS_PER_THREAD];
@@ -1559,8 +1559,8 @@ public:
   //!   modify members of the key.
   template <class DecomposerT>
   _CCCL_DEVICE _CCCL_FORCEINLINE //
-  typename ::cuda::std::enable_if< //
-    !::cuda::std::is_convertible_v<DecomposerT, int>>::type
+  ::cuda::std::enable_if_t< //
+    !::cuda::std::is_convertible_v<DecomposerT, int>>
   SortBlockedToStriped(KeyT (&keys)[ITEMS_PER_THREAD], DecomposerT decomposer)
   {
     NullType values[ITEMS_PER_THREAD];
@@ -1704,8 +1704,8 @@ public:
   //!   comparison (e.g., `(sizeof(float) + sizeof(long long int)) * 8`)
   template <class DecomposerT>
   _CCCL_DEVICE _CCCL_FORCEINLINE //
-  typename ::cuda::std::enable_if< //
-    !::cuda::std::is_convertible_v<DecomposerT, int>>::type
+  ::cuda::std::enable_if_t< //
+    !::cuda::std::is_convertible_v<DecomposerT, int>>
   SortBlockedToStriped(KeyT (&keys)[ITEMS_PER_THREAD],
                        ValueT (&values)[ITEMS_PER_THREAD],
                        DecomposerT decomposer,
@@ -1770,8 +1770,8 @@ public:
   //!   modify members of the key.
   template <class DecomposerT>
   _CCCL_DEVICE _CCCL_FORCEINLINE //
-  typename ::cuda::std::enable_if< //
-    !::cuda::std::is_convertible_v<DecomposerT, int>>::type
+  ::cuda::std::enable_if_t< //
+    !::cuda::std::is_convertible_v<DecomposerT, int>>
   SortBlockedToStriped(KeyT (&keys)[ITEMS_PER_THREAD], ValueT (&values)[ITEMS_PER_THREAD], DecomposerT decomposer)
   {
     SortBlockedToStriped(
@@ -1899,8 +1899,8 @@ public:
   //!   comparison (e.g., `(sizeof(float) + sizeof(long long int)) * 8`)
   template <class DecomposerT>
   _CCCL_DEVICE _CCCL_FORCEINLINE //
-  typename ::cuda::std::enable_if< //
-    !::cuda::std::is_convertible_v<DecomposerT, int>>::type
+  ::cuda::std::enable_if_t< //
+    !::cuda::std::is_convertible_v<DecomposerT, int>>
   SortDescendingBlockedToStriped(KeyT (&keys)[ITEMS_PER_THREAD], DecomposerT decomposer, int begin_bit, int end_bit)
   {
     NullType values[ITEMS_PER_THREAD];
@@ -1960,8 +1960,8 @@ public:
   //!   modify members of the key.
   template <class DecomposerT>
   _CCCL_DEVICE _CCCL_FORCEINLINE //
-  typename ::cuda::std::enable_if< //
-    !::cuda::std::is_convertible_v<DecomposerT, int>>::type
+  ::cuda::std::enable_if_t< //
+    !::cuda::std::is_convertible_v<DecomposerT, int>>
   SortDescendingBlockedToStriped(KeyT (&keys)[ITEMS_PER_THREAD], DecomposerT decomposer)
   {
     NullType values[ITEMS_PER_THREAD];
@@ -2104,8 +2104,8 @@ public:
   //!   comparison (e.g., `(sizeof(float) + sizeof(long long int)) * 8`)
   template <class DecomposerT>
   _CCCL_DEVICE _CCCL_FORCEINLINE //
-  typename ::cuda::std::enable_if< //
-    !::cuda::std::is_convertible_v<DecomposerT, int>>::type
+  ::cuda::std::enable_if_t< //
+    !::cuda::std::is_convertible_v<DecomposerT, int>>
   SortDescendingBlockedToStriped(
     KeyT (&keys)[ITEMS_PER_THREAD],
     ValueT (&values)[ITEMS_PER_THREAD],
@@ -2171,8 +2171,8 @@ public:
   //!   modify members of the key.
   template <class DecomposerT>
   _CCCL_DEVICE _CCCL_FORCEINLINE //
-  typename ::cuda::std::enable_if< //
-    !::cuda::std::is_convertible_v<DecomposerT, int>>::type
+  ::cuda::std::enable_if_t< //
+    !::cuda::std::is_convertible_v<DecomposerT, int>>
   SortDescendingBlockedToStriped(
     KeyT (&keys)[ITEMS_PER_THREAD], ValueT (&values)[ITEMS_PER_THREAD], DecomposerT decomposer)
   {

--- a/cub/cub/block/block_radix_sort.cuh
+++ b/cub/cub/block/block_radix_sort.cuh
@@ -261,7 +261,7 @@ private:
     BLOCK_THREADS = BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z,
 
     // Whether or not there are values to be trucked along with keys
-    KEYS_ONLY = ::cuda::std::is_same<ValueT, NullType>::value,
+    KEYS_ONLY = ::cuda::std::is_same_v<ValueT, NullType>,
   };
 
   // KeyT traits and unsigned bits type
@@ -695,7 +695,7 @@ public:
   template <class DecomposerT>
   _CCCL_DEVICE _CCCL_FORCEINLINE //
   typename ::cuda::std::enable_if< //
-    !::cuda::std::is_convertible<DecomposerT, int>::value>::type
+    !::cuda::std::is_convertible_v<DecomposerT, int>>::type
   Sort(KeyT (&keys)[ITEMS_PER_THREAD], DecomposerT decomposer, int begin_bit, int end_bit)
   {
     NullType values[ITEMS_PER_THREAD];
@@ -755,7 +755,7 @@ public:
   template <class DecomposerT>
   _CCCL_DEVICE _CCCL_FORCEINLINE //
   typename ::cuda::std::enable_if< //
-    !::cuda::std::is_convertible<DecomposerT, int>::value>::type
+    !::cuda::std::is_convertible_v<DecomposerT, int>>::type
   Sort(KeyT (&keys)[ITEMS_PER_THREAD], DecomposerT decomposer)
   {
     Sort(keys, decomposer, 0, detail::radix::traits_t<KeyT>::default_end_bit(decomposer));
@@ -896,7 +896,7 @@ public:
   template <class DecomposerT>
   _CCCL_DEVICE _CCCL_FORCEINLINE //
   typename ::cuda::std::enable_if< //
-    !::cuda::std::is_convertible<DecomposerT, int>::value>::type
+    !::cuda::std::is_convertible_v<DecomposerT, int>>::type
   Sort(KeyT (&keys)[ITEMS_PER_THREAD],
        ValueT (&values)[ITEMS_PER_THREAD],
        DecomposerT decomposer,
@@ -966,7 +966,7 @@ public:
   template <class DecomposerT>
   _CCCL_DEVICE _CCCL_FORCEINLINE //
   typename ::cuda::std::enable_if< //
-    !::cuda::std::is_convertible<DecomposerT, int>::value>::type
+    !::cuda::std::is_convertible_v<DecomposerT, int>>::type
   Sort(KeyT (&keys)[ITEMS_PER_THREAD], ValueT (&values)[ITEMS_PER_THREAD], DecomposerT decomposer)
   {
     Sort(keys, values, decomposer, 0, detail::radix::traits_t<KeyT>::default_end_bit(decomposer));
@@ -1087,7 +1087,7 @@ public:
   template <class DecomposerT>
   _CCCL_DEVICE _CCCL_FORCEINLINE //
   typename ::cuda::std::enable_if< //
-    !::cuda::std::is_convertible<DecomposerT, int>::value>::type
+    !::cuda::std::is_convertible_v<DecomposerT, int>>::type
   SortDescending(KeyT (&keys)[ITEMS_PER_THREAD], DecomposerT decomposer, int begin_bit, int end_bit)
   {
     NullType values[ITEMS_PER_THREAD];
@@ -1147,7 +1147,7 @@ public:
   template <class DecomposerT>
   _CCCL_DEVICE _CCCL_FORCEINLINE //
   typename ::cuda::std::enable_if< //
-    !::cuda::std::is_convertible<DecomposerT, int>::value>::type
+    !::cuda::std::is_convertible_v<DecomposerT, int>>::type
   SortDescending(KeyT (&keys)[ITEMS_PER_THREAD], DecomposerT decomposer)
   {
     NullType values[ITEMS_PER_THREAD];
@@ -1295,7 +1295,7 @@ public:
   template <class DecomposerT>
   _CCCL_DEVICE _CCCL_FORCEINLINE //
   typename ::cuda::std::enable_if< //
-    !::cuda::std::is_convertible<DecomposerT, int>::value>::type
+    !::cuda::std::is_convertible_v<DecomposerT, int>>::type
   SortDescending(KeyT (&keys)[ITEMS_PER_THREAD],
                  ValueT (&values)[ITEMS_PER_THREAD],
                  DecomposerT decomposer,
@@ -1365,7 +1365,7 @@ public:
   template <class DecomposerT>
   _CCCL_DEVICE _CCCL_FORCEINLINE //
   typename ::cuda::std::enable_if< //
-    !::cuda::std::is_convertible<DecomposerT, int>::value>::type
+    !::cuda::std::is_convertible_v<DecomposerT, int>>::type
   SortDescending(KeyT (&keys)[ITEMS_PER_THREAD], ValueT (&values)[ITEMS_PER_THREAD], DecomposerT decomposer)
   {
     SortBlocked(
@@ -1499,7 +1499,7 @@ public:
   template <class DecomposerT>
   _CCCL_DEVICE _CCCL_FORCEINLINE //
   typename ::cuda::std::enable_if< //
-    !::cuda::std::is_convertible<DecomposerT, int>::value>::type
+    !::cuda::std::is_convertible_v<DecomposerT, int>>::type
   SortBlockedToStriped(KeyT (&keys)[ITEMS_PER_THREAD], DecomposerT decomposer, int begin_bit, int end_bit)
   {
     NullType values[ITEMS_PER_THREAD];
@@ -1560,7 +1560,7 @@ public:
   template <class DecomposerT>
   _CCCL_DEVICE _CCCL_FORCEINLINE //
   typename ::cuda::std::enable_if< //
-    !::cuda::std::is_convertible<DecomposerT, int>::value>::type
+    !::cuda::std::is_convertible_v<DecomposerT, int>>::type
   SortBlockedToStriped(KeyT (&keys)[ITEMS_PER_THREAD], DecomposerT decomposer)
   {
     NullType values[ITEMS_PER_THREAD];
@@ -1705,7 +1705,7 @@ public:
   template <class DecomposerT>
   _CCCL_DEVICE _CCCL_FORCEINLINE //
   typename ::cuda::std::enable_if< //
-    !::cuda::std::is_convertible<DecomposerT, int>::value>::type
+    !::cuda::std::is_convertible_v<DecomposerT, int>>::type
   SortBlockedToStriped(KeyT (&keys)[ITEMS_PER_THREAD],
                        ValueT (&values)[ITEMS_PER_THREAD],
                        DecomposerT decomposer,
@@ -1771,7 +1771,7 @@ public:
   template <class DecomposerT>
   _CCCL_DEVICE _CCCL_FORCEINLINE //
   typename ::cuda::std::enable_if< //
-    !::cuda::std::is_convertible<DecomposerT, int>::value>::type
+    !::cuda::std::is_convertible_v<DecomposerT, int>>::type
   SortBlockedToStriped(KeyT (&keys)[ITEMS_PER_THREAD], ValueT (&values)[ITEMS_PER_THREAD], DecomposerT decomposer)
   {
     SortBlockedToStriped(
@@ -1900,7 +1900,7 @@ public:
   template <class DecomposerT>
   _CCCL_DEVICE _CCCL_FORCEINLINE //
   typename ::cuda::std::enable_if< //
-    !::cuda::std::is_convertible<DecomposerT, int>::value>::type
+    !::cuda::std::is_convertible_v<DecomposerT, int>>::type
   SortDescendingBlockedToStriped(KeyT (&keys)[ITEMS_PER_THREAD], DecomposerT decomposer, int begin_bit, int end_bit)
   {
     NullType values[ITEMS_PER_THREAD];
@@ -1961,7 +1961,7 @@ public:
   template <class DecomposerT>
   _CCCL_DEVICE _CCCL_FORCEINLINE //
   typename ::cuda::std::enable_if< //
-    !::cuda::std::is_convertible<DecomposerT, int>::value>::type
+    !::cuda::std::is_convertible_v<DecomposerT, int>>::type
   SortDescendingBlockedToStriped(KeyT (&keys)[ITEMS_PER_THREAD], DecomposerT decomposer)
   {
     NullType values[ITEMS_PER_THREAD];
@@ -2105,7 +2105,7 @@ public:
   template <class DecomposerT>
   _CCCL_DEVICE _CCCL_FORCEINLINE //
   typename ::cuda::std::enable_if< //
-    !::cuda::std::is_convertible<DecomposerT, int>::value>::type
+    !::cuda::std::is_convertible_v<DecomposerT, int>>::type
   SortDescendingBlockedToStriped(
     KeyT (&keys)[ITEMS_PER_THREAD],
     ValueT (&values)[ITEMS_PER_THREAD],
@@ -2172,7 +2172,7 @@ public:
   template <class DecomposerT>
   _CCCL_DEVICE _CCCL_FORCEINLINE //
   typename ::cuda::std::enable_if< //
-    !::cuda::std::is_convertible<DecomposerT, int>::value>::type
+    !::cuda::std::is_convertible_v<DecomposerT, int>>::type
   SortDescendingBlockedToStriped(
     KeyT (&keys)[ITEMS_PER_THREAD], ValueT (&values)[ITEMS_PER_THREAD], DecomposerT decomposer)
   {

--- a/cub/cub/block/radix_rank_sort_operations.cuh
+++ b/cub/cub/block/radix_rank_sort_operations.cuh
@@ -74,7 +74,7 @@ CUB_NAMESPACE_BEGIN
     and only one of them is used, the sorting works correctly. For double, the
     same applies, but with 64-bit patterns.
 */
-template <typename KeyT, bool IsFP = ::cuda::is_floating_point<KeyT>::value>
+template <typename KeyT, bool IsFP = ::cuda::is_floating_point_v<KeyT>>
 struct BaseDigitExtractor
 {
   using TraitsT      = Traits<KeyT>;

--- a/cub/cub/block/radix_rank_sort_operations.cuh
+++ b/cub/cub/block/radix_rank_sort_operations.cuh
@@ -221,9 +221,9 @@ struct is_tuple_of_references_to_fundamental_types_t : ::cuda::std::false_type
 template <class... Ts>
 struct is_tuple_of_references_to_fundamental_types_t< //
   ::cuda::std::tuple<Ts&...>, //
-  typename ::cuda::std::enable_if< //
+  ::cuda::std::enable_if_t< //
     all_t<is_fundamental_type<Ts>::value...>::value //
-    >::type> //
+    >> //
     : ::cuda::std::true_type
 {};
 
@@ -298,7 +298,7 @@ struct min_raw_binary_key_f
   template <class T>
   _CCCL_HOST_DEVICE void operator()(T& field)
   {
-    using traits                               = traits_t<typename ::cuda::std::remove_cv<T>::type>;
+    using traits                               = traits_t<::cuda::std::remove_cv_t<T>>;
     using bit_ordered_type                     = typename traits::bit_ordered_type;
     reinterpret_cast<bit_ordered_type&>(field) = traits::min_raw_binary_key(detail::identity_decomposer_t{});
   }
@@ -318,7 +318,7 @@ struct max_raw_binary_key_f
   template <class T>
   _CCCL_HOST_DEVICE void operator()(T& field)
   {
-    using traits                               = traits_t<typename ::cuda::std::remove_cv<T>::type>;
+    using traits                               = traits_t<::cuda::std::remove_cv_t<T>>;
     using bit_ordered_type                     = typename traits::bit_ordered_type;
     reinterpret_cast<bit_ordered_type&>(field) = traits::max_raw_binary_key(detail::identity_decomposer_t{});
   }
@@ -338,7 +338,7 @@ struct to_bit_ordered_f
   template <class T>
   _CCCL_HOST_DEVICE void operator()(T& field)
   {
-    using traits                 = traits_t<typename ::cuda::std::remove_cv<T>::type>;
+    using traits                 = traits_t<::cuda::std::remove_cv_t<T>>;
     using bit_ordered_type       = typename traits::bit_ordered_type;
     using bit_ordered_conversion = typename traits::bit_ordered_conversion_policy;
 
@@ -361,7 +361,7 @@ struct from_bit_ordered_f
   template <class T>
   _CCCL_HOST_DEVICE void operator()(T& field)
   {
-    using traits                 = traits_t<typename ::cuda::std::remove_cv<T>::type>;
+    using traits                 = traits_t<::cuda::std::remove_cv_t<T>>;
     using bit_ordered_type       = typename traits::bit_ordered_type;
     using bit_ordered_conversion = typename traits::bit_ordered_conversion_policy;
 
@@ -384,7 +384,7 @@ struct inverse_f
   template <class T>
   _CCCL_HOST_DEVICE void operator()(T& field)
   {
-    using traits           = traits_t<typename ::cuda::std::remove_cv<T>::type>;
+    using traits           = traits_t<::cuda::std::remove_cv_t<T>>;
     using bit_ordered_type = typename traits::bit_ordered_type;
 
     auto& ordered_field = reinterpret_cast<bit_ordered_type&>(field);
@@ -437,7 +437,7 @@ struct digit_f
     }
     else
     {
-      using traits           = traits_t<typename ::cuda::std::remove_cv<T>::type>;
+      using traits           = traits_t<::cuda::std::remove_cv_t<T>>;
       using bit_ordered_type = typename traits::bit_ordered_type;
 
       const ::cuda::std::uint32_t bits_to_copy = (::cuda::std::min)(src_size - src_bit_start, num_bits);

--- a/cub/cub/detail/array_utils.cuh
+++ b/cub/cub/detail/array_utils.cuh
@@ -70,7 +70,7 @@ _CCCL_NODISCARD _CCCL_DEVICE _CCCL_FORCEINLINE ::cuda::std::array<CastType, cub:
 to_array(const Input& input)
 {
   using InputType = ::cuda::std::remove_cvref_t<decltype(input[0])>;
-  using CastType1 = ::cuda::std::_If<::cuda::std::is_same<CastType, void>::value, InputType, CastType>;
+  using CastType1 = ::cuda::std::_If<::cuda::std::is_same_v<CastType, void>, InputType, CastType>;
   return to_array_impl<CastType1>(input, ::cuda::std::make_index_sequence<cub::detail::static_size_v<Input>()>{});
 }
 

--- a/cub/cub/detail/choose_offset.cuh
+++ b/cub/cub/detail/choose_offset.cuh
@@ -57,7 +57,7 @@ struct choose_offset
 {
   // NumItemsT must be an integral type (but not bool).
   static_assert(::cuda::std::is_integral_v<NumItemsT>
-                  && !::cuda::std::is_same_v<typename ::cuda::std::remove_cv<NumItemsT>::type, bool>,
+                  && !::cuda::std::is_same_v<::cuda::std::remove_cv_t<NumItemsT>, bool>,
                 "NumItemsT must be an integral type, but not bool");
 
   // Unsigned integer type for global offsets.
@@ -80,7 +80,7 @@ struct promote_small_offset
 {
   // NumItemsT must be an integral type (but not bool).
   static_assert(::cuda::std::is_integral_v<NumItemsT>
-                  && !::cuda::std::is_same_v<typename ::cuda::std::remove_cv<NumItemsT>::type, bool>,
+                  && !::cuda::std::is_same_v<::cuda::std::remove_cv_t<NumItemsT>, bool>,
                 "NumItemsT must be an integral type, but not bool");
 
   // Unsigned integer type for global offsets.
@@ -104,7 +104,7 @@ struct choose_signed_offset
 {
   // NumItemsT must be an integral type (but not bool).
   static_assert(::cuda::std::is_integral_v<NumItemsT>
-                  && !::cuda::std::is_same_v<typename ::cuda::std::remove_cv<NumItemsT>::type, bool>,
+                  && !::cuda::std::is_same_v<::cuda::std::remove_cv_t<NumItemsT>, bool>,
                 "NumItemsT must be an integral type, but not bool");
 
   // Signed integer type for global offsets.

--- a/cub/cub/detail/choose_offset.cuh
+++ b/cub/cub/detail/choose_offset.cuh
@@ -56,8 +56,8 @@ template <typename NumItemsT>
 struct choose_offset
 {
   // NumItemsT must be an integral type (but not bool).
-  static_assert(::cuda::std::is_integral<NumItemsT>::value
-                  && !::cuda::std::is_same<typename ::cuda::std::remove_cv<NumItemsT>::type, bool>::value,
+  static_assert(::cuda::std::is_integral_v<NumItemsT>
+                  && !::cuda::std::is_same_v<typename ::cuda::std::remove_cv<NumItemsT>::type, bool>,
                 "NumItemsT must be an integral type, but not bool");
 
   // Unsigned integer type for global offsets.
@@ -79,8 +79,8 @@ template <typename NumItemsT>
 struct promote_small_offset
 {
   // NumItemsT must be an integral type (but not bool).
-  static_assert(::cuda::std::is_integral<NumItemsT>::value
-                  && !::cuda::std::is_same<typename ::cuda::std::remove_cv<NumItemsT>::type, bool>::value,
+  static_assert(::cuda::std::is_integral_v<NumItemsT>
+                  && !::cuda::std::is_same_v<typename ::cuda::std::remove_cv<NumItemsT>::type, bool>,
                 "NumItemsT must be an integral type, but not bool");
 
   // Unsigned integer type for global offsets.
@@ -103,18 +103,17 @@ template <typename NumItemsT>
 struct choose_signed_offset
 {
   // NumItemsT must be an integral type (but not bool).
-  static_assert(::cuda::std::is_integral<NumItemsT>::value
-                  && !::cuda::std::is_same<typename ::cuda::std::remove_cv<NumItemsT>::type, bool>::value,
+  static_assert(::cuda::std::is_integral_v<NumItemsT>
+                  && !::cuda::std::is_same_v<typename ::cuda::std::remove_cv<NumItemsT>::type, bool>,
                 "NumItemsT must be an integral type, but not bool");
 
   // Signed integer type for global offsets.
   // uint32 -> int64, else
   // LEQ 4B -> int32, else
   // int64
-  using type =
-    ::cuda::std::_If<(::cuda::std::is_integral<NumItemsT>::value && ::cuda::std::is_unsigned<NumItemsT>::value),
-                     ::cuda::std::int64_t,
-                     ::cuda::std::_If<(sizeof(NumItemsT) <= 4), ::cuda::std::int32_t, ::cuda::std::int64_t>>;
+  using type = ::cuda::std::_If<(::cuda::std::is_integral_v<NumItemsT> && ::cuda::std::is_unsigned_v<NumItemsT>),
+                                ::cuda::std::int64_t,
+                                ::cuda::std::_If<(sizeof(NumItemsT) <= 4), ::cuda::std::int32_t, ::cuda::std::int64_t>>;
 
   /**
    * Checks if the given num_items can be covered by the selected offset type. If not, returns cudaErrorInvalidValue,

--- a/cub/cub/detail/fast_modulo_division.cuh
+++ b/cub/cub/detail/fast_modulo_division.cuh
@@ -67,13 +67,13 @@ struct larger_unsigned_type
 };
 
 template <typename T>
-struct larger_unsigned_type<T, typename ::cuda::std::enable_if<(sizeof(T) < 4)>::type>
+struct larger_unsigned_type<T, ::cuda::std::enable_if_t<(sizeof(T) < 4)>>
 {
   using type = ::cuda::std::uint32_t;
 };
 
 template <typename T>
-struct larger_unsigned_type<T, typename ::cuda::std::enable_if<(sizeof(T) == 4)>::type>
+struct larger_unsigned_type<T, ::cuda::std::enable_if_t<(sizeof(T) == 4)>>
 {
   using type = ::cuda::std::uint64_t;
 };
@@ -81,7 +81,7 @@ struct larger_unsigned_type<T, typename ::cuda::std::enable_if<(sizeof(T) == 4)>
 #if _CCCL_HAS_INT128()
 
 template <typename T>
-struct larger_unsigned_type<T, typename ::cuda::std::enable_if<(sizeof(T) == 8)>::type>
+struct larger_unsigned_type<T, ::cuda::std::enable_if_t<(sizeof(T) == 8)>>
 {
   using type = __uint128_t;
 };
@@ -92,7 +92,7 @@ template <typename T>
 using larger_unsigned_type_t = typename larger_unsigned_type<T>::type;
 
 template <typename T>
-using unsigned_implicit_prom_t = typename ::cuda::std::make_unsigned<implicit_prom_t<T>>::type;
+using unsigned_implicit_prom_t = ::cuda::std::make_unsigned_t<implicit_prom_t<T>>;
 
 template <typename T>
 using supported_integral =

--- a/cub/cub/detail/fast_modulo_division.cuh
+++ b/cub/cub/detail/fast_modulo_division.cuh
@@ -95,8 +95,8 @@ template <typename T>
 using unsigned_implicit_prom_t = typename ::cuda::std::make_unsigned<implicit_prom_t<T>>::type;
 
 template <typename T>
-using supported_integral = ::cuda::std::bool_constant<
-  ::cuda::std::is_integral<T>::value && !::cuda::std::is_same<T, bool>::value && (sizeof(T) <= 8)>;
+using supported_integral =
+  ::cuda::std::bool_constant<::cuda::std::is_integral_v<T> && !::cuda::std::is_same_v<T, bool> && (sizeof(T) <= 8)>;
 
 /***********************************************************************************************************************
  * Extract higher bits after multiplication
@@ -143,7 +143,7 @@ class fast_div_mod
   static_assert(supported_integral<T1>::value, "unsupported type");
 
   // uint16_t is a special case that would requires complex logic. Workaround: convert to int
-  using T          = ::cuda::std::conditional_t<::cuda::std::is_same<T1, ::cuda::std::uint16_t>::value, int, T1>;
+  using T          = ::cuda::std::conditional_t<::cuda::std::is_same_v<T1, ::cuda::std::uint16_t>, int, T1>;
   using unsigned_t = unsigned_implicit_prom_t<T>;
 
 public:

--- a/cub/cub/detail/nvtx3.hpp
+++ b/cub/cub/detail/nvtx3.hpp
@@ -652,9 +652,10 @@ NVTX3_INLINE_IF_REQUESTED namespace NVTX3_VERSION_NAMESPACE
   struct is_c_string : std::false_type
   {};
   template <typename T>
-  struct is_c_string<T,
-                     typename std::enable_if<std::is_convertible<T, char const*>::value
-                                             || std::is_convertible<T, wchar_t const*>::value>::type> : std::true_type
+  struct is_c_string<
+    T,
+    typename std::enable_if<std::is_convertible_v<T, char const*> || std::is_convertible_v<T, wchar_t const*>>::type>
+      : std::true_type
   {};
 
   template <typename T>

--- a/cub/cub/detail/nvtx3.hpp
+++ b/cub/cub/detail/nvtx3.hpp
@@ -652,9 +652,8 @@ NVTX3_INLINE_IF_REQUESTED namespace NVTX3_VERSION_NAMESPACE
   struct is_c_string : std::false_type
   {};
   template <typename T>
-  struct is_c_string<
-    T,
-    typename std::enable_if<std::is_convertible_v<T, char const*> || std::is_convertible_v<T, wchar_t const*>>::type>
+  struct is_c_string<T,
+                     std::enable_if_t<std::is_convertible_v<T, char const*> || std::is_convertible_v<T, wchar_t const*>>>
       : std::true_type
   {};
 
@@ -783,7 +782,7 @@ NVTX3_INLINE_IF_REQUESTED namespace NVTX3_VERSION_NAMESPACE
      * name the `domain` object.
      * @return Reference to the `domain` corresponding to the type `D`.
      */
-    template <typename D = global, typename std::enable_if<detail::is_c_string<decltype(D::name)>::value, int>::type = 0>
+    template <typename D = global, std::enable_if_t<detail::is_c_string<decltype(D::name)>::value, int> = 0>
     static domain const& get() noexcept
     {
       static domain const d(D::name);
@@ -795,8 +794,7 @@ NVTX3_INLINE_IF_REQUESTED namespace NVTX3_VERSION_NAMESPACE
      * `D` has a `name` member that is not directly convertible to either
      * `char const*` or `wchar_t const*`.
      */
-    template <typename D                                                                         = global,
-              typename std::enable_if<!detail::is_c_string<decltype(D::name)>::value, int>::type = 0>
+    template <typename D = global, std::enable_if_t<!detail::is_c_string<decltype(D::name)>::value, int> = 0>
     static domain const& get() noexcept
     {
       NVTX3_STATIC_ASSERT(detail::always_false<D>::value,
@@ -811,7 +809,7 @@ NVTX3_INLINE_IF_REQUESTED namespace NVTX3_VERSION_NAMESPACE
      * @brief Overload of `domain::get` to provide a clear compile error when
      * `D` does not have a `name` member.
      */
-    template <typename D = global, typename std::enable_if<!detail::has_name<D>::value, int>::type = 0>
+    template <typename D = global, std::enable_if_t<!detail::has_name<D>::value, int> = 0>
     static domain const& get() noexcept
     {
       NVTX3_STATIC_ASSERT(detail::always_false<D>::value,
@@ -1246,8 +1244,8 @@ NVTX3_INLINE_IF_REQUESTED namespace NVTX3_VERSION_NAMESPACE
      */
     template <
       typename C,
-      typename std::enable_if<detail::is_c_string<decltype(C::name)>::value && detail::is_uint32<decltype(C::id)>::value,
-                              int>::type = 0>
+      std::enable_if_t<detail::is_c_string<decltype(C::name)>::value && detail::is_uint32<decltype(C::id)>::value, int> =
+        0>
     static named_category_in const& get() noexcept
     {
       static named_category_in const cat(C::id, C::name);
@@ -1260,10 +1258,10 @@ NVTX3_INLINE_IF_REQUESTED namespace NVTX3_VERSION_NAMESPACE
      * required types.  `name` must be directly convertible to `char const*` or
      * `wchar_t const*`, and `id` must be `uint32_t`.
      */
-    template <typename C,
-              typename std::enable_if<!detail::is_c_string<decltype(C::name)>::value
-                                        || !detail::is_uint32<decltype(C::id)>::value,
-                                      int>::type = 0>
+    template <
+      typename C,
+      std::enable_if_t<!detail::is_c_string<decltype(C::name)>::value || !detail::is_uint32<decltype(C::id)>::value,
+                       int> = 0>
     static named_category_in const& get() noexcept
     {
       NVTX3_STATIC_ASSERT(detail::is_c_string<decltype(C::name)>::value,
@@ -1281,8 +1279,7 @@ NVTX3_INLINE_IF_REQUESTED namespace NVTX3_VERSION_NAMESPACE
      * @brief Overload of `named_category_in::get` to provide a clear compile error
      * when `C` does not have the required `name` and `id` members.
      */
-    template <typename C,
-              typename std::enable_if<!detail::has_name<C>::value || !detail::has_id<C>::value, int>::type = 0>
+    template <typename C, std::enable_if_t<!detail::has_name<C>::value || !detail::has_id<C>::value, int> = 0>
     static named_category_in const& get() noexcept
     {
       NVTX3_STATIC_ASSERT(detail::has_name<C>::value,
@@ -1443,7 +1440,7 @@ NVTX3_INLINE_IF_REQUESTED namespace NVTX3_VERSION_NAMESPACE
      * registered string's contents.
      * @return Reference to a `registered_string_in` associated with the type `M`.
      */
-    template <typename M, typename std::enable_if<detail::is_c_string<decltype(M::message)>::value, int>::type = 0>
+    template <typename M, std::enable_if_t<detail::is_c_string<decltype(M::message)>::value, int> = 0>
     static registered_string_in const& get() noexcept
     {
       static registered_string_in const regstr(M::message);
@@ -1455,7 +1452,7 @@ NVTX3_INLINE_IF_REQUESTED namespace NVTX3_VERSION_NAMESPACE
      * when `M` has a `message` member that is not directly convertible to either
      * `char const*` or `wchar_t const*`.
      */
-    template <typename M, typename std::enable_if<!detail::is_c_string<decltype(M::message)>::value, int>::type = 0>
+    template <typename M, std::enable_if_t<!detail::is_c_string<decltype(M::message)>::value, int> = 0>
     static registered_string_in const& get() noexcept
     {
       NVTX3_STATIC_ASSERT(detail::always_false<M>::value,
@@ -1470,7 +1467,7 @@ NVTX3_INLINE_IF_REQUESTED namespace NVTX3_VERSION_NAMESPACE
      * @brief Overload of `registered_string_in::get` to provide a clear compile error when
      * `M` does not have a `message` member.
      */
-    template <typename M, typename std::enable_if<!detail::has_message<M>::value, int>::type = 0>
+    template <typename M, std::enable_if_t<!detail::has_message<M>::value, int> = 0>
     static registered_string_in const& get() noexcept
     {
       NVTX3_STATIC_ASSERT(detail::always_false<M>::value,

--- a/cub/cub/detail/type_traits.cuh
+++ b/cub/cub/detail/type_traits.cuh
@@ -64,15 +64,9 @@ template <typename Invokable, typename... Args>
 using invoke_result_t = ::cuda::std::invoke_result_t<Invokable, Args...>;
 
 template <typename T, typename... TArgs>
-_CCCL_NODISCARD _CCCL_HOST_DEVICE constexpr bool are_same()
-{
-  return ::cuda::std::conjunction<::cuda::std::is_same<T, TArgs>...>::value;
-}
-
-template <typename T, typename... TArgs>
 _CCCL_NODISCARD _CCCL_HOST_DEVICE constexpr bool is_one_of()
 {
-  return ::cuda::std::disjunction<::cuda::std::is_same<T, TArgs>...>::value;
+  return ::cuda::std::disjunction_v<::cuda::std::is_same<T, TArgs>...>;
 }
 
 template <typename...>

--- a/cub/cub/detail/uninitialized_copy.cuh
+++ b/cub/cub/detail/uninitialized_copy.cuh
@@ -53,14 +53,14 @@ _CCCL_HOST_DEVICE void uninitialized_copy_single(T* ptr, U&& val)
   new (ptr) T(::cuda::std::forward<U>(val));
 }
 #else
-template <typename T, typename U, typename ::cuda::std::enable_if<::cuda::std::is_trivially_copyable_v<T>, int>::type = 0>
+template <typename T, typename U, ::cuda::std::enable_if_t<::cuda::std::is_trivially_copyable_v<T>, int> = 0>
 _CCCL_HOST_DEVICE void uninitialized_copy_single(T* ptr, U&& val)
 {
   // gevtushenko: placement new should work here as well, but the code generated for copy assignment is sometimes better
   *ptr = ::cuda::std::forward<U>(val);
 }
 
-template <typename T, typename U, typename ::cuda::std::enable_if<!::cuda::std::is_trivially_copyable_v<T>, int>::type = 0>
+template <typename T, typename U, ::cuda::std::enable_if_t<!::cuda::std::is_trivially_copyable_v<T>, int> = 0>
 _CCCL_HOST_DEVICE void uninitialized_copy_single(T* ptr, U&& val)
 {
   new (ptr) T(::cuda::std::forward<U>(val));

--- a/cub/cub/detail/uninitialized_copy.cuh
+++ b/cub/cub/detail/uninitialized_copy.cuh
@@ -53,18 +53,14 @@ _CCCL_HOST_DEVICE void uninitialized_copy_single(T* ptr, U&& val)
   new (ptr) T(::cuda::std::forward<U>(val));
 }
 #else
-template <typename T,
-          typename U,
-          typename ::cuda::std::enable_if<::cuda::std::is_trivially_copyable<T>::value, int>::type = 0>
+template <typename T, typename U, typename ::cuda::std::enable_if<::cuda::std::is_trivially_copyable_v<T>, int>::type = 0>
 _CCCL_HOST_DEVICE void uninitialized_copy_single(T* ptr, U&& val)
 {
   // gevtushenko: placement new should work here as well, but the code generated for copy assignment is sometimes better
   *ptr = ::cuda::std::forward<U>(val);
 }
 
-template <typename T,
-          typename U,
-          typename ::cuda::std::enable_if<!::cuda::std::is_trivially_copyable<T>::value, int>::type = 0>
+template <typename T, typename U, typename ::cuda::std::enable_if<!::cuda::std::is_trivially_copyable_v<T>, int>::type = 0>
 _CCCL_HOST_DEVICE void uninitialized_copy_single(T* ptr, U&& val)
 {
   new (ptr) T(::cuda::std::forward<U>(val));

--- a/cub/cub/device/device_for.cuh
+++ b/cub/cub/device/device_for.cuh
@@ -229,7 +229,7 @@ public:
   CUB_RUNTIME_FUNCTION static cudaError_t
   Bulk(void* d_temp_storage, size_t& temp_storage_bytes, ShapeT shape, OpT op, cudaStream_t stream = {})
   {
-    static_assert(::cuda::std::is_integral<ShapeT>::value, "ShapeT must be an integral type");
+    static_assert(::cuda::std::is_integral_v<ShapeT>, "ShapeT must be an integral type");
 
     if (d_temp_storage == nullptr)
     {
@@ -580,7 +580,7 @@ public:
   CUB_RUNTIME_FUNCTION static cudaError_t Bulk(ShapeT shape, OpT op, cudaStream_t stream = {})
   {
     CUB_DETAIL_NVTX_RANGE_SCOPE("cub::DeviceFor::Bulk");
-    static_assert(::cuda::std::is_integral<ShapeT>::value, "ShapeT must be an integral type");
+    static_assert(::cuda::std::is_integral_v<ShapeT>, "ShapeT must be an integral type");
     using offset_t = ShapeT;
     return detail::for_each::dispatch_t<offset_t, OpT>::dispatch(static_cast<offset_t>(shape), op, stream);
   }

--- a/cub/cub/device/device_memcpy.cuh
+++ b/cub/cub/device/device_memcpy.cuh
@@ -175,10 +175,10 @@ struct DeviceMemcpy
     cudaStream_t stream = 0)
   {
     CUB_DETAIL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceMemcpy::Batched");
-    static_assert(::cuda::std::is_pointer<cub::detail::value_t<InputBufferIt>>::value,
+    static_assert(::cuda::std::is_pointer_v<cub::detail::value_t<InputBufferIt>>,
                   "DeviceMemcpy::Batched only supports copying of memory buffers."
                   "Please consider using DeviceCopy::Batched instead.");
-    static_assert(::cuda::std::is_pointer<cub::detail::value_t<OutputBufferIt>>::value,
+    static_assert(::cuda::std::is_pointer_v<cub::detail::value_t<OutputBufferIt>>,
                   "DeviceMemcpy::Batched only supports copying of memory buffers."
                   "Please consider using DeviceCopy::Batched instead.");
 

--- a/cub/cub/device/device_radix_sort.cuh
+++ b/cub/cub/device/device_radix_sort.cuh
@@ -468,7 +468,7 @@ public:
   template <typename KeyT, typename ValueT, typename NumItemsT, typename DecomposerT>
   CUB_RUNTIME_FUNCTION static //
     typename ::cuda::std::enable_if< //
-      !::cuda::std::is_convertible<DecomposerT, int>::value, //
+      !::cuda::std::is_convertible_v<DecomposerT, int>, //
       cudaError_t>::type
     SortPairs(void* d_temp_storage,
               size_t& temp_storage_bytes,
@@ -608,7 +608,7 @@ public:
   template <typename KeyT, typename ValueT, typename NumItemsT, typename DecomposerT>
   CUB_RUNTIME_FUNCTION static //
     typename ::cuda::std::enable_if< //
-      !::cuda::std::is_convertible<DecomposerT, int>::value, //
+      !::cuda::std::is_convertible_v<DecomposerT, int>, //
       cudaError_t>::type
     SortPairs(void* d_temp_storage,
               size_t& temp_storage_bytes,
@@ -882,7 +882,7 @@ public:
   template <typename KeyT, typename ValueT, typename NumItemsT, typename DecomposerT>
   CUB_RUNTIME_FUNCTION static //
     typename ::cuda::std::enable_if< //
-      !::cuda::std::is_convertible<DecomposerT, int>::value, //
+      !::cuda::std::is_convertible_v<DecomposerT, int>, //
       cudaError_t>::type
     SortPairs(void* d_temp_storage,
               size_t& temp_storage_bytes,
@@ -1025,7 +1025,7 @@ public:
   template <typename KeyT, typename ValueT, typename NumItemsT, typename DecomposerT>
   CUB_RUNTIME_FUNCTION static //
     typename ::cuda::std::enable_if< //
-      !::cuda::std::is_convertible<DecomposerT, int>::value, //
+      !::cuda::std::is_convertible_v<DecomposerT, int>, //
       cudaError_t>::type
     SortPairs(void* d_temp_storage,
               size_t& temp_storage_bytes,
@@ -1302,7 +1302,7 @@ public:
   template <typename KeyT, typename ValueT, typename NumItemsT, typename DecomposerT>
   CUB_RUNTIME_FUNCTION static //
     typename ::cuda::std::enable_if< //
-      !::cuda::std::is_convertible<DecomposerT, int>::value, //
+      !::cuda::std::is_convertible_v<DecomposerT, int>, //
       cudaError_t>::type
     SortPairsDescending(
       void* d_temp_storage,
@@ -1444,7 +1444,7 @@ public:
   template <typename KeyT, typename ValueT, typename NumItemsT, typename DecomposerT>
   CUB_RUNTIME_FUNCTION static //
     typename ::cuda::std::enable_if< //
-      !::cuda::std::is_convertible<DecomposerT, int>::value, //
+      !::cuda::std::is_convertible_v<DecomposerT, int>, //
       cudaError_t>::type
     SortPairsDescending(
       void* d_temp_storage,
@@ -1715,7 +1715,7 @@ public:
   template <typename KeyT, typename ValueT, typename NumItemsT, typename DecomposerT>
   CUB_RUNTIME_FUNCTION static //
     typename ::cuda::std::enable_if< //
-      !::cuda::std::is_convertible<DecomposerT, int>::value, //
+      !::cuda::std::is_convertible_v<DecomposerT, int>, //
       cudaError_t>::type
     SortPairsDescending(
       void* d_temp_storage,
@@ -1859,7 +1859,7 @@ public:
   template <typename KeyT, typename ValueT, typename NumItemsT, typename DecomposerT>
   CUB_RUNTIME_FUNCTION static //
     typename ::cuda::std::enable_if< //
-      !::cuda::std::is_convertible<DecomposerT, int>::value, //
+      !::cuda::std::is_convertible_v<DecomposerT, int>, //
       cudaError_t>::type
     SortPairsDescending(
       void* d_temp_storage,
@@ -2129,7 +2129,7 @@ public:
   template <typename KeyT, typename NumItemsT, typename DecomposerT>
   CUB_RUNTIME_FUNCTION static //
     typename ::cuda::std::enable_if< //
-      !::cuda::std::is_convertible<DecomposerT, int>::value, //
+      !::cuda::std::is_convertible_v<DecomposerT, int>, //
       cudaError_t>::type
     SortKeys(void* d_temp_storage,
              size_t& temp_storage_bytes,
@@ -2259,7 +2259,7 @@ public:
   template <typename KeyT, typename NumItemsT, typename DecomposerT>
   CUB_RUNTIME_FUNCTION static //
     typename ::cuda::std::enable_if< //
-      !::cuda::std::is_convertible<DecomposerT, int>::value, //
+      !::cuda::std::is_convertible_v<DecomposerT, int>, //
       cudaError_t>::type
     SortKeys(void* d_temp_storage,
              size_t& temp_storage_bytes,
@@ -2505,7 +2505,7 @@ public:
   template <typename KeyT, typename NumItemsT, typename DecomposerT>
   CUB_RUNTIME_FUNCTION static //
     typename ::cuda::std::enable_if< //
-      !::cuda::std::is_convertible<DecomposerT, int>::value, //
+      !::cuda::std::is_convertible_v<DecomposerT, int>, //
       cudaError_t>::type
     SortKeys(void* d_temp_storage,
              size_t& temp_storage_bytes,
@@ -2636,7 +2636,7 @@ public:
   template <typename KeyT, typename NumItemsT, typename DecomposerT>
   CUB_RUNTIME_FUNCTION static //
     typename ::cuda::std::enable_if< //
-      !::cuda::std::is_convertible<DecomposerT, int>::value, //
+      !::cuda::std::is_convertible_v<DecomposerT, int>, //
       cudaError_t>::type
     SortKeys(void* d_temp_storage,
              size_t& temp_storage_bytes,
@@ -2886,7 +2886,7 @@ public:
   template <typename KeyT, typename NumItemsT, typename DecomposerT>
   CUB_RUNTIME_FUNCTION static //
     typename ::cuda::std::enable_if< //
-      !::cuda::std::is_convertible<DecomposerT, int>::value, //
+      !::cuda::std::is_convertible_v<DecomposerT, int>, //
       cudaError_t>::type
     SortKeysDescending(
       void* d_temp_storage,
@@ -3014,7 +3014,7 @@ public:
   template <typename KeyT, typename NumItemsT, typename DecomposerT>
   CUB_RUNTIME_FUNCTION static //
     typename ::cuda::std::enable_if< //
-      !::cuda::std::is_convertible<DecomposerT, int>::value, //
+      !::cuda::std::is_convertible_v<DecomposerT, int>, //
       cudaError_t>::type
     SortKeysDescending(
       void* d_temp_storage,
@@ -3256,7 +3256,7 @@ public:
   template <typename KeyT, typename NumItemsT, typename DecomposerT>
   CUB_RUNTIME_FUNCTION static //
     typename ::cuda::std::enable_if< //
-      !::cuda::std::is_convertible<DecomposerT, int>::value, //
+      !::cuda::std::is_convertible_v<DecomposerT, int>, //
       cudaError_t>::type
     SortKeysDescending(
       void* d_temp_storage,
@@ -3388,7 +3388,7 @@ public:
   template <typename KeyT, typename NumItemsT, typename DecomposerT>
   CUB_RUNTIME_FUNCTION static //
     typename ::cuda::std::enable_if< //
-      !::cuda::std::is_convertible<DecomposerT, int>::value, //
+      !::cuda::std::is_convertible_v<DecomposerT, int>, //
       cudaError_t>::type
     SortKeysDescending(
       void* d_temp_storage,

--- a/cub/cub/device/device_radix_sort.cuh
+++ b/cub/cub/device/device_radix_sort.cuh
@@ -467,9 +467,9 @@ public:
   //!   Default is stream<sub>0</sub>.
   template <typename KeyT, typename ValueT, typename NumItemsT, typename DecomposerT>
   CUB_RUNTIME_FUNCTION static //
-    typename ::cuda::std::enable_if< //
+    ::cuda::std::enable_if_t< //
       !::cuda::std::is_convertible_v<DecomposerT, int>, //
-      cudaError_t>::type
+      cudaError_t>
     SortPairs(void* d_temp_storage,
               size_t& temp_storage_bytes,
               const KeyT* d_keys_in,
@@ -607,9 +607,9 @@ public:
   //!   Default is stream<sub>0</sub>.
   template <typename KeyT, typename ValueT, typename NumItemsT, typename DecomposerT>
   CUB_RUNTIME_FUNCTION static //
-    typename ::cuda::std::enable_if< //
+    ::cuda::std::enable_if_t< //
       !::cuda::std::is_convertible_v<DecomposerT, int>, //
-      cudaError_t>::type
+      cudaError_t>
     SortPairs(void* d_temp_storage,
               size_t& temp_storage_bytes,
               const KeyT* d_keys_in,
@@ -881,9 +881,9 @@ public:
   //!   Default is stream<sub>0</sub>.
   template <typename KeyT, typename ValueT, typename NumItemsT, typename DecomposerT>
   CUB_RUNTIME_FUNCTION static //
-    typename ::cuda::std::enable_if< //
+    ::cuda::std::enable_if_t< //
       !::cuda::std::is_convertible_v<DecomposerT, int>, //
-      cudaError_t>::type
+      cudaError_t>
     SortPairs(void* d_temp_storage,
               size_t& temp_storage_bytes,
               DoubleBuffer<KeyT>& d_keys,
@@ -1024,9 +1024,9 @@ public:
   //!   Default is stream<sub>0</sub>.
   template <typename KeyT, typename ValueT, typename NumItemsT, typename DecomposerT>
   CUB_RUNTIME_FUNCTION static //
-    typename ::cuda::std::enable_if< //
+    ::cuda::std::enable_if_t< //
       !::cuda::std::is_convertible_v<DecomposerT, int>, //
-      cudaError_t>::type
+      cudaError_t>
     SortPairs(void* d_temp_storage,
               size_t& temp_storage_bytes,
               DoubleBuffer<KeyT>& d_keys,
@@ -1301,9 +1301,9 @@ public:
   //!   Default is stream<sub>0</sub>.
   template <typename KeyT, typename ValueT, typename NumItemsT, typename DecomposerT>
   CUB_RUNTIME_FUNCTION static //
-    typename ::cuda::std::enable_if< //
+    ::cuda::std::enable_if_t< //
       !::cuda::std::is_convertible_v<DecomposerT, int>, //
-      cudaError_t>::type
+      cudaError_t>
     SortPairsDescending(
       void* d_temp_storage,
       size_t& temp_storage_bytes,
@@ -1443,9 +1443,9 @@ public:
   //!   Default is stream<sub>0</sub>.
   template <typename KeyT, typename ValueT, typename NumItemsT, typename DecomposerT>
   CUB_RUNTIME_FUNCTION static //
-    typename ::cuda::std::enable_if< //
+    ::cuda::std::enable_if_t< //
       !::cuda::std::is_convertible_v<DecomposerT, int>, //
-      cudaError_t>::type
+      cudaError_t>
     SortPairsDescending(
       void* d_temp_storage,
       size_t& temp_storage_bytes,
@@ -1714,9 +1714,9 @@ public:
   //!   Default is stream<sub>0</sub>.
   template <typename KeyT, typename ValueT, typename NumItemsT, typename DecomposerT>
   CUB_RUNTIME_FUNCTION static //
-    typename ::cuda::std::enable_if< //
+    ::cuda::std::enable_if_t< //
       !::cuda::std::is_convertible_v<DecomposerT, int>, //
-      cudaError_t>::type
+      cudaError_t>
     SortPairsDescending(
       void* d_temp_storage,
       size_t& temp_storage_bytes,
@@ -1858,9 +1858,9 @@ public:
   //!   Default is stream<sub>0</sub>.
   template <typename KeyT, typename ValueT, typename NumItemsT, typename DecomposerT>
   CUB_RUNTIME_FUNCTION static //
-    typename ::cuda::std::enable_if< //
+    ::cuda::std::enable_if_t< //
       !::cuda::std::is_convertible_v<DecomposerT, int>, //
-      cudaError_t>::type
+      cudaError_t>
     SortPairsDescending(
       void* d_temp_storage,
       size_t& temp_storage_bytes,
@@ -2128,9 +2128,9 @@ public:
   //!   Default is stream<sub>0</sub>.
   template <typename KeyT, typename NumItemsT, typename DecomposerT>
   CUB_RUNTIME_FUNCTION static //
-    typename ::cuda::std::enable_if< //
+    ::cuda::std::enable_if_t< //
       !::cuda::std::is_convertible_v<DecomposerT, int>, //
-      cudaError_t>::type
+      cudaError_t>
     SortKeys(void* d_temp_storage,
              size_t& temp_storage_bytes,
              const KeyT* d_keys_in,
@@ -2258,9 +2258,9 @@ public:
   //!   Default is stream<sub>0</sub>.
   template <typename KeyT, typename NumItemsT, typename DecomposerT>
   CUB_RUNTIME_FUNCTION static //
-    typename ::cuda::std::enable_if< //
+    ::cuda::std::enable_if_t< //
       !::cuda::std::is_convertible_v<DecomposerT, int>, //
-      cudaError_t>::type
+      cudaError_t>
     SortKeys(void* d_temp_storage,
              size_t& temp_storage_bytes,
              const KeyT* d_keys_in,
@@ -2504,9 +2504,9 @@ public:
   //!   Default is stream<sub>0</sub>.
   template <typename KeyT, typename NumItemsT, typename DecomposerT>
   CUB_RUNTIME_FUNCTION static //
-    typename ::cuda::std::enable_if< //
+    ::cuda::std::enable_if_t< //
       !::cuda::std::is_convertible_v<DecomposerT, int>, //
-      cudaError_t>::type
+      cudaError_t>
     SortKeys(void* d_temp_storage,
              size_t& temp_storage_bytes,
              DoubleBuffer<KeyT>& d_keys,
@@ -2635,9 +2635,9 @@ public:
   //!   Default is stream<sub>0</sub>.
   template <typename KeyT, typename NumItemsT, typename DecomposerT>
   CUB_RUNTIME_FUNCTION static //
-    typename ::cuda::std::enable_if< //
+    ::cuda::std::enable_if_t< //
       !::cuda::std::is_convertible_v<DecomposerT, int>, //
-      cudaError_t>::type
+      cudaError_t>
     SortKeys(void* d_temp_storage,
              size_t& temp_storage_bytes,
              DoubleBuffer<KeyT>& d_keys,
@@ -2885,9 +2885,9 @@ public:
   //!   Default is stream<sub>0</sub>.
   template <typename KeyT, typename NumItemsT, typename DecomposerT>
   CUB_RUNTIME_FUNCTION static //
-    typename ::cuda::std::enable_if< //
+    ::cuda::std::enable_if_t< //
       !::cuda::std::is_convertible_v<DecomposerT, int>, //
-      cudaError_t>::type
+      cudaError_t>
     SortKeysDescending(
       void* d_temp_storage,
       size_t& temp_storage_bytes,
@@ -3013,9 +3013,9 @@ public:
   //!   Default is stream<sub>0</sub>.
   template <typename KeyT, typename NumItemsT, typename DecomposerT>
   CUB_RUNTIME_FUNCTION static //
-    typename ::cuda::std::enable_if< //
+    ::cuda::std::enable_if_t< //
       !::cuda::std::is_convertible_v<DecomposerT, int>, //
-      cudaError_t>::type
+      cudaError_t>
     SortKeysDescending(
       void* d_temp_storage,
       size_t& temp_storage_bytes,
@@ -3255,9 +3255,9 @@ public:
   //!   Default is stream<sub>0</sub>.
   template <typename KeyT, typename NumItemsT, typename DecomposerT>
   CUB_RUNTIME_FUNCTION static //
-    typename ::cuda::std::enable_if< //
+    ::cuda::std::enable_if_t< //
       !::cuda::std::is_convertible_v<DecomposerT, int>, //
-      cudaError_t>::type
+      cudaError_t>
     SortKeysDescending(
       void* d_temp_storage,
       size_t& temp_storage_bytes,
@@ -3387,9 +3387,9 @@ public:
   //!   Default is stream<sub>0</sub>.
   template <typename KeyT, typename NumItemsT, typename DecomposerT>
   CUB_RUNTIME_FUNCTION static //
-    typename ::cuda::std::enable_if< //
+    ::cuda::std::enable_if_t< //
       !::cuda::std::is_convertible_v<DecomposerT, int>, //
-      cudaError_t>::type
+      cudaError_t>
     SortKeysDescending(
       void* d_temp_storage,
       size_t& temp_storage_bytes,

--- a/cub/cub/device/device_select.cuh
+++ b/cub/cub/device/device_select.cuh
@@ -1049,9 +1049,9 @@ struct DeviceSelect
             typename NumItemsT,
             typename EqualityOpT>
   CUB_RUNTIME_FUNCTION __forceinline__ static //
-    typename ::cuda::std::enable_if< //
+    ::cuda::std::enable_if_t< //
       !::cuda::std::is_convertible_v<EqualityOpT, cudaStream_t>, //
-      cudaError_t>::type
+      cudaError_t>
     UniqueByKey(
       void* d_temp_storage,
       size_t& temp_storage_bytes,

--- a/cub/cub/device/device_select.cuh
+++ b/cub/cub/device/device_select.cuh
@@ -1050,7 +1050,7 @@ struct DeviceSelect
             typename EqualityOpT>
   CUB_RUNTIME_FUNCTION __forceinline__ static //
     typename ::cuda::std::enable_if< //
-      !::cuda::std::is_convertible<EqualityOpT, cudaStream_t>::value, //
+      !::cuda::std::is_convertible_v<EqualityOpT, cudaStream_t>, //
       cudaError_t>::type
     UniqueByKey(
       void* d_temp_storage,

--- a/cub/cub/device/dispatch/dispatch_batch_memcpy.cuh
+++ b/cub/cub/device/dispatch/dispatch_batch_memcpy.cuh
@@ -112,9 +112,9 @@ __launch_bounds__(int(ChainedPolicyT::ActivePolicy::AgentLargeBufferPolicyT::BLO
   using ActivePolicyT = typename ChainedPolicyT::ActivePolicy::AgentLargeBufferPolicyT;
   using BufferSizeT   = value_t<BufferSizeIteratorT>;
   /// Internal load/store type. For byte-wise memcpy, a single-byte type
-  using AliasT = typename ::cuda::std::conditional<MemcpyOpt == CopyAlg::Memcpy,
-                                                   std::iterator_traits<char*>,
-                                                   std::iterator_traits<value_t<InputBufferIt>>>::type::value_type;
+  using AliasT = typename ::cuda::std::conditional_t<MemcpyOpt == CopyAlg::Memcpy,
+                                                     std::iterator_traits<char*>,
+                                                     std::iterator_traits<value_t<InputBufferIt>>>::value_type;
   /// Types of the input and output buffers
   using InputBufferT  = value_t<InputBufferIt>;
   using OutputBufferT = value_t<OutputBufferIt>;

--- a/cub/cub/device/dispatch/dispatch_histogram.cuh
+++ b/cub/cub/device/dispatch/dispatch_histogram.cuh
@@ -630,7 +630,7 @@ public:
   struct ScaleTransform
   {
   private:
-    using CommonT = typename ::cuda::std::common_type<LevelT, SampleT>::type;
+    using CommonT = ::cuda::std::common_type_t<LevelT, SampleT>;
     static_assert(::cuda::std::is_convertible_v<CommonT, int>,
                   "The common type of `LevelT` and `SampleT` must be "
                   "convertible to `int`.");
@@ -764,7 +764,7 @@ public:
     /**
      * @brief Bin computation for integral types of up to 64-bit types
      */
-    template <typename T, typename ::cuda::std::enable_if<is_integral_excl_int128<T>::value, int>::type = 0>
+    template <typename T, ::cuda::std::enable_if_t<is_integral_excl_int128<T>::value, int> = 0>
     _CCCL_HOST_DEVICE _CCCL_FORCEINLINE int ComputeBin(T sample, T min_level, ScaleT scale)
     {
       return static_cast<int>(
@@ -772,7 +772,7 @@ public:
         / static_cast<IntArithmeticT>(scale.fraction.range));
     }
 
-    template <typename T, typename ::cuda::std::enable_if<!is_integral_excl_int128<T>::value, int>::type = 0>
+    template <typename T, ::cuda::std::enable_if_t<!is_integral_excl_int128<T>::value, int> = 0>
     _CCCL_HOST_DEVICE _CCCL_FORCEINLINE int ComputeBin(T sample, T min_level, ScaleT scale)
     {
       return this->ComputeBin(sample, min_level, scale, ::cuda::std::is_floating_point<T>{});

--- a/cub/cub/device/dispatch/dispatch_histogram.cuh
+++ b/cub/cub/device/dispatch/dispatch_histogram.cuh
@@ -608,7 +608,7 @@ public:
       // Wrap the native input pointer with CacheModifiedInputIterator
       // or Directly use the supplied input iterator type
       using WrappedLevelIteratorT =
-        ::cuda::std::_If<::cuda::std::is_pointer<LevelIteratorT>::value,
+        ::cuda::std::_If<::cuda::std::is_pointer_v<LevelIteratorT>,
                          CacheModifiedInputIterator<LOAD_MODIFIER, LevelT, OffsetT>,
                          LevelIteratorT>;
 
@@ -631,10 +631,10 @@ public:
   {
   private:
     using CommonT = typename ::cuda::std::common_type<LevelT, SampleT>::type;
-    static_assert(::cuda::std::is_convertible<CommonT, int>::value,
+    static_assert(::cuda::std::is_convertible_v<CommonT, int>,
                   "The common type of `LevelT` and `SampleT` must be "
                   "convertible to `int`.");
-    static_assert(::cuda::std::is_trivially_copyable<CommonT>::value,
+    static_assert(::cuda::std::is_trivially_copyable_v<CommonT>,
                   "The common type of `LevelT` and `SampleT` must be "
                   "trivially copyable.");
 
@@ -649,8 +649,8 @@ public:
       uint32_t, //
 #if _CCCL_HAS_INT128()
       ::cuda::std::_If< //
-        (::cuda::std::is_same<CommonT, __int128_t>::value || //
-         ::cuda::std::is_same<CommonT, __uint128_t>::value), //
+        (::cuda::std::is_same_v<CommonT, __int128_t> || //
+         ::cuda::std::is_same_v<CommonT, __uint128_t>), //
         CommonT, //
         uint64_t> //
 #else // ^^^ _CCCL_HAS_INT128() ^^^ / vvv !_CCCL_HAS_INT128() vvv
@@ -662,7 +662,7 @@ public:
     template <typename T>
     using is_integral_excl_int128 =
 #if _CCCL_HAS_INT128()
-      ::cuda::std::_If<::cuda::std::is_same<T, __int128_t>::value&& ::cuda::std::is_same<T, __uint128_t>::value,
+      ::cuda::std::_If<::cuda::std::is_same_v<T, __int128_t>&& ::cuda::std::is_same_v<T, __uint128_t>,
                        ::cuda::std::false_type,
                        ::cuda::std::is_integral<T>>;
 #else // ^^^ _CCCL_HAS_INT128() ^^^ / vvv !_CCCL_HAS_INT128() vvv
@@ -927,7 +927,7 @@ public:
       policy_hub<detail::value_t<SampleIteratorT>, CounterT, NUM_CHANNELS, NUM_ACTIVE_CHANNELS, isEven>;
 
     using MaxPolicyT =
-      typename ::cuda::std::_If<::cuda::std::is_void<PolicyHub>::value, fallback_policy_hub, PolicyHub>::MaxPolicy;
+      typename ::cuda::std::_If<::cuda::std::is_void_v<PolicyHub>, fallback_policy_hub, PolicyHub>::MaxPolicy;
     cudaError error = cudaSuccess;
 
     do
@@ -1103,7 +1103,7 @@ public:
       policy_hub<detail::value_t<SampleIteratorT>, CounterT, NUM_CHANNELS, NUM_ACTIVE_CHANNELS, isEven>;
 
     using MaxPolicyT =
-      typename ::cuda::std::_If<::cuda::std::is_void<PolicyHub>::value, fallback_policy_hub, PolicyHub>::MaxPolicy;
+      typename ::cuda::std::_If<::cuda::std::is_void_v<PolicyHub>, fallback_policy_hub, PolicyHub>::MaxPolicy;
     cudaError error = cudaSuccess;
 
     do
@@ -1243,7 +1243,7 @@ public:
       policy_hub<detail::value_t<SampleIteratorT>, CounterT, NUM_CHANNELS, NUM_ACTIVE_CHANNELS, isEven>;
 
     using MaxPolicyT =
-      typename ::cuda::std::_If<::cuda::std::is_void<PolicyHub>::value, fallback_policy_hub, PolicyHub>::MaxPolicy;
+      typename ::cuda::std::_If<::cuda::std::is_void_v<PolicyHub>, fallback_policy_hub, PolicyHub>::MaxPolicy;
     cudaError error = cudaSuccess;
 
     do
@@ -1434,7 +1434,7 @@ public:
       policy_hub<detail::value_t<SampleIteratorT>, CounterT, NUM_CHANNELS, NUM_ACTIVE_CHANNELS, isEven>;
 
     using MaxPolicyT =
-      typename ::cuda::std::_If<::cuda::std::is_void<PolicyHub>::value, fallback_policy_hub, PolicyHub>::MaxPolicy;
+      typename ::cuda::std::_If<::cuda::std::is_void_v<PolicyHub>, fallback_policy_hub, PolicyHub>::MaxPolicy;
     cudaError error = cudaSuccess;
 
     do

--- a/cub/cub/device/dispatch/dispatch_merge.cuh
+++ b/cub/cub/device/dispatch/dispatch_merge.cuh
@@ -122,9 +122,8 @@ __launch_bounds__(
   using key_t = value_t<KeyIt1>;
   static_assert(::cuda::std::__invokable<CompareOp, key_t, key_t>::value,
                 "Comparison operator cannot compare two keys");
-  static_assert(
-    ::cuda::std::is_convertible<typename ::cuda::std::__invoke_of<CompareOp, key_t, key_t>::type, bool>::value,
-    "Comparison operator must be convertible to bool");
+  static_assert(::cuda::std::is_convertible_v<typename ::cuda::std::__invoke_of<CompareOp, key_t, key_t>::type, bool>,
+                "Comparison operator must be convertible to bool");
 
   using MergeAgent = typename choose_merge_agent<
     typename MaxPolicy::ActivePolicy::merge_policy,

--- a/cub/cub/device/dispatch/dispatch_radix_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_radix_sort.cuh
@@ -390,7 +390,7 @@ __launch_bounds__(int(ChainedPolicyT::ActivePolicy::SingleTilePolicy::BLOCK_THRE
   {
     BLOCK_THREADS    = ChainedPolicyT::ActivePolicy::SingleTilePolicy::BLOCK_THREADS,
     ITEMS_PER_THREAD = ChainedPolicyT::ActivePolicy::SingleTilePolicy::ITEMS_PER_THREAD,
-    KEYS_ONLY        = ::cuda::std::is_same<ValueT, NullType>::value,
+    KEYS_ONLY        = ::cuda::std::is_same_v<ValueT, NullType>,
   };
 
   // BlockRadixSort type
@@ -577,7 +577,7 @@ __launch_bounds__(int((ALT_DIGIT_BITS) ? ChainedPolicyT::ActivePolicy::AltSegmen
     RADIX_BITS       = SegmentedPolicyT::RADIX_BITS,
     TILE_ITEMS       = BLOCK_THREADS * ITEMS_PER_THREAD,
     RADIX_DIGITS     = 1 << RADIX_BITS,
-    KEYS_ONLY        = ::cuda::std::is_same<ValueT, NullType>::value,
+    KEYS_ONLY        = ::cuda::std::is_same_v<ValueT, NullType>,
   };
 
   // Upsweep type
@@ -881,7 +881,7 @@ struct DispatchRadixSort
   //------------------------------------------------------------------------------
 
   // Whether this is a keys-only (or key-value) sort
-  static constexpr bool KEYS_ONLY = ::cuda::std::is_same<ValueT, NullType>::value;
+  static constexpr bool KEYS_ONLY = ::cuda::std::is_same_v<ValueT, NullType>;
 
   using max_policy_t = typename PolicyHub::MaxPolicy;
 
@@ -1909,7 +1909,7 @@ struct DispatchSegmentedRadixSort
   //------------------------------------------------------------------------------
 
   // Whether this is a keys-only (or key-value) sort
-  static constexpr bool KEYS_ONLY = ::cuda::std::is_same<ValueT, NullType>::value;
+  static constexpr bool KEYS_ONLY = ::cuda::std::is_same_v<ValueT, NullType>;
 
   using max_policy_t = typename PolicyHub::MaxPolicy;
 

--- a/cub/cub/device/dispatch/dispatch_scan_by_key.cuh
+++ b/cub/cub/device/dispatch/dispatch_scan_by_key.cuh
@@ -234,8 +234,7 @@ template <
   typename AccumT = ::cuda::std::__accumulator_t<
     ScanOpT,
     cub::detail::value_t<ValuesInputIteratorT>,
-    ::cuda::std::
-      _If<::cuda::std::is_same<InitValueT, NullType>::value, cub::detail::value_t<ValuesInputIteratorT>, InitValueT>>,
+    ::cuda::std::_If<::cuda::std::is_same_v<InitValueT, NullType>, cub::detail::value_t<ValuesInputIteratorT>, InitValueT>>,
   typename PolicyHub =
     detail::scan_by_key::policy_hub<KeysInputIteratorT, AccumT, cub::detail::value_t<ValuesInputIteratorT>, ScanOpT>>
 struct DispatchScanByKey

--- a/cub/cub/device/dispatch/dispatch_segmented_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_segmented_sort.cuh
@@ -195,7 +195,7 @@ __launch_bounds__(ChainedPolicyT::ActivePolicy::LargeSegmentPolicy::BLOCK_THREAD
     typename AgentWarpMergeSortT::TempStorage medium_warp_sort;
   } temp_storage;
 
-  constexpr bool keys_only = ::cuda::std::is_same<ValueT, NullType>::value;
+  constexpr bool keys_only = ::cuda::std::is_same_v<ValueT, NullType>;
   AgentSegmentedRadixSortT agent(num_items, temp_storage.block_sort);
 
   constexpr int begin_bit = 0;
@@ -489,7 +489,7 @@ __launch_bounds__(ChainedPolicyT::ActivePolicy::LargeSegmentPolicy::BLOCK_THREAD
   const OffsetT segment_end                     = d_end_offsets[global_segment_id];
   const OffsetT num_items                       = segment_end - segment_begin;
 
-  constexpr bool keys_only = ::cuda::std::is_same<ValueT, NullType>::value;
+  constexpr bool keys_only = ::cuda::std::is_same_v<ValueT, NullType>;
   AgentSegmentedRadixSortT agent(num_items, storage);
 
   d_keys_in_orig += segment_begin;
@@ -767,7 +767,7 @@ struct DispatchSegmentedSort
     detail::segmented_sort::OffsetIteratorT<EndOffsetIteratorT,
                                             THRUST_NS_QUALIFIER::constant_iterator<global_segment_offset_t>>;
 
-  static constexpr int KEYS_ONLY = ::cuda::std::is_same<ValueT, NullType>::value;
+  static constexpr int KEYS_ONLY = ::cuda::std::is_same_v<ValueT, NullType>;
 
   struct LargeSegmentsSelectorT
   {

--- a/cub/cub/device/dispatch/dispatch_transform.cuh
+++ b/cub/cub/device/dispatch/dispatch_transform.cuh
@@ -92,7 +92,7 @@ _CCCL_DEVICE _CCCL_FORCEINLINE void prefetch_tile(const T* addr, int tile_size)
 // TODO(miscco): we should probably constrain It to not be a contiguous iterator in C++17 (and change the overload
 // above to accept any contiguous iterator)
 // overload for any iterator that is not a pointer, do nothing
-template <int, typename It, ::cuda::std::enable_if_t<!::cuda::std::is_pointer<It>::value, int> = 0>
+template <int, typename It, ::cuda::std::enable_if_t<!::cuda::std::is_pointer_v<It>, int> = 0>
 _CCCL_DEVICE _CCCL_FORCEINLINE void prefetch_tile(It, int)
 {}
 
@@ -169,12 +169,12 @@ template <class F, class Tuple>
 _CCCL_DEVICE _CCCL_FORCEINLINE auto poor_apply(F&& f, Tuple&& t) -> decltype(poor_apply_impl(
   ::cuda::std::forward<F>(f),
   ::cuda::std::forward<Tuple>(t),
-  ::cuda::std::make_index_sequence<::cuda::std::tuple_size<::cuda::std::remove_reference_t<Tuple>>::value>{}))
+  ::cuda::std::make_index_sequence<::cuda::std::tuple_size_v<::cuda::std::remove_reference_t<Tuple>>>{}))
 {
   return poor_apply_impl(
     ::cuda::std::forward<F>(f),
     ::cuda::std::forward<Tuple>(t),
-    ::cuda::std::make_index_sequence<::cuda::std::tuple_size<::cuda::std::remove_reference_t<Tuple>>::value>{});
+    ::cuda::std::make_index_sequence<::cuda::std::tuple_size_v<::cuda::std::remove_reference_t<Tuple>>>{});
 }
 
 // Implementation notes on memcpy_async and UBLKCP kernels regarding copy alignment and padding
@@ -422,7 +422,7 @@ union kernel_arg
   aligned_base_ptr<value_t<It>> aligned_ptr; // first member is trivial
   It iterator; // may not be trivially [default|copy]-constructible
 
-  static_assert(::cuda::std::is_trivial<decltype(aligned_ptr)>::value, "");
+  static_assert(::cuda::std::is_trivial_v<decltype(aligned_ptr)>, "");
 
   // Sometimes It is not trivially [default|copy]-constructible (e.g.
   // thrust::normal_iterator<thrust::device_pointer<T>>), so because of
@@ -634,8 +634,8 @@ struct dispatch_t<StableAddress,
                   TransformOp,
                   PolicyHub>
 {
-  static_assert(::cuda::std::is_same<Offset, ::cuda::std::int32_t>::value
-                  || ::cuda::std::is_same<Offset, ::cuda::std::int64_t>::value,
+  static_assert(::cuda::std::is_same_v<Offset, ::cuda::std::int32_t>
+                  || ::cuda::std::is_same_v<Offset, ::cuda::std::int64_t>,
                 "cub::DeviceTransform is only tested and tuned for 32-bit or 64-bit signed offset types");
 
   ::cuda::std::tuple<RandomAccessIteratorsIn...> in;

--- a/cub/cub/device/dispatch/kernels/for_each.cuh
+++ b/cub/cub/device/dispatch/kernels/for_each.cuh
@@ -79,9 +79,9 @@ struct has_unique_value_overload<
   Value,
   Fn,
   typename ::cuda::std::enable_if<
-              !::cuda::std::is_reference<first_parameter_t<Fn>>::value &&
-              ::cuda::std::is_convertible<Value, first_parameter_t<Fn>
-             >::value>::type>
+              !::cuda::std::is_reference_v<first_parameter_t<Fn>> &&
+              ::cuda::std::is_convertible_v<Value, first_parameter_t<Fn>
+             >>::type>
     : ::cuda::std::true_type
 {};
 
@@ -92,10 +92,10 @@ template <typename Value, typename Fn>
 using can_regain_copy_freedom =
   ::cuda::std::integral_constant<
     bool,
-    ::cuda::std::is_trivially_constructible<Value>::value &&
-    ::cuda::std::is_trivially_copy_assignable<Value>::value &&
-    ::cuda::std::is_trivially_move_assignable<Value>::value &&
-    ::cuda::std::is_trivially_destructible<Value>::value &&
+    ::cuda::std::is_trivially_constructible_v<Value> &&
+    ::cuda::std::is_trivially_copy_assignable_v<Value> &&
+    ::cuda::std::is_trivially_move_assignable_v<Value> &&
+    ::cuda::std::is_trivially_destructible_v<Value> &&
     has_unique_value_overload<Value, Fn>::value>;
 // clang-format on
 

--- a/cub/cub/device/dispatch/kernels/for_each.cuh
+++ b/cub/cub/device/dispatch/kernels/for_each.cuh
@@ -78,10 +78,10 @@ template <class Value, class Fn>
 struct has_unique_value_overload<
   Value,
   Fn,
-  typename ::cuda::std::enable_if<
+  ::cuda::std::enable_if_t<
               !::cuda::std::is_reference_v<first_parameter_t<Fn>> &&
               ::cuda::std::is_convertible_v<Value, first_parameter_t<Fn>
-             >>::type>
+             >>>
     : ::cuda::std::true_type
 {};
 

--- a/cub/cub/device/dispatch/tuning/tuning_merge.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_merge.cuh
@@ -49,7 +49,7 @@ namespace merge
 template <typename KeyT, typename ValueT>
 struct policy_hub
 {
-  static constexpr bool has_values = !::cuda::std::is_same<ValueT, NullType>::value;
+  static constexpr bool has_values = !::cuda::std::is_same_v<ValueT, NullType>;
 
   using tune_type = char[has_values ? sizeof(KeyT) + sizeof(ValueT) : sizeof(KeyT)];
 

--- a/cub/cub/device/dispatch/tuning/tuning_radix_sort.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_radix_sort.cuh
@@ -299,7 +299,7 @@ struct policy_hub
   //------------------------------------------------------------------------------
 
   // Whether this is a keys-only (or key-value) sort
-  static constexpr bool KEYS_ONLY = ::cuda::std::is_same<ValueT, NullType>::value;
+  static constexpr bool KEYS_ONLY = ::cuda::std::is_same_v<ValueT, NullType>;
 
   // Dominant-sized key/value type
   using DominantT = ::cuda::std::_If<(sizeof(ValueT) > sizeof(KeyT)), ValueT, KeyT>;
@@ -879,7 +879,7 @@ struct policy_hub
     static constexpr int SINGLE_TILE_RADIX_BITS = (sizeof(KeyT) > 1) ? 6 : 5;
     static constexpr int SEGMENTED_RADIX_BITS   = (sizeof(KeyT) > 1) ? 6 : 5;
     static constexpr int OFFSET_64BIT           = sizeof(OffsetT) == 8 ? 1 : 0;
-    static constexpr int FLOAT_KEYS             = ::cuda::std::is_same<KeyT, float>::value ? 1 : 0;
+    static constexpr int FLOAT_KEYS             = ::cuda::std::is_same_v<KeyT, float> ? 1 : 0;
 
     using OnesweepPolicyKey32 = AgentRadixSortOnesweepPolicy<
       384,

--- a/cub/cub/device/dispatch/tuning/tuning_segmented_sort.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_segmented_sort.cuh
@@ -51,7 +51,7 @@ template <typename KeyT, typename ValueT>
 struct policy_hub
 {
   using DominantT                = ::cuda::std::_If<(sizeof(ValueT) > sizeof(KeyT)), ValueT, KeyT>;
-  static constexpr int KEYS_ONLY = ::cuda::std::is_same<ValueT, NullType>::value;
+  static constexpr int KEYS_ONLY = ::cuda::std::is_same_v<ValueT, NullType>;
 
   struct Policy500 : ChainedPolicy<500, Policy500, Policy500>
   {

--- a/cub/cub/device/dispatch/tuning/tuning_select_if.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_select_if.cuh
@@ -1446,13 +1446,13 @@ struct sm100_tuning<Input,
 template <class InputT>
 constexpr primitive is_primitive()
 {
-  return detail::is_primitive<InputT>::value ? primitive::yes : primitive::no;
+  return detail::is_primitive_v<InputT> ? primitive::yes : primitive::no;
 }
 
 template <class FlagT>
 constexpr flagged is_flagged()
 {
-  return ::cuda::std::is_same<FlagT, NullType>::value ? flagged::no : flagged::yes;
+  return ::cuda::std::is_same_v<FlagT, NullType> ? flagged::no : flagged::yes;
 }
 
 template <bool KeepRejects>

--- a/cub/cub/device/dispatch/tuning/tuning_transform.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_transform.cuh
@@ -142,9 +142,9 @@ struct policy_hub<RequiresStableAddress, ::cuda::std::tuple<RandomAccessIterator
 {
   static constexpr bool no_input_streams = sizeof...(RandomAccessIteratorsIn) == 0;
   static constexpr bool all_contiguous =
-    ::cuda::std::conjunction<THRUST_NS_QUALIFIER::is_contiguous_iterator<RandomAccessIteratorsIn>...>::value;
+    ::cuda::std::conjunction_v<THRUST_NS_QUALIFIER::is_contiguous_iterator<RandomAccessIteratorsIn>...>;
   static constexpr bool all_values_trivially_reloc =
-    ::cuda::std::conjunction<THRUST_NS_QUALIFIER::is_trivially_relocatable<value_t<RandomAccessIteratorsIn>>...>::value;
+    ::cuda::std::conjunction_v<THRUST_NS_QUALIFIER::is_trivially_relocatable<value_t<RandomAccessIteratorsIn>>...>;
 
   static constexpr bool can_memcpy = all_contiguous && all_values_trivially_reloc;
 

--- a/cub/cub/iterator/cache_modified_input_iterator.cuh
+++ b/cub/cub/iterator/cache_modified_input_iterator.cuh
@@ -140,7 +140,7 @@ public:
   /// Constructor
   template <typename QualifiedValueType>
   _CCCL_HOST_DEVICE _CCCL_FORCEINLINE CacheModifiedInputIterator(QualifiedValueType* ptr) ///< Native pointer to wrap
-      : ptr(const_cast<typename ::cuda::std::remove_cv<QualifiedValueType>::type*>(ptr))
+      : ptr(const_cast<::cuda::std::remove_cv_t<QualifiedValueType>*>(ptr))
   {}
 
   /// Postfix increment

--- a/cub/cub/iterator/tex_obj_input_iterator.cuh
+++ b/cub/cub/iterator/tex_obj_input_iterator.cuh
@@ -169,7 +169,7 @@ public:
   template <typename QualifiedT>
   cudaError_t BindTexture(QualifiedT* ptr, size_t bytes, size_t tex_offset = 0)
   {
-    this->ptr        = const_cast<typename std::remove_cv<QualifiedT>::type*>(ptr);
+    this->ptr        = const_cast<std::remove_cv_t<QualifiedT>*>(ptr);
     this->tex_offset = static_cast<difference_type>(tex_offset);
 
     cudaChannelFormatDesc channel_desc = cudaCreateChannelDesc<TextureWord>();

--- a/cub/cub/thread/thread_load.cuh
+++ b/cub/cub/thread/thread_load.cuh
@@ -355,7 +355,7 @@ template <typename T>
 _CCCL_DEVICE _CCCL_FORCEINLINE T
 ThreadLoad(const T* ptr, detail::constant_t<LOAD_VOLATILE> /*modifier*/, ::cuda::std::true_type /*is_pointer*/)
 {
-  return ThreadLoadVolatilePointer(ptr, detail::bool_constant_v<detail::is_primitive<T>::value>);
+  return ThreadLoadVolatilePointer(ptr, detail::bool_constant_v<detail::is_primitive_v<T>>);
 }
 
 /**

--- a/cub/cub/thread/thread_reduce.cuh
+++ b/cub/cub/thread/thread_reduce.cuh
@@ -464,7 +464,7 @@ _CCCL_NODISCARD _CCCL_DEVICE constexpr bool enable_promotion()
   using cub::detail::is_one_of;
   using ::cuda::std::is_same;
   using T = ::cuda::std::remove_cvref_t<decltype(::cuda::std::declval<Input>()[0])>;
-  return ::cuda::std::is_integral<T>::value && sizeof(T) <= 2
+  return ::cuda::std::is_integral_v<T> && sizeof(T) <= 2
       && is_one_of<ReductionOp,
                    ::cuda::std::plus<>,
                    ::cuda::std::plus<T>,

--- a/cub/cub/thread/thread_sort.cuh
+++ b/cub/cub/thread/thread_sort.cuh
@@ -86,7 +86,7 @@ template <typename KeyT, typename ValueT, typename CompareOp, int ITEMS_PER_THRE
 _CCCL_DEVICE _CCCL_FORCEINLINE void
 StableOddEvenSort(KeyT (&keys)[ITEMS_PER_THREAD], ValueT (&items)[ITEMS_PER_THREAD], CompareOp compare_op)
 {
-  constexpr bool KEYS_ONLY = ::cuda::std::is_same<ValueT, NullType>::value;
+  constexpr bool KEYS_ONLY = ::cuda::std::is_same_v<ValueT, NullType>;
 
 #pragma unroll
   for (int i = 0; i < ITEMS_PER_THREAD; ++i)

--- a/cub/cub/util_math.cuh
+++ b/cub/cub/util_math.cuh
@@ -54,7 +54,7 @@ namespace detail
 
 template <typename T>
 using is_integral_or_enum =
-  ::cuda::std::integral_constant<bool, ::cuda::std::is_integral<T>::value || ::cuda::std::is_enum<T>::value>;
+  ::cuda::std::integral_constant<bool, ::cuda::std::is_integral_v<T> || ::cuda::std::is_enum_v<T>>;
 
 /**
  * Computes lhs + rhs, but bounds the result to the maximum number representable by the given type, if the addition
@@ -66,7 +66,7 @@ using is_integral_or_enum =
 template <typename OffsetT>
 _CCCL_HOST_DEVICE _CCCL_FORCEINLINE OffsetT safe_add_bound_to_max(OffsetT lhs, OffsetT rhs)
 {
-  static_assert(::cuda::std::is_integral<OffsetT>::value, "OffsetT must be an integral type");
+  static_assert(::cuda::std::is_integral_v<OffsetT>, "OffsetT must be an integral type");
   static_assert(sizeof(OffsetT) >= 4, "OffsetT must be at least 32 bits in size");
   auto const capped_operand_rhs = (::cuda::std::min)(rhs, ::cuda::std::numeric_limits<OffsetT>::max() - lhs);
   return lhs + capped_operand_rhs;

--- a/cub/cub/util_type.cuh
+++ b/cub/cub/util_type.cuh
@@ -1002,7 +1002,7 @@ template <> struct NumericTraits<bool> :                BaseTraits<UNSIGNED_INTE
  * \brief Type traits
  */
 template <typename T>
-struct Traits : NumericTraits<typename ::cuda::std::remove_cv<T>::type>
+struct Traits : NumericTraits<::cuda::std::remove_cv_t<T>>
 {};
 
 namespace detail

--- a/cub/cub/util_type.cuh
+++ b/cub/cub/util_type.cuh
@@ -96,7 +96,7 @@ using value_t =
   typename std::iterator_traits<Iterator>::value_type;
 #  endif // !_CCCL_COMPILER(NVRTC)
 
-template <typename It, typename FallbackT, bool = ::cuda::std::is_void<::cuda::std::remove_pointer_t<It>>::value>
+template <typename It, typename FallbackT, bool = ::cuda::std::is_void_v<::cuda::std::remove_pointer_t<It>>>
 struct non_void_value_impl
 {
   using type = FallbackT;
@@ -108,8 +108,8 @@ struct non_void_value_impl<It, FallbackT, false>
   // we consider thrust::discard_iterator's value_type as `void` as well, so users can switch from
   // cub::DiscardInputIterator to thrust::discard_iterator.
   using type =
-    ::cuda::std::_If<::cuda::std::is_void<value_t<It>>::value
-                       || ::cuda::std::is_same<value_t<It>, THRUST_NS_QUALIFIER::discard_iterator<>::value_type>::value,
+    ::cuda::std::_If<::cuda::std::is_void_v<value_t<It>>
+                       || ::cuda::std::is_same_v<value_t<It>, THRUST_NS_QUALIFIER::discard_iterator<>::value_type>,
                      FallbackT,
                      value_t<It>>;
 };

--- a/cub/cub/util_vsmem.cuh
+++ b/cub/cub/util_vsmem.cuh
@@ -149,7 +149,7 @@ public:
    * @note Needs to be followed by `__syncthreads()` if the function returns true and the virtual shared memory is
    * supposed to be reused after this function call.
    */
-  template <bool needs_vsmem_ = needs_vsmem, typename ::cuda::std::enable_if<!needs_vsmem_, int>::type = 0>
+  template <bool needs_vsmem_ = needs_vsmem, ::cuda::std::enable_if_t<!needs_vsmem_, int> = 0>
   static _CCCL_DEVICE _CCCL_FORCEINLINE bool discard_temp_storage(typename AgentT::TempStorage& temp_storage)
   {
     return false;
@@ -162,7 +162,7 @@ public:
    * @note Needs to be followed by `__syncthreads()` if the function returns true and the virtual shared memory is
    * supposed to be reused after this function call.
    */
-  template <bool needs_vsmem_ = needs_vsmem, typename ::cuda::std::enable_if<needs_vsmem_, int>::type = 0>
+  template <bool needs_vsmem_ = needs_vsmem, ::cuda::std::enable_if_t<needs_vsmem_, int> = 0>
   static _CCCL_DEVICE _CCCL_FORCEINLINE bool discard_temp_storage(typename AgentT::TempStorage& temp_storage)
   {
     // Ensure all threads finished using temporary storage

--- a/cub/cub/warp/specializations/warp_reduce_shfl.cuh
+++ b/cub/cub/warp/specializations/warp_reduce_shfl.cuh
@@ -602,9 +602,9 @@ struct WarpReduceShfl
   }
 
   template <class U = T>
-  _CCCL_DEVICE _CCCL_FORCEINLINE typename ::cuda::std::enable_if<
+  _CCCL_DEVICE _CCCL_FORCEINLINE ::cuda::std::enable_if_t<
     (::cuda::std::is_same_v<int, U> || ::cuda::std::is_same_v<unsigned int, U>) && detail::reduce_add_exists<>::value,
-    T>::type
+    T>
   ReduceImpl(::cuda::std::true_type /* all_lanes_valid */,
              T input,
              int /* valid_items */,
@@ -621,9 +621,9 @@ struct WarpReduceShfl
   }
 
   template <class U = T>
-  _CCCL_DEVICE _CCCL_FORCEINLINE typename ::cuda::std::enable_if<
+  _CCCL_DEVICE _CCCL_FORCEINLINE ::cuda::std::enable_if_t<
     (::cuda::std::is_same_v<int, U> || ::cuda::std::is_same_v<unsigned int, U>) && detail::reduce_min_exists<>::value,
-    T>::type
+    T>
   ReduceImpl(
     ::cuda::std::true_type /* all_lanes_valid */, T input, int /* valid_items */, ::cuda::minimum<> /* reduction_op */)
   {
@@ -638,9 +638,9 @@ struct WarpReduceShfl
   }
 
   template <class U = T>
-  _CCCL_DEVICE _CCCL_FORCEINLINE typename ::cuda::std::enable_if<
+  _CCCL_DEVICE _CCCL_FORCEINLINE ::cuda::std::enable_if_t<
     (::cuda::std::is_same_v<int, U> || ::cuda::std::is_same_v<unsigned int, U>) && detail::reduce_max_exists<>::value,
-    T>::type
+    T>
   ReduceImpl(
     ::cuda::std::true_type /* all_lanes_valid */, T input, int /* valid_items */, ::cuda::maximum<> /* reduction_op */)
   {

--- a/cub/cub/warp/specializations/warp_reduce_shfl.cuh
+++ b/cub/cub/warp/specializations/warp_reduce_shfl.cuh
@@ -122,7 +122,7 @@ struct WarpReduceShfl
       /// Whether the data type is a small (32b or less) integer for which we can use a single SHFL instruction per
       /// exchange
       IS_SMALL_UNSIGNED =
-        ::cuda::std::is_integral<S>::value && ::cuda::std::is_unsigned<S>::value && (sizeof(S) <= sizeof(unsigned int)),
+        ::cuda::std::is_integral_v<S> && ::cuda::std::is_unsigned_v<S> && (sizeof(S) <= sizeof(unsigned int)),
     };
   };
 
@@ -602,10 +602,9 @@ struct WarpReduceShfl
   }
 
   template <class U = T>
-  _CCCL_DEVICE _CCCL_FORCEINLINE
-  typename ::cuda::std::enable_if<(::cuda::std::is_same<int, U>::value || ::cuda::std::is_same<unsigned int, U>::value)
-                                    && detail::reduce_add_exists<>::value,
-                                  T>::type
+  _CCCL_DEVICE _CCCL_FORCEINLINE typename ::cuda::std::enable_if<
+    (::cuda::std::is_same_v<int, U> || ::cuda::std::is_same_v<unsigned int, U>) && detail::reduce_add_exists<>::value,
+    T>::type
   ReduceImpl(::cuda::std::true_type /* all_lanes_valid */,
              T input,
              int /* valid_items */,
@@ -622,10 +621,9 @@ struct WarpReduceShfl
   }
 
   template <class U = T>
-  _CCCL_DEVICE _CCCL_FORCEINLINE
-  typename ::cuda::std::enable_if<(::cuda::std::is_same<int, U>::value || ::cuda::std::is_same<unsigned int, U>::value)
-                                    && detail::reduce_min_exists<>::value,
-                                  T>::type
+  _CCCL_DEVICE _CCCL_FORCEINLINE typename ::cuda::std::enable_if<
+    (::cuda::std::is_same_v<int, U> || ::cuda::std::is_same_v<unsigned int, U>) && detail::reduce_min_exists<>::value,
+    T>::type
   ReduceImpl(
     ::cuda::std::true_type /* all_lanes_valid */, T input, int /* valid_items */, ::cuda::minimum<> /* reduction_op */)
   {
@@ -640,10 +638,9 @@ struct WarpReduceShfl
   }
 
   template <class U = T>
-  _CCCL_DEVICE _CCCL_FORCEINLINE
-  typename ::cuda::std::enable_if<(::cuda::std::is_same<int, U>::value || ::cuda::std::is_same<unsigned int, U>::value)
-                                    && detail::reduce_max_exists<>::value,
-                                  T>::type
+  _CCCL_DEVICE _CCCL_FORCEINLINE typename ::cuda::std::enable_if<
+    (::cuda::std::is_same_v<int, U> || ::cuda::std::is_same_v<unsigned int, U>) && detail::reduce_max_exists<>::value,
+    T>::type
   ReduceImpl(
     ::cuda::std::true_type /* all_lanes_valid */, T input, int /* valid_items */, ::cuda::maximum<> /* reduction_op */)
   {

--- a/cub/cub/warp/specializations/warp_scan_shfl.cuh
+++ b/cub/cub/warp/specializations/warp_scan_shfl.cuh
@@ -90,7 +90,7 @@ struct WarpScanShfl
       /// Whether the data type is a small (32b or less) integer for which we can use a single SFHL instruction per
       /// exchange
       IS_SMALL_UNSIGNED =
-        ::cuda::std::is_integral<S>::value && ::cuda::std::is_unsigned<S>::value && (sizeof(S) <= sizeof(unsigned int)),
+        ::cuda::std::is_integral_v<S> && ::cuda::std::is_unsigned_v<S> && (sizeof(S) <= sizeof(unsigned int)),
     };
   };
 

--- a/cub/cub/warp/warp_merge_sort.cuh
+++ b/cub/cub/warp/warp_merge_sort.cuh
@@ -132,7 +132,7 @@ class WarpMergeSort
 {
 private:
   static constexpr bool IS_ARCH_WARP = LOGICAL_WARP_THREADS == CUB_WARP_THREADS(0);
-  static constexpr bool KEYS_ONLY    = ::cuda::std::is_same<ValueT, NullType>::value;
+  static constexpr bool KEYS_ONLY    = ::cuda::std::is_same_v<ValueT, NullType>;
   static constexpr int TILE_SIZE     = ITEMS_PER_THREAD * LOGICAL_WARP_THREADS;
 
   using BlockMergeSortStrategyT =

--- a/cub/cub/warp/warp_scan.cuh
+++ b/cub/cub/warp/warp_scan.cuh
@@ -173,7 +173,7 @@ private:
     IS_POW_OF_TWO = ((LOGICAL_WARP_THREADS & (LOGICAL_WARP_THREADS - 1)) == 0),
 
     /// Whether the data type is an integer (which has fully-associative addition)
-    IS_INTEGER = cuda::std::is_integral<T>::value
+    IS_INTEGER = cuda::std::is_integral_v<T>
   };
 
   /// Internal specialization.

--- a/cub/test/catch2_large_array_sort_helper.cuh
+++ b/cub/test/catch2_large_array_sort_helper.cuh
@@ -253,7 +253,7 @@ struct large_array_sort_helper
   // Pass the sorted outputs to verify_stable_pair_sort to validate.
   void initialize_for_stable_pair_sort(c2h::seed_t seed, std::size_t num_items, bool is_descending)
   {
-    static_assert(!::cuda::std::is_same<ValueType, cub::NullType>::value, "ValueType must be valid.");
+    static_assert(!::cuda::std::is_same_v<ValueType, cub::NullType>, "ValueType must be valid.");
     using summary_t = detail::summary<KeyType>;
 
     const std::size_t max_summaries = this->compute_max_summaries(num_items);
@@ -371,7 +371,7 @@ struct large_array_sort_helper
     const c2h::device_vector<KeyType>& keys,
     const c2h::device_vector<ValueType>& values)
   {
-    static_assert(!::cuda::std::is_same<ValueType, cub::NullType>::value, "ValueType must be valid.");
+    static_assert(!::cuda::std::is_same_v<ValueType, cub::NullType>, "ValueType must be valid.");
 
     const std::size_t max_summaries = this->compute_max_summaries(num_items);
     const std::size_t num_summaries = this->compute_num_summaries(num_items, max_summaries);

--- a/cub/test/catch2_segmented_sort_helper.cuh
+++ b/cub/test/catch2_segmented_sort_helper.cuh
@@ -523,7 +523,7 @@ void generate_unsorted_derived_inputs(
 {
   C2H_TIME_SCOPE("GenerateUnsortedDerivedInputs");
 
-  static constexpr bool sort_pairs = !::cuda::std::is_same<ValueT, cub::NullType>::value;
+  static constexpr bool sort_pairs = !::cuda::std::is_same_v<ValueT, cub::NullType>;
 
   const int num_segments = static_cast<int>(d_offsets.size() - 1);
   const int* offsets     = thrust::raw_pointer_cast(d_offsets.data());
@@ -589,7 +589,7 @@ void generate_random_unsorted_inputs(c2h::seed_t seed, //
 
   c2h::gen(make_key_seed(seed), d_keys);
 
-  _CCCL_IF_CONSTEXPR (!::cuda::std::is_same<ValueT, cub::NullType>::value)
+  _CCCL_IF_CONSTEXPR (!::cuda::std::is_same_v<ValueT, cub::NullType>)
   {
     c2h::gen(make_value_seed(seed), d_values);
   }
@@ -608,7 +608,7 @@ void host_sort_random_inputs(
 {
   C2H_TIME_SCOPE("host_sort_random_inputs");
 
-  constexpr bool sort_pairs = !::cuda::std::is_same<ValueT, cub::NullType>::value;
+  constexpr bool sort_pairs = !::cuda::std::is_same_v<ValueT, cub::NullType>;
 
   (void) h_unsorted_values; // Unused for key-only sort.
 
@@ -754,7 +754,7 @@ void validate_sorted_random_outputs(
   REQUIRE((d_ref_keys == d_sorted_keys) == true);
 
   // Verify segment-by-segment that the values are appropriately sorted for an unstable key-value sort:
-  _CCCL_IF_CONSTEXPR (!::cuda::std::is_same<ValueT, cub::NullType>::value)
+  _CCCL_IF_CONSTEXPR (!::cuda::std::is_same_v<ValueT, cub::NullType>)
   {
     _CCCL_IF_CONSTEXPR (STABLE)
     {
@@ -806,7 +806,7 @@ CUB_RUNTIME_FUNCTION cudaError_t call_cub_segmented_sort_api(
   cudaStream_t stream = 0)
 {
   using KeyT                = unwrap_value_t<WrappedKeyT>;
-  constexpr bool sort_pairs = !::cuda::std::is_same<ValueT, cub::NullType>::value;
+  constexpr bool sort_pairs = !::cuda::std::is_same_v<ValueT, cub::NullType>;
 
   // Unused for key-only sort.
   (void) values_selector;
@@ -1280,7 +1280,7 @@ template <typename KeyT, typename ValueT = cub::NullType>
 void test_segments_derived(const c2h::device_vector<int>& d_offsets_vec)
 {
   C2H_TIME_SECTION_INIT();
-  constexpr bool sort_pairs = !::cuda::std::is_same<ValueT, cub::NullType>::value;
+  constexpr bool sort_pairs = !::cuda::std::is_same_v<ValueT, cub::NullType>;
 
   const int num_items    = d_offsets_vec.back();
   const int num_segments = static_cast<int>(d_offsets_vec.size() - 1);
@@ -1370,7 +1370,7 @@ void test_segments_random(
   const int* d_begin_offsets,
   const int* d_end_offsets)
 {
-  constexpr bool sort_pairs = !::cuda::std::is_same<ValueT, cub::NullType>::value;
+  constexpr bool sort_pairs = !::cuda::std::is_same_v<ValueT, cub::NullType>;
 
   CAPTURE(c2h::type_name<KeyT>(), //
           c2h::type_name<ValueT>(),

--- a/cub/test/catch2_test_device_adjacent_difference_substract_left.cu
+++ b/cub/test/catch2_test_device_adjacent_difference_substract_left.cu
@@ -163,7 +163,7 @@ C2H_TEST("DeviceAdjacentDifference::SubtractLeftCopy works with pointers", "[dev
 template <class T>
 struct cust_diff
 {
-  template <class T2, cuda::std::enable_if_t<cuda::std::is_same<T, T2>::value, int> = 0>
+  template <class T2, cuda::std::enable_if_t<cuda::std::is_same_v<T, T2>, int> = 0>
   __host__ __device__ constexpr T2 operator()(const T2& lhs, const T2& rhs) const noexcept
   {
     return lhs - rhs;

--- a/cub/test/catch2_test_device_adjacent_difference_substract_right.cu
+++ b/cub/test/catch2_test_device_adjacent_difference_substract_right.cu
@@ -92,7 +92,7 @@ C2H_TEST("DeviceAdjacentDifference::SubtractRightCopy does not change the input"
 template <class T>
 struct ref_diff
 {
-  template <class T2, cuda::std::enable_if_t<cuda::std::is_same<T, T2>::value, int> = 0>
+  template <class T2, cuda::std::enable_if_t<cuda::std::is_same_v<T, T2>, int> = 0>
   __host__ __device__ constexpr T2 operator()(const T2& lhs, const T2& rhs) const noexcept
   {
     return rhs - lhs;

--- a/cub/test/catch2_test_device_bulk.cu
+++ b/cub/test/catch2_test_device_bulk.cu
@@ -52,7 +52,7 @@ struct incrementer_t
   template <class OffsetT>
   __device__ void operator()(OffsetT i)
   {
-    static_assert(cuda::std::is_same<T, OffsetT>::value, "T and OffsetT must be the same type");
+    static_assert(cuda::std::is_same_v<T, OffsetT>, "T and OffsetT must be the same type");
     atomicAdd(d_counts + i, 1); // Check if `i` was served more than once
   }
 };

--- a/cub/test/catch2_test_device_histogram.cu
+++ b/cub/test/catch2_test_device_histogram.cu
@@ -288,7 +288,7 @@ void test_even_and_range(LevelT max_level, int max_level_count, OffsetT width, O
     }
 
     auto sample_to_bin_index = [&](int channel, SampleT sample) {
-      using common_t             = typename cs::common_type<LevelT, SampleT>::type;
+      using common_t             = cs::common_type_t<LevelT, SampleT>;
       const auto n               = num_levels[channel];
       const auto max             = static_cast<common_t>(upper_level[channel]);
       const auto min             = static_cast<common_t>(lower_level[channel]);
@@ -422,7 +422,7 @@ using types =
 C2H_TEST("DeviceHistogram::Histogram* basic use", "[histogram][device]", types)
 {
   using sample_t = c2h::get<0, TestType>;
-  using level_t  = typename cs::conditional<cuda::is_floating_point_v<sample_t>, sample_t, int>::type;
+  using level_t  = cs::conditional_t<cuda::is_floating_point_v<sample_t>, sample_t, int>;
   // Max for int8/uint8 is 2^8, for half_t is 2^10. Beyond, we would need a different level generation
   const auto max_level       = level_t{sizeof(sample_t) == 1 ? 126 : 1024};
   const auto max_level_count = (sizeof(sample_t) == 1 ? 126 : 1024) + 1;
@@ -534,7 +534,7 @@ C2H_TEST("DeviceHistogram::Histogram* down-conversion size_t to int", "[histogra
 {
   _CCCL_IF_CONSTEXPR (sizeof(size_t) != sizeof(int))
   {
-    using offset_t = cs::make_signed<size_t>::type;
+    using offset_t = cs::make_signed_t<size_t>;
     test_even_and_range<unsigned char, 4, 3, int>(256, 256 + 1, offset_t{1920}, offset_t{1080});
   }
 }

--- a/cub/test/catch2_test_device_histogram.cu
+++ b/cub/test/catch2_test_device_histogram.cu
@@ -422,7 +422,7 @@ using types =
 C2H_TEST("DeviceHistogram::Histogram* basic use", "[histogram][device]", types)
 {
   using sample_t = c2h::get<0, TestType>;
-  using level_t  = typename cs::conditional<cuda::is_floating_point<sample_t>::value, sample_t, int>::type;
+  using level_t  = typename cs::conditional<cuda::is_floating_point_v<sample_t>, sample_t, int>::type;
   // Max for int8/uint8 is 2^8, for half_t is 2^10. Beyond, we would need a different level generation
   const auto max_level       = level_t{sizeof(sample_t) == 1 ? 126 : 1024};
   const auto max_level_count = (sizeof(sample_t) == 1 ? 126 : 1024) + 1;

--- a/cub/test/catch2_test_device_merge.cu
+++ b/cub/test/catch2_test_device_merge.cu
@@ -87,9 +87,8 @@ C2H_TEST("DeviceMerge::MergeKeys large key types", "[merge][device]", c2h::type_
     sizeof(key_t) * cub::detail::merge::fallback_BLOCK_THREADS * cub::detail::merge::fallback_ITEMS_PER_THREAD;
   static_assert(agent_sm > cub::detail::max_smem_per_block,
                 "key_t is not big enough to exceed SM and trigger fallback policy");
-  static_assert(
-    ::cuda::std::is_same<key_t, large_type_fallb>::value == (fallback_sm <= cub::detail::max_smem_per_block),
-    "SM consumption by fallback policy should fit into max_smem_per_block");
+  static_assert(::cuda::std::is_same_v<key_t, large_type_fallb> == (fallback_sm <= cub::detail::max_smem_per_block),
+                "SM consumption by fallback policy should fit into max_smem_per_block");
 
   test_keys<key_t, offset_t>(
     3623,

--- a/cub/test/catch2_test_device_reduce.cuh
+++ b/cub/test/catch2_test_device_reduce.cuh
@@ -227,7 +227,7 @@ thrust::constant_iterator<__nv_bfloat16, OffsetT> inline unwrap_it(thrust::const
 #endif // TEST_BF_T()
 
 template <typename T>
-using unwrap_value_t = typename std::remove_reference<decltype(*unwrap_it(std::declval<T*>()))>::type;
+using unwrap_value_t = std::remove_reference_t<decltype(*unwrap_it(std::declval<T*>()))>;
 
 template <class WrappedItT, //
           class ItT = decltype(unwrap_it(std::declval<WrappedItT>()))>

--- a/cub/test/catch2_test_device_reduce.cuh
+++ b/cub/test/catch2_test_device_reduce.cuh
@@ -231,7 +231,7 @@ using unwrap_value_t = typename std::remove_reference<decltype(*unwrap_it(std::d
 
 template <class WrappedItT, //
           class ItT = decltype(unwrap_it(std::declval<WrappedItT>()))>
-std::integral_constant<bool, !std::is_same<WrappedItT, ItT>::value> //
+std::integral_constant<bool, !std::is_same_v<WrappedItT, ItT>> //
   inline reference_extended_fp(WrappedItT)
 {
   return {};

--- a/cub/test/catch2_test_device_scan.cu
+++ b/cub/test/catch2_test_device_scan.cu
@@ -143,7 +143,7 @@ C2H_TEST("Device scan works with all device interfaces", "[scan][device]", full_
     REQUIRE(expected_result == out_result);
 
     // Run test in-place
-    _CCCL_IF_CONSTEXPR (std::is_same<input_t, output_t>::value)
+    _CCCL_IF_CONSTEXPR (std::is_same_v<input_t, output_t>)
     {
       device_inclusive_sum(d_in_it, d_in_it, num_items);
 
@@ -171,7 +171,7 @@ C2H_TEST("Device scan works with all device interfaces", "[scan][device]", full_
     REQUIRE(expected_result == out_result);
 
     // Run test in-place
-    _CCCL_IF_CONSTEXPR (std::is_same<input_t, output_t>::value)
+    _CCCL_IF_CONSTEXPR (std::is_same_v<input_t, output_t>)
     {
       device_exclusive_sum(d_in_it, d_in_it, num_items);
 
@@ -201,7 +201,7 @@ C2H_TEST("Device scan works with all device interfaces", "[scan][device]", full_
     REQUIRE(expected_result == out_result);
 
     // Run test in-place
-    _CCCL_IF_CONSTEXPR (std::is_same<input_t, output_t>::value)
+    _CCCL_IF_CONSTEXPR (std::is_same_v<input_t, output_t>)
     {
       device_inclusive_scan(unwrap_it(d_in_it), unwrap_it(d_in_it), op_t{}, num_items);
 
@@ -236,7 +236,7 @@ C2H_TEST("Device scan works with all device interfaces", "[scan][device]", full_
     REQUIRE(expected_result == out_result);
 
     // Run test in-place
-    _CCCL_IF_CONSTEXPR (std::is_same<input_t, output_t>::value)
+    _CCCL_IF_CONSTEXPR (std::is_same_v<input_t, output_t>)
     {
       device_inclusive_scan_with_init(unwrap_it(d_in_it), unwrap_it(d_in_it), scan_op, init_value, num_items);
 
@@ -269,7 +269,7 @@ C2H_TEST("Device scan works with all device interfaces", "[scan][device]", full_
     REQUIRE(expected_result == out_result);
 
     // Run test in-place
-    _CCCL_IF_CONSTEXPR (std::is_same<input_t, output_t>::value)
+    _CCCL_IF_CONSTEXPR (std::is_same_v<input_t, output_t>)
     {
       device_exclusive_scan(unwrap_it(d_in_it), unwrap_it(d_in_it), scan_op, init_t{}, num_items);
 
@@ -307,7 +307,7 @@ C2H_TEST("Device scan works with all device interfaces", "[scan][device]", full_
     REQUIRE(expected_result == out_result);
 
     // Run test in-place
-    _CCCL_IF_CONSTEXPR (std::is_same<input_t, output_t>::value)
+    _CCCL_IF_CONSTEXPR (std::is_same_v<input_t, output_t>)
     {
       device_exclusive_scan(unwrap_it(d_in_it), unwrap_it(d_in_it), scan_op, future_init_value, num_items);
 

--- a/cub/test/catch2_test_device_scan_by_key.cu
+++ b/cub/test/catch2_test_device_scan_by_key.cu
@@ -140,7 +140,7 @@ C2H_TEST("Device scan works with all device interfaces", "[by_key][scan][device]
     REQUIRE(expected_result == out_values);
 
     // Run test in-place
-    _CCCL_IF_CONSTEXPR (std::is_same<value_t, output_t>::value)
+    _CCCL_IF_CONSTEXPR (std::is_same_v<value_t, output_t>)
     {
       // Copy input values to memory allocated for output values, to ensure in_values are
       // unchanged for a (potentially) subsequent test that uses in_values as input
@@ -171,7 +171,7 @@ C2H_TEST("Device scan works with all device interfaces", "[by_key][scan][device]
     REQUIRE(expected_result == out_values);
 
     // Run test in-place
-    _CCCL_IF_CONSTEXPR (std::is_same<value_t, output_t>::value)
+    _CCCL_IF_CONSTEXPR (std::is_same_v<value_t, output_t>)
     {
       // Copy input values to memory allocated for output values, to ensure in_values are
       // unchanged for a (potentially) subsequent test that uses in_values as input
@@ -203,7 +203,7 @@ C2H_TEST("Device scan works with all device interfaces", "[by_key][scan][device]
     REQUIRE(expected_result == out_values);
 
     // Run test in-place
-    _CCCL_IF_CONSTEXPR (std::is_same<value_t, output_t>::value)
+    _CCCL_IF_CONSTEXPR (std::is_same_v<value_t, output_t>)
     {
       // Copy input values to memory allocated for output values, to ensure in_values are
       // unchanged for a (potentially) subsequent test that uses in_values as input
@@ -240,7 +240,7 @@ C2H_TEST("Device scan works with all device interfaces", "[by_key][scan][device]
     REQUIRE(expected_result == out_values);
 
     // Run test in-place
-    _CCCL_IF_CONSTEXPR (std::is_same<value_t, output_t>::value)
+    _CCCL_IF_CONSTEXPR (std::is_same_v<value_t, output_t>)
     {
       // Copy input values to memory allocated for output values, to ensure in_values are
       // unchanged for a (potentially) subsequent test that uses in_values as input

--- a/cub/test/catch2_test_device_transform.cu
+++ b/cub/test/catch2_test_device_transform.cu
@@ -538,8 +538,8 @@ struct non_trivial
     return a.data == b.data;
   }
 };
-static_assert(!::cuda::std::is_trivially_copyable<non_trivial>::value, ""); // as required by the standard
-static_assert(!thrust::is_trivially_relocatable<non_trivial>::value, ""); // CUB uses this check internally
+static_assert(!::cuda::std::is_trivially_copyable_v<non_trivial>); // as required by the standard
+static_assert(!thrust::is_trivially_relocatable_v<non_trivial>); // CUB uses this check internally
 
 // Note(bgruber): I gave up on writing a test that checks whether the copy ctor/assignment operator is actually called
 // (e.g. by tracking/counting invocations of those), since C++ allows (but not guarantees) elision of these operations.
@@ -615,6 +615,6 @@ C2H_TEST("DeviceTransform::Transform aligned_base_ptr", "[device][device_transfo
   using It         = thrust::reverse_iterator<thrust::detail::normal_iterator<thrust::device_ptr<int>>>;
   using kernel_arg = cub::detail::transform::kernel_arg<It>;
 
-  STATIC_REQUIRE(::cuda::std::is_constructible<kernel_arg>::value);
-  STATIC_REQUIRE(::cuda::std::is_copy_constructible<kernel_arg>::value);
+  STATIC_REQUIRE(::cuda::std::is_constructible_v<kernel_arg>);
+  STATIC_REQUIRE(::cuda::std::is_copy_constructible_v<kernel_arg>);
 }

--- a/cub/test/catch2_test_radix_operations.cu
+++ b/cub/test/catch2_test_radix_operations.cu
@@ -154,20 +154,20 @@ struct tuple_decomposer_t<::cuda::std::tuple<Ts...>>
 
 // clang-format off
 template <std::size_t I, class... Ts>
-typename ::cuda::std::enable_if<I == 0>::type
+::cuda::std::enable_if_t<I == 0>
 buffer_to_tpl_helper(const char *buffer, ::cuda::std::tuple<Ts...> &tpl)
 {
   constexpr std::size_t element_size =
-    sizeof(typename ::cuda::std::tuple_element<I, ::cuda::std::tuple<Ts...>>::type);
+    sizeof(::cuda::std::tuple_element_t<I, ::cuda::std::tuple<Ts...>>);
   std::memcpy(&::cuda::std::get<I>(tpl), buffer, element_size);
 }
 
 template <std::size_t I, class... Ts>
-typename ::cuda::std::enable_if <I != 0>::type
+::cuda::std::enable_if_t <I != 0>
 buffer_to_tpl_helper(const char *buffer, ::cuda::std::tuple<Ts...> &tpl)
 {
   constexpr std::size_t element_size =
-    sizeof(typename ::cuda::std::tuple_element<I, ::cuda::std::tuple<Ts...>>::type);
+    sizeof(::cuda::std::tuple_element_t<I, ::cuda::std::tuple<Ts...>>);
   std::memcpy(&::cuda::std::get<I>(tpl), buffer, element_size);
   buffer_to_tpl_helper<I - 1>(buffer + element_size, tpl);
 }
@@ -179,20 +179,20 @@ void buffer_to_tpl(const char *buffer, ::cuda::std::tuple<Ts...> &tpl)
 }
 
 template <std::size_t I, class... Ts>
-typename ::cuda::std::enable_if<I == 0>::type
+::cuda::std::enable_if_t<I == 0>
 tpl_to_buffer_helper(char *buffer, ::cuda::std::tuple<Ts...> &tpl)
 {
   constexpr std::size_t element_size =
-    sizeof(typename ::cuda::std::tuple_element<I, ::cuda::std::tuple<Ts...>>::type);
+    sizeof(::cuda::std::tuple_element_t<I, ::cuda::std::tuple<Ts...>>);
   std::memcpy(buffer, &::cuda::std::get<I>(tpl), element_size);
 }
 
 template <std::size_t I, class... Ts>
-typename ::cuda::std::enable_if <I != 0>::type
+::cuda::std::enable_if_t <I != 0>
 tpl_to_buffer_helper(char *buffer, ::cuda::std::tuple<Ts...> &tpl)
 {
   constexpr std::size_t element_size =
-    sizeof(typename ::cuda::std::tuple_element<I, ::cuda::std::tuple<Ts...>>::type);
+    sizeof(::cuda::std::tuple_element_t<I, ::cuda::std::tuple<Ts...>>);
   std::memcpy(buffer, &::cuda::std::get<I>(tpl), element_size);
   tpl_to_buffer_helper<I - 1>(buffer + element_size, tpl);
 }
@@ -204,45 +204,45 @@ void tpl_to_buffer(char *buffer, ::cuda::std::tuple<Ts...> &tpl)
 }
 
 template <std::size_t I = 0, class... Ts>
-typename ::cuda::std::enable_if<I >= sizeof...(Ts), int>::type
+::cuda::std::enable_if_t<I >= sizeof...(Ts), int>
 tpl_to_max_bits(::cuda::std::tuple<Ts...> &)
 {
   return 0;
 }
 
 template <std::size_t I = 0, class... Ts>
-typename ::cuda::std::enable_if <I < sizeof...(Ts), int>::type
+ ::cuda::std::enable_if_t <I < sizeof...(Ts), int>
 tpl_to_max_bits(::cuda::std::tuple<Ts...> &tpl)
 {
   constexpr std::size_t element_size =
-    sizeof(typename ::cuda::std::tuple_element<I, ::cuda::std::tuple<Ts...>>::type);
+    sizeof(::cuda::std::tuple_element_t<I, ::cuda::std::tuple<Ts...>>);
   return element_size * CHAR_BIT + tpl_to_max_bits<I + 1>(tpl);
 }
 
 template <std::size_t I = 0, class... Ts>
-typename ::cuda::std::enable_if<I >= sizeof...(Ts)>::type
+ ::cuda::std::enable_if_t<I >= sizeof...(Ts)>
 tpl_to_min(::cuda::std::tuple<Ts...> &)
 {}
 
 template <std::size_t I = 0, class... Ts>
-typename ::cuda::std::enable_if <I < sizeof...(Ts)>::type
+ ::cuda::std::enable_if_t <I < sizeof...(Ts)>
 tpl_to_min(::cuda::std::tuple<Ts...> &tpl)
 {
-  using T = typename ::cuda::std::tuple_element<I, ::cuda::std::tuple<Ts...>>::type;
+  using T =  ::cuda::std::tuple_element_t<I, ::cuda::std::tuple<Ts...>>;
   ::cuda::std::get<I>(tpl) = std::numeric_limits<T>::lowest();
   tpl_to_min<I + 1>(tpl);
 }
 
 template <std::size_t I = 0, class... Ts>
-typename ::cuda::std::enable_if<I >= sizeof...(Ts)>::type
+ ::cuda::std::enable_if_t<I >= sizeof...(Ts)>
 tpl_to_max(::cuda::std::tuple<Ts...> &)
 {}
 
 template <std::size_t I = 0, class... Ts>
-typename ::cuda::std::enable_if <I < sizeof...(Ts)>::type
+ ::cuda::std::enable_if_t <I < sizeof...(Ts)>
 tpl_to_max(::cuda::std::tuple<Ts...> &tpl)
 {
-  using T = typename ::cuda::std::tuple_element<I, ::cuda::std::tuple<Ts...>>::type;
+  using T =  ::cuda::std::tuple_element_t<I, ::cuda::std::tuple<Ts...>>;
   ::cuda::std::get<I>(tpl) = std::numeric_limits<T>::max();
   tpl_to_max<I + 1>(tpl);
 }
@@ -503,9 +503,9 @@ C2H_TEST("Radix operations reorder values for pair types",
          fundamental_signed_types)
 {
   using T1    = typename c2h::get<0, TestType>;
-  using UT1   = typename std::make_unsigned<T1>::type;
+  using UT1   = std::make_unsigned_t<T1>;
   using T2    = typename c2h::get<1, TestType>;
-  using UT2   = typename std::make_unsigned<T2>::type;
+  using UT2   = std::make_unsigned_t<T2>;
   using tpl_t = ::cuda::std::tuple<T1, T2>;
 
   using traits            = cub::detail::radix::traits_t<tpl_t>;

--- a/cub/test/catch2_test_util_choose_offset.cu
+++ b/cub/test/catch2_test_util_choose_offset.cu
@@ -36,28 +36,28 @@
 C2H_TEST("Tests choose_offset", "[util][type]")
 {
   // Uses unsigned 32-bit type for signed 32-bit type
-  STATIC_REQUIRE(::cuda::std::is_same<cub::detail::choose_offset_t<std::int32_t>, std::uint32_t>::value);
+  STATIC_REQUIRE(::cuda::std::is_same_v<cub::detail::choose_offset_t<std::int32_t>, std::uint32_t>);
 
   // Uses unsigned 32-bit type for type smaller than 32 bits
-  STATIC_REQUIRE(::cuda::std::is_same<cub::detail::choose_offset_t<std::int8_t>, std::uint32_t>::value);
+  STATIC_REQUIRE(::cuda::std::is_same_v<cub::detail::choose_offset_t<std::int8_t>, std::uint32_t>);
 
   // Uses unsigned 64-bit type for signed 64-bit type
-  STATIC_REQUIRE(::cuda::std::is_same<cub::detail::choose_offset_t<std::int64_t>, unsigned long long>::value);
+  STATIC_REQUIRE(::cuda::std::is_same_v<cub::detail::choose_offset_t<std::int64_t>, unsigned long long>);
 }
 
 C2H_TEST("Tests choose_signed_offset", "[util][type]")
 {
   // Uses signed 64-bit type for unsigned signed 32-bit type
-  STATIC_REQUIRE(::cuda::std::is_same<cub::detail::choose_signed_offset_t<std::uint32_t>, std::int64_t>::value);
+  STATIC_REQUIRE(::cuda::std::is_same_v<cub::detail::choose_signed_offset_t<std::uint32_t>, std::int64_t>);
 
   // Uses signed 32-bit type for signed 32-bit type
-  STATIC_REQUIRE(::cuda::std::is_same<cub::detail::choose_signed_offset_t<std::int32_t>, std::int32_t>::value);
+  STATIC_REQUIRE(::cuda::std::is_same_v<cub::detail::choose_signed_offset_t<std::int32_t>, std::int32_t>);
 
   // Uses signed 32-bit type for type smaller than 32 bits
-  STATIC_REQUIRE(::cuda::std::is_same<cub::detail::choose_signed_offset_t<std::int8_t>, std::int32_t>::value);
+  STATIC_REQUIRE(::cuda::std::is_same_v<cub::detail::choose_signed_offset_t<std::int8_t>, std::int32_t>);
 
   // Uses signed 64-bit type for signed 64-bit type
-  STATIC_REQUIRE(::cuda::std::is_same<cub::detail::choose_signed_offset_t<std::int64_t>, std::int64_t>::value);
+  STATIC_REQUIRE(::cuda::std::is_same_v<cub::detail::choose_signed_offset_t<std::int64_t>, std::int64_t>);
 
   // Offset type covers maximum number representable by a signed 32-bit integer
   REQUIRE(cudaSuccess
@@ -78,26 +78,23 @@ C2H_TEST("Tests choose_signed_offset", "[util][type]")
 C2H_TEST("Tests promote_small_offset", "[util][type]")
 {
   // Uses input type for types of at least 32 bits
-  STATIC_REQUIRE(::cuda::std::is_same<typename cub::detail::promote_small_offset_t<std::int32_t>, std::int32_t>::value);
+  STATIC_REQUIRE(::cuda::std::is_same_v<typename cub::detail::promote_small_offset_t<std::int32_t>, std::int32_t>);
 
   // Uses input type for types of at least 32 bits
-  STATIC_REQUIRE(
-    ::cuda::std::is_same<typename cub::detail::promote_small_offset_t<std::uint32_t>, std::uint32_t>::value);
+  STATIC_REQUIRE(::cuda::std::is_same_v<typename cub::detail::promote_small_offset_t<std::uint32_t>, std::uint32_t>);
 
   // Uses input type for types of at least 32 bits
-  STATIC_REQUIRE(
-    ::cuda::std::is_same<typename cub::detail::promote_small_offset_t<std::uint64_t>, std::uint64_t>::value);
+  STATIC_REQUIRE(::cuda::std::is_same_v<typename cub::detail::promote_small_offset_t<std::uint64_t>, std::uint64_t>);
 
   // Uses input type for types of at least 32 bits
-  STATIC_REQUIRE(::cuda::std::is_same<typename cub::detail::promote_small_offset_t<std::int64_t>, std::int64_t>::value);
+  STATIC_REQUIRE(::cuda::std::is_same_v<typename cub::detail::promote_small_offset_t<std::int64_t>, std::int64_t>);
 
   // Uses 32-bit type for type smaller than 32 bits
-  STATIC_REQUIRE(::cuda::std::is_same<typename cub::detail::promote_small_offset_t<std::int8_t>, std::int32_t>::value);
+  STATIC_REQUIRE(::cuda::std::is_same_v<typename cub::detail::promote_small_offset_t<std::int8_t>, std::int32_t>);
 
   // Uses 32-bit type for type smaller than 32 bits
-  STATIC_REQUIRE(::cuda::std::is_same<typename cub::detail::promote_small_offset_t<std::int16_t>, std::int32_t>::value);
+  STATIC_REQUIRE(::cuda::std::is_same_v<typename cub::detail::promote_small_offset_t<std::int16_t>, std::int32_t>);
 
   // Uses 32-bit type for type smaller than 32 bits
-  STATIC_REQUIRE(
-    ::cuda::std::is_same<typename cub::detail::promote_small_offset_t<std::uint16_t>, std::int32_t>::value);
+  STATIC_REQUIRE(::cuda::std::is_same_v<typename cub::detail::promote_small_offset_t<std::uint16_t>, std::int32_t>);
 }

--- a/cub/test/catch2_test_util_type.cu
+++ b/cub/test/catch2_test_util_type.cu
@@ -42,26 +42,26 @@ C2H_TEST("Tests non_void_value_t", "[util][type]")
   using non_void_fancy_it = thrust::counting_iterator<int>;
 
   // falls back for const void*
-  STATIC_REQUIRE(::cuda::std::is_same<fallback_t, //
-                                      cub::detail::non_void_value_t<const void*, fallback_t>>::value);
+  STATIC_REQUIRE(::cuda::std::is_same_v<fallback_t, //
+                                        cub::detail::non_void_value_t<const void*, fallback_t>>);
   // falls back for const volatile void*
-  STATIC_REQUIRE(::cuda::std::is_same<fallback_t, //
-                                      cub::detail::non_void_value_t<const volatile void*, fallback_t>>::value);
+  STATIC_REQUIRE(::cuda::std::is_same_v<fallback_t, //
+                                        cub::detail::non_void_value_t<const volatile void*, fallback_t>>);
   // falls back for volatile void*
-  STATIC_REQUIRE(::cuda::std::is_same<fallback_t, //
-                                      cub::detail::non_void_value_t<volatile void*, fallback_t>>::value);
+  STATIC_REQUIRE(::cuda::std::is_same_v<fallback_t, //
+                                        cub::detail::non_void_value_t<volatile void*, fallback_t>>);
   // falls back for void*
-  STATIC_REQUIRE(::cuda::std::is_same<fallback_t, //
-                                      cub::detail::non_void_value_t<void*, fallback_t>>::value);
+  STATIC_REQUIRE(::cuda::std::is_same_v<fallback_t, //
+                                        cub::detail::non_void_value_t<void*, fallback_t>>);
   // works for int*
-  STATIC_REQUIRE(::cuda::std::is_same<int, //
-                                      cub::detail::non_void_value_t<int*, void>>::value);
+  STATIC_REQUIRE(::cuda::std::is_same_v<int, //
+                                        cub::detail::non_void_value_t<int*, void>>);
   // falls back for fancy iterator with a void value type
-  STATIC_REQUIRE(::cuda::std::is_same<fallback_t, //
-                                      cub::detail::non_void_value_t<void_fancy_it, fallback_t>>::value);
+  STATIC_REQUIRE(::cuda::std::is_same_v<fallback_t, //
+                                        cub::detail::non_void_value_t<void_fancy_it, fallback_t>>);
   // works for a fancy iterator that has int as value type
-  STATIC_REQUIRE(::cuda::std::is_same<int, //
-                                      cub::detail::non_void_value_t<non_void_fancy_it, fallback_t>>::value);
+  STATIC_REQUIRE(::cuda::std::is_same_v<int, //
+                                        cub::detail::non_void_value_t<non_void_fancy_it, fallback_t>>);
 }
 
 CUB_DEFINE_DETECT_NESTED_TYPE(cat_detect, cat);

--- a/cub/test/catch2_test_vsmem.cu
+++ b/cub/test/catch2_test_vsmem.cu
@@ -173,10 +173,9 @@ void __global__ __launch_bounds__(
   kernel_test_info->uses_vsmem_ptr =
     (reinterpret_cast<char*>(&temp_storage)
      == (static_cast<char*>(vsmem.gmem_ptr) + (blockIdx.x * vsmem_helper_t::vsmem_per_block)));
-  kernel_test_info->uses_fallback_agent =
-    ::cuda::std::is_same<typename vsmem_helper_t::agent_t, fallback_agent_t>::value;
+  kernel_test_info->uses_fallback_agent = ::cuda::std::is_same_v<typename vsmem_helper_t::agent_t, fallback_agent_t>;
   kernel_test_info->uses_fallback_policy =
-    ::cuda::std::is_same<typename vsmem_helper_t::agent_policy_t, fallback_policy_t>::value;
+    ::cuda::std::is_same_v<typename vsmem_helper_t::agent_policy_t, fallback_policy_t>;
 
   // Instantiate the algorithm's agent
   agent_t agent(temp_storage, d_in, d_out);

--- a/cub/test/catch2_test_warp_exchange.cuh
+++ b/cub/test/catch2_test_warp_exchange.cuh
@@ -42,11 +42,7 @@ template <typename InputT, typename OutputT, int ItemsPerThread, cub::WarpExchan
 struct exchange_data_t;
 
 template <typename InputT, typename OutputT, int ItemsPerThread, cub::WarpExchangeAlgorithm Alg>
-struct exchange_data_t<InputT,
-                       OutputT,
-                       ItemsPerThread,
-                       Alg,
-                       typename std::enable_if<std::is_same<InputT, OutputT>::value>::type>
+struct exchange_data_t<InputT, OutputT, ItemsPerThread, Alg, typename std::enable_if<std::is_same_v<InputT, OutputT>>::type>
 {
   InputT input[ItemsPerThread];
   OutputT (&output)[ItemsPerThread] = input;
@@ -60,11 +56,7 @@ struct exchange_data_t<InputT,
 };
 
 template <typename InputT, typename OutputT, int ItemsPerThread, cub::WarpExchangeAlgorithm Alg>
-struct exchange_data_t<InputT,
-                       OutputT,
-                       ItemsPerThread,
-                       Alg,
-                       typename std::enable_if<!std::is_same<InputT, OutputT>::value>::type>
+struct exchange_data_t<InputT, OutputT, ItemsPerThread, Alg, typename std::enable_if<!std::is_same_v<InputT, OutputT>>::type>
 {
   InputT input[ItemsPerThread];
   OutputT output[ItemsPerThread];

--- a/cub/test/catch2_test_warp_exchange.cuh
+++ b/cub/test/catch2_test_warp_exchange.cuh
@@ -42,7 +42,7 @@ template <typename InputT, typename OutputT, int ItemsPerThread, cub::WarpExchan
 struct exchange_data_t;
 
 template <typename InputT, typename OutputT, int ItemsPerThread, cub::WarpExchangeAlgorithm Alg>
-struct exchange_data_t<InputT, OutputT, ItemsPerThread, Alg, typename std::enable_if<std::is_same_v<InputT, OutputT>>::type>
+struct exchange_data_t<InputT, OutputT, ItemsPerThread, Alg, std::enable_if_t<std::is_same_v<InputT, OutputT>>>
 {
   InputT input[ItemsPerThread];
   OutputT (&output)[ItemsPerThread] = input;
@@ -56,7 +56,7 @@ struct exchange_data_t<InputT, OutputT, ItemsPerThread, Alg, typename std::enabl
 };
 
 template <typename InputT, typename OutputT, int ItemsPerThread, cub::WarpExchangeAlgorithm Alg>
-struct exchange_data_t<InputT, OutputT, ItemsPerThread, Alg, typename std::enable_if<!std::is_same_v<InputT, OutputT>>::type>
+struct exchange_data_t<InputT, OutputT, ItemsPerThread, Alg, std::enable_if_t<!std::is_same_v<InputT, OutputT>>>
 {
   InputT input[ItemsPerThread];
   OutputT output[ItemsPerThread];

--- a/cub/test/catch2_test_warp_reduce.cu
+++ b/cub/test/catch2_test_warp_reduce.cu
@@ -204,7 +204,7 @@ void warp_reduce(c2h::device_vector<T>& in, c2h::device_vector<T>& out, ActionT 
 /**
  * @brief Compares the results returned from system under test against the expected results.
  */
-template <typename T, typename ::cuda::std::enable_if<::cuda::std::is_floating_point_v<T>, int>::type = 0>
+template <typename T, ::cuda::std::enable_if_t<::cuda::std::is_floating_point_v<T>, int> = 0>
 void verify_results(const c2h::host_vector<T>& expected_data, const c2h::device_vector<T>& test_results)
 {
   REQUIRE_APPROX_EQ(expected_data, test_results);
@@ -213,7 +213,7 @@ void verify_results(const c2h::host_vector<T>& expected_data, const c2h::device_
 /**
  * @brief Compares the results returned from system under test against the expected results.
  */
-template <typename T, typename ::cuda::std::enable_if<!::cuda::std::is_floating_point_v<T>, int>::type = 0>
+template <typename T, ::cuda::std::enable_if_t<!::cuda::std::is_floating_point_v<T>, int> = 0>
 void verify_results(const c2h::host_vector<T>& expected_data, const c2h::device_vector<T>& test_results)
 {
   REQUIRE(expected_data == test_results);

--- a/cub/test/catch2_test_warp_reduce.cu
+++ b/cub/test/catch2_test_warp_reduce.cu
@@ -204,7 +204,7 @@ void warp_reduce(c2h::device_vector<T>& in, c2h::device_vector<T>& out, ActionT 
 /**
  * @brief Compares the results returned from system under test against the expected results.
  */
-template <typename T, typename ::cuda::std::enable_if<::cuda::std::is_floating_point<T>::value, int>::type = 0>
+template <typename T, typename ::cuda::std::enable_if<::cuda::std::is_floating_point_v<T>, int>::type = 0>
 void verify_results(const c2h::host_vector<T>& expected_data, const c2h::device_vector<T>& test_results)
 {
   REQUIRE_APPROX_EQ(expected_data, test_results);
@@ -213,7 +213,7 @@ void verify_results(const c2h::host_vector<T>& expected_data, const c2h::device_
 /**
  * @brief Compares the results returned from system under test against the expected results.
  */
-template <typename T, typename ::cuda::std::enable_if<!::cuda::std::is_floating_point<T>::value, int>::type = 0>
+template <typename T, typename ::cuda::std::enable_if<!::cuda::std::is_floating_point_v<T>, int>::type = 0>
 void verify_results(const c2h::host_vector<T>& expected_data, const c2h::device_vector<T>& test_results)
 {
   REQUIRE(expected_data == test_results);

--- a/cub/test/internal/catch2_test_fast_div_mod.cu
+++ b/cub/test/internal/catch2_test_fast_div_mod.cu
@@ -58,7 +58,7 @@ C2H_TEST("FastDivMod random", "[FastDivMod][Random]", index_types)
   auto divisor             = GENERATE_COPY(take(20, random(+index_type{1}, max_value)));
   fast_div_mod<index_type> div_mod(static_cast<index_type>(divisor));
   CAPTURE(c2h::type_name<index_type>(), dividend, divisor);
-  static_assert(std::is_same<decltype(dividend / divisor), decltype(div_mod(dividend).quotient)>::value,
+  static_assert(std::is_same_v<decltype(dividend / divisor), decltype(div_mod(dividend).quotient)>,
                 "quotient type mismatch");
   REQUIRE(dividend / divisor == div_mod(dividend).quotient);
   REQUIRE(dividend % divisor == div_mod(dividend).remainder);

--- a/cub/test/test_device_batch_copy.cu
+++ b/cub/test/test_device_batch_copy.cu
@@ -55,10 +55,10 @@ template <typename T>
 void GenerateRandomData(
   T* rand_out,
   const std::size_t num_items,
-  const T min_rand_val                                                      = std::numeric_limits<T>::min(),
-  const T max_rand_val                                                      = std::numeric_limits<T>::max(),
-  const std::uint_fast32_t seed                                             = 320981U,
-  typename std::enable_if<std::is_integral_v<T> && (sizeof(T) >= 2)>::type* = nullptr)
+  const T min_rand_val                                         = std::numeric_limits<T>::min(),
+  const T max_rand_val                                         = std::numeric_limits<T>::max(),
+  const std::uint_fast32_t seed                                = 320981U,
+  std::enable_if_t<std::is_integral_v<T> && (sizeof(T) >= 2)>* = nullptr)
 {
   // initialize random number generator
   std::mt19937 rng(seed);
@@ -114,12 +114,12 @@ GetShuffledRangeOffsets(const c2h::host_vector<RangeSizeT>& range_sizes, const s
 }
 
 template <size_t n, typename... T>
-typename std::enable_if<n >= thrust::tuple_size<thrust::tuple<T...>>::value>::type
+std::enable_if_t<n >= thrust::tuple_size<thrust::tuple<T...>>::value>
 print_tuple(std::ostream&, const thrust::tuple<T...>&)
 {}
 
 template <size_t n, typename... T>
-typename std::enable_if<n + 1 <= thrust::tuple_size<thrust::tuple<T...>>::value>::type
+std::enable_if_t<n + 1 <= thrust::tuple_size<thrust::tuple<T...>>::value>
 print_tuple(std::ostream& os, const thrust::tuple<T...>& tup)
 {
   _CCCL_IF_CONSTEXPR (n != 0)

--- a/cub/test/test_device_batch_copy.cu
+++ b/cub/test/test_device_batch_copy.cu
@@ -55,10 +55,10 @@ template <typename T>
 void GenerateRandomData(
   T* rand_out,
   const std::size_t num_items,
-  const T min_rand_val                                                           = std::numeric_limits<T>::min(),
-  const T max_rand_val                                                           = std::numeric_limits<T>::max(),
-  const std::uint_fast32_t seed                                                  = 320981U,
-  typename std::enable_if<std::is_integral<T>::value && (sizeof(T) >= 2)>::type* = nullptr)
+  const T min_rand_val                                                      = std::numeric_limits<T>::min(),
+  const T max_rand_val                                                      = std::numeric_limits<T>::max(),
+  const std::uint_fast32_t seed                                             = 320981U,
+  typename std::enable_if<std::is_integral_v<T> && (sizeof(T) >= 2)>::type* = nullptr)
 {
   // initialize random number generator
   std::mt19937 rng(seed);

--- a/cub/test/test_device_batch_memcpy.cu
+++ b/cub/test/test_device_batch_memcpy.cu
@@ -54,10 +54,10 @@ template <typename T>
 void GenerateRandomData(
   T* rand_out,
   const std::size_t num_items,
-  const T min_rand_val                                                      = std::numeric_limits<T>::min(),
-  const T max_rand_val                                                      = std::numeric_limits<T>::max(),
-  const std::uint_fast32_t seed                                             = 320981U,
-  typename std::enable_if<std::is_integral_v<T> && (sizeof(T) >= 2)>::type* = nullptr)
+  const T min_rand_val                                         = std::numeric_limits<T>::min(),
+  const T max_rand_val                                         = std::numeric_limits<T>::max(),
+  const std::uint_fast32_t seed                                = 320981U,
+  std::enable_if_t<std::is_integral_v<T> && (sizeof(T) >= 2)>* = nullptr)
 {
   // initialize random number generator
   std::mt19937 rng(seed);

--- a/cub/test/test_device_batch_memcpy.cu
+++ b/cub/test/test_device_batch_memcpy.cu
@@ -54,10 +54,10 @@ template <typename T>
 void GenerateRandomData(
   T* rand_out,
   const std::size_t num_items,
-  const T min_rand_val                                                           = std::numeric_limits<T>::min(),
-  const T max_rand_val                                                           = std::numeric_limits<T>::max(),
-  const std::uint_fast32_t seed                                                  = 320981U,
-  typename std::enable_if<std::is_integral<T>::value && (sizeof(T) >= 2)>::type* = nullptr)
+  const T min_rand_val                                                      = std::numeric_limits<T>::min(),
+  const T max_rand_val                                                      = std::numeric_limits<T>::max(),
+  const std::uint_fast32_t seed                                             = 320981U,
+  typename std::enable_if<std::is_integral_v<T> && (sizeof(T) >= 2)>::type* = nullptr)
 {
   // initialize random number generator
   std::mt19937 rng(seed);

--- a/cub/test/thread_reduce/catch2_test_thread_reduce.cu
+++ b/cub/test/thread_reduce/catch2_test_thread_reduce.cu
@@ -279,14 +279,14 @@ using cub_operator_fp_list =
  **********************************************************************************************************************/
 
 _CCCL_TEMPLATE(typename T)
-_CCCL_REQUIRES((::cuda::std::is_floating_point<T>::value))
+_CCCL_REQUIRES((::cuda::std::is_floating_point_v<T>) )
 void verify_results(const T& expected_data, const T& test_results)
 {
   REQUIRE_THAT(expected_data, Catch::Matchers::WithinRel(test_results, T{0.05}));
 }
 
 _CCCL_TEMPLATE(typename T)
-_CCCL_REQUIRES((!::cuda::std::is_floating_point<T>::value))
+_CCCL_REQUIRES((!::cuda::std::is_floating_point_v<T>) )
 void verify_results(const T& expected_data, const T& test_results)
 {
   REQUIRE(expected_data == test_results);

--- a/docs/cub/developer_overview.rst
+++ b/docs/cub/developer_overview.rst
@@ -275,8 +275,8 @@ Due to  this limitation, we can't specialize on the PTX version.
 
     template <class U = T>
     __device__ __forceinline__
-      typename std::enable_if<std::is_same<int, U>::value ||
-                              std::is_same<unsigned int, U>::value,
+      typename std::enable_if<std::is_same_v<int, U> ||
+                              std::is_same_v<unsigned int, U>,
                               T>::type
         ReduceImpl(T input,
                   int,               // valid_items


### PR DESCRIPTION
## Description

- replace value traits, e.g. `std::is_same` -> `std::is_same_v`
- replace type traits, e.g. `std::enable_if` -> `std::enable_if_t`

(same for `cuda::std` namespace)
Benefits in readability and potentially in compile-time