### PR TITLE
Use `_CCCL_REQUIRES_EXPR` in test code

### DIFF
--- a/libcudacxx/test/libcudacxx/std/concepts/concepts.lang/concept.default.init/default_initializable.verify.cpp
+++ b/libcudacxx/test/libcudacxx/std/concepts/concepts.lang/concept.default.init/default_initializable.verify.cpp
@@ -18,10 +18,7 @@
 #include "test_macros.h"
 
 template <class T>
-_CCCL_CONCEPT_FRAGMENT(brace_initializable_, requires()(T{}));
-
-template <class T>
-_CCCL_CONCEPT brace_initializable = _CCCL_FRAGMENT(brace_initializable_, T);
+_CCCL_CONCEPT brace_initializable = _CCCL_REQUIRES_EXPR((T))((T{}));
 
 __host__ __device__ void test()
 {

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/indirectcallable/indirectinvocable/indirect_result_t.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/indirectcallable/indirectinvocable/indirect_result_t.compile.pass.cpp
@@ -23,16 +23,9 @@ static_assert(cuda::std::same_as<cuda::std::indirect_result_t<long S::*, S*>, lo
 static_assert(cuda::std::same_as<cuda::std::indirect_result_t<S && (S::*) (), S*>, S&&>, "");
 static_assert(cuda::std::same_as<cuda::std::indirect_result_t<int S::* (S::*) (int) const, S*, int*>, int S::*>, "");
 
-#if TEST_STD_VER > 2017
 template <class F, class... Is>
-constexpr bool has_indirect_result = requires { typename cuda::std::indirect_result_t<F, Is...>; };
-#else
-template <class F, class... Is>
-_CCCL_CONCEPT_FRAGMENT(has_indirect_result_, requires()(typename(cuda::std::indirect_result_t<F, Is...>)));
-
-template <class F, class... Is>
-_CCCL_CONCEPT has_indirect_result = _CCCL_FRAGMENT(has_indirect_result_, F, Is...);
-#endif
+_CCCL_CONCEPT has_indirect_result =
+  _CCCL_REQUIRES_EXPR((F, variadic Is))(typename(cuda::std::indirect_result_t<F, Is...>));
 
 static_assert(!has_indirect_result<int (*)(int), int>, ""); // int isn't indirectly_readable
 static_assert(!has_indirect_result<int, int*>, ""); // int isn't invocable

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/indirectcallable/projected/projected.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/indirectcallable/projected/projected.compile.pass.cpp
@@ -53,16 +53,8 @@ static_assert(cuda::std::same_as<ContiguousIterator::value_type, S>, "");
 static_assert(cuda::std::same_as<decltype(*cuda::std::declval<ContiguousIterator>()), S&>, "");
 static_assert(cuda::std::same_as<cuda::std::iter_difference_t<ContiguousIterator>, cuda::std::ptrdiff_t>, "");
 
-#if TEST_STD_VER > 2017
 template <class I, class F>
-constexpr bool projectable = requires { typename cuda::std::projected<I, F>; };
-#else
-template <class I, class F>
-_CCCL_CONCEPT_FRAGMENT(projectable_, requires()(typename(cuda::std::projected<I, F>)));
-
-template <class I, class F>
-_CCCL_CONCEPT projectable = _CCCL_FRAGMENT(projectable_, I, F);
-#endif
+_CCCL_CONCEPT projectable = _CCCL_REQUIRES_EXPR((I, F))(typename(cuda::std::projected<I, F>));
 
 static_assert(!projectable<int, void (*)(int)>, ""); // int isn't indirectly_readable
 static_assert(!projectable<S, void (*)(int)>, ""); // S isn't weakly_incrementable

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.assoc.types/incrementable.traits/incrementable_traits.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.assoc.types/incrementable.traits/incrementable_traits.compile.pass.cpp
@@ -15,31 +15,14 @@
 
 #include "test_macros.h"
 
-#if TEST_STD_VER > 2017
 template <class T>
-concept check_has_difference_type = requires { typename cuda::std::incrementable_traits<T>::difference_type; };
+_CCCL_CONCEPT check_has_difference_type =
+  _CCCL_REQUIRES_EXPR((T))(typename(typename cuda::std::incrementable_traits<T>::difference_type));
 
 template <class T, class Expected>
-concept check_difference_type_matches =
-  check_has_difference_type<T>
-  && cuda::std::same_as<typename cuda::std::incrementable_traits<T>::difference_type, Expected>;
-#else
-template <class T, class = void>
-_CCCL_INLINE_VAR constexpr bool check_has_difference_type = false;
-
-template <class T>
-_CCCL_INLINE_VAR constexpr bool
-  check_has_difference_type<T, cuda::std::void_t<typename cuda::std::incrementable_traits<T>::difference_type>> = true;
-
-template <class T, class Expected>
-_CCCL_CONCEPT_FRAGMENT(
-  check_difference_type_matches_,
-  requires()(requires(check_has_difference_type<T>),
-             requires(cuda::std::same_as<typename cuda::std::incrementable_traits<T>::difference_type, Expected>)));
-
-template <class T, class Expected>
-_CCCL_CONCEPT check_difference_type_matches = _CCCL_FRAGMENT(check_difference_type_matches_, T, Expected);
-#endif
+_CCCL_CONCEPT check_difference_type_matches = _CCCL_REQUIRES_EXPR(
+  (T, Expected))(requires(check_has_difference_type<T>),
+                 requires(cuda::std::same_as<typename cuda::std::incrementable_traits<T>::difference_type, Expected>));
 
 template <class T, class Expected>
 __host__ __device__ constexpr bool check_incrementable_traits()

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.assoc.types/readable.traits/indirectly_readable_traits.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.assoc.types/readable.traits/indirectly_readable_traits.compile.pass.cpp
@@ -13,31 +13,14 @@
 #include <cuda/std/concepts>
 #include <cuda/std/iterator>
 
-#if TEST_STD_VER > 2017
 template <class T>
-concept has_no_value_type = !requires { typename cuda::std::indirectly_readable_traits<T>::value_type; };
+_CCCL_CONCEPT has_no_value_type =
+  !_CCCL_REQUIRES_EXPR((T))(typename(typename cuda::std::indirectly_readable_traits<T>::value_type));
 
 template <class T, class Expected>
-concept value_type_matches =
-  cuda::std::same_as<typename cuda::std::indirectly_readable_traits<T>::value_type, Expected>;
-
-#else
-template <class T>
-_CCCL_CONCEPT_FRAGMENT(has_no_value_type_,
-                       requires()(typename(typename cuda::std::indirectly_readable_traits<T>::value_type)));
-
-template <class T>
-_CCCL_CONCEPT has_no_value_type = !_CCCL_FRAGMENT(has_no_value_type_, T);
-
-template <class T, class Expected>
-_CCCL_CONCEPT_FRAGMENT(
-  value_type_matches_,
-  requires()(typename(typename cuda::std::indirectly_readable_traits<T>::value_type),
-             requires(cuda::std::same_as<typename cuda::std::indirectly_readable_traits<T>::value_type, Expected>)));
-
-template <class T, class Expected>
-_CCCL_CONCEPT value_type_matches = _CCCL_FRAGMENT(value_type_matches_, T, Expected);
-#endif
+_CCCL_CONCEPT value_type_matches = _CCCL_REQUIRES_EXPR(
+  (T, Expected))(typename(typename cuda::std::indirectly_readable_traits<T>::value_type),
+                 requires(cuda::std::same_as<typename cuda::std::indirectly_readable_traits<T>::value_type, Expected>));
 
 template <class T>
 __host__ __device__ constexpr bool check_pointer()

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.readable/iter_common_reference_t.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.readable/iter_common_reference_t.compile.pass.cpp
@@ -65,16 +65,9 @@ struct T3
 static_assert(cuda::std::same_as<cuda::std::iter_common_reference_t<T3>, Common>, "");
 
 // Make sure we're SFINAE-friendly
-#if TEST_STD_VER > 2017
 template <class T>
-constexpr bool has_common_reference = requires { typename cuda::std::iter_common_reference_t<T>; };
-#else
-template <class T>
-_CCCL_CONCEPT_FRAGMENT(has_common_reference_, requires()(typename(cuda::std::iter_common_reference_t<T>)));
+_CCCL_CONCEPT has_common_reference = _CCCL_REQUIRES_EXPR((T))(typename(cuda::std::iter_common_reference_t<T>));
 
-template <class T>
-_CCCL_CONCEPT has_common_reference = _CCCL_FRAGMENT(has_common_reference_, T);
-#endif
 struct NotIndirectlyReadable
 {};
 static_assert(!has_common_reference<NotIndirectlyReadable>, "");

--- a/libcudacxx/test/libcudacxx/std/iterators/predef.iterators/reverse.iterators/sized_sentinel.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/predef.iterators/reverse.iterators/sized_sentinel.compile.pass.cpp
@@ -14,16 +14,8 @@
 #include "test_iterators.h"
 #include "test_macros.h"
 
-#if TEST_STD_VER > 2017
 template <class T>
-concept HasMinus = requires(T t) { t - t; };
-#else
-template <class T>
-_CCCL_CONCEPT_FRAGMENT(HasMinus_, requires(T t)(t - t));
-
-template <class T>
-_CCCL_CONCEPT HasMinus = _CCCL_FRAGMENT(HasMinus_, T);
-#endif
+_CCCL_CONCEPT HasMinus = _CCCL_REQUIRES_EXPR((T), T t)((t - t));
 
 using sized_it = random_access_iterator<int*>;
 static_assert(cuda::std::sized_sentinel_for<sized_it, sized_it>);

--- a/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.all/range.ref.view/range.ref.view.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.adaptors/range.all/range.ref.view/range.ref.view.pass.cpp
@@ -182,31 +182,14 @@ struct Cpp20InputRange
 template <>
 inline constexpr bool cuda::std::ranges::enable_borrowed_range<Cpp20InputRange> = true;
 
-#if TEST_STD_VER >= 2020
 template <class R>
-concept EmptyIsInvocable = requires(cuda::std::ranges::ref_view<R> view) { view.empty(); };
+_CCCL_CONCEPT EmptyIsInvocable = _CCCL_REQUIRES_EXPR((R), cuda::std::ranges::ref_view<R> view)((view.empty()));
 
 template <class R>
-concept SizeIsInvocable = requires(cuda::std::ranges::ref_view<R> view) { view.size(); };
+_CCCL_CONCEPT SizeIsInvocable = _CCCL_REQUIRES_EXPR((R), cuda::std::ranges::ref_view<R> view)((view.size()));
 
 template <class R>
-concept DataIsInvocable = requires(cuda::std::ranges::ref_view<R> view) { view.data(); };
-#else // ^^^ C++20 ^^^ / vvv C++17 vvv
-template <class R>
-_CCCL_CONCEPT_FRAGMENT(EmptyIsInvocable_, requires(cuda::std::ranges::ref_view<R> view)((view.empty())));
-template <class R>
-_CCCL_CONCEPT EmptyIsInvocable = _CCCL_FRAGMENT(EmptyIsInvocable_, R);
-
-template <class R>
-_CCCL_CONCEPT_FRAGMENT(SizeIsInvocable_, requires(cuda::std::ranges::ref_view<R> view)((view.size())));
-template <class R>
-_CCCL_CONCEPT SizeIsInvocable = _CCCL_FRAGMENT(SizeIsInvocable_, R);
-
-template <class R>
-_CCCL_CONCEPT_FRAGMENT(DataIsInvocable_, requires(cuda::std::ranges::ref_view<R> view)((view.data())));
-template <class R>
-_CCCL_CONCEPT DataIsInvocable = _CCCL_FRAGMENT(DataIsInvocable_, R);
-#endif // TEST_STD_VER <= 2017
+_CCCL_CONCEPT DataIsInvocable = _CCCL_REQUIRES_EXPR((R), cuda::std::ranges::ref_view<R> view)((view.data()));
 
 // Testing ctad.
 static_assert(cuda::std::same_as<decltype(cuda::std::ranges::ref_view(cuda::std::declval<Range&>())),

--- a/libcudacxx/test/libcudacxx/std/utilities/expected/expected.expected/assign/emplace.intializer_list.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/expected/expected.expected/assign/emplace.intializer_list.pass.cpp
@@ -31,9 +31,8 @@
 #include "test_macros.h"
 
 template <class T, class... Args>
-_CCCL_CONCEPT_FRAGMENT(CanEmplace_, requires(T t, Args&&... args)((t.emplace(cuda::std::forward<Args>(args)...))));
-template <class T, class... Args>
-constexpr bool CanEmplace = _CCCL_FRAGMENT(CanEmplace_, T, Args...);
+_CCCL_CONCEPT CanEmplace =
+  _CCCL_REQUIRES_EXPR((T, variadic Args), T t, Args&&... args)((t.emplace(cuda::std::forward<Args>(args)...)));
 
 static_assert(CanEmplace<cuda::std::expected<int, int>, int>, "");
 

--- a/libcudacxx/test/libcudacxx/std/utilities/expected/expected.expected/assign/emplace.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/expected/expected.expected/assign/emplace.pass.cpp
@@ -32,9 +32,8 @@
 #include "test_macros.h"
 
 template <class T, class... Args>
-_CCCL_CONCEPT_FRAGMENT(CanEmplace_, requires(T t, Args&&... args)((t.emplace(cuda::std::forward<Args>(args)...))));
-template <class T, class... Args>
-constexpr bool CanEmplace = _CCCL_FRAGMENT(CanEmplace_, T, Args...);
+_CCCL_CONCEPT CanEmplace =
+  _CCCL_REQUIRES_EXPR((T, variadic Args), T t, Args&&... args)((t.emplace(cuda::std::forward<Args>(args)...)));
 
 static_assert(CanEmplace<cuda::std::expected<int, int>, int>, "");
 

--- a/libcudacxx/test/libcudacxx/std/utilities/expected/expected.expected/ctor/ctor.inplace.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/expected/expected.expected/ctor/ctor.inplace.pass.cpp
@@ -41,11 +41,8 @@ template <class T>
 __host__ __device__ void conversion_test(T);
 
 template <class T, class... Args>
-_CCCL_CONCEPT_FRAGMENT(ImplicitlyConstructible_,
-                       requires(Args&&... args)((conversion_test<T>({cuda::std::forward<Args>(args)...}))));
-
-template <class T, class... Args>
-constexpr bool ImplicitlyConstructible = _CCCL_FRAGMENT(ImplicitlyConstructible_, T, Args...);
+_CCCL_CONCEPT ImplicitlyConstructible = _CCCL_REQUIRES_EXPR((T, variadic Args), T t, Args&&... args)(
+  (conversion_test<T>({cuda::std::forward<Args>(args)...})));
 static_assert(ImplicitlyConstructible<int, int>, "");
 
 static_assert(!ImplicitlyConstructible<cuda::std::expected<int, int>, cuda::std::in_place_t>, "");

--- a/libcudacxx/test/libcudacxx/std/utilities/expected/expected.expected/ctor/ctor.inplace_init_list.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/expected/expected.expected/ctor/ctor.inplace_init_list.pass.cpp
@@ -51,11 +51,8 @@ template <class T>
 __host__ __device__ void conversion_test(T);
 
 template <class T, class... Args>
-_CCCL_CONCEPT_FRAGMENT(ImplicitlyConstructible_,
-                       requires(Args&&... args)((conversion_test<T>({cuda::std::forward<Args>(args)...}))));
-
-template <class T, class... Args>
-constexpr bool ImplicitlyConstructible = _CCCL_FRAGMENT(ImplicitlyConstructible_, T, Args...);
+_CCCL_CONCEPT ImplicitlyConstructible = _CCCL_REQUIRES_EXPR((T, variadic Args), T t, Args&&... args)(
+  (conversion_test<T>({cuda::std::forward<Args>(args)...})));
 static_assert(ImplicitlyConstructible<int, int>, "");
 
 #if defined(_LIBCUDACXX_HAS_VECTOR)

--- a/libcudacxx/test/libcudacxx/std/utilities/expected/expected.expected/ctor/ctor.unexpect.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/expected/expected.expected/ctor/ctor.unexpect.pass.cpp
@@ -41,11 +41,8 @@ template <class T>
 __host__ __device__ void conversion_test(T);
 
 template <class T, class... Args>
-_CCCL_CONCEPT_FRAGMENT(ImplicitlyConstructible_,
-                       requires(Args&&... args)((conversion_test<T>({cuda::std::forward<Args>(args)...}))));
-
-template <class T, class... Args>
-constexpr bool ImplicitlyConstructible = _CCCL_FRAGMENT(ImplicitlyConstructible_, T, Args...);
+_CCCL_CONCEPT ImplicitlyConstructible = _CCCL_REQUIRES_EXPR((T, variadic Args), T t, Args&&... args)(
+  (conversion_test<T>({cuda::std::forward<Args>(args)...})));
 static_assert(ImplicitlyConstructible<int, int>, "");
 
 static_assert(!ImplicitlyConstructible<cuda::std::expected<int, int>, cuda::std::unexpect_t>, "");

--- a/libcudacxx/test/libcudacxx/std/utilities/expected/expected.expected/ctor/ctor.unexpect_init_list.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/expected/expected.expected/ctor/ctor.unexpect_init_list.pass.cpp
@@ -52,11 +52,8 @@ template <class T>
 __host__ __device__ void conversion_test(T);
 
 template <class T, class... Args>
-_CCCL_CONCEPT_FRAGMENT(ImplicitlyConstructible_,
-                       requires(Args&&... args)((conversion_test<T>({cuda::std::forward<Args>(args)...}))));
-
-template <class T, class... Args>
-constexpr bool ImplicitlyConstructible = _CCCL_FRAGMENT(ImplicitlyConstructible_, T, Args...);
+_CCCL_CONCEPT ImplicitlyConstructible = _CCCL_REQUIRES_EXPR((T, variadic Args), T t, Args&&... args)(
+  (conversion_test<T>({cuda::std::forward<Args>(args)...})));
 static_assert(ImplicitlyConstructible<int, int>, "");
 
 #if defined(_LIBCUDACXX_HAS_VECTOR)

--- a/libcudacxx/test/libcudacxx/std/utilities/expected/expected.expected/swap/member.swap.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/expected/expected.expected/swap/member.swap.pass.cpp
@@ -30,9 +30,8 @@
 
 // Test Constraints:
 template <class T, class E>
-_CCCL_CONCEPT_FRAGMENT(HasMemberSwap_, requires(cuda::std::expected<T, E> x, cuda::std::expected<T, E> y)((x.swap(y))));
-template <class T, class E>
-_CCCL_CONCEPT HasMemberSwap = _CCCL_FRAGMENT(HasMemberSwap_, T, E);
+_CCCL_CONCEPT HasMemberSwap =
+  _CCCL_REQUIRES_EXPR((T, E), cuda::std::expected<T, E> x, cuda::std::expected<T, E> y)((x.swap(y)));
 
 static_assert(HasMemberSwap<int, int>, "");
 

--- a/libcudacxx/test/libcudacxx/std/utilities/expected/expected.unexpected/ctor/ctor.inplace.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/expected/expected.unexpected/ctor/ctor.inplace.pass.cpp
@@ -36,11 +36,8 @@ template <class T>
 __host__ __device__ void conversion_test(T);
 
 template <class T, class... Args>
-_CCCL_CONCEPT_FRAGMENT(ImplicitlyConstructible_,
-                       requires(Args&&... args)((conversion_test<T>({cuda::std::forward<Args>(args)...}))));
-
-template <class T, class... Args>
-constexpr bool ImplicitlyConstructible = _CCCL_FRAGMENT(ImplicitlyConstructible_, T, Args...);
+_CCCL_CONCEPT ImplicitlyConstructible = _CCCL_REQUIRES_EXPR((T, variadic Args), T t, Args&&... args)(
+  (conversion_test<T>({cuda::std::forward<Args>(args)...})));
 
 static_assert(ImplicitlyConstructible<int, int>, "");
 static_assert(!ImplicitlyConstructible<cuda::std::unexpected<int>, cuda::std::in_place_t, int>, "");

--- a/libcudacxx/test/libcudacxx/std/utilities/expected/expected.unexpected/ctor/ctor.inplace_init_list.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/expected/expected.unexpected/ctor/ctor.inplace_init_list.pass.cpp
@@ -72,11 +72,8 @@ template <class T>
 __host__ __device__ void conversion_test(T);
 
 template <class T, class... Args>
-_CCCL_CONCEPT_FRAGMENT(ImplicitlyConstructible_,
-                       requires(Args&&... args)((conversion_test<T>({cuda::std::forward<Args>(args)...}))));
-
-template <class T, class... Args>
-constexpr bool ImplicitlyConstructible = _CCCL_FRAGMENT(ImplicitlyConstructible_, T, Args...);
+_CCCL_CONCEPT ImplicitlyConstructible = _CCCL_REQUIRES_EXPR((T, variadic Args), T t, Args&&... args)(
+  (conversion_test<T>({cuda::std::forward<Args>(args)...})));
 
 static_assert(ImplicitlyConstructible<int, int>, "");
 static_assert(

--- a/libcudacxx/test/libcudacxx/std/utilities/expected/expected.void/ctor/ctor.unexpect.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/expected/expected.void/ctor/ctor.unexpect.pass.cpp
@@ -41,11 +41,8 @@ template <class T>
 __host__ __device__ void conversion_test(T);
 
 template <class T, class... Args>
-_CCCL_CONCEPT_FRAGMENT(ImplicitlyConstructible_,
-                       requires(Args&&... args)((conversion_test<T>({cuda::std::forward<Args>(args)...}))));
-
-template <class T, class... Args>
-constexpr bool ImplicitlyConstructible = _CCCL_FRAGMENT(ImplicitlyConstructible_, T, Args...);
+_CCCL_CONCEPT ImplicitlyConstructible = _CCCL_REQUIRES_EXPR((T, variadic Args), T t, Args&&... args)(
+  (conversion_test<T>({cuda::std::forward<Args>(args)...})));
 static_assert(ImplicitlyConstructible<int, int>, "");
 
 static_assert(!ImplicitlyConstructible<cuda::std::expected<void, int>, cuda::std::unexpect_t>, "");

--- a/libcudacxx/test/libcudacxx/std/utilities/expected/expected.void/ctor/ctor.unexpect_init_list.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/expected/expected.void/ctor/ctor.unexpect_init_list.pass.cpp
@@ -51,11 +51,8 @@ template <class T>
 __host__ __device__ void conversion_test(T);
 
 template <class T, class... Args>
-_CCCL_CONCEPT_FRAGMENT(ImplicitlyConstructible_,
-                       requires(Args&&... args)((conversion_test<T>({cuda::std::forward<Args>(args)...}))));
-
-template <class T, class... Args>
-constexpr bool ImplicitlyConstructible = _CCCL_FRAGMENT(ImplicitlyConstructible_, T, Args...);
+_CCCL_CONCEPT ImplicitlyConstructible = _CCCL_REQUIRES_EXPR((T, variadic Args), T t, Args&&... args)(
+  (conversion_test<T>({cuda::std::forward<Args>(args)...})));
 static_assert(ImplicitlyConstructible<int, int>, "");
 
 #if defined(_LIBCUDACXX_HAS_VECTOR)

--- a/libcudacxx/test/libcudacxx/std/utilities/expected/expected.void/swap/member.swap.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/expected/expected.void/swap/member.swap.pass.cpp
@@ -29,10 +29,8 @@
 
 // Test Constraints:
 template <class E>
-_CCCL_CONCEPT_FRAGMENT(HasMemberSwap_,
-                       requires(cuda::std::expected<void, E> x, cuda::std::expected<void, E> y)((x.swap(y))));
-template <class E>
-_CCCL_CONCEPT HasMemberSwap = _CCCL_FRAGMENT(HasMemberSwap_, E);
+_CCCL_CONCEPT HasMemberSwap =
+  _CCCL_REQUIRES_EXPR((E), cuda::std::expected<void, E> x, cuda::std::expected<void, E> y)((x.swap(y)));
 
 static_assert(HasMemberSwap<int>, "");
 

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.create/make_unique_for_overwrite.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.create/make_unique_for_overwrite.pass.cpp
@@ -26,11 +26,8 @@
 #include "test_macros.h"
 
 template <class T, class... Args>
-_CCCL_CONCEPT_FRAGMENT(
-  HasMakeUniqueForOverwrite_,
-  requires(Args&&... args)((cuda::std::make_unique_for_overwrite<T>(cuda::std::forward<Args>(args)...))));
-template <class T, class... Args>
-constexpr bool HasMakeUniqueForOverwrite = _CCCL_FRAGMENT(HasMakeUniqueForOverwrite_, T, Args...);
+_CCCL_CONCEPT HasMakeUniqueForOverwrite = _CCCL_REQUIRES_EXPR((T, variadic Args), T t, Args&&... args)(
+  (cuda::std::make_unique_for_overwrite<T>(cuda::std::forward<Args>(args)...)));
 
 struct Foo
 {

--- a/libcudacxx/test/libcudacxx/std/utilities/optional/optional.monadic/or_else.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/optional/optional.monadic/or_else.pass.cpp
@@ -23,23 +23,9 @@ struct NonMovable
   NonMovable(NonMovable&&) = delete;
 };
 
-#if TEST_STD_VER > 2017
-
 template <class Opt, class F>
-concept has_or_else = requires(Opt&& opt, F&& f) {
-  { cuda::std::forward<Opt>(opt).or_else(cuda::std::forward<F>(f)) };
-};
-
-#else
-
-template <class Opt, class F>
-_CCCL_CONCEPT_FRAGMENT(HasOrElse,
-                       requires(Opt&& opt, F&& f)(cuda::std::forward<Opt>(opt).or_else(cuda::std::forward<F>(f))));
-
-template <class Opt, class F>
-_CCCL_CONCEPT has_or_else = _CCCL_FRAGMENT(HasOrElse, Opt, F);
-
-#endif
+_CCCL_CONCEPT has_or_else =
+  _CCCL_REQUIRES_EXPR((Opt, F), Opt&& opt, F&& f)((cuda::std::forward<Opt>(opt).or_else(cuda::std::forward<F>(f))));
 
 template <class T>
 __host__ __device__ cuda::std::optional<T> return_optional();


### PR DESCRIPTION
This cleans up the code considerably and is also easier to read once one knows the syntax