### PR TITLE
[PTX] Add shl, shr, bmsk, prmt

### DIFF
--- a/docs/libcudacxx/ptx/instructions.rst
+++ b/docs/libcudacxx/ptx/instructions.rst
@@ -6,6 +6,10 @@ PTX Instructions
 .. toctree::
    :maxdepth: 1
 
+   instructions/shr
+   instructions/shl
+   instructions/bmsk
+   instructions/prmt
    instructions/barrier_cluster
    instructions/bfind
    instructions/clusterlaunchcontrol
@@ -88,7 +92,7 @@ Instructions by section
    * - `szext <https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#integer-arithmetic-instructions-szext>`__
      - No
    * - `bmsk <https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#integer-arithmetic-instructions-bmsk>`__
-     - No
+     - Yes, CCCL 3.0.0 / CUDA 13.0
    * - `dp4a <https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#integer-arithmetic-instructions-dp4a>`__
      - No
    * - `dp2a <https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#integer-arithmetic-instructions-dp2a>`__
@@ -238,9 +242,9 @@ Instructions by section
    * - `shf <https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#logic-and-shift-instructions-shf>`__
      - No
    * - `shl <https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#logic-and-shift-instructions-shl>`__
-     - No
+     - Yes, CCCL 3.0.0 / CUDA 13.0
    * - `shr <https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#logic-and-shift-instructions-shr>`__
-     - No
+     - Yes, CCCL 3.0.0 / CUDA 13.0
 
 .. list-table:: `Data Movement and Conversion Instructions <https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#data-movement-and-conversion-instructions>`__
    :widths: 50 50
@@ -255,7 +259,7 @@ Instructions by section
    * - `shfl.sync <https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#data-movement-and-conversion-instructions-shfl-sync>`__
      - Yes, CCCL 2.9.0 / CUDA 12.9
    * - `prmt <https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#data-movement-and-conversion-instructions-prmt>`__
-     - No
+     - Yes, CCCL 3.0.0 / CUDA 13.0
    * - `ld <https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#data-movement-and-conversion-instructions-ld>`__
      - No
    * - `ld.global.nc <https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#data-movement-and-conversion-instructions-ld-global-nc>`__

--- a/docs/libcudacxx/ptx/instructions/bmsk.rst
+++ b/docs/libcudacxx/ptx/instructions/bmsk.rst
@@ -1,0 +1,9 @@
+.. _libcudacxx-ptx-instructions-bmsk:
+
+bmsk
+====
+
+-  PTX ISA:
+   `bmsk <https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#integer-arithmetic-instructions-bmsk>`__
+
+.. include:: generated/bmsk.rst

--- a/docs/libcudacxx/ptx/instructions/generated/bmsk.rst
+++ b/docs/libcudacxx/ptx/instructions/generated/bmsk.rst
@@ -1,0 +1,22 @@
+..
+   This file was automatically generated. Do not edit.
+
+bmsk.clamp.b32
+^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // bmsk.clamp.b32 dest, a_reg, b_reg; // PTX ISA 76, SM_70
+   template <typename = void>
+   __device__ static inline uint32_t bmsk_clamp(
+     uint32_t a_reg,
+     uint32_t b_reg);
+
+bmsk.wrap.b32
+^^^^^^^^^^^^^
+.. code:: cuda
+
+   // bmsk.wrap.b32 dest, a_reg, b_reg; // PTX ISA 76, SM_70
+   template <typename = void>
+   __device__ static inline uint32_t bmsk_wrap(
+     uint32_t a_reg,
+     uint32_t b_reg);

--- a/docs/libcudacxx/ptx/instructions/generated/prmt.rst
+++ b/docs/libcudacxx/ptx/instructions/generated/prmt.rst
@@ -1,0 +1,79 @@
+..
+   This file was automatically generated. Do not edit.
+
+prmt.b32
+^^^^^^^^
+.. code:: cuda
+
+   // prmt.b32 dest, a_reg, b_reg, c_reg; // PTX ISA 20, SM_50
+   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
+   __device__ static inline uint32_t prmt(
+     B32 a_reg,
+     B32 b_reg,
+     uint32_t c_reg);
+
+prmt.b32.f4e
+^^^^^^^^^^^^
+.. code:: cuda
+
+   // prmt.b32.f4e dest, a_reg, b_reg, c_reg; // PTX ISA 20, SM_50
+   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
+   __device__ static inline uint32_t prmt_f4e(
+     B32 a_reg,
+     B32 b_reg,
+     uint32_t c_reg);
+
+prmt.b32.b4e
+^^^^^^^^^^^^
+.. code:: cuda
+
+   // prmt.b32.b4e dest, a_reg, b_reg, c_reg; // PTX ISA 20, SM_50
+   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
+   __device__ static inline uint32_t prmt_b4e(
+     B32 a_reg,
+     B32 b_reg,
+     uint32_t c_reg);
+
+prmt.b32.rc8
+^^^^^^^^^^^^
+.. code:: cuda
+
+   // prmt.b32.rc8 dest, a_reg, b_reg, c_reg; // PTX ISA 20, SM_50
+   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
+   __device__ static inline uint32_t prmt_rc8(
+     B32 a_reg,
+     B32 b_reg,
+     uint32_t c_reg);
+
+prmt.b32.ecl
+^^^^^^^^^^^^
+.. code:: cuda
+
+   // prmt.b32.ecl dest, a_reg, b_reg, c_reg; // PTX ISA 20, SM_50
+   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
+   __device__ static inline uint32_t prmt_ecl(
+     B32 a_reg,
+     B32 b_reg,
+     uint32_t c_reg);
+
+prmt.b32.ecr
+^^^^^^^^^^^^
+.. code:: cuda
+
+   // prmt.b32.ecr dest, a_reg, b_reg, c_reg; // PTX ISA 20, SM_50
+   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
+   __device__ static inline uint32_t prmt_ecr(
+     B32 a_reg,
+     B32 b_reg,
+     uint32_t c_reg);
+
+prmt.b32.rc16
+^^^^^^^^^^^^^
+.. code:: cuda
+
+   // prmt.b32.rc16 dest, a_reg, b_reg, c_reg; // PTX ISA 20, SM_50
+   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
+   __device__ static inline uint32_t prmt_rc16(
+     B32 a_reg,
+     B32 b_reg,
+     uint32_t c_reg);

