### PR TITLE
Minimize usage of cub::Traits

### DIFF
--- a/c2h/include/c2h/bfloat16.cuh
+++ b/c2h/include/c2h/bfloat16.cuh
@@ -266,6 +266,11 @@ public:
 };
 _LIBCUDACXX_END_NAMESPACE_STD
 
+template <>
+struct CUB_NS_QUALIFIER::NumericTraits<bfloat16_t>
+    : CUB_NS_QUALIFIER::BaseTraits<FLOATING_POINT, unsigned short, bfloat16_t>
+{};
+
 #ifdef __GNUC__
 #  pragma GCC diagnostic pop
 #endif

--- a/c2h/include/c2h/bfloat16.cuh
+++ b/c2h/include/c2h/bfloat16.cuh
@@ -266,13 +266,6 @@ public:
 };
 _LIBCUDACXX_END_NAMESPACE_STD
 
-_CCCL_SUPPRESS_DEPRECATED_PUSH
-template <>
-struct CUB_NS_QUALIFIER::NumericTraits<bfloat16_t>
-    : CUB_NS_QUALIFIER::BaseTraits<FLOATING_POINT, unsigned short, bfloat16_t>
-{};
-_CCCL_SUPPRESS_DEPRECATED_POP
-
 #ifdef __GNUC__
 #  pragma GCC diagnostic pop
 #endif

--- a/c2h/include/c2h/bfloat16.cuh
+++ b/c2h/include/c2h/bfloat16.cuh
@@ -268,7 +268,7 @@ _LIBCUDACXX_END_NAMESPACE_STD
 
 template <>
 struct CUB_NS_QUALIFIER::NumericTraits<bfloat16_t>
-    : CUB_NS_QUALIFIER::BaseTraits<FLOATING_POINT, unsigned short, bfloat16_t>
+    : CUB_NS_QUALIFIER::BaseTraits<FLOATING_POINT, true, unsigned short, bfloat16_t>
 {};
 
 #ifdef __GNUC__

--- a/c2h/include/c2h/half.cuh
+++ b/c2h/include/c2h/half.cuh
@@ -361,6 +361,10 @@ public:
 };
 _LIBCUDACXX_END_NAMESPACE_STD
 
+template <>
+struct CUB_NS_QUALIFIER::NumericTraits<half_t> : CUB_NS_QUALIFIER::BaseTraits<FLOATING_POINT, unsigned short, half_t>
+{};
+
 #ifdef __GNUC__
 #  pragma GCC diagnostic pop
 #endif

--- a/c2h/include/c2h/half.cuh
+++ b/c2h/include/c2h/half.cuh
@@ -361,12 +361,6 @@ public:
 };
 _LIBCUDACXX_END_NAMESPACE_STD
 
-_CCCL_SUPPRESS_DEPRECATED_PUSH
-template <>
-struct CUB_NS_QUALIFIER::NumericTraits<half_t> : CUB_NS_QUALIFIER::BaseTraits<FLOATING_POINT, unsigned short, half_t>
-{};
-_CCCL_SUPPRESS_DEPRECATED_POP
-
 #ifdef __GNUC__
 #  pragma GCC diagnostic pop
 #endif

--- a/c2h/include/c2h/half.cuh
+++ b/c2h/include/c2h/half.cuh
@@ -362,7 +362,8 @@ public:
 _LIBCUDACXX_END_NAMESPACE_STD
 
 template <>
-struct CUB_NS_QUALIFIER::NumericTraits<half_t> : CUB_NS_QUALIFIER::BaseTraits<FLOATING_POINT, unsigned short, half_t>
+struct CUB_NS_QUALIFIER::NumericTraits<half_t>
+    : CUB_NS_QUALIFIER::BaseTraits<FLOATING_POINT, true, unsigned short, half_t>
 {};
 
 #ifdef __GNUC__

--- a/c2h/include/c2h/test_util_vec.h
+++ b/c2h/include/c2h/test_util_vec.h
@@ -289,7 +289,7 @@ C2H_VEC_OVERLOAD(ulonglong, unsigned long long)
 C2H_VEC_OVERLOAD(float, float)
 C2H_VEC_OVERLOAD(double, double)
 
