### PR TITLE
fix `-Werror=unused-result`

### DIFF
--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.container/empty.array.fail.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.container/empty.array.fail.cpp
@@ -11,10 +11,10 @@
 // <cuda/std/iterator>
 // template <class T, size_t N> constexpr bool empty(const T (&array)[N]) noexcept;
 
-// UNSUPPORTED: c++17
 // UNSUPPORTED: clang-3.3, clang-3.4, clang-3.5, clang-3.6, clang-3.7, clang-3.8
-// nvrtc will not generate warnings/failures on nodiscard attribute
+// nvrtc and nvhpc will not generate warnings/failures on nodiscard attribute
 // UNSUPPORTED: nvrtc
+// UNSUPPORTED: nvhpc
 
 #include <cuda/std/iterator>
 

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.container/empty.container.fail.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.container/empty.container.fail.cpp
@@ -11,10 +11,10 @@
 // <cuda/std/iterator>
 // template <class C> constexpr auto empty(const C& c) -> decltype(c.empty());
 
-// UNSUPPORTED: c++17
 // UNSUPPORTED: clang-3.3, clang-3.4, clang-3.5, clang-3.6, clang-3.7, clang-3.8
-// nvrtc will not generate warnings/failures on nodiscard attribute
+// nvrtc and nvhpc will not generate warnings/failures on nodiscard attribute
 // UNSUPPORTED: nvrtc
+// UNSUPPORTED: nvhpc
 
 #include <cuda/std/array>
 #include <cuda/std/iterator>

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.container/empty.initializer_list.fail.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.container/empty.initializer_list.fail.cpp
@@ -11,7 +11,6 @@
 // <cuda/std/iterator>
 // template <class E> constexpr bool empty(initializer_list<E> il) noexcept;
 
-// UNSUPPORTED: c++17
 // UNSUPPORTED: clang-3.3, clang-3.4, clang-3.5, clang-3.6, clang-3.7, clang-3.8
 // nvrtc will not generate warnings/failures on nodiscard attribute
 // UNSUPPORTED: nvrtc

--- a/libcudacxx/test/utils/libcudacxx/test/executor.py
+++ b/libcudacxx/test/utils/libcudacxx/test/executor.py
@@ -49,7 +49,7 @@ class NoopExecutor(Executor):
         super(NoopExecutor, self).__init__()
 
     def run(self, exe_path, cmd=None, work_dir=".", file_deps=None, env=None):
-        return (cmd, "", "", 0)
+        return (cmd, "", "", 1 if (cmd and cmd.endswith("runfail.cpp")) else 0)
 
 
 class PrefixExecutor(Executor):

--- a/libcudacxx/test/utils/libcudacxx/test/executor.py
+++ b/libcudacxx/test/utils/libcudacxx/test/executor.py
@@ -49,7 +49,7 @@ class NoopExecutor(Executor):
         super(NoopExecutor, self).__init__()
 
     def run(self, exe_path, cmd=None, work_dir=".", file_deps=None, env=None):
-        return (cmd, "", "", 1 if (cmd and cmd.endswith("runfail.cpp")) else 0)
+        return (cmd, "", "", 0)
 
 
 class PrefixExecutor(Executor):

--- a/libcudacxx/test/utils/libcudacxx/test/format.py
+++ b/libcudacxx/test/utils/libcudacxx/test/format.py
@@ -269,7 +269,15 @@ class LibcxxTestFormat(object):
             # nodiscard before enabling it
             test_str_list = [b"ignoring return value", b"nodiscard", b"NODISCARD"]
             if any(test_str in contents for test_str in test_str_list):
-                test_cxx.flags += ["-Xcompiler", "-Werror=unused-result"]
+                if test_cxx.type != "nvc++":
+                    test_cxx.flags += [
+                        "-Xcompiler",
+                        "-Werror",
+                        "-Xcompiler",
+                        "-Wunused",
+                    ]
+                else:
+                    test_cxx.flags += ["-Xcompiler", "-Werror=unused-result"]
         cmd, out, err, rc = test_cxx.compile(source_path, out=os.devnull)
 
         def check_rc(rc):

--- a/libcudacxx/test/utils/libcudacxx/test/format.py
+++ b/libcudacxx/test/utils/libcudacxx/test/format.py
@@ -269,7 +269,7 @@ class LibcxxTestFormat(object):
             # nodiscard before enabling it
             test_str_list = [b"ignoring return value", b"nodiscard", b"NODISCARD"]
             if any(test_str in contents for test_str in test_str_list):
-                test_cxx.flags += ["-Werror=unused-result"]
+                test_cxx.flags += ["-Xcompiler", "-Werror=unused-result"]
         cmd, out, err, rc = test_cxx.compile(source_path, out=os.devnull)
 
         def check_rc(rc):


### PR DESCRIPTION
Partially fix https://github.com/NVIDIA/cccl/issues/3809

## Description

Fix `libcudacxx/test/utils/libcudacxx/test/format.py` by replacing `-Werror=unused-result` with `-Xcompiler -Werror=unused-result`