--- a/docs/libcudacxx/ptx/instructions/generated/shl.rst
+++ b/docs/libcudacxx/ptx/instructions/generated/shl.rst
@@ -1,0 +1,32 @@
+..
+   This file was automatically generated. Do not edit.
+
+shl.b16
+^^^^^^^
+.. code:: cuda
+
+   // shl.b16 dest, a_reg, b_reg; // PTX ISA 10, SM_50
+   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
+   __device__ static inline B16 shl(
+     B16 a_reg,
+     uint32_t b_reg);
+
+shl.b32
+^^^^^^^
+.. code:: cuda
+
+   // shl.b32 dest, a_reg, b_reg; // PTX ISA 10, SM_50
+   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
+   __device__ static inline B32 shl(
+     B32 a_reg,
+     uint32_t b_reg);
+
+shl.b64
+^^^^^^^
+.. code:: cuda
+
+   // shl.b64 dest, a_reg, b_reg; // PTX ISA 10, SM_50
+   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
+   __device__ static inline B64 shl(
+     B64 a_reg,
+     uint32_t b_reg);

--- a/docs/libcudacxx/ptx/instructions/generated/shr.rst
+++ b/docs/libcudacxx/ptx/instructions/generated/shr.rst
@@ -1,0 +1,62 @@
+..
+   This file was automatically generated. Do not edit.
+
+shr.b16
+^^^^^^^
+.. code:: cuda
+
+   // shr.b16 dest, a_reg, b_reg; // PTX ISA 10, SM_50
+   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
+   __device__ static inline B16 shr(
+     B16 a_reg,
+     uint32_t b_reg);
+
+shr.b32
+^^^^^^^
+.. code:: cuda
+
+   // shr.b32 dest, a_reg, b_reg; // PTX ISA 10, SM_50
+   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
+   __device__ static inline B32 shr(
+     B32 a_reg,
+     uint32_t b_reg);
+
+shr.b64
+^^^^^^^
+.. code:: cuda
+
+   // shr.b64 dest, a_reg, b_reg; // PTX ISA 10, SM_50
+   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
+   __device__ static inline B64 shr(
+     B64 a_reg,
+     uint32_t b_reg);
+
+shr.s16
+^^^^^^^
+.. code:: cuda
+
+   // shr.s16 dest, a_reg, b_reg; // PTX ISA 10, SM_50
+   template <typename = void>
+   __device__ static inline int16_t shr(
+     int16_t a_reg,
+     uint32_t b_reg);
+
+shr.s32
+^^^^^^^
+.. code:: cuda
+
+   // shr.s32 dest, a_reg, b_reg; // PTX ISA 10, SM_50
+   template <typename = void>
+   __device__ static inline int32_t shr(
+     int32_t a_reg,
+     uint32_t b_reg);
+
+shr.s64
+^^^^^^^
+.. code:: cuda
+
+   // shr.s64 dest, a_reg, b_reg; // PTX ISA 10, SM_50
+   template <typename = void>
+   __device__ static inline int64_t shr(
+     int64_t a_reg,
+     uint32_t b_reg);

--- a/docs/libcudacxx/ptx/instructions/prmt.rst
+++ b/docs/libcudacxx/ptx/instructions/prmt.rst
@@ -1,0 +1,9 @@
+.. _libcudacxx-ptx-instructions-prmt:
+
+prmt
+====
+
+-  PTX ISA:
+   `prmt <https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#data-movement-and-conversion-instructions-prmt>`__
+
+.. include:: generated/prmt.rst

--- a/docs/libcudacxx/ptx/instructions/shl.rst
+++ b/docs/libcudacxx/ptx/instructions/shl.rst
@@ -1,0 +1,9 @@
+.. _libcudacxx-ptx-instructions-shl:
+
+shl
+===
+
+-  PTX ISA:
+   `shl <https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#logic-and-shift-instructions-shl>`__
+
+.. include:: generated/shl.rst

--- a/docs/libcudacxx/ptx/instructions/shr.rst
+++ b/docs/libcudacxx/ptx/instructions/shr.rst
@@ -1,0 +1,9 @@
+.. _libcudacxx-ptx-instructions-shr:
+
+shr
+===
+
+-  PTX ISA:
+   `shr <https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#logic-and-shift-instructions-shr>`__
+
+.. include:: generated/shr.rst

--- a/libcudacxx/codegen/add_ptx_instruction.py
+++ b/libcudacxx/codegen/add_ptx_instruction.py
@@ -6,6 +6,7 @@ docs = Path("docs/libcudacxx/ptx/instructions")
 test = Path("libcudacxx/test/libcudacxx/cuda/ptx")
 src = Path("libcudacxx/include/cuda/__ptx/instructions")
 ptx_header = Path("libcudacxx/include/cuda/ptx")
+instr_docs = Path("docs/libcudacxx/ptx/instructions.rst")
 
 
 def add_docs(ptx_instr, url):
@@ -28,7 +29,8 @@ def add_docs(ptx_instr, url):
 
 def add_test(ptx_instr):
     cpp_instr = ptx_instr.replace(".", "_")