-// Specialize cub::NumericTraits and cuda::std::numeric_limits for vector types.
+// Specialize cuda::std::numeric_limits for vector types.
 
 #  define REPEAT_TO_LIST_1(a)  a
 #  define REPEAT_TO_LIST_2(a)  a, a
@@ -298,23 +298,6 @@ C2H_VEC_OVERLOAD(double, double)
 #  define REPEAT_TO_LIST(N, a) _CCCL_PP_CAT(REPEAT_TO_LIST_, N)(a)
 
 #  define C2H_VEC_TRAITS_OVERLOAD_IMPL(T, BaseT, N)                               \
-    CUB_NAMESPACE_BEGIN                                                           \
-    template <>                                                                   \
-    struct NumericTraits<T>                                                       \
-    {                                                                             \
-      static __host__ __device__ T Max()                                          \
-      {                                                                           \
-        T retval = {REPEAT_TO_LIST(N, NumericTraits<BaseT>::Max())};              \
-        return retval;                                                            \
-      }                                                                           \
-      static __host__ __device__ T Lowest()                                       \
-      {                                                                           \
-        T retval = {REPEAT_TO_LIST(N, NumericTraits<BaseT>::Lowest())};           \
-        return retval;                                                            \
-      }                                                                           \
-    };                                                                            \
-    CUB_NAMESPACE_END                                                             \
-                                                                                  \
     _LIBCUDACXX_BEGIN_NAMESPACE_STD                                               \
     template <>                                                                   \
     class numeric_limits<T>                                                       \

--- a/cub/benchmarks/bench/reduce/arg_extrema.cu
+++ b/cub/benchmarks/bench/reduce/arg_extrema.cu
@@ -4,6 +4,7 @@
 #include <cub/device/device_reduce.cuh>
 #include <cub/device/dispatch/dispatch_streaming_reduce.cuh>
 
+#include <cuda/std/limits>
 #include <cuda/std/type_traits>
 
 #include <nvbench_helper.cuh>
@@ -57,7 +58,9 @@ struct policy_hub_t
     // Type used for the final result
     using output_tuple_t = cub::KeyValuePair<global_offset_t, T>;
 
-    auto const init = ::cuda::std::is_same_v<OpT, cub::ArgMin> ? cub::Traits<T>::Max() : cub::Traits<T>::Lowest();
+    auto const init = ::cuda::std::is_same_v<OpT, cub::ArgMin>
+                      ? ::cuda::std::numeric_limits<T>::max()
+                      : ::cuda::std::numeric_limits<T>::lowest();
 
 #if !TUNE_BASE
     using policy_t   = policy_hub_t<output_tuple_t, per_partition_offset_t>;

--- a/cub/cub/device/device_reduce.cuh
+++ b/cub/cub/device/device_reduce.cuh
@@ -51,6 +51,8 @@
 
 #include <thrust/iterator/tabulate_output_iterator.h>
 
+#include <cuda/std/limits>
+
 #include <iterator>
 
 CUB_NAMESPACE_BEGIN
@@ -334,7 +336,7 @@ struct DeviceReduce
   //! @rst
   //! Computes a device-wide minimum using the less-than (``<``) operator.
   //!
-  //! - Uses ``std::numeric_limits<T>::max()`` as the initial value of the reduction.
+  //! - Uses ``::cuda::std::numeric_limits<T>::max()`` as the initial value of the reduction.
   //! - Does not support ``<`` operators that are non-commutative.
   //! - Provides "run-to-run" determinism for pseudo-associative reduction
   //!   (e.g., addition of floating point types) on the same GPU device.
@@ -433,8 +435,7 @@ struct DeviceReduce
       d_out,
       static_cast<OffsetT>(num_items),
       ::cuda::minimum<>{},
-      // TODO(bgruber): replace with ::cuda::std::numeric_limits<T>::max() (breaking change)
-      Traits<InitT>::Max(),
+      ::cuda::std::numeric_limits<InitT>::max(),
       stream);
   }
 
@@ -583,7 +584,7 @@ struct DeviceReduce
   //!   (assuming the value type of ``d_in`` is ``T``)
   //!
   //!   - The minimum is written to ``d_out.value`` and its offset in the input array is written to ``d_out.key``.
