### PR TITLE
Move to cuda::std::iterator_traits in CUB

### DIFF
--- a/c2h/include/c2h/fill_striped.h
+++ b/c2h/include/c2h/fill_striped.h
@@ -139,7 +139,7 @@ struct scalar_to_vec_t
 template <int LogicalWarpThreads, int ItemsPerThread, int BlockThreads, typename IteratorT>
 void fill_striped(IteratorT it)
 {
-  using T = cub::detail::value_t<IteratorT>;
+  using T = cub::detail::iter_value_t<IteratorT>;
 
   constexpr int warps_in_block = BlockThreads / LogicalWarpThreads;
   constexpr int items_per_warp = LogicalWarpThreads * ItemsPerThread;

--- a/c2h/include/c2h/fill_striped.h
+++ b/c2h/include/c2h/fill_striped.h
@@ -139,7 +139,7 @@ struct scalar_to_vec_t
 template <int LogicalWarpThreads, int ItemsPerThread, int BlockThreads, typename IteratorT>
 void fill_striped(IteratorT it)
 {
-  using T = cub::detail::iter_value_t<IteratorT>;
+  using T = cub::detail::it_value_t<IteratorT>;
 
   constexpr int warps_in_block = BlockThreads / LogicalWarpThreads;
   constexpr int items_per_warp = LogicalWarpThreads * ItemsPerThread;

--- a/cub/cub/agent/agent_batch_memcpy.cuh
+++ b/cub/cub/agent/agent_batch_memcpy.cuh
@@ -557,16 +557,16 @@ private:
   /// Internal load/store type. For byte-wise memcpy, a single-byte type
   using AliasT =
     typename ::cuda::std::conditional<IsMemcpy,
-                                      std::iterator_traits<char*>,
-                                      std::iterator_traits<cub::detail::value_t<InputBufferIt>>>::type::value_type;
+                                      ::cuda::std::iterator_traits<char*>,
+                                      ::cuda::std::iterator_traits<iter_value_t<InputBufferIt>>>::type::value_type;
 
   /// Types of the input and output buffers
-  using InputBufferT  = cub::detail::value_t<InputBufferIt>;
-  using OutputBufferT = cub::detail::value_t<OutputBufferIt>;
+  using InputBufferT  = value_t<InputBufferIt>;
+  using OutputBufferT = value_t<OutputBufferIt>;
 
   /// Type that has to be sufficiently large to hold any of the buffers' sizes.
   /// The BufferSizeIteratorT's value type must be convertible to this type.
-  using BufferSizeT = cub::detail::value_t<BufferSizeIteratorT>;
+  using BufferSizeT = value_t<BufferSizeIteratorT>;
 
   /// Type used to index into the tile of buffers that this thread block is assigned to.
   using BlockBufferOffsetT = uint16_t;

--- a/cub/cub/agent/agent_batch_memcpy.cuh
+++ b/cub/cub/agent/agent_batch_memcpy.cuh
@@ -555,10 +555,7 @@ private:
   // TYPE DECLARATIONS
   //---------------------------------------------------------------------
   /// Internal load/store type. For byte-wise memcpy, a single-byte type
-  using AliasT =
-    typename ::cuda::std::conditional<IsMemcpy,
-                                      ::cuda::std::iterator_traits<char*>,
-                                      ::cuda::std::iterator_traits<iter_value_t<InputBufferIt>>>::type::value_type;
+  using AliasT = ::cuda::std::conditional_t<IsMemcpy, char, iter_value_t<iter_value_t<InputBufferIt>>>;
 
   /// Types of the input and output buffers
   using InputBufferT  = value_t<InputBufferIt>;

--- a/cub/cub/agent/agent_batch_memcpy.cuh
+++ b/cub/cub/agent/agent_batch_memcpy.cuh
@@ -555,17 +555,16 @@ private:
   // TYPE DECLARATIONS
   //---------------------------------------------------------------------
   /// Internal load/store type. For byte-wise memcpy, a single-byte type
-  using AliasT = typename ::cuda::std::conditional_t<IsMemcpy,
-                                                     ::cuda::std::type_identity<char>,
-                                                     lazy_trait<iter_value_t, iter_value_t<InputBufferIt>>>::type;
+  using AliasT = typename ::cuda::std::
+    conditional_t<IsMemcpy, ::cuda::std::type_identity<char>, lazy_trait<it_value_t, it_value_t<InputBufferIt>>>::type;
 
   /// Types of the input and output buffers
-  using InputBufferT  = iter_value_t<InputBufferIt>;
-  using OutputBufferT = iter_value_t<OutputBufferIt>;
+  using InputBufferT  = it_value_t<InputBufferIt>;
+  using OutputBufferT = it_value_t<OutputBufferIt>;
 
   /// Type that has to be sufficiently large to hold any of the buffers' sizes.
   /// The BufferSizeIteratorT's value type must be convertible to this type.
-  using BufferSizeT = iter_value_t<BufferSizeIteratorT>;
+  using BufferSizeT = it_value_t<BufferSizeIteratorT>;
 
   /// Type used to index into the tile of buffers that this thread block is assigned to.
   using BlockBufferOffsetT = uint16_t;

--- a/cub/cub/agent/agent_batch_memcpy.cuh
+++ b/cub/cub/agent/agent_batch_memcpy.cuh
@@ -555,7 +555,9 @@ private:
   // TYPE DECLARATIONS
   //---------------------------------------------------------------------
   /// Internal load/store type. For byte-wise memcpy, a single-byte type
-  using AliasT = ::cuda::std::conditional_t<IsMemcpy, char, iter_value_t<iter_value_t<InputBufferIt>>>;
+  using AliasT = typename ::cuda::std::conditional_t<IsMemcpy,
+                                                     ::cuda::std::type_identity<char>,
+                                                     lazy_trait<iter_value_t, iter_value_t<InputBufferIt>>>::type;
 
   /// Types of the input and output buffers
   using InputBufferT  = iter_value_t<InputBufferIt>;

--- a/cub/cub/agent/agent_batch_memcpy.cuh
+++ b/cub/cub/agent/agent_batch_memcpy.cuh
@@ -558,12 +558,12 @@ private:
   using AliasT = ::cuda::std::conditional_t<IsMemcpy, char, iter_value_t<iter_value_t<InputBufferIt>>>;
 
   /// Types of the input and output buffers
-  using InputBufferT  = value_t<InputBufferIt>;
-  using OutputBufferT = value_t<OutputBufferIt>;
+  using InputBufferT  = iter_value_t<InputBufferIt>;
+  using OutputBufferT = iter_value_t<OutputBufferIt>;
 
   /// Type that has to be sufficiently large to hold any of the buffers' sizes.
   /// The BufferSizeIteratorT's value type must be convertible to this type.
-  using BufferSizeT = value_t<BufferSizeIteratorT>;
+  using BufferSizeT = iter_value_t<BufferSizeIteratorT>;
 
   /// Type used to index into the tile of buffers that this thread block is assigned to.
   using BlockBufferOffsetT = uint16_t;

--- a/cub/cub/agent/agent_histogram.cuh
+++ b/cub/cub/agent/agent_histogram.cuh
@@ -189,7 +189,7 @@ struct AgentHistogram
   //---------------------------------------------------------------------
 
   /// The sample type of the input iterator
-  using SampleT = cub::detail::iter_value_t<SampleIteratorT>;
+  using SampleT = cub::detail::it_value_t<SampleIteratorT>;
 
   /// The pixel type of SampleT
   using PixelT = typename CubVector<SampleT, NUM_CHANNELS>::Type;

--- a/cub/cub/agent/agent_histogram.cuh
+++ b/cub/cub/agent/agent_histogram.cuh
@@ -189,7 +189,7 @@ struct AgentHistogram
   //---------------------------------------------------------------------
 
   /// The sample type of the input iterator
-  using SampleT = cub::detail::value_t<SampleIteratorT>;
+  using SampleT = cub::detail::iter_value_t<SampleIteratorT>;
 
   /// The pixel type of SampleT
   using PixelT = typename CubVector<SampleT, NUM_CHANNELS>::Type;

--- a/cub/cub/agent/agent_merge.cuh
+++ b/cub/cub/agent/agent_merge.cuh
@@ -61,8 +61,8 @@ struct agent_t
   using policy = Policy;
 
   // key and value type are taken from the first input sequence (consistent with old Thrust behavior)
-  using key_type  = typename iter_value_t<KeysIt1>;
-  using item_type = typename value_t<ItemsIt1>;
+  using key_type  = iter_value_t<KeysIt1>;
+  using item_type = iter_value_t<ItemsIt1>;
 
   using keys_load_it1  = typename THRUST_NS_QUALIFIER::cuda_cub::core::detail::LoadIterator<Policy, KeysIt1>::type;
   using keys_load_it2  = typename THRUST_NS_QUALIFIER::cuda_cub::core::detail::LoadIterator<Policy, KeysIt2>::type;

--- a/cub/cub/agent/agent_merge.cuh
+++ b/cub/cub/agent/agent_merge.cuh
@@ -61,8 +61,8 @@ struct agent_t
   using policy = Policy;
 
   // key and value type are taken from the first input sequence (consistent with old Thrust behavior)
-  using key_type  = typename ::cuda::std::iterator_traits<KeysIt1>::value_type;
-  using item_type = typename ::cuda::std::iterator_traits<ItemsIt1>::value_type;
+  using key_type  = typename iter_value_t<KeysIt1>;
+  using item_type = typename value_t<ItemsIt1>;
 
   using keys_load_it1  = typename THRUST_NS_QUALIFIER::cuda_cub::core::detail::LoadIterator<Policy, KeysIt1>::type;
   using keys_load_it2  = typename THRUST_NS_QUALIFIER::cuda_cub::core::detail::LoadIterator<Policy, KeysIt2>::type;

--- a/cub/cub/agent/agent_merge.cuh
+++ b/cub/cub/agent/agent_merge.cuh
@@ -61,8 +61,8 @@ struct agent_t
   using policy = Policy;
 
   // key and value type are taken from the first input sequence (consistent with old Thrust behavior)
-  using key_type  = iter_value_t<KeysIt1>;
-  using item_type = iter_value_t<ItemsIt1>;
+  using key_type  = it_value_t<KeysIt1>;
+  using item_type = it_value_t<ItemsIt1>;
 
   using keys_load_it1  = typename THRUST_NS_QUALIFIER::cuda_cub::core::detail::LoadIterator<Policy, KeysIt1>::type;
   using keys_load_it2  = typename THRUST_NS_QUALIFIER::cuda_cub::core::detail::LoadIterator<Policy, KeysIt2>::type;

--- a/cub/cub/agent/agent_reduce.cuh
+++ b/cub/cub/agent/agent_reduce.cuh
@@ -142,7 +142,7 @@ struct AgentReduce
   //---------------------------------------------------------------------
 
   /// The input value type
-  using InputT = iter_value_t<InputIteratorT>;
+  using InputT = it_value_t<InputIteratorT>;
 
   /// Vector type of InputT for data movement
   using VectorT = typename CubVector<InputT, AgentReducePolicy::VECTOR_LOAD_LENGTH>::Type;

--- a/cub/cub/agent/agent_reduce.cuh
+++ b/cub/cub/agent/agent_reduce.cuh
@@ -142,7 +142,7 @@ struct AgentReduce
   //---------------------------------------------------------------------
 
   /// The input value type
-  using InputT = value_t<InputIteratorT>;
+  using InputT = iter_value_t<InputIteratorT>;
 
   /// Vector type of InputT for data movement
   using VectorT = typename CubVector<InputT, AgentReducePolicy::VECTOR_LOAD_LENGTH>::Type;

--- a/cub/cub/agent/agent_reduce_by_key.cuh
+++ b/cub/cub/agent/agent_reduce_by_key.cuh
@@ -177,7 +177,7 @@ struct AgentReduceByKey
   using KeyOutputT = non_void_value_t<UniqueOutputIteratorT, KeyInputT>;
 
   // The input values type
-  using ValueInputT = value_t<ValuesInputIteratorT>;
+  using ValueInputT = iter_value_t<ValuesInputIteratorT>;
 
   // Tuple type for scanning (pairs accumulated segment-value with
   // segment-index)

--- a/cub/cub/agent/agent_reduce_by_key.cuh
+++ b/cub/cub/agent/agent_reduce_by_key.cuh
@@ -171,13 +171,13 @@ struct AgentReduceByKey
   //---------------------------------------------------------------------
 
   // The input keys type
-  using KeyInputT = iter_value_t<KeysInputIteratorT>;
+  using KeyInputT = it_value_t<KeysInputIteratorT>;
 
   // The output keys type
   using KeyOutputT = non_void_value_t<UniqueOutputIteratorT, KeyInputT>;
 
   // The input values type
-  using ValueInputT = iter_value_t<ValuesInputIteratorT>;
+  using ValueInputT = it_value_t<ValuesInputIteratorT>;
 
   // Tuple type for scanning (pairs accumulated segment-value with
   // segment-index)

--- a/cub/cub/agent/agent_reduce_by_key.cuh
+++ b/cub/cub/agent/agent_reduce_by_key.cuh
@@ -171,7 +171,7 @@ struct AgentReduceByKey
   //---------------------------------------------------------------------
 
   // The input keys type
-  using KeyInputT = value_t<KeysInputIteratorT>;
+  using KeyInputT = iter_value_t<KeysInputIteratorT>;
 
   // The output keys type
   using KeyOutputT = non_void_value_t<UniqueOutputIteratorT, KeyInputT>;

--- a/cub/cub/agent/agent_rle.cuh
+++ b/cub/cub/agent/agent_rle.cuh
@@ -173,7 +173,7 @@ struct AgentRle
   //---------------------------------------------------------------------
 
   /// The input value type
-  using T = cub::detail::value_t<InputIteratorT>;
+  using T = cub::detail::iter_value_t<InputIteratorT>;
 
   /// The lengths output value type
   using LengthT = cub::detail::non_void_value_t<LengthsOutputIteratorT, OffsetT>;

--- a/cub/cub/agent/agent_rle.cuh
+++ b/cub/cub/agent/agent_rle.cuh
@@ -173,7 +173,7 @@ struct AgentRle
   //---------------------------------------------------------------------
 
   /// The input value type
-  using T = cub::detail::iter_value_t<InputIteratorT>;
+  using T = cub::detail::it_value_t<InputIteratorT>;
 
   /// The lengths output value type
   using LengthT = cub::detail::non_void_value_t<LengthsOutputIteratorT, OffsetT>;

--- a/cub/cub/agent/agent_scan.cuh
+++ b/cub/cub/agent/agent_scan.cuh
@@ -157,7 +157,7 @@ struct AgentScan
   //---------------------------------------------------------------------
 
   // The input value type
-  using InputT = cub::detail::iter_value_t<InputIteratorT>;
+  using InputT = cub::detail::it_value_t<InputIteratorT>;
 
   // Tile status descriptor interface type
   using ScanTileStateT = ScanTileState<AccumT>;

--- a/cub/cub/agent/agent_scan.cuh
+++ b/cub/cub/agent/agent_scan.cuh
@@ -157,7 +157,7 @@ struct AgentScan
   //---------------------------------------------------------------------
 
   // The input value type
-  using InputT = cub::detail::value_t<InputIteratorT>;
+  using InputT = cub::detail::iter_value_t<InputIteratorT>;
 
   // Tile status descriptor interface type
   using ScanTileStateT = ScanTileState<AccumT>;

--- a/cub/cub/agent/agent_scan_by_key.cuh
+++ b/cub/cub/agent/agent_scan_by_key.cuh
@@ -145,8 +145,8 @@ struct AgentScanByKey
   // Types and constants
   //---------------------------------------------------------------------
 
-  using KeyT               = iter_value_t<KeysInputIteratorT>;
-  using InputT             = iter_value_t<ValuesInputIteratorT>;
+  using KeyT               = it_value_t<KeysInputIteratorT>;
+  using InputT             = it_value_t<ValuesInputIteratorT>;
   using FlagValuePairT     = KeyValuePair<int, AccumT>;
   using ReduceBySegmentOpT = ScanBySegmentOp<ScanOpT>;
 

--- a/cub/cub/agent/agent_scan_by_key.cuh
+++ b/cub/cub/agent/agent_scan_by_key.cuh
@@ -145,8 +145,8 @@ struct AgentScanByKey
   // Types and constants
   //---------------------------------------------------------------------
 
-  using KeyT               = value_t<KeysInputIteratorT>;
-  using InputT             = value_t<ValuesInputIteratorT>;
+  using KeyT               = iter_value_t<KeysInputIteratorT>;
+  using InputT             = iter_value_t<ValuesInputIteratorT>;
   using FlagValuePairT     = KeyValuePair<int, AccumT>;
   using ReduceBySegmentOpT = ScanBySegmentOp<ScanOpT>;
 

--- a/cub/cub/agent/agent_select_if.cuh
+++ b/cub/cub/agent/agent_select_if.cuh
@@ -230,7 +230,7 @@ struct AgentSelectIf
   using InputT = iter_value_t<InputIteratorT>;
 
   // The flag value type
-  using FlagT = value_t<FlagsInputIteratorT>;
+  using FlagT = iter_value_t<FlagsInputIteratorT>;
 
   // Constants
   enum

--- a/cub/cub/agent/agent_select_if.cuh
+++ b/cub/cub/agent/agent_select_if.cuh
@@ -227,7 +227,7 @@ struct AgentSelectIf
   using MemoryOrderedTileStateT = tile_state_with_memory_order<ScanTileStateT, memory_order>;
 
   // The input value type
-  using InputT = value_t<InputIteratorT>;
+  using InputT = iter_value_t<InputIteratorT>;
 
   // The flag value type
   using FlagT = value_t<FlagsInputIteratorT>;

--- a/cub/cub/agent/agent_select_if.cuh
+++ b/cub/cub/agent/agent_select_if.cuh
@@ -227,10 +227,10 @@ struct AgentSelectIf
   using MemoryOrderedTileStateT = tile_state_with_memory_order<ScanTileStateT, memory_order>;
 
   // The input value type
-  using InputT = iter_value_t<InputIteratorT>;
+  using InputT = it_value_t<InputIteratorT>;
 
   // The flag value type
-  using FlagT = iter_value_t<FlagsInputIteratorT>;
+  using FlagT = it_value_t<FlagsInputIteratorT>;
 
   // Constants
   enum

--- a/cub/cub/agent/agent_three_way_partition.cuh
+++ b/cub/cub/agent/agent_three_way_partition.cuh
@@ -180,7 +180,7 @@ struct AgentThreeWayPartition
   //---------------------------------------------------------------------
 
   // The input value type
-  using InputT = iter_value_t<InputIteratorT>;
+  using InputT = it_value_t<InputIteratorT>;
 
   using AccumPackHelperT = accumulator_pack_t<OffsetT>;
   using AccumPackT       = typename AccumPackHelperT::pack_t;

--- a/cub/cub/agent/agent_three_way_partition.cuh
+++ b/cub/cub/agent/agent_three_way_partition.cuh
@@ -180,7 +180,7 @@ struct AgentThreeWayPartition
   //---------------------------------------------------------------------
 
   // The input value type
-  using InputT = value_t<InputIteratorT>;
+  using InputT = iter_value_t<InputIteratorT>;
 
   using AccumPackHelperT = accumulator_pack_t<OffsetT>;
   using AccumPackT       = typename AccumPackHelperT::pack_t;

--- a/cub/cub/agent/agent_unique_by_key.cuh
+++ b/cub/cub/agent/agent_unique_by_key.cuh
@@ -133,7 +133,7 @@ struct AgentUniqueByKey
   //---------------------------------------------------------------------
 
   // The input key and value type
-  using KeyT   = cub::detail::value_t<KeyInputIteratorT>;
+  using KeyT   = cub::detail::iter_value_t<KeyInputIteratorT>;
   using ValueT = cub::detail::value_t<ValueInputIteratorT>;
 
   // Tile status descriptor interface type

--- a/cub/cub/agent/agent_unique_by_key.cuh
+++ b/cub/cub/agent/agent_unique_by_key.cuh
@@ -133,8 +133,8 @@ struct AgentUniqueByKey
   //---------------------------------------------------------------------
 
   // The input key and value type
-  using KeyT   = cub::detail::iter_value_t<KeyInputIteratorT>;
-  using ValueT = cub::detail::iter_value_t<ValueInputIteratorT>;
+  using KeyT   = cub::detail::it_value_t<KeyInputIteratorT>;
+  using ValueT = cub::detail::it_value_t<ValueInputIteratorT>;
 
   // Tile status descriptor interface type
   using ScanTileStateT = ScanTileState<OffsetT>;

--- a/cub/cub/agent/agent_unique_by_key.cuh
+++ b/cub/cub/agent/agent_unique_by_key.cuh
@@ -134,7 +134,7 @@ struct AgentUniqueByKey
 
   // The input key and value type
   using KeyT   = cub::detail::iter_value_t<KeyInputIteratorT>;
-  using ValueT = cub::detail::value_t<ValueInputIteratorT>;
+  using ValueT = cub::detail::iter_value_t<ValueInputIteratorT>;
 
   // Tile status descriptor interface type
   using ScanTileStateT = ScanTileState<OffsetT>;

--- a/cub/cub/block/block_load.cuh
+++ b/cub/cub/block/block_load.cuh
@@ -1250,7 +1250,7 @@ public:
   //! @}  end member group
 };
 
-template <class Policy, class It, class T = cub::detail::value_t<It>>
+template <class Policy, class It, class T = cub::detail::iter_value_t<It>>
 struct BlockLoadType
 {
   using type = cub::BlockLoad<T, Policy::BLOCK_THREADS, Policy::ITEMS_PER_THREAD, Policy::LOAD_ALGORITHM>;

--- a/cub/cub/block/block_load.cuh
+++ b/cub/cub/block/block_load.cuh
@@ -1250,7 +1250,7 @@ public:
   //! @}  end member group
 };
 
-template <class Policy, class It, class T = cub::detail::iter_value_t<It>>
+template <class Policy, class It, class T = cub::detail::it_value_t<It>>
 struct BlockLoadType
 {
   using type = cub::BlockLoad<T, Policy::BLOCK_THREADS, Policy::ITEMS_PER_THREAD, Policy::LOAD_ALGORITHM>;

--- a/cub/cub/block/block_merge_sort.cuh
+++ b/cub/cub/block/block_merge_sort.cuh
@@ -66,8 +66,8 @@ MergePath(KeyIt1 keys1, KeyIt2 keys2, OffsetT keys1_count, OffsetT keys2_count, 
   {
     const OffsetT mid = cub::MidPoint<OffsetT>(keys1_begin, keys1_end);
     // pull copies of the keys before calling binary_pred so proxy references are unwrapped
-    const detail::value_t<KeyIt1> key1 = keys1[mid];
-    const detail::value_t<KeyIt2> key2 = keys2[diag - 1 - mid];
+    const detail::iter_value_t<KeyIt1> key1 = keys1[mid];
+    const detail::value_t<KeyIt2> key2      = keys2[diag - 1 - mid];
     if (binary_pred(key2, key1))
     {
       keys1_end = mid;

--- a/cub/cub/block/block_merge_sort.cuh
+++ b/cub/cub/block/block_merge_sort.cuh
@@ -67,7 +67,7 @@ MergePath(KeyIt1 keys1, KeyIt2 keys2, OffsetT keys1_count, OffsetT keys2_count, 
     const OffsetT mid = cub::MidPoint<OffsetT>(keys1_begin, keys1_end);
     // pull copies of the keys before calling binary_pred so proxy references are unwrapped
     const detail::iter_value_t<KeyIt1> key1 = keys1[mid];
-    const detail::value_t<KeyIt2> key2      = keys2[diag - 1 - mid];
+    const detail::iter_value_t<KeyIt2> key2 = keys2[diag - 1 - mid];
     if (binary_pred(key2, key1))
     {
       keys1_end = mid;

--- a/cub/cub/block/block_merge_sort.cuh
+++ b/cub/cub/block/block_merge_sort.cuh
@@ -66,8 +66,8 @@ MergePath(KeyIt1 keys1, KeyIt2 keys2, OffsetT keys1_count, OffsetT keys2_count, 
   {
     const OffsetT mid = cub::MidPoint<OffsetT>(keys1_begin, keys1_end);
     // pull copies of the keys before calling binary_pred so proxy references are unwrapped
-    const detail::iter_value_t<KeyIt1> key1 = keys1[mid];
-    const detail::iter_value_t<KeyIt2> key2 = keys2[diag - 1 - mid];
+    const detail::it_value_t<KeyIt1> key1 = keys1[mid];
+    const detail::it_value_t<KeyIt2> key2 = keys2[diag - 1 - mid];
     if (binary_pred(key2, key1))
     {
       keys1_end = mid;

--- a/cub/cub/block/block_store.cuh
+++ b/cub/cub/block/block_store.cuh
@@ -1227,7 +1227,7 @@ public:
 };
 
 #ifndef _CCCL_DOXYGEN_INVOKED // Do not document
-template <class Policy, class It, class T = cub::detail::iter_value_t<It>>
+template <class Policy, class It, class T = cub::detail::it_value_t<It>>
 struct BlockStoreType
 {
   using type = cub::BlockStore<T, Policy::BLOCK_THREADS, Policy::ITEMS_PER_THREAD, Policy::STORE_ALGORITHM>;

--- a/cub/cub/block/block_store.cuh
+++ b/cub/cub/block/block_store.cuh
@@ -1227,7 +1227,7 @@ public:
 };
 
 #ifndef _CCCL_DOXYGEN_INVOKED // Do not document
-template <class Policy, class It, class T = cub::detail::value_t<It>>
+template <class Policy, class It, class T = cub::detail::iter_value_t<It>>
 struct BlockStoreType
 {
   using type = cub::BlockStore<T, Policy::BLOCK_THREADS, Policy::ITEMS_PER_THREAD, Policy::STORE_ALGORITHM>;

--- a/cub/cub/device/device_for.cuh
+++ b/cub/cub/device/device_for.cuh
@@ -596,7 +596,7 @@ private:
     using offset_t = NumItemsT;
     // Disable auto-vectorization for now:
     // constexpr bool use_vectorization =
-    //   detail::for_each::can_regain_copy_freedom<detail::value_t<RandomAccessIteratorT>, OpT>::value
+    //   detail::for_each::can_regain_copy_freedom<detail::iter_value_t<RandomAccessIteratorT>, OpT>::value
     //   && THRUST_NS_QUALIFIER::is_contiguous_iterator<RandomAccessIteratorT>::value;
     using use_vectorization_t = ::cuda::std::bool_constant<false>;
     return for_each_n<RandomAccessIteratorT, offset_t, OpT>(first, num_items, op, stream, use_vectorization_t{});

--- a/cub/cub/device/device_for.cuh
+++ b/cub/cub/device/device_for.cuh
@@ -157,7 +157,7 @@ private:
   {
     auto* unwrapped_first = THRUST_NS_QUALIFIER::unwrap_contiguous_iterator(first);
     using wrapped_op_t =
-      detail::for_each::op_wrapper_vectorized_t<OffsetT, OpT, detail::iter_value_t<ContiguousIteratorT>>;
+      detail::for_each::op_wrapper_vectorized_t<OffsetT, OpT, detail::it_value_t<ContiguousIteratorT>>;
 
     if (is_aligned<typename wrapped_op_t::vector_t>(unwrapped_first))
     { // Vectorize loads
@@ -596,7 +596,7 @@ private:
     using offset_t = NumItemsT;
     // Disable auto-vectorization for now:
     // constexpr bool use_vectorization =
-    //   detail::for_each::can_regain_copy_freedom<detail::iter_value_t<RandomAccessIteratorT>, OpT>::value
+    //   detail::for_each::can_regain_copy_freedom<detail::it_value_t<RandomAccessIteratorT>, OpT>::value
     //   && THRUST_NS_QUALIFIER::is_contiguous_iterator<RandomAccessIteratorT>::value;
     using use_vectorization_t = ::cuda::std::bool_constant<false>;
     return for_each_n<RandomAccessIteratorT, offset_t, OpT>(first, num_items, op, stream, use_vectorization_t{});
@@ -708,7 +708,7 @@ public:
   {
     CUB_DETAIL_NVTX_RANGE_SCOPE("cub::DeviceFor::ForEach");
 
-    using offset_t       = detail::iter_difference_t<RandomAccessIteratorT>;
+    using offset_t       = detail::it_difference_t<RandomAccessIteratorT>;
     const auto num_items = static_cast<offset_t>(THRUST_NS_QUALIFIER::distance(first, last));
     return ForEachNNoNVTX(first, num_items, op, stream);
   }
@@ -835,7 +835,7 @@ public:
   ForEachCopy(RandomAccessIteratorT first, RandomAccessIteratorT last, OpT op, cudaStream_t stream = {})
   {
     CUB_DETAIL_NVTX_RANGE_SCOPE("cub::DeviceFor::ForEachCopy");
-    using offset_t       = detail::iter_difference_t<RandomAccessIteratorT>;
+    using offset_t       = detail::it_difference_t<RandomAccessIteratorT>;
     const auto num_items = static_cast<offset_t>(THRUST_NS_QUALIFIER::distance(first, last));
     return ForEachCopyNNoNVTX(first, num_items, op, stream);
   }

--- a/cub/cub/device/device_for.cuh
+++ b/cub/cub/device/device_for.cuh
@@ -708,10 +708,8 @@ public:
   {
     CUB_DETAIL_NVTX_RANGE_SCOPE("cub::DeviceFor::ForEach");
 
-    using offset_t = typename ::cuda::std::iterator_traits<RandomAccessIteratorT>::difference_type;
-
+    using offset_t       = detail::iter_difference_t<RandomAccessIteratorT>;
     const auto num_items = static_cast<offset_t>(THRUST_NS_QUALIFIER::distance(first, last));
-
     return ForEachNNoNVTX(first, num_items, op, stream);
   }
 
@@ -837,7 +835,7 @@ public:
   ForEachCopy(RandomAccessIteratorT first, RandomAccessIteratorT last, OpT op, cudaStream_t stream = {})
   {
     CUB_DETAIL_NVTX_RANGE_SCOPE("cub::DeviceFor::ForEachCopy");
-    using offset_t       = typename ::cuda::std::iterator_traits<RandomAccessIteratorT>::difference_type;
+    using offset_t       = detail::iter_difference_t<RandomAccessIteratorT>;
     const auto num_items = static_cast<offset_t>(THRUST_NS_QUALIFIER::distance(first, last));
     return ForEachCopyNNoNVTX(first, num_items, op, stream);
   }

--- a/cub/cub/device/device_for.cuh
+++ b/cub/cub/device/device_for.cuh
@@ -44,15 +44,16 @@
 
 #include <thrust/detail/raw_reference_cast.h>
 #include <thrust/distance.h>
-#include <thrust/iterator/iterator_traits.h>
 #include <thrust/system/cuda/detail/core/util.h>
 #include <thrust/type_traits/is_contiguous_iterator.h>
 #include <thrust/type_traits/unwrap_contiguous_iterator.h>
 
+#include <cuda/std/iterator>
+#include <cuda/std/type_traits>
+
 #if __cccl_lib_mdspan
 #  include <cuda/std/__mdspan/extents.h>
 #endif // __cccl_lib_mdspan
-#include <cuda/std/type_traits>
 
 CUB_NAMESPACE_BEGIN
 
@@ -155,7 +156,8 @@ private:
     ContiguousIteratorT first, OffsetT num_items, OpT op, cudaStream_t stream, ::cuda::std::true_type /* vectorize */)
   {
     auto* unwrapped_first = THRUST_NS_QUALIFIER::unwrap_contiguous_iterator(first);
-    using wrapped_op_t = detail::for_each::op_wrapper_vectorized_t<OffsetT, OpT, detail::value_t<ContiguousIteratorT>>;
+    using wrapped_op_t =
+      detail::for_each::op_wrapper_vectorized_t<OffsetT, OpT, detail::iter_value_t<ContiguousIteratorT>>;
 
     if (is_aligned<typename wrapped_op_t::vector_t>(unwrapped_first))
     { // Vectorize loads
@@ -706,7 +708,7 @@ public:
   {
     CUB_DETAIL_NVTX_RANGE_SCOPE("cub::DeviceFor::ForEach");
 
-    using offset_t = typename THRUST_NS_QUALIFIER::iterator_traits<RandomAccessIteratorT>::difference_type;
+    using offset_t = typename ::cuda::std::iterator_traits<RandomAccessIteratorT>::difference_type;
 
     const auto num_items = static_cast<offset_t>(THRUST_NS_QUALIFIER::distance(first, last));
 
@@ -835,7 +837,7 @@ public:
   ForEachCopy(RandomAccessIteratorT first, RandomAccessIteratorT last, OpT op, cudaStream_t stream = {})
   {
     CUB_DETAIL_NVTX_RANGE_SCOPE("cub::DeviceFor::ForEachCopy");
-    using offset_t       = typename THRUST_NS_QUALIFIER::iterator_traits<RandomAccessIteratorT>::difference_type;
+    using offset_t       = typename ::cuda::std::iterator_traits<RandomAccessIteratorT>::difference_type;
     const auto num_items = static_cast<offset_t>(THRUST_NS_QUALIFIER::distance(first, last));
     return ForEachCopyNNoNVTX(first, num_items, op, stream);
   }

--- a/cub/cub/device/device_histogram.cuh
+++ b/cub/cub/device/device_histogram.cuh
@@ -190,7 +190,7 @@ struct DeviceHistogram
     cudaStream_t stream = 0)
   {
     /// The sample value type of the input iterator
-    using SampleT = cub::detail::value_t<SampleIteratorT>;
+    using SampleT = cub::detail::iter_value_t<SampleIteratorT>;
     return MultiHistogramEven<1, 1>(
       d_temp_storage,
       temp_storage_bytes,
@@ -509,7 +509,7 @@ struct DeviceHistogram
     cudaStream_t stream = 0)
   {
     /// The sample value type of the input iterator
-    using SampleT = cub::detail::value_t<SampleIteratorT>;
+    using SampleT = cub::detail::iter_value_t<SampleIteratorT>;
 
     return MultiHistogramEven<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
       d_temp_storage,
@@ -700,7 +700,7 @@ struct DeviceHistogram
     CUB_DETAIL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceHistogram::MultiHistogramEven");
 
     /// The sample value type of the input iterator
-    using SampleT = cub::detail::value_t<SampleIteratorT>;
+    using SampleT = cub::detail::iter_value_t<SampleIteratorT>;
     ::cuda::std::bool_constant<sizeof(SampleT) == 1> is_byte_sample;
 
     if constexpr (sizeof(OffsetT) > sizeof(int))
@@ -850,7 +850,7 @@ struct DeviceHistogram
     cudaStream_t stream = 0)
   {
     /// The sample value type of the input iterator
-    using SampleT = cub::detail::value_t<SampleIteratorT>;
+    using SampleT = cub::detail::iter_value_t<SampleIteratorT>;
     return MultiHistogramRange<1, 1>(
       d_temp_storage,
       temp_storage_bytes,
@@ -1145,7 +1145,7 @@ struct DeviceHistogram
     cudaStream_t stream = 0)
   {
     /// The sample value type of the input iterator
-    using SampleT = cub::detail::value_t<SampleIteratorT>;
+    using SampleT = cub::detail::iter_value_t<SampleIteratorT>;
 
     return MultiHistogramRange<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
       d_temp_storage,

--- a/cub/cub/device/device_histogram.cuh
+++ b/cub/cub/device/device_histogram.cuh
@@ -190,7 +190,7 @@ struct DeviceHistogram
     cudaStream_t stream = 0)
   {
     /// The sample value type of the input iterator
-    using SampleT = cub::detail::iter_value_t<SampleIteratorT>;
+    using SampleT = cub::detail::it_value_t<SampleIteratorT>;
     return MultiHistogramEven<1, 1>(
       d_temp_storage,
       temp_storage_bytes,
@@ -509,7 +509,7 @@ struct DeviceHistogram
     cudaStream_t stream = 0)
   {
     /// The sample value type of the input iterator
-    using SampleT = cub::detail::iter_value_t<SampleIteratorT>;
+    using SampleT = cub::detail::it_value_t<SampleIteratorT>;
 
     return MultiHistogramEven<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
       d_temp_storage,
@@ -700,7 +700,7 @@ struct DeviceHistogram
     CUB_DETAIL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceHistogram::MultiHistogramEven");
 
     /// The sample value type of the input iterator
-    using SampleT = cub::detail::iter_value_t<SampleIteratorT>;
+    using SampleT = cub::detail::it_value_t<SampleIteratorT>;
     ::cuda::std::bool_constant<sizeof(SampleT) == 1> is_byte_sample;
 
     if constexpr (sizeof(OffsetT) > sizeof(int))
@@ -850,7 +850,7 @@ struct DeviceHistogram
     cudaStream_t stream = 0)
   {
     /// The sample value type of the input iterator
-    using SampleT = cub::detail::iter_value_t<SampleIteratorT>;
+    using SampleT = cub::detail::it_value_t<SampleIteratorT>;
     return MultiHistogramRange<1, 1>(
       d_temp_storage,
       temp_storage_bytes,
@@ -1145,7 +1145,7 @@ struct DeviceHistogram
     cudaStream_t stream = 0)
   {
     /// The sample value type of the input iterator
-    using SampleT = cub::detail::iter_value_t<SampleIteratorT>;
+    using SampleT = cub::detail::it_value_t<SampleIteratorT>;
 
     return MultiHistogramRange<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
       d_temp_storage,
@@ -1326,7 +1326,7 @@ struct DeviceHistogram
     CUB_DETAIL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceHistogram::MultiHistogramRange");
 
     /// The sample value type of the input iterator
-    using SampleT = cub::detail::iter_value_t<SampleIteratorT>;
+    using SampleT = cub::detail::it_value_t<SampleIteratorT>;
     ::cuda::std::bool_constant<sizeof(SampleT) == 1> is_byte_sample;
 
     if constexpr (sizeof(OffsetT) > sizeof(int))

--- a/cub/cub/device/device_histogram.cuh
+++ b/cub/cub/device/device_histogram.cuh
@@ -1326,7 +1326,7 @@ struct DeviceHistogram
     CUB_DETAIL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceHistogram::MultiHistogramRange");
 
     /// The sample value type of the input iterator
-    using SampleT = cub::detail::value_t<SampleIteratorT>;
+    using SampleT = cub::detail::iter_value_t<SampleIteratorT>;
     ::cuda::std::bool_constant<sizeof(SampleT) == 1> is_byte_sample;
 
     if constexpr (sizeof(OffsetT) > sizeof(int))

--- a/cub/cub/device/device_memcpy.cuh
+++ b/cub/cub/device/device_memcpy.cuh
@@ -175,10 +175,10 @@ struct DeviceMemcpy
     cudaStream_t stream = 0)
   {
     CUB_DETAIL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceMemcpy::Batched");
-    static_assert(::cuda::std::is_pointer_v<cub::detail::iter_value_t<InputBufferIt>>,
+    static_assert(::cuda::std::is_pointer_v<cub::detail::it_value_t<InputBufferIt>>,
                   "DeviceMemcpy::Batched only supports copying of memory buffers."
                   "Please consider using DeviceCopy::Batched instead.");
-    static_assert(::cuda::std::is_pointer_v<cub::detail::iter_value_t<OutputBufferIt>>,
+    static_assert(::cuda::std::is_pointer_v<cub::detail::it_value_t<OutputBufferIt>>,
                   "DeviceMemcpy::Batched only supports copying of memory buffers."
                   "Please consider using DeviceCopy::Batched instead.");
 

--- a/cub/cub/device/device_memcpy.cuh
+++ b/cub/cub/device/device_memcpy.cuh
@@ -178,7 +178,7 @@ struct DeviceMemcpy
     static_assert(::cuda::std::is_pointer_v<cub::detail::iter_value_t<InputBufferIt>>,
                   "DeviceMemcpy::Batched only supports copying of memory buffers."
                   "Please consider using DeviceCopy::Batched instead.");
-    static_assert(::cuda::std::is_pointer_v<cub::detail::value_t<OutputBufferIt>>,
+    static_assert(::cuda::std::is_pointer_v<cub::detail::iter_value_t<OutputBufferIt>>,
                   "DeviceMemcpy::Batched only supports copying of memory buffers."
                   "Please consider using DeviceCopy::Batched instead.");
 

--- a/cub/cub/device/device_memcpy.cuh
+++ b/cub/cub/device/device_memcpy.cuh
@@ -175,7 +175,7 @@ struct DeviceMemcpy
     cudaStream_t stream = 0)
   {
     CUB_DETAIL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceMemcpy::Batched");
-    static_assert(::cuda::std::is_pointer_v<cub::detail::value_t<InputBufferIt>>,
+    static_assert(::cuda::std::is_pointer_v<cub::detail::iter_value_t<InputBufferIt>>,
                   "DeviceMemcpy::Batched only supports copying of memory buffers."
                   "Please consider using DeviceCopy::Batched instead.");
     static_assert(::cuda::std::is_pointer_v<cub::detail::value_t<OutputBufferIt>>,

--- a/cub/cub/device/device_reduce.cuh
+++ b/cub/cub/device/device_reduce.cuh
@@ -318,7 +318,7 @@ struct DeviceReduce
     using OffsetT = detail::choose_offset_t<NumItemsT>;
 
     // The output value type
-    using OutputT = cub::detail::non_void_value_t<OutputIteratorT, cub::detail::value_t<InputIteratorT>>;
+    using OutputT = cub::detail::non_void_value_t<OutputIteratorT, cub::detail::iter_value_t<InputIteratorT>>;
 
     using InitT = OutputT;
 
@@ -424,7 +424,7 @@ struct DeviceReduce
     using OffsetT = detail::choose_offset_t<NumItemsT>;
 
     // The input value type
-    using InputT = cub::detail::value_t<InputIteratorT>;
+    using InputT = cub::detail::iter_value_t<InputIteratorT>;
 
     using InitT = InputT;
 
@@ -539,7 +539,7 @@ struct DeviceReduce
     CUB_DETAIL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceReduce::ArgMin");
 
     // The input type
-    using InputValueT = cub::detail::value_t<InputIteratorT>;
+    using InputValueT = cub::detail::iter_value_t<InputIteratorT>;
 
     // Offset type used within the kernel and to index within one partition
     using PerPartitionOffsetT = int;
@@ -673,7 +673,7 @@ struct DeviceReduce
     using OffsetT = int;
 
     // The input type
-    using InputValueT = cub::detail::value_t<InputIteratorT>;
+    using InputValueT = cub::detail::iter_value_t<InputIteratorT>;
 
     // The output tuple type
     using OutputTupleT = cub::detail::non_void_value_t<OutputIteratorT, KeyValuePair<OffsetT, InputValueT>>;
@@ -785,7 +785,7 @@ struct DeviceReduce
     using OffsetT = detail::choose_offset_t<NumItemsT>;
 
     // The input value type
-    using InputT = cub::detail::value_t<InputIteratorT>;
+    using InputT = cub::detail::iter_value_t<InputIteratorT>;
 
     using InitT = InputT;
 
@@ -900,7 +900,7 @@ struct DeviceReduce
     CUB_DETAIL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceReduce::ArgMax");
 
     // The input type
-    using InputValueT = cub::detail::value_t<InputIteratorT>;
+    using InputValueT = cub::detail::iter_value_t<InputIteratorT>;
 
     // Offset type used within the kernel and to index within one partition
     using PerPartitionOffsetT = int;
@@ -1038,7 +1038,7 @@ struct DeviceReduce
     using OffsetT = int;
 
     // The input type
-    using InputValueT = cub::detail::value_t<InputIteratorT>;
+    using InputValueT = cub::detail::iter_value_t<InputIteratorT>;
 
     // The output tuple type
     using OutputTupleT = cub::detail::non_void_value_t<OutputIteratorT, KeyValuePair<OffsetT, InputValueT>>;

--- a/cub/cub/device/device_reduce.cuh
+++ b/cub/cub/device/device_reduce.cuh
@@ -318,7 +318,7 @@ struct DeviceReduce
     using OffsetT = detail::choose_offset_t<NumItemsT>;
 
     // The output value type
-    using OutputT = cub::detail::non_void_value_t<OutputIteratorT, cub::detail::iter_value_t<InputIteratorT>>;
+    using OutputT = cub::detail::non_void_value_t<OutputIteratorT, cub::detail::it_value_t<InputIteratorT>>;
 
     using InitT = OutputT;
 
@@ -424,7 +424,7 @@ struct DeviceReduce
     using OffsetT = detail::choose_offset_t<NumItemsT>;
 
     // The input value type
-    using InputT = cub::detail::iter_value_t<InputIteratorT>;
+    using InputT = cub::detail::it_value_t<InputIteratorT>;
 
     using InitT = InputT;
 
@@ -539,7 +539,7 @@ struct DeviceReduce
     CUB_DETAIL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceReduce::ArgMin");
 
     // The input type
-    using InputValueT = cub::detail::iter_value_t<InputIteratorT>;
+    using InputValueT = cub::detail::it_value_t<InputIteratorT>;
 
     // Offset type used within the kernel and to index within one partition
     using PerPartitionOffsetT = int;
@@ -673,7 +673,7 @@ struct DeviceReduce
     using OffsetT = int;
 
     // The input type
-    using InputValueT = cub::detail::iter_value_t<InputIteratorT>;
+    using InputValueT = cub::detail::it_value_t<InputIteratorT>;
 
     // The output tuple type
     using OutputTupleT = cub::detail::non_void_value_t<OutputIteratorT, KeyValuePair<OffsetT, InputValueT>>;
@@ -785,7 +785,7 @@ struct DeviceReduce
     using OffsetT = detail::choose_offset_t<NumItemsT>;
 
     // The input value type
-    using InputT = cub::detail::iter_value_t<InputIteratorT>;
+    using InputT = cub::detail::it_value_t<InputIteratorT>;
 
     using InitT = InputT;
 
@@ -900,7 +900,7 @@ struct DeviceReduce
     CUB_DETAIL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceReduce::ArgMax");
 
     // The input type
-    using InputValueT = cub::detail::iter_value_t<InputIteratorT>;
+    using InputValueT = cub::detail::it_value_t<InputIteratorT>;
 
     // Offset type used within the kernel and to index within one partition
     using PerPartitionOffsetT = int;
@@ -1038,7 +1038,7 @@ struct DeviceReduce
     using OffsetT = int;
 
     // The input type
-    using InputValueT = cub::detail::iter_value_t<InputIteratorT>;
+    using InputValueT = cub::detail::it_value_t<InputIteratorT>;
 
     // The output tuple type
     using OutputTupleT = cub::detail::non_void_value_t<OutputIteratorT, KeyValuePair<OffsetT, InputValueT>>;

--- a/cub/cub/device/device_run_length_encode.cuh
+++ b/cub/cub/device/device_run_length_encode.cuh
@@ -205,7 +205,7 @@ struct DeviceRunLengthEncode
 
     using accum_t = ::cuda::std::__accumulator_t<reduction_op, length_t, length_t>;
 
-    using key_t = cub::detail::non_void_value_t<UniqueOutputIteratorT, cub::detail::value_t<InputIteratorT>>;
+    using key_t = cub::detail::non_void_value_t<UniqueOutputIteratorT, cub::detail::iter_value_t<InputIteratorT>>;
 
     using policy_t = detail::rle::encode::policy_hub<accum_t, key_t>;
 

--- a/cub/cub/device/device_run_length_encode.cuh
+++ b/cub/cub/device/device_run_length_encode.cuh
@@ -205,7 +205,7 @@ struct DeviceRunLengthEncode
 
     using accum_t = ::cuda::std::__accumulator_t<reduction_op, length_t, length_t>;
 
-    using key_t = cub::detail::non_void_value_t<UniqueOutputIteratorT, cub::detail::iter_value_t<InputIteratorT>>;
+    using key_t = cub::detail::non_void_value_t<UniqueOutputIteratorT, cub::detail::it_value_t<InputIteratorT>>;
 
     using policy_t = detail::rle::encode::policy_hub<accum_t, key_t>;
 

--- a/cub/cub/device/device_scan.cuh
+++ b/cub/cub/device/device_scan.cuh
@@ -191,7 +191,7 @@ struct DeviceScan
 
     // Unsigned integer type for global offsets
     using OffsetT = detail::choose_offset_t<NumItemsT>;
-    using InitT   = cub::detail::value_t<InputIteratorT>;
+    using InitT   = cub::detail::iter_value_t<InputIteratorT>;
 
     // Initial value
     InitT init_value{};
@@ -1156,7 +1156,7 @@ struct DeviceScan
 
     // Unsigned integer type for global offsets
     using OffsetT = detail::choose_offset_t<NumItemsT>;
-    using AccumT  = ::cuda::std::__accumulator_t<ScanOpT, cub::detail::value_t<InputIteratorT>, InitValueT>;
+    using AccumT  = ::cuda::std::__accumulator_t<ScanOpT, cub::detail::iter_value_t<InputIteratorT>, InitValueT>;
 
     return DispatchScan<
       InputIteratorT,

--- a/cub/cub/device/device_scan.cuh
+++ b/cub/cub/device/device_scan.cuh
@@ -191,7 +191,7 @@ struct DeviceScan
 
     // Unsigned integer type for global offsets
     using OffsetT = detail::choose_offset_t<NumItemsT>;
-    using InitT   = cub::detail::iter_value_t<InputIteratorT>;
+    using InitT   = cub::detail::it_value_t<InputIteratorT>;
 
     // Initial value
     InitT init_value{};
@@ -1156,7 +1156,7 @@ struct DeviceScan
 
     // Unsigned integer type for global offsets
     using OffsetT = detail::choose_offset_t<NumItemsT>;
-    using AccumT  = ::cuda::std::__accumulator_t<ScanOpT, cub::detail::iter_value_t<InputIteratorT>, InitValueT>;
+    using AccumT  = ::cuda::std::__accumulator_t<ScanOpT, cub::detail::it_value_t<InputIteratorT>, InitValueT>;
 
     return DispatchScan<
       InputIteratorT,
@@ -1390,7 +1390,7 @@ struct DeviceScan
 
     // Unsigned integer type for global offsets
     using OffsetT = detail::choose_offset_t<NumItemsT>;
-    using InitT   = cub::detail::iter_value_t<ValuesInputIteratorT>;
+    using InitT   = cub::detail::it_value_t<ValuesInputIteratorT>;
 
     // Initial value
     InitT init_value{};

--- a/cub/cub/device/device_scan.cuh
+++ b/cub/cub/device/device_scan.cuh
@@ -1390,7 +1390,7 @@ struct DeviceScan
 
     // Unsigned integer type for global offsets
     using OffsetT = detail::choose_offset_t<NumItemsT>;
-    using InitT   = cub::detail::value_t<ValuesInputIteratorT>;
+    using InitT   = cub::detail::iter_value_t<ValuesInputIteratorT>;
 
     // Initial value
     InitT init_value{};

--- a/cub/cub/device/device_segmented_reduce.cuh
+++ b/cub/cub/device/device_segmented_reduce.cuh
@@ -366,7 +366,7 @@ public:
     using OffsetT = detail::common_iterator_value_t<BeginOffsetIteratorT, EndOffsetIteratorT>;
 
     // The output value type
-    using OutputT = cub::detail::non_void_value_t<OutputIteratorT, cub::detail::iter_value_t<InputIteratorT>>;
+    using OutputT = cub::detail::non_void_value_t<OutputIteratorT, cub::detail::it_value_t<InputIteratorT>>;
     using integral_offset_check = ::cuda::std::is_integral<OffsetT>;
 
     static_assert(integral_offset_check::value, "Offset iterator value type should be integral.");
@@ -489,7 +489,7 @@ public:
     using OffsetT = detail::common_iterator_value_t<BeginOffsetIteratorT, EndOffsetIteratorT>;
 
     // The input value type
-    using InputT                = cub::detail::iter_value_t<InputIteratorT>;
+    using InputT                = cub::detail::it_value_t<InputIteratorT>;
     using integral_offset_check = ::cuda::std::is_integral<OffsetT>;
 
     static_assert(integral_offset_check::value, "Offset iterator value type should be integral.");
@@ -618,7 +618,7 @@ public:
     using OffsetT = int; // detail::common_iterator_value_t<BeginOffsetIteratorT, EndOffsetIteratorT>;
 
     // The input type
-    using InputValueT = cub::detail::iter_value_t<InputIteratorT>;
+    using InputValueT = cub::detail::it_value_t<InputIteratorT>;
 
     // The output tuple type
     using OutputTupleT = cub::detail::non_void_value_t<OutputIteratorT, KeyValuePair<OffsetT, InputValueT>>;
@@ -755,7 +755,7 @@ public:
     using OffsetT = detail::common_iterator_value_t<BeginOffsetIteratorT, EndOffsetIteratorT>;
 
     // The input value type
-    using InputT = cub::detail::iter_value_t<InputIteratorT>;
+    using InputT = cub::detail::it_value_t<InputIteratorT>;
 
     using integral_offset_check = ::cuda::std::is_integral<OffsetT>;
     static_assert(integral_offset_check::value, "Offset iterator value type should be integral.");
@@ -882,7 +882,7 @@ public:
     using OffsetT = int; // detail::common_iterator_value_t<BeginOffsetIteratorT, EndOffsetIteratorT>;
 
     // The input type
-    using InputValueT = cub::detail::iter_value_t<InputIteratorT>;
+    using InputValueT = cub::detail::it_value_t<InputIteratorT>;
 
     // The output tuple type
     using OutputTupleT = cub::detail::non_void_value_t<OutputIteratorT, KeyValuePair<OffsetT, InputValueT>>;

--- a/cub/cub/device/device_segmented_reduce.cuh
+++ b/cub/cub/device/device_segmented_reduce.cuh
@@ -366,7 +366,7 @@ public:
     using OffsetT = detail::common_iterator_value_t<BeginOffsetIteratorT, EndOffsetIteratorT>;
 
     // The output value type
-    using OutputT               = cub::detail::non_void_value_t<OutputIteratorT, cub::detail::value_t<InputIteratorT>>;
+    using OutputT = cub::detail::non_void_value_t<OutputIteratorT, cub::detail::iter_value_t<InputIteratorT>>;
     using integral_offset_check = ::cuda::std::is_integral<OffsetT>;
 
     static_assert(integral_offset_check::value, "Offset iterator value type should be integral.");
@@ -489,7 +489,7 @@ public:
     using OffsetT = detail::common_iterator_value_t<BeginOffsetIteratorT, EndOffsetIteratorT>;
 
     // The input value type
-    using InputT                = cub::detail::value_t<InputIteratorT>;
+    using InputT                = cub::detail::iter_value_t<InputIteratorT>;
     using integral_offset_check = ::cuda::std::is_integral<OffsetT>;
 
     static_assert(integral_offset_check::value, "Offset iterator value type should be integral.");
@@ -618,7 +618,7 @@ public:
     using OffsetT = int; // detail::common_iterator_value_t<BeginOffsetIteratorT, EndOffsetIteratorT>;
 
     // The input type
-    using InputValueT = cub::detail::value_t<InputIteratorT>;
+    using InputValueT = cub::detail::iter_value_t<InputIteratorT>;
 
     // The output tuple type
     using OutputTupleT = cub::detail::non_void_value_t<OutputIteratorT, KeyValuePair<OffsetT, InputValueT>>;
@@ -755,7 +755,7 @@ public:
     using OffsetT = detail::common_iterator_value_t<BeginOffsetIteratorT, EndOffsetIteratorT>;
 
     // The input value type
-    using InputT = cub::detail::value_t<InputIteratorT>;
+    using InputT = cub::detail::iter_value_t<InputIteratorT>;
 
     using integral_offset_check = ::cuda::std::is_integral<OffsetT>;
     static_assert(integral_offset_check::value, "Offset iterator value type should be integral.");
@@ -882,7 +882,7 @@ public:
     using OffsetT = int; // detail::common_iterator_value_t<BeginOffsetIteratorT, EndOffsetIteratorT>;
 
     // The input type
-    using InputValueT = cub::detail::value_t<InputIteratorT>;
+    using InputValueT = cub::detail::iter_value_t<InputIteratorT>;
 
     // The output tuple type
     using OutputTupleT = cub::detail::non_void_value_t<OutputIteratorT, KeyValuePair<OffsetT, InputValueT>>;

--- a/cub/cub/device/dispatch/dispatch_adjacent_difference.cuh
+++ b/cub/cub/device/dispatch/dispatch_adjacent_difference.cuh
@@ -122,7 +122,7 @@ template <typename InputIteratorT,
           typename PolicyHub = detail::adjacent_difference::policy_hub<InputIteratorT, AliasOpt == MayAlias::Yes>>
 struct DispatchAdjacentDifference
 {
-  using InputT = typename std::iterator_traits<InputIteratorT>::value_type;
+  using InputT = detail::iter_value_t<InputIteratorT>;
 
   void* d_temp_storage;
   size_t& temp_storage_bytes;

--- a/cub/cub/device/dispatch/dispatch_adjacent_difference.cuh
+++ b/cub/cub/device/dispatch/dispatch_adjacent_difference.cuh
@@ -122,7 +122,7 @@ template <typename InputIteratorT,
           typename PolicyHub = detail::adjacent_difference::policy_hub<InputIteratorT, AliasOpt == MayAlias::Yes>>
 struct DispatchAdjacentDifference
 {
-  using InputT = detail::iter_value_t<InputIteratorT>;
+  using InputT = detail::it_value_t<InputIteratorT>;
 
   void* d_temp_storage;
   size_t& temp_storage_bytes;

--- a/cub/cub/device/dispatch/dispatch_batch_memcpy.cuh
+++ b/cub/cub/device/dispatch/dispatch_batch_memcpy.cuh
@@ -113,8 +113,9 @@ __launch_bounds__(int(ChainedPolicyT::ActivePolicy::AgentLargeBufferPolicyT::BLO
   using ActivePolicyT = typename ChainedPolicyT::ActivePolicy::AgentLargeBufferPolicyT;
   using BufferSizeT   = iter_value_t<BufferSizeIteratorT>;
   /// Internal load/store type. For byte-wise memcpy, a single-byte type
-  using AliasT =
-    typename ::cuda::std::conditional_t<MemcpyOpt == CopyAlg::Memcpy, char, iter_value_t<iter_value_t<InputBufferIt>>>;
+  using AliasT = typename ::cuda::std::conditional_t<MemcpyOpt == CopyAlg::Memcpy,
+                                                     ::cuda::std::type_identity<char>,
+                                                     lazy_trait<iter_value_t, iter_value_t<InputBufferIt>>>::type;
   /// Types of the input and output buffers
   using InputBufferT  = iter_value_t<InputBufferIt>;
   using OutputBufferT = iter_value_t<OutputBufferIt>;

--- a/cub/cub/device/dispatch/dispatch_batch_memcpy.cuh
+++ b/cub/cub/device/dispatch/dispatch_batch_memcpy.cuh
@@ -56,6 +56,7 @@
 
 #include <cuda/std/__algorithm/max.h>
 #include <cuda/std/__algorithm/min.h>
+#include <cuda/std/iterator>
 #include <cuda/std/type_traits>
 
 #include <cstdint>
@@ -110,14 +111,15 @@ __launch_bounds__(int(ChainedPolicyT::ActivePolicy::AgentLargeBufferPolicyT::BLO
 {
   using StatusWord    = typename TileT::StatusWord;
   using ActivePolicyT = typename ChainedPolicyT::ActivePolicy::AgentLargeBufferPolicyT;
-  using BufferSizeT   = value_t<BufferSizeIteratorT>;
+  using BufferSizeT   = iter_value_t<BufferSizeIteratorT>;
   /// Internal load/store type. For byte-wise memcpy, a single-byte type
-  using AliasT = typename ::cuda::std::conditional_t<MemcpyOpt == CopyAlg::Memcpy,
-                                                     std::iterator_traits<char*>,
-                                                     std::iterator_traits<value_t<InputBufferIt>>>::value_type;
+  using AliasT =
+    typename ::cuda::std::conditional_t<MemcpyOpt == CopyAlg::Memcpy,
+                                        ::cuda::std::iterator_traits<char*>,
+                                        ::cuda::std::iterator_traits<iter_value_t<InputBufferIt>>>::value_type;
   /// Types of the input and output buffers
-  using InputBufferT  = value_t<InputBufferIt>;
-  using OutputBufferT = value_t<OutputBufferIt>;
+  using InputBufferT  = iter_value_t<InputBufferIt>;
+  using OutputBufferT = iter_value_t<OutputBufferIt>;
 
   constexpr uint32_t BLOCK_THREADS    = ActivePolicyT::BLOCK_THREADS;
   constexpr uint32_t ITEMS_PER_THREAD = ActivePolicyT::BYTES_PER_THREAD;
@@ -240,7 +242,7 @@ __launch_bounds__(int(ChainedPolicyT::ActivePolicy::AgentSmallBufferPolicyT::BLO
     BLevBlockOffsetTileState blev_block_scan_state)
 {
   // Internal type used for storing a buffer's size
-  using BufferSizeT = value_t<BufferSizeIteratorT>;
+  using BufferSizeT = iter_value_t<BufferSizeIteratorT>;
 
   // Alias the correct tuning policy for the current compilation pass' architecture
   using AgentBatchMemcpyPolicyT = typename ChainedPolicyT::ActivePolicy::AgentSmallBufferPolicyT;
@@ -313,7 +315,7 @@ struct DispatchBatchMemcpy
   using BufferTileOffsetScanStateT = typename cub::ScanTileState<BlockOffsetT>;
 
   // Internal type used to keep track of a buffer's size
-  using BufferSizeT = cub::detail::value_t<BufferSizeIteratorT>;
+  using BufferSizeT = cub::detail::iter_value_t<BufferSizeIteratorT>;
 
   //------------------------------------------------------------------------------
   // Member Variables
@@ -397,7 +399,7 @@ struct DispatchBatchMemcpy
     BlockOffsetT num_tiles = ::cuda::ceil_div(num_buffers, TILE_SIZE);
 
     using BlevBufferSrcsOutT =
-      ::cuda::std::_If<MemcpyOpt == CopyAlg::Memcpy, const void*, cub::detail::value_t<InputBufferIt>>;
+      ::cuda::std::_If<MemcpyOpt == CopyAlg::Memcpy, const void*, cub::detail::iter_value_t<InputBufferIt>>;
     using BlevBufferDstOutT =
       ::cuda::std::_If<MemcpyOpt == CopyAlg::Memcpy, void*, cub::detail::value_t<OutputBufferIt>>;
     using BlevBufferSrcsOutItT        = BlevBufferSrcsOutT*;

--- a/cub/cub/device/dispatch/dispatch_batch_memcpy.cuh
+++ b/cub/cub/device/dispatch/dispatch_batch_memcpy.cuh
@@ -114,9 +114,7 @@ __launch_bounds__(int(ChainedPolicyT::ActivePolicy::AgentLargeBufferPolicyT::BLO
   using BufferSizeT   = iter_value_t<BufferSizeIteratorT>;
   /// Internal load/store type. For byte-wise memcpy, a single-byte type
   using AliasT =
-    typename ::cuda::std::conditional_t<MemcpyOpt == CopyAlg::Memcpy,
-                                        ::cuda::std::iterator_traits<char*>,
-                                        ::cuda::std::iterator_traits<iter_value_t<InputBufferIt>>>::value_type;
+    typename ::cuda::std::conditional_t<MemcpyOpt == CopyAlg::Memcpy, char, iter_value_t<iter_value_t<InputBufferIt>>>;
   /// Types of the input and output buffers
   using InputBufferT  = iter_value_t<InputBufferIt>;
   using OutputBufferT = iter_value_t<OutputBufferIt>;

--- a/cub/cub/device/dispatch/dispatch_batch_memcpy.cuh
+++ b/cub/cub/device/dispatch/dispatch_batch_memcpy.cuh
@@ -111,14 +111,14 @@ __launch_bounds__(int(ChainedPolicyT::ActivePolicy::AgentLargeBufferPolicyT::BLO
 {
   using StatusWord    = typename TileT::StatusWord;
   using ActivePolicyT = typename ChainedPolicyT::ActivePolicy::AgentLargeBufferPolicyT;
-  using BufferSizeT   = iter_value_t<BufferSizeIteratorT>;
+  using BufferSizeT   = it_value_t<BufferSizeIteratorT>;
   /// Internal load/store type. For byte-wise memcpy, a single-byte type
   using AliasT = typename ::cuda::std::conditional_t<MemcpyOpt == CopyAlg::Memcpy,
                                                      ::cuda::std::type_identity<char>,
-                                                     lazy_trait<iter_value_t, iter_value_t<InputBufferIt>>>::type;
+                                                     lazy_trait<it_value_t, it_value_t<InputBufferIt>>>::type;
   /// Types of the input and output buffers
-  using InputBufferT  = iter_value_t<InputBufferIt>;
-  using OutputBufferT = iter_value_t<OutputBufferIt>;
+  using InputBufferT  = it_value_t<InputBufferIt>;
+  using OutputBufferT = it_value_t<OutputBufferIt>;
 
   constexpr uint32_t BLOCK_THREADS    = ActivePolicyT::BLOCK_THREADS;
   constexpr uint32_t ITEMS_PER_THREAD = ActivePolicyT::BYTES_PER_THREAD;
@@ -241,7 +241,7 @@ __launch_bounds__(int(ChainedPolicyT::ActivePolicy::AgentSmallBufferPolicyT::BLO
     BLevBlockOffsetTileState blev_block_scan_state)
 {
   // Internal type used for storing a buffer's size
-  using BufferSizeT = iter_value_t<BufferSizeIteratorT>;
+  using BufferSizeT = it_value_t<BufferSizeIteratorT>;
 
   // Alias the correct tuning policy for the current compilation pass' architecture
   using AgentBatchMemcpyPolicyT = typename ChainedPolicyT::ActivePolicy::AgentSmallBufferPolicyT;
@@ -314,7 +314,7 @@ struct DispatchBatchMemcpy
   using BufferTileOffsetScanStateT = typename cub::ScanTileState<BlockOffsetT>;
 
   // Internal type used to keep track of a buffer's size
-  using BufferSizeT = cub::detail::iter_value_t<BufferSizeIteratorT>;
+  using BufferSizeT = cub::detail::it_value_t<BufferSizeIteratorT>;
 
   //------------------------------------------------------------------------------
   // Member Variables
@@ -398,9 +398,9 @@ struct DispatchBatchMemcpy
     BlockOffsetT num_tiles = ::cuda::ceil_div(num_buffers, TILE_SIZE);
 
     using BlevBufferSrcsOutT =
-      ::cuda::std::_If<MemcpyOpt == CopyAlg::Memcpy, const void*, cub::detail::iter_value_t<InputBufferIt>>;
+      ::cuda::std::_If<MemcpyOpt == CopyAlg::Memcpy, const void*, cub::detail::it_value_t<InputBufferIt>>;
     using BlevBufferDstOutT =
-      ::cuda::std::_If<MemcpyOpt == CopyAlg::Memcpy, void*, cub::detail::iter_value_t<OutputBufferIt>>;
+      ::cuda::std::_If<MemcpyOpt == CopyAlg::Memcpy, void*, cub::detail::it_value_t<OutputBufferIt>>;
     using BlevBufferSrcsOutItT        = BlevBufferSrcsOutT*;
     using BlevBufferDstsOutItT        = BlevBufferDstOutT*;
     using BlevBufferSizesOutItT       = BufferSizeT*;

--- a/cub/cub/device/dispatch/dispatch_batch_memcpy.cuh
+++ b/cub/cub/device/dispatch/dispatch_batch_memcpy.cuh
@@ -399,7 +399,7 @@ struct DispatchBatchMemcpy
     using BlevBufferSrcsOutT =
       ::cuda::std::_If<MemcpyOpt == CopyAlg::Memcpy, const void*, cub::detail::iter_value_t<InputBufferIt>>;
     using BlevBufferDstOutT =
-      ::cuda::std::_If<MemcpyOpt == CopyAlg::Memcpy, void*, cub::detail::value_t<OutputBufferIt>>;
+      ::cuda::std::_If<MemcpyOpt == CopyAlg::Memcpy, void*, cub::detail::iter_value_t<OutputBufferIt>>;
     using BlevBufferSrcsOutItT        = BlevBufferSrcsOutT*;
     using BlevBufferDstsOutItT        = BlevBufferDstOutT*;
     using BlevBufferSizesOutItT       = BufferSizeT*;

--- a/cub/cub/device/dispatch/dispatch_histogram.cuh
+++ b/cub/cub/device/dispatch/dispatch_histogram.cuh
@@ -569,7 +569,7 @@ public:
   //---------------------------------------------------------------------
 
   /// The sample value type of the input iterator
-  using SampleT = cub::detail::value_t<SampleIteratorT>;
+  using SampleT = cub::detail::iter_value_t<SampleIteratorT>;
 
   enum
   {
@@ -924,7 +924,7 @@ public:
     // Should we call DispatchHistogram<....., PolicyHub=void> in DeviceHistogram?
     static constexpr bool isEven = 0;
     using fallback_policy_hub    = detail::histogram::
-      policy_hub<detail::value_t<SampleIteratorT>, CounterT, NUM_CHANNELS, NUM_ACTIVE_CHANNELS, isEven>;
+      policy_hub<detail::iter_value_t<SampleIteratorT>, CounterT, NUM_CHANNELS, NUM_ACTIVE_CHANNELS, isEven>;
 
     using MaxPolicyT =
       typename ::cuda::std::_If<::cuda::std::is_void_v<PolicyHub>, fallback_policy_hub, PolicyHub>::MaxPolicy;
@@ -1100,7 +1100,7 @@ public:
   {
     static constexpr bool isEven = 0;
     using fallback_policy_hub    = detail::histogram::
-      policy_hub<detail::value_t<SampleIteratorT>, CounterT, NUM_CHANNELS, NUM_ACTIVE_CHANNELS, isEven>;
+      policy_hub<detail::iter_value_t<SampleIteratorT>, CounterT, NUM_CHANNELS, NUM_ACTIVE_CHANNELS, isEven>;
 
     using MaxPolicyT =
       typename ::cuda::std::_If<::cuda::std::is_void_v<PolicyHub>, fallback_policy_hub, PolicyHub>::MaxPolicy;

--- a/cub/cub/device/dispatch/dispatch_histogram.cuh
+++ b/cub/cub/device/dispatch/dispatch_histogram.cuh
@@ -569,7 +569,7 @@ public:
   //---------------------------------------------------------------------
 
   /// The sample value type of the input iterator
-  using SampleT = cub::detail::iter_value_t<SampleIteratorT>;
+  using SampleT = cub::detail::it_value_t<SampleIteratorT>;
 
   enum
   {
@@ -924,7 +924,7 @@ public:
     // Should we call DispatchHistogram<....., PolicyHub=void> in DeviceHistogram?
     static constexpr bool isEven = 0;
     using fallback_policy_hub    = detail::histogram::
-      policy_hub<detail::iter_value_t<SampleIteratorT>, CounterT, NUM_CHANNELS, NUM_ACTIVE_CHANNELS, isEven>;
+      policy_hub<detail::it_value_t<SampleIteratorT>, CounterT, NUM_CHANNELS, NUM_ACTIVE_CHANNELS, isEven>;
 
     using MaxPolicyT =
       typename ::cuda::std::_If<::cuda::std::is_void_v<PolicyHub>, fallback_policy_hub, PolicyHub>::MaxPolicy;
@@ -1100,7 +1100,7 @@ public:
   {
     static constexpr bool isEven = 0;
     using fallback_policy_hub    = detail::histogram::
-      policy_hub<detail::iter_value_t<SampleIteratorT>, CounterT, NUM_CHANNELS, NUM_ACTIVE_CHANNELS, isEven>;
+      policy_hub<detail::it_value_t<SampleIteratorT>, CounterT, NUM_CHANNELS, NUM_ACTIVE_CHANNELS, isEven>;
 
     using MaxPolicyT =
       typename ::cuda::std::_If<::cuda::std::is_void_v<PolicyHub>, fallback_policy_hub, PolicyHub>::MaxPolicy;
@@ -1240,7 +1240,7 @@ public:
   {
     static constexpr bool isEven = 1;
     using fallback_policy_hub    = detail::histogram::
-      policy_hub<detail::iter_value_t<SampleIteratorT>, CounterT, NUM_CHANNELS, NUM_ACTIVE_CHANNELS, isEven>;
+      policy_hub<detail::it_value_t<SampleIteratorT>, CounterT, NUM_CHANNELS, NUM_ACTIVE_CHANNELS, isEven>;
 
     using MaxPolicyT =
       typename ::cuda::std::_If<::cuda::std::is_void_v<PolicyHub>, fallback_policy_hub, PolicyHub>::MaxPolicy;
@@ -1431,7 +1431,7 @@ public:
   {
     static constexpr bool isEven = 1;
     using fallback_policy_hub    = detail::histogram::
-      policy_hub<detail::iter_value_t<SampleIteratorT>, CounterT, NUM_CHANNELS, NUM_ACTIVE_CHANNELS, isEven>;
+      policy_hub<detail::it_value_t<SampleIteratorT>, CounterT, NUM_CHANNELS, NUM_ACTIVE_CHANNELS, isEven>;
 
     using MaxPolicyT =
       typename ::cuda::std::_If<::cuda::std::is_void_v<PolicyHub>, fallback_policy_hub, PolicyHub>::MaxPolicy;

--- a/cub/cub/device/dispatch/dispatch_histogram.cuh
+++ b/cub/cub/device/dispatch/dispatch_histogram.cuh
@@ -1240,7 +1240,7 @@ public:
   {
     static constexpr bool isEven = 1;
     using fallback_policy_hub    = detail::histogram::
-      policy_hub<detail::value_t<SampleIteratorT>, CounterT, NUM_CHANNELS, NUM_ACTIVE_CHANNELS, isEven>;
+      policy_hub<detail::iter_value_t<SampleIteratorT>, CounterT, NUM_CHANNELS, NUM_ACTIVE_CHANNELS, isEven>;
 
     using MaxPolicyT =
       typename ::cuda::std::_If<::cuda::std::is_void_v<PolicyHub>, fallback_policy_hub, PolicyHub>::MaxPolicy;
@@ -1431,7 +1431,7 @@ public:
   {
     static constexpr bool isEven = 1;
     using fallback_policy_hub    = detail::histogram::
-      policy_hub<detail::value_t<SampleIteratorT>, CounterT, NUM_CHANNELS, NUM_ACTIVE_CHANNELS, isEven>;
+      policy_hub<detail::iter_value_t<SampleIteratorT>, CounterT, NUM_CHANNELS, NUM_ACTIVE_CHANNELS, isEven>;
 
     using MaxPolicyT =
       typename ::cuda::std::_If<::cuda::std::is_void_v<PolicyHub>, fallback_policy_hub, PolicyHub>::MaxPolicy;

--- a/cub/cub/device/dispatch/dispatch_merge.cuh
+++ b/cub/cub/device/dispatch/dispatch_merge.cuh
@@ -119,7 +119,7 @@ __launch_bounds__(
     vsmem_t global_temp_storage)
 {
   // the merge agent loads keys into a local array of KeyIt1::value_type, on which the comparisons are performed
-  using key_t = iter_value_t<KeyIt1>;
+  using key_t = it_value_t<KeyIt1>;
   static_assert(::cuda::std::__invokable<CompareOp, key_t, key_t>::value,
                 "Comparison operator cannot compare two keys");
   static_assert(::cuda::std::is_convertible_v<typename ::cuda::std::__invoke_of<CompareOp, key_t, key_t>::type, bool>,
@@ -164,7 +164,7 @@ template <typename KeyIt1,
           typename ValueIt3,
           typename Offset,
           typename CompareOp,
-          typename PolicyHub = detail::merge::policy_hub<iter_value_t<KeyIt1>, iter_value_t<ValueIt1>>>
+          typename PolicyHub = detail::merge::policy_hub<it_value_t<KeyIt1>, it_value_t<ValueIt1>>>
 struct dispatch_t
 {
   void* d_temp_storage;

--- a/cub/cub/device/dispatch/dispatch_merge.cuh
+++ b/cub/cub/device/dispatch/dispatch_merge.cuh
@@ -119,7 +119,7 @@ __launch_bounds__(
     vsmem_t global_temp_storage)
 {
   // the merge agent loads keys into a local array of KeyIt1::value_type, on which the comparisons are performed
-  using key_t = value_t<KeyIt1>;
+  using key_t = iter_value_t<KeyIt1>;
   static_assert(::cuda::std::__invokable<CompareOp, key_t, key_t>::value,
                 "Comparison operator cannot compare two keys");
   static_assert(::cuda::std::is_convertible_v<typename ::cuda::std::__invoke_of<CompareOp, key_t, key_t>::type, bool>,
@@ -164,7 +164,7 @@ template <typename KeyIt1,
           typename ValueIt3,
           typename Offset,
           typename CompareOp,
-          typename PolicyHub = detail::merge::policy_hub<value_t<KeyIt1>, value_t<ValueIt1>>>
+          typename PolicyHub = detail::merge::policy_hub<iter_value_t<KeyIt1>, iter_value_t<ValueIt1>>>
 struct dispatch_t
 {
   void* d_temp_storage;

--- a/cub/cub/device/dispatch/dispatch_merge_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_merge_sort.cuh
@@ -64,8 +64,8 @@ template <typename MaxPolicyT,
           typename CompareOpT>
 struct DeviceMergeSortKernelSource
 {
-  using KeyT   = cub::detail::value_t<KeyIteratorT>;
-  using ValueT = cub::detail::value_t<ValueIteratorT>;
+  using KeyT   = cub::detail::iter_value_t<KeyIteratorT>;
+  using ValueT = cub::detail::iter_value_t<ValueIteratorT>;
 
   CUB_DEFINE_KERNEL_GETTER(
     MergeSortBlockSortKernel,
@@ -127,10 +127,10 @@ template <
        ValueIteratorT,
        OffsetT,
        CompareOpT,
-       cub::detail::value_t<KeyIteratorT>,
-       cub::detail::value_t<ValueIteratorT>>,
-  typename KeyT   = cub::detail::value_t<KeyIteratorT>,
-  typename ValueT = cub::detail::value_t<ValueIteratorT>>
+       cub::detail::iter_value_t<KeyIteratorT>,
+       cub::detail::iter_value_t<ValueIteratorT>>,
+  typename KeyT   = cub::detail::iter_value_t<KeyIteratorT>,
+  typename ValueT = cub::detail::iter_value_t<ValueIteratorT>>
 struct DispatchMergeSort
 {
   /// Whether or not there are values to be trucked along with keys

--- a/cub/cub/device/dispatch/dispatch_merge_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_merge_sort.cuh
@@ -64,8 +64,8 @@ template <typename MaxPolicyT,
           typename CompareOpT>
 struct DeviceMergeSortKernelSource
 {
-  using KeyT   = cub::detail::iter_value_t<KeyIteratorT>;
-  using ValueT = cub::detail::iter_value_t<ValueIteratorT>;
+  using KeyT   = cub::detail::it_value_t<KeyIteratorT>;
+  using ValueT = cub::detail::it_value_t<ValueIteratorT>;
 
   CUB_DEFINE_KERNEL_GETTER(
     MergeSortBlockSortKernel,
@@ -127,10 +127,10 @@ template <
        ValueIteratorT,
        OffsetT,
        CompareOpT,
-       cub::detail::iter_value_t<KeyIteratorT>,
-       cub::detail::iter_value_t<ValueIteratorT>>,
-  typename KeyT   = cub::detail::iter_value_t<KeyIteratorT>,
-  typename ValueT = cub::detail::iter_value_t<ValueIteratorT>>
+       cub::detail::it_value_t<KeyIteratorT>,
+       cub::detail::it_value_t<ValueIteratorT>>,
+  typename KeyT   = cub::detail::it_value_t<KeyIteratorT>,
+  typename ValueT = cub::detail::it_value_t<ValueIteratorT>>
 struct DispatchMergeSort
 {
   /// Whether or not there are values to be trucked along with keys

--- a/cub/cub/device/dispatch/dispatch_reduce.cuh
+++ b/cub/cub/device/dispatch/dispatch_reduce.cuh
@@ -137,8 +137,8 @@ template <typename InputIteratorT,
           typename OutputIteratorT,
           typename OffsetT,
           typename ReductionOpT,
-          typename InitT  = cub::detail::non_void_value_t<OutputIteratorT, cub::detail::value_t<InputIteratorT>>,
-          typename AccumT = ::cuda::std::__accumulator_t<ReductionOpT, cub::detail::value_t<InputIteratorT>, InitT>,
+          typename InitT = cub::detail::non_void_value_t<OutputIteratorT, cub::detail::iter_value_t<InputIteratorT>>,
+          typename AccumT = ::cuda::std::__accumulator_t<ReductionOpT, cub::detail::iter_value_t<InputIteratorT>, InitT>,
           typename TransformOpT = ::cuda::std::__identity,
           typename PolicyHub    = detail::reduce::policy_hub<AccumT, OffsetT, ReductionOpT>,
           typename KernelSource = detail::reduce::DeviceReduceKernelSource<
@@ -573,8 +573,10 @@ template <
   typename ReductionOpT,
   typename TransformOpT,
   typename InitT,
-  typename AccumT = ::cuda::std::
-    __accumulator_t<ReductionOpT, cub::detail::invoke_result_t<TransformOpT, cub::detail::value_t<InputIteratorT>>, InitT>,
+  typename AccumT =
+    ::cuda::std::__accumulator_t<ReductionOpT,
+                                 cub::detail::invoke_result_t<TransformOpT, cub::detail::iter_value_t<InputIteratorT>>,
+                                 InitT>,
   typename PolicyHub    = detail::reduce::policy_hub<AccumT, OffsetT, ReductionOpT>,
   typename KernelSource = detail::reduce::DeviceReduceKernelSource<
     typename PolicyHub::MaxPolicy,

--- a/cub/cub/device/dispatch/dispatch_reduce.cuh
+++ b/cub/cub/device/dispatch/dispatch_reduce.cuh
@@ -667,26 +667,27 @@ struct DeviceSegmentedReduceKernelSource
  *   value type
  */
 
-template <typename InputIteratorT,
-          typename OutputIteratorT,
-          typename BeginOffsetIteratorT,
-          typename EndOffsetIteratorT,
-          typename OffsetT,
-          typename ReductionOpT,
-          typename InitT     = cub::detail::non_void_value_t<OutputIteratorT, cub::detail::value_t<InputIteratorT>>,
-          typename AccumT    = ::cuda::std::__accumulator_t<ReductionOpT, cub::detail::value_t<InputIteratorT>, InitT>,
-          typename PolicyHub = detail::reduce::policy_hub<AccumT, OffsetT, ReductionOpT>,
-          typename KernelSource = detail::reduce::DeviceSegmentedReduceKernelSource<
-            typename PolicyHub::MaxPolicy,
-            InputIteratorT,
-            OutputIteratorT,
-            BeginOffsetIteratorT,
-            EndOffsetIteratorT,
-            OffsetT,
-            ReductionOpT,
-            InitT,
-            AccumT>,
-          typename KernelLauncherFactory = detail::TripleChevronFactory>
+template <
+  typename InputIteratorT,
+  typename OutputIteratorT,
+  typename BeginOffsetIteratorT,
+  typename EndOffsetIteratorT,
+  typename OffsetT,
+  typename ReductionOpT,
+  typename InitT        = cub::detail::non_void_value_t<OutputIteratorT, cub::detail::iter_value_t<InputIteratorT>>,
+  typename AccumT       = ::cuda::std::__accumulator_t<ReductionOpT, cub::detail::iter_value_t<InputIteratorT>, InitT>,
+  typename PolicyHub    = detail::reduce::policy_hub<AccumT, OffsetT, ReductionOpT>,
+  typename KernelSource = detail::reduce::DeviceSegmentedReduceKernelSource<
+    typename PolicyHub::MaxPolicy,
+    InputIteratorT,
+    OutputIteratorT,
+    BeginOffsetIteratorT,
+    EndOffsetIteratorT,
+    OffsetT,
+    ReductionOpT,
+    InitT,
+    AccumT>,
+  typename KernelLauncherFactory = detail::TripleChevronFactory>
 struct DispatchSegmentedReduce
 {
   //---------------------------------------------------------------------------

--- a/cub/cub/device/dispatch/dispatch_reduce.cuh
+++ b/cub/cub/device/dispatch/dispatch_reduce.cuh
@@ -137,8 +137,8 @@ template <typename InputIteratorT,
           typename OutputIteratorT,
           typename OffsetT,
           typename ReductionOpT,
-          typename InitT = cub::detail::non_void_value_t<OutputIteratorT, cub::detail::iter_value_t<InputIteratorT>>,
-          typename AccumT = ::cuda::std::__accumulator_t<ReductionOpT, cub::detail::iter_value_t<InputIteratorT>, InitT>,
+          typename InitT  = cub::detail::non_void_value_t<OutputIteratorT, cub::detail::it_value_t<InputIteratorT>>,
+          typename AccumT = ::cuda::std::__accumulator_t<ReductionOpT, cub::detail::it_value_t<InputIteratorT>, InitT>,
           typename TransformOpT = ::cuda::std::__identity,
           typename PolicyHub    = detail::reduce::policy_hub<AccumT, OffsetT, ReductionOpT>,
           typename KernelSource = detail::reduce::DeviceReduceKernelSource<
@@ -575,7 +575,7 @@ template <
   typename InitT,
   typename AccumT =
     ::cuda::std::__accumulator_t<ReductionOpT,
-                                 cub::detail::invoke_result_t<TransformOpT, cub::detail::iter_value_t<InputIteratorT>>,
+                                 cub::detail::invoke_result_t<TransformOpT, cub::detail::it_value_t<InputIteratorT>>,
                                  InitT>,
   typename PolicyHub    = detail::reduce::policy_hub<AccumT, OffsetT, ReductionOpT>,
   typename KernelSource = detail::reduce::DeviceReduceKernelSource<
@@ -667,27 +667,26 @@ struct DeviceSegmentedReduceKernelSource
  *   value type
  */
 
-template <
-  typename InputIteratorT,
-  typename OutputIteratorT,
-  typename BeginOffsetIteratorT,
-  typename EndOffsetIteratorT,
-  typename OffsetT,
-  typename ReductionOpT,
-  typename InitT        = cub::detail::non_void_value_t<OutputIteratorT, cub::detail::iter_value_t<InputIteratorT>>,
-  typename AccumT       = ::cuda::std::__accumulator_t<ReductionOpT, cub::detail::iter_value_t<InputIteratorT>, InitT>,
-  typename PolicyHub    = detail::reduce::policy_hub<AccumT, OffsetT, ReductionOpT>,
-  typename KernelSource = detail::reduce::DeviceSegmentedReduceKernelSource<
-    typename PolicyHub::MaxPolicy,
-    InputIteratorT,
-    OutputIteratorT,
-    BeginOffsetIteratorT,
-    EndOffsetIteratorT,
-    OffsetT,
-    ReductionOpT,
-    InitT,
-    AccumT>,
-  typename KernelLauncherFactory = detail::TripleChevronFactory>
+template <typename InputIteratorT,
+          typename OutputIteratorT,
+          typename BeginOffsetIteratorT,
+          typename EndOffsetIteratorT,
+          typename OffsetT,
+          typename ReductionOpT,
+          typename InitT  = cub::detail::non_void_value_t<OutputIteratorT, cub::detail::it_value_t<InputIteratorT>>,
+          typename AccumT = ::cuda::std::__accumulator_t<ReductionOpT, cub::detail::it_value_t<InputIteratorT>, InitT>,
+          typename PolicyHub    = detail::reduce::policy_hub<AccumT, OffsetT, ReductionOpT>,
+          typename KernelSource = detail::reduce::DeviceSegmentedReduceKernelSource<
+            typename PolicyHub::MaxPolicy,
+            InputIteratorT,
+            OutputIteratorT,
+            BeginOffsetIteratorT,
+            EndOffsetIteratorT,
+            OffsetT,
+            ReductionOpT,
+            InitT,
+            AccumT>,
+          typename KernelLauncherFactory = detail::TripleChevronFactory>
 struct DispatchSegmentedReduce
 {
   //---------------------------------------------------------------------------

--- a/cub/cub/device/dispatch/dispatch_reduce_by_key.cuh
+++ b/cub/cub/device/dispatch/dispatch_reduce_by_key.cuh
@@ -226,7 +226,7 @@ template <typename KeysInputIteratorT,
           typename ReductionOpT,
           typename OffsetT,
           typename AccumT    = ::cuda::std::__accumulator_t<ReductionOpT,
-                                                            cub::detail::value_t<ValuesInputIteratorT>,
+                                                            cub::detail::iter_value_t<ValuesInputIteratorT>,
                                                             cub::detail::value_t<ValuesInputIteratorT>>,
           typename PolicyHub = detail::reduce_by_key::policy_hub<
             ReductionOpT,

--- a/cub/cub/device/dispatch/dispatch_reduce_by_key.cuh
+++ b/cub/cub/device/dispatch/dispatch_reduce_by_key.cuh
@@ -227,11 +227,11 @@ template <typename KeysInputIteratorT,
           typename OffsetT,
           typename AccumT    = ::cuda::std::__accumulator_t<ReductionOpT,
                                                             cub::detail::iter_value_t<ValuesInputIteratorT>,
-                                                            cub::detail::value_t<ValuesInputIteratorT>>,
+                                                            cub::detail::iter_value_t<ValuesInputIteratorT>>,
           typename PolicyHub = detail::reduce_by_key::policy_hub<
             ReductionOpT,
             AccumT,
-            cub::detail::non_void_value_t<UniqueOutputIteratorT, cub::detail::value_t<KeysInputIteratorT>>>>
+            cub::detail::non_void_value_t<UniqueOutputIteratorT, cub::detail::iter_value_t<KeysInputIteratorT>>>>
 struct DispatchReduceByKey
 {
   //-------------------------------------------------------------------------
@@ -239,7 +239,7 @@ struct DispatchReduceByKey
   //-------------------------------------------------------------------------
 
   // The input values type
-  using ValueInputT = cub::detail::value_t<ValuesInputIteratorT>;
+  using ValueInputT = cub::detail::iter_value_t<ValuesInputIteratorT>;
 
   static constexpr int INIT_KERNEL_THREADS = 128;
 

--- a/cub/cub/device/dispatch/dispatch_reduce_by_key.cuh
+++ b/cub/cub/device/dispatch/dispatch_reduce_by_key.cuh
@@ -226,12 +226,12 @@ template <typename KeysInputIteratorT,
           typename ReductionOpT,
           typename OffsetT,
           typename AccumT    = ::cuda::std::__accumulator_t<ReductionOpT,
-                                                            cub::detail::iter_value_t<ValuesInputIteratorT>,
-                                                            cub::detail::iter_value_t<ValuesInputIteratorT>>,
+                                                            cub::detail::it_value_t<ValuesInputIteratorT>,
+                                                            cub::detail::it_value_t<ValuesInputIteratorT>>,
           typename PolicyHub = detail::reduce_by_key::policy_hub<
             ReductionOpT,
             AccumT,
-            cub::detail::non_void_value_t<UniqueOutputIteratorT, cub::detail::iter_value_t<KeysInputIteratorT>>>>
+            cub::detail::non_void_value_t<UniqueOutputIteratorT, cub::detail::it_value_t<KeysInputIteratorT>>>>
 struct DispatchReduceByKey
 {
   //-------------------------------------------------------------------------
@@ -239,7 +239,7 @@ struct DispatchReduceByKey
   //-------------------------------------------------------------------------
 
   // The input values type
-  using ValueInputT = cub::detail::iter_value_t<ValuesInputIteratorT>;
+  using ValueInputT = cub::detail::it_value_t<ValuesInputIteratorT>;
 
   static constexpr int INIT_KERNEL_THREADS = 128;
 

--- a/cub/cub/device/dispatch/dispatch_rle.cuh
+++ b/cub/cub/device/dispatch/dispatch_rle.cuh
@@ -194,7 +194,7 @@ template <typename InputIteratorT,
           typename OffsetT,
           typename PolicyHub =
             detail::rle::non_trivial_runs::policy_hub<cub::detail::non_void_value_t<LengthsOutputIteratorT, OffsetT>,
-                                                      cub::detail::iter_value_t<InputIteratorT>>>
+                                                      cub::detail::it_value_t<InputIteratorT>>>
 struct DeviceRleDispatch
 {
   /******************************************************************************

--- a/cub/cub/device/dispatch/dispatch_rle.cuh
+++ b/cub/cub/device/dispatch/dispatch_rle.cuh
@@ -194,7 +194,7 @@ template <typename InputIteratorT,
           typename OffsetT,
           typename PolicyHub =
             detail::rle::non_trivial_runs::policy_hub<cub::detail::non_void_value_t<LengthsOutputIteratorT, OffsetT>,
-                                                      cub::detail::value_t<InputIteratorT>>>
+                                                      cub::detail::iter_value_t<InputIteratorT>>>
 struct DeviceRleDispatch
 {
   /******************************************************************************

--- a/cub/cub/device/dispatch/dispatch_scan.cuh
+++ b/cub/cub/device/dispatch/dispatch_scan.cuh
@@ -147,11 +147,11 @@ template <
   typename AccumT                 = ::cuda::std::__accumulator_t<ScanOpT,
                                                                  cub::detail::iter_value_t<InputIteratorT>,
                                                                  ::cuda::std::_If<::cuda::std::is_same_v<InitValueT, NullType>,
-                                                                                  cub::detail::value_t<InputIteratorT>,
+                                                                                  cub::detail::iter_value_t<InputIteratorT>,
                                                                                   typename InitValueT::value_type>>,
   ForceInclusive EnforceInclusive = ForceInclusive::No,
-  typename PolicyHub =
-    detail::scan::policy_hub<detail::value_t<InputIteratorT>, detail::value_t<OutputIteratorT>, AccumT, OffsetT, ScanOpT>,
+  typename PolicyHub              = detail::scan::
+    policy_hub<detail::iter_value_t<InputIteratorT>, detail::iter_value_t<OutputIteratorT>, AccumT, OffsetT, ScanOpT>,
   typename KernelSource = detail::scan::DeviceScanKernelSource<
     typename PolicyHub::MaxPolicy,
     InputIteratorT,

--- a/cub/cub/device/dispatch/dispatch_scan.cuh
+++ b/cub/cub/device/dispatch/dispatch_scan.cuh
@@ -145,7 +145,7 @@ template <
   typename InitValueT,
   typename OffsetT,
   typename AccumT                 = ::cuda::std::__accumulator_t<ScanOpT,
-                                                                 cub::detail::value_t<InputIteratorT>,
+                                                                 cub::detail::iter_value_t<InputIteratorT>,
                                                                  ::cuda::std::_If<::cuda::std::is_same_v<InitValueT, NullType>,
                                                                                   cub::detail::value_t<InputIteratorT>,
                                                                                   typename InitValueT::value_type>>,

--- a/cub/cub/device/dispatch/dispatch_scan.cuh
+++ b/cub/cub/device/dispatch/dispatch_scan.cuh
@@ -145,13 +145,13 @@ template <
   typename InitValueT,
   typename OffsetT,
   typename AccumT                 = ::cuda::std::__accumulator_t<ScanOpT,
-                                                                 cub::detail::iter_value_t<InputIteratorT>,
+                                                                 cub::detail::it_value_t<InputIteratorT>,
                                                                  ::cuda::std::_If<::cuda::std::is_same_v<InitValueT, NullType>,
-                                                                                  cub::detail::iter_value_t<InputIteratorT>,
+                                                                                  cub::detail::it_value_t<InputIteratorT>,
                                                                                   typename InitValueT::value_type>>,
   ForceInclusive EnforceInclusive = ForceInclusive::No,
   typename PolicyHub              = detail::scan::
-    policy_hub<detail::iter_value_t<InputIteratorT>, detail::iter_value_t<OutputIteratorT>, AccumT, OffsetT, ScanOpT>,
+    policy_hub<detail::it_value_t<InputIteratorT>, detail::it_value_t<OutputIteratorT>, AccumT, OffsetT, ScanOpT>,
   typename KernelSource = detail::scan::DeviceScanKernelSource<
     typename PolicyHub::MaxPolicy,
     InputIteratorT,

--- a/cub/cub/device/dispatch/dispatch_scan_by_key.cuh
+++ b/cub/cub/device/dispatch/dispatch_scan_by_key.cuh
@@ -136,7 +136,7 @@ template <typename ChainedPolicyT,
           typename InitValueT,
           typename OffsetT,
           typename AccumT,
-          typename KeyT = cub::detail::iter_value_t<KeysInputIteratorT>>
+          typename KeyT = cub::detail::it_value_t<KeysInputIteratorT>>
 __launch_bounds__(int(ChainedPolicyT::ActivePolicy::ScanByKeyPolicyT::BLOCK_THREADS))
   CUB_DETAIL_KERNEL_ATTRIBUTES void DeviceScanByKeyKernel(
     KeysInputIteratorT d_keys_in,
@@ -176,7 +176,7 @@ template <typename ScanTileStateT, typename KeysInputIteratorT, typename OffsetT
 CUB_DETAIL_KERNEL_ATTRIBUTES void DeviceScanByKeyInitKernel(
   ScanTileStateT tile_state,
   KeysInputIteratorT d_keys_in,
-  cub::detail::iter_value_t<KeysInputIteratorT>* d_keys_prev_in,
+  cub::detail::it_value_t<KeysInputIteratorT>* d_keys_prev_in,
   OffsetT items_per_tile,
   int num_tiles)
 {
@@ -233,11 +233,11 @@ template <
   typename OffsetT,
   typename AccumT = ::cuda::std::__accumulator_t<
     ScanOpT,
-    cub::detail::iter_value_t<ValuesInputIteratorT>,
+    cub::detail::it_value_t<ValuesInputIteratorT>,
     ::cuda::std::
-      _If<::cuda::std::is_same_v<InitValueT, NullType>, cub::detail::iter_value_t<ValuesInputIteratorT>, InitValueT>>,
+      _If<::cuda::std::is_same_v<InitValueT, NullType>, cub::detail::it_value_t<ValuesInputIteratorT>, InitValueT>>,
   typename PolicyHub =
-    detail::scan_by_key::policy_hub<KeysInputIteratorT, AccumT, cub::detail::iter_value_t<ValuesInputIteratorT>, ScanOpT>>
+    detail::scan_by_key::policy_hub<KeysInputIteratorT, AccumT, cub::detail::it_value_t<ValuesInputIteratorT>, ScanOpT>>
 struct DispatchScanByKey
 {
   //---------------------------------------------------------------------
@@ -247,10 +247,10 @@ struct DispatchScanByKey
   static constexpr int INIT_KERNEL_THREADS = 128;
 
   // The input key type
-  using KeyT = cub::detail::iter_value_t<KeysInputIteratorT>;
+  using KeyT = cub::detail::it_value_t<KeysInputIteratorT>;
 
   // The input value type
-  using InputT = cub::detail::iter_value_t<ValuesInputIteratorT>;
+  using InputT = cub::detail::it_value_t<ValuesInputIteratorT>;
 
   // Tile state used for the decoupled look-back
   using ScanByKeyTileStateT = ReduceByKeyScanTileState<AccumT, int>;

--- a/cub/cub/device/dispatch/dispatch_scan_by_key.cuh
+++ b/cub/cub/device/dispatch/dispatch_scan_by_key.cuh
@@ -176,7 +176,7 @@ template <typename ScanTileStateT, typename KeysInputIteratorT, typename OffsetT
 CUB_DETAIL_KERNEL_ATTRIBUTES void DeviceScanByKeyInitKernel(
   ScanTileStateT tile_state,
   KeysInputIteratorT d_keys_in,
-  cub::detail::value_t<KeysInputIteratorT>* d_keys_prev_in,
+  cub::detail::iter_value_t<KeysInputIteratorT>* d_keys_prev_in,
   OffsetT items_per_tile,
   int num_tiles)
 {
@@ -233,10 +233,11 @@ template <
   typename OffsetT,
   typename AccumT = ::cuda::std::__accumulator_t<
     ScanOpT,
-    cub::detail::value_t<ValuesInputIteratorT>,
-    ::cuda::std::_If<::cuda::std::is_same_v<InitValueT, NullType>, cub::detail::value_t<ValuesInputIteratorT>, InitValueT>>,
+    cub::detail::iter_value_t<ValuesInputIteratorT>,
+    ::cuda::std::
+      _If<::cuda::std::is_same_v<InitValueT, NullType>, cub::detail::iter_value_t<ValuesInputIteratorT>, InitValueT>>,
   typename PolicyHub =
-    detail::scan_by_key::policy_hub<KeysInputIteratorT, AccumT, cub::detail::value_t<ValuesInputIteratorT>, ScanOpT>>
+    detail::scan_by_key::policy_hub<KeysInputIteratorT, AccumT, cub::detail::iter_value_t<ValuesInputIteratorT>, ScanOpT>>
 struct DispatchScanByKey
 {
   //---------------------------------------------------------------------
@@ -246,10 +247,10 @@ struct DispatchScanByKey
   static constexpr int INIT_KERNEL_THREADS = 128;
 
   // The input key type
-  using KeyT = cub::detail::value_t<KeysInputIteratorT>;
+  using KeyT = cub::detail::iter_value_t<KeysInputIteratorT>;
 
   // The input value type
-  using InputT = cub::detail::value_t<ValuesInputIteratorT>;
+  using InputT = cub::detail::iter_value_t<ValuesInputIteratorT>;
 
   // Tile state used for the decoupled look-back
   using ScanByKeyTileStateT = ReduceByKeyScanTileState<AccumT, int>;

--- a/cub/cub/device/dispatch/dispatch_scan_by_key.cuh
+++ b/cub/cub/device/dispatch/dispatch_scan_by_key.cuh
@@ -136,7 +136,7 @@ template <typename ChainedPolicyT,
           typename InitValueT,
           typename OffsetT,
           typename AccumT,
-          typename KeyT = cub::detail::value_t<KeysInputIteratorT>>
+          typename KeyT = cub::detail::iter_value_t<KeysInputIteratorT>>
 __launch_bounds__(int(ChainedPolicyT::ActivePolicy::ScanByKeyPolicyT::BLOCK_THREADS))
   CUB_DETAIL_KERNEL_ATTRIBUTES void DeviceScanByKeyKernel(
     KeysInputIteratorT d_keys_in,

--- a/cub/cub/device/dispatch/dispatch_select_if.cuh
+++ b/cub/cub/device/dispatch/dispatch_select_if.cuh
@@ -422,7 +422,7 @@ template <
   SelectImpl SelectionOpt,
   typename PolicyHub = detail::select::policy_hub<
     detail::iter_value_t<InputIteratorT>,
-    detail::value_t<FlagsInputIteratorT>,
+    detail::iter_value_t<FlagsInputIteratorT>,
     // if/flagged/unique only have a single code path for different offset types, partition has different code paths
     ::cuda::std::conditional_t<SelectionOpt == SelectImpl::Partition, OffsetT, detail::select::per_partition_offset_t>,
     detail::select::is_partition_distinct_output_t<SelectedOutputIteratorT>::value,

--- a/cub/cub/device/dispatch/dispatch_select_if.cuh
+++ b/cub/cub/device/dispatch/dispatch_select_if.cuh
@@ -421,7 +421,7 @@ template <
   typename OffsetT,
   SelectImpl SelectionOpt,
   typename PolicyHub = detail::select::policy_hub<
-    detail::value_t<InputIteratorT>,
+    detail::iter_value_t<InputIteratorT>,
     detail::value_t<FlagsInputIteratorT>,
     // if/flagged/unique only have a single code path for different offset types, partition has different code paths
     ::cuda::std::conditional_t<SelectionOpt == SelectImpl::Partition, OffsetT, detail::select::per_partition_offset_t>,

--- a/cub/cub/device/dispatch/dispatch_select_if.cuh
+++ b/cub/cub/device/dispatch/dispatch_select_if.cuh
@@ -421,8 +421,8 @@ template <
   typename OffsetT,
   SelectImpl SelectionOpt,
   typename PolicyHub = detail::select::policy_hub<
-    detail::iter_value_t<InputIteratorT>,
-    detail::iter_value_t<FlagsInputIteratorT>,
+    detail::it_value_t<InputIteratorT>,
+    detail::it_value_t<FlagsInputIteratorT>,
     // if/flagged/unique only have a single code path for different offset types, partition has different code paths
     ::cuda::std::conditional_t<SelectionOpt == SelectImpl::Partition, OffsetT, detail::select::per_partition_offset_t>,
     detail::select::is_partition_distinct_output_t<SelectedOutputIteratorT>::value,

--- a/cub/cub/device/dispatch/dispatch_three_way_partition.cuh
+++ b/cub/cub/device/dispatch/dispatch_three_way_partition.cuh
@@ -241,7 +241,7 @@ template <typename InputIteratorT,
           typename SelectSecondPartOp,
           typename OffsetT,
           typename PolicyHub = detail::three_way_partition::
-            policy_hub<cub::detail::iter_value_t<InputIteratorT>, detail::three_way_partition::per_partition_offset_t>>
+            policy_hub<cub::detail::it_value_t<InputIteratorT>, detail::three_way_partition::per_partition_offset_t>>
 struct DispatchThreeWayPartitionIf
 {
   /*****************************************************************************

--- a/cub/cub/device/dispatch/dispatch_three_way_partition.cuh
+++ b/cub/cub/device/dispatch/dispatch_three_way_partition.cuh
@@ -241,7 +241,7 @@ template <typename InputIteratorT,
           typename SelectSecondPartOp,
           typename OffsetT,
           typename PolicyHub = detail::three_way_partition::
-            policy_hub<cub::detail::value_t<InputIteratorT>, detail::three_way_partition::per_partition_offset_t>>
+            policy_hub<cub::detail::iter_value_t<InputIteratorT>, detail::three_way_partition::per_partition_offset_t>>
 struct DispatchThreeWayPartitionIf
 {
   /*****************************************************************************

--- a/cub/cub/device/dispatch/dispatch_unique_by_key.cuh
+++ b/cub/cub/device/dispatch/dispatch_unique_by_key.cuh
@@ -79,15 +79,16 @@ CUB_NAMESPACE_BEGIN
  * @tparam OffsetT
  *   Signed integer type for global offsets
  */
-template <typename KeyInputIteratorT,
-          typename ValueInputIteratorT,
-          typename KeyOutputIteratorT,
-          typename ValueOutputIteratorT,
-          typename NumSelectedIteratorT,
-          typename EqualityOpT,
-          typename OffsetT,
-          typename PolicyHub = detail::unique_by_key::policy_hub<detail::iter_value_t<KeyInputIteratorT>,
-                                                                 detail::iter_value_t<ValueInputIteratorT>>>
+template <
+  typename KeyInputIteratorT,
+  typename ValueInputIteratorT,
+  typename KeyOutputIteratorT,
+  typename ValueOutputIteratorT,
+  typename NumSelectedIteratorT,
+  typename EqualityOpT,
+  typename OffsetT,
+  typename PolicyHub =
+    detail::unique_by_key::policy_hub<detail::it_value_t<KeyInputIteratorT>, detail::it_value_t<ValueInputIteratorT>>>
 struct DispatchUniqueByKey
 {
   /******************************************************************************
@@ -100,8 +101,8 @@ struct DispatchUniqueByKey
   };
 
   // The input key and value type
-  using KeyT   = detail::iter_value_t<KeyInputIteratorT>;
-  using ValueT = detail::iter_value_t<ValueInputIteratorT>;
+  using KeyT   = detail::it_value_t<KeyInputIteratorT>;
+  using ValueT = detail::it_value_t<ValueInputIteratorT>;
 
   // Tile status descriptor interface type
   using ScanTileStateT = ScanTileState<OffsetT>;

--- a/cub/cub/device/dispatch/dispatch_unique_by_key.cuh
+++ b/cub/cub/device/dispatch/dispatch_unique_by_key.cuh
@@ -79,15 +79,16 @@ CUB_NAMESPACE_BEGIN
  * @tparam OffsetT
  *   Signed integer type for global offsets
  */
-template <typename KeyInputIteratorT,
-          typename ValueInputIteratorT,
-          typename KeyOutputIteratorT,
-          typename ValueOutputIteratorT,
-          typename NumSelectedIteratorT,
-          typename EqualityOpT,
-          typename OffsetT,
-          typename PolicyHub =
-            detail::unique_by_key::policy_hub<detail::value_t<KeyInputIteratorT>, detail::value_t<ValueInputIteratorT>>>
+template <
+  typename KeyInputIteratorT,
+  typename ValueInputIteratorT,
+  typename KeyOutputIteratorT,
+  typename ValueOutputIteratorT,
+  typename NumSelectedIteratorT,
+  typename EqualityOpT,
+  typename OffsetT,
+  typename PolicyHub =
+    detail::unique_by_key::policy_hub<detail::iter_value_t<KeyInputIteratorT>, detail::value_t<ValueInputIteratorT>>>
 struct DispatchUniqueByKey
 {
   /******************************************************************************
@@ -100,8 +101,8 @@ struct DispatchUniqueByKey
   };
 
   // The input key and value type
-  using KeyT   = typename std::iterator_traits<KeyInputIteratorT>::value_type;
-  using ValueT = typename std::iterator_traits<ValueInputIteratorT>::value_type;
+  using KeyT   = detail::value_t<KeyInputIteratorT>;
+  using ValueT = detail::value_t<ValueInputIteratorT>;
 
   // Tile status descriptor interface type
   using ScanTileStateT = ScanTileState<OffsetT>;

--- a/cub/cub/device/dispatch/dispatch_unique_by_key.cuh
+++ b/cub/cub/device/dispatch/dispatch_unique_by_key.cuh
@@ -79,16 +79,15 @@ CUB_NAMESPACE_BEGIN
  * @tparam OffsetT
  *   Signed integer type for global offsets
  */
-template <
-  typename KeyInputIteratorT,
-  typename ValueInputIteratorT,
-  typename KeyOutputIteratorT,
-  typename ValueOutputIteratorT,
-  typename NumSelectedIteratorT,
-  typename EqualityOpT,
-  typename OffsetT,
-  typename PolicyHub =
-    detail::unique_by_key::policy_hub<detail::iter_value_t<KeyInputIteratorT>, detail::value_t<ValueInputIteratorT>>>
+template <typename KeyInputIteratorT,
+          typename ValueInputIteratorT,
+          typename KeyOutputIteratorT,
+          typename ValueOutputIteratorT,
+          typename NumSelectedIteratorT,
+          typename EqualityOpT,
+          typename OffsetT,
+          typename PolicyHub = detail::unique_by_key::policy_hub<detail::iter_value_t<KeyInputIteratorT>,
+                                                                 detail::iter_value_t<ValueInputIteratorT>>>
 struct DispatchUniqueByKey
 {
   /******************************************************************************
@@ -101,8 +100,8 @@ struct DispatchUniqueByKey
   };
 
   // The input key and value type
-  using KeyT   = detail::value_t<KeyInputIteratorT>;
-  using ValueT = detail::value_t<ValueInputIteratorT>;
+  using KeyT   = detail::iter_value_t<KeyInputIteratorT>;
+  using ValueT = detail::iter_value_t<ValueInputIteratorT>;
 
   // Tile status descriptor interface type
   using ScanTileStateT = ScanTileState<OffsetT>;

--- a/cub/cub/device/dispatch/kernels/transform.cuh
+++ b/cub/cub/device/dispatch/kernels/transform.cuh
@@ -361,7 +361,7 @@ _CCCL_DEVICE void transform_kernel_impl(
 template <typename It>
 union kernel_arg
 {
-  aligned_base_ptr<value_t<It>> aligned_ptr; // first member is trivial
+  aligned_base_ptr<iter_value_t<It>> aligned_ptr; // first member is trivial
   It iterator; // may not be trivially [default|copy]-constructible
 
   static_assert(::cuda::std::is_trivial_v<decltype(aligned_ptr)>, "");

--- a/cub/cub/device/dispatch/kernels/transform.cuh
+++ b/cub/cub/device/dispatch/kernels/transform.cuh
@@ -59,7 +59,7 @@ _CCCL_DEVICE _CCCL_FORCEINLINE void prefetch_tile(It begin, int tile_size)
   {
     constexpr int prefetch_byte_stride = 128; // TODO(bgruber): should correspond to cache line size. Does this need to
                                               // be architecture dependent?
-    const int tile_size_bytes = tile_size * sizeof(value_t<It>);
+    const int tile_size_bytes = tile_size * sizeof(iter_value_t<It>);
     // prefetch does not stall and unrolling just generates a lot of unnecessary computations and predicate handling
 #pragma unroll 1
     for (int offset = threadIdx.x * prefetch_byte_stride; offset < tile_size_bytes;

--- a/cub/cub/device/dispatch/kernels/transform.cuh
+++ b/cub/cub/device/dispatch/kernels/transform.cuh
@@ -59,7 +59,7 @@ _CCCL_DEVICE _CCCL_FORCEINLINE void prefetch_tile(It begin, int tile_size)
   {
     constexpr int prefetch_byte_stride = 128; // TODO(bgruber): should correspond to cache line size. Does this need to
                                               // be architecture dependent?
-    const int tile_size_bytes = tile_size * sizeof(iter_value_t<It>);
+    const int tile_size_bytes = tile_size * sizeof(it_value_t<It>);
     // prefetch does not stall and unrolling just generates a lot of unnecessary computations and predicate handling
 #pragma unroll 1
     for (int offset = threadIdx.x * prefetch_byte_stride; offset < tile_size_bytes;
@@ -361,7 +361,7 @@ _CCCL_DEVICE void transform_kernel_impl(
 template <typename It>
 union kernel_arg
 {
-  aligned_base_ptr<iter_value_t<It>> aligned_ptr; // first member is trivial
+  aligned_base_ptr<it_value_t<It>> aligned_ptr; // first member is trivial
   It iterator; // may not be trivially [default|copy]-constructible
 
   static_assert(::cuda::std::is_trivial_v<decltype(aligned_ptr)>, "");

--- a/cub/cub/device/dispatch/tuning/tuning_adjacent_difference.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_adjacent_difference.cuh
@@ -50,7 +50,7 @@ namespace adjacent_difference
 template <typename InputIteratorT, bool MayAlias>
 struct policy_hub
 {
-  using ValueT = typename std::iterator_traits<InputIteratorT>::value_type;
+  using ValueT = iter_value_t<InputIteratorT>;
 
   struct Policy500 : ChainedPolicy<500, Policy500, Policy500>
   {

--- a/cub/cub/device/dispatch/tuning/tuning_adjacent_difference.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_adjacent_difference.cuh
@@ -50,7 +50,7 @@ namespace adjacent_difference
 template <typename InputIteratorT, bool MayAlias>
 struct policy_hub
 {
-  using ValueT = iter_value_t<InputIteratorT>;
+  using ValueT = it_value_t<InputIteratorT>;
 
   struct Policy500 : ChainedPolicy<500, Policy500, Policy500>
   {

--- a/cub/cub/device/dispatch/tuning/tuning_merge_sort.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_merge_sort.cuh
@@ -73,7 +73,7 @@ CUB_RUNTIME_FUNCTION MergeSortPolicyWrapper<PolicyT> MakeMergeSortPolicyWrapper(
 template <typename KeyIteratorT>
 struct policy_hub
 {
-  using KeyT = iter_value_t<KeyIteratorT>;
+  using KeyT = it_value_t<KeyIteratorT>;
 
   struct Policy500 : ChainedPolicy<500, Policy500, Policy500>
   {

--- a/cub/cub/device/dispatch/tuning/tuning_merge_sort.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_merge_sort.cuh
@@ -73,7 +73,7 @@ CUB_RUNTIME_FUNCTION MergeSortPolicyWrapper<PolicyT> MakeMergeSortPolicyWrapper(
 template <typename KeyIteratorT>
 struct policy_hub
 {
-  using KeyT = value_t<KeyIteratorT>;
+  using KeyT = iter_value_t<KeyIteratorT>;
 
   struct Policy500 : ChainedPolicy<500, Policy500, Policy500>
   {

--- a/cub/cub/device/dispatch/tuning/tuning_scan_by_key.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan_by_key.cuh
@@ -912,7 +912,7 @@ struct sm100_tuning<KeyT, ValueT, primitive_op::yes, key_size::_8, val_size::_8,
 template <typename KeysInputIteratorT, typename AccumT, typename ValueT, typename ScanOpT>
 struct policy_hub
 {
-  using key_t                               = value_t<KeysInputIteratorT>;
+  using key_t                               = iter_value_t<KeysInputIteratorT>;
   static constexpr int max_input_bytes      = static_cast<int>((::cuda::std::max)(sizeof(key_t), sizeof(AccumT)));
   static constexpr int combined_input_bytes = static_cast<int>(sizeof(key_t) + sizeof(AccumT));
 

--- a/cub/cub/device/dispatch/tuning/tuning_scan_by_key.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan_by_key.cuh
@@ -912,7 +912,7 @@ struct sm100_tuning<KeyT, ValueT, primitive_op::yes, key_size::_8, val_size::_8,
 template <typename KeysInputIteratorT, typename AccumT, typename ValueT, typename ScanOpT>
 struct policy_hub
 {
-  using key_t                               = iter_value_t<KeysInputIteratorT>;
+  using key_t                               = it_value_t<KeysInputIteratorT>;
   static constexpr int max_input_bytes      = static_cast<int>((::cuda::std::max)(sizeof(key_t), sizeof(AccumT)));
   static constexpr int combined_input_bytes = static_cast<int>(sizeof(key_t) + sizeof(AccumT));
 

--- a/cub/cub/device/dispatch/tuning/tuning_transform.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_transform.cuh
@@ -144,7 +144,7 @@ struct policy_hub<RequiresStableAddress, ::cuda::std::tuple<RandomAccessIterator
   static constexpr bool all_contiguous =
     ::cuda::std::conjunction_v<THRUST_NS_QUALIFIER::is_contiguous_iterator<RandomAccessIteratorsIn>...>;
   static constexpr bool all_values_trivially_reloc =
-    ::cuda::std::conjunction_v<THRUST_NS_QUALIFIER::is_trivially_relocatable<value_t<RandomAccessIteratorsIn>>...>;
+    ::cuda::std::conjunction_v<THRUST_NS_QUALIFIER::is_trivially_relocatable<iter_value_t<RandomAccessIteratorsIn>>...>;
 
   static constexpr bool can_memcpy = all_contiguous && all_values_trivially_reloc;
 
@@ -169,7 +169,7 @@ struct policy_hub<RequiresStableAddress, ::cuda::std::tuple<RandomAccessIterator
         async_policy::block_threads * async_policy::min_items_per_thread)
       > int{max_smem_per_block};
     static constexpr bool any_type_is_overalinged =
-      ((alignof(value_t<RandomAccessIteratorsIn>) > bulk_copy_alignment) || ...);
+      ((alignof(iter_value_t<RandomAccessIteratorsIn>) > bulk_copy_alignment) || ...);
 
     static constexpr bool use_fallback =
       RequiresStableAddress || !can_memcpy || no_input_streams || exhaust_smem || any_type_is_overalinged;

--- a/cub/cub/device/dispatch/tuning/tuning_transform.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_transform.cuh
@@ -108,7 +108,7 @@ _CCCL_HOST_DEVICE constexpr int sum(int head, Ts... tail)
 template <typename... Its>
 _CCCL_HOST_DEVICE constexpr auto loaded_bytes_per_iteration() -> int
 {
-  return (int{sizeof(iter_value_t<Its>)} + ... + 0);
+  return (int{sizeof(it_value_t<Its>)} + ... + 0);
 }
 
 constexpr int bulk_copy_alignment     = 128;
@@ -144,7 +144,7 @@ struct policy_hub<RequiresStableAddress, ::cuda::std::tuple<RandomAccessIterator
   static constexpr bool all_contiguous =
     ::cuda::std::conjunction_v<THRUST_NS_QUALIFIER::is_contiguous_iterator<RandomAccessIteratorsIn>...>;
   static constexpr bool all_values_trivially_reloc =
-    ::cuda::std::conjunction_v<THRUST_NS_QUALIFIER::is_trivially_relocatable<iter_value_t<RandomAccessIteratorsIn>>...>;
+    ::cuda::std::conjunction_v<THRUST_NS_QUALIFIER::is_trivially_relocatable<it_value_t<RandomAccessIteratorsIn>>...>;
 
   static constexpr bool can_memcpy = all_contiguous && all_values_trivially_reloc;
 
@@ -169,7 +169,7 @@ struct policy_hub<RequiresStableAddress, ::cuda::std::tuple<RandomAccessIterator
         async_policy::block_threads * async_policy::min_items_per_thread)
       > int{max_smem_per_block};
     static constexpr bool any_type_is_overalinged =
-      ((alignof(iter_value_t<RandomAccessIteratorsIn>) > bulk_copy_alignment) || ...);
+      ((alignof(it_value_t<RandomAccessIteratorsIn>) > bulk_copy_alignment) || ...);
 
     static constexpr bool use_fallback =
       RequiresStableAddress || !can_memcpy || no_input_streams || exhaust_smem || any_type_is_overalinged;

--- a/cub/cub/device/dispatch/tuning/tuning_transform.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_transform.cuh
@@ -108,7 +108,7 @@ _CCCL_HOST_DEVICE constexpr int sum(int head, Ts... tail)
 template <typename... Its>
 _CCCL_HOST_DEVICE constexpr auto loaded_bytes_per_iteration() -> int
 {
-  return (int{sizeof(value_t<Its>)} + ... + 0);
+  return (int{sizeof(iter_value_t<Its>)} + ... + 0);
 }
 
 constexpr int bulk_copy_alignment     = 128;

--- a/cub/cub/device/dispatch/tuning/tuning_unique_by_key.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_unique_by_key.cuh
@@ -849,6 +849,6 @@ struct policy_hub
 template <typename KeyInputIteratorT, typename ValueInputIteratorT = unsigned long long int*>
 using DeviceUniqueByKeyPolicy CCCL_DEPRECATED_BECAUSE("This class is considered an implementation detail and it will "
                                                       "be removed.") =
-  detail::unique_by_key::policy_hub<detail::iter_value_t<KeyInputIteratorT>, detail::iter_value_t<ValueInputIteratorT>>;
+  detail::unique_by_key::policy_hub<detail::it_value_t<KeyInputIteratorT>, detail::it_value_t<ValueInputIteratorT>>;
 
 CUB_NAMESPACE_END

--- a/cub/cub/device/dispatch/tuning/tuning_unique_by_key.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_unique_by_key.cuh
@@ -849,6 +849,6 @@ struct policy_hub
 template <typename KeyInputIteratorT, typename ValueInputIteratorT = unsigned long long int*>
 using DeviceUniqueByKeyPolicy CCCL_DEPRECATED_BECAUSE("This class is considered an implementation detail and it will "
                                                       "be removed.") =
-  detail::unique_by_key::policy_hub<detail::value_t<KeyInputIteratorT>, detail::value_t<ValueInputIteratorT>>;
+  detail::unique_by_key::policy_hub<detail::iter_value_t<KeyInputIteratorT>, detail::value_t<ValueInputIteratorT>>;
 
 CUB_NAMESPACE_END

--- a/cub/cub/device/dispatch/tuning/tuning_unique_by_key.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_unique_by_key.cuh
@@ -849,6 +849,6 @@ struct policy_hub
 template <typename KeyInputIteratorT, typename ValueInputIteratorT = unsigned long long int*>
 using DeviceUniqueByKeyPolicy CCCL_DEPRECATED_BECAUSE("This class is considered an implementation detail and it will "
                                                       "be removed.") =
-  detail::unique_by_key::policy_hub<detail::iter_value_t<KeyInputIteratorT>, detail::value_t<ValueInputIteratorT>>;
+  detail::unique_by_key::policy_hub<detail::iter_value_t<KeyInputIteratorT>, detail::iter_value_t<ValueInputIteratorT>>;
 
 CUB_NAMESPACE_END

--- a/cub/cub/iterator/arg_index_input_iterator.cuh
+++ b/cub/cub/iterator/arg_index_input_iterator.cuh
@@ -46,7 +46,6 @@
 #include <cub/util_type.cuh>
 
 #include <thrust/iterator/iterator_facade.h>
-#include <thrust/iterator/iterator_traits.h>
 
 #if !_CCCL_COMPILER(NVRTC)
 #  include <ostream>
@@ -106,7 +105,7 @@ CUB_NAMESPACE_BEGIN
  */
 template <typename InputIteratorT,
           typename OffsetT      = ptrdiff_t,
-          typename OutputValueT = cub::detail::value_t<InputIteratorT>>
+          typename OutputValueT = detail::iter_value_t<InputIteratorT>>
 class ArgIndexInputIterator
 {
 public:

--- a/cub/cub/iterator/arg_index_input_iterator.cuh
+++ b/cub/cub/iterator/arg_index_input_iterator.cuh
@@ -105,7 +105,7 @@ CUB_NAMESPACE_BEGIN
  */
 template <typename InputIteratorT,
           typename OffsetT      = ptrdiff_t,
-          typename OutputValueT = detail::iter_value_t<InputIteratorT>>
+          typename OutputValueT = detail::it_value_t<InputIteratorT>>
 class ArgIndexInputIterator
 {
 public:

--- a/cub/cub/iterator/cache_modified_input_iterator.cuh
+++ b/cub/cub/iterator/cache_modified_input_iterator.cuh
@@ -47,7 +47,6 @@
 #  include <cuda/std/iterator>
 #else // ^^^ _CCCL_COMPILER(NVRTC) ^^^ // vvv !_CCCL_COMPILER(NVRTC) vvv
 #  include <thrust/iterator/iterator_facade.h>
-#  include <thrust/iterator/iterator_traits.h>
 
 #  include <iostream>
 #  include <iterator>

--- a/cub/cub/iterator/cache_modified_output_iterator.cuh
+++ b/cub/cub/iterator/cache_modified_output_iterator.cuh
@@ -47,7 +47,6 @@
 #include <cub/thread/thread_store.cuh>
 
 #include <thrust/iterator/iterator_facade.h>
-#include <thrust/iterator/iterator_traits.h>
 
 #include <iosfwd>
 

--- a/cub/cub/iterator/tex_obj_input_iterator.cuh
+++ b/cub/cub/iterator/tex_obj_input_iterator.cuh
@@ -48,7 +48,6 @@
 #include <cub/util_debug.cuh>
 
 #include <thrust/iterator/iterator_facade.h>
-#include <thrust/iterator/iterator_traits.h>
 
 #include <ostream>
 

--- a/cub/cub/thread/thread_load.cuh
+++ b/cub/cub/thread/thread_load.cuh
@@ -106,7 +106,7 @@ enum CacheLoadModifier
  *   <b>[inferred]</b> The input's iterator type \iterator
  */
 template <CacheLoadModifier MODIFIER, typename RandomAccessIterator>
-_CCCL_DEVICE _CCCL_FORCEINLINE cub::detail::value_t<RandomAccessIterator> ThreadLoad(RandomAccessIterator itr);
+_CCCL_DEVICE _CCCL_FORCEINLINE cub::detail::iter_value_t<RandomAccessIterator> ThreadLoad(RandomAccessIterator itr);
 
 //@}  end member group
 

--- a/cub/cub/thread/thread_load.cuh
+++ b/cub/cub/thread/thread_load.cuh
@@ -106,7 +106,7 @@ enum CacheLoadModifier
  *   <b>[inferred]</b> The input's iterator type \iterator
  */
 template <CacheLoadModifier MODIFIER, typename RandomAccessIterator>
-_CCCL_DEVICE _CCCL_FORCEINLINE cub::detail::iter_value_t<RandomAccessIterator> ThreadLoad(RandomAccessIterator itr);
+_CCCL_DEVICE _CCCL_FORCEINLINE cub::detail::it_value_t<RandomAccessIterator> ThreadLoad(RandomAccessIterator itr);
 
 //@}  end member group
 
@@ -306,7 +306,7 @@ _CUB_LOAD_ALL(LOAD_LDG, global.nc)
  * ThreadLoad definition for LOAD_DEFAULT modifier on iterator types
  */
 template <typename RandomAccessIterator>
-_CCCL_DEVICE _CCCL_FORCEINLINE cub::detail::iter_value_t<RandomAccessIterator> ThreadLoad(
+_CCCL_DEVICE _CCCL_FORCEINLINE cub::detail::it_value_t<RandomAccessIterator> ThreadLoad(
   RandomAccessIterator itr, detail::constant_t<LOAD_DEFAULT> /*modifier*/, ::cuda::std::false_type /*is_pointer*/)
 {
   return *itr;
@@ -374,7 +374,7 @@ ThreadLoad(T const* ptr, detail::constant_t<MODIFIER> /*modifier*/, ::cuda::std:
 }
 
 template <CacheLoadModifier MODIFIER, typename RandomAccessIterator>
-_CCCL_DEVICE _CCCL_FORCEINLINE cub::detail::iter_value_t<RandomAccessIterator> ThreadLoad(RandomAccessIterator itr)
+_CCCL_DEVICE _CCCL_FORCEINLINE cub::detail::it_value_t<RandomAccessIterator> ThreadLoad(RandomAccessIterator itr)
 {
   return ThreadLoad(
     itr, detail::constant_v<MODIFIER>, detail::bool_constant_v<::cuda::std::is_pointer_v<RandomAccessIterator>>);

--- a/cub/cub/thread/thread_load.cuh
+++ b/cub/cub/thread/thread_load.cuh
@@ -306,7 +306,7 @@ _CUB_LOAD_ALL(LOAD_LDG, global.nc)
  * ThreadLoad definition for LOAD_DEFAULT modifier on iterator types
  */
 template <typename RandomAccessIterator>
-_CCCL_DEVICE _CCCL_FORCEINLINE cub::detail::value_t<RandomAccessIterator> ThreadLoad(
+_CCCL_DEVICE _CCCL_FORCEINLINE cub::detail::iter_value_t<RandomAccessIterator> ThreadLoad(
   RandomAccessIterator itr, detail::constant_t<LOAD_DEFAULT> /*modifier*/, ::cuda::std::false_type /*is_pointer*/)
 {
   return *itr;
@@ -374,7 +374,7 @@ ThreadLoad(T const* ptr, detail::constant_t<MODIFIER> /*modifier*/, ::cuda::std:
 }
 
 template <CacheLoadModifier MODIFIER, typename RandomAccessIterator>
-_CCCL_DEVICE _CCCL_FORCEINLINE cub::detail::value_t<RandomAccessIterator> ThreadLoad(RandomAccessIterator itr)
+_CCCL_DEVICE _CCCL_FORCEINLINE cub::detail::iter_value_t<RandomAccessIterator> ThreadLoad(RandomAccessIterator itr)
 {
   return ThreadLoad(
     itr, detail::constant_v<MODIFIER>, detail::bool_constant_v<::cuda::std::is_pointer_v<RandomAccessIterator>>);

--- a/cub/cub/thread/thread_search.cuh
+++ b/cub/cub/thread/thread_search.cuh
@@ -60,7 +60,7 @@ _CCCL_HOST_DEVICE _CCCL_FORCEINLINE void MergePathSearch(
   OffsetT diagonal, AIteratorT a, BIteratorT b, OffsetT a_len, OffsetT b_len, CoordinateT& path_coordinate)
 {
   /// The value type of the input iterator
-  using T = cub::detail::value_t<AIteratorT>;
+  using T = cub::detail::iter_value_t<AIteratorT>;
 
   OffsetT split_min = CUB_MAX(diagonal - b_len, 0);
   OffsetT split_max = CUB_MIN(diagonal, a_len);

--- a/cub/cub/thread/thread_search.cuh
+++ b/cub/cub/thread/thread_search.cuh
@@ -60,7 +60,7 @@ _CCCL_HOST_DEVICE _CCCL_FORCEINLINE void MergePathSearch(
   OffsetT diagonal, AIteratorT a, BIteratorT b, OffsetT a_len, OffsetT b_len, CoordinateT& path_coordinate)
 {
   /// The value type of the input iterator
-  using T = cub::detail::iter_value_t<AIteratorT>;
+  using T = cub::detail::it_value_t<AIteratorT>;
 
   OffsetT split_min = CUB_MAX(diagonal - b_len, 0);
   OffsetT split_max = CUB_MIN(diagonal, a_len);

--- a/cub/cub/util_type.cuh
+++ b/cub/cub/util_type.cuh
@@ -80,12 +80,22 @@ CUB_NAMESPACE_BEGIN
 #ifndef _CCCL_DOXYGEN_INVOKED // Do not document
 namespace detail
 {
-using ::cuda::std::iter_difference_t;
-using ::cuda::std::iter_reference_t;
-using ::cuda::std::iter_value_t;
+// the following iterator helpers are not named iter_value_t etc, like the C++20 facilities, because they are defined in
+// terms of C++17 iterator_traits and not the new C++20 indirectly_readable trait etc. This allows them to detect nested
+// value_type, difference_type and reference aliases, which the new C+20 traits do not consider (they only consider
+// specializations of iterator_traits). Also, a value_type of void remains supported (needed by some output iterators).
 
-template <typename T>
-using iter_pointer_t = typename ::cuda::std::iterator_traits<T>::pointer;
+template <typename It>
+using it_value_t = typename ::cuda::std::iterator_traits<It>::value_type;
+
+template <typename It>
+using it_reference_t = typename ::cuda::std::iterator_traits<It>::reference;
+
+template <typename It>
+using it_difference_t = typename ::cuda::std::iterator_traits<It>::difference_type;
+
+template <typename It>
+using it_pointer_t = typename ::cuda::std::iterator_traits<It>::pointer;
 
 // use this whenever you need to lazily evaluate a trait. E.g., as an alternative in replace_if_use_default.
 template <template <typename...> typename Trait, typename... Args>
@@ -106,10 +116,10 @@ struct non_void_value_impl<It, FallbackT, false>
   // we consider thrust::discard_iterator's value_type as `void` as well, so users can switch from
   // cub::DiscardInputIterator to thrust::discard_iterator.
   using type =
-    ::cuda::std::_If<::cuda::std::is_void_v<iter_value_t<It>>
-                       || ::cuda::std::is_same_v<iter_value_t<It>, THRUST_NS_QUALIFIER::discard_iterator<>::value_type>,
+    ::cuda::std::_If<::cuda::std::is_void_v<it_value_t<It>>
+                       || ::cuda::std::is_same_v<it_value_t<It>, THRUST_NS_QUALIFIER::discard_iterator<>::value_type>,
                      FallbackT,
-                     iter_value_t<It>>;
+                     it_value_t<It>>;
 };
 
 /**

--- a/cub/cub/util_type.cuh
+++ b/cub/cub/util_type.cuh
@@ -84,6 +84,16 @@ using ::cuda::std::iter_difference_t;
 using ::cuda::std::iter_reference_t;
 using ::cuda::std::iter_value_t;
 
+template <typename T>
+using iter_pointer_t = typename ::cuda::std::iterator_traits<T>::pointer;
+
+// use this whenever you need to lazily evaluate a trait. E.g., as an alternative in replace_if_use_default.
+template <template <typename...> typename Trait, typename... Args>
+struct lazy_trait
+{
+  using type = Trait<Args...>;
+};
+
 template <typename It, typename FallbackT, bool = ::cuda::std::is_void_v<::cuda::std::remove_pointer_t<It>>>
 struct non_void_value_impl
 {

--- a/cub/test/catch2_test_block_load.cu
+++ b/cub/test/catch2_test_block_load.cu
@@ -49,7 +49,7 @@ template <int ItemsPerThread,
           typename OutputIteratorT>
 __global__ void kernel(cuda::std::true_type, InputIteratorT input, OutputIteratorT output, int num_items)
 {
-  using input_t      = cub::detail::iter_value_t<InputIteratorT>;
+  using input_t      = cub::detail::it_value_t<InputIteratorT>;
   using block_load_t = cub::BlockLoad<input_t, ThreadsInBlock, ItemsPerThread, LoadAlgorithm>;
   using storage_t    = typename block_load_t::TempStorage;
 

--- a/cub/test/catch2_test_block_load.cu
+++ b/cub/test/catch2_test_block_load.cu
@@ -49,7 +49,7 @@ template <int ItemsPerThread,
           typename OutputIteratorT>
 __global__ void kernel(cuda::std::true_type, InputIteratorT input, OutputIteratorT output, int num_items)
 {
-  using input_t      = cub::detail::value_t<InputIteratorT>;
+  using input_t      = cub::detail::iter_value_t<InputIteratorT>;
   using block_load_t = cub::BlockLoad<input_t, ThreadsInBlock, ItemsPerThread, LoadAlgorithm>;
   using storage_t    = typename block_load_t::TempStorage;
 

--- a/cub/test/catch2_test_block_radix_sort.cuh
+++ b/cub/test/catch2_test_block_radix_sort.cuh
@@ -44,7 +44,7 @@ template <typename InputIteratorT,
 __global__ void
 kernel(ActionT action, InputIteratorT input, OutputIteratorT output, int begin_bit, int end_bit, bool striped)
 {
-  using key_t = cub::detail::iter_value_t<InputIteratorT>;
+  using key_t = cub::detail::it_value_t<InputIteratorT>;
   using block_radix_sort_t =
     cub::BlockRadixSort<key_t, ThreadsInBlock, ItemsPerThread, cub::NullType, RadixBits, Memoize, Algorithm, ShmemConfig>;
 
@@ -121,8 +121,8 @@ __global__ void kernel(
   int end_bit,
   bool striped)
 {
-  using key_t   = cub::detail::iter_value_t<InputKeyIteratorT>;
-  using value_t = cub::detail::iter_value_t<InputValueIteratorT>;
+  using key_t   = cub::detail::it_value_t<InputKeyIteratorT>;
+  using value_t = cub::detail::it_value_t<InputValueIteratorT>;
   using block_radix_sort_t =
     cub::BlockRadixSort<key_t, ThreadsInBlock, ItemsPerThread, value_t, RadixBits, Memoize, Algorithm, ShmemConfig>;
 

--- a/cub/test/catch2_test_block_radix_sort.cuh
+++ b/cub/test/catch2_test_block_radix_sort.cuh
@@ -121,8 +121,8 @@ __global__ void kernel(
   int end_bit,
   bool striped)
 {
-  using key_t   = cub::detail::value_t<InputKeyIteratorT>;
-  using value_t = cub::detail::value_t<InputValueIteratorT>;
+  using key_t   = cub::detail::iter_value_t<InputKeyIteratorT>;
+  using value_t = cub::detail::iter_value_t<InputValueIteratorT>;
   using block_radix_sort_t =
     cub::BlockRadixSort<key_t, ThreadsInBlock, ItemsPerThread, value_t, RadixBits, Memoize, Algorithm, ShmemConfig>;
 

--- a/cub/test/catch2_test_block_radix_sort.cuh
+++ b/cub/test/catch2_test_block_radix_sort.cuh
@@ -44,7 +44,7 @@ template <typename InputIteratorT,
 __global__ void
 kernel(ActionT action, InputIteratorT input, OutputIteratorT output, int begin_bit, int end_bit, bool striped)
 {
-  using key_t = cub::detail::value_t<InputIteratorT>;
+  using key_t = cub::detail::iter_value_t<InputIteratorT>;
   using block_radix_sort_t =
     cub::BlockRadixSort<key_t, ThreadsInBlock, ItemsPerThread, cub::NullType, RadixBits, Memoize, Algorithm, ShmemConfig>;
 

--- a/cub/test/catch2_test_block_run_length_decode.cu
+++ b/cub/test/catch2_test_block_run_length_decode.cu
@@ -75,7 +75,7 @@ public:
 
 private:
   using RunItemT   = cub::detail::iter_value_t<ItemItT>;
-  using RunLengthT = cub::detail::value_t<RunLengthsItT>;
+  using RunLengthT = cub::detail::iter_value_t<RunLengthsItT>;
 
   using BlockRunOffsetScanT = cub::BlockScan<RunLengthT, BLOCK_DIM_X, cub::BLOCK_SCAN_RAKING, BLOCK_DIM_Y, BLOCK_DIM_Z>;
 

--- a/cub/test/catch2_test_block_run_length_decode.cu
+++ b/cub/test/catch2_test_block_run_length_decode.cu
@@ -74,7 +74,7 @@ public:
   static constexpr bool TEST_RELATIVE_OFFSETS = TEST_RELATIVE_OFFSETS_;
 
 private:
-  using RunItemT   = cub::detail::value_t<ItemItT>;
+  using RunItemT   = cub::detail::iter_value_t<ItemItT>;
   using RunLengthT = cub::detail::value_t<RunLengthsItT>;
 
   using BlockRunOffsetScanT = cub::BlockScan<RunLengthT, BLOCK_DIM_X, cub::BLOCK_SCAN_RAKING, BLOCK_DIM_Y, BLOCK_DIM_Z>;

--- a/cub/test/catch2_test_block_run_length_decode.cu
+++ b/cub/test/catch2_test_block_run_length_decode.cu
@@ -74,8 +74,8 @@ public:
   static constexpr bool TEST_RELATIVE_OFFSETS = TEST_RELATIVE_OFFSETS_;
 
 private:
-  using RunItemT   = cub::detail::iter_value_t<ItemItT>;
-  using RunLengthT = cub::detail::iter_value_t<RunLengthsItT>;
+  using RunItemT   = cub::detail::it_value_t<ItemItT>;
+  using RunLengthT = cub::detail::it_value_t<RunLengthsItT>;
 
   using BlockRunOffsetScanT = cub::BlockScan<RunLengthT, BLOCK_DIM_X, cub::BLOCK_SCAN_RAKING, BLOCK_DIM_Y, BLOCK_DIM_Z>;
 

--- a/cub/test/catch2_test_block_store.cu
+++ b/cub/test/catch2_test_block_store.cu
@@ -57,7 +57,7 @@ template <typename InputIteratorT,
           cub::BlockStoreAlgorithm StoreAlgorithm>
 __global__ void kernel(std::integral_constant<bool, true>, InputIteratorT input, OutputIteratorT output, int num_items)
 {
-  using input_t       = cub::detail::value_t<InputIteratorT>;
+  using input_t       = cub::detail::iter_value_t<InputIteratorT>;
   using block_store_t = cub::BlockStore<input_t, ThreadsInBlock, ItemsPerThread, StoreAlgorithm>;
   using storage_t     = typename block_store_t::TempStorage;
 

--- a/cub/test/catch2_test_block_store.cu
+++ b/cub/test/catch2_test_block_store.cu
@@ -57,7 +57,7 @@ template <typename InputIteratorT,
           cub::BlockStoreAlgorithm StoreAlgorithm>
 __global__ void kernel(std::integral_constant<bool, true>, InputIteratorT input, OutputIteratorT output, int num_items)
 {
-  using input_t       = cub::detail::iter_value_t<InputIteratorT>;
+  using input_t       = cub::detail::it_value_t<InputIteratorT>;
   using block_store_t = cub::BlockStore<input_t, ThreadsInBlock, ItemsPerThread, StoreAlgorithm>;
   using storage_t     = typename block_store_t::TempStorage;
 
@@ -111,7 +111,7 @@ template <int ItemsPerThread,
           typename OutputIteratorT>
 void block_store(InputIteratorT input, OutputIteratorT output, int num_items)
 {
-  using input_t                       = cub::detail::iter_value_t<InputIteratorT>;
+  using input_t                       = cub::detail::it_value_t<InputIteratorT>;
   using block_store_t                 = cub::BlockStore<input_t, ThreadsInBlock, ItemsPerThread, StoreAlgorithm>;
   using storage_t                     = typename block_store_t::TempStorage;
   constexpr bool sufficient_resources = sizeof(storage_t) <= cub::detail::max_smem_per_block;

--- a/cub/test/catch2_test_block_store.cu
+++ b/cub/test/catch2_test_block_store.cu
@@ -111,7 +111,7 @@ template <int ItemsPerThread,
           typename OutputIteratorT>
 void block_store(InputIteratorT input, OutputIteratorT output, int num_items)
 {
-  using input_t                       = cub::detail::value_t<InputIteratorT>;
+  using input_t                       = cub::detail::iter_value_t<InputIteratorT>;
   using block_store_t                 = cub::BlockStore<input_t, ThreadsInBlock, ItemsPerThread, StoreAlgorithm>;
   using storage_t                     = typename block_store_t::TempStorage;
   constexpr bool sufficient_resources = sizeof(storage_t) <= cub::detail::max_smem_per_block;

--- a/cub/test/catch2_test_device_for_utils.cu
+++ b/cub/test/catch2_test_device_for_utils.cu
@@ -88,13 +88,13 @@ struct value_const_t
 template <class T>
 void test()
 {
-  STATIC_REQUIRE(cub::detail::for_each::has_unique_value_overload<T, value_t<T>>::value);
+  STATIC_REQUIRE(cub::detail::for_each::has_unique_value_overload<T, iter_value_t<T>>::value);
   STATIC_REQUIRE(cub::detail::for_each::has_unique_value_overload<T, value_const_t<T>>::value);
   STATIC_REQUIRE(cub::detail::for_each::has_unique_value_overload<T, value_ret_t<T>>::value);
   STATIC_REQUIRE(!cub::detail::for_each::has_unique_value_overload<T, rref_t<T>>::value);
   STATIC_REQUIRE(!cub::detail::for_each::has_unique_value_overload<T, ref_t<T>>::value);
   STATIC_REQUIRE(!cub::detail::for_each::has_unique_value_overload<T, const_ref_t<T>>::value);
-  STATIC_REQUIRE(!cub::detail::for_each::has_unique_value_overload<T, overload_value_t<T>>::value);
+  STATIC_REQUIRE(!cub::detail::for_each::has_unique_value_overload<T, overload_iter_value_t<T>>::value);
   STATIC_REQUIRE(!cub::detail::for_each::has_unique_value_overload<T, tpl_value_t>::value);
 }
 
@@ -104,5 +104,5 @@ C2H_TEST("Device for utils correctly detect value overloads", "[for][device]")
   test<double>();
 
   // conversions do not work ;(
-  STATIC_REQUIRE(cub::detail::for_each::has_unique_value_overload<char, value_t<int>>::value);
+  STATIC_REQUIRE(cub::detail::for_each::has_unique_value_overload<char, iter_value_t<int>>::value);
 }

--- a/cub/test/catch2_test_device_for_utils.cu
+++ b/cub/test/catch2_test_device_for_utils.cu
@@ -88,13 +88,13 @@ struct value_const_t
 template <class T>
 void test()
 {
-  STATIC_REQUIRE(cub::detail::for_each::has_unique_value_overload<T, iter_value_t<T>>::value);
+  STATIC_REQUIRE(cub::detail::for_each::has_unique_value_overload<T, value_t<T>>::value);
   STATIC_REQUIRE(cub::detail::for_each::has_unique_value_overload<T, value_const_t<T>>::value);
   STATIC_REQUIRE(cub::detail::for_each::has_unique_value_overload<T, value_ret_t<T>>::value);
   STATIC_REQUIRE(!cub::detail::for_each::has_unique_value_overload<T, rref_t<T>>::value);
   STATIC_REQUIRE(!cub::detail::for_each::has_unique_value_overload<T, ref_t<T>>::value);
   STATIC_REQUIRE(!cub::detail::for_each::has_unique_value_overload<T, const_ref_t<T>>::value);
-  STATIC_REQUIRE(!cub::detail::for_each::has_unique_value_overload<T, overload_iter_value_t<T>>::value);
+  STATIC_REQUIRE(!cub::detail::for_each::has_unique_value_overload<T, overload_value_t<T>>::value);
   STATIC_REQUIRE(!cub::detail::for_each::has_unique_value_overload<T, tpl_value_t>::value);
 }
 
@@ -104,5 +104,5 @@ C2H_TEST("Device for utils correctly detect value overloads", "[for][device]")
   test<double>();
 
   // conversions do not work ;(
-  STATIC_REQUIRE(cub::detail::for_each::has_unique_value_overload<char, iter_value_t<int>>::value);
+  STATIC_REQUIRE(cub::detail::for_each::has_unique_value_overload<char, value_t<int>>::value);
 }

--- a/cub/test/catch2_test_device_reduce.cu
+++ b/cub/test/catch2_test_device_reduce.cu
@@ -149,7 +149,7 @@ C2H_TEST("Device reduce works with all device interfaces", "[reduce][device]", f
     // Run test
     c2h::device_vector<output_t> out_result(num_segments);
     auto d_out_it = thrust::raw_pointer_cast(out_result.data());
-    using init_t  = cub::detail::value_t<decltype(unwrap_it(d_out_it))>;
+    using init_t  = cub::detail::iter_value_t<decltype(unwrap_it(d_out_it))>;
     device_reduce(unwrap_it(d_in_it), unwrap_it(d_out_it), num_items, reduction_op, init_t{});
 
     // Verify result

--- a/cub/test/catch2_test_device_reduce.cu
+++ b/cub/test/catch2_test_device_reduce.cu
@@ -149,7 +149,7 @@ C2H_TEST("Device reduce works with all device interfaces", "[reduce][device]", f
     // Run test
     c2h::device_vector<output_t> out_result(num_segments);
     auto d_out_it = thrust::raw_pointer_cast(out_result.data());
-    using init_t  = cub::detail::iter_value_t<decltype(unwrap_it(d_out_it))>;
+    using init_t  = cub::detail::it_value_t<decltype(unwrap_it(d_out_it))>;
     device_reduce(unwrap_it(d_in_it), unwrap_it(d_out_it), num_items, reduction_op, init_t{});
 
     // Verify result

--- a/cub/test/catch2_test_device_reduce.cuh
+++ b/cub/test/catch2_test_device_reduce.cuh
@@ -270,7 +270,7 @@ inline void compute_host_reference(
     auto seg_end   = seg_begin + h_sizes_begin[segment];
     // TODO Should this be using cub accumulator t?
     h_data_out[segment] =
-      static_cast<cub::detail::value_t<ResultOutItT>>(std::accumulate(seg_begin, seg_end, init, reduction_op));
+      static_cast<cub::detail::iter_value_t<ResultOutItT>>(std::accumulate(seg_begin, seg_end, init, reduction_op));
   }
 }
 

--- a/cub/test/catch2_test_device_reduce.cuh
+++ b/cub/test/catch2_test_device_reduce.cuh
@@ -270,7 +270,7 @@ inline void compute_host_reference(
     auto seg_end   = seg_begin + h_sizes_begin[segment];
     // TODO Should this be using cub accumulator t?
     h_data_out[segment] =
-      static_cast<cub::detail::iter_value_t<ResultOutItT>>(std::accumulate(seg_begin, seg_end, init, reduction_op));
+      static_cast<cub::detail::it_value_t<ResultOutItT>>(std::accumulate(seg_begin, seg_end, init, reduction_op));
   }
 }
 

--- a/cub/test/catch2_test_device_scan.cu
+++ b/cub/test/catch2_test_device_scan.cu
@@ -266,7 +266,7 @@ C2H_TEST("Device scan works with all device interfaces", "[scan][device]", full_
     // Run test
     c2h::device_vector<output_t> out_result(num_items);
     auto d_out_it = thrust::raw_pointer_cast(out_result.data());
-    using init_t  = cub::detail::value_t<decltype(unwrap_it(d_out_it))>;
+    using init_t  = cub::detail::iter_value_t<decltype(unwrap_it(d_out_it))>;
     device_exclusive_scan(unwrap_it(d_in_it), unwrap_it(d_out_it), scan_op, init_t{}, num_items);
 
     // Verify result

--- a/cub/test/catch2_test_device_scan.cu
+++ b/cub/test/catch2_test_device_scan.cu
@@ -301,7 +301,7 @@ C2H_TEST("Device scan works with all device interfaces", "[scan][device]", full_
     // Run test
     c2h::device_vector<output_t> out_result(num_items);
     auto d_out_it = thrust::raw_pointer_cast(out_result.data());
-    using init_t  = cub::detail::value_t<decltype(unwrap_it(d_out_it))>;
+    using init_t  = cub::detail::iter_value_t<decltype(unwrap_it(d_out_it))>;
     c2h::device_vector<init_t> d_initial_value(1);
     d_initial_value[0]     = static_cast<init_t>(*unwrap_it(&init_value));
     auto future_init_value = cub::FutureValue<init_t>(thrust::raw_pointer_cast(d_initial_value.data()));

--- a/cub/test/catch2_test_device_scan.cu
+++ b/cub/test/catch2_test_device_scan.cu
@@ -266,7 +266,7 @@ C2H_TEST("Device scan works with all device interfaces", "[scan][device]", full_
     // Run test
     c2h::device_vector<output_t> out_result(num_items);
     auto d_out_it = thrust::raw_pointer_cast(out_result.data());
-    using init_t  = cub::detail::iter_value_t<decltype(unwrap_it(d_out_it))>;
+    using init_t  = cub::detail::it_value_t<decltype(unwrap_it(d_out_it))>;
     device_exclusive_scan(unwrap_it(d_in_it), unwrap_it(d_out_it), scan_op, init_t{}, num_items);
 
     // Verify result
@@ -301,7 +301,7 @@ C2H_TEST("Device scan works with all device interfaces", "[scan][device]", full_
     // Run test
     c2h::device_vector<output_t> out_result(num_items);
     auto d_out_it = thrust::raw_pointer_cast(out_result.data());
-    using init_t  = cub::detail::iter_value_t<decltype(unwrap_it(d_out_it))>;
+    using init_t  = cub::detail::it_value_t<decltype(unwrap_it(d_out_it))>;
     c2h::device_vector<init_t> d_initial_value(1);
     d_initial_value[0]     = static_cast<init_t>(*unwrap_it(&init_value));
     auto future_init_value = cub::FutureValue<init_t>(thrust::raw_pointer_cast(d_initial_value.data()));

--- a/cub/test/catch2_test_device_scan.cuh
+++ b/cub/test/catch2_test_device_scan.cuh
@@ -63,9 +63,9 @@ struct Mod2Equality
 template <typename InputIt, typename OutputIt, typename InitT, typename BinaryOp>
 void compute_exclusive_scan_reference(InputIt first, InputIt last, OutputIt result, InitT init, BinaryOp op)
 {
-  using value_t  = cub::detail::value_t<InputIt>;
+  using value_t  = cub::detail::iter_value_t<InputIt>;
   using accum_t  = ::cuda::std::__accumulator_t<BinaryOp, value_t, InitT>;
-  using output_t = cub::detail::value_t<OutputIt>;
+  using output_t = cub::detail::iter_value_t<OutputIt>;
   accum_t acc    = static_cast<accum_t>(init);
   for (; first != last; ++first)
   {
@@ -77,9 +77,9 @@ void compute_exclusive_scan_reference(InputIt first, InputIt last, OutputIt resu
 template <typename InputIt, typename OutputIt, typename BinaryOp, typename InitT>
 void compute_inclusive_scan_reference(InputIt first, InputIt last, OutputIt result, BinaryOp op, InitT init)
 {
-  using value_t  = cub::detail::value_t<InputIt>;
+  using value_t  = cub::detail::iter_value_t<InputIt>;
   using accum_t  = ::cuda::std::__accumulator_t<BinaryOp, value_t, InitT>;
-  using output_t = cub::detail::value_t<OutputIt>;
+  using output_t = cub::detail::iter_value_t<OutputIt>;
   accum_t acc    = static_cast<accum_t>(init);
   for (; first != last; ++first)
   {
@@ -103,9 +103,9 @@ void compute_exclusive_scan_by_key_reference(
   InitT init,
   std::size_t num_items)
 {
-  using value_t  = cub::detail::value_t<ValueInItT>;
+  using value_t  = cub::detail::iter_value_t<ValueInItT>;
   using accum_t  = ::cuda::std::__accumulator_t<ScanOpT, value_t, InitT>;
-  using output_t = cub::detail::value_t<ValuesOutItT>;
+  using output_t = cub::detail::iter_value_t<ValuesOutItT>;
 
   if (num_items > 0)
   {
@@ -154,9 +154,9 @@ void compute_inclusive_scan_by_key_reference(
   EqualityOpT equality_op,
   std::size_t num_items)
 {
-  using value_t  = cub::detail::value_t<ValueInItT>;
+  using value_t  = cub::detail::iter_value_t<ValueInItT>;
   using accum_t  = ::cuda::std::__accumulator_t<ScanOpT, value_t, value_t>;
-  using output_t = cub::detail::value_t<ValuesOutItT>;
+  using output_t = cub::detail::iter_value_t<ValuesOutItT>;
 
   for (std::size_t i = 0; i < num_items;)
   {

--- a/cub/test/catch2_test_device_scan.cuh
+++ b/cub/test/catch2_test_device_scan.cuh
@@ -63,9 +63,9 @@ struct Mod2Equality
 template <typename InputIt, typename OutputIt, typename InitT, typename BinaryOp>
 void compute_exclusive_scan_reference(InputIt first, InputIt last, OutputIt result, InitT init, BinaryOp op)
 {
-  using value_t  = cub::detail::iter_value_t<InputIt>;
+  using value_t  = cub::detail::it_value_t<InputIt>;
   using accum_t  = ::cuda::std::__accumulator_t<BinaryOp, value_t, InitT>;
-  using output_t = cub::detail::iter_value_t<OutputIt>;
+  using output_t = cub::detail::it_value_t<OutputIt>;
   accum_t acc    = static_cast<accum_t>(init);
   for (; first != last; ++first)
   {
@@ -77,9 +77,9 @@ void compute_exclusive_scan_reference(InputIt first, InputIt last, OutputIt resu
 template <typename InputIt, typename OutputIt, typename BinaryOp, typename InitT>
 void compute_inclusive_scan_reference(InputIt first, InputIt last, OutputIt result, BinaryOp op, InitT init)
 {
-  using value_t  = cub::detail::iter_value_t<InputIt>;
+  using value_t  = cub::detail::it_value_t<InputIt>;
   using accum_t  = ::cuda::std::__accumulator_t<BinaryOp, value_t, InitT>;
-  using output_t = cub::detail::iter_value_t<OutputIt>;
+  using output_t = cub::detail::it_value_t<OutputIt>;
   accum_t acc    = static_cast<accum_t>(init);
   for (; first != last; ++first)
   {
@@ -103,9 +103,9 @@ void compute_exclusive_scan_by_key_reference(
   InitT init,
   std::size_t num_items)
 {
-  using value_t  = cub::detail::iter_value_t<ValueInItT>;
+  using value_t  = cub::detail::it_value_t<ValueInItT>;
   using accum_t  = ::cuda::std::__accumulator_t<ScanOpT, value_t, InitT>;
-  using output_t = cub::detail::iter_value_t<ValuesOutItT>;
+  using output_t = cub::detail::it_value_t<ValuesOutItT>;
 
   if (num_items > 0)
   {
@@ -154,9 +154,9 @@ void compute_inclusive_scan_by_key_reference(
   EqualityOpT equality_op,
   std::size_t num_items)
 {
-  using value_t  = cub::detail::iter_value_t<ValueInItT>;
+  using value_t  = cub::detail::it_value_t<ValueInItT>;
   using accum_t  = ::cuda::std::__accumulator_t<ScanOpT, value_t, value_t>;
-  using output_t = cub::detail::iter_value_t<ValuesOutItT>;
+  using output_t = cub::detail::it_value_t<ValuesOutItT>;
 
   for (std::size_t i = 0; i < num_items;)
   {

--- a/cub/test/catch2_test_device_scan_by_key.cu
+++ b/cub/test/catch2_test_device_scan_by_key.cu
@@ -232,7 +232,7 @@ C2H_TEST("Device scan works with all device interfaces", "[by_key][scan][device]
     // Run test
     c2h::device_vector<output_t> out_values(num_items);
     auto d_values_out_it = thrust::raw_pointer_cast(out_values.data());
-    using init_t         = cub::detail::value_t<decltype(unwrap_it(d_values_out_it))>;
+    using init_t         = cub::detail::iter_value_t<decltype(unwrap_it(d_values_out_it))>;
     device_exclusive_scan_by_key(
       d_keys_it, unwrap_it(d_values_it), unwrap_it(d_values_out_it), scan_op, init_t{}, num_items, eq_op_t{});
 

--- a/cub/test/catch2_test_device_scan_by_key.cu
+++ b/cub/test/catch2_test_device_scan_by_key.cu
@@ -232,7 +232,7 @@ C2H_TEST("Device scan works with all device interfaces", "[by_key][scan][device]
     // Run test
     c2h::device_vector<output_t> out_values(num_items);
     auto d_values_out_it = thrust::raw_pointer_cast(out_values.data());
-    using init_t         = cub::detail::iter_value_t<decltype(unwrap_it(d_values_out_it))>;
+    using init_t         = cub::detail::it_value_t<decltype(unwrap_it(d_values_out_it))>;
     device_exclusive_scan_by_key(
       d_keys_it, unwrap_it(d_values_it), unwrap_it(d_values_out_it), scan_op, init_t{}, num_items, eq_op_t{});
 

--- a/cub/test/catch2_test_device_scan_iterators.cu
+++ b/cub/test/catch2_test_device_scan_iterators.cu
@@ -170,7 +170,7 @@ C2H_TEST("Device scan works with iterators", "[scan][device]", iterator_type_lis
     // Run test
     c2h::device_vector<output_t> out_result(num_items);
     auto d_out_it = thrust::raw_pointer_cast(out_result.data());
-    using init_t  = cub::detail::value_t<decltype(unwrap_it(d_out_it))>;
+    using init_t  = cub::detail::iter_value_t<decltype(unwrap_it(d_out_it))>;
     c2h::device_vector<init_t> d_initial_value(1);
     d_initial_value[0]     = static_cast<init_t>(init_value);
     auto future_init_value = cub::FutureValue<init_t>(thrust::raw_pointer_cast(d_initial_value.data()));

--- a/cub/test/catch2_test_device_scan_iterators.cu
+++ b/cub/test/catch2_test_device_scan_iterators.cu
@@ -170,7 +170,7 @@ C2H_TEST("Device scan works with iterators", "[scan][device]", iterator_type_lis
     // Run test
     c2h::device_vector<output_t> out_result(num_items);
     auto d_out_it = thrust::raw_pointer_cast(out_result.data());
-    using init_t  = cub::detail::iter_value_t<decltype(unwrap_it(d_out_it))>;
+    using init_t  = cub::detail::it_value_t<decltype(unwrap_it(d_out_it))>;
     c2h::device_vector<init_t> d_initial_value(1);
     d_initial_value[0]     = static_cast<init_t>(init_value);
     auto future_init_value = cub::FutureValue<init_t>(thrust::raw_pointer_cast(d_initial_value.data()));

--- a/cub/test/catch2_test_device_segmented_reduce.cu
+++ b/cub/test/catch2_test_device_segmented_reduce.cu
@@ -128,7 +128,7 @@ C2H_TEST("Device reduce works with all device interfaces", "[segmented][reduce][
     // Run test
     c2h::device_vector<output_t> out_result(num_segments);
     auto d_out_it = thrust::raw_pointer_cast(out_result.data());
-    using init_t  = cub::detail::value_t<decltype(unwrap_it(d_out_it))>;
+    using init_t  = cub::detail::iter_value_t<decltype(unwrap_it(d_out_it))>;
     device_segmented_reduce(
       unwrap_it(d_in_it), unwrap_it(d_out_it), num_segments, d_offsets_it, d_offsets_it + 1, reduction_op, init_t{});
 

--- a/cub/test/catch2_test_device_segmented_reduce.cu
+++ b/cub/test/catch2_test_device_segmented_reduce.cu
@@ -128,7 +128,7 @@ C2H_TEST("Device reduce works with all device interfaces", "[segmented][reduce][
     // Run test
     c2h::device_vector<output_t> out_result(num_segments);
     auto d_out_it = thrust::raw_pointer_cast(out_result.data());
-    using init_t  = cub::detail::iter_value_t<decltype(unwrap_it(d_out_it))>;
+    using init_t  = cub::detail::it_value_t<decltype(unwrap_it(d_out_it))>;
     device_segmented_reduce(
       unwrap_it(d_in_it), unwrap_it(d_out_it), num_segments, d_offsets_it, d_offsets_it + 1, reduction_op, init_t{});
 

--- a/cub/test/catch2_test_device_select_common.cuh
+++ b/cub/test/catch2_test_device_select_common.cuh
@@ -61,7 +61,7 @@ struct modx_and_add_divy
 template <typename SelectedItT, typename RejectedItT>
 struct index_to_expected_partition_op
 {
-  using value_t = cub::detail::iter_value_t<SelectedItT>;
+  using value_t = cub::detail::it_value_t<SelectedItT>;
   SelectedItT expected_selected_it;
   RejectedItT expected_rejected_it;
   std::int64_t expected_num_selected;

--- a/cub/test/catch2_test_device_select_common.cuh
+++ b/cub/test/catch2_test_device_select_common.cuh
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <cub/util_type.cuh>
+
 #include <thrust/iterator/constant_iterator.h>
 
 #include <cuda/std/type_traits>
@@ -59,7 +61,7 @@ struct modx_and_add_divy
 template <typename SelectedItT, typename RejectedItT>
 struct index_to_expected_partition_op
 {
-  using value_t = typename ::cuda::std::iterator_traits<SelectedItT>::value_type;
+  using value_t = cub::detail::iter_value_t<SelectedItT>;
   SelectedItT expected_selected_it;
   RejectedItT expected_rejected_it;
   std::int64_t expected_num_selected;

--- a/cub/test/catch2_test_iterator.cu
+++ b/cub/test/catch2_test_iterator.cu
@@ -36,6 +36,7 @@ _CCCL_SUPPRESS_DEPRECATED_PUSH
 
 #include <cub/iterator/arg_index_input_iterator.cuh>
 #include <cub/iterator/cache_modified_input_iterator.cuh>
+#include <cub/iterator/cache_modified_output_iterator.cuh>
 #include <cub/iterator/tex_obj_input_iterator.cuh>
 #include <cub/util_allocator.cuh>
 #include <cub/util_type.cuh>
@@ -117,32 +118,35 @@ void test_iterator(InputIteratorT d_in, const c2h::host_vector<T>& h_reference) 
   CHECK(d_in == h_itrs[1]);
 }
 
-using cache_modifiers =
-  c2h::enum_type_list<cub::CacheLoadModifier,
-                      cub::LOAD_DEFAULT,
-                      cub::LOAD_CA,
-                      cub::LOAD_CG,
-                      cub::LOAD_CS,
-                      cub::LOAD_CV,
-                      cub::LOAD_LDG,
-                      cub::LOAD_VOLATILE>;
+static_assert(
+  ::cuda::std::is_void_v<cub::detail::it_value_t<cub::CacheModifiedOutputIterator<cub::STORE_DEFAULT, int>>>);
 
-C2H_TEST("Test cache modified iterator", "[iterator]", types, cache_modifiers)
-{
-  using T                       = c2h::get<0, TestType>;
-  constexpr auto cache_modifier = c2h::get<1, TestType>::value;
-  constexpr int TEST_VALUES     = 11000;
-
-  c2h::device_vector<T> d_data(TEST_VALUES);
-  c2h::gen(C2H_SEED(1), d_data);
-  c2h::host_vector<T> h_data(d_data);
-
-  const auto h_reference = c2h::host_vector<T>{
-    h_data[0], h_data[100], h_data[1000], h_data[10000], h_data[1], h_data[21], h_data[11], h_data[0]};
-  test_iterator(
-    cub::CacheModifiedInputIterator<cache_modifier, T>(const_cast<const T*>(thrust::raw_pointer_cast(d_data.data()))),
-    h_reference);
-}
+// using cache_modifiers =
+//   c2h::enum_type_list<cub::CacheLoadModifier,
+//                       cub::LOAD_DEFAULT,
+//                       cub::LOAD_CA,
+//                       cub::LOAD_CG,
+//                       cub::LOAD_CS,
+//                       cub::LOAD_CV,
+//                       cub::LOAD_LDG,
+//                       cub::LOAD_VOLATILE>;
+//
+// C2H_TEST("Test cache modified iterator", "[iterator]", types, cache_modifiers)
+// {
+//   using T                       = c2h::get<0, TestType>;
+//   constexpr auto cache_modifier = c2h::get<1, TestType>::value;
+//   constexpr int TEST_VALUES     = 11000;
+//
+//   c2h::device_vector<T> d_data(TEST_VALUES);
+//   c2h::gen(C2H_SEED(1), d_data);
+//   c2h::host_vector<T> h_data(d_data);
+//
+//   const auto h_reference = c2h::host_vector<T>{
+//     h_data[0], h_data[100], h_data[1000], h_data[10000], h_data[1], h_data[21], h_data[11], h_data[0]};
+//   test_iterator(
+//     cub::CacheModifiedInputIterator<cache_modifier, T>(const_cast<const
+//     T*>(thrust::raw_pointer_cast(d_data.data()))), h_reference);
+// }
 
 template <typename T>
 struct transform_op_t

--- a/cub/test/catch2_test_vsmem.cu
+++ b/cub/test/catch2_test_vsmem.cu
@@ -87,7 +87,7 @@ struct agent_dummy_algorithm_t
   static constexpr auto items_per_thread = ActivePolicyT::ITEMS_PER_THREAD;
   static constexpr auto tile_size        = block_threads * items_per_thread;
 
-  using item_t = cub::detail::iter_value_t<InputIteratorT>;
+  using item_t = cub::detail::it_value_t<InputIteratorT>;
 
   using block_load_t = cub::BlockLoad<item_t, block_threads, items_per_thread, cub::BLOCK_LOAD_TRANSPOSE>;
 
@@ -193,7 +193,7 @@ void __global__ __launch_bounds__(
 template <typename InputIteratorT>
 struct device_dummy_algorithm_policy_t
 {
-  using item_t = cub::detail::iter_value_t<InputIteratorT>;
+  using item_t = cub::detail::it_value_t<InputIteratorT>;
 
   static constexpr int FALLBACK_BLOCK_THREADS = 64;
 
@@ -219,7 +219,7 @@ template <typename InputIteratorT,
           typename PolicyHub = device_dummy_algorithm_policy_t<InputIteratorT>>
 struct dispatch_dummy_algorithm_t
 {
-  using item_t = cub::detail::iter_value_t<InputIteratorT>;
+  using item_t = cub::detail::it_value_t<InputIteratorT>;
 
   /// Device-accessible allocation of temporary storage. When nullptr, the required
   /// allocation size is written to \p temp_storage_bytes and no work is done.

--- a/cub/test/catch2_test_vsmem.cu
+++ b/cub/test/catch2_test_vsmem.cu
@@ -87,7 +87,7 @@ struct agent_dummy_algorithm_t
   static constexpr auto items_per_thread = ActivePolicyT::ITEMS_PER_THREAD;
   static constexpr auto tile_size        = block_threads * items_per_thread;
 
-  using item_t = cub::detail::value_t<InputIteratorT>;
+  using item_t = cub::detail::iter_value_t<InputIteratorT>;
 
   using block_load_t = cub::BlockLoad<item_t, block_threads, items_per_thread, cub::BLOCK_LOAD_TRANSPOSE>;
 

--- a/cub/test/catch2_test_vsmem.cu
+++ b/cub/test/catch2_test_vsmem.cu
@@ -193,7 +193,7 @@ void __global__ __launch_bounds__(
 template <typename InputIteratorT>
 struct device_dummy_algorithm_policy_t
 {
-  using item_t = cub::detail::value_t<InputIteratorT>;
+  using item_t = cub::detail::iter_value_t<InputIteratorT>;
 
   static constexpr int FALLBACK_BLOCK_THREADS = 64;
 
@@ -219,7 +219,7 @@ template <typename InputIteratorT,
           typename PolicyHub = device_dummy_algorithm_policy_t<InputIteratorT>>
 struct dispatch_dummy_algorithm_t
 {
-  using item_t = cub::detail::value_t<InputIteratorT>;
+  using item_t = cub::detail::iter_value_t<InputIteratorT>;
 
   /// Device-accessible allocation of temporary storage. When nullptr, the required
   /// allocation size is written to \p temp_storage_bytes and no work is done.

--- a/thrust/thrust/system/cuda/detail/scan.h
+++ b/thrust/thrust/system/cuda/detail/scan.h
@@ -120,7 +120,7 @@ _CCCL_HOST_DEVICE OutputIt inclusive_scan_n_impl(
   ScanOp scan_op)
 {
   using InputValueT = cub::detail::InputValue<InitValueT>;
-  using ValueT      = cub::detail::value_t<InputIt>;
+  using ValueT      = cub::detail::iter_value_t<InputIt>;
   using AccumT      = ::cuda::std::__accumulator_t<ScanOp, ValueT, InitValueT>;
 
   using Dispatch32 =

--- a/thrust/thrust/system/cuda/detail/scan.h
+++ b/thrust/thrust/system/cuda/detail/scan.h
@@ -120,7 +120,7 @@ _CCCL_HOST_DEVICE OutputIt inclusive_scan_n_impl(
   ScanOp scan_op)
 {
   using InputValueT = cub::detail::InputValue<InitValueT>;
-  using ValueT      = cub::detail::iter_value_t<InputIt>;
+  using ValueT      = cub::detail::it_value_t<InputIt>;
   using AccumT      = ::cuda::std::__accumulator_t<ScanOp, ValueT, InitValueT>;
 
   using Dispatch32 =


### PR DESCRIPTION
We now provide the following aliases:
```c++
namespace cub::detail {
template <typename It>
using it_value_t = typename ::cuda::std::iterator_traits<It>::value_type;

template <typename It>
using it_reference_t = typename ::cuda::std::iterator_traits<It>::reference;

template <typename It>
using it_difference_t = typename ::cuda::std::iterator_traits<It>::difference_type;

template <typename It>
using it_pointer_t = typename ::cuda::std::iterator_traits<It>::pointer;
}
```
Also, `cub::detail::value_t` is replaced by this.

I also provide the following rational:
```
// the following iterator helpers are not named iter_value_t etc, like the C++20 facilities, because they are defined in
// terms of C++17 iterator_traits and not the new C++20 indirectly_readable trait etc. This allows them to detect nested
// value_type, difference_type and reference aliases, which the new C+20 traits do not consider (they only consider
// specializations of iterator_traits). Also, a value_type of void remains supported (needed by some output iterators).
```