### PR TITLE
Add support for single item per thread calls to block_scan.exclusive_scan

### DIFF
--- a/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_scan.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_scan.py
@@ -1,6 +1,8 @@
-# Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from typing import Callable, Literal, Type
 
 import numba
 
@@ -10,79 +12,158 @@ from cuda.cooperative.experimental._types import (
     Dependency,
     DependentArray,
     DependentOperator,
+    DependentReference,
     Invocable,
     Pointer,
     TemplateParameter,
 )
 
+CUB_BLOCK_SCAN_ALGOS = {
+    "raking": "::cub::BlockScanAlgorithm::BLOCK_SCAN_RAKING",
+    "raking_memoize": "::cub::BlockScanAlgorithm::BLOCK_SCAN_RAKING_MEMOIZE",
+    "warp_scans": "::cub::BlockScanAlgorithm::BLOCK_SCAN_WARP_SCANS",
+}
 
-def exclusive_sum(dtype, threads_in_block, items_per_thread, prefix_op=None):
-    """Computes an exclusive block-wide prefix sum using addition (+) as the scan operator.
-    Each thread contributes an array of consecutive input elements.
-    The value of 0 is applied as the initial value, and is assigned to first output element in *thread*\ :sub:`0`.
 
-    Example:
-        The code snippet below illustrates an exclusive prefix sum of 512 integer items that
-        are partitioned in a :ref:`blocked arrangement <flexible-data-arrangement>` across 128 threads
-        where each thread owns 4 consecutive items.
+def _scan(
+    dtype: Type[numba.types.Number],
+    threads_in_block: int,
+    items_per_thread: int = 1,
+    mode: Literal["exclusive"] = "exclusive",
+    scan_op: Literal["+"] = "+",
+    block_prefix_callback_op: Callable = None,
+    algorithm: Literal["raking", "raking_memoize", "warp_scans"] = "raking",
+) -> Callable:
+    if algorithm not in CUB_BLOCK_SCAN_ALGOS:
+        raise ValueError(f"Unsupported algorithm: {algorithm}")
 
-        .. literalinclude:: ../../python/cuda_cooperative/tests/test_block_scan_api.py
-            :language: python
-            :dedent:
-            :start-after: example-begin imports
-            :end-before: example-end imports
+    if items_per_thread < 1:
+        raise ValueError("items_per_thread must be greater than or equal to 1")
 
-        Below is the code snippet that demonstrates the usage of the ``exclusive_sum`` API:
+    if mode != "exclusive":
+        raise ValueError(f"Unsupported mode: {mode}")
 
-        .. literalinclude:: ../../python/cuda_cooperative/tests/test_block_scan_api.py
-            :language: python
-            :dedent:
-            :start-after: example-begin exclusive-sum
-            :end-before: example-end exclusive-sum
+    specialization_kwds = {
+        "T": dtype,
+        "BLOCK_DIM_X": threads_in_block,
+        "ALGORITHM": CUB_BLOCK_SCAN_ALGOS[algorithm],
+    }
 
-        Suppose the set of input ``thread_data`` across the block of threads is
-        ``{ [1, 1, 1, 1], [1, 1, 1, 1], ..., [1, 1, 1, 1] }``.
-        The corresponding output ``thread_data`` in those threads will be
-        ``{ [0, 1, 2, 3], [4, 5, 6, 7], ..., [508, 509, 510, 511] }``.
+    template_parameters = [
+        TemplateParameter("T"),
+        TemplateParameter("BLOCK_DIM_X"),
+        TemplateParameter("ALGORITHM"),
+    ]
 
-    Args:
-        dtype: Data type being scanned
-        threads_in_block: The number of threads in a block
-        items_per_thread: The number of items each thread owns
+    fake_return = False
 
-    Returns:
-        A callable object that can be linked to and invoked from a CUDA kernel
-    """
+    if scan_op != "+":
+        raise ValueError(f"Unsupported scan_op: {scan_op}")
+    else:
+        if items_per_thread == 1:
+            parameters = [
+                # Signature:
+                # void BlockScan<T, BLOCK_DIM_X, ALGORITHM>(
+                #     temp_storage
+                # ).<Inclusive|Exclusive>Sum(
+                #     T, # input
+                #     T& # output
+                # )
+                [
+                    # temp_storage
+                    Pointer(numba.uint8),
+                    # T input
+                    DependentReference(Dependency("T")),
+                    # T& output
+                    DependentReference(Dependency("T"), is_output=True),
+                ],
+                # Signature:
+                # void BlockScan<T, BLOCK_DIM_X, ALGORITHM>(
+                #     temp_storage
+                # ).<Inclusive|Exclusive>Sum(
+                #     T,                     # input
+                #     T&,                    # output
+                #     BlockPrefixCallbackOp& # block_prefix_callback_op
+                # )
+                [
+                    # temp_storage
+                    Pointer(numba.uint8),
+                    # T input
+                    DependentReference(Dependency("T")),
+                    # T& output
+                    DependentReference(Dependency("T"), is_output=True),
+                    # BlockPrefixCallbackOp& block_prefix_callback_op
+                    DependentOperator(
+                        Dependency("T"),
+                        [Dependency("T")],
+                        Dependency("BlockPrefixCallbackOp"),
+                    ),
+                ],
+            ]
+
+            fake_return = True
+
+        else:
+            assert items_per_thread > 1, items_per_thread
+
+            parameters = [
+                # Signature:
+                # void BlockScan<T, BLOCK_DIM_X, ITEMS_PER_THREAD, ALGORITHM>(
+                #     temp_storage
+                # ).<Inclusive|Exclusive>Sum(
+                #     T (&)[ITEMS_PER_THREAD], # input
+                #     T (&)[ITEMS_PER_THREAD]  # output
+                # )
+                [
+                    # temp_storage
+                    Pointer(numba.uint8),
+                    # T (&)[ITEMS_PER_THREAD] input
+                    DependentArray(Dependency("T"), Dependency("ITEMS_PER_THREAD")),
+                    # T (&)[ITEMS_PER_THREAD] output
+                    DependentArray(Dependency("T"), Dependency("ITEMS_PER_THREAD")),
+                ],
+                # Signature:
+                # void BlockScan<T, BLOCK_DIM_X, ITEMS_PER_THREAD, ALGORITHM>(
+                #     temp_storage
+                # ).<Inclusive|Exclusive>Sum(
+                #     T (&)[ITEMS_PER_THREAD], # input
+                #     T (&)[ITEMS_PER_THREAD], # output
+                #     BlockPrefixCallbackOp&   # block_prefix_callback_op
+                # )
+                [
+                    # temp_storage
+                    Pointer(numba.uint8),
+                    # T (&)[ITEMS_PER_THREAD] input
+                    DependentArray(Dependency("T"), Dependency("ITEMS_PER_THREAD")),
+                    # T (&)[ITEMS_PER_THREAD] output
+                    DependentArray(Dependency("T"), Dependency("ITEMS_PER_THREAD")),
+                    # BlockPrefixCallbackOp& block_prefix_callback_op
+                    DependentOperator(
+                        Dependency("T"),
+                        [Dependency("T")],
+                        Dependency("BlockPrefixCallbackOp"),
+                    ),
+                ],
+            ]
+
+            specialization_kwds["ITEMS_PER_THREAD"] = items_per_thread
+
+            template_parameters.append(TemplateParameter("ITEMS_PER_THREAD"))
+
     template = Algorithm(
         "BlockScan",
         "ExclusiveSum",
         "block_scan",
         ["cub/block/block_scan.cuh"],
-        [TemplateParameter("T"), TemplateParameter("BLOCK_DIM_X")],
-        [
-            [
-                Pointer(numba.uint8),
-                DependentArray(Dependency("T"), Dependency("ITEMS_PER_THREAD")),
-                DependentArray(Dependency("T"), Dependency("ITEMS_PER_THREAD")),
-                DependentOperator(
-                    Dependency("T"), [Dependency("T")], Dependency("PrefixOp")
-                ),
-            ],
-            [
-                Pointer(numba.uint8),
-                DependentArray(Dependency("T"), Dependency("ITEMS_PER_THREAD")),
-                DependentArray(Dependency("T"), Dependency("ITEMS_PER_THREAD")),
-            ],
-        ],
+        template_parameters,
+        parameters,
+        fake_return=fake_return,
     )
