### PR TITLE
Allow RAPIDS workflow to run on an arbitrary branch.

### DIFF
--- a/.github/workflows/build-rapids.yml
+++ b/.github/workflows/build-rapids.yml
@@ -1,8 +1,19 @@
 name: Build all RAPIDS repositories
 
 on:
+  workflow_dispatch:
   workflow_call:
     inputs:
+      override_cccl_tag:
+        description: "If set, override the tag used for the CCCL repository."
+        required: false
+        default: ""
+        type: string
+      override_cccl_version:
+        description: "If set, override the version used by rapids-cmake to patch CCCL."
+        required: false
+        default: ""
+        type: string
       enable_slack_alerts:
         description: "If true, a message will be posted to the CCCL GHA CI Alert channel if the workflow fails."
         required: false
@@ -57,6 +68,8 @@ jobs:
           role-duration-seconds: 43200 # 12h
       - name: Run command # Do not change this step's name, it is checked in parse-job-times.py
         env:
+          CCCL_TAG: ${{ inputs.override_cccl_tag }}
+          CCCL_VERSION: ${{ inputs.override_cccl_version }}
           CI: true
           RAPIDS_LIBS: ${{ matrix.libs }}
           # Uncomment any of these to customize the git repo and branch for a RAPIDS lib:
@@ -146,6 +159,8 @@ jobs:
             --docker \
             --cuda ${{matrix.cuda}} \
             --host rapids-conda \
+            --env "CCCL_TAG=${CCCL_TAG}" \
+            --env "CCCL_VERSION=${CCCL_VERSION}" \
             --env "AWS_ROLE_ARN=" \
             --env "AWS_REGION=$AWS_REGION" \
             --env "SCCACHE_REGION=$AWS_REGION" \

--- a/ci/rapids/post-create-command.sh
+++ b/ci/rapids/post-create-command.sh
@@ -64,9 +64,36 @@ _create_rapids_cmake_override_json() {
         rapids_cmake_upstream="$(yq '.x-git-defaults.upstream' /opt/rapids-build-utils/manifest.yaml)";
     fi
 
+    # Define CCCL_TAG to override the default CCCL SHA. Otherwise the current HEAD of the local checkout is used.
+    if test -n "${CCCL_TAG-}"; then
+        # If CCCL_TAG is defined, fetch it to the local checkout
+        git fetch origin "${CCCL_TAG}";
+        cccl_sha="$(git -C "${HOME}/cccl" rev-parse FETCH_HEAD)";
+    else
+        cccl_sha="$(git -C "${HOME}/cccl" rev-parse HEAD)";
+    fi
+    echo "CCCL_VERSION: ${CCCL_VERSION-}";
+    echo "CCCL_TAG: ${CCCL_TAG-}";
+    echo "cccl_sha: ${cccl_sha}";
+
+    echo
+    echo "Replacing CCCL repo information in rapids-cmake versions.json:";
     curl -fsSL -o- "https://raw.githubusercontent.com/${rapids_cmake_upstream}/rapids-cmake/${rapids_cmake_tag}/rapids-cmake/cpm/versions.json" \
-  | jq -r ".packages.CCCL *= {\"git_url\": \"${HOME}/cccl\", \"git_tag\": \"$(git -C "${HOME}/cccl" rev-parse HEAD)\", \"always_download\": true}" \
-  | tee ~/rapids-cmake-override-versions.json;
+  | jq -r ".packages.CCCL *= {\"git_url\": \"${HOME}/cccl\", \"git_tag\": \"${cccl_sha}\", \"always_download\": true}" \
+  > ~/rapids-cmake-override-versions-cccl-repo.json;
+
+    if test -n "${CCCL_VERSION-}"; then
+        echo "Patching CCCL_VERSION in rapids-cmake versions.json:";
+        jq -r ".packages.CCCL.version = \"${CCCL_VERSION}\"" ~/rapids-cmake-override-versions-cccl-repo.json \
+      > ~/rapids-cmake-override-versions.json;
+    else
+        echo "Using the default CCCL version in rapids-cmake versions.json:";
+        mv ~/rapids-cmake-override-versions-cccl-repo.json ~/rapids-cmake-override-versions.json;
+    fi
+
+    echo
+    echo "Final rapids-cmake-override-versions.json:";
+    cat ~/rapids-cmake-override-versions.json;
 
     # Define default CMake args for each repo
     local -a cmake_args=(BUILD_TESTS BUILD_BENCHMARKS BUILD_PRIMS_BENCH BUILD_CUGRAPH_MG_TESTS);


### PR DESCRIPTION
The makes the workflows runnable via that Actions tab in Github.

The `override_cccl_tag` may be used to specify an arbitrary git ref for RAPIDS to use. If left blank, the HEAD of the target branch will be used. This allows us to e.g. build RAPIDS with an older version of CCCL, while using the workflow definitions in `main`. This way we can add nightly jobs if desired.

The `override_cccl_version` is used to override the CCCL version that rapids-cmake uses to determine which CCCL patches are needed. If left empty, the default version used by upstream RAPIDS (currently 2.7.0) will be used.