-  //!   - The ``{1, std::numeric_limits<T>::max()}`` tuple is produced for zero-length inputs
+  //!   - The ``{1, ::cuda::std::numeric_limits<T>::max()}`` tuple is produced for zero-length inputs
   //!
   //! - Does not support ``<`` operators that are non-commutative.
   //! - Provides "run-to-run" determinism for pseudo-associative reduction
@@ -690,8 +691,7 @@ struct DeviceReduce
     ArgIndexInputIteratorT d_indexed_in(d_in);
 
     // Initial value
-    // TODO Address https://github.com/NVIDIA/cub/issues/651
-    InitT initial_value{AccumT(1, Traits<InputValueT>::Max())};
+    InitT initial_value{AccumT(1, ::cuda::std::numeric_limits<InputValueT>::max())};
 
     return DispatchReduce<ArgIndexInputIteratorT, OutputIteratorT, OffsetT, cub::ArgMin, InitT, AccumT>::Dispatch(
       d_temp_storage, temp_storage_bytes, d_indexed_in, d_out, num_items, cub::ArgMin(), initial_value, stream);
@@ -700,7 +700,7 @@ struct DeviceReduce
   //! @rst
   //! Computes a device-wide maximum using the greater-than (``>``) operator.
   //!
-  //! - Uses ``std::numeric_limits<T>::lowest()`` as the initial value of the reduction.
+  //! - Uses ``::cuda::std::numeric_limits<T>::lowest()`` as the initial value of the reduction.
   //! - Does not support ``>`` operators that are non-commutative.
   //! - Provides "run-to-run" determinism for pseudo-associative reduction
   //!   (e.g., addition of floating point types) on the same GPU device.
@@ -796,8 +796,7 @@ struct DeviceReduce
       d_out,
       static_cast<OffsetT>(num_items),
       ::cuda::maximum<>{},
-      // TODO(bgruber): replace with ::cuda::std::numeric_limits<T>::lowest() (breaking change)
-      Traits<InitT>::Lowest(),
+      ::cuda::std::numeric_limits<InitT>::lowest(),
       stream);
   }
 
@@ -948,7 +947,7 @@ struct DeviceReduce
   //!
   //!   - The maximum is written to ``d_out.value`` and its offset in the input
   //!     array is written to ``d_out.key``.
-  //!   - The ``{1, std::numeric_limits<T>::lowest()}`` tuple is produced for zero-length inputs
+  //!   - The ``{1, ::cuda::std::numeric_limits<T>::lowest()}`` tuple is produced for zero-length inputs
   //!
   //! - Does not support ``>`` operators that are non-commutative.
   //! - Provides "run-to-run" determinism for pseudo-associative reduction
@@ -1057,9 +1056,7 @@ struct DeviceReduce
     ArgIndexInputIteratorT d_indexed_in(d_in);
 
     // Initial value
-    // TODO Address https://github.com/NVIDIA/cub/issues/651
-    // TODO(bgruber): replace with ::cuda::std::numeric_limits<T>::lowest() (breaking change)
-    InitT initial_value{AccumT(1, Traits<InputValueT>::Lowest())};
+    InitT initial_value{AccumT(1, ::cuda::std::numeric_limits<InputValueT>::lowest())};
 
     return DispatchReduce<ArgIndexInputIteratorT, OutputIteratorT, OffsetT, cub::ArgMax, InitT, AccumT>::Dispatch(
       d_temp_storage, temp_storage_bytes, d_indexed_in, d_out, num_items, cub::ArgMax(), initial_value, stream);

--- a/cub/cub/device/device_segmented_reduce.cuh
+++ b/cub/cub/device/device_segmented_reduce.cuh
@@ -49,6 +49,7 @@
 #include <cub/iterator/arg_index_input_iterator.cuh>
 #include <cub/util_type.cuh>
 
+#include <cuda/std/limits>
 #include <cuda/std/type_traits>
 
 #include <iterator>
@@ -392,7 +393,7 @@ public:
   //! @rst
   //! Computes a device-wide segmented minimum using the less-than (``<``) operator.
   //!
