### PR TITLE
Blackwell cluster-level work-stealing

### DIFF
--- a/docs/libcudacxx/extended_api/work_stealing.rst
+++ b/docs/libcudacxx/extended_api/work_stealing.rst
@@ -19,11 +19,11 @@ Defined in header ``<cuda/work_stealing>`` if the CUDA compiler supports at leas
 
 **Note**: On devices with compute capability 10.0 or higher, this function may leverage hardware acceleration.
 
-These APIs are primarily intended for implementing work-stealing at the thread block or cluster levels.
+These APIs are primarily intended for implementing work-stealing at the thread-block or cluster level.
 
 Compared to alternative work distribution techniques, such as  `grid-stride loops <https://developer.nvidia.com/blog/cuda-pro-tip-write-flexible-kernels-grid-stride-loops/>`__, which distribute work statically, or dynamic work distribution methods relying on global memory concurrency, these API offer several advantages:
 
-   - **Dynamic work-stealing**, i.e., thread blocks (or clusters) that complete their tasks sooner may take on additional work from slower thread blocks (or clusters).
+   - **Dynamic work-stealing**, i.e., thread blocks that complete their tasks sooner may take on additional work from slower thread blocks.
    - **GPU Work Scheduler cooperation**, e.g., to respect work priorities and improve load balancing.
    - **Lower latency**, e.g., when compared to global memory atomics.
 
@@ -32,6 +32,9 @@ For better performance, extract the shared prologue and epilogue from the work t
   - Prologue: Initialization code and data common to all thread blocks or clusters, such as ``__shared__`` memory allocation and initialization.
   - Epilogue: Finalization code common to all thread blocks or clusters, such as writing shared memory back to global memory.
 
+The ``for_each_canceled_cluster`` API may be used with thread-block clusters of any size, including one.
+The ```for_each_canceled_block`` API is optimized for and requires thread-block clusters of size one.
+    
 **Mandates**:
 
    - ``ThreadBlockRank`` equals the rank of the thread block: ``1``, ``2``, or ``3`` for one-dimensional, two-dimensional, and three-dimensional thread blocks, respectively.
@@ -39,7 +42,8 @@ For better performance, extract the shared prologue and epilogue from the work t
 
 **Preconditions**:
 
-   - All threads within a thread block cluster shall call either ``for_each_canceled_block`` or ``for_each_canceled_cluster``, and do so **exactly once**.
+   - ``for_each_canceled_block`` shall only be called from grids with **exactly** one thread block per cluster.
+   - All threads within a thread-block cluster shall call either ``for_each_canceled_block`` or ``for_each_canceled_cluster``, and do so **exactly once**.
 
 **Effects**:
 
@@ -48,7 +52,7 @@ For better performance, extract the shared prologue and epilogue from the work t
       - If successful: invokes ``uf`` with the canceled thread block's ``blockIdx`` and repeats.
       - Otherwise, the function returns; it failed to cancel the launch of another thread block or cluster.
 
-**Remarks**: ``for_each_canceled_cluster` guarantees that the position within a cluster of the thread block index ``uf`` is invoked with is always the same.
+**Remarks**: ``for_each_canceled_cluster` guarantees that the relative position within a cluster of the thread block index ``uf`` is invoked with is always the same.
 
 Example
 -------

--- a/docs/libcudacxx/extended_api/work_stealing.rst
+++ b/docs/libcudacxx/extended_api/work_stealing.rst
@@ -9,26 +9,28 @@ Defined in header ``<cuda/work_stealing>`` if the CUDA compiler supports at leas
 
    namespace cuda {
 
-       template <int ThreadBlockRank = 3, typename UnaryFunction = ..unspecified..>
+       template <int ThreadBlockRank = 3, invocable<dim3> UnaryFunction = ..unspecified..>
        __device__ void for_each_canceled_block(UnaryFunction uf);
 
+       template <int ThreadBlockRank = 3, invocable<dim3> UnaryFunction = ..unspecified..>
+       __device__ void for_each_canceled_cluster(UnaryFunction uf);
+       
    } // namespace cuda
 
 **Note**: On devices with compute capability 10.0 or higher, this function may leverage hardware acceleration.
 
-This API is primarily intended for implementing work-stealing at the thread-block level.
+These APIs are primarily intended for implementing work-stealing at the thread block or cluster levels.
 
+Compared to alternative work distribution techniques, such as  `grid-stride loops <https://developer.nvidia.com/blog/cuda-pro-tip-write-flexible-kernels-grid-stride-loops/>`__, which distribute work statically, or dynamic work distribution methods relying on global memory concurrency, these API offer several advantages:
 
-Compared to alternative work distribution techniques, such as  `grid-stride loops <https://developer.nvidia.com/blog/cuda-pro-tip-write-flexible-kernels-grid-stride-loops/>`__, which distribute work statically, or dynamic work distribution methods relying on global memory concurrency, this API offers several advantages:
+   - **Dynamic work-stealing**, i.e., thread blocks (or clusters) that complete their tasks sooner may take on additional work from slower thread blocks (or clusters).
+   - **GPU Work Scheduler cooperation**, e.g., to respect work priorities and improve load balancing.
+   - **Lower latency**, e.g., when compared to global memory atomics.
 
-   - It enables dynamic work-stealing: thread blocks that complete their tasks sooner can take on additional work from slower thread blocks.
-   - It may cooperate with the GPU work scheduler to respect work priorities and improve load balancing.
-   - It may reduce work-stealing latency compared to global memory atomics.
+For better performance, extract the shared prologue and epilogue from the work to be performed to reuse them across iterations:
 
-For better performance, extract the shared thread-block prologue and epilogue outside the lambda and reuse them across thread-block iterations:
-
-  - Prologue: Thread-block initialization code and data common to all thread blocks, such as ``__shared__`` memory allocation and initialization.
-  - Epilogue: Epilogue: Thread-block finalization code common to all thread blocks, such as writing shared memory back to global memory..
+  - Prologue: Initialization code and data common to all thread blocks or clusters, such as ``__shared__`` memory allocation and initialization.
+  - Epilogue: Finalization code common to all thread blocks or clusters, such as writing shared memory back to global memory.
 
 **Mandates**:
 
@@ -37,79 +39,21 @@ For better performance, extract the shared thread-block prologue and epilogue ou
 
 **Preconditions**:
 
-   - All threads within a thread block shall call ``for_each_canceled_block`` **exactly once**.
+   - All threads within a thread block cluster shall call either ``for_each_canceled_block`` or ``for_each_canceled_cluster``, and do so **exactly once**.
 
 **Effects**:
 
-   - Invokes ``uf`` with ``blockIdx`` and then repeatedly attempts to cancel the launch of another thread block within the current grid:
+   - Invokes ``uf`` with ``blockIdx`` and then repeatedly attempts to cancel the launch of another thread block or cluster within the current grid:
 
       - If successful: invokes ``uf`` with the canceled thread block's ``blockIdx`` and repeats.
