### PR TITLE
Guard PDL by availability

### DIFF
--- a/libcudacxx/include/cuda/std/__cccl/cuda_capabilities.h
+++ b/libcudacxx/include/cuda/std/__cccl/cuda_capabilities.h
@@ -37,7 +37,7 @@
 #endif // no system header
 
 // True, when programmatic dependent launch is available, otherwise false.
-#define _CCCL_HAS_PDL 1
+#define _CCCL_HAS_PDL _CCCL_CUDACC_AT_LEAST(12, 0)
 
 #if _CCCL_HAS_PDL
 // Waits for the previous kernel to complete (when it reaches its final membar). Should be put before the first global


### PR DESCRIPTION
We removed that in an effort to drop support for 11.x but we need to keep it a bit longer in place for NVHPC SDK as that still builds with 11.8 for a while
