### PR TITLE
Enable `cuda::std::ssize` for C++17

### DIFF
--- a/libcudacxx/include/cuda/std/__iterator/size.h
+++ b/libcudacxx/include/cuda/std/__iterator/size.h
@@ -40,7 +40,6 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr size_t size(const _Tp (&)[_Sz]) noexcept
   return _Sz;
 }
 
-#if _CCCL_STD_VER > 2017
 _CCCL_EXEC_CHECK_DISABLE
 template <class _Cont>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr auto ssize(const _Cont& __c) noexcept(
@@ -60,7 +59,6 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr ptrdiff_t ssize(const _Tp (&)[_Sz]) noexcept
   return _Sz;
 }
 _CCCL_DIAG_POP
-#endif // _CCCL_STD_VER > 2017
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.container/ssize.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.container/ssize.pass.cpp
@@ -7,8 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++17
-
 // <cuda/std/iterator>
 // template <class C> constexpr auto ssize(const C& c)
 //     -> common_type_t<ptrdiff_t, make_signed_t<decltype(c.size())>>;                    // C++20


### PR DESCRIPTION
No reason to not enable it