### PR TITLE
Fix incorrect availability of `variant` in docs

### DIFF
--- a/docs/libcudacxx/standard_api/utility_library.rst
+++ b/docs/libcudacxx/standard_api/utility_library.rst
@@ -54,7 +54,7 @@ the information about the individual features for details.
      - libcu++ 1.3.0 / CCCL 2.0.0 / CUDA 11.2
    * - :ref:`libcudacxx-standard-api-utility-variant`
      - Type safe union type
-     - CCCL 2.3.0 / CUDA 12.4
+     - CCCL 2.4.0 / CUDA 12.5
    * - :ref:`libcudacxx-standard-api-utility-version`
      - Compile-time version information and feature test macros
      - libcu++ 1.2.0 / CCCL 2.0.0 / CUDA 11.1


### PR DESCRIPTION
I thought it was already available in 2.3.0 but it turned out to be only in 2.4.0

Fixes #3858