### PR TITLE
Increase libcudacxx test timeout

### DIFF
--- a/libcudacxx/test/libcudacxx/CMakeLists.txt
+++ b/libcudacxx/test/libcudacxx/CMakeLists.txt
@@ -140,6 +140,6 @@ add_test(NAME libcudacxx.test.lit COMMAND
 )
 
 set_tests_properties(libcudacxx.test.lit PROPERTIES
-  TIMEOUT 6400
+  TIMEOUT 10800 # 3hr, some CI machines are slow
   RUN_SERIAL TRUE
 )


### PR DESCRIPTION
The nightly T4 tests are consistently timing out.