-    specialization = template.specialize(
-        {
-            "T": dtype,
-            "BLOCK_DIM_X": threads_in_block,
-            "ITEMS_PER_THREAD": items_per_thread,
-            "PrefixOp": prefix_op,
-        }
-    )
+
+    if block_prefix_callback_op is not None:
+        specialization_kwds["BlockPrefixCallbackOp"] = block_prefix_callback_op
+
+    specialization = template.specialize(specialization_kwds)
     return Invocable(
         temp_files=[
             make_binary_tempfile(ltoir, ".ltoir")
@@ -90,4 +171,25 @@ def exclusive_sum(dtype, threads_in_block, items_per_thread, prefix_op=None):
         ],
         temp_storage_bytes=specialization.get_temp_storage_bytes(),
         algorithm=specialization,
+    )
+
+
+def exclusive_sum(
+    dtype: Type[numba.types.Number],
+    threads_in_block: int,
+    items_per_thread: int = 1,
+    prefix_op: Callable = None,
+    algorithm: Literal["raking", "raking_memoize", "warp_scans"] = "raking",
+) -> Callable:
+    """
+    Computes an exclusive block-wide prefix sum.
+    """
+    return _scan(
+        dtype=dtype,
+        threads_in_block=threads_in_block,
+        items_per_thread=items_per_thread,
+        mode="exclusive",
+        scan_op="+",
+        block_prefix_callback_op=prefix_op,
+        algorithm=algorithm,
     )