-  //! - Uses ``std::numeric_limits<T>::max()`` as the initial value of the reduction for each segment.
+  //! - Uses ``::cuda::std::numeric_limits<T>::max()`` as the initial value of the reduction for each segment.
   //! - When input a contiguous sequence of segments, a single sequence
   //!   ``segment_offsets`` (of length ``num_segments + 1``) can be aliased for both
   //!   the ``d_begin_offsets`` and ``d_end_offsets`` parameters (where the latter is
@@ -508,8 +509,7 @@ public:
       d_begin_offsets,
       d_end_offsets,
       ::cuda::minimum<>{},
-      // TODO(bgruber): replace with ::cuda::std::numeric_limits<T>::max() (breaking change)
-      Traits<InputT>::Max(),
+      ::cuda::std::numeric_limits<InputT>::max(),
       stream);
   }
 
@@ -522,7 +522,7 @@ public:
   //!
   //!   - The minimum of the *i*\ :sup:`th` segment is written to
   //!     ``d_out[i].value`` and its offset in that segment is written to ``d_out[i].key``.
-  //!   - The ``{1, std::numeric_limits<T>::max()}`` tuple is produced for zero-length inputs
+  //!   - The ``{1, ::cuda::std::numeric_limits<T>::max()}`` tuple is produced for zero-length inputs
   //!
   //! - When input a contiguous sequence of segments, a single sequence
   //!   ``segment_offsets`` (of length ``num_segments + 1``) can be aliased for both
@@ -636,8 +636,7 @@ public:
     ArgIndexInputIteratorT d_indexed_in(d_in);
 
     // Initial value
-    // TODO Address https://github.com/NVIDIA/cub/issues/651
-    InitT initial_value{AccumT(1, Traits<InputValueT>::Max())};
+    InitT initial_value{AccumT(1, ::cuda::std::numeric_limits<InputValueT>::max())};
 
     using integral_offset_check = ::cuda::std::is_integral<OffsetT>;
     static_assert(integral_offset_check::value, "Offset iterator value type should be integral.");
@@ -666,7 +665,7 @@ public:
   //! @rst
   //! Computes a device-wide segmented maximum using the greater-than (``>``) operator.
   //!
-  //! - Uses ``std::numeric_limits<T>::lowest()`` as the initial value of the reduction.
+  //! - Uses ``::cuda::std::numeric_limits<T>::lowest()`` as the initial value of the reduction.
   //! - When input a contiguous sequence of segments, a single sequence
   //!   ``segment_offsets`` (of length ``num_segments + 1``) can be aliased
   //!   for both the ``d_begin_offsets`` and ``d_end_offsets`` parameters (where
@@ -771,8 +770,7 @@ public:
       d_begin_offsets,
       d_end_offsets,
       ::cuda::maximum<>{},
-      // TODO(bgruber): replace with ::cuda::std::numeric_limits<T>::lowest() (breaking change)
-      Traits<InputT>::Lowest(),
+      ::cuda::std::numeric_limits<InputT>::lowest(),
       stream);
   }
 
@@ -785,7 +783,7 @@ public:
   //!
   //!   - The maximum of the *i*\ :sup:`th` segment is written to
   //!     ``d_out[i].value`` and its offset in that segment is written to ``d_out[i].key``.
-  //!   - The ``{1, std::numeric_limits<T>::lowest()}`` tuple is produced for zero-length inputs
+  //!   - The ``{1, ::cuda::std::numeric_limits<T>::lowest()}`` tuple is produced for zero-length inputs
   //!
   //! - When input a contiguous sequence of segments, a single sequence
   //!   ``segment_offsets`` (of length ``num_segments + 1``) can be aliased
@@ -902,8 +900,7 @@ public:
     ArgIndexInputIteratorT d_indexed_in(d_in);
 
     // Initial value
-    // TODO Address https://github.com/NVIDIA/cub/issues/651
-    InitT initial_value{AccumT(1, Traits<InputValueT>::Lowest())};
+    InitT initial_value{AccumT(1, ::cuda::std::numeric_limits<InputValueT>::lowest())};
 
     using integral_offset_check = ::cuda::std::is_integral<OffsetT>;
     static_assert(integral_offset_check::value, "Offset iterator value type should be integral.");

