### PR TITLE
Refactor and make NVRTC compile `<cub/util_device>`

### DIFF
--- a/cub/cub/util_device.cuh
+++ b/cub/cub/util_device.cuh
@@ -53,13 +53,16 @@
 // for backward compatibility
 #include <cub/util_temporary_storage.cuh>
 
-#include <cuda/std/__cuda/ensure_current_device.h> // IWYU pragma: export
 #include <cuda/std/type_traits>
 #include <cuda/std/utility>
 
-#include <array>
-#include <atomic>
-#include <cassert>
+#if !_CCCL_COMPILER(NVRTC)
+#  include <cuda/std/__cuda/ensure_current_device.h> // IWYU pragma: export
+
+#  include <array>
+#  include <atomic>
+#  include <cassert>
+#endif // !_CCCL_COMPILER(NVRTC)
 
 #include <nv/target>
 
@@ -80,6 +83,7 @@ CUB_DETAIL_KERNEL_ATTRIBUTES void EmptyKernel()
 
 #endif // _CCCL_DOXYGEN_INVOKED
 
+#if !_CCCL_COMPILER(NVRTC)
 /**
  * \brief Returns the current device or -1 if an error occurred.
  */
@@ -93,13 +97,13 @@ CUB_RUNTIME_FUNCTION inline int CurrentDevice()
   return device;
 }
 
-#ifndef _CCCL_DOXYGEN_INVOKED // Do not document
+#  ifndef _CCCL_DOXYGEN_INVOKED // Do not document
 
 //! @brief RAII helper which saves the current device and switches to the specified device on construction and switches
 //! to the saved device on destruction.
 using SwitchDevice = ::cuda::__ensure_current_device;
 
-#endif // _CCCL_DOXYGEN_INVOKED
+#  endif // _CCCL_DOXYGEN_INVOKED
 
 /**
  * \brief Returns the number of CUDA devices available or -1 if an error
@@ -141,7 +145,7 @@ CUB_RUNTIME_FUNCTION inline int DeviceCount()
   return result;
 }
 
-#ifndef _CCCL_DOXYGEN_INVOKED // Do not document
+#  ifndef _CCCL_DOXYGEN_INVOKED // Do not document
 /**
  * \brief Per-device cache for a CUDA attribute value; the attribute is queried
  *        and stored for each device upon construction.
@@ -256,7 +260,7 @@ public:
     return entry.payload;
   }
 };
-#endif // _CCCL_DOXYGEN_INVOKED
+#  endif // _CCCL_DOXYGEN_INVOKED
 
 /**
  * \brief Retrieves the PTX version that will be used on the current device (major * 100 + minor * 10).
@@ -276,11 +280,11 @@ CUB_RUNTIME_FUNCTION inline cudaError_t PtxVersionUncached(int& ptx_version)
   // in device code.
   // <nv/target> may provide an abstraction for this eventually. For now,
   // we have to keep this usage of __CUDA_ARCH__.
-#if defined(_NVHPC_CUDA)
-#  define CUB_TEMP_GET_PTX __builtin_current_device_sm()
-#else
-#  define CUB_TEMP_GET_PTX __CUDA_ARCH__
-#endif
+#  if defined(_NVHPC_CUDA)
+#    define CUB_TEMP_GET_PTX __builtin_current_device_sm()
+#  else
+#    define CUB_TEMP_GET_PTX __CUDA_ARCH__
+#  endif
 
   cudaError_t result = cudaSuccess;
   NV_IF_TARGET(
@@ -300,7 +304,7 @@ CUB_RUNTIME_FUNCTION inline cudaError_t PtxVersionUncached(int& ptx_version)
 
       ptx_version = CUB_TEMP_GET_PTX;));
 
-#undef CUB_TEMP_GET_PTX
+#  undef CUB_TEMP_GET_PTX
 
   return result;
 }
@@ -438,15 +442,15 @@ namespace detail
 //! sync result is returned. Otherwise, does nothing.
 CUB_RUNTIME_FUNCTION inline cudaError_t DebugSyncStream(cudaStream_t stream)
 {
-#ifndef CUB_DEBUG_SYNC
+#  ifndef CUB_DEBUG_SYNC
   (void) stream;
   return cudaSuccess;
-#else // CUB_DEBUG_SYNC
+#  else // CUB_DEBUG_SYNC
   NV_IF_TARGET(
     NV_IS_HOST,
     (_CubLog("%s", "Synchronizing...\n"); return SyncStream(stream);),
     ((void) stream; _CubLog("%s", "WARNING: Skipping CUB debug synchronization in device code"); return cudaSuccess;));
-#endif // CUB_DEBUG_SYNC
+#  endif // CUB_DEBUG_SYNC
 }
 
 /** \brief Gets whether the current device supports unified addressing */
@@ -597,6 +601,7 @@ struct KernelConfig
 };
 
 } // namespace detail
