### PR TITLE
[STF] Enable freeze on logical tokens

### DIFF
--- a/cudax/include/cuda/experimental/__stf/internal/logical_data.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/logical_data.cuh
@@ -2103,9 +2103,14 @@ reserved::logical_data_untyped_impl::get_frozen(task& fake_task, const data_plac
   // This will also update the MSI states of the logical data instances.
   reserved::fetch_data(ctx, d, id, fake_task, m, ::std::nullopt, dplace, prereqs);
 
-  // Make sure we now have a valid copy
-  assert(used_instances[int(id)].is_allocated());
-  assert(used_instances[int(id)].get_msir() != reserved::msir_state_id::invalid);
+  // Make sure we now have a valid copy (unless this is a token, because
+  // fetch_data will only enforce dependencies and will not move or allocate
+  // data)
+  if constexpr (!::std::is_same_v<T, void_interface>)
+  {
+    assert(used_instances[int(id)].is_allocated());
+    assert(used_instances[int(id)].get_msir() != reserved::msir_state_id::invalid);
+  }
 
   return ::std::pair<T, event_list>(dinterface->instance<T>(id), mv(prereqs));
 }

--- a/cudax/test/stf/CMakeLists.txt
+++ b/cudax/test/stf/CMakeLists.txt
@@ -85,6 +85,7 @@ set(stf_test_codegen_sources
   freeze/freeze.cu
   freeze/freeze_rw.cu
   freeze/task_fence.cu
+  freeze/token.cu
   graph/epoch.cu
   graph/for_each_batched.cu
   graph/for_each_batched_write.cu

--- a/cudax/test/stf/freeze/token.cu
+++ b/cudax/test/stf/freeze/token.cu
@@ -15,8 +15,7 @@
  *
  */
 
-#include <cuda/experimental/__stf/graph/graph_ctx.cuh>
-#include <cuda/experimental/__stf/stream/stream_ctx.cuh>
+#include <cuda/experimental/stf.cuh>
 
 using namespace cuda::experimental::stf;
 

--- a/cudax/test/stf/freeze/token.cu
+++ b/cudax/test/stf/freeze/token.cu
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDASTF in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+/**
+ * @file
+ *
+ * @brief Freeze token
+ *
+ */
+
+#include <cuda/experimental/__stf/graph/graph_ctx.cuh>
+#include <cuda/experimental/__stf/stream/stream_ctx.cuh>
+
+using namespace cuda::experimental::stf;
+
+int main()
+{
+  context ctx;
+
+  auto ltoken = ctx.logical_token();
+
+  auto ftoken = ctx.freeze(ltoken);
+
+  cudaStream_t stream = ctx.pick_stream();
+  // This makes any future operations in this CUDA stream depend on the
+  // availability of the token
+  [[maybe_unused]] auto dtoken = ftoken.get(data_place::current_device(), stream);
+  ftoken.unfreeze(stream);
+
+  ctx.finalize();
+}


### PR DESCRIPTION
## Description
The freeze mechanism allow to access data outside tasks in an asynchronous way. Logical tokens are specific types of logical data with no data associated, so we need to adapt how we manipulate them in the freeze mechanism to take into account the fact that there is no data to fetch/allocate.

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes <!-- Link issue here -->

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
