### PR TITLE
Consider specializations of `std::iterator_traits`

### DIFF
--- a/libcudacxx/include/cuda/std/__fwd/iterator_traits.h
+++ b/libcudacxx/include/cuda/std/__fwd/iterator_traits.h
@@ -1,0 +1,36 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___FWD_ITERATOR_TRAITS_H
+#define _LIBCUDACXX___FWD_ITERATOR_TRAITS_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+_LIBCUDACXX_BEGIN_NAMESPACE_STD
+
+#if !defined(_CCCL_NO_CONCEPTS)
+template <class>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT iterator_traits;
+#else // ^^^ !_CCCL_NO_CONCEPTS ^^^ / vvv _CCCL_NO_CONCEPTS
+template <class, class = void>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT iterator_traits;
+#endif // _CCCL_NO_CONCEPTS
+
+_LIBCUDACXX_END_NAMESPACE_STD
+
+#endif // _LIBCUDACXX___FWD_ITERATOR_TRAITS_H

--- a/libcudacxx/include/cuda/std/__iterator/incrementable_traits.h
+++ b/libcudacxx/include/cuda/std/__iterator/incrementable_traits.h
@@ -82,9 +82,7 @@ struct incrementable_traits<_Tp>
 // generated from the primary template, and `iterator_traits<RI>::difference_type` otherwise.
 template <class _Ip>
 using iter_difference_t =
-  typename conditional_t<__is_primary_template<iterator_traits<remove_cvref_t<_Ip>>>::value,
-                         incrementable_traits<remove_cvref_t<_Ip>>,
-                         iterator_traits<remove_cvref_t<_Ip>>>::difference_type;
+  typename __select_traits<remove_cvref_t<_Ip>, incrementable_traits<remove_cvref_t<_Ip>>>::difference_type;
 
 #else // ^^^ !_CCCL_NO_CONCEPTS ^^^ / vvv _CCCL_NO_CONCEPTS vvv
 
@@ -141,9 +139,7 @@ struct incrementable_traits<_Tp,
 // generated from the primary template, and `iterator_traits<RI>::difference_type` otherwise.
 template <class _Ip>
 using iter_difference_t =
-  typename conditional_t<__is_primary_template<iterator_traits<remove_cvref_t<_Ip>>>::value,
-                         incrementable_traits<remove_cvref_t<_Ip>>,
-                         iterator_traits<remove_cvref_t<_Ip>>>::difference_type;
+  typename __select_traits<remove_cvref_t<_Ip>, incrementable_traits<remove_cvref_t<_Ip>>>::difference_type;
 
 #endif // _CCCL_NO_CONCEPTS
 

--- a/libcudacxx/include/cuda/std/__iterator/incrementable_traits.h
+++ b/libcudacxx/include/cuda/std/__iterator/incrementable_traits.h
@@ -23,6 +23,7 @@
 
 #include <cuda/std/__concepts/arithmetic.h>
 #include <cuda/std/__concepts/same_as.h>
+#include <cuda/std/__fwd/iterator_traits.h>
 #include <cuda/std/__type_traits/conditional.h>
 #include <cuda/std/__type_traits/enable_if.h>
 #include <cuda/std/__type_traits/is_const.h>
@@ -75,9 +76,6 @@ struct incrementable_traits<_Tp>
 {
   using difference_type = make_signed_t<decltype(declval<_Tp>() - declval<_Tp>())>;
 };
-
-template <class>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT iterator_traits;
 
 // Let `RI` be `remove_cvref_t<I>`. The type `iter_difference_t<I>` denotes
 // `incrementable_traits<RI>::difference_type` if `iterator_traits<RI>` names a specialization
@@ -137,9 +135,6 @@ struct incrementable_traits<_Tp,
 {
   using difference_type = make_signed_t<decltype(declval<_Tp>() - declval<_Tp>())>;
 };
-
-template <class, class = void>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT iterator_traits;
 
 // Let `RI` be `remove_cvref_t<I>`. The type `iter_difference_t<I>` denotes
 // `incrementable_traits<RI>::difference_type` if `iterator_traits<RI>` names a specialization

--- a/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
+++ b/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
@@ -216,7 +216,7 @@ _LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(_Iter, __priority_tag<1>) ->
   typename _ITER_TRAITS<_Iter>::iterator_category;
 template <class _Iter>
 _LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(_Iter, __priority_tag<0>)