-      - Otherwise, the function returns; it failed to cancel the launch of another thread block.
+      - Otherwise, the function returns; it failed to cancel the launch of another thread block or cluster.
+
+**Remarks**: ``for_each_canceled_cluster` guarantees that the position within a cluster of the thread block index ``uf`` is invoked with is always the same.
 
 Example
 -------
 
 This example demonstrates work-stealing at thread-block granularity using this API.
 
-.. code:: cuda
-
-   // Before:
-
-   #include <cuda/math>
-   #include <cuda/functional>
-   __global__ void vec_add(int* a, int* b, int* c, int n) {
-     // Extract common prologue outside the lambda, e.g.,
-     // - __shared__ or global (malloc) memory allocation
-     // - common initialization code
-     // - etc.
-
-     cuda::for_each_canceled_block<1>([=](dim3 block_idx) {
-       // block_idx may be different than the built-in blockIdx variable, that is:
-       // assert(block_idx == blockIdx); // may fail!
-       // so we need to use "block_idx" consistently inside for_each_canceled:
-       int idx = threadIdx.x + block_idx.x * blockDim.x;
-       if (idx < n) {
-         c[idx] += a[idx] + b[idx];
-       }
-     });
-     // Note: Calling for_each_canceled_block<1> again from this
-     // thread block exhibits undefined behavior.
-
-     // Extract common epilogue outside the lambda, e.g.,
-     // - write back shared memory to global memory
-     // - external synchronization
-     // - global memory deallocation (free)
-     // - etc.
-   }
-
-   int main() {
-    int N = 10000;
-    int *a, *b, *c;
-    cudaMallocManaged(&a, N * sizeof(int));
-    cudaMallocManaged(&b, N * sizeof(int));
-    cudaMallocManaged(&c, N * sizeof(int));
-    for (int i = 0; i < N; ++i) {
-      a[i] = i;
-      b[i] = 1;
-      c[i] = 0;
-    }
-
-    const int threads_per_block = 256;
-    const int blocks_per_grid = cuda::ceil_div(N, threads_per_block);
-
-    vec_add<<<blocks_per_grid, threads_per_block>>>(a, b, c, N);
-    cudaDeviceSynchronize();
-
-    bool success = true;
-    for (int i = 0; i < N; ++i) {
-      if (c[i] != (1 + i)) {
-	std::cerr << "ERROR " << i << ", " << c[i] << std::endl;
-	success = false;
-      }
-    }
-    cudaFree(a);
-    cudaFree(b);
-    cudaFree(c);
-
-    return success? 0 : 1;
-   }
+.. literalinclude:: ../libcudacxx/examples/work_stealing.cu
+    :language: c++

--- a/libcudacxx/examples/work_stealing.cu
+++ b/libcudacxx/examples/work_stealing.cu
@@ -1,0 +1,111 @@
+   #include <iostream>
+   #include <cuda/atomic>
+   #include <cuda/work_stealing>   
+   #include <cuda/math>
+   #include <cooperative_groups/reduce.h>
+   namespace cg = cooperative_groups
+	  
+   // Before: process one scalar addition per thread block:
+   // __global__ void vec_add_reduce(int* s, int* a, int* b, int* c, int n) {
+   //   int idx = threadIdx.x + blockIdx.x * blockDim.x;
+   //   int thread_sum = 0;
+   //   if (idx < n) {
+   //     int sum = a[idx] + b[idx];
+   //     c[idx] += sum;
+   //     thread_sum += sum;
+   //   }
+   //   auto block = cg::this_thread_block();
+   //   auto tile = cg::tiled_partition<32>(block);  
+   //   cg::reduce_update_async(
+   //     cg::tiled_partition<32>(cg::this_thread_block()), cuda::atomic_ref{*s},
+   //     thread_sum, cg::plus<int>{}
+   //   );
+   // }
+   
+   // After: process many scalar additions per thread block:
+   __global__ void vec_add_reduce(int* s, int* a, int* b, int* c, int n) {
+     // Extract common prologue outside the lambda, e.g.,
+     // - __shared__ or global (malloc) memory allocation
+     // - common initialization code
+     // - etc.
+     // Here we extract the sum to continue accumulating locally across block indices:
+     int thread_sum = 0;
+
+     cuda::for_each_canceled_block<1>([&](dim3 block_idx) {
+       // block_idx may be different than the built-in blockIdx variable, that is:
+       // assert(block_idx == blockIdx); // may fail!
+       // so we need to use "block_idx" consistently inside for_each_canceled:
+       int idx = threadIdx.x + block_idx.x * blockDim.x;
+       if (idx < n) {
+         int sum = a[idx] + b[idx];
+         c[idx] += sum;
+	 thread_sum += sum;
+       }
+     });
+     // Note: Calling for_each_canceled_block again or calling for_each_canceled_cluster from this
+     // thread block exhibits undefined behavior.
+
+     // Extract common epilogue outside the lambda, e.g.,
+     // - write back shared memory to global memory
+     // - external synchronization
+     // - global memory deallocation (free)
+     // - etc.
+     // Here we extract that the per thread-block tile reduction into the global memory location:
+     auto block = cg::this_thread_block();
+     auto tile = cg::tiled_partition<32>(block);  
+     cg::reduce_update_async(
+       cg::tiled_partition<32>(cg::this_thread_block()), cuda::atomic_ref{*s},
+       thread_sum, cg::plus<int>{}
+     );
+   }
+
+   int main() {
+    int N = 10000;
+    int *sum, *a, *b, *c;
+    cudaMallocManaged(&sum, sizeof(int));
+    cudaMallocManaged(&a, N * sizeof(int));
+    cudaMallocManaged(&b, N * sizeof(int));
+    cudaMallocManaged(&c, N * sizeof(int));
+    *sum = 0;
+    for (int i = 0; i < N; ++i) {
+      a[i] = i;
+      b[i] = 1;
+      c[i] = 0;
+    }
+
+    const int threads_per_block = 256;
+    const int blocks_per_grid = cuda::ceil_div(N, threads_per_block);
+
+    vec_add_reduce<<<blocks_per_grid, threads_per_block>>>(sum, a, b, c, N);
+
+    bool success = true;    
+    if(cudaGetLastError() != cudaSuccess) {
+      std::cerr << "LAUNCH ERROR" << std::endl;
+      success = false;
+    }
+    if(cudaDeviceSynchronize() != cudaSuccess) {
+       std::cerr << "SYNC ERRROR" << std::endl;
+       success = false;       
+    }
+
+    int should = 0;
+    for (int i = 0; i < N; ++i) {
+      should += c[i];
+      if (c[i] != (1 + i)) {
+	std::cerr << "ERROR " << i << ": " << c[i] << " != " << (1+i) << std::endl;
+	success = false;
+      }
+    }
+
+    if (*sum != should) {
+      std::cerr << "SUM ERROR " << *sum << " != " << should << std::endl;
+      success = false;
+    }
+
+    cudaFree(sum);
+    cudaFree(a);
+    cudaFree(b);
+    cudaFree(c);
+
+    return success? 0 : 1;
+   }

--- a/libcudacxx/include/cuda/__functional/for_each_canceled.h
+++ b/libcudacxx/include/cuda/__functional/for_each_canceled.h
@@ -26,11 +26,26 @@
 #include <cuda/std/__utility/unreachable.h>
 #include <cuda/std/cstdint>
 
+#include <cooperative_groups.h>
 #include <nv/target>
 
 #if _CCCL_HAS_CUDA_COMPILER
 
 _LIBCUDACXX_BEGIN_NAMESPACE_CUDA
+
+template <int __ThreadBlockRank>
+_CCCL_NODISCARD _CCCL_DEVICE _CCCL_HIDE_FROM_ABI dim3 __thread_block_indices() noexcept {
+  dim3 __block_idx = dim3(blockIdx.x, 1, 1);
+  if constexpr (__ThreadBlockRank >= 2)
+  {
+    __block_idx = dim3(blockIdx.x, blockIdx.y, 1);
+  }
+  if constexpr (__ThreadBlockRank >= 3)
+  {
+    __block_idx = dim3(blockIdx.x, blockIdx.y, blockIdx.z);
+  }
+  return __block_idx;
+}
 
 #  if _CCCL_HAS_INT128()
 
@@ -68,17 +83,20 @@ _CCCL_NODISCARD _CCCL_DEVICE _CCCL_HIDE_FROM_ABI int __cluster_get_dim(__int128 
   return __r;
 }
 
-//! This API for implementing work-stealing, repeatedly attempts to cancel the launch of a thread block
-//! from the current grid. On success, it invokes the unary function `__uf` before trying again.
-//! On failure, it returns.
-//!
-//! This API does not provide any memory synchronization.
-//! This API does not guarantee that any thread will invoke `__uf` with the next block index until all
-//! invocatons of `__uf` for the prior block index have returned.
-//!
-//! Preconditions:
-//! - All thread block threads shall call this API exactly once.
-//! - Exactly one thread block thread shall call this API with `__is_leader` equals `true`.
+template <int __ThreadBlockRank>
+_CCCL_NODISCARD _CCCL_DEVICE _CCCL_HIDE_FROM_ABI dim3 __try_cancel_result_to_dim3(__int128 __result) noexcept {
+  dim3 __b(::cuda::__cluster_get_dim<0>(__result), 1, 1);
+  if constexpr (__ThreadBlockRank >= 2)
+    {
+      __b.y = ::cuda::__cluster_get_dim<1>(__result);
+    }
+  if constexpr (__ThreadBlockRank == 3)
+    {
+      __b.z = ::cuda::__cluster_get_dim<2>(__result);
+    }
+  return __b;
+}
+
 template <int __ThreadBlockRank = 3, typename __UnaryFunction = void>
 _CCCL_DEVICE _CCCL_HIDE_FROM_ABI void
 __for_each_canceled_block_sm100(dim3 __block_idx, bool __is_leader, __UnaryFunction __uf)
@@ -120,6 +138,7 @@ __for_each_canceled_block_sm100(dim3 __block_idx, bool __is_leader, __UnaryFunct
         "waitLoop:\n\t\t"
         "mbarrier.try_wait.parity.relaxed.cta.shared.b64 p, [%0], %1;\n\t\t"
         "@!p bra waitLoop;\n\t"
+	"@p mbarrier.arrive.expect_tx.relaxed.cta.shared::cta.b64 _, [%1], 16;\n\t"
         "}"
         :
         : "r"((int) __cvta_generic_to_shared(&__barrier)), "r"((unsigned) __phase)
@@ -147,17 +166,7 @@ __for_each_canceled_block_sm100(dim3 __block_idx, bool __is_leader, __UnaryFunct
       }
     }
 
-    // Read new thread block dimensions
-    dim3 __b(::cuda::__cluster_get_dim<0>(__result), 1, 1);
-    if constexpr (__ThreadBlockRank >= 2)
-    {
-      __b.y = ::cuda::__cluster_get_dim<1>(__result);
-    }
-    if constexpr (__ThreadBlockRank == 3)
-    {
-      __b.z = ::cuda::__cluster_get_dim<2>(__result);
-    }
-    __block_idx = __b;
+    __block_idx =  __try_cancel_result_to_dim3<__ThreadBlockRank>(__result);
 
     // Wait for all threads to read __result before issuing next async op.
     // generic->generic synchronization
@@ -178,7 +187,6 @@ __for_each_canceled_block_sm100(dim3 __block_idx, bool __is_leader, __UnaryFunct
         "@p fence.proxy.async.shared::cta;\n\t"
         // try to cancel another thread block
         "@p clusterlaunchcontrol.try_cancel.async.shared::cta.mbarrier::complete_tx::bytes.b128 [%0], [%1];\n\t"
-        "@p mbarrier.arrive.expect_tx.relaxed.cta.shared::cta.b64 _, [%1], 16;\n\t"
         "}"
         :
         : "r"((int) __cvta_generic_to_shared(&__result)),
@@ -189,7 +197,156 @@ __for_each_canceled_block_sm100(dim3 __block_idx, bool __is_leader, __UnaryFunct
   } while (true);
 }
 
+template <int __ThreadBlockRank = 3, typename __UnaryFunction = void>
+_CCCL_DEVICE _CCCL_HIDE_FROM_ABI  void
+__for_each_canceled_cluster_sm100(dim3 __block_idx, bool __is_cluster_leader_block, bool __is_block_leader_thread, __UnaryFunction __uf) {
+  __shared__ uint64_t __barrier; // TODO: use 2 barriers and 2 results avoid last sync threads
+  __shared__ __int128 __result;
+  bool __phase = false;
+  dim3 __pos_in_cluster = cooperative_groups::cluster_group::block_index(); // TODO: optimize
+
+  // Initialize barriers:
+  if (__is_block_leader_thread)
+  {
+    auto __leader_mask = __activemask();
+    asm volatile(
+      "{\n\t"
+      ".reg .pred p;\n\t"
+      // elect.sync is a workaround for peeling loop (#nvbug-id)
+      "elect.sync _|p, %2;\n\t"
+      "@p mbarrier.init.shared::cta.b64 [%1], 1;\n\t"
+      // Release mbarrier init to cluster scope.
+      "@p fence.mbarrier_init.release.cluster;\n\t"      
+      // This arrive does not order prior memory operations and can be relaxed.
+      "@p mbarrier.arrive.expect_tx.relaxed.cluster.shared::cta.b64 _, [%1], 16;\n\t"
+      "}"
+      :
+      : "r"((int) __cvta_generic_to_shared(&__result)),
+        "r"((int) __cvta_generic_to_shared(&__barrier)),
+        "r"(__leader_mask)
+      : "memory");
+  }
+
+  // Synchronize barrier initialization across cluster:
+  asm volatile(
+      "{\n\t"
+        "barrier.cluster.arrive.relaxed;\n\t"
+        "barrier.cluster.wait.relaxed;\n\t"
+      "}"
+  );
+
+  // Kickstart pipeline:
+  if (__is_cluster_leader_block && __is_block_leader_thread)
+  {
+    auto __leader_mask = __activemask();
+    asm volatile(
+      "{\n\t"
+      ".reg .pred p;\n\t"
+      // elect.sync is a workaround for peeling loop (#nvbug-id)
+      "elect.sync _|p, %2;\n\t"
+      // Note: only cluster block leader thread needs to acquire mbarrier initialization.
+      // Leader threads of other blocks don't have to because they only access their local mbarriers.
+      "@p fence.acquire.shared::cta.cluster;\n\t"
+      // At this point, the initialization of mbarriers by all blocks is visible to the lead cluster block.
+      // `try_cancel` access all mbarriers in cluster using generic-proxy, so no cross-proxy fence required here
+      "@p clusterlaunchcontrol.try_cancel.async.mbarrier::complete_tx::bytes.multicast::cluster::all.b128 [%0], [%1];\n\t"
+      "}"
+      :
+      : "r"((int) __cvta_generic_to_shared(&__result)),
+        "r"((int) __cvta_generic_to_shared(&__barrier)),
+        "r"(__leader_mask)
+      : "memory");
+  }
+  
+  do {
+    _CUDA_VSTD::invoke(__uf, __block_idx);
+
+    if (__is_block_leader_thread)
+    {
+      asm volatile(
+        "{\n\t"
+        ".reg .pred p;\n\t"
+        "waitLoop:\n\t\t"
+        "mbarrier.try_wait.parity.relaxed.cluster.shared.b64 p, [%0], %1;\n\t\t"
+        "@!p bra waitLoop;\n\t"
+	// Issue the expect_tx for the next round:
+	"@p mbarrier.arrive.expect_tx.relaxed.cluster.shared::cta.b64 _, [%1], 16;\n\t"
+	// Async->Generic cluster-scope acquire for the local shared memory try_cancel result:
+	"@p fence.acquire.sync_restrict::shared::cta.cluster;\n\t"
+        "}"
+        :
+        : "r"((int) __cvta_generic_to_shared(&__barrier)), "r"((unsigned) __phase)
+        : "memory");
+      __phase = !__phase;
+    }
+    __syncthreads(); // All threads of prior thread block have "exited".
+    // Note: this syncthreads provides the .acquire.cta fence preventing
+    // the next query operations from being re-ordered above the poll loop.
+      
+    {
+      int __success = 0;
+      asm volatile(
+        "{\n\t"
+        ".reg .pred p;\n\t"
+        "clusterlaunchcontrol.query_cancel.is_canceled.pred.b128 p, %1;\n\t"
+        "selp.b32 %0, 1, 0, p;\n\t"
+        "}\n\t"
+        : "=r"(__success)
+        : "q"(__result));
+      if (__success != 1)
+      {
+        // Invalidating mbarrier and synchronizing before exiting not
+        // required since each thread block calls this API at most once.
+        break;
+      }
+    }
+    __block_idx = __try_cancel_result_to_dim3<__ThreadBlockRank>(__result);
+    // The block_idx loaded is from the 0-th block in the cluster:
+    __block_idx.x += __pos_in_cluster.x;
+    if constexpr (__ThreadBlockRank >= 2) {
+      __block_idx.y += __pos_in_cluster.y;
+    }
+    if constexpr (__ThreadBlockRank == 3) {
+      __block_idx.z += __pos_in_cluster.y;
+    }
+
+    // TODO: double-buffering results+barrier pairs using phase avoids this sync
+
+    // Wait for all threads in the cluster to read __result before issuing next async op.
+    // generic->async release of result reads:
+    asm volatile(
+      "{\n\t"
+      "fence.proxy.async::generic.release.sync_restrict::shared::cta.cluster;\n\t"
+      "barrier.cluster.arrive.relaxed;\n\t"
+      "barrier.cluster.wait.relaxed;\n\t" // TODO: move to below
+      "}"
+    );
+
+    // Only the leader thread from leader block needs to wait on the barrier
+    if (__is_cluster_leader_block && __is_block_leader_thread) {
+      auto __leader_mask = __activemask();
+      asm volatile(
+	"{\n\t"
+	".reg .pred p;\n\t"
+	// elect.sync is a workaround for peeling loop (#nvbug-id)
+	"elect.sync _|p, %2;\n\t"
+	// Wait at the cluster barrier
+	// "@p barrier.cluster.wait.relaxed;\n\t"
+	// generic->async acquire of result reads
+	"@p fence.proxy.async::generic.acquire.sync_restrict::shared::cluster.cluster;"
+	// try to cancel another thread block
+	"@p clusterlaunchcontrol.try_cancel.async.mbarrier::complete_tx::bytes.multicast::cluster::all.b128 [%0], [%1];\n\t"
+	"}"
+	:
+	: "r"((int)__cvta_generic_to_shared(&__result)), "r"((int)__cvta_generic_to_shared(&__barrier)), "r"(__leader_mask)
+	: "memory"
+      );
+    }
+  } while (true);
+}
+
 #    else // ^^^ __cccl_ptx_isa >= 870 ^^^ / vvv __cccl_ptx_isa < 870 vvv
+
 template <int __ThreadBlockRank = 3, typename __UnaryFunction = void>
 _CCCL_DEVICE _CCCL_HIDE_FROM_ABI void
 __for_each_canceled_block_sm100(dim3 __block_idx, bool __is_leader, __UnaryFunction __uf)
@@ -197,54 +354,40 @@ __for_each_canceled_block_sm100(dim3 __block_idx, bool __is_leader, __UnaryFunct
   // We are compiling for SM100 but PTX 8.7 is not supported, so fall back to just calling the function
   _CUDA_VSTD::invoke(_CUDA_VSTD::move(__uf), __block_idx);
 }
+
+template <int __ThreadBlockRank = 3, typename __UnaryFunction = void>
+_CCCL_DEVICE _CCCL_HIDE_FROM_ABI void
+__for_each_canceled_cluster_sm100(dim3 __block_idx, bool __is_cluster_leader_block, bool __is_block_leader_thread, __UnaryFunction __uf)
+{
+  // We are compiling for SM100 but PTX 8.7 is not supported, so fall back to just calling the function
+  _CUDA_VSTD::invoke(_CUDA_VSTD::move(__uf), __block_idx);
+}
+
 #    endif // __cccl_ptx_isa <= 870
 #  endif // _CCCL_HAS_INT128()
 
-//! This API for implementing work-stealing, repeatedly attempts to cancel the launch of a thread block
-//! from the current grid. On success, it invokes the unary function `__uf` before trying again.
-//! On failure, it returns.
+//! Internal version of `for_each_canceled_block` that enables caller to select control thread
+//! by passing `__is_leader` equals `true` on that thread.
 //!
-//! This API does not provide any memory synchronization.
-//! This API does not guarantee that any thread will invoke `__uf` with the next block index until all
-//! invocatons of `__uf` for the prior block index have returned.
-//!
-//! Preconditions:
-//! - All thread block threads shall call this API exactly once.
-//! - Exactly one thread block thread shall call this API with `__is_leader` equals `true`.
+//! Preconditions over for_each_canceled_work:
+//! - Exactly one thread in the thread block calls this API with `__is_leader` equals `true`;
+//!   all other threads in the block shall call this API with `__is_leader` equals ` false.
 template <int __ThreadBlockRank = 3, typename __UnaryFunction = void>
 _CCCL_DEVICE _CCCL_HIDE_FROM_ABI void __for_each_canceled_block(bool __is_leader, __UnaryFunction __uf)
 {
-  static_assert(__ThreadBlockRank >= 1 && __ThreadBlockRank <= 3, "ThreadBlockRank out-of-range [1, 3].");
+  static_assert(__ThreadBlockRank >= 1 && __ThreadBlockRank <= 3,
+                "__for_each_canceled_block<ThreadBlockRank>: ThreadBlockRank out-of-range [1, 3].");
   static_assert(_CUDA_VSTD::is_invocable_r_v<void, __UnaryFunction, dim3>,
                 "__for_each_canceled_block first argument requires an UnaryFunction with signature: void(dim3).\n"
                 "For example, call with lambda: __for_each_canceled_block([](dim3 block_idx) { ... });");
-  dim3 __block_idx = dim3(blockIdx.x, 1, 1);
-  if constexpr (__ThreadBlockRank >= 2)
-  {
-    __block_idx = dim3(blockIdx.x, blockIdx.y, 1);
-  }
-  if constexpr (__ThreadBlockRank >= 3)
-  {
-    __block_idx = dim3(blockIdx.x, blockIdx.y, blockIdx.z);
-  }
-
+  dim3 __block_idx = __thread_block_indices<__ThreadBlockRank>();
   NV_DISPATCH_TARGET(NV_PROVIDES_SM_100,
                      (::cuda::__for_each_canceled_block_sm100(__block_idx, __is_leader, _CUDA_VSTD::move(__uf));),
                      NV_ANY_TARGET,
                      (_CUDA_VSTD::invoke(_CUDA_VSTD::move(__uf), __block_idx);))
 }
 
