### PR TITLE
CI summary fix

### DIFF
--- a/.github/actions/workflow-results/prepare-execution-summary.py
+++ b/.github/actions/workflow-results/prepare-execution-summary.py
@@ -69,7 +69,7 @@ def update_summary_entry(entry, job, job_times=None):
     else:
         entry["failed"] += 1
 
-    if job_times:
+    if job_times and job["id"] in job_times:
         time_info = job_times[job["id"]]
         job_time = time_info["job_seconds"]
         command_time = time_info["command_seconds"]

--- a/.github/actions/workflow-results/prepare-execution-summary.py
+++ b/.github/actions/workflow-results/prepare-execution-summary.py
@@ -21,7 +21,7 @@ def natural_sort_key(key):
     # Natural sort impl (handles embedded numbers in strings, case insensitive)
     return [
         (int(text) if text.isdigit() else text.lower())
-        for text in re.split("(\d+)", key)
+        for text in re.split("(\\d+)", key)
     ]
 
 


### PR DESCRIPTION
Noticed some issues in the CI summaries for the nightlies. This fixes a regex and handles the case where a dependent job's prerequisite job failed to run.