-  -> enable_if_t<__is_primary_template<iterator_traits<_Iter>>::value, random_access_iterator_tag>;
+  -> enable_if_t<__is_primary_cccl_template<iterator_traits<_Iter>>::value, random_access_iterator_tag>;
 
 template <class _Iter>
 using __iter_concept_t = decltype(_CUDA_VSTD::__iter_concept_fn<_Iter>(declval<_Iter>(), __priority_tag<3>{}));

--- a/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
+++ b/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
@@ -28,6 +28,7 @@
 #include <cuda/std/__concepts/equality_comparable.h>
 #include <cuda/std/__concepts/same_as.h>
 #include <cuda/std/__concepts/totally_ordered.h>
+#include <cuda/std/__fwd/iterator_traits.h>
 #include <cuda/std/__fwd/pair.h>
 #include <cuda/std/__iterator/incrementable_traits.h>
 #include <cuda/std/__iterator/readable_traits.h>
@@ -89,9 +90,6 @@ concept __dereferenceable = requires(_Tp& __t) {
 template <__dereferenceable _Tp>
 using iter_reference_t = decltype(*declval<_Tp&>());
 
-template <class>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT iterator_traits;
-
 #else // ^^^ _CCCL_NO_CONCEPTS ^^^ // vvv !_CCCL_NO_CONCEPTS vvv
 
 template <class _Tp>
@@ -116,8 +114,6 @@ _CCCL_CONCEPT __dereferenceable = _CCCL_FRAGMENT(__dereferenceable_, _Tp);
 template <class _Tp>
 using iter_reference_t = enable_if_t<__dereferenceable<_Tp>, decltype(*declval<_Tp&>())>;
 
-template <class, class>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT iterator_traits;
 #endif // !_CCCL_NO_CONCEPTS
 
 #if _CCCL_COMPILER(NVRTC)

--- a/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
+++ b/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
@@ -517,7 +517,7 @@ struct __iterator_traits<_Ip>
 template <class _Ip>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT iterator_traits : __iterator_traits<_Ip>
 {
-  using __primary_template = iterator_traits;
+  using __cccl_primary_template = iterator_traits;
 };
 
 #else // ^^^ !_CCCL_NO_CONCEPTS ^^^ / vvv _CCCL_NO_CONCEPTS vvv
@@ -797,7 +797,7 @@ struct __iterator_traits<_Ip,
 template <class _Ip, class>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT iterator_traits : __iterator_traits<_Ip>
 {
-  using __primary_template = iterator_traits;
+  using __cccl_primary_template = iterator_traits;
 };
 
 #endif // !_CCCL_NO_CONCEPTS

--- a/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
+++ b/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
@@ -156,7 +156,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT contiguous_iterator_tag : public random_acc
 template <class _Iter>
 struct __iter_traits_cache
 {
-  using type = _If<__is_primary_template<iterator_traits<_Iter>>::value, _Iter, iterator_traits<_Iter>>;
+  using type = __select_traits<remove_cvref_t<_Iter>, remove_cvref_t<_Iter>>;
 };
 template <class _Iter>
 using _ITER_TRAITS = typename __iter_traits_cache<_Iter>::type;

--- a/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
+++ b/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
@@ -236,24 +236,6 @@ template <class _Iter>
 using _ITER_CONCEPT = typename __iter_concept_cache<_Iter>::type;
 
 template <class _Tp>
-struct __has_iterator_typedefs
-{
-private:
-  template <class _Up>
-  _LIBCUDACXX_HIDE_FROM_ABI static false_type __test(...);
-  template <class _Up>
-  _LIBCUDACXX_HIDE_FROM_ABI static true_type
-  __test(void_t<typename _Up::iterator_category>* = nullptr,
-         void_t<typename _Up::difference_type>*   = nullptr,
-         void_t<typename _Up::value_type>*        = nullptr,
-         void_t<typename _Up::reference>*         = nullptr,
-         void_t<typename _Up::pointer>*           = nullptr);
-
-public:
-  static const bool value = decltype(__test<_Tp>(0, 0, 0, 0, 0))::value;
-};
-
-template <class _Tp>
 struct __has_iterator_category
 {
 private:

--- a/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
+++ b/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
@@ -216,7 +216,7 @@ _LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(_Iter, __priority_tag<1>) ->
   typename _ITER_TRAITS<_Iter>::iterator_category;
 template <class _Iter>
 _LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(_Iter, __priority_tag<0>)
-  -> enable_if_t<__is_primary_cccl_template<iterator_traits<_Iter>>::value, random_access_iterator_tag>;
+  -> enable_if_t<__is_primary_cccl_template<_Iter>::value, random_access_iterator_tag>;
 
 template <class _Iter>
 using __iter_concept_t = decltype(_CUDA_VSTD::__iter_concept_fn<_Iter>(declval<_Iter>(), __priority_tag<3>{}));

--- a/libcudacxx/include/cuda/std/__iterator/readable_traits.h
+++ b/libcudacxx/include/cuda/std/__iterator/readable_traits.h
@@ -22,6 +22,7 @@
 #endif // no system header
 
 #include <cuda/std/__concepts/same_as.h>
+#include <cuda/std/__fwd/iterator_traits.h>
 #include <cuda/std/__iterator/incrementable_traits.h>
 #include <cuda/std/__type_traits/conditional.h>
 #include <cuda/std/__type_traits/enable_if.h>
@@ -93,9 +94,6 @@ template <__has_member_value_type _Tp>
         && same_as<remove_cv_t<typename _Tp::element_type>, remove_cv_t<typename _Tp::value_type>>
 struct indirectly_readable_traits<_Tp> : __cond_value_type<typename _Tp::value_type>
 {};
-
-template <class>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT iterator_traits;
 
 // Let `RI` be `remove_cvref_t<I>`. The type `iter_value_t<I>` denotes
 // `indirectly_readable_traits<RI>::value_type` if `iterator_traits<RI>` names a specialization
@@ -170,9 +168,6 @@ struct indirectly_readable_traits<
               && same_as<remove_cv_t<typename _Tp::element_type>, remove_cv_t<typename _Tp::value_type>>>>
     : __cond_value_type<typename _Tp::value_type>
 {};
-
-template <class, class>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT iterator_traits;
 
 // Let `RI` be `remove_cvref_t<I>`. The type `iter_value_t<I>` denotes
 // `indirectly_readable_traits<RI>::value_type` if `iterator_traits<RI>` names a specialization

--- a/libcudacxx/include/cuda/std/__iterator/readable_traits.h
+++ b/libcudacxx/include/cuda/std/__iterator/readable_traits.h
@@ -100,9 +100,7 @@ struct indirectly_readable_traits<_Tp> : __cond_value_type<typename _Tp::value_t
 // generated from the primary template, and `iterator_traits<RI>::value_type` otherwise.
 template <class _Ip>
 using iter_value_t =
-  typename conditional_t<__is_primary_template<iterator_traits<remove_cvref_t<_Ip>>>::value,
-                         indirectly_readable_traits<remove_cvref_t<_Ip>>,
-                         iterator_traits<remove_cvref_t<_Ip>>>::value_type;
+  typename __select_traits<remove_cvref_t<_Ip>, indirectly_readable_traits<remove_cvref_t<_Ip>>>::value_type;
 
 #else // ^^^ !_CCCL_NO_CONCEPTS ^^^ / vvv _CCCL_NO_CONCEPTS vvv
 
@@ -174,9 +172,7 @@ struct indirectly_readable_traits<
 // generated from the primary template, and `iterator_traits<RI>::value_type` otherwise.
 template <class _Ip>
 using iter_value_t =
-  typename conditional_t<__is_primary_template<iterator_traits<remove_cvref_t<_Ip>>>::value,
-                         indirectly_readable_traits<remove_cvref_t<_Ip>>,
-                         iterator_traits<remove_cvref_t<_Ip>>>::value_type;
+  typename __select_traits<remove_cvref_t<_Ip>, indirectly_readable_traits<remove_cvref_t<_Ip>>>::value_type;
 
 #endif // _CCCL_NO_CONCEPTS
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_primary_template.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_primary_template.h
@@ -20,6 +20,7 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/std/__type_traits/conditional.h>
 #include <cuda/std/__type_traits/enable_if.h>
 #include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/__type_traits/is_valid_expansion.h>
@@ -44,6 +45,10 @@ using __test_for_primary_template = enable_if_t<_IsSame<_Tp, typename _Tp::__ccc
 template <class _Tp>
 using __is_primary_template = _IsValidExpansion<__test_for_primary_template, _Tp>;
 #endif // !_CCCL_COMPILER(MSVC)
+
+template <class _Iter, class _OtherTraits>
+using __select_traits =
+  conditional_t<__is_primary_template<iterator_traits<_Iter>>::value, _OtherTraits, iterator_traits<_Iter>>;
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_primary_template.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_primary_template.h
@@ -93,16 +93,16 @@ struct __is_primary_std_template<_Iter, void_t<typename ::std::iterator_traits<_
 {};
 #  endif // _MSVC_STL_VERSION || _IS_WRS
 
-// C++17 has issues with e.g void* and other pointers.
-// C++20 fails subsumption if we use the indirection
-#  if !defined(_CCCL_NO_CONCEPTS)
+// Without ranges we need to guard against e.g void*
+// With ranges we fail subsumption if we use the indirection
+#  if defined(__cpp_lib_ranges)
 template <class _Iter, class _OtherTraits>
 using __select_traits =
   conditional_t<__is_primary_std_template<_Iter>::value,
                 conditional_t<__is_primary_cccl_template<_Iter>::value, _OtherTraits, iterator_traits<_Iter>>,
                 ::std::iterator_traits<_Iter>>;
 
-#  else // ^^^ !_CCCL_NO_CONCEPTS ^^^ / vvv _CCCL_NO_CONCEPTS vvv
+#  else // ^^^ __cpp_lib_ranges ^^^ / vvv !__cpp_lib_ranges vvv
 
 template <class _Iter, class _OtherTraits, bool = _CCCL_TRAIT(is_pointer, _Iter)>
 struct __select_traits_impl
@@ -123,7 +123,7 @@ struct __select_traits_impl<_Iter, _OtherTraits, true>
 template <class _Iter, class _OtherTraits>
 using __select_traits = typename __select_traits_impl<_Iter, _OtherTraits>::type;
 
-#  endif // _CCCL_NO_CONCEPTS
+#  endif // !__cpp_lib_ranges
 
 #endif // !_CCCL_COMPILER(NVRTC)
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_primary_template.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_primary_template.h
@@ -69,9 +69,18 @@ using __select_traits = conditional_t<__is_primary_cccl_template<_Iter>::value, 
 
 // We also need to respect what the user is defining to std::iterator_traits
 #  if defined(__GLIBCXX__)
-// libstdc++ uses `__is_base_of`
+// libstdc++ uses `is_base_of`
+template <class _Iter, bool>
+struct __is_primary_std_template_impl : is_base_of<::std::__iterator_traits<_Iter>, ::std::iterator_traits<_Iter>>
+{};
 template <class _Iter>
-struct __is_primary_std_template : is_base_of<::std::__iterator_traits<_Iter>, ::std::iterator_traits<_Iter>>
+struct __is_primary_std_template_impl<_Iter, true> : true_type
+{};
+
+// This is needed because with a defaulted template argument subsumption fails for C++20 for concepts
+// that involve incrementable_traits
+template <class _Iter>
+struct __is_primary_std_template : __is_primary_std_template_impl<_Iter, _CCCL_TRAIT(is_pointer, _Iter)>
 {};
 #  elif defined(_LIBCPP_VERSION)
 // libc++ uses the same mechanism than we do with __primary_template
@@ -81,8 +90,17 @@ template <class _Iter>
 using __is_primary_std_template = _IsValidExpansion<__test_for_primary_template, ::std::iterator_traits<_Iter>>;
 #  elif defined(_MSVC_STL_VERSION) || defined(_IS_WRS)
 // On MSVC we must check for the base class because `_From_primary` is only defined in C++20
+template <class _Iter, bool>
+struct __is_primary_std_template_impl : is_base_of<::std::_Iterator_traits_base<_Iter>, ::std::iterator_traits<_Iter>>
+{};
 template <class _Iter>
-struct __is_primary_std_template : is_base_of<::std::_Iterator_traits_base<_Iter>, ::std::iterator_traits<_Iter>>
+struct __is_primary_std_template_impl<_Iter, true> : true_type
+{};
+
+// This is needed because with a defaulted template argument subsumption fails for C++20 for concepts
+// that involve incrementable_traits
+template <class _Iter>
+struct __is_primary_std_template : __is_primary_std_template_impl<_Iter, _CCCL_TRAIT(is_pointer, _Iter)>
 {};
 #  endif // _MSVC_STL_VERSION || _IS_WRS
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_primary_template.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_primary_template.h
@@ -33,14 +33,14 @@ struct __is_primary_template : false_type
 {};
 
 template <class _Tp>
-struct __is_primary_template<_Tp, void_t<typename _Tp::__primary_template>>
-    : public is_same<_Tp, typename _Tp::__primary_template>
+struct __is_primary_template<_Tp, void_t<typename _Tp::__cccl_primary_template>>
+    : public is_same<_Tp, typename _Tp::__cccl_primary_template>
 {};
 
 #else // ^^^ _CCCL_COMPILER(MSVC) ^^^ / vvv !_CCCL_COMPILER(MSVC) vvv
 
 template <class _Tp>
-using __test_for_primary_template = enable_if_t<_IsSame<_Tp, typename _Tp::__primary_template>::value>;
+using __test_for_primary_template = enable_if_t<_IsSame<_Tp, typename _Tp::__cccl_primary_template>::value>;
 template <class _Tp>
 using __is_primary_template = _IsValidExpansion<__test_for_primary_template, _Tp>;
 #endif // !_CCCL_COMPILER(MSVC)

--- a/libcudacxx/include/cuda/std/__type_traits/is_primary_template.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_primary_template.h
@@ -30,11 +30,11 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 #if _CCCL_COMPILER(MSVC)
 template <class _Tp, class = void>
-struct __is_primary_template : false_type
+struct __is_primary_cccl_template : false_type
 {};
 
 template <class _Tp>
-struct __is_primary_template<_Tp, void_t<typename _Tp::__cccl_primary_template>>
+struct __is_primary_cccl_template<_Tp, void_t<typename _Tp::__cccl_primary_template>>
     : public is_same<_Tp, typename _Tp::__cccl_primary_template>
 {};
 
@@ -43,12 +43,12 @@ struct __is_primary_template<_Tp, void_t<typename _Tp::__cccl_primary_template>>
 template <class _Tp>
 using __test_for_primary_template = enable_if_t<_IsSame<_Tp, typename _Tp::__cccl_primary_template>::value>;
 template <class _Tp>
-using __is_primary_template = _IsValidExpansion<__test_for_primary_template, _Tp>;
+using __is_primary_cccl_template = _IsValidExpansion<__test_for_primary_template, _Tp>;
 #endif // !_CCCL_COMPILER(MSVC)
 
 template <class _Iter, class _OtherTraits>
 using __select_traits =
-  conditional_t<__is_primary_template<iterator_traits<_Iter>>::value, _OtherTraits, iterator_traits<_Iter>>;
+  conditional_t<__is_primary_cccl_template<iterator_traits<_Iter>>::value, _OtherTraits, iterator_traits<_Iter>>;
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_primary_template.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_primary_template.h
@@ -20,6 +20,7 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/std/__fwd/iterator_traits.h>
 #include <cuda/std/__type_traits/conditional.h>
 #include <cuda/std/__type_traits/enable_if.h>
 #include <cuda/std/__type_traits/is_same.h>
@@ -29,26 +30,25 @@
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 #if _CCCL_COMPILER(MSVC)
-template <class _Tp, class = void>
+template <class _Iter, class = void>
 struct __is_primary_cccl_template : false_type
 {};
 
-template <class _Tp>
-struct __is_primary_cccl_template<_Tp, void_t<typename _Tp::__cccl_primary_template>>
-    : public is_same<_Tp, typename _Tp::__cccl_primary_template>
+template <class _Iter>
+struct __is_primary_cccl_template<_Iter, void_t<typename iterator_traits<_Iter>::__cccl_primary_template>>
+    : public is_same<iterator_traits<_Iter>, typename iterator_traits<_Iter>::__cccl_primary_template>
 {};
 
 #else // ^^^ _CCCL_COMPILER(MSVC) ^^^ / vvv !_CCCL_COMPILER(MSVC) vvv
 
-template <class _Tp>
-using __test_for_primary_template = enable_if_t<_IsSame<_Tp, typename _Tp::__cccl_primary_template>::value>;
-template <class _Tp>
-using __is_primary_cccl_template = _IsValidExpansion<__test_for_primary_template, _Tp>;
+template <class _Traits>
+using __test_for_primary_template = enable_if_t<_IsSame<_Traits, typename _Traits::__cccl_primary_template>::value>;
+template <class _Iter>
+using __is_primary_cccl_template = _IsValidExpansion<__test_for_primary_template, iterator_traits<_Iter>>;
 #endif // !_CCCL_COMPILER(MSVC)
 
 template <class _Iter, class _OtherTraits>
-using __select_traits =
-  conditional_t<__is_primary_cccl_template<iterator_traits<_Iter>>::value, _OtherTraits, iterator_traits<_Iter>>;
+using __select_traits = conditional_t<__is_primary_cccl_template<_Iter>::value, _OtherTraits, iterator_traits<_Iter>>;
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_primary_template.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_primary_template.h
@@ -71,10 +71,8 @@ using __select_traits = conditional_t<__is_primary_cccl_template<_Iter>::value, 
 #  if defined(__GLIBCXX__)
 // libstdc++ uses `__is_base_of`
 template <class _Iter>
-using __test_for_primary_std_template =
-  enable_if_t<_CCCL_TRAIT(is_base_of, ::std::__iterator_traits<_Iter, void>, ::std::iterator_traits<_Iter>)>;
-template <class _Iter>
-using __is_primary_std_template = _IsValidExpansion<__test_for_primary_std_template, _Iter>;
+struct __is_primary_std_template : is_base_of<::std::__iterator_traits<_Iter>, ::std::iterator_traits<_Iter>>
+{};
 #  elif defined(_LIBCPP_VERSION)
 // libc++ uses the same mechanism than we do with __primary_template
 template <class _Traits>
@@ -82,14 +80,9 @@ using __test_for_primary_std_template = enable_if_t<_IsSame<_Traits, typename _T
 template <class _Iter>
 using __is_primary_std_template = _IsValidExpansion<__test_for_primary_template, ::std::iterator_traits<_Iter>>;
 #  elif defined(_MSVC_STL_VERSION) || defined(_IS_WRS)
-// MSVC uses the same mechanism than we do with _From_primary
-template <class _Iter, class = void>
-struct __is_primary_std_template : true_type
-{};
-
+// On MSVC we must check for the base class because `_From_primary` is only defined in C++20
 template <class _Iter>
-struct __is_primary_std_template<_Iter, void_t<typename ::std::iterator_traits<_Iter>::_From_primary>>
-    : public is_same<::std::iterator_traits<_Iter>, typename ::std::iterator_traits<_Iter>::_From_primary>
+struct __is_primary_std_template : is_base_of<::std::_Iterator_traits_base<_Iter>, ::std::iterator_traits<_Iter>>
 {};
 #  endif // _MSVC_STL_VERSION || _IS_WRS
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_primary_template.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_primary_template.h
@@ -23,13 +23,20 @@
 #include <cuda/std/__fwd/iterator_traits.h>
 #include <cuda/std/__type_traits/conditional.h>
 #include <cuda/std/__type_traits/enable_if.h>
+#include <cuda/std/__type_traits/is_base_of.h>
+#include <cuda/std/__type_traits/is_pointer.h>
 #include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/__type_traits/is_valid_expansion.h>
 #include <cuda/std/__type_traits/void_t.h>
 
+#if !_CCCL_COMPILER(NVRTC)
+#  include <iterator>
+#endif // !_CCCL_COMPILER(NVRTC)
+
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 #if _CCCL_COMPILER(MSVC)
+
 template <class _Iter, class = void>
 struct __is_primary_cccl_template : false_type
 {};
@@ -45,10 +52,80 @@ template <class _Traits>
 using __test_for_primary_template = enable_if_t<_IsSame<_Traits, typename _Traits::__cccl_primary_template>::value>;
 template <class _Iter>
 using __is_primary_cccl_template = _IsValidExpansion<__test_for_primary_template, iterator_traits<_Iter>>;
+
 #endif // !_CCCL_COMPILER(MSVC)
+
+#if _CCCL_COMPILER(NVRTC)
+
+// No ::std::traits with NVRTC
+template <class _Iter>
+struct __is_primary_std_template : true_type
+{};
 
 template <class _Iter, class _OtherTraits>
 using __select_traits = conditional_t<__is_primary_cccl_template<_Iter>::value, _OtherTraits, iterator_traits<_Iter>>;
+
+#else // ^^^ _CCCL_COMPILER(NVRTC) ^^^ / vvv !_CCCL_COMPILER(NVRTC) vvv
+
+// We also need to respect what the user is defining to std::iterator_traits
+#  if defined(__GLIBCXX__)
+// libstdc++ uses `__is_base_of`
+template <class _Iter>
+using __test_for_primary_std_template =
+  enable_if_t<_CCCL_TRAIT(is_base_of, ::std::__iterator_traits<_Iter, void>, ::std::iterator_traits<_Iter>)>;
+template <class _Iter>
+using __is_primary_std_template = _IsValidExpansion<__test_for_primary_std_template, _Iter>;
+#  elif defined(_LIBCPP_VERSION)
+// libc++ uses the same mechanism than we do with __primary_template
+template <class _Traits>
+using __test_for_primary_std_template = enable_if_t<_IsSame<_Traits, typename _Traits::__primary_template>::value>;
+template <class _Iter>
+using __is_primary_std_template = _IsValidExpansion<__test_for_primary_template, ::std::iterator_traits<_Iter>>;
+#  elif defined(_MSVC_STL_VERSION) || defined(_IS_WRS)
+// MSVC uses the same mechanism than we do with _From_primary
+template <class _Iter, class = void>
+struct __is_primary_std_template : false_type
+{};
+
+template <class _Iter>
+struct __is_primary_std_template<_Iter, void_t<typename ::std::iterator_traits<_Iter>::_From_primary>>
+    : public is_same<::std::iterator_traits<_Iter>, typename ::std::iterator_traits<_Iter>::_From_primary>
+{};
+#  endif // _MSVC_STL_VERSION || _IS_WRS
+
+// C++17 has issues with e.g void* and other pointers.
+// C++20 fails subsumption if we use the indirection
+#  if !defined(_CCCL_NO_CONCEPTS)
+template <class _Iter, class _OtherTraits>
+using __select_traits =
+  conditional_t<__is_primary_std_template<_Iter>::value,
+                conditional_t<__is_primary_cccl_template<_Iter>::value, _OtherTraits, iterator_traits<_Iter>>,
+                ::std::iterator_traits<_Iter>>;
+
+#  else // ^^^ !_CCCL_NO_CONCEPTS ^^^ / vvv _CCCL_NO_CONCEPTS vvv
+
+template <class _Iter, class _OtherTraits, bool = _CCCL_TRAIT(is_pointer, _Iter)>
+struct __select_traits_impl
+{
+  using type =
+    conditional_t<__is_primary_std_template<_Iter>::value,
+                  conditional_t<__is_primary_cccl_template<_Iter>::value, _OtherTraits, iterator_traits<_Iter>>,
+                  ::std::iterator_traits<_Iter>>;
+};
+
+// Pointers are treated specially. Also guards against void* issues
+template <class _Iter, class _OtherTraits>
+struct __select_traits_impl<_Iter, _OtherTraits, true>
+{
+  using type = iterator_traits<_Iter>;
+};
+
+template <class _Iter, class _OtherTraits>
+using __select_traits = typename __select_traits_impl<_Iter, _OtherTraits>::type;
+
+#  endif // _CCCL_NO_CONCEPTS
+
+#endif // !_CCCL_COMPILER(NVRTC)
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_primary_template.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_primary_template.h
@@ -84,7 +84,7 @@ using __is_primary_std_template = _IsValidExpansion<__test_for_primary_template,
 #  elif defined(_MSVC_STL_VERSION) || defined(_IS_WRS)
 // MSVC uses the same mechanism than we do with _From_primary
 template <class _Iter, class = void>
-struct __is_primary_std_template : false_type
+struct __is_primary_std_template : true_type
 {};
 
 template <class _Iter>

--- a/libcudacxx/include/cuda/std/__type_traits/is_primary_template.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_primary_template.h
@@ -102,37 +102,11 @@ struct __is_primary_std_template : bool_constant<__is_primary_std_template_impl<
 {};
 #  endif // _MSVC_STL_VERSION || _IS_WRS
 
-// Without ranges we need to guard against e.g void*
-// With ranges we fail subsumption if we use the indirection
-#  if defined(__cpp_lib_ranges)
 template <class _Iter, class _OtherTraits>
 using __select_traits =
   conditional_t<__is_primary_std_template<_Iter>::value,
                 conditional_t<__is_primary_cccl_template<_Iter>::value, _OtherTraits, iterator_traits<_Iter>>,
                 ::std::iterator_traits<_Iter>>;
-
-#  else // ^^^ __cpp_lib_ranges ^^^ / vvv !__cpp_lib_ranges vvv
-
-template <class _Iter, class _OtherTraits, bool = _CCCL_TRAIT(is_pointer, _Iter)>
-struct __select_traits_impl
-{
-  using type =
-    conditional_t<__is_primary_std_template<_Iter>::value,
-                  conditional_t<__is_primary_cccl_template<_Iter>::value, _OtherTraits, iterator_traits<_Iter>>,
-                  ::std::iterator_traits<_Iter>>;
-};
-
-// Pointers are treated specially. Also guards against void* issues
-template <class _Iter, class _OtherTraits>
-struct __select_traits_impl<_Iter, _OtherTraits, true>
-{
-  using type = iterator_traits<_Iter>;
-};
-
-template <class _Iter, class _OtherTraits>
-using __select_traits = typename __select_traits_impl<_Iter, _OtherTraits>::type;
-
-#  endif // !__cpp_lib_ranges
 
 #endif // !_CCCL_COMPILER(NVRTC)
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_primary_template.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_primary_template.h
@@ -71,16 +71,15 @@ using __select_traits = conditional_t<__is_primary_cccl_template<_Iter>::value, 
 #  if defined(__GLIBCXX__)
 // libstdc++ uses `is_base_of`
 template <class _Iter, bool>
-struct __is_primary_std_template_impl : is_base_of<::std::__iterator_traits<_Iter>, ::std::iterator_traits<_Iter>>
-{};
+_CCCL_INLINE_VAR constexpr bool __is_primary_std_template_impl =
+  _CCCL_TRAIT(is_base_of, ::std::__iterator_traits<_Iter>, ::std::iterator_traits<_Iter>);
 template <class _Iter>
-struct __is_primary_std_template_impl<_Iter, true> : true_type
-{};
+_CCCL_INLINE_VAR constexpr bool __is_primary_std_template_impl<_Iter, true> = true;
 
 // This is needed because with a defaulted template argument subsumption fails for C++20 for concepts
 // that involve incrementable_traits
 template <class _Iter>
-struct __is_primary_std_template : __is_primary_std_template_impl<_Iter, _CCCL_TRAIT(is_pointer, _Iter)>
+struct __is_primary_std_template : bool_constant<__is_primary_std_template_impl<_Iter, _CCCL_TRAIT(is_pointer, _Iter)>>
 {};
 #  elif defined(_LIBCPP_VERSION)
 // libc++ uses the same mechanism than we do with __primary_template
@@ -91,16 +90,15 @@ using __is_primary_std_template = _IsValidExpansion<__test_for_primary_template,
 #  elif defined(_MSVC_STL_VERSION) || defined(_IS_WRS)
 // On MSVC we must check for the base class because `_From_primary` is only defined in C++20
 template <class _Iter, bool>
-struct __is_primary_std_template_impl : is_base_of<::std::_Iterator_traits_base<_Iter>, ::std::iterator_traits<_Iter>>
-{};
+_CCCL_INLINE_VAR constexpr bool __is_primary_std_template_impl =
+  _CCCL_TRAIT(is_base_of, ::std::_Iterator_traits_base<_Iter>, ::std::iterator_traits<_Iter>);
 template <class _Iter>
-struct __is_primary_std_template_impl<_Iter, true> : true_type
-{};
+_CCCL_INLINE_VAR constexpr bool __is_primary_std_template_impl<_Iter, true> = true;
 
 // This is needed because with a defaulted template argument subsumption fails for C++20 for concepts
 // that involve incrementable_traits
 template <class _Iter>
-struct __is_primary_std_template : __is_primary_std_template_impl<_Iter, _CCCL_TRAIT(is_pointer, _Iter)>
+struct __is_primary_std_template : bool_constant<__is_primary_std_template_impl<_Iter, _CCCL_TRAIT(is_pointer, _Iter)>>
 {};
 #  endif // _MSVC_STL_VERSION || _IS_WRS
 

--- a/libcudacxx/test/libcudacxx/std/ranges/range.req/range.refinements/subsumption.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.req/range.refinements/subsumption.compile.pass.cpp
@@ -3,12 +3,12 @@
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2024-25 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++17
-// UNSUPPORTED: msvc-19.16
+// UNSUPPORTED: clang-14
 
 // template<class T>
 // concept input_iterator;


### PR DESCRIPTION
Currently our iterator machinery is completely built upon `cuda::std::iterator_traits`.

However, most users of host only types will only ever work with `std::iterator_traits`

That might lead to breakage or even worse silent degradation because we do not properly recognize iterator properties.

This refactors our machinery to first consider whether there are specializations of `std::iterator_traits` and use them if available