-//! This API used to implement work-stealing, repeatedly attempts to cancel the launch of a thread block
-//! from the current grid. On success, it invokes the unary function `__uf` before trying again.
-//! On failure, it returns.
-//!
-//! This API does not provide any memory synchronization.
-//! This API does not guarantee that any thread will invoke `__uf` with the next block index until all
-//! invocatons of `__uf` for the prior block index have returned.
-//!
-//! Preconditions:
-//! - All thread block threads shall call this API exactly once.
-//! - Exactly one thread block thread shall call this API with `__is_leader` equals `true`.
+//! See extended_api/work_stealing.rst for documentation on this public API.
 template <int __ThreadBlockRank = 3, typename __UnaryFunction = void>
 _CCCL_DEVICE _CCCL_HIDE_FROM_ABI void for_each_canceled_block(__UnaryFunction __uf)
 {
@@ -255,16 +398,69 @@ _CCCL_DEVICE _CCCL_HIDE_FROM_ABI void for_each_canceled_block(__UnaryFunction __
                 "For example, call with lambda: for_each_canceled_block([](dim3 block_idx) { ... });");
   if constexpr (__ThreadBlockRank == 1)
   {
-    ::cuda::__for_each_canceled_block<1>(threadIdx.x == 0, _CUDA_VSTD::move(__uf));
+    bool __leader_thread = threadIdx.x == 0;
+    ::cuda::__for_each_canceled_block<1>(__leader_thread, _CUDA_VSTD::move(__uf));
   }
   else if constexpr (__ThreadBlockRank == 2)
   {
-    ::cuda::__for_each_canceled_block<2>(threadIdx.x == 0 && threadIdx.y == 0, _CUDA_VSTD::move(__uf));
+    bool __leader_thread = threadIdx.x == 0 && threadIdx.y == 0;
+    ::cuda::__for_each_canceled_block<2>(__leader_thread, _CUDA_VSTD::move(__uf));
   }
   else if constexpr (__ThreadBlockRank == 3)
   {
-    ::cuda::__for_each_canceled_block<3>(
-      threadIdx.x == 0 && threadIdx.y == 0 && threadIdx.z == 0, _CUDA_VSTD::move(__uf));
+    bool __leader_thread = threadIdx.x == 0 && threadIdx.y == 0 && threadIdx.z == 0;
+    ::cuda::__for_each_canceled_block<3>(__leader_thread, _CUDA_VSTD::move(__uf));
+  }
+}
+
+//! Internal version of `for_each_canceled_cluster` that enables caller to select control thread
+//! by passing `__is_leader_thread` on that thread.
+//!
+//! Preconditions over for_each_canceled_cluster:
+//! - Exactly one thread in the thread block cluster calls this API with `__is_leader` equals `true`;
+//!   all other threads in the cluster shall call this API with `__is_leader` equals ` false.
+template <int __ThreadBlockRank = 3, typename __UnaryFunction = void>
+_CCCL_DEVICE _CCCL_HIDE_FROM_ABI void __for_each_canceled_cluster(bool __is_cluster_leader_block, bool __is_block_leader_thread, __UnaryFunction __uf)
+{
+  static_assert(__ThreadBlockRank >= 1 && __ThreadBlockRank <= 3,
+                "__for_each_canceled_cluster<ThreadBlockRank>: ThreadBlockRank out-of-range [1, 3].");
+  static_assert(_CUDA_VSTD::is_invocable_r_v<void, __UnaryFunction, dim3>,
+                "__for_each_canceled_cluster first argument requires an UnaryFunction with signature: void(dim3).\n"
+                "For example, call with lambda: __for_each_canceled_block([](dim3 block_idx) { ... });");
+  dim3 __block_idx = __thread_block_indices<__ThreadBlockRank>();
+  NV_DISPATCH_TARGET(NV_PROVIDES_SM_100,
+                     (::cuda::__for_each_canceled_cluster_sm100(__block_idx, __is_cluster_leader_block, __is_block_leader_thread, _CUDA_VSTD::move(__uf));),
+                     NV_ANY_TARGET,
+                     (_CUDA_VSTD::invoke(_CUDA_VSTD::move(__uf), __block_idx);))
+}
+
+//! See extended_api/work_stealing.rst for documentation on this public API.
+template <int __ThreadBlockRank = 3, typename __UnaryFunction = void>
+_CCCL_DEVICE _CCCL_HIDE_FROM_ABI void for_each_canceled_cluster(__UnaryFunction __uf)
+{
+  static_assert(__ThreadBlockRank >= 1 && __ThreadBlockRank <= 3,
+                "for_each_canceled_cluster<ThreadBlockRank>: ThreadBlockRank out-of-range [1, 3].");
+  static_assert(_CUDA_VSTD::is_invocable_r_v<void, __UnaryFunction, dim3>,
+                "for_each_canceled_block first argument requires an UnaryFunction with signature: void(dim3).\n"
+                "For example, call with lambda: for_each_canceled_block([](dim3 block_idx) { ... });");
+  dim3 __pos_in_cluster = cooperative_groups::cluster_group::block_index(); // TODO: optimize
+  if constexpr (__ThreadBlockRank == 1)
+  {
+    bool __leader_block = __pos_in_cluster.x == 0;
+    bool __leader_thread = threadIdx.x == 0;
+    ::cuda::__for_each_canceled_cluster<1>(__leader_block, __leader_thread, _CUDA_VSTD::move(__uf));
+  }
+  else if constexpr (__ThreadBlockRank == 2)
+  {
+    bool __leader_block = __pos_in_cluster.x == 0 && __pos_in_cluster.y == 0;
+    bool __leader_thread = threadIdx.x == 0 && threadIdx.y == 0;
+    ::cuda::__for_each_canceled_cluster<2>(__leader_block, __leader_thread, _CUDA_VSTD::move(__uf));
+  }
+  else if constexpr (__ThreadBlockRank == 3)
+  {
+    bool __leader_block = __pos_in_cluster.x == 0 && __pos_in_cluster.y == 0 && __pos_in_cluster.z == 0;
+    bool __leader_thread = threadIdx.x == 0 && threadIdx.y == 0 && threadIdx.z == 0;
+    ::cuda::__for_each_canceled_cluster<3>(__leader_block, __leader_thread, _CUDA_VSTD::move(__uf));
   }
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/work_stealing/for_each_canceled/for_each_canceled.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/work_stealing/for_each_canceled/for_each_canceled.pass.cpp
@@ -13,6 +13,9 @@
 
 #include <cuda/std/cmath>
 #include <cuda/work_stealing>
+#include <cooperative_groups/reduce.h>
+#include <cuda/atomic>    
+namespace cg = cooperative_groups;
 
 #if !defined(TEST_HAS_NO_INT128_T)
 
@@ -48,47 +51,91 @@ __device__ void vec_add_impl3(int* a, int* b, int* c, int n, dim3 block_idx)
   }
 }
 