-    (test / f"ptx.{ptx_instr}.compile.pass.cpp").write_text(
+    dst = test / f"ptx.{ptx_instr}.compile.pass.cpp"
+    dst.write_text(
         f"""//===----------------------------------------------------------------------===//
 //
 // Part of libcu++, the C++ Standard Library for your entire system,
@@ -99,11 +101,26 @@ _LIBCUDACXX_END_NAMESPACE_CUDA_PTX
     )
 
 
-def add_include_reminder(ptx_instr):
+def add_ptx_header_include(ptx_instr):
     cpp_instr = ptx_instr.replace(".", "_")
     txt = ptx_header.read_text()
-    reminder = f"""// TODO: #include <cuda/__ptx/instructions/{cpp_instr}.h>"""
-    ptx_header.write_text(f"{txt}\n{reminder}\n")
+    # just add as first new include. clang-format will sort it in
+    idx = txt.index("#include <cuda/__ptx/instructions")
+    txt = (
+        txt[:idx]
+        + f"""#include <cuda/__ptx/instructions/{cpp_instr}.h>\n"""
+        + txt[idx:]
+    )
+    ptx_header.write_text(txt)
+
+
+def add_docs_include(ptx_instr):
+    cpp_instr = ptx_instr.replace(".", "_")
+    txt = instr_docs.read_text()
+    # just add as first new include
+    idx = txt.index("   instructions/")
+    txt = txt[:idx] + f"   instructions/{cpp_instr}\n" + txt[idx:]
+    instr_docs.write_text(txt)
 
 
 if __name__ == "__main__":
@@ -126,4 +143,5 @@ if __name__ == "__main__":
     add_test(ptx_instr)
     add_docs(ptx_instr, url)
     add_src(ptx_instr)
-    add_include_reminder(ptx_instr)
+    add_ptx_header_include(ptx_instr)
+    add_docs_include(ptx_instr)

--- a/libcudacxx/include/cuda/__ptx/instructions/bmsk.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/bmsk.h
@@ -1,0 +1,37 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_PTX_BMSK_H_
+#define _CUDA_PTX_BMSK_H_
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/__ptx/ptx_dot_variants.h>
+#include <cuda/__ptx/ptx_helper_functions.h>
+#include <cuda/std/cstdint>
+
+#include <nv/target> // __CUDA_MINIMUM_ARCH__ and friends
+
+_LIBCUDACXX_BEGIN_NAMESPACE_CUDA_PTX
+
+#include <cuda/__ptx/instructions/generated/bmsk.h>
+
+_LIBCUDACXX_END_NAMESPACE_CUDA_PTX
+
+#endif // _CUDA_PTX_BMSK_H_

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/bmsk.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/bmsk.h
@@ -1,0 +1,54 @@
+// This file was automatically generated. Do not edit.
+
+#ifndef _CUDA_PTX_GENERATED_BMSK_H_
+#define _CUDA_PTX_GENERATED_BMSK_H_
+
+/*
+// bmsk.clamp.b32 dest, a_reg, b_reg; // PTX ISA 76, SM_70
+template <typename = void>
+__device__ static inline uint32_t bmsk_clamp(
+  uint32_t a_reg,
+  uint32_t b_reg);
+*/
+#if __cccl_ptx_isa >= 760
+extern "C" _CCCL_DEVICE void __cuda_ptx_bmsk_clamp_is_not_supported_before_SM_70__();
+template <typename = void>
+_CCCL_DEVICE static inline _CUDA_VSTD::uint32_t bmsk_clamp(_CUDA_VSTD::uint32_t __a_reg, _CUDA_VSTD::uint32_t __b_reg)
+{
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
+  _CUDA_VSTD::uint32_t __dest;
+  asm("bmsk.clamp.b32 %0, %1, %2;" : "=r"(__dest) : "r"(__a_reg), "r"(__b_reg) :);
+  return __dest;
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_bmsk_clamp_is_not_supported_before_SM_70__();
+  return 0;
+#  endif
+}
+#endif // __cccl_ptx_isa >= 760
+
+/*
+// bmsk.wrap.b32 dest, a_reg, b_reg; // PTX ISA 76, SM_70
+template <typename = void>
+__device__ static inline uint32_t bmsk_wrap(
+  uint32_t a_reg,
+  uint32_t b_reg);
+*/
+#if __cccl_ptx_isa >= 760
+extern "C" _CCCL_DEVICE void __cuda_ptx_bmsk_wrap_is_not_supported_before_SM_70__();
+template <typename = void>
+_CCCL_DEVICE static inline _CUDA_VSTD::uint32_t bmsk_wrap(_CUDA_VSTD::uint32_t __a_reg, _CUDA_VSTD::uint32_t __b_reg)
+{
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
+  _CUDA_VSTD::uint32_t __dest;
+  asm("bmsk.wrap.b32 %0, %1, %2;" : "=r"(__dest) : "r"(__a_reg), "r"(__b_reg) :);
+  return __dest;
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_bmsk_wrap_is_not_supported_before_SM_70__();
+  return 0;
+#  endif
+}
+#endif // __cccl_ptx_isa >= 760
+
+#endif // _CUDA_PTX_GENERATED_BMSK_H_

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/prmt.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/prmt.h
@@ -1,0 +1,230 @@
+// This file was automatically generated. Do not edit.
+
+#ifndef _CUDA_PTX_GENERATED_PRMT_H_
+#define _CUDA_PTX_GENERATED_PRMT_H_
+
+/*
+// prmt.b32 dest, a_reg, b_reg, c_reg; // PTX ISA 20, SM_50
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
+__device__ static inline uint32_t prmt(
+  B32 a_reg,
+  B32 b_reg,
+  uint32_t c_reg);
+*/
+#if __cccl_ptx_isa >= 200
+extern "C" _CCCL_DEVICE void __cuda_ptx_prmt_is_not_supported_before_SM_50__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _CUDA_VSTD::uint32_t prmt(_B32 __a_reg, _B32 __b_reg, _CUDA_VSTD::uint32_t __c_reg)
+{
+  static_assert(sizeof(_B32) == 4, "");
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 500
+  _CUDA_VSTD::uint32_t __dest;
+  asm("prmt.b32 %0, %1, %2, %3;"
+      : "=r"(__dest)
+      : "r"(/*as_b32*/ *reinterpret_cast<const _CUDA_VSTD::int32_t*>(&__a_reg)),
+        "r"(/*as_b32*/ *reinterpret_cast<const _CUDA_VSTD::int32_t*>(&__b_reg)),
+        "r"(__c_reg)
+      :);
+  return __dest;
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_prmt_is_not_supported_before_SM_50__();
+  return 0;
+#  endif
+}
+#endif // __cccl_ptx_isa >= 200
+
+/*
+// prmt.b32.f4e dest, a_reg, b_reg, c_reg; // PTX ISA 20, SM_50
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
+__device__ static inline uint32_t prmt_f4e(
+  B32 a_reg,
+  B32 b_reg,
+  uint32_t c_reg);
+*/
+#if __cccl_ptx_isa >= 200
+extern "C" _CCCL_DEVICE void __cuda_ptx_prmt_f4e_is_not_supported_before_SM_50__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _CUDA_VSTD::uint32_t prmt_f4e(_B32 __a_reg, _B32 __b_reg, _CUDA_VSTD::uint32_t __c_reg)
+{
+  static_assert(sizeof(_B32) == 4, "");
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 500
+  _CUDA_VSTD::uint32_t __dest;
+  asm("prmt.b32.f4e %0, %1, %2, %3;"
+      : "=r"(__dest)
+      : "r"(/*as_b32*/ *reinterpret_cast<const _CUDA_VSTD::int32_t*>(&__a_reg)),
+        "r"(/*as_b32*/ *reinterpret_cast<const _CUDA_VSTD::int32_t*>(&__b_reg)),
+        "r"(__c_reg)
+      :);
+  return __dest;
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_prmt_f4e_is_not_supported_before_SM_50__();
+  return 0;
+#  endif
+}
+#endif // __cccl_ptx_isa >= 200
+
+/*
+// prmt.b32.b4e dest, a_reg, b_reg, c_reg; // PTX ISA 20, SM_50
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
+__device__ static inline uint32_t prmt_b4e(
+  B32 a_reg,
+  B32 b_reg,
+  uint32_t c_reg);
+*/
+#if __cccl_ptx_isa >= 200
+extern "C" _CCCL_DEVICE void __cuda_ptx_prmt_b4e_is_not_supported_before_SM_50__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _CUDA_VSTD::uint32_t prmt_b4e(_B32 __a_reg, _B32 __b_reg, _CUDA_VSTD::uint32_t __c_reg)
+{
+  static_assert(sizeof(_B32) == 4, "");
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 500
+  _CUDA_VSTD::uint32_t __dest;
+  asm("prmt.b32.b4e %0, %1, %2, %3;"
+      : "=r"(__dest)
+      : "r"(/*as_b32*/ *reinterpret_cast<const _CUDA_VSTD::int32_t*>(&__a_reg)),
+        "r"(/*as_b32*/ *reinterpret_cast<const _CUDA_VSTD::int32_t*>(&__b_reg)),
+        "r"(__c_reg)
+      :);
+  return __dest;
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_prmt_b4e_is_not_supported_before_SM_50__();
+  return 0;
+#  endif
+}
+#endif // __cccl_ptx_isa >= 200
+
+/*
+// prmt.b32.rc8 dest, a_reg, b_reg, c_reg; // PTX ISA 20, SM_50
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
+__device__ static inline uint32_t prmt_rc8(
+  B32 a_reg,
+  B32 b_reg,
+  uint32_t c_reg);
+*/
+#if __cccl_ptx_isa >= 200
+extern "C" _CCCL_DEVICE void __cuda_ptx_prmt_rc8_is_not_supported_before_SM_50__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _CUDA_VSTD::uint32_t prmt_rc8(_B32 __a_reg, _B32 __b_reg, _CUDA_VSTD::uint32_t __c_reg)
+{
+  static_assert(sizeof(_B32) == 4, "");
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 500
+  _CUDA_VSTD::uint32_t __dest;
+  asm("prmt.b32.rc8 %0, %1, %2, %3;"
+      : "=r"(__dest)
+      : "r"(/*as_b32*/ *reinterpret_cast<const _CUDA_VSTD::int32_t*>(&__a_reg)),
+        "r"(/*as_b32*/ *reinterpret_cast<const _CUDA_VSTD::int32_t*>(&__b_reg)),
+        "r"(__c_reg)
+      :);
+  return __dest;
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_prmt_rc8_is_not_supported_before_SM_50__();
+  return 0;
+#  endif
+}
+#endif // __cccl_ptx_isa >= 200
+
+/*
+// prmt.b32.ecl dest, a_reg, b_reg, c_reg; // PTX ISA 20, SM_50
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
+__device__ static inline uint32_t prmt_ecl(
+  B32 a_reg,
+  B32 b_reg,
+  uint32_t c_reg);
+*/
+#if __cccl_ptx_isa >= 200
+extern "C" _CCCL_DEVICE void __cuda_ptx_prmt_ecl_is_not_supported_before_SM_50__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _CUDA_VSTD::uint32_t prmt_ecl(_B32 __a_reg, _B32 __b_reg, _CUDA_VSTD::uint32_t __c_reg)
+{
+  static_assert(sizeof(_B32) == 4, "");
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 500
+  _CUDA_VSTD::uint32_t __dest;
+  asm("prmt.b32.ecl %0, %1, %2, %3;"
+      : "=r"(__dest)
+      : "r"(/*as_b32*/ *reinterpret_cast<const _CUDA_VSTD::int32_t*>(&__a_reg)),
+        "r"(/*as_b32*/ *reinterpret_cast<const _CUDA_VSTD::int32_t*>(&__b_reg)),
+        "r"(__c_reg)
+      :);
+  return __dest;
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_prmt_ecl_is_not_supported_before_SM_50__();
+  return 0;
+#  endif
+}
+#endif // __cccl_ptx_isa >= 200
+
+/*
+// prmt.b32.ecr dest, a_reg, b_reg, c_reg; // PTX ISA 20, SM_50
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
+__device__ static inline uint32_t prmt_ecr(
+  B32 a_reg,
+  B32 b_reg,
+  uint32_t c_reg);
+*/
+#if __cccl_ptx_isa >= 200
+extern "C" _CCCL_DEVICE void __cuda_ptx_prmt_ecr_is_not_supported_before_SM_50__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _CUDA_VSTD::uint32_t prmt_ecr(_B32 __a_reg, _B32 __b_reg, _CUDA_VSTD::uint32_t __c_reg)
+{
+  static_assert(sizeof(_B32) == 4, "");
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 500
+  _CUDA_VSTD::uint32_t __dest;
+  asm("prmt.b32.ecr %0, %1, %2, %3;"
+      : "=r"(__dest)
+      : "r"(/*as_b32*/ *reinterpret_cast<const _CUDA_VSTD::int32_t*>(&__a_reg)),
+        "r"(/*as_b32*/ *reinterpret_cast<const _CUDA_VSTD::int32_t*>(&__b_reg)),
+        "r"(__c_reg)
+      :);
+  return __dest;
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_prmt_ecr_is_not_supported_before_SM_50__();
+  return 0;
+#  endif
+}
+#endif // __cccl_ptx_isa >= 200
+
+/*
+// prmt.b32.rc16 dest, a_reg, b_reg, c_reg; // PTX ISA 20, SM_50
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
+__device__ static inline uint32_t prmt_rc16(
+  B32 a_reg,
+  B32 b_reg,
+  uint32_t c_reg);
+*/
+#if __cccl_ptx_isa >= 200
+extern "C" _CCCL_DEVICE void __cuda_ptx_prmt_rc16_is_not_supported_before_SM_50__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _CUDA_VSTD::uint32_t prmt_rc16(_B32 __a_reg, _B32 __b_reg, _CUDA_VSTD::uint32_t __c_reg)
+{
+  static_assert(sizeof(_B32) == 4, "");
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 500
+  _CUDA_VSTD::uint32_t __dest;
+  asm("prmt.b32.rc16 %0, %1, %2, %3;"
+      : "=r"(__dest)
+      : "r"(/*as_b32*/ *reinterpret_cast<const _CUDA_VSTD::int32_t*>(&__a_reg)),
+        "r"(/*as_b32*/ *reinterpret_cast<const _CUDA_VSTD::int32_t*>(&__b_reg)),
+        "r"(__c_reg)
+      :);
+  return __dest;
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_prmt_rc16_is_not_supported_before_SM_50__();
+  return 0;
+#  endif
+}
+#endif // __cccl_ptx_isa >= 200
+
+#endif // _CUDA_PTX_GENERATED_PRMT_H_

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/shl.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/shl.h
@@ -1,0 +1,96 @@
+// This file was automatically generated. Do not edit.
+
+#ifndef _CUDA_PTX_GENERATED_SHL_H_
+#define _CUDA_PTX_GENERATED_SHL_H_
+
+/*
+// shl.b16 dest, a_reg, b_reg; // PTX ISA 10, SM_50
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
+__device__ static inline B16 shl(
+  B16 a_reg,
+  uint32_t b_reg);
+*/
+#if __cccl_ptx_isa >= 100
+extern "C" _CCCL_DEVICE void __cuda_ptx_shl_is_not_supported_before_SM_50__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16 shl(_B16 __a_reg, _CUDA_VSTD::uint32_t __b_reg)
+{
+  static_assert(sizeof(_B16) == 2, "");
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 500
+  _CUDA_VSTD::uint16_t __dest;
+  asm("shl.b16 %0, %1, %2;"
+      : "=h"(__dest)
+      : "h"(/*as_b16*/ *reinterpret_cast<const _CUDA_VSTD::int16_t*>(&__a_reg)), "r"(__b_reg)
+      :);
+  return *reinterpret_cast<_B16*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_shl_is_not_supported_before_SM_50__();
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 100
+
+/*
+// shl.b32 dest, a_reg, b_reg; // PTX ISA 10, SM_50
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
+__device__ static inline B32 shl(
+  B32 a_reg,
+  uint32_t b_reg);
+*/
+#if __cccl_ptx_isa >= 100
+extern "C" _CCCL_DEVICE void __cuda_ptx_shl_is_not_supported_before_SM_50__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32 shl(_B32 __a_reg, _CUDA_VSTD::uint32_t __b_reg)
+{
+  static_assert(sizeof(_B32) == 4, "");
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 500
+  _CUDA_VSTD::uint32_t __dest;
+  asm("shl.b32 %0, %1, %2;"
+      : "=r"(__dest)
+      : "r"(/*as_b32*/ *reinterpret_cast<const _CUDA_VSTD::int32_t*>(&__a_reg)), "r"(__b_reg)
+      :);
+  return *reinterpret_cast<_B32*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_shl_is_not_supported_before_SM_50__();
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 100
+
+/*
+// shl.b64 dest, a_reg, b_reg; // PTX ISA 10, SM_50
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
+__device__ static inline B64 shl(
+  B64 a_reg,
+  uint32_t b_reg);
+*/
+#if __cccl_ptx_isa >= 100
+extern "C" _CCCL_DEVICE void __cuda_ptx_shl_is_not_supported_before_SM_50__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64 shl(_B64 __a_reg, _CUDA_VSTD::uint32_t __b_reg)
+{
+  static_assert(sizeof(_B64) == 8, "");
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 500
+  _CUDA_VSTD::uint64_t __dest;
+  asm("shl.b64 %0, %1, %2;"
+      : "=l"(__dest)
+      : "l"(/*as_b64*/ *reinterpret_cast<const _CUDA_VSTD::int64_t*>(&__a_reg)), "r"(__b_reg)
+      :);
+  return *reinterpret_cast<_B64*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_shl_is_not_supported_before_SM_50__();
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 100
+
+#endif // _CUDA_PTX_GENERATED_SHL_H_

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/shr.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/shr.h
@@ -1,0 +1,168 @@
+// This file was automatically generated. Do not edit.
+
+#ifndef _CUDA_PTX_GENERATED_SHR_H_
+#define _CUDA_PTX_GENERATED_SHR_H_
+
+/*
+// shr.b16 dest, a_reg, b_reg; // PTX ISA 10, SM_50
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
+__device__ static inline B16 shr(
+  B16 a_reg,
+  uint32_t b_reg);
+*/
+#if __cccl_ptx_isa >= 100
+extern "C" _CCCL_DEVICE void __cuda_ptx_shr_is_not_supported_before_SM_50__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16 shr(_B16 __a_reg, _CUDA_VSTD::uint32_t __b_reg)
+{
+  static_assert(sizeof(_B16) == 2, "");
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 500
+  _CUDA_VSTD::uint16_t __dest;
+  asm("shr.b16 %0, %1, %2;"
+      : "=h"(__dest)
+      : "h"(/*as_b16*/ *reinterpret_cast<const _CUDA_VSTD::int16_t*>(&__a_reg)), "r"(__b_reg)
+      :);
+  return *reinterpret_cast<_B16*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_shr_is_not_supported_before_SM_50__();
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 100
+
+/*
+// shr.b32 dest, a_reg, b_reg; // PTX ISA 10, SM_50
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
+__device__ static inline B32 shr(
+  B32 a_reg,
+  uint32_t b_reg);
+*/
+#if __cccl_ptx_isa >= 100
+extern "C" _CCCL_DEVICE void __cuda_ptx_shr_is_not_supported_before_SM_50__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32 shr(_B32 __a_reg, _CUDA_VSTD::uint32_t __b_reg)
+{
+  static_assert(sizeof(_B32) == 4, "");
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 500
+  _CUDA_VSTD::uint32_t __dest;
+  asm("shr.b32 %0, %1, %2;"
+      : "=r"(__dest)
+      : "r"(/*as_b32*/ *reinterpret_cast<const _CUDA_VSTD::int32_t*>(&__a_reg)), "r"(__b_reg)
+      :);
+  return *reinterpret_cast<_B32*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_shr_is_not_supported_before_SM_50__();
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 100
+
+/*
+// shr.b64 dest, a_reg, b_reg; // PTX ISA 10, SM_50
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
+__device__ static inline B64 shr(
+  B64 a_reg,
+  uint32_t b_reg);
+*/
+#if __cccl_ptx_isa >= 100
+extern "C" _CCCL_DEVICE void __cuda_ptx_shr_is_not_supported_before_SM_50__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64 shr(_B64 __a_reg, _CUDA_VSTD::uint32_t __b_reg)
+{
+  static_assert(sizeof(_B64) == 8, "");
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 500
+  _CUDA_VSTD::uint64_t __dest;
+  asm("shr.b64 %0, %1, %2;"
+      : "=l"(__dest)
+      : "l"(/*as_b64*/ *reinterpret_cast<const _CUDA_VSTD::int64_t*>(&__a_reg)), "r"(__b_reg)
+      :);
+  return *reinterpret_cast<_B64*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_shr_is_not_supported_before_SM_50__();
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 100
+
+/*
+// shr.s16 dest, a_reg, b_reg; // PTX ISA 10, SM_50
+template <typename = void>
+__device__ static inline int16_t shr(
+  int16_t a_reg,
+  uint32_t b_reg);
+*/
+#if __cccl_ptx_isa >= 100
+extern "C" _CCCL_DEVICE void __cuda_ptx_shr_is_not_supported_before_SM_50__();
+template <typename = void>
+_CCCL_DEVICE static inline _CUDA_VSTD::int16_t shr(_CUDA_VSTD::int16_t __a_reg, _CUDA_VSTD::uint32_t __b_reg)
+{
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 500
+  _CUDA_VSTD::int16_t __dest;
+  asm("shr.s16 %0, %1, %2;" : "=h"(__dest) : "h"(__a_reg), "r"(__b_reg) :);
+  return __dest;
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_shr_is_not_supported_before_SM_50__();
+  return 0;
+#  endif
+}
+#endif // __cccl_ptx_isa >= 100
+
+/*
+// shr.s32 dest, a_reg, b_reg; // PTX ISA 10, SM_50
+template <typename = void>
+__device__ static inline int32_t shr(
+  int32_t a_reg,
+  uint32_t b_reg);
+*/
+#if __cccl_ptx_isa >= 100
+extern "C" _CCCL_DEVICE void __cuda_ptx_shr_is_not_supported_before_SM_50__();
+template <typename = void>
+_CCCL_DEVICE static inline _CUDA_VSTD::int32_t shr(_CUDA_VSTD::int32_t __a_reg, _CUDA_VSTD::uint32_t __b_reg)
+{
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 500
+  _CUDA_VSTD::int32_t __dest;
+  asm("shr.s32 %0, %1, %2;" : "=r"(__dest) : "r"(__a_reg), "r"(__b_reg) :);
+  return __dest;
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_shr_is_not_supported_before_SM_50__();
+  return 0;
+#  endif
+}
+#endif // __cccl_ptx_isa >= 100
+
+/*
+// shr.s64 dest, a_reg, b_reg; // PTX ISA 10, SM_50
+template <typename = void>
+__device__ static inline int64_t shr(
+  int64_t a_reg,
+  uint32_t b_reg);
+*/
+#if __cccl_ptx_isa >= 100
+extern "C" _CCCL_DEVICE void __cuda_ptx_shr_is_not_supported_before_SM_50__();
+template <typename = void>
+_CCCL_DEVICE static inline _CUDA_VSTD::int64_t shr(_CUDA_VSTD::int64_t __a_reg, _CUDA_VSTD::uint32_t __b_reg)
+{
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 500
+  _CUDA_VSTD::int64_t __dest;
+  asm("shr.s64 %0, %1, %2;" : "=l"(__dest) : "l"(__a_reg), "r"(__b_reg) :);
+  return __dest;
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_shr_is_not_supported_before_SM_50__();
+  return 0;
+#  endif
+}
+#endif // __cccl_ptx_isa >= 100
+
+#endif // _CUDA_PTX_GENERATED_SHR_H_

--- a/libcudacxx/include/cuda/__ptx/instructions/prmt.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/prmt.h
@@ -1,0 +1,37 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_PTX_PRMT_H_
+#define _CUDA_PTX_PRMT_H_
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/__ptx/ptx_dot_variants.h>
+#include <cuda/__ptx/ptx_helper_functions.h>
+#include <cuda/std/cstdint>
+
+#include <nv/target> // __CUDA_MINIMUM_ARCH__ and friends
+
+_LIBCUDACXX_BEGIN_NAMESPACE_CUDA_PTX
+
+#include <cuda/__ptx/instructions/generated/prmt.h>
+
+_LIBCUDACXX_END_NAMESPACE_CUDA_PTX
+
+#endif // _CUDA_PTX_PRMT_H_

--- a/libcudacxx/include/cuda/__ptx/instructions/shl.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/shl.h
@@ -1,0 +1,37 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_PTX_SHL_H_
+#define _CUDA_PTX_SHL_H_
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/__ptx/ptx_dot_variants.h>
+#include <cuda/__ptx/ptx_helper_functions.h>
+#include <cuda/std/cstdint>
+
+#include <nv/target> // __CUDA_MINIMUM_ARCH__ and friends
+
+_LIBCUDACXX_BEGIN_NAMESPACE_CUDA_PTX
+
+#include <cuda/__ptx/instructions/generated/shl.h>
+
+_LIBCUDACXX_END_NAMESPACE_CUDA_PTX
+
+#endif // _CUDA_PTX_SHL_H_

--- a/libcudacxx/include/cuda/__ptx/instructions/shr.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/shr.h
@@ -1,0 +1,37 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_PTX_SHR_H_
+#define _CUDA_PTX_SHR_H_
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/__ptx/ptx_dot_variants.h>
+#include <cuda/__ptx/ptx_helper_functions.h>
+#include <cuda/std/cstdint>
+
+#include <nv/target> // __CUDA_MINIMUM_ARCH__ and friends
+
+_LIBCUDACXX_BEGIN_NAMESPACE_CUDA_PTX
+
+#include <cuda/__ptx/instructions/generated/shr.h>
+
+_LIBCUDACXX_END_NAMESPACE_CUDA_PTX
+
+#endif // _CUDA_PTX_SHR_H_

--- a/libcudacxx/include/cuda/ptx
+++ b/libcudacxx/include/cuda/ptx
@@ -71,6 +71,7 @@
 
 #include <cuda/__ptx/instructions/barrier_cluster.h>
 #include <cuda/__ptx/instructions/bfind.h>
+#include <cuda/__ptx/instructions/bmsk.h>
 #include <cuda/__ptx/instructions/clusterlaunchcontrol.h>
 #include <cuda/__ptx/instructions/cp_async_bulk.h>
 #include <cuda/__ptx/instructions/cp_async_bulk_commit_group.h>
@@ -90,8 +91,11 @@
 #include <cuda/__ptx/instructions/multimem_ld_reduce.h>
 #include <cuda/__ptx/instructions/multimem_red.h>
 #include <cuda/__ptx/instructions/multimem_st.h>
+#include <cuda/__ptx/instructions/prmt.h>
 #include <cuda/__ptx/instructions/red_async.h>
 #include <cuda/__ptx/instructions/shfl_sync.h>
+#include <cuda/__ptx/instructions/shl.h>
+#include <cuda/__ptx/instructions/shr.h>
 #include <cuda/__ptx/instructions/st_async.h>
 #include <cuda/__ptx/instructions/st_bulk.h>
 #include <cuda/__ptx/instructions/tcgen05_alloc.h>

--- a/libcudacxx/test/libcudacxx/cuda/ptx/generated/bmsk.h
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/generated/bmsk.h
@@ -1,0 +1,34 @@
+// This file was automatically generated. Do not edit.
+
+// We use a special strategy to force the generation of the PTX. This is mainly
+// a fight against dead-code-elimination in the NVVM layer.
+//
+// The reason we need this strategy is because certain older versions of ptxas
+// segfault when a non-sensical sequence of PTX is generated. So instead, we try
+// to force the instantiation and compilation to PTX of all the overloads of the
+// PTX wrapping functions.
+//
+// We do this by writing a function pointer of each overload to the kernel
+// parameter `fn_ptr`.
+//
+// Because `fn_ptr` is possibly visible outside this translation unit, the
+// compiler must compile all the functions which are stored.
+
+__global__ void test_bmsk(void** fn_ptr)
+{
+#if __cccl_ptx_isa >= 760
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_70,
+    (
+        // bmsk.clamp.b32 dest, a_reg, b_reg;
+        * fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)(uint32_t, uint32_t)>(cuda::ptx::bmsk_clamp));));
+#endif // __cccl_ptx_isa >= 760
+
+#if __cccl_ptx_isa >= 760
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_70,
+    (
+        // bmsk.wrap.b32 dest, a_reg, b_reg;
+        * fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)(uint32_t, uint32_t)>(cuda::ptx::bmsk_wrap));));
+#endif // __cccl_ptx_isa >= 760
+}

--- a/libcudacxx/test/libcudacxx/cuda/ptx/generated/prmt.h
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/generated/prmt.h
@@ -1,0 +1,74 @@
+// This file was automatically generated. Do not edit.
+
+// We use a special strategy to force the generation of the PTX. This is mainly
+// a fight against dead-code-elimination in the NVVM layer.
+//
+// The reason we need this strategy is because certain older versions of ptxas
+// segfault when a non-sensical sequence of PTX is generated. So instead, we try
+// to force the instantiation and compilation to PTX of all the overloads of the
+// PTX wrapping functions.
+//
+// We do this by writing a function pointer of each overload to the kernel
+// parameter `fn_ptr`.
+//
+// Because `fn_ptr` is possibly visible outside this translation unit, the
+// compiler must compile all the functions which are stored.
+
+__global__ void test_prmt(void** fn_ptr)
+{
+#if __cccl_ptx_isa >= 200
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_50,
+    (
+        // prmt.b32 dest, a_reg, b_reg, c_reg;
+        * fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)(int32_t, int32_t, uint32_t)>(cuda::ptx::prmt));));
+#endif // __cccl_ptx_isa >= 200
+
+#if __cccl_ptx_isa >= 200
+  NV_IF_TARGET(NV_PROVIDES_SM_50,
+               (
+                   // prmt.b32.f4e dest, a_reg, b_reg, c_reg;
+                   * fn_ptr++ = reinterpret_cast<void*>(
+                     static_cast<uint32_t (*)(int32_t, int32_t, uint32_t)>(cuda::ptx::prmt_f4e));));
+#endif // __cccl_ptx_isa >= 200
+
+#if __cccl_ptx_isa >= 200
+  NV_IF_TARGET(NV_PROVIDES_SM_50,
+               (
+                   // prmt.b32.b4e dest, a_reg, b_reg, c_reg;
+                   * fn_ptr++ = reinterpret_cast<void*>(
+                     static_cast<uint32_t (*)(int32_t, int32_t, uint32_t)>(cuda::ptx::prmt_b4e));));
+#endif // __cccl_ptx_isa >= 200
+
+#if __cccl_ptx_isa >= 200
+  NV_IF_TARGET(NV_PROVIDES_SM_50,
+               (
+                   // prmt.b32.rc8 dest, a_reg, b_reg, c_reg;
+                   * fn_ptr++ = reinterpret_cast<void*>(
+                     static_cast<uint32_t (*)(int32_t, int32_t, uint32_t)>(cuda::ptx::prmt_rc8));));
+#endif // __cccl_ptx_isa >= 200
+
+#if __cccl_ptx_isa >= 200
+  NV_IF_TARGET(NV_PROVIDES_SM_50,
+               (
+                   // prmt.b32.ecl dest, a_reg, b_reg, c_reg;
+                   * fn_ptr++ = reinterpret_cast<void*>(
+                     static_cast<uint32_t (*)(int32_t, int32_t, uint32_t)>(cuda::ptx::prmt_ecl));));
+#endif // __cccl_ptx_isa >= 200
+
+#if __cccl_ptx_isa >= 200
+  NV_IF_TARGET(NV_PROVIDES_SM_50,
+               (
+                   // prmt.b32.ecr dest, a_reg, b_reg, c_reg;
+                   * fn_ptr++ = reinterpret_cast<void*>(
+                     static_cast<uint32_t (*)(int32_t, int32_t, uint32_t)>(cuda::ptx::prmt_ecr));));
+#endif // __cccl_ptx_isa >= 200
+
+#if __cccl_ptx_isa >= 200
+  NV_IF_TARGET(NV_PROVIDES_SM_50,
+               (
+                   // prmt.b32.rc16 dest, a_reg, b_reg, c_reg;
+                   * fn_ptr++ = reinterpret_cast<void*>(
+                     static_cast<uint32_t (*)(int32_t, int32_t, uint32_t)>(cuda::ptx::prmt_rc16));));
+#endif // __cccl_ptx_isa >= 200
+}

