### PR TITLE
[STF] Ensure dot_section::guard is actually movable

### DIFF
--- a/cudax/include/cuda/experimental/__stf/internal/dot.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/dot.cuh
@@ -367,10 +367,8 @@ public:
 
       // Move constructor: transfer ownership and disable the moved-from guard.
       guard(guard&& other) noexcept
-          : active(other.active)
-      {
-        other.active = false; // Prevent the moved-from object from calling section::pop()
-      }
+          : active(cuda::std::exchange(other.active, false))
+      {}
 
       // Move assignment, disable the moved-from guard
       guard& operator=(guard&& other) noexcept

--- a/cudax/include/cuda/experimental/__stf/internal/dot.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/dot.cuh
@@ -377,7 +377,8 @@ public:
       {
         if (this != &other)
         {
-          // Clean up current resource if needed.
+          // Clean up current resource if needed. We must call the pop method
+          // of the existing guard before overwriting it with a new guard.
           if (active)
           {
             section::pop();

--- a/cudax/test/stf/CMakeLists.txt
+++ b/cudax/test/stf/CMakeLists.txt
@@ -9,6 +9,7 @@ set(stf_test_sources
   dot/graph_print_to_dot.cu
   dot/sections.cu
   dot/sections_2.cu
+  dot/section_movable.cu
   dot/with_events.cu
   error_checks/ctx_mismatch.cu
   error_checks/data_interface_mismatch.cu

--- a/cudax/test/stf/dot/section_movable.cu
+++ b/cudax/test/stf/dot/section_movable.cu
@@ -10,7 +10,7 @@
 
 /**
  * @file
- * @brief Test if we can store dot sections in an optional
+ * @brief Test if dot section guards are movable and if we can them as an optional value
  */
 
 #include <cuda/experimental/stf.cuh>

--- a/cudax/test/stf/dot/section_movable.cu
+++ b/cudax/test/stf/dot/section_movable.cu
@@ -1,0 +1,47 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDASTF in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+/**
+ * @file
+ * @brief Test if we can store dot sections in an optional
+ */
+
+#include <cuda/experimental/stf.cuh>
+
+#include <optional>
+#include <vector>
+
+using namespace cuda::experimental::stf;
+
+int main()
+{
+  context ctx;
+
+  // Ensure the guard is movable
+  {
+    auto g  = ctx.dot_section("foo");
+    auto g2 = mv(g);
+  }
+
+  // Ensure the guard can be stored as an optional
+  ::std::vector<::std::optional<reserved::dot::section::guard>> nested_sections;
+
+  for (size_t depth = 0; depth < 3; depth++)
+  {
+    nested_sections.emplace_back(ctx.dot_section("foo"));
+  }
+
+  for (size_t depth = 0; depth < 3; depth++)
+  {
+    nested_sections.pop_back();
+  }
+
+  ctx.finalize();
+}


### PR DESCRIPTION
## Description

The current implementation of the dot_section::guard object used to implement ctx.dot_section(...) annotations is currently not movable, so that we cannot store the guard in an optional for example. This fixes the implementation and adds a test.

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes <!-- Link issue here -->

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