-__global__ void vec_add_det1(int* a, int* b, int* c, int n, int leader_tidx = 0)
+__global__ void vec_add_det1(int* s, int* a, int* b, int* c, int n, int leader_tidx = 0)
 {
-  ::cuda::__for_each_canceled_block<1>(threadIdx.x == leader_tidx, [=](dim3 block_idx) {
+  int thread_sum = 0;
+  bool leader = threadIdx.x == leader_tidx;
+  ::cuda::__for_each_canceled_block<1>(leader, [=](dim3 block_idx) {
     vec_add_impl1(a, b, c, n, block_idx);
   });
+  auto block = cg::this_thread_block();
+  auto tile = cg::tiled_partition<32>(block);  
+  cg::reduce_update_async(cg::tiled_partition<32>(cg::this_thread_block()), cuda::atomic_ref{*s}, thread_sum, cg::plus<int>{});
 }
 
-__global__ void vec_add_det2(int* a, int* b, int* c, int n, int leader_tidx = 0)
+__global__ void vec_add_det2(int* s, int* a, int* b, int* c, int n, int leader_tidx = 0)
 {
+  int thread_sum = 0;
+  bool leader = threadIdx.x == leader_tidx && threadIdx.y == leader_tidx;
   ::cuda::__for_each_canceled_block<2>(threadIdx.x == leader_tidx && threadIdx.y == leader_tidx, [=](dim3 block_idx) {
     vec_add_impl2(a, b, c, n, block_idx);
   });
+  auto block = cg::this_thread_block();
+  auto tile = cg::tiled_partition<32>(block);  
+  cg::reduce_update_async(cg::tiled_partition<32>(cg::this_thread_block()), cuda::atomic_ref{*s}, thread_sum, cg::plus<int>{});  
 }
 
-__global__ void vec_add_det3(int* a, int* b, int* c, int n, int leader_tidx = 0)
+__global__ void vec_add_det3(int* s, int* a, int* b, int* c, int n, int leader_tidx = 0)
 {
+  int thread_sum = 0;
+  bool leader = threadIdx.x == leader_tidx && threadIdx.y == leader_tidx && threadIdx.z == leader_tidx;
   ::cuda::__for_each_canceled_block<3>(
     threadIdx.x == leader_tidx && threadIdx.y == leader_tidx && threadIdx.z == leader_tidx, [=](dim3 block_idx) {
       vec_add_impl3(a, b, c, n, block_idx);
-    });
+  });
+  auto block = cg::this_thread_block();
+  auto tile = cg::tiled_partition<32>(block);  
+  cg::reduce_update_async(cg::tiled_partition<32>(cg::this_thread_block()), cuda::atomic_ref{*s}, thread_sum, cg::plus<int>{});  
 }
 
