### PR TITLE
Specify namespace of InvokePasses call from Invoke

### DIFF
--- a/cub/cub/device/dispatch/dispatch_reduce.cuh
+++ b/cub/cub/device/dispatch/dispatch_reduce.cuh
@@ -446,12 +446,13 @@ struct DispatchReduce
           wrapped_policy.SingleTile().BlockThreads() * wrapped_policy.SingleTile().ItemsPerThread()))
     {
       // Small, single tile size
-      return InvokeSingleTile(kernel_source.SingleTileKernel(), wrapped_policy);
+      return DispatchReduce::InvokeSingleTile(kernel_source.SingleTileKernel(), wrapped_policy);
     }
     else
     {
       // Regular size
-      return InvokePasses(kernel_source.ReductionKernel(), kernel_source.SingleTileSecondKernel(), wrapped_policy);
+      return DispatchReduce::InvokePasses(
+        kernel_source.ReductionKernel(), kernel_source.SingleTileSecondKernel(), wrapped_policy);
     }
   }
 
@@ -852,7 +853,7 @@ struct DispatchSegmentedReduce
   {
     auto wrapped_policy = detail::reduce::MakeReducePolicyWrapper(policy);
     // Force kernel code-generation in all compiler passes
-    return InvokePasses(kernel_source.SegmentedReduceKernel(), wrapped_policy);
+    return DispatchSegmentedReduce::InvokePasses(kernel_source.SegmentedReduceKernel(), wrapped_policy);
   }
 
   //---------------------------------------------------------------------------

--- a/cub/cub/device/dispatch/dispatch_scan.cuh
+++ b/cub/cub/device/dispatch/dispatch_scan.cuh
@@ -406,7 +406,7 @@ struct DispatchScan
   {
     auto wrapped_policy = detail::scan::MakeScanPolicyWrapper(active_policy);
     // Ensure kernels are instantiated.
-    return Invoke(kernel_source.InitKernel(), kernel_source.ScanKernel(), wrapped_policy);
+    return DispatchScan::Invoke(kernel_source.InitKernel(), kernel_source.ScanKernel(), wrapped_policy);
   }
 
   /**


### PR DESCRIPTION
This commit makes the change for "dispatch/dispatch_reduce.cuh" and "dispatch/dispatch_scan.cuh" for now.

## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes gh-3864

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