--- a/cub/cub/util_type.cuh
+++ b/cub/cub/util_type.cuh
@@ -1069,10 +1069,7 @@ namespace detail
 {
 template <typename T>
 struct Traits : NumericTraits<::cuda::std::remove_cv_t<T>>
-{
-  static_assert(::cuda::std::numeric_limits<T>::is_specialized,
-                "Please also specialize cuda::std::numeric_limits for T");
-};
+{};
 } // namespace detail
 
 //! \brief Query type traits for radix sort key operations, decoupled lookback and tunings. To add support for your own

--- a/cub/cub/util_type.cuh
+++ b/cub/cub/util_type.cuh
@@ -1078,8 +1078,10 @@ namespace detail
 // we cannot befriend is_primitive on GCC < 11, since it's a template (bug)
 struct is_primitive_impl
 {
+  // must be a struct instead of an alias, so the access of Traits<T>::is_primitive happens in the context of this class
   template <typename T>
-  using is_primitive = ::cuda::std::bool_constant<Traits<T>::is_primitive>;
+  struct is_primitive : ::cuda::std::bool_constant<Traits<T>::is_primitive>
+  {};
 };
 // This trait serves two purposes:
 // 1. It is used for tunings to detect whether we have a build-in arithmetic type for which we can expect certain

--- a/cub/cub/util_type.cuh
+++ b/cub/cub/util_type.cuh
@@ -782,6 +782,9 @@ enum Category
 
 namespace detail
 {
+template <typename T>
+struct is_primitive;
+
 template <Category _CATEGORY, bool _PRIMITIVE, typename _UnsignedBits, typename T>
 struct BaseTraits
 {
@@ -998,7 +1001,7 @@ struct NumericTraits<__uint128_t>
 
 private:
   template <typename>
-  friend struct is_primitive;
+  friend struct detail::is_primitive;
 
   static constexpr bool is_primitive = false;
 };
@@ -1041,7 +1044,7 @@ struct NumericTraits<__int128_t>
 
 private:
   template <typename>
-  friend struct is_primitive;
+  friend struct detail::is_primitive;
 
   static constexpr bool is_primitive = false;
 };
@@ -1090,10 +1093,8 @@ template <typename T>
 struct is_primitive : ::cuda::std::bool_constant<Traits<T>::is_primitive>
 {};
 
-#  ifndef _CCCL_NO_VARIABLE_TEMPLATES
 template <typename T>
-inline constexpr bool is_primitive_v = is_primitive<T>::value;
-#  endif // !_CCCL_NO_VARIABLE_TEMPLATES
+_CCCL_INLINE_VAR constexpr bool is_primitive_v = is_primitive<T>::value;
 } // namespace detail
 
 #endif // _CCCL_DOXYGEN_INVOKED

