### PR TITLE
Fix atomic_thread_fence codegen

### DIFF
--- a/libcudacxx/codegen/generators/fence.h
+++ b/libcudacxx/codegen/generators/fence.h
@@ -72,7 +72,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_fence({0}, {2})
   {
     for (const auto& sem : fence_semantics)
     {
-      out << fmt::format(intrinsic_fence, semantic_tag(sem), semantic(sem), scope_tag(sco), scope(sco));
+      out << fmt::format(intrinsic_fence, scope_tag(sco), semantic(sem), semantic_tag(sem), scope(sco));
     }
   }
   out << "\n"

--- a/libcudacxx/codegen/generators/fence.h
+++ b/libcudacxx/codegen/generators/fence.h
@@ -72,7 +72,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_fence({0}, {2})
   {
     for (const auto& sem : fence_semantics)
     {
-      out << fmt::format(intrinsic_fence, scope_tag(sco), scope(sco), semantic_tag(sem), semantic(sem));
+      out << fmt::format(intrinsic_fence, semantic_tag(sem), semantic(sem), scope_tag(sco), scope(sco));
     }
   }
   out << "\n"

--- a/libcudacxx/include/cuda/std/__atomic/functions/cuda_ptx_generated.h
+++ b/libcudacxx/include/cuda/std/__atomic/functions/cuda_ptx_generated.h
@@ -55,7 +55,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_fence(__thread_scope_block_tag, __
 static inline _CCCL_DEVICE void __cuda_atomic_fence(__thread_scope_cluster_tag, __atomic_cuda_acq_rel)
 { asm volatile("fence.acq_rel.cluster;" ::: "memory"); }
 static inline _CCCL_DEVICE void __cuda_atomic_fence(__thread_scope_cluster_tag, __atomic_cuda_seq_cst)
-{ asm volatile("fence.sc.cluster.;" ::: "memory"); }
+{ asm volatile("fence.sc.cluster;" ::: "memory"); }
 static inline _CCCL_DEVICE void __cuda_atomic_fence(__thread_scope_device_tag, __atomic_cuda_acq_rel)
 { asm volatile("fence.acq_rel.gpu;" ::: "memory"); }
 static inline _CCCL_DEVICE void __cuda_atomic_fence(__thread_scope_device_tag, __atomic_cuda_seq_cst)

--- a/libcudacxx/include/cuda/std/__atomic/functions/cuda_ptx_generated.h
+++ b/libcudacxx/include/cuda/std/__atomic/functions/cuda_ptx_generated.h
@@ -49,21 +49,21 @@ static inline _CCCL_DEVICE void __cuda_atomic_membar(__thread_scope_device_tag)
 static inline _CCCL_DEVICE void __cuda_atomic_membar(__thread_scope_system_tag)
 { asm volatile("membar.sys;" ::: "memory"); }
 static inline _CCCL_DEVICE void __cuda_atomic_fence(__thread_scope_block_tag, __atomic_cuda_acq_rel)
-{ asm volatile("fence.cta.acq_rel;" ::: "memory"); }
+{ asm volatile("fence.acq_rel.cta;" ::: "memory"); }
 static inline _CCCL_DEVICE void __cuda_atomic_fence(__thread_scope_block_tag, __atomic_cuda_seq_cst)
-{ asm volatile("fence.cta.sc;" ::: "memory"); }
+{ asm volatile("fence.sc.cta;" ::: "memory"); }
 static inline _CCCL_DEVICE void __cuda_atomic_fence(__thread_scope_cluster_tag, __atomic_cuda_acq_rel)
-{ asm volatile("fence.cluster.acq_rel;" ::: "memory"); }
+{ asm volatile("fence.acq_rel.cluster;" ::: "memory"); }
 static inline _CCCL_DEVICE void __cuda_atomic_fence(__thread_scope_cluster_tag, __atomic_cuda_seq_cst)
-{ asm volatile("fence.cluster.sc;" ::: "memory"); }
+{ asm volatile("fence.sc.cluster.;" ::: "memory"); }
 static inline _CCCL_DEVICE void __cuda_atomic_fence(__thread_scope_device_tag, __atomic_cuda_acq_rel)
-{ asm volatile("fence.gpu.acq_rel;" ::: "memory"); }
+{ asm volatile("fence.acq_rel.gpu;" ::: "memory"); }
 static inline _CCCL_DEVICE void __cuda_atomic_fence(__thread_scope_device_tag, __atomic_cuda_seq_cst)
-{ asm volatile("fence.gpu.sc;" ::: "memory"); }
+{ asm volatile("fence.sc.gpu;" ::: "memory"); }
 static inline _CCCL_DEVICE void __cuda_atomic_fence(__thread_scope_system_tag, __atomic_cuda_acq_rel)
-{ asm volatile("fence.sys.acq_rel;" ::: "memory"); }
+{ asm volatile("fence.acq_rel.sys;" ::: "memory"); }
 static inline _CCCL_DEVICE void __cuda_atomic_fence(__thread_scope_system_tag, __atomic_cuda_seq_cst)
-{ asm volatile("fence.sys.sc;" ::: "memory"); }
+{ asm volatile("fence.sc.sys;" ::: "memory"); }
 
 template <typename _Sco>
 static inline _CCCL_DEVICE void __atomic_thread_fence_cuda(int __memorder, _Sco) {


### PR DESCRIPTION
## Description

libcu++ generates incorrect PTX for `atomic_thread_fence`: it generates `fence{.sco}{.sem}` instead of `fence{.sem}{.sco}`. This PR fixes that.

## Checklist
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