+#endif // !_CCCL_COMPILER(NVRTC)
 
 /// Helper for dispatching into a policy chain
 template <int PolicyPtxVersion, typename PolicyT, typename PrevPolicyT>
@@ -605,30 +610,33 @@ struct ChainedPolicy
   /// The policy for the active compiler pass
   using ActivePolicy = ::cuda::std::_If<(CUB_PTX_ARCH < PolicyPtxVersion), typename PrevPolicyT::ActivePolicy, PolicyT>;
 
+#if !_CCCL_COMPILER(NVRTC)
   /// Specializes and dispatches op in accordance to the first policy in the chain of adequate PTX version
   template <typename FunctorT>
   CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t Invoke(int device_ptx_version, FunctorT& op)
   {
     // __CUDA_ARCH_LIST__ is only available from CTK 11.5 onwards
-#ifdef __CUDA_ARCH_LIST__
+#  ifdef __CUDA_ARCH_LIST__
     return runtime_to_compiletime<1, __CUDA_ARCH_LIST__>(device_ptx_version, op);
     // NV_TARGET_SM_INTEGER_LIST is defined by NVHPC. The values need to be multiplied by 10 to match
     // __CUDA_ARCH_LIST__. E.g. arch 860 from __CUDA_ARCH_LIST__ corresponds to arch 86 from NV_TARGET_SM_INTEGER_LIST.
-#elif defined(NV_TARGET_SM_INTEGER_LIST)
+#  elif defined(NV_TARGET_SM_INTEGER_LIST)
     return runtime_to_compiletime<10, NV_TARGET_SM_INTEGER_LIST>(device_ptx_version, op);
-#else
+#  else
     if (device_ptx_version < PolicyPtxVersion)
     {
       return PrevPolicyT::Invoke(device_ptx_version, op);
     }
     return op.template Invoke<PolicyT>();
-#endif
+#  endif
   }
+#endif // !_CCCL_COMPILER(NVRTC)
 
 private:
   template <int, typename, typename>
   friend struct ChainedPolicy; // let us call invoke_static of other ChainedPolicy instantiations
 
+#if !_CCCL_COMPILER(NVRTC)
   template <int ArchMult, int... CudaArches, typename FunctorT>
   CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t runtime_to_compiletime(int device_ptx_version, FunctorT& op)
   {
@@ -654,6 +662,7 @@ private:
       return op.template Invoke<PolicyT>();
     }
   }
+#endif // !_CCCL_COMPILER(NVRTC)
 };
 
 /// Helper for dispatching into a policy chain (end-of-chain specialization)
@@ -666,6 +675,7 @@ struct ChainedPolicy<PolicyPtxVersion, PolicyT, PolicyT>
   /// The policy for the active compiler pass
   using ActivePolicy = PolicyT;
 
+#if !_CCCL_COMPILER(NVRTC)
   /// Specializes and dispatches op in accordance to the first policy in the chain of adequate PTX version
   template <typename FunctorT>
   CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t Invoke(int /*ptx_version*/, FunctorT& op)
@@ -679,10 +689,11 @@ private:
   {
     return op.template Invoke<PolicyT>();
   }
+#endif // !_CCCL_COMPILER(NVRTC)
 };
 
 CUB_NAMESPACE_END
 
-#if _CCCL_HAS_CUDA_COMPILER
+#if _CCCL_HAS_CUDA_COMPILER && !_CCCL_COMPILER(NVRTC)
 #  include <cub/detail/launcher/cuda_runtime.cuh> // to complete the definition of TripleChevronFactory
-#endif // _CCCL_HAS_CUDA_COMPILER
+#endif // _CCCL_HAS_CUDA_COMPILER && !_CCCL_COMPILER(NVRTC)

--- a/cub/cub/util_device.cuh
+++ b/cub/cub/util_device.cuh
@@ -26,14 +26,8 @@
  *
  ******************************************************************************/
 
-/**
- * \file
- * Properties of a given CUDA device and the corresponding PTX bundle.
- *
- * \note
- * This file contains __host__ only functions and utilities, and should not be
- * included in code paths that could be online-compiled (ex: using NVRTC).
- */
+//! \file
+//! Properties of a given CUDA device and the corresponding PTX bundle.
 
 #pragma once
 

--- a/cub/test/catch2_test_nvrtc.cu
+++ b/cub/test/catch2_test_nvrtc.cu
@@ -62,6 +62,7 @@ TEST_CASE("Test nvrtc", "[test][nvrtc]")
     #include <cub/device/dispatch/kernels/segmented_reduce.cuh>
     #include <cub/device/dispatch/kernels/radix_sort.cuh>
     #include <cub/device/dispatch/kernels/unique_by_key.cuh>
+    #include <cub/util_device.cuh>
 
     #include <thrust/iterator/constant_iterator.h>
     #include <thrust/iterator/counting_iterator.h>


### PR DESCRIPTION
The first commit is a refactoring of `ChainedPolicy` using C++17. The second makes the header compile with NVRTC.