### PR TITLE
Fix installing CCCL for irregular environments

### DIFF
--- a/.devcontainer/cccl-entrypoint.sh
+++ b/.devcontainer/cccl-entrypoint.sh
@@ -4,11 +4,29 @@
 
 set -e;
 
-devcontainer-utils-post-create-command;
-devcontainer-utils-init-git;
-devcontainer-utils-post-attach-command;
+SKIP_INIT=false
 
-cd /home/coder/cccl/
+echo "$@"
+
+while true; do
+    case "$1" in
+        --skip-init)
+            echo "Skipping initializing devcontainer"
+            SKIP_INIT=true;
+            shift 1;
+            ;;
+        *)
+            break;
+    esac
+done
+
+if ! $SKIP_INIT; then
+    devcontainer-utils-post-create-command;
+    devcontainer-utils-init-git;
+    devcontainer-utils-post-attach-command;
+
+    cd /home/coder/cccl/;
+fi
 
 if test $# -gt 0; then
     exec "$@";

--- a/ci/install_cccl.sh
+++ b/ci/install_cccl.sh
@@ -37,6 +37,11 @@ if [ $VERBOSE ]; then
     set -x
 fi
 
+# Remove sccache as this build doesn't require caching
+unset CMAKE_C_COMPILER_LAUNCHER;
+unset CMAKE_CXX_COMPILER_LAUNCHER;
+unset CMAKE_CUDA_COMPILER_LAUNCHER;
+
 # Move to cccl/ dir
 pushd ".." > /dev/null
 GROUP_NAME="🛠️  CMake Configure CCCL - Install"


### PR DESCRIPTION
## Description

This allows installing CCCL in environments that are not necessarily equipped with a normal checkout. e.g. when using worktrees.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