--- a/python/cuda_cooperative/tests/test_block_scan_api.py
+++ b/python/cuda_cooperative/tests/test_block_scan_api.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
@@ -19,11 +19,11 @@ patch.patch_numba_linker(lto=True)
 def test_block_exclusive_sum():
     # example-begin exclusive-sum
     items_per_thread = 4
-    threads_per_block = 128
+    threads_in_block = 128
 
     # Specialize exclusive sum for a 1D block of 128 threads owning 4 integer items each
     block_exclusive_sum = cudax.block.exclusive_sum(
-        numba.int32, threads_per_block, items_per_thread
+        numba.int32, threads_in_block, items_per_thread
     )
 
     # Link the exclusive sum to a CUDA kernel
@@ -43,11 +43,42 @@ def test_block_exclusive_sum():
 
     # example-end exclusive-sum
 
-    tile_size = threads_per_block * items_per_thread
+    tile_size = threads_in_block * items_per_thread
 
     h_keys = np.ones(tile_size, dtype=np.int32)
     d_keys = cuda.to_device(h_keys)
-    kernel[1, threads_per_block](d_keys)
+    kernel[1, threads_in_block](d_keys)
+    h_keys = d_keys.copy_to_host()
+    for i in range(tile_size):
+        assert h_keys[i] == i
+
+
+def test_block_exclusive_sum_single_input_per_thread():
+    # example-begin exclusive-sum-single-input-per-thread
+    threads_in_block = 128
+
+    # Specialize exclusive sum for a 1D block of 128 threads.  Each thread
+    # owns a single integer item.
+    block_exclusive_sum = cudax.block.exclusive_sum(numba.int32, threads_in_block)
+
+    # Link the exclusive sum to a CUDA kernel
+    @cuda.jit(link=block_exclusive_sum.files)
+    def kernel(data):
+        thread_data = 1
+
+        # Collectively compute the block-wide exclusive prefix sum.
+        result = block_exclusive_sum(thread_data)
+
+        # Copy the result back to the output.
+        data[cuda.threadIdx.x] = result
+
+    # example-end exclusive-sum-single-input-per-thread
+
+    tile_size = threads_in_block
+
+    h_keys = np.ones(tile_size, dtype=np.int32)
+    d_keys = cuda.to_device(h_keys)
+    kernel[1, threads_in_block](d_keys)
     h_keys = d_keys.copy_to_host()
     for i in range(tile_size):
         assert h_keys[i] == i


### PR DESCRIPTION
This PR adds explicit support for mapping `block_scan.exclusive_sum(items_per_thread=1)` calls to the CUB C++ API `BlockScan<...>::ExclusiveSum(T input, T& output, ...)` specializations (instead of the `T (&input)[ITEMS_PER_THREAD], T (&output)[ITEMS_PER_THREAD])` specializations).

Additionally, I've refactored the implementation to use a private `_scan()` function that will handle all include/exclusive sum/scan invocations in subsequent PRs. 

Reference issue is #3772.