--- a/cub/cub/util_type.cuh
+++ b/cub/cub/util_type.cuh
@@ -871,6 +871,8 @@ struct BaseTraits<FLOATING_POINT, _UnsignedBits, T>
 {
   static_assert(::cuda::std::numeric_limits<T>::is_specialized,
                 "Please also specialize cuda::std::numeric_limits for T");
+  static_assert(::cuda::is_floating_point<T>::value, "Please also specialize cuda::is_floating_point for T");
+  static_assert(::cuda::is_floating_point_v<T>, "Please also specialize cuda::is_floating_point_v for T");
 
   using UnsignedBits = _UnsignedBits;
 

--- a/cub/examples/device/example_device_radix_sort_custom.cu
+++ b/cub/examples/device/example_device_radix_sort_custom.cu
@@ -114,10 +114,10 @@ int main()
   std::cout << "l:\t" << to_binary_representation(l) << '\n';
   std::cout << "g:\t" << to_binary_representation(g) << "\n\n";
 
-  std::cout << "As you can see, `l` key happened to be larger in the bit-lexicographicl order.\n";
-  std::cout << "Since there's no reflection in C++, we can't inspect the type and convert \n";
-  std::cout << "each field into the bit-lexicographicl order. You can tell CUB how to do that\n";
-  std::cout << "by specializing cub::RadixTraits for the `custom_t`:\n\n";
+  std::cout << "As you can see, `l` key happened to be larger in the bit-lexicographical order.\n";
+  std::cout << "Since there's no reflection in C++ (yet), we can't inspect the type and convert \n";
+  std::cout << "each field into the bit-lexicographical order. You can tell CUB how to do that\n";
+  std::cout << "by providing a decomposer for the `custom_t`:\n\n";
 
   std::cout << "\tstruct decomposer_t \n";
   std::cout << "\t{\n";
@@ -132,7 +132,7 @@ int main()
   std::cout << "Decomposer allows you to specify which fields are most significant and which\n";
   std::cout << "are least significant. In our case, `f` is the most significant field and\n";
   std::cout << "`i` is the least significant field. The decomposer is then used by CUB to convert\n";
-  std::cout << "the `custom_t` into the bit-lexicographicl order:\n\n";
+  std::cout << "the `custom_t` into the bit-lexicographical order:\n\n";
 
   using conversion_policy = cub::detail::radix::traits_t<custom_t>::bit_ordered_conversion_policy;
   l                       = conversion_policy::to_bit_ordered(decomposer_t{}, l);
@@ -148,7 +148,7 @@ int main()
   std::cout << "g:\t" << to_binary_representation(g) << "\n\n";
 
   std::cout << '\n';
-  std::cout << "As you can see, `g` is now actually larger than `l` in the bit-lexicographicl order.\n";
+  std::cout << "As you can see, `g` is now actually larger than `l` in the bit-lexicographical order.\n";
   std::cout << "After binning, CUB is able to restore the original key:\n\n";
 
   l = conversion_policy::from_bit_ordered(decomposer_t{}, l);

--- a/cub/test/catch2_test_device_reduce.cuh
+++ b/cub/test/catch2_test_device_reduce.cuh
@@ -114,29 +114,6 @@ CUB_NAMESPACE_END
 
 CUB_NAMESPACE_BEGIN
 
-// TODO(bgruber): drop this when we drop cub::Traits
-template <template <typename> class... Policies>
-struct NumericTraits<c2h::custom_type_t<Policies...>>
-{
-  using custom_t = c2h::custom_type_t<Policies...>;
-
-  __host__ __device__ static custom_t Max()
-  {
-    custom_t val{};
-    val.key = NumericTraits<decltype(std::declval<custom_t>().key)>::Max();
-    val.val = NumericTraits<decltype(std::declval<custom_t>().val)>::Max();
-    return val;
-  }
-
-  __host__ __device__ static custom_t Lowest()
-  {
-    custom_t val{};
-    val.key = NumericTraits<decltype(std::declval<custom_t>().key)>::Lowest();
-    val.val = NumericTraits<decltype(std::declval<custom_t>().val)>::Lowest();
-    return val;
-  }
-};
-
 template <typename Key, typename Value>
 static std::ostream& operator<<(std::ostream& os, const KeyValuePair<Key, Value>& val)
 {

--- a/cub/test/catch2_test_device_segmented_sort_keys.cu
+++ b/cub/test/catch2_test_device_segmented_sort_keys.cu
@@ -32,7 +32,9 @@
 
 #include "catch2_radix_sort_helper.cuh"
 #include "catch2_segmented_sort_helper.cuh"
+#include <c2h/bfloat16.cuh>
 #include <c2h/catch2_test_helper.h>
+#include <c2h/half.cuh>
 
 // FIXME: Graph launch disabled, algorithm syncs internally. WAR exists for device-launch, figure out how to enable for
 // graph launch.

--- a/cub/test/catch2_test_util_type.cu
+++ b/cub/test/catch2_test_util_type.cu
@@ -80,3 +80,30 @@ C2H_TEST("Test CUB_DEFINE_DETECT_NESTED_TYPE", "[util][type]")
   STATIC_REQUIRE(cat_detect<HasCat>::value);
   STATIC_REQUIRE(!cat_detect<HasDog>::value);
 }
+
+// Lots of libraries (like pytorch or tensorflow) bring their own half types and customize cub::Traits for them.
+struct CustomHalf
+{
+  int16_t payload;
+};
+
+C2H_TEST("Test CustomHalf", "[util][type]")
+{
+  // type not registered with cub::Traits
+  STATIC_REQUIRE(!cub::detail::is_primitive<CustomHalf>::value);
+  STATIC_REQUIRE(!cuda::std::is_floating_point<CustomHalf>::value);
+  STATIC_REQUIRE(!cuda::std::is_floating_point_v<CustomHalf>);
+  STATIC_REQUIRE(!cuda::is_floating_point<CustomHalf>::value);
+  STATIC_REQUIRE(!cuda::is_floating_point_v<CustomHalf>);
+  STATIC_REQUIRE(!cuda::std::numeric_limits<CustomHalf>::is_specialized);
+
+  // type registered with cub::Traits (specializes NumericTraits, numeric_limits, and is_floating_point)
+  STATIC_REQUIRE(cub::detail::is_primitive<half_t>::value);
+  STATIC_REQUIRE(!cuda::std::is_floating_point<half_t>::value); // the std traits are not affected
+  STATIC_REQUIRE(!cuda::std::is_floating_point_v<half_t>);
+  STATIC_REQUIRE(cuda::is_floating_point<half_t>::value);
+  STATIC_REQUIRE(cuda::is_floating_point_v<half_t>);
+  STATIC_REQUIRE(cuda::std::numeric_limits<half_t>::is_specialized);
+  CHECK(cuda::std::numeric_limits<half_t>::max() == half_t::max());
+  CHECK(cuda::std::numeric_limits<half_t>::lowest() == half_t::lowest());
+}

--- a/cub/test/test_util.h
+++ b/cub/test/test_util.h
@@ -966,31 +966,6 @@ __host__ __device__ __forceinline__ void InitValue(GenMode gen_mode, TestFoo& va
   InitValue(gen_mode, value.w, index);
 }
 
-/// numeric_limits<TestFoo> specialization
-CUB_NAMESPACE_BEGIN
-template <>
-struct NumericTraits<TestFoo>
-{
-  __host__ __device__ static TestFoo Max()
-  {
-    return TestFoo::MakeTestFoo(
-      NumericTraits<long long>::Max(),
-      NumericTraits<int>::Max(),
-      NumericTraits<short>::Max(),
-      NumericTraits<char>::Max());
-  }
-
-  __host__ __device__ static TestFoo Lowest()
-  {
-    return TestFoo::MakeTestFoo(
-      NumericTraits<long long>::Lowest(),
-      NumericTraits<int>::Lowest(),
-      NumericTraits<short>::Lowest(),
-      NumericTraits<char>::Lowest());
-  }
-};
-CUB_NAMESPACE_END
-
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 template <>
 class numeric_limits<TestFoo>
@@ -1120,23 +1095,6 @@ __host__ __device__ __forceinline__ void InitValue(GenMode gen_mode, TestBar& va
   InitValue(gen_mode, value.x, index);
   InitValue(gen_mode, value.y, index);
 }
-
-/// numeric_limits<TestBar> specialization
-CUB_NAMESPACE_BEGIN
-template <>
-struct NumericTraits<TestBar>
-{
-  __host__ __device__ static TestBar Max()
-  {
-    return TestBar(NumericTraits<long long>::Max(), NumericTraits<int>::Max());
-  }
-
-  __host__ __device__ static TestBar Lowest()
-  {
-    return TestBar(NumericTraits<long long>::Lowest(), NumericTraits<int>::Lowest());
-  }
-};
-CUB_NAMESPACE_END
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 template <>


### PR DESCRIPTION
* Replace all uses of cub::Traits other than radix sort key twiddling by numeric_limits
* Drop obsolete specializations of cub::NumericTraits
* Fix radix sort custom type example mentioning non-existent cub::RadixTraits
* Replace cub::BaseTraits and cub::Traits by aliases so uses can no longer specialize it
* Deprecate cub::Traits::Max|Lowest
* Extend documentation of trait classes
* Fix: readd template parameter to cub::BaseTraits to specify whether a type is primitive
* Make is_primitive depend on cub::Traits again

Fixes: #920

Addresses parts of #3381