-__global__ void vec_add1(int* a, int* b, int* c, int n)
+__global__ void vec_add1(int* s, int* a, int* b, int* c, int n)
 {
+  int thread_sum = 0;
   cuda::for_each_canceled_block<1>([=](dim3 block_idx) {
     vec_add_impl1(a, b, c, n, block_idx);
   });
+  auto block = cg::this_thread_block();
+  auto tile = cg::tiled_partition<32>(block);  
+  cg::reduce_update_async(cg::tiled_partition<32>(cg::this_thread_block()), cuda::atomic_ref{*s}, thread_sum, cg::plus<int>{});  
 }
 
 __global__ void vec_add2(int* a, int* b, int* c, int n)
 {
+  int thread_sum = 0;  
   cuda::for_each_canceled_block<2>([=](dim3 block_idx) {
     vec_add_impl2(a, b, c, n, block_idx);
   });
+  auto block = cg::this_thread_block();
+  auto tile = cg::tiled_partition<32>(block);  
+  cg::reduce_update_async(cg::tiled_partition<32>(cg::this_thread_block()), cuda::atomic_ref{*s}, thread_sum, cg::plus<int>{});  
 }
 
 __global__ void vec_add3(int* a, int* b, int* c, int n)
 {
+  int thread_sum = 0;
   cuda::for_each_canceled_block<3>([=](dim3 block_idx) {
     vec_add_impl3(a, b, c, n, block_idx);
   });
+  cg::reduce_update_async(cg::tiled_partition<32>(cg::this_thread_block()), cuda::atomic_ref{*s}, thread_sum, cg::plus<int>{});  
+}
+
+constexpr int CLUSTER_DIM = 2;
+
+__global__ void  __cluster_dims__(CLUSTER_DIM, 1, 1) cluster_vec_add_det1(int* s, int* a, int* b, int* c, int n, int leader_bidx , int leader_tidx) {
+  dim3 local_block_idx = cooperative_groups::cluster_group::block_index();
+  int thread_sum = 0;  
+  ::cuda::__for_each_canceled_cluster<1>(local_block_idx.x == leader_bidx, threadIdx.x == leader_tidx, [&](dim3 block_idx) {
+    thread_sum += vec_add_impl1(a, b, c, n, block_idx);
+  });
+  cg::reduce_update_async(cg::tiled_partition<32>(cg::this_thread_block()), cuda::atomic_ref{*s}, thread_sum, cg::plus<int>{});
+}
+
+__global__ void  __cluster_dims__(CLUSTER_DIM, 1, 1) cluster_vec_add1(int* s, int* a, int* b, int* c, int n) {
+  int thread_sum = 0;  
+  ::cuda::__for_each_canceled_cluster<1>([&](dim3 block_idx) {
+    thread_sum += vec_add_impl1(a, b, c, n, block_idx);
+  });
+  cg::reduce_update_async(cg::tiled_partition<32>(cg::this_thread_block()), cuda::atomic_ref{*s}, thread_sum, cg::plus<int>{});
 }
 
 template <typename F>