--- a/libcudacxx/test/libcudacxx/cuda/ptx/generated/shl.h
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/generated/shl.h
@@ -1,0 +1,39 @@
+// This file was automatically generated. Do not edit.
+
+// We use a special strategy to force the generation of the PTX. This is mainly
+// a fight against dead-code-elimination in the NVVM layer.
+//
+// The reason we need this strategy is because certain older versions of ptxas
+// segfault when a non-sensical sequence of PTX is generated. So instead, we try
+// to force the instantiation and compilation to PTX of all the overloads of the
+// PTX wrapping functions.
+//
+// We do this by writing a function pointer of each overload to the kernel
+// parameter `fn_ptr`.
+//
+// Because `fn_ptr` is possibly visible outside this translation unit, the
+// compiler must compile all the functions which are stored.
+
+__global__ void test_shl(void** fn_ptr)
+{
+#if __cccl_ptx_isa >= 100
+  NV_IF_TARGET(NV_PROVIDES_SM_50,
+               (
+                   // shl.b16 dest, a_reg, b_reg;
+                   * fn_ptr++ = reinterpret_cast<void*>(static_cast<int16_t (*)(int16_t, uint32_t)>(cuda::ptx::shl));));
+#endif // __cccl_ptx_isa >= 100
+
+#if __cccl_ptx_isa >= 100
+  NV_IF_TARGET(NV_PROVIDES_SM_50,
+               (
+                   // shl.b32 dest, a_reg, b_reg;
+                   * fn_ptr++ = reinterpret_cast<void*>(static_cast<int32_t (*)(int32_t, uint32_t)>(cuda::ptx::shl));));
+#endif // __cccl_ptx_isa >= 100
+
+#if __cccl_ptx_isa >= 100
+  NV_IF_TARGET(NV_PROVIDES_SM_50,
+               (
+                   // shl.b64 dest, a_reg, b_reg;
+                   * fn_ptr++ = reinterpret_cast<void*>(static_cast<int64_t (*)(int64_t, uint32_t)>(cuda::ptx::shl));));
+#endif // __cccl_ptx_isa >= 100
+}

