### PR TITLE
[STF] virtual to_string() method for STF contexts

### DIFF
--- a/cudax/include/cuda/experimental/__stf/graph/graph_ctx.cuh
+++ b/cudax/include/cuda/experimental/__stf/graph/graph_ctx.cuh
@@ -216,6 +216,11 @@ class graph_ctx : public backend_ctx<graph_ctx>
 
     ~impl() override {}
 
+    ::std::string to_string() const override
+    {
+      return "graph backend context";
+    }
+
     // Due to circular dependencies, we need to define it here, and not in backend_ctx_untyped
     void update_uncached_allocator(block_allocator_untyped custom) override
     {
@@ -289,11 +294,6 @@ public:
       : backend_ctx<graph_ctx>(::std::make_shared<impl>(g))
   {}
   ///@}
-
-  ::std::string to_string() const
-  {
-    return "graph backend context";
-  }
 
   using backend_ctx<graph_ctx>::task;
 

--- a/cudax/include/cuda/experimental/__stf/internal/backend_ctx.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/backend_ctx.cuh
@@ -605,6 +605,8 @@ protected:
       return size_t(-1);
     }
 
+    virtual ::std::string to_string() const = 0;
+
     /**
      * @brief Indicate if the backend needs to keep track of dangling events, or if these will be automatically
      * synchronized
@@ -911,6 +913,11 @@ public:
   size_t epoch() const
   {
     return pimpl->epoch();
+  }
+
+  ::std::string to_string() const
+  {
+    return pimpl->to_string();
   }
 
   bool track_dangling_events() const

--- a/cudax/include/cuda/experimental/__stf/stream/stream_ctx.cuh
+++ b/cudax/include/cuda/experimental/__stf/stream/stream_ctx.cuh
@@ -221,11 +221,6 @@ public:
   // Indicate if the finalize() call should be blocking or not
   bool blocking_finalize = true;
 
-  ::std::string to_string() const
-  {
-    return "stream backend context";
-  }
-
   using backend_ctx<stream_ctx>::task;
 
   /**
@@ -693,6 +688,11 @@ private:
       auto e = reserved::record_event_in_stream(decorated_stream(stream));
       /// e->set_symbol(mv(event_symbol));
       return event_list(mv(e));
+    }
+
+    ::std::string to_string() const override
+    {
+      return "stream backend context";
     }
 
     // We need to ensure all dangling events have been completed (eg. by having


### PR DESCRIPTION
Define the to_string() method of the context as a virtual method rather than just defining it in graph_ctx and stream_ctx. This makes it possible to access the name of the context even if we don't have its type when using type-erased contexts

## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes <!-- Link issue here -->

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
