### PR TITLE
Drop deprecated CUB macros

### DIFF
--- a/cub/cub/thread/thread_search.cuh
+++ b/cub/cub/thread/thread_search.cuh
@@ -46,6 +46,8 @@
 #include <cub/util_namespace.cuh>
 #include <cub/util_type.cuh>
 
+#include <cuda/std/__algorithm_>
+
 #include <nv/target>
 
 CUB_NAMESPACE_BEGIN

--- a/cub/cub/util_macro.cuh
+++ b/cub/cub/util_macro.cuh
@@ -49,43 +49,6 @@
 
 CUB_NAMESPACE_BEGIN
 
-#ifndef CUB_MAX
-/// Select maximum(a, b)
-/// Deprecated since [2.8]
-#  define CUB_MAX(a, b) (((b) > (a)) ? (b) : (a))
-#endif
-
-#ifndef CUB_MIN
-/// Select minimum(a, b)
-/// Deprecated since [2.8]
-#  define CUB_MIN(a, b) (((b) < (a)) ? (b) : (a))
-#endif
-
-#ifndef CUB_QUOTIENT_FLOOR
-/// Quotient of x/y rounded down to nearest integer
-/// Deprecated since [2.8]
-#  define CUB_QUOTIENT_FLOOR(x, y) ((x) / (y))
-#endif
-
-#ifndef CUB_QUOTIENT_CEILING
-/// Quotient of x/y rounded up to nearest integer
-/// Deprecated since [2.8]
-// FIXME(bgruber): the following computation can overflow, use cuda::ceil_div instead
-#  define CUB_QUOTIENT_CEILING(x, y) (((x) + (y) - 1) / (y))
-#endif
-
-#ifndef CUB_ROUND_UP_NEAREST
-/// x rounded up to the nearest multiple of y
-/// Deprecated since [2.8]
-#  define CUB_ROUND_UP_NEAREST(x, y) (CUB_QUOTIENT_CEILING(x, y) * y)
-#endif
-
-#ifndef CUB_ROUND_DOWN_NEAREST
-/// x rounded down to the nearest multiple of y
-/// Deprecated since [2.8]
-#  define CUB_ROUND_DOWN_NEAREST(x, y) (((x) / (y)) * y)
-#endif
-
 #ifndef CUB_DETAIL_KERNEL_ATTRIBUTES
 #  define CUB_DETAIL_KERNEL_ATTRIBUTES CCCL_DETAIL_KERNEL_ATTRIBUTES
 #endif

--- a/cub/cub/warp/specializations/warp_scan_shfl.cuh
+++ b/cub/cub/warp/specializations/warp_scan_shfl.cuh
@@ -49,6 +49,7 @@
 #include <cub/util_type.cuh>
 
 #include <cuda/ptx>
+#include <cuda/std/__algorithm_>
 
 CUB_NAMESPACE_BEGIN
 namespace detail


### PR DESCRIPTION
Split out of #3748, since it causes SASS changes in at least `cub.bench.copy.memcpy.base`. Several split-off PRs proposed sub-parts, accompanied by SASS diffs and benchmarks. The remainder of this PR is now only the removal of the unused macros (and the addition of a few missing includes).