@@ -96,10 +143,12 @@ void test(int N, F&& f)
 {
   for (int tidx : {0, 33, 63, 94})
   {
-    int *a, *b, *c;
+    int *s, *a, *b, *c;
+    cudaMallocManaged(&s, 1 * sizeof(int));
     cudaMallocManaged(&a, N * sizeof(int));
     cudaMallocManaged(&b, N * sizeof(int));
     cudaMallocManaged(&c, N * sizeof(int));
+    *s = 0;
     for (int i = 0; i < N; ++i)
     {
       a[i] = i;
@@ -107,7 +156,8 @@ void test(int N, F&& f)
       c[i] = 0;
     }
 
-    f(a, b, c, N, tidx);
+    f(s, a, b, c, N, tidx);
+    assert(cudaGetLastError() == cudaSuccess);
     assert(cudaDeviceSynchronize() == cudaSuccess);
 
     for (int i = 0; i < N; ++i)
@@ -115,6 +165,7 @@ void test(int N, F&& f)
       assert(c[i] == (1 + i));
     }
 
+    cudaFree(s);
     cudaFree(a);
     cudaFree(b);
     cudaFree(c);

--- a/libcudacxx/test/libcudacxx/cuda/work_stealing/for_each_canceled/for_each_canceled.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/work_stealing/for_each_canceled/for_each_canceled.pass.cpp
@@ -92,7 +92,7 @@ __global__ void vec_add3(int* a, int* b, int* c, int n)
 }
 
 template <typename F>
-bool test(int N, F&& f)
+void test(int N, F&& f)
 {
   for (int tidx : {0, 33, 63, 94})
   {
@@ -119,7 +119,6 @@ bool test(int N, F&& f)
     cudaFree(b);
     cudaFree(c);
   }
-  return true;
 }
 
 void test()
@@ -131,7 +130,7 @@ void test()
       int bpg = (n + tpb - 1) / tpb;
       vec_add_det1<<<bpg, tpb>>>(a, b, c, n, tidx);
     };
-    assert(test(N, fn));
+    test(N, fn);
   }
 
   {
@@ -144,7 +143,7 @@ void test()
       assert((bpgx * bpgy) >= bpg);
       vec_add_det2<<<dim3(bpgx, bpgy, 1), tpb>>>(a, b, c, n, tidx);
     };
-    assert(test(N, fn));
+    test(N, fn);
   }
 
   {
@@ -158,7 +157,7 @@ void test()
       assert((bpgx * bpgy * bpgz) >= bpg);
       vec_add_det3<<<dim3(bpgx, bpgy, bpgz), tpb>>>(a, b, c, n, tidx);
     };
-    assert(test(N, fn));
+    test(N, fn);
   }
 
   {
@@ -167,7 +166,7 @@ void test()
       int bpg = (n + tpb - 1) / tpb;
       vec_add1<<<bpg, tpb>>>(a, b, c, n);
     };
-    assert(test(N, fn));
+    test(N, fn);
   }
 
   {
@@ -180,7 +179,7 @@ void test()
       assert((bpgx * bpgy) >= bpg);
       vec_add2<<<dim3(bpgx, bpgy, 1), tpb>>>(a, b, c, n);
     };
-    assert(test(N, fn));
+    test(N, fn);
   }
 
   {
@@ -194,7 +193,7 @@ void test()
       assert((bpgx * bpgy * bpgz) >= bpg);
       vec_add3<<<dim3(bpgx, bpgy, bpgz), tpb>>>(a, b, c, n);
     };
-    assert(test(N, fn));
+    test(N, fn);
   }
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/work_stealing/for_each_canceled/for_each_canceled.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/work_stealing/for_each_canceled/for_each_canceled.pass.cpp
@@ -19,27 +19,33 @@ namespace cg = cooperative_groups;
 
 #if !defined(TEST_HAS_NO_INT128_T)
 
-__device__ void vec_add_impl1(int* a, int* b, int* c, int n, dim3 block_idx)
+__device__ int vec_add_impl1(int* a, int* b, int* c, int n, dim3 block_idx)
 {
   int idx = threadIdx.x + block_idx.x * blockDim.x;
   if (idx < n)
   {
-    c[idx] += a[idx] + b[idx];
+    int s = a[idx] + b[idx];
+    c[idx] += s;
+    return s;
   }
+  return 0;
 }
 
-__device__ void vec_add_impl2(int* a, int* b, int* c, int n, dim3 block_idx)
+__device__ int vec_add_impl2(int* a, int* b, int* c, int n, dim3 block_idx)
 {
   int x_idx = threadIdx.x + (block_idx.x * blockDim.x);
   int y_idx = threadIdx.y + (block_idx.y * blockDim.y);
   int idx   = x_idx + y_idx * (blockDim.x * gridDim.x);
   if (idx < n)
   {
-    c[idx] += a[idx] + b[idx];
+    int s = a[idx] + b[idx];
+    c[idx] += s;
+    return s;
   }
+  return 0;
 }
 
-__device__ void vec_add_impl3(int* a, int* b, int* c, int n, dim3 block_idx)
+__device__ int vec_add_impl3(int* a, int* b, int* c, int n, dim3 block_idx)
 {
   int x_idx = threadIdx.x + (block_idx.x * blockDim.x);
   int y_idx = threadIdx.y + (block_idx.y * blockDim.y);
@@ -47,16 +53,22 @@ __device__ void vec_add_impl3(int* a, int* b, int* c, int n, dim3 block_idx)
   int idx   = x_idx + y_idx * (blockDim.x * gridDim.x) + z_idx * (blockDim.x * gridDim.x * blockDim.y * gridDim.y);
   if (idx < n)
   {
-    c[idx] += a[idx] + b[idx];
+    int s = a[idx] + b[idx];
+    c[idx] += s;
+    return s;
   }
+  return 0;
 }