--- a/libcudacxx/test/libcudacxx/cuda/ptx/generated/shr.h
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/generated/shr.h
@@ -1,0 +1,60 @@
+// This file was automatically generated. Do not edit.
+
+// We use a special strategy to force the generation of the PTX. This is mainly
+// a fight against dead-code-elimination in the NVVM layer.
+//
+// The reason we need this strategy is because certain older versions of ptxas
+// segfault when a non-sensical sequence of PTX is generated. So instead, we try
+// to force the instantiation and compilation to PTX of all the overloads of the
+// PTX wrapping functions.
+//
+// We do this by writing a function pointer of each overload to the kernel
+// parameter `fn_ptr`.
+//
+// Because `fn_ptr` is possibly visible outside this translation unit, the
+// compiler must compile all the functions which are stored.
+
+__global__ void test_shr(void** fn_ptr)
+{
+#if __cccl_ptx_isa >= 100
+  NV_IF_TARGET(NV_PROVIDES_SM_50,
+               (
+                   // shr.b16 dest, a_reg, b_reg;
+                   * fn_ptr++ = reinterpret_cast<void*>(static_cast<int16_t (*)(int16_t, uint32_t)>(cuda::ptx::shr));));
+#endif // __cccl_ptx_isa >= 100
+
+#if __cccl_ptx_isa >= 100
+  NV_IF_TARGET(NV_PROVIDES_SM_50,
+               (
+                   // shr.b32 dest, a_reg, b_reg;
+                   * fn_ptr++ = reinterpret_cast<void*>(static_cast<int32_t (*)(int32_t, uint32_t)>(cuda::ptx::shr));));
+#endif // __cccl_ptx_isa >= 100
+
+#if __cccl_ptx_isa >= 100
+  NV_IF_TARGET(NV_PROVIDES_SM_50,
+               (
+                   // shr.b64 dest, a_reg, b_reg;
+                   * fn_ptr++ = reinterpret_cast<void*>(static_cast<int64_t (*)(int64_t, uint32_t)>(cuda::ptx::shr));));
+#endif // __cccl_ptx_isa >= 100
+
+#if __cccl_ptx_isa >= 100
+  NV_IF_TARGET(NV_PROVIDES_SM_50,
+               (
+                   // shr.s16 dest, a_reg, b_reg;
+                   * fn_ptr++ = reinterpret_cast<void*>(static_cast<int16_t (*)(int16_t, uint32_t)>(cuda::ptx::shr));));
+#endif // __cccl_ptx_isa >= 100
+
+#if __cccl_ptx_isa >= 100
+  NV_IF_TARGET(NV_PROVIDES_SM_50,
+               (
+                   // shr.s32 dest, a_reg, b_reg;
+                   * fn_ptr++ = reinterpret_cast<void*>(static_cast<int32_t (*)(int32_t, uint32_t)>(cuda::ptx::shr));));
+#endif // __cccl_ptx_isa >= 100
+
+#if __cccl_ptx_isa >= 100
+  NV_IF_TARGET(NV_PROVIDES_SM_50,
+               (
+                   // shr.s64 dest, a_reg, b_reg;
+                   * fn_ptr++ = reinterpret_cast<void*>(static_cast<int64_t (*)(int64_t, uint32_t)>(cuda::ptx::shr));));
+#endif // __cccl_ptx_isa >= 100
+}

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.bmsk.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.bmsk.compile.pass.cpp
@@ -1,0 +1,22 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+// UNSUPPORTED: libcpp-has-no-threads
+
+// <cuda/ptx>
+
+#include <cuda/ptx>
+#include <cuda/std/utility>
+
+#include "generated/bmsk.h"
+
+int main(int, char**)
+{
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.prmt.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.prmt.compile.pass.cpp
@@ -1,0 +1,22 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+// UNSUPPORTED: libcpp-has-no-threads
+
+// <cuda/ptx>
+
+#include <cuda/ptx>
+#include <cuda/std/utility>
+
+#include "generated/prmt.h"
+
+int main(int, char**)
+{
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.shl.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.shl.compile.pass.cpp
@@ -1,0 +1,22 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+// UNSUPPORTED: libcpp-has-no-threads
+
+// <cuda/ptx>
+
+#include <cuda/ptx>
+#include <cuda/std/utility>
+
+#include "generated/shl.h"
+
+int main(int, char**)
+{
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.shr.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.shr.compile.pass.cpp
@@ -1,0 +1,22 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+// UNSUPPORTED: libcpp-has-no-threads
+
+// <cuda/ptx>
+
+#include <cuda/ptx>
+#include <cuda/std/utility>
+
+#include "generated/shr.h"
+
+int main(int, char**)
+{
+  return 0;
+}


### PR DESCRIPTION
This PR just applies the generated files from libcudaptx for those instructions and calls `add_ptx_instruction.py` for all of them. The availability table in the docs has been updated as well.