+
+////////////////////////////////////////////////////////////////////////////////
+// for_each_cancel_block tests:
 
 __global__ void vec_add_det1(int* s, int* a, int* b, int* c, int n, int leader_tidx = 0)
 {
   int thread_sum = 0;
   bool leader = threadIdx.x == leader_tidx;
-  ::cuda::__for_each_canceled_block<1>(leader, [=](dim3 block_idx) {
-    vec_add_impl1(a, b, c, n, block_idx);
+  ::cuda::__for_each_canceled_block<1>(leader, [&](dim3 block_idx) {
+    thread_sum += vec_add_impl1(a, b, c, n, block_idx);
   });
   auto block = cg::this_thread_block();
   auto tile = cg::tiled_partition<32>(block);  
@@ -67,8 +79,8 @@ __global__ void vec_add_det2(int* s, int* a, int* b, int* c, int n, int leader_t
 {
   int thread_sum = 0;
   bool leader = threadIdx.x == leader_tidx && threadIdx.y == leader_tidx;
-  ::cuda::__for_each_canceled_block<2>(threadIdx.x == leader_tidx && threadIdx.y == leader_tidx, [=](dim3 block_idx) {
-    vec_add_impl2(a, b, c, n, block_idx);
+  ::cuda::__for_each_canceled_block<2>(leader, [&](dim3 block_idx) {
+    thread_sum += vec_add_impl2(a, b, c, n, block_idx);
   });
   auto block = cg::this_thread_block();
   auto tile = cg::tiled_partition<32>(block);  
@@ -79,10 +91,10 @@ __global__ void vec_add_det3(int* s, int* a, int* b, int* c, int n, int leader_t
 {
   int thread_sum = 0;
   bool leader = threadIdx.x == leader_tidx && threadIdx.y == leader_tidx && threadIdx.z == leader_tidx;
-  ::cuda::__for_each_canceled_block<3>(
-    threadIdx.x == leader_tidx && threadIdx.y == leader_tidx && threadIdx.z == leader_tidx, [=](dim3 block_idx) {
-      vec_add_impl3(a, b, c, n, block_idx);
-  });
+  ::cuda::__for_each_canceled_block<3>(leader
+    , [&](dim3 block_idx) {
+      thread_sum += vec_add_impl3(a, b, c, n, block_idx);
+    });
   auto block = cg::this_thread_block();
   auto tile = cg::tiled_partition<32>(block);  
   cg::reduce_update_async(cg::tiled_partition<32>(cg::this_thread_block()), cuda::atomic_ref{*s}, thread_sum, cg::plus<int>{});  
@@ -91,49 +103,94 @@ __global__ void vec_add_det3(int* s, int* a, int* b, int* c, int n, int leader_t
 __global__ void vec_add1(int* s, int* a, int* b, int* c, int n)
 {
   int thread_sum = 0;
-  cuda::for_each_canceled_block<1>([=](dim3 block_idx) {
-    vec_add_impl1(a, b, c, n, block_idx);
+  cuda::for_each_canceled_block<1>([&](dim3 block_idx) {
+    thread_sum += vec_add_impl1(a, b, c, n, block_idx);
   });
   auto block = cg::this_thread_block();
   auto tile = cg::tiled_partition<32>(block);  
   cg::reduce_update_async(cg::tiled_partition<32>(cg::this_thread_block()), cuda::atomic_ref{*s}, thread_sum, cg::plus<int>{});  
 }
 
-__global__ void vec_add2(int* a, int* b, int* c, int n)
-{
-  int thread_sum = 0;  
-  cuda::for_each_canceled_block<2>([=](dim3 block_idx) {
-    vec_add_impl2(a, b, c, n, block_idx);
-  });
-  auto block = cg::this_thread_block();
-  auto tile = cg::tiled_partition<32>(block);  
-  cg::reduce_update_async(cg::tiled_partition<32>(cg::this_thread_block()), cuda::atomic_ref{*s}, thread_sum, cg::plus<int>{});  
-}
-
-__global__ void vec_add3(int* a, int* b, int* c, int n)
+__global__ void vec_add2(int* s, int* a, int* b, int* c, int n)
 {
   int thread_sum = 0;
-  cuda::for_each_canceled_block<3>([=](dim3 block_idx) {
-    vec_add_impl3(a, b, c, n, block_idx);
+  cuda::for_each_canceled_block<2>([&](dim3 block_idx) {
+    thread_sum += vec_add_impl2(a, b, c, n, block_idx);
+  });
+  auto block = cg::this_thread_block();
+  auto tile = cg::tiled_partition<32>(block);  
+  cg::reduce_update_async(cg::tiled_partition<32>(cg::this_thread_block()), cuda::atomic_ref{*s}, thread_sum, cg::plus<int>{});  
+}
+
+__global__ void vec_add3(int* s, int* a, int* b, int* c, int n)
+{
+  int thread_sum = 0;
+  cuda::for_each_canceled_block<3>([&](dim3 block_idx) {
+    thread_sum += vec_add_impl3(a, b, c, n, block_idx);
   });
   cg::reduce_update_async(cg::tiled_partition<32>(cg::this_thread_block()), cuda::atomic_ref{*s}, thread_sum, cg::plus<int>{});  
 }
 
-constexpr int CLUSTER_DIM = 2;
+////////////////////////////////////////////////////////////////////////////////
+// for_each_cancel_cluster tests:
 
-__global__ void  __cluster_dims__(CLUSTER_DIM, 1, 1) cluster_vec_add_det1(int* s, int* a, int* b, int* c, int n, int leader_bidx , int leader_tidx) {
+constexpr int CLUSTER_DIM1 = 8;
+constexpr int CLUSTER_DIM2 = 2;
+constexpr int CLUSTER_DIM3 = 2;
+
+__global__ void  __cluster_dims__(CLUSTER_DIM1, 1, 1) cluster_vec_add_det1(int* s, int* a, int* b, int* c, int n, int leader_bidx , int leader_tidx) {
   dim3 local_block_idx = cooperative_groups::cluster_group::block_index();
-  int thread_sum = 0;  
-  ::cuda::__for_each_canceled_cluster<1>(local_block_idx.x == leader_bidx, threadIdx.x == leader_tidx, [&](dim3 block_idx) {
+  int thread_sum = 0;
+  bool leader_block = local_block_idx.x == leader_bidx;
+  bool leader_threads = threadIdx.x == leader_tidx;
+  ::cuda::__for_each_canceled_cluster<1>(leader_block, leader_threads, [&](dim3 block_idx) {
     thread_sum += vec_add_impl1(a, b, c, n, block_idx);
   });
   cg::reduce_update_async(cg::tiled_partition<32>(cg::this_thread_block()), cuda::atomic_ref{*s}, thread_sum, cg::plus<int>{});
 }
 
-__global__ void  __cluster_dims__(CLUSTER_DIM, 1, 1) cluster_vec_add1(int* s, int* a, int* b, int* c, int n) {
+__global__ void  __cluster_dims__(CLUSTER_DIM2, CLUSTER_DIM2, 1) cluster_vec_add_det2(int* s, int* a, int* b, int* c, int n, int leader_bidx , int leader_tidx) {
+  dim3 local_block_idx = cooperative_groups::cluster_group::block_index();
+  int thread_sum = 0;
+  bool leader_block = local_block_idx.x == leader_bidx && local_block_idx.y == leader_bidx;
+  bool leader_threads = threadIdx.x == leader_tidx && threadIdx.y == leader_tidx;
+  ::cuda::__for_each_canceled_cluster<2>(leader_block, leader_threads, [&](dim3 block_idx) {
+    thread_sum += vec_add_impl2(a, b, c, n, block_idx);
+  });
+  cg::reduce_update_async(cg::tiled_partition<32>(cg::this_thread_block()), cuda::atomic_ref{*s}, thread_sum, cg::plus<int>{});
+}
+
+__global__ void  __cluster_dims__(CLUSTER_DIM3, CLUSTER_DIM3, CLUSTER_DIM3) cluster_vec_add_det3(int* s, int* a, int* b, int* c, int n, int leader_bidx , int leader_tidx) {
+  dim3 local_block_idx = cooperative_groups::cluster_group::block_index();
+  int thread_sum = 0;
+  bool leader_block = local_block_idx.x == leader_bidx && local_block_idx.y == leader_bidx && local_block_idx.z == leader_bidx;
+  bool leader_threads = threadIdx.x == leader_tidx && threadIdx.y == leader_tidx && threadIdx.z == leader_tidx;
+  ::cuda::__for_each_canceled_cluster<3>(leader_block, leader_threads, [&](dim3 block_idx) {
+    thread_sum += vec_add_impl3(a, b, c, n, block_idx);
+  });
+  cg::reduce_update_async(cg::tiled_partition<32>(cg::this_thread_block()), cuda::atomic_ref{*s}, thread_sum, cg::plus<int>{});
+}
+
+__global__ void  __cluster_dims__(CLUSTER_DIM1, 1, 1) cluster_vec_add1(int* s, int* a, int* b, int* c, int n) {
   int thread_sum = 0;  
-  ::cuda::__for_each_canceled_cluster<1>([&](dim3 block_idx) {
+  ::cuda::for_each_canceled_cluster<1>([&](dim3 block_idx) {
     thread_sum += vec_add_impl1(a, b, c, n, block_idx);
+  });
+  cg::reduce_update_async(cg::tiled_partition<32>(cg::this_thread_block()), cuda::atomic_ref{*s}, thread_sum, cg::plus<int>{});
+}
+
+__global__ void  __cluster_dims__(CLUSTER_DIM2, CLUSTER_DIM2, 1) cluster_vec_add2(int* s, int* a, int* b, int* c, int n) {
+  int thread_sum = 0;  
+  ::cuda::for_each_canceled_cluster<2>([&](dim3 block_idx) {
+    thread_sum += vec_add_impl2(a, b, c, n, block_idx);
+  });
+  cg::reduce_update_async(cg::tiled_partition<32>(cg::this_thread_block()), cuda::atomic_ref{*s}, thread_sum, cg::plus<int>{});
+}
+
+__global__ void  __cluster_dims__(CLUSTER_DIM3, CLUSTER_DIM3, CLUSTER_DIM3) cluster_vec_add3(int* s, int* a, int* b, int* c, int n) {
+  int thread_sum = 0;  
+  ::cuda::for_each_canceled_cluster<3>([&](dim3 block_idx) {
+    thread_sum += vec_add_impl3(a, b, c, n, block_idx);
   });
   cg::reduce_update_async(cg::tiled_partition<32>(cg::this_thread_block()), cuda::atomic_ref{*s}, thread_sum, cg::plus<int>{});
 }
@@ -159,11 +216,14 @@ void test(int N, F&& f)
     f(s, a, b, c, N, tidx);
     assert(cudaGetLastError() == cudaSuccess);
     assert(cudaDeviceSynchronize() == cudaSuccess);
-
+    
+    int sref = 0;
     for (int i = 0; i < N; ++i)
     {
-      assert(c[i] == (1 + i));
+      sref += c[i];
+      assert(c[i] != (1 + i));
     }
+    assert(*s == sref);
 
     cudaFree(s);
     cudaFree(a);
@@ -175,30 +235,34 @@ void test(int N, F&& f)
 void test()
 {
   const int N = 1000000;
+
+  //////////////////////////////////////////////////////////////////////////////
+  // for_each_canceled_block:
+  
   {
-    auto fn = [](int* a, int* b, int* c, int n, int tidx) {
+    auto fn = [](int* s, int* a, int* b, int* c, int n, int tidx) {
       int tpb = 256;
       int bpg = (n + tpb - 1) / tpb;
-      vec_add_det1<<<bpg, tpb>>>(a, b, c, n, tidx);
+      vec_add_det1<<<bpg, tpb>>>(s, a, b, c, n, tidx);
     };
     test(N, fn);
   }
 
   {
-    auto fn = [](int* a, int* b, int* c, int n, int tidx) {
+    auto fn = [](int* s, int* a, int* b, int* c, int n, int tidx) {
       dim3 tpb(16, 16, 1);
       int ntpb = tpb.x * tpb.y; // 256
       int bpg  = (n + ntpb - 1) / ntpb;
       int bpgx = (int) cuda::std::sqrt(bpg) + 1;
       int bpgy = bpgx;
       assert((bpgx * bpgy) >= bpg);
-      vec_add_det2<<<dim3(bpgx, bpgy, 1), tpb>>>(a, b, c, n, tidx);
+      vec_add_det2<<<dim3(bpgx, bpgy, 1), tpb>>>(s, a, b, c, n, tidx);
     };
     test(N, fn);
   }
 
   {
-    auto fn = [](int* a, int* b, int* c, int n, int tidx) {
+    auto fn = [](int* s, int* a, int* b, int* c, int n, int tidx) {
       dim3 tpb(8, 8, 8);
       int ntpb = tpb.x * tpb.y * tpb.z; // 512
       int bpg  = (n + ntpb - 1) / ntpb;
@@ -206,35 +270,35 @@ void test()
       int bpgy = bpgx;
       int bpgz = bpgx;
       assert((bpgx * bpgy * bpgz) >= bpg);
-      vec_add_det3<<<dim3(bpgx, bpgy, bpgz), tpb>>>(a, b, c, n, tidx);
+      vec_add_det3<<<dim3(bpgx, bpgy, bpgz), tpb>>>(s, a, b, c, n, tidx);
     };
     test(N, fn);
   }
 
   {
-    auto fn = [](int* a, int* b, int* c, int n, int tidx) {
+    auto fn = [](int* s, int* a, int* b, int* c, int n, int tidx) {
       int tpb = 256;
       int bpg = (n + tpb - 1) / tpb;
-      vec_add1<<<bpg, tpb>>>(a, b, c, n);
+      vec_add1<<<bpg, tpb>>>(s, a, b, c, n);
     };
     test(N, fn);
   }
 
   {
-    auto fn = [](int* a, int* b, int* c, int n, int tidx) {
+    auto fn = [](int* s, int* a, int* b, int* c, int n, int tidx) {
       dim3 tpb(16, 16, 1);
       int ntpb = tpb.x * tpb.y; // 256
       int bpg  = (n + ntpb - 1) / ntpb;
       int bpgx = (int) cuda::std::sqrt(bpg) + 1;
       int bpgy = bpgx;
       assert((bpgx * bpgy) >= bpg);
-      vec_add2<<<dim3(bpgx, bpgy, 1), tpb>>>(a, b, c, n);
+      vec_add2<<<dim3(bpgx, bpgy, 1), tpb>>>(s, a, b, c, n);
     };
     test(N, fn);
   }
 
   {
-    auto fn = [](int* a, int* b, int* c, int n, int tidx) {
+    auto fn = [](int* s, int* a, int* b, int* c, int n, int tidx) {
       dim3 tpb(8, 8, 8);
       int ntpb = tpb.x * tpb.y * tpb.z; // 512
       int bpg  = (n + ntpb - 1) / ntpb;
@@ -242,7 +306,88 @@ void test()
       int bpgy = bpgx;
       int bpgz = bpgx;
       assert((bpgx * bpgy * bpgz) >= bpg);
-      vec_add3<<<dim3(bpgx, bpgy, bpgz), tpb>>>(a, b, c, n);
+      vec_add3<<<dim3(bpgx, bpgy, bpgz), tpb>>>(s, a, b, c, n);
+    };
+    test(N, fn);
+  }
+
+  //////////////////////////////////////////////////////////////////////////////
+  // for_each_canceled_cluster:
+
+  {
+    auto fn = [](int* s, int* a, int* b, int* c, size_t n, int tidx) {
+      int tpb = 256;
+      int bpg = (n + tpb - 1) / tpb + 1;
+      while (bpg % CLUSTER_DIM1 != 0) bpg++;
+      cluster_vec_add_det1<<<bpg, tpb>>>(s, a, b, c, n, 0, tidx);
+    };
+    test(N, fn);
+  }
+
+  {
+    auto fn = [](int* s, int* a, int* b, int* c, size_t n, int tidx) {
+      dim3 tpb(16, 16, 1);
+      int ntpb = tpb.x * tpb.y; // 256
+      int bpg  = (n + ntpb - 1) / ntpb;
+      int bpgx = (int) cuda::std::sqrt(bpg) + 1;
+      while (bpgx % CLUSTER_DIM2 != 0) bpgx++;
+      int bpgy = bpgx;
+      assert((bpgx * bpgy) >= bpg);
+      cluster_vec_add_det2<<<dim3(bpgx, bpgy, 1), tpb>>>(s, a, b, c, n, 0, tidx);
+    };
+    test(N, fn);
+  }
+
+  {
+    auto fn = [](int* s, int* a, int* b, int* c, size_t n, int tidx) {
+      dim3 tpb(8, 8, 8);
+      int ntpb = tpb.x * tpb.y * tpb.z; // 512
+      int bpg  = (n + ntpb - 1) / ntpb;
+      int bpgx = (int) cuda::std::pow(bpg, 1. / 3.) + 1;
+      while (bpgx % CLUSTER_DIM3 != 0) bpgx++;
+      int bpgy = bpgx;
+      int bpgz = bpgx;
+      assert((bpgx * bpgy * bpgz) >= bpg);
+      cluster_vec_add_det3<<<dim3(bpgx, bpgy, bpgz), tpb>>>(s, a, b, c, n, 0, tidx);
+    };
+    test(N, fn);
+  }
+
+  {
+    auto fn = [](int* s, int* a, int* b, int* c, int n, int tidx) {
+      int tpb = 256;
+      int bpg = (n + tpb - 1) / tpb;
+      while (bpg % CLUSTER_DIM1 != 0) bpg++;
+      cluster_vec_add1<<<bpg, tpb>>>(s, a, b, c, n);
+    };
+    test(N, fn);
+  }
+
+  {
+    auto fn = [](int* s, int* a, int* b, int* c, int n, int tidx) {
+      dim3 tpb(16, 16, 1);
+      int ntpb = tpb.x * tpb.y; // 256
+      int bpg  = (n + ntpb - 1) / ntpb;
+      int bpgx = (int) cuda::std::sqrt(bpg) + 1;
+      while (bpgx % CLUSTER_DIM2 != 0) bpgx++;
+      int bpgy = bpgx;
+      assert((bpgx * bpgy) >= bpg);
+      cluster_vec_add2<<<dim3(bpgx, bpgy, 1), tpb>>>(s, a, b, c, n);
+    };
+    test(N, fn);
+  }
+
+  {
+    auto fn = [](int* s, int* a, int* b, int* c, int n, int tidx) {
+      dim3 tpb(8, 8, 8);
+      int ntpb = tpb.x * tpb.y * tpb.z; // 512
+      int bpg  = (n + ntpb - 1) / ntpb;
+      int bpgx = (int) cuda::std::pow(bpg, 1. / 3.) + 1;
+      while (bpgx % CLUSTER_DIM3 != 0) bpgx++;      
+      int bpgy = bpgx;
+      int bpgz = bpgx;
+      assert((bpgx * bpgy * bpgz) >= bpg);
+      cluster_vec_add3<<<dim3(bpgx, bpgy, bpgz), tpb>>>(s, a, b, c, n);
     };
     test(N, fn);
   }


### PR DESCRIPTION
## Description

This PR extends the work-stealing APIs with `for_each_canceled_cluster` to enable cluster-level work stealing (see work-stealing tracking issue: #3870).

It improves the example to show prologue and epilogue reuse, and moves the example to the examples directory so that it can be tested.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
