### PR TITLE
Implement more of cmath

### DIFF
--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -188,6 +188,12 @@
 #  define _CCCL_BUILTIN_CONSTANT_P(...) __builtin_constant_p(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(builtin_constant_p)
 
+#if _CCCL_CHECK_BUILTIN(builtin_cos) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_COSF(...) __builtin_cosf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_COS(...)  __builtin_cos(__VA_ARGS__)
+#  define _CCCL_BUILTIN_COSL(...) __builtin_cosl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_cos)
+
 #if _CCCL_CHECK_BUILTIN(builtin_exp) || _CCCL_COMPILER(GCC)
 #  define _CCCL_BUILTIN_EXPF(...) __builtin_expf(__VA_ARGS__)
 #  define _CCCL_BUILTIN_EXP(...)  __builtin_exp(__VA_ARGS__)
@@ -593,11 +599,23 @@
 #  define _CCCL_BUILTIN_SIGNBIT(...) __builtin_signbit(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(builtin_signbit)
 
+#if _CCCL_CHECK_BUILTIN(builtin_sin) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_SINF(...) __builtin_sinf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_SIN(...)  __builtin_sin(__VA_ARGS__)
+#  define _CCCL_BUILTIN_SINL(...) __builtin_sinl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_sin)
+
 #if _CCCL_CHECK_BUILTIN(builtin_sqrt) || _CCCL_COMPILER(GCC)
 #  define _CCCL_BUILTIN_SQRTF(...) __builtin_sqrtf(__VA_ARGS__)
 #  define _CCCL_BUILTIN_SQRT(...)  __builtin_sqrt(__VA_ARGS__)
 #  define _CCCL_BUILTIN_SQRTL(...) __builtin_sqrtl(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(builtin_sqrt)
+
+#if _CCCL_CHECK_BUILTIN(builtin_tan) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_TANF(...) __builtin_tanf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_TAN(...)  __builtin_tan(__VA_ARGS__)
+#  define _CCCL_BUILTIN_TANL(...) __builtin_tanl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_tan)
 
 #if _CCCL_CHECK_BUILTIN(builtin_trunc) || _CCCL_COMPILER(GCC)
 #  define _CCCL_BUILTIN_TRUNCF(...) __builtin_truncf(__VA_ARGS__)

--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -86,15 +86,23 @@
 #  define _CCCL_BUILTIN_ARRAY_EXTENT(...) __array_extent(__VA_ARGS__)
 #endif // _CCCL_HAS_BUILTIN(__array_extent)
 
-#if _CCCL_HAS_BUILTIN(__builtin_assume_aligned) || _CCCL_COMPILER(MSVC, >=, 19, 23) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_ASSUME_ALIGNED(...) __builtin_assume_aligned(__VA_ARGS__)
-#endif // _CCCL_HAS_BUILTIN(__builtin_assume_aligned)
+#if _CCCL_CHECK_BUILTIN(builtin_acos) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_ACOSF(...) __builtin_acosf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_ACOS(...)  __builtin_acos(__VA_ARGS__)
+#  define _CCCL_BUILTIN_ACOSL(...) __builtin_acosl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_acos)
 
 // nvhpc has a bug where it supports __builtin_addressof but does not mark it via _CCCL_CHECK_BUILTIN
 #if _CCCL_CHECK_BUILTIN(builtin_addressof) || _CCCL_COMPILER(GCC, >=, 7) || _CCCL_COMPILER(MSVC) \
   || _CCCL_COMPILER(NVHPC)
 #  define _CCCL_BUILTIN_ADDRESSOF(...) __builtin_addressof(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(builtin_addressof)
+
+#if _CCCL_CHECK_BUILTIN(builtin_asin) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_ASINF(...) __builtin_asinf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_ASIN(...)  __builtin_asin(__VA_ARGS__)
+#  define _CCCL_BUILTIN_ASINL(...) __builtin_asinl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_asin)
 
 #if _CCCL_CHECK_BUILTIN(builtin_assume) || _CCCL_COMPILER(CLANG) || _CCCL_COMPILER(NVHPC)
 #  define _CCCL_BUILTIN_ASSUME(...) __builtin_assume(__VA_ARGS__)
@@ -108,11 +116,21 @@
 #  define _CCCL_BUILTIN_ASSUME(...)
 #endif // _CCCL_CHECK_BUILTIN(builtin_assume)
 
-#if _CCCL_CHECK_BUILTIN(builtin_prefetch) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_PREFETCH(...) NV_IF_TARGET(NV_IS_HOST, __builtin_prefetch(__VA_ARGS__);)
-#else
-#  define _CCCL_BUILTIN_PREFETCH(...)
-#endif // _CCCL_CHECK_BUILTIN(builtin_prefetch)
+#if _CCCL_HAS_BUILTIN(__builtin_assume_aligned) || _CCCL_COMPILER(MSVC, >=, 19, 23) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_ASSUME_ALIGNED(...) __builtin_assume_aligned(__VA_ARGS__)
+#endif // _CCCL_HAS_BUILTIN(__builtin_assume_aligned)
+
+#if _CCCL_CHECK_BUILTIN(builtin_atan) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_ATANF(...) __builtin_atanf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_ATAN(...)  __builtin_atan(__VA_ARGS__)
+#  define _CCCL_BUILTIN_ATANL(...) __builtin_atanl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_atan)
+
+#if _CCCL_CHECK_BUILTIN(builtin_atan2) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_ATAN2F(...) __builtin_atan2f(__VA_ARGS__)
+#  define _CCCL_BUILTIN_ATAN2(...)  __builtin_atan2(__VA_ARGS__)
+#  define _CCCL_BUILTIN_ATAN2L(...) __builtin_atan2l(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_atan2)
 
 // MSVC supports __builtin_bit_cast from 19.25 on
 #if _CCCL_CHECK_BUILTIN(builtin_bit_cast) || _CCCL_COMPILER(MSVC, >, 19, 25)
@@ -562,6 +580,12 @@
 #  undef _CCCL_BUILTIN_POW
 #  undef _CCCL_BUILTIN_POWL
 #endif // _CCCL_CUDA_COMPILER(CLANG)
+
+#if _CCCL_CHECK_BUILTIN(builtin_prefetch) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_PREFETCH(...) NV_IF_TARGET(NV_IS_HOST, __builtin_prefetch(__VA_ARGS__);)
+#else
+#  define _CCCL_BUILTIN_PREFETCH(...)
+#endif // _CCCL_CHECK_BUILTIN(builtin_prefetch)
 
 #if _CCCL_CHECK_BUILTIN(builtin_rint) || _CCCL_COMPILER(GCC)
 #  define _CCCL_BUILTIN_RINTF(...) __builtin_rintf(__VA_ARGS__)

--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -340,6 +340,12 @@
 #  define _CCCL_BUILTIN_HUGE_VALL() static_cast<long double>(__builtin_huge_val())
 #endif // _CCCL_CHECK_BUILTIN(builtin_huge_vall)
 
+#if _CCCL_CHECK_BUILTIN(builtin_hypot) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_HYPOTF(...) __builtin_hypotf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_HYPOT(...)  __builtin_hypot(__VA_ARGS__)
+#  define _CCCL_BUILTIN_HYPOTL(...) __builtin_hypotl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_hypot)
+
 #if _CCCL_CHECK_BUILTIN(builtin_is_constant_evaluated) || _CCCL_COMPILER(GCC, >=, 9) || _CCCL_COMPILER(MSVC, >, 19, 24)
 #  define _CCCL_BUILTIN_IS_CONSTANT_EVALUATED(...) __builtin_is_constant_evaluated(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(builtin_is_constant_evaluated)

--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -373,6 +373,12 @@
 #  undef _CCCL_BUILTIN_LDEXPL
 #endif // _CCCL_CUDA_COMPILER(CLANG)
 
+#if _CCCL_CHECK_BUILTIN(builtin_lgamma) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_LGAMMAF(...) __builtin_lgammaf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_LGAMMA(...)  __builtin_lgamma(__VA_ARGS__)
+#  define _CCCL_BUILTIN_LGAMMAL(...) __builtin_lgammal(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_lgamma)
+
 #if _CCCL_HAS_BUILTIN(__builtin_LINE) || _CCCL_COMPILER(GCC) || _CCCL_COMPILER(MSVC, >=, 19, 27)
 #  define _CCCL_BUILTIN_LINE() __builtin_LINE()
 #else // ^^^ _CCCL_HAS_BUILTIN(__builtin_LINE) ^^^ / vvv !_CCCL_HAS_BUILTIN(__builtin_LINE) vvv
@@ -676,6 +682,12 @@
 #  define _CCCL_BUILTIN_TANH(...)  __builtin_tanh(__VA_ARGS__)
 #  define _CCCL_BUILTIN_TANHL(...) __builtin_tanhl(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(builtin_tan)
+
+#if _CCCL_CHECK_BUILTIN(builtin_tgamma) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_TGAMMAF(...) __builtin_tgammaf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_TGAMMA(...)  __builtin_tgamma(__VA_ARGS__)
+#  define _CCCL_BUILTIN_TGAMMAL(...) __builtin_tgammal(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_tgamma)
 
 #if _CCCL_CHECK_BUILTIN(builtin_trunc) || _CCCL_COMPILER(GCC)
 #  define _CCCL_BUILTIN_TRUNCF(...) __builtin_truncf(__VA_ARGS__)

--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -194,6 +194,12 @@
 #  define _CCCL_BUILTIN_COSL(...) __builtin_cosl(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(builtin_cos)
 
+#if _CCCL_CHECK_BUILTIN(builtin_cosh) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_COSHF(...) __builtin_coshf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_COSH(...)  __builtin_cosh(__VA_ARGS__)
+#  define _CCCL_BUILTIN_COSHL(...) __builtin_coshl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_cos)
+
 #if _CCCL_CHECK_BUILTIN(builtin_exp) || _CCCL_COMPILER(GCC)
 #  define _CCCL_BUILTIN_EXPF(...) __builtin_expf(__VA_ARGS__)
 #  define _CCCL_BUILTIN_EXP(...)  __builtin_exp(__VA_ARGS__)
@@ -605,6 +611,12 @@
 #  define _CCCL_BUILTIN_SINL(...) __builtin_sinl(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(builtin_sin)
 
+#if _CCCL_CHECK_BUILTIN(builtin_sinh) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_SINHF(...) __builtin_sinhf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_SINH(...)  __builtin_sinh(__VA_ARGS__)
+#  define _CCCL_BUILTIN_SINHL(...) __builtin_sinhl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_sin)
+
 #if _CCCL_CHECK_BUILTIN(builtin_sqrt) || _CCCL_COMPILER(GCC)
 #  define _CCCL_BUILTIN_SQRTF(...) __builtin_sqrtf(__VA_ARGS__)
 #  define _CCCL_BUILTIN_SQRT(...)  __builtin_sqrt(__VA_ARGS__)
@@ -615,6 +627,12 @@
 #  define _CCCL_BUILTIN_TANF(...) __builtin_tanf(__VA_ARGS__)
 #  define _CCCL_BUILTIN_TAN(...)  __builtin_tan(__VA_ARGS__)
 #  define _CCCL_BUILTIN_TANL(...) __builtin_tanl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_tan)
+
+#if _CCCL_CHECK_BUILTIN(builtin_tanh) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_TANHF(...) __builtin_tanhf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_TANH(...)  __builtin_tanh(__VA_ARGS__)
+#  define _CCCL_BUILTIN_TANHL(...) __builtin_tanhl(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(builtin_tan)
 
 #if _CCCL_CHECK_BUILTIN(builtin_trunc) || _CCCL_COMPILER(GCC)

--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -92,11 +92,23 @@
 #  define _CCCL_BUILTIN_ACOSL(...) __builtin_acosl(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(builtin_acos)
 
+#if _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_ACOSF
+#  undef _CCCL_BUILTIN_ACOS
+#  undef _CCCL_BUILTIN_ACOSL
+#endif // _CCCL_CUDA_COMPILER(CLANG)
+
 #if _CCCL_CHECK_BUILTIN(builtin_acosh) || _CCCL_COMPILER(GCC)
 #  define _CCCL_BUILTIN_ACOSHF(...) __builtin_acoshf(__VA_ARGS__)
 #  define _CCCL_BUILTIN_ACOSH(...)  __builtin_acosh(__VA_ARGS__)
 #  define _CCCL_BUILTIN_ACOSHL(...) __builtin_acoshl(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(builtin_acosh)
+
+#if _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_ACOSHF
+#  undef _CCCL_BUILTIN_ACOSH
+#  undef _CCCL_BUILTIN_ACOSHL
+#endif // _CCCL_CUDA_COMPILER(CLANG)
 
 // nvhpc has a bug where it supports __builtin_addressof but does not mark it via _CCCL_CHECK_BUILTIN
 #if _CCCL_CHECK_BUILTIN(builtin_addressof) || _CCCL_COMPILER(GCC, >=, 7) || _CCCL_COMPILER(MSVC) \
@@ -108,13 +120,25 @@
 #  define _CCCL_BUILTIN_ASINF(...) __builtin_asinf(__VA_ARGS__)
 #  define _CCCL_BUILTIN_ASIN(...)  __builtin_asin(__VA_ARGS__)
 #  define _CCCL_BUILTIN_ASINL(...) __builtin_asinl(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(builtin_asinh)
+#endif // _CCCL_CHECK_BUILTIN(builtin_asin)
+
+#if _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_ASINF
+#  undef _CCCL_BUILTIN_ASIN
+#  undef _CCCL_BUILTIN_ASINL
+#endif // _CCCL_CUDA_COMPILER(CLANG)
 
 #if _CCCL_CHECK_BUILTIN(builtin_asinh) || _CCCL_COMPILER(GCC)
 #  define _CCCL_BUILTIN_ASINHF(...) __builtin_asinhf(__VA_ARGS__)
 #  define _CCCL_BUILTIN_ASINH(...)  __builtin_asinh(__VA_ARGS__)
 #  define _CCCL_BUILTIN_ASINHL(...) __builtin_asinhl(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(builtin_asin)
+
+#if _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_ASINHF
+#  undef _CCCL_BUILTIN_ASINH
+#  undef _CCCL_BUILTIN_ASINHL
+#endif // _CCCL_CUDA_COMPILER(CLANG)
 
 #if _CCCL_CHECK_BUILTIN(builtin_assume) || _CCCL_COMPILER(CLANG) || _CCCL_COMPILER(NVHPC)
 #  define _CCCL_BUILTIN_ASSUME(...) __builtin_assume(__VA_ARGS__)
@@ -138,17 +162,35 @@
 #  define _CCCL_BUILTIN_ATANL(...) __builtin_atanl(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(builtin_atan)
 
+#if _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_ATANF
+#  undef _CCCL_BUILTIN_ATAN
+#  undef _CCCL_BUILTIN_ATANL
+#endif // _CCCL_CUDA_COMPILER(CLANG)
+
 #if _CCCL_CHECK_BUILTIN(builtin_atan2) || _CCCL_COMPILER(GCC)
 #  define _CCCL_BUILTIN_ATAN2F(...) __builtin_atan2f(__VA_ARGS__)
 #  define _CCCL_BUILTIN_ATAN2(...)  __builtin_atan2(__VA_ARGS__)
 #  define _CCCL_BUILTIN_ATAN2L(...) __builtin_atan2l(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(builtin_atan2)
 
+#if _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_ATAN2F
+#  undef _CCCL_BUILTIN_ATAN2
+#  undef _CCCL_BUILTIN_ATAN2L
+#endif // _CCCL_CUDA_COMPILER(CLANG)
+
 #if _CCCL_CHECK_BUILTIN(builtin_atanh) || _CCCL_COMPILER(GCC)
 #  define _CCCL_BUILTIN_ATANHF(...) __builtin_atanhf(__VA_ARGS__)
 #  define _CCCL_BUILTIN_ATANH(...)  __builtin_atanh(__VA_ARGS__)
 #  define _CCCL_BUILTIN_ATANHL(...) __builtin_atanhl(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(builtin_atanh)
+
+#if _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_ATANHF
+#  undef _CCCL_BUILTIN_ATANH
+#  undef _CCCL_BUILTIN_ATANHL
+#endif // _CCCL_CUDA_COMPILER(CLANG)
 
 // MSVC supports __builtin_bit_cast from 19.25 on
 #if _CCCL_CHECK_BUILTIN(builtin_bit_cast) || _CCCL_COMPILER(MSVC, >, 19, 25)
@@ -230,11 +272,23 @@
 #  define _CCCL_BUILTIN_COSL(...) __builtin_cosl(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(builtin_cos)
 
+#if _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_COSF
+#  undef _CCCL_BUILTIN_COS
+#  undef _CCCL_BUILTIN_COSL
+#endif // _CCCL_CUDA_COMPILER(CLANG)
+
 #if _CCCL_CHECK_BUILTIN(builtin_cosh) || _CCCL_COMPILER(GCC)
 #  define _CCCL_BUILTIN_COSHF(...) __builtin_coshf(__VA_ARGS__)
 #  define _CCCL_BUILTIN_COSH(...)  __builtin_cosh(__VA_ARGS__)
 #  define _CCCL_BUILTIN_COSHL(...) __builtin_coshl(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(builtin_cos)
+#endif // _CCCL_CHECK_BUILTIN(builtin_cosh)
+
+#if _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_COSHF
+#  undef _CCCL_BUILTIN_COSH
+#  undef _CCCL_BUILTIN_COSHL
+#endif // _CCCL_CUDA_COMPILER(CLANG)
 
 #if _CCCL_CHECK_BUILTIN(builtin_exp) || _CCCL_COMPILER(GCC)
 #  define _CCCL_BUILTIN_EXPF(...) __builtin_expf(__VA_ARGS__)
@@ -346,6 +400,12 @@
 #  define _CCCL_BUILTIN_HYPOTL(...) __builtin_hypotl(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(builtin_hypot)
 
+#if _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_HYPOTF
+#  undef _CCCL_BUILTIN_HYPOT
+#  undef _CCCL_BUILTIN_HYPOTL
+#endif // _CCCL_CUDA_COMPILER(CLANG)
+
 #if _CCCL_CHECK_BUILTIN(builtin_is_constant_evaluated) || _CCCL_COMPILER(GCC, >=, 9) || _CCCL_COMPILER(MSVC, >, 19, 24)
 #  define _CCCL_BUILTIN_IS_CONSTANT_EVALUATED(...) __builtin_is_constant_evaluated(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(builtin_is_constant_evaluated)
@@ -384,6 +444,12 @@
 #  define _CCCL_BUILTIN_LGAMMA(...)  __builtin_lgamma(__VA_ARGS__)
 #  define _CCCL_BUILTIN_LGAMMAL(...) __builtin_lgammal(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(builtin_lgamma)
+
+#if _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_LGAMMAF
+#  undef _CCCL_BUILTIN_LGAMMA
+#  undef _CCCL_BUILTIN_LGAMMAL
+#endif // _CCCL_CUDA_COMPILER(CLANG)
 
 #if _CCCL_HAS_BUILTIN(__builtin_LINE) || _CCCL_COMPILER(GCC) || _CCCL_COMPILER(MSVC, >=, 19, 27)
 #  define _CCCL_BUILTIN_LINE() __builtin_LINE()
@@ -665,11 +731,23 @@
 #  define _CCCL_BUILTIN_SINL(...) __builtin_sinl(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(builtin_sin)
 
+#if _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_SINF
+#  undef _CCCL_BUILTIN_SIN
+#  undef _CCCL_BUILTIN_SINL
+#endif // _CCCL_CUDA_COMPILER(CLANG)
+
 #if _CCCL_CHECK_BUILTIN(builtin_sinh) || _CCCL_COMPILER(GCC)
 #  define _CCCL_BUILTIN_SINHF(...) __builtin_sinhf(__VA_ARGS__)
 #  define _CCCL_BUILTIN_SINH(...)  __builtin_sinh(__VA_ARGS__)
 #  define _CCCL_BUILTIN_SINHL(...) __builtin_sinhl(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(builtin_sin)
+
+#if _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_SINHF
+#  undef _CCCL_BUILTIN_SINH
+#  undef _CCCL_BUILTIN_SINHL
+#endif // _CCCL_CUDA_COMPILER(CLANG)
 
 #if _CCCL_CHECK_BUILTIN(builtin_sqrt) || _CCCL_COMPILER(GCC)
 #  define _CCCL_BUILTIN_SQRTF(...) __builtin_sqrtf(__VA_ARGS__)
@@ -683,17 +761,35 @@
 #  define _CCCL_BUILTIN_TANL(...) __builtin_tanl(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(builtin_tan)
 
+#if _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_TANF
+#  undef _CCCL_BUILTIN_TAN
+#  undef _CCCL_BUILTIN_TANL
+#endif // _CCCL_CUDA_COMPILER(CLANG)
+
 #if _CCCL_CHECK_BUILTIN(builtin_tanh) || _CCCL_COMPILER(GCC)
 #  define _CCCL_BUILTIN_TANHF(...) __builtin_tanhf(__VA_ARGS__)
 #  define _CCCL_BUILTIN_TANH(...)  __builtin_tanh(__VA_ARGS__)
 #  define _CCCL_BUILTIN_TANHL(...) __builtin_tanhl(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(builtin_tan)
 
+#if _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_TANHF
+#  undef _CCCL_BUILTIN_TANH
+#  undef _CCCL_BUILTIN_TANHL
+#endif // _CCCL_CUDA_COMPILER(CLANG)
+
 #if _CCCL_CHECK_BUILTIN(builtin_tgamma) || _CCCL_COMPILER(GCC)
 #  define _CCCL_BUILTIN_TGAMMAF(...) __builtin_tgammaf(__VA_ARGS__)
 #  define _CCCL_BUILTIN_TGAMMA(...)  __builtin_tgamma(__VA_ARGS__)
 #  define _CCCL_BUILTIN_TGAMMAL(...) __builtin_tgammal(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(builtin_tgamma)
+
+#if _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_TGAMMAF
+#  undef _CCCL_BUILTIN_TGAMMA
+#  undef _CCCL_BUILTIN_TGAMMAL
+#endif // _CCCL_CUDA_COMPILER(CLANG)
 
 #if _CCCL_CHECK_BUILTIN(builtin_trunc) || _CCCL_COMPILER(GCC)
 #  define _CCCL_BUILTIN_TRUNCF(...) __builtin_truncf(__VA_ARGS__)

--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -92,6 +92,12 @@
 #  define _CCCL_BUILTIN_ACOSL(...) __builtin_acosl(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(builtin_acos)
 
+#if _CCCL_CHECK_BUILTIN(builtin_acosh) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_ACOSHF(...) __builtin_acoshf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_ACOSH(...)  __builtin_acosh(__VA_ARGS__)
+#  define _CCCL_BUILTIN_ACOSHL(...) __builtin_acoshl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_acosh)
+
 // nvhpc has a bug where it supports __builtin_addressof but does not mark it via _CCCL_CHECK_BUILTIN
 #if _CCCL_CHECK_BUILTIN(builtin_addressof) || _CCCL_COMPILER(GCC, >=, 7) || _CCCL_COMPILER(MSVC) \
   || _CCCL_COMPILER(NVHPC)
@@ -102,6 +108,12 @@
 #  define _CCCL_BUILTIN_ASINF(...) __builtin_asinf(__VA_ARGS__)
 #  define _CCCL_BUILTIN_ASIN(...)  __builtin_asin(__VA_ARGS__)
 #  define _CCCL_BUILTIN_ASINL(...) __builtin_asinl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_asinh)
+
+#if _CCCL_CHECK_BUILTIN(builtin_asinh) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_ASINHF(...) __builtin_asinhf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_ASINH(...)  __builtin_asinh(__VA_ARGS__)
+#  define _CCCL_BUILTIN_ASINHL(...) __builtin_asinhl(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(builtin_asin)
 
 #if _CCCL_CHECK_BUILTIN(builtin_assume) || _CCCL_COMPILER(CLANG) || _CCCL_COMPILER(NVHPC)
@@ -131,6 +143,12 @@
 #  define _CCCL_BUILTIN_ATAN2(...)  __builtin_atan2(__VA_ARGS__)
 #  define _CCCL_BUILTIN_ATAN2L(...) __builtin_atan2l(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(builtin_atan2)
+
+#if _CCCL_CHECK_BUILTIN(builtin_atanh) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_ATANHF(...) __builtin_atanhf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_ATANH(...)  __builtin_atanh(__VA_ARGS__)
+#  define _CCCL_BUILTIN_ATANHL(...) __builtin_atanhl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_atanh)
 
 // MSVC supports __builtin_bit_cast from 19.25 on
 #if _CCCL_CHECK_BUILTIN(builtin_bit_cast) || _CCCL_COMPILER(MSVC, >, 19, 25)

--- a/libcudacxx/include/cuda/std/__cmath/gamma.h
+++ b/libcudacxx/include/cuda/std/__cmath/gamma.h
@@ -1,0 +1,172 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___CMATH_GAMMA_H
+#define _LIBCUDACXX___CMATH_GAMMA_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__cmath/common.h>
+#include <cuda/std/__type_traits/enable_if.h>
+#include <cuda/std/__type_traits/is_integral.h>
+
+#include <nv/target>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_STD
+
+// lgamma
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float lgamma(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_LGAMMAF)
+  return _CCCL_BUILTIN_LGAMMAF(__x);
+#else // ^^^ _CCCL_BUILTIN_LGAMMAF ^^^ / vvv !_CCCL_BUILTIN_LGAMMAF vvv
+  return ::lgammaf(__x);
+#endif // !_CCCL_BUILTIN_LGAMMAF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float lgammaf(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_LGAMMAF)
+  return _CCCL_BUILTIN_LGAMMAF(__x);
+#else // ^^^ _CCCL_BUILTIN_LGAMMAF ^^^ / vvv !_CCCL_BUILTIN_LGAMMAF vvv
+  return ::lgammaf(__x);
+#endif // !_CCCL_BUILTIN_LGAMMAF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double lgamma(double __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_LGAMMA)
+  return _CCCL_BUILTIN_LGAMMA(__x);
+#else // ^^^ _CCCL_BUILTIN_LGAMMA ^^^ / vvv !_CCCL_BUILTIN_LGAMMA vvv
+  return ::lgamma(__x);
+#endif // !_CCCL_BUILTIN_LGAMMA
+}
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double lgamma(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_LGAMMAL)
+  return _CCCL_BUILTIN_LGAMMAL(__x);
+#  else // ^^^ _CCCL_BUILTIN_LGAMMAL ^^^ / vvv !_CCCL_BUILTIN_LGAMMAL vvv
+  return ::lgammal(__x);
+#  endif // !_CCCL_BUILTIN_LGAMMAL
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double lgammal(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_LGAMMAL)
+  return _CCCL_BUILTIN_LGAMMAL(__x);
+#  else // ^^^ _CCCL_BUILTIN_LGAMMAL ^^^ / vvv !_CCCL_BUILTIN_LGAMMAL vvv
+  return ::lgammal(__x);
+#  endif // !_CCCL_BUILTIN_LGAMMAL
+}
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#if defined(_LIBCUDACXX_HAS_NVFP16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __half lgamma(__half __x) noexcept
+{
+  return __float2half(_CUDA_VSTD::lgammaf(__half2float(__x)));
+}
+#endif // _LIBCUDACXX_HAS_NVFP16
+
+#if defined(_LIBCUDACXX_HAS_NVBF16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 lgamma(__nv_bfloat16 __x) noexcept
+{
+  return __float2bfloat16(_CUDA_VSTD::lgammaf(__bfloat162float(__x)));
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double lgamma(_Integer __x) noexcept
+{
+  return _CUDA_VSTD::lgamma((double) __x);
+}
+
+// tgamma
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float tgamma(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_TGAMMAF)
+  return _CCCL_BUILTIN_TGAMMAF(__x);
+#else // ^^^ _CCCL_BUILTIN_TGAMMAF ^^^ / vvv !_CCCL_BUILTIN_TGAMMAF vvv
+  return ::tgammaf(__x);
+#endif // !_CCCL_BUILTIN_TGAMMAF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float tgammaf(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_TGAMMAF)
+  return _CCCL_BUILTIN_TGAMMAF(__x);
+#else // ^^^ _CCCL_BUILTIN_TGAMMAF ^^^ / vvv !_CCCL_BUILTIN_TGAMMAF vvv
+  return ::tgammaf(__x);
+#endif // !_CCCL_BUILTIN_TGAMMAF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double tgamma(double __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_TGAMMA)
+  return _CCCL_BUILTIN_TGAMMA(__x);
+#else // ^^^ _CCCL_BUILTIN_TGAMMA ^^^ / vvv !_CCCL_BUILTIN_TGAMMA vvv
+  return ::tgamma(__x);
+#endif // !_CCCL_BUILTIN_TGAMMA
+}
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double tgamma(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_TGAMMAL)
+  return _CCCL_BUILTIN_TGAMMAL(__x);
+#  else // ^^^ _CCCL_BUILTIN_TGAMMAL ^^^ / vvv !_CCCL_BUILTIN_TGAMMAL vvv
+  return ::tgammal(__x);
+#  endif // !_CCCL_BUILTIN_TGAMMAL
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double tgammal(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_TGAMMAL)
+  return _CCCL_BUILTIN_TGAMMAL(__x);
+#  else // ^^^ _CCCL_BUILTIN_TGAMMAL ^^^ / vvv !_CCCL_BUILTIN_TGAMMAL vvv
+  return ::tgammal(__x);
+#  endif // !_CCCL_BUILTIN_TGAMMAL
+}
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#if defined(_LIBCUDACXX_HAS_NVFP16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __half tgamma(__half __x) noexcept
+{
+  return __float2half(_CUDA_VSTD::tgammaf(__half2float(__x)));
+}
+#endif // _LIBCUDACXX_HAS_NVFP16
+
+#if defined(_LIBCUDACXX_HAS_NVBF16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 tgamma(__nv_bfloat16 __x) noexcept
+{
+  return __float2bfloat16(_CUDA_VSTD::tgammaf(__bfloat162float(__x)));
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double tgamma(_Integer __x) noexcept
+{
+  return _CUDA_VSTD::tgamma((double) __x);
+}
+
+_LIBCUDACXX_END_NAMESPACE_STD
+
+#endif // _LIBCUDACXX___CMATH_GAMMA_H

--- a/libcudacxx/include/cuda/std/__cmath/hyperbolic_functions.h
+++ b/libcudacxx/include/cuda/std/__cmath/hyperbolic_functions.h
@@ -1,0 +1,241 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___CMATH_HYPERBOLIC_FUNCTIONS_H
+#define _LIBCUDACXX___CMATH_HYPERBOLIC_FUNCTIONS_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__cmath/common.h>
+#include <cuda/std/__type_traits/enable_if.h>
+#include <cuda/std/__type_traits/is_integral.h>
+
+#include <nv/target>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_STD
+
+// cosh
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float cosh(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_COSHF)
+  return _CCCL_BUILTIN_COSHF(__x);
+#else // ^^^ _CCCL_BUILTIN_COSHF ^^^ / vvv !_CCCL_BUILTIN_COSHF vvv
+  return ::coshf(__x);
+#endif // !_CCCL_BUILTIN_COSHF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float coshf(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_COSHF)
+  return _CCCL_BUILTIN_COSHF(__x);
+#else // ^^^ _CCCL_BUILTIN_COSHF ^^^ / vvv !_CCCL_BUILTIN_COSHF vvv
+  return ::coshf(__x);
+#endif // !_CCCL_BUILTIN_COSHF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double cosh(double __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_COSH)
+  return _CCCL_BUILTIN_COSH(__x);
+#else // ^^^ _CCCL_BUILTIN_COSH ^^^ / vvv !_CCCL_BUILTIN_COSH vvv
+  return ::cosh(__x);
+#endif // !_CCCL_BUILTIN_COSH
+}
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double cosh(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_COSHL)
+  return _CCCL_BUILTIN_COSHL(__x);
+#  else // ^^^ _CCCL_BUILTIN_COSHL ^^^ / vvv !_CCCL_BUILTIN_COSHL vvv
+  return ::coshl(__x);
+#  endif // !_CCCL_BUILTIN_COSHL
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double coshl(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_COSHL)
+  return _CCCL_BUILTIN_COSHL(__x);
+#  else // ^^^ _CCCL_BUILTIN_COSHL ^^^ / vvv !_CCCL_BUILTIN_COSHL vvv
+  return ::coshl(__x);
+#  endif // !_CCCL_BUILTIN_COSHL
+}
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#if defined(_LIBCUDACXX_HAS_NVFP16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __half cosh(__half __x) noexcept
+{
+  return __float2half(_CUDA_VSTD::coshf(__half2float(__x)));
+}
+#endif // _LIBCUDACXX_HAS_NVFP16
+
+#if defined(_LIBCUDACXX_HAS_NVBF16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 cosh(__nv_bfloat16 __x) noexcept
+{
+  return __float2bfloat16(_CUDA_VSTD::coshf(__bfloat162float(__x)));
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double cosh(_Integer __x) noexcept
+{
+  return _CUDA_VSTD::cosh((double) __x);
+}
+
+// sinh
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float sinh(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_SINHF)
+  return _CCCL_BUILTIN_SINHF(__x);
+#else // ^^^ _CCCL_BUILTIN_SINHF ^^^ / vvv !_CCCL_BUILTIN_SINHF vvv
+  return ::sinhf(__x);
+#endif // !_CCCL_BUILTIN_SINHF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float sinhf(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_SINHF)
+  return _CCCL_BUILTIN_SINHF(__x);
+#else // ^^^ _CCCL_BUILTIN_SINHF ^^^ / vvv !_CCCL_BUILTIN_SINHF vvv
+  return ::sinhf(__x);
+#endif // !_CCCL_BUILTIN_SINHF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double sinh(double __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_SINH)
+  return _CCCL_BUILTIN_SINH(__x);
+#else // ^^^ _CCCL_BUILTIN_SINH ^^^ / vvv !_CCCL_BUILTIN_SINH vvv
+  return ::sinh(__x);
+#endif // !_CCCL_BUILTIN_SINH
+}
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double sinh(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_SINHL)
+  return _CCCL_BUILTIN_SINHL(__x);
+#  else // ^^^ _CCCL_BUILTIN_SINHL ^^^ / vvv !_CCCL_BUILTIN_SINHL vvv
+  return ::sinhl(__x);
+#  endif // !_CCCL_BUILTIN_SINHL
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double sinhl(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_SINHL)
+  return _CCCL_BUILTIN_SINHL(__x);
+#  else // ^^^ _CCCL_BUILTIN_SINHL ^^^ / vvv !_CCCL_BUILTIN_SINHL vvv
+  return ::sinhl(__x);
+#  endif // !_CCCL_BUILTIN_SINHL
+}
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#if defined(_LIBCUDACXX_HAS_NVFP16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __half sinh(__half __x) noexcept
+{
+  return __float2half(_CUDA_VSTD::sinhf(__half2float(__x)));
+}
+#endif // _LIBCUDACXX_HAS_NVFP16
+
+#if defined(_LIBCUDACXX_HAS_NVBF16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 sinh(__nv_bfloat16 __x) noexcept
+{
+  return __float2bfloat16(_CUDA_VSTD::sinhf(__bfloat162float(__x)));
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double sinh(_Integer __x) noexcept
+{
+  return _CUDA_VSTD::sinh((double) __x);
+}
+
+// tanh
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float tanh(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_TANHF)
+  return _CCCL_BUILTIN_TANHF(__x);
+#else // ^^^ _CCCL_BUILTIN_TANHF ^^^ / vvv !_CCCL_BUILTIN_TANHF vvv
+  return ::tanhf(__x);
+#endif // !_CCCL_BUILTIN_TANHF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float tanhf(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_TANHF)
+  return _CCCL_BUILTIN_TANHF(__x);
+#else // ^^^ _CCCL_BUILTIN_TANHF ^^^ / vvv !_CCCL_BUILTIN_TANHF vvv
+  return ::tanhf(__x);
+#endif // !_CCCL_BUILTIN_TANHF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double tanh(double __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_TANH)
+  return _CCCL_BUILTIN_TANH(__x);
+#else // ^^^ _CCCL_BUILTIN_TANH ^^^ / vvv !_CCCL_BUILTIN_TANH vvv
+  return ::tanh(__x);
+#endif // !_CCCL_BUILTIN_TANH
+}
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double tanh(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_TANHL)
+  return _CCCL_BUILTIN_TANHL(__x);
+#  else // ^^^ _CCCL_BUILTIN_TANHL ^^^ / vvv !_CCCL_BUILTIN_TANHL vvv
+  return ::tanhl(__x);
+#  endif // !_CCCL_BUILTIN_TANHL
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double tanhl(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_TANHL)
+  return _CCCL_BUILTIN_TANHL(__x);
+#  else // ^^^ _CCCL_BUILTIN_TANHL ^^^ / vvv !_CCCL_BUILTIN_TANHL vvv
+  return ::tanhl(__x);
+#  endif // !_CCCL_BUILTIN_TANHL
+}
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#if defined(_LIBCUDACXX_HAS_NVFP16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __half tanh(__half __x) noexcept
+{
+  return __float2half(_CUDA_VSTD::tanhf(__half2float(__x)));
+}
+#endif // _LIBCUDACXX_HAS_NVFP16
+
+#if defined(_LIBCUDACXX_HAS_NVBF16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 tanh(__nv_bfloat16 __x) noexcept
+{
+  return __float2bfloat16(_CUDA_VSTD::tanhf(__bfloat162float(__x)));
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double tanh(_Integer __x) noexcept
+{
+  return _CUDA_VSTD::tanh((double) __x);
+}
+
+_LIBCUDACXX_END_NAMESPACE_STD
+
+#endif // _LIBCUDACXX___CMATH_HYPERBOLIC_FUNCTIONS_H

--- a/libcudacxx/include/cuda/std/__cmath/hypot.h
+++ b/libcudacxx/include/cuda/std/__cmath/hypot.h
@@ -1,0 +1,204 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___CMATH_HYPOT_H
+#define _LIBCUDACXX___CMATH_HYPOT_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__cmath/abs.h>
+#include <cuda/std/__cmath/common.h>
+#include <cuda/std/__cmath/exponential_functions.h>
+#include <cuda/std/__cmath/min_max.h>
+#include <cuda/std/__cmath/roots.h>
+#include <cuda/std/__type_traits/enable_if.h>
+#include <cuda/std/__type_traits/is_arithmetic.h>
+#include <cuda/std/__type_traits/is_integral.h>
+#include <cuda/std/__type_traits/promote.h>
+#include <cuda/std/limits>
+
+#include <nv/target>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_STD
+
+// hypot
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float hypot(float __x, float __y) noexcept
+{
+#if defined(_CCCL_BUILTIN_HYPOTF)
+  return _CCCL_BUILTIN_HYPOTF(__x, __y);
+#else // ^^^ _CCCL_BUILTIN_HYPOTF ^^^ // vvv !_CCCL_BUILTIN_HYPOTF vvv
+  return ::hypotf(__x, __y);
+#endif // !_CCCL_BUILTIN_HYPOTF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float hypotf(float __x, float __y) noexcept
+{
+#if defined(_CCCL_BUILTIN_HYPOTF)
+  return _CCCL_BUILTIN_HYPOTF(__x, __y);
+#else // ^^^ _CCCL_BUILTIN_HYPOTF ^^^ // vvv !_CCCL_BUILTIN_HYPOTF vvv
+  return ::hypotf(__x, __y);
+#endif // !_CCCL_BUILTIN_HYPOTF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double hypot(double __x, double __y) noexcept
+{
+#if defined(_CCCL_BUILTIN_HYPOT)
+  return _CCCL_BUILTIN_HYPOT(__x, __y);
+#else // ^^^ _CCCL_BUILTIN_HYPOT ^^^ // vvv !_CCCL_BUILTIN_HYPOT vvv
+  return ::hypot(__x, __y);
+#endif // !_CCCL_BUILTIN_HYPOT
+}
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double hypot(long double __x, long double __y) noexcept
+{
+#  if defined(_CCCL_BUILTIN_HYPOTL)
+  return _CCCL_BUILTIN_HYPOTL(__x, __y);
+#  else // ^^^ _CCCL_BUILTIN_HYPOTL ^^^ // vvv !_CCCL_BUILTIN_HYPOTL vvv
+  return ::hypotl(__x, __y);
+#  endif // !_CCCL_BUILTIN_HYPOTL
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double hypotl(long double __x, long double __y) noexcept
+{
+#  if defined(_CCCL_BUILTIN_HYPOTL)
+  return _CCCL_BUILTIN_HYPOTL(__x, __y);
+#  else // ^^^ _CCCL_BUILTIN_HYPOTL ^^^ // vvv !_CCCL_BUILTIN_HYPOTL vvv
+  return ::hypotl(__x, __y);
+#  endif // !_CCCL_BUILTIN_HYPOTL
+}
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#if defined(_LIBCUDACXX_HAS_NVFP16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __half hypot(__half __x, __half __y) noexcept
+{
+  return __float2half(_CUDA_VSTD::hypotf(__half2float(__x), __half2float(__y)));
+}
+#endif // _LIBCUDACXX_HAS_NVFP16
+
+#if defined(_LIBCUDACXX_HAS_NVBF16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 hypot(__nv_bfloat16 __x, __nv_bfloat16 __y) noexcept
+{
+  return __float2bfloat16(_CUDA_VSTD::hypotf(__bfloat162float(__x), __bfloat162float(__y)));
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+template <class _A1, class _A2, enable_if_t<_CCCL_TRAIT(is_arithmetic, _A1) && _CCCL_TRAIT(is_arithmetic, _A2), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __promote_t<_A1, _A2> hypot(_A1 __x, _A2 __y) noexcept
+{
+  using __result_type = __promote_t<_A1, _A2>;
+  static_assert(!(_CCCL_TRAIT(is_same, _A1, __result_type) && _CCCL_TRAIT(is_same, _A2, __result_type)), "");
+  return _CUDA_VSTD::hypot((__result_type) __x, (__result_type) __y);
+}
+
+// hypot 3-arg
+
+// Computes the three-dimensional hypotenuse: `std::hypot(x,y,z)`.
+// The naive implementation might over-/underflow which is why this implementation is more involved:
+//    If the square of an argument might run into issues, we scale the arguments appropriately.
+// See https://github.com/llvm/llvm-project/issues/92782 for a detailed discussion and summary.
+template <class _Tp>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _Tp __hypot(_Tp __x, _Tp __y, _Tp __z)
+{
+  // Factors needed to determine if over-/underflow might happen
+  constexpr int __exp            = _CUDA_VSTD::numeric_limits<_Tp>::max_exponent / 2;
+  const _Tp __overflow_threshold = _CUDA_VSTD::ldexp(_Tp(1), __exp);
+  const _Tp __overflow_scale     = _CUDA_VSTD::ldexp(_Tp(1), -(__exp + 20));
+
+  // Scale arguments depending on their size
+  const _Tp __max_abs =
+    _CUDA_VSTD::fmax(_CUDA_VSTD::fabs(__x), _CUDA_VSTD::fmax(_CUDA_VSTD::fabs(__y), _CUDA_VSTD::fabs(__z)));
+  _Tp __scale;
+  if (__max_abs > __overflow_threshold)
+  { // x*x + y*y + z*z might overflow
+    __scale = __overflow_scale;
+  }
+  else if (__max_abs < 1 / __overflow_threshold)
+  { // x*x + y*y + z*z might underflow
+    __scale = 1 / __overflow_scale;
+  }
+  else
+  {
+    __scale = 1;
+  }
+  __x *= __scale;
+  __y *= __scale;
+  __z *= __scale;
+
+  // Compute hypot of scaled arguments and undo scaling
+  return _CUDA_VSTD::sqrt(__x * __x + __y * __y + __z * __z) / __scale;
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float hypot(float __x, float __y, float __z) noexcept
+{
+  return _CUDA_VSTD::__hypot(__x, __y, __z);
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float hypotf(float __x, float __y, float __z) noexcept
+{
+  return _CUDA_VSTD::__hypot(__x, __y, __z);
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double hypot(double __x, double __y, double __z) noexcept
+{
+  return _CUDA_VSTD::__hypot(__x, __y, __z);
+}
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double hypot(long double __x, long double __y, long double __z) noexcept
+{
+  return _CUDA_VSTD::__hypot(__x, __y, __z);
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double hypotl(long double __x, long double __y, long double __z) noexcept
+{
+  return _CUDA_VSTD::__hypot(__x, __y, __z);
+}
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#if defined(_LIBCUDACXX_HAS_NVFP16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __half hypot(__half __x, __half __y, __half __z) noexcept
+{
+  return __float2half(_CUDA_VSTD::__hypot(__half2float(__x), __half2float(__y), __half2float(__z)));
+}
+#endif // _LIBCUDACXX_HAS_NVFP16
+
+#if defined(_LIBCUDACXX_HAS_NVBF16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16
+hypot(__nv_bfloat16 __x, __nv_bfloat16 __y, __nv_bfloat16 __z) noexcept
+{
+  return __float2bfloat16(_CUDA_VSTD::__hypot(__bfloat162float(__x), __bfloat162float(__y), __bfloat162float(__z)));
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+_CCCL_TEMPLATE(class _A1, class _A2, class _A3)
+_CCCL_REQUIRES(_CCCL_TRAIT(is_arithmetic, _A1) _CCCL_AND _CCCL_TRAIT(is_arithmetic, _A2)
+                 _CCCL_AND _CCCL_TRAIT(is_arithmetic, _A3))
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __promote_t<_A1, _A2, _A3> hypot(_A1 __x, _A2 __y, _A3 __z) noexcept
+{
+  using __result_type = __promote_t<_A1, _A2, _A3>;
+  static_assert(!(_CCCL_TRAIT(is_same, _A1, __result_type) && _CCCL_TRAIT(is_same, _A2, __result_type)
+                  && _CCCL_TRAIT(is_same, _A3, __result_type)),
+                "");
+  return _CUDA_VSTD::hypot((__result_type) __x, (__result_type) __y, (__result_type) __z);
+}
+
+_LIBCUDACXX_END_NAMESPACE_STD
+
+#endif // _LIBCUDACXX___CMATH_HYPOT_H

--- a/libcudacxx/include/cuda/std/__cmath/inverse_hyperbolic_functions.h
+++ b/libcudacxx/include/cuda/std/__cmath/inverse_hyperbolic_functions.h
@@ -1,0 +1,241 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___CMATH_INVERSE_HYPERBOLIC_FUNCTIONS_H
+#define _LIBCUDACXX___CMATH_INVERSE_HYPERBOLIC_FUNCTIONS_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__cmath/common.h>
+#include <cuda/std/__type_traits/enable_if.h>
+#include <cuda/std/__type_traits/is_integral.h>
+
+#include <nv/target>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_STD
+
+// acosh
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float acosh(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_ACOSHF)
+  return _CCCL_BUILTIN_ACOSHF(__x);
+#else // ^^^ _CCCL_BUILTIN_ACOSHF ^^^ / vvv !_CCCL_BUILTIN_ACOSHF vvv
+  return ::acoshf(__x);
+#endif // !_CCCL_BUILTIN_ACOSHF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float acoshf(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_ACOSHF)
+  return _CCCL_BUILTIN_ACOSHF(__x);
+#else // ^^^ _CCCL_BUILTIN_ACOSHF ^^^ / vvv !_CCCL_BUILTIN_ACOSHF vvv
+  return ::acoshf(__x);
+#endif // !_CCCL_BUILTIN_ACOSHF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double acosh(double __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_ACOSH)
+  return _CCCL_BUILTIN_ACOSH(__x);
+#else // ^^^ _CCCL_BUILTIN_ACOSH ^^^ / vvv !_CCCL_BUILTIN_ACOSH vvv
+  return ::acosh(__x);
+#endif // !_CCCL_BUILTIN_ACOSH
+}
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double acosh(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_ACOSHL)
+  return _CCCL_BUILTIN_ACOSHL(__x);
+#  else // ^^^ _CCCL_BUILTIN_ACOSHL ^^^ / vvv !_CCCL_BUILTIN_ACOSHL vvv
+  return ::acoshl(__x);
+#  endif // !_CCCL_BUILTIN_ACOSHL
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double acoshl(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_ACOSHL)
+  return _CCCL_BUILTIN_ACOSHL(__x);
+#  else // ^^^ _CCCL_BUILTIN_ACOSHL ^^^ / vvv !_CCCL_BUILTIN_ACOSHL vvv
+  return ::acoshl(__x);
+#  endif // !_CCCL_BUILTIN_ACOSHL
+}
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#if defined(_LIBCUDACXX_HAS_NVFP16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __half acosh(__half __x) noexcept
+{
+  return __float2half(_CUDA_VSTD::acoshf(__half2float(__x)));
+}
+#endif // _LIBCUDACXX_HAS_NVFP16
+
+#if defined(_LIBCUDACXX_HAS_NVBF16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 acosh(__nv_bfloat16 __x) noexcept
+{
+  return __float2bfloat16(_CUDA_VSTD::acoshf(__bfloat162float(__x)));
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double acosh(_Integer __x) noexcept
+{
+  return _CUDA_VSTD::acosh((double) __x);
+}
+
+// asinh
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float asinh(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_ASINHF)
+  return _CCCL_BUILTIN_ASINHF(__x);
+#else // ^^^ _CCCL_BUILTIN_ASINHF ^^^ / vvv !_CCCL_BUILTIN_ASINHF vvv
+  return ::asinhf(__x);
+#endif // !_CCCL_BUILTIN_ASINHF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float asinhf(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_ASINHF)
+  return _CCCL_BUILTIN_ASINHF(__x);
+#else // ^^^ _CCCL_BUILTIN_ASINHF ^^^ / vvv !_CCCL_BUILTIN_ASINHF vvv
+  return ::asinhf(__x);
+#endif // !_CCCL_BUILTIN_ASINHF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double asinh(double __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_ASINH)
+  return _CCCL_BUILTIN_ASINH(__x);
+#else // ^^^ _CCCL_BUILTIN_ASINH ^^^ / vvv !_CCCL_BUILTIN_ASINH vvv
+  return ::asinh(__x);
+#endif // !_CCCL_BUILTIN_ASINH
+}
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double asinh(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_ASINHL)
+  return _CCCL_BUILTIN_ASINHL(__x);
+#  else // ^^^ _CCCL_BUILTIN_ASINHL ^^^ / vvv !_CCCL_BUILTIN_ASINHL vvv
+  return ::asinhl(__x);
+#  endif // !_CCCL_BUILTIN_ASINHL
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double asinhl(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_ASINHL)
+  return _CCCL_BUILTIN_ASINHL(__x);
+#  else // ^^^ _CCCL_BUILTIN_ASINHL ^^^ / vvv !_CCCL_BUILTIN_ASINHL vvv
+  return ::asinhl(__x);
+#  endif // !_CCCL_BUILTIN_ASINHL
+}
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#if defined(_LIBCUDACXX_HAS_NVFP16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __half asinh(__half __x) noexcept
+{
+  return __float2half(_CUDA_VSTD::asinhf(__half2float(__x)));
+}
+#endif // _LIBCUDACXX_HAS_NVFP16
+
+#if defined(_LIBCUDACXX_HAS_NVBF16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 asinh(__nv_bfloat16 __x) noexcept
+{
+  return __float2bfloat16(_CUDA_VSTD::asinhf(__bfloat162float(__x)));
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double asinh(_Integer __x) noexcept
+{
+  return _CUDA_VSTD::asinh((double) __x);
+}
+
+// atanh
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float atanh(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_ATANHF)
+  return _CCCL_BUILTIN_ATANHF(__x);
+#else // ^^^ _CCCL_BUILTIN_ATANHF ^^^ / vvv !_CCCL_BUILTIN_ATANHF vvv
+  return ::atanhf(__x);
+#endif // !_CCCL_BUILTIN_ATANHF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float atanhf(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_ATANHF)
+  return _CCCL_BUILTIN_ATANHF(__x);
+#else // ^^^ _CCCL_BUILTIN_ATANHF ^^^ / vvv !_CCCL_BUILTIN_ATANHF vvv
+  return ::atanhf(__x);
+#endif // !_CCCL_BUILTIN_ATANHF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double atanh(double __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_ATANH)
+  return _CCCL_BUILTIN_ATANH(__x);
+#else // ^^^ _CCCL_BUILTIN_ATANH ^^^ / vvv !_CCCL_BUILTIN_ATANH vvv
+  return ::atanh(__x);
+#endif // !_CCCL_BUILTIN_ATANH
+}
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double atanh(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_ATANHL)
+  return _CCCL_BUILTIN_ATANHL(__x);
+#  else // ^^^ _CCCL_BUILTIN_ATANHL ^^^ / vvv !_CCCL_BUILTIN_ATANHL vvv
+  return ::atanhl(__x);
+#  endif // !_CCCL_BUILTIN_ATANHL
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double atanhl(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_ATANHL)
+  return _CCCL_BUILTIN_ATANHL(__x);
+#  else // ^^^ _CCCL_BUILTIN_ATANHL ^^^ / vvv !_CCCL_BUILTIN_ATANHL vvv
+  return ::atanhl(__x);
+#  endif // !_CCCL_BUILTIN_ATANHL
+}
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#if defined(_LIBCUDACXX_HAS_NVFP16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __half atanh(__half __x) noexcept
+{
+  return __float2half(_CUDA_VSTD::atanhf(__half2float(__x)));
+}
+#endif // _LIBCUDACXX_HAS_NVFP16
+
+#if defined(_LIBCUDACXX_HAS_NVBF16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 atanh(__nv_bfloat16 __x) noexcept
+{
+  return __float2bfloat16(_CUDA_VSTD::atanhf(__bfloat162float(__x)));
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double atanh(_Integer __x) noexcept
+{
+  return _CUDA_VSTD::atanh((double) __x);
+}
+
+_LIBCUDACXX_END_NAMESPACE_STD
+
+#endif // _LIBCUDACXX___CMATH_INVERSE_HYPERBOLIC_FUNCTIONS_H

--- a/libcudacxx/include/cuda/std/__cmath/inverse_trigonometric_functions.h
+++ b/libcudacxx/include/cuda/std/__cmath/inverse_trigonometric_functions.h
@@ -1,0 +1,314 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___CMATH_INVERSE_TRIGONOMETRIC_FUNCTIONS_H
+#define _LIBCUDACXX___CMATH_INVERSE_TRIGONOMETRIC_FUNCTIONS_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__cmath/common.h>
+#include <cuda/std/__type_traits/enable_if.h>
+#include <cuda/std/__type_traits/is_arithmetic.h>
+#include <cuda/std/__type_traits/is_integral.h>
+#include <cuda/std/__type_traits/promote.h>
+
+#include <nv/target>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_STD
+
+// acos
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float acos(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_ACOSF)
+  return _CCCL_BUILTIN_ACOSF(__x);
+#else // ^^^ _CCCL_BUILTIN_ACOSF ^^^ / vvv !_CCCL_BUILTIN_ACOSF vvv
+  return ::acosf(__x);
+#endif // !_CCCL_BUILTIN_ACOSF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float acosf(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_ACOSF)
+  return _CCCL_BUILTIN_ACOSF(__x);
+#else // ^^^ _CCCL_BUILTIN_ACOSF ^^^ / vvv !_CCCL_BUILTIN_ACOSF vvv
+  return ::acosf(__x);
+#endif // !_CCCL_BUILTIN_ACOSF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double acos(double __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_ACOS)
+  return _CCCL_BUILTIN_ACOS(__x);
+#else // ^^^ _CCCL_BUILTIN_ACOS ^^^ / vvv !_CCCL_BUILTIN_ACOS vvv
+  return ::acos(__x);
+#endif // !_CCCL_BUILTIN_ACOS
+}
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double acos(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_ACOSL)
+  return _CCCL_BUILTIN_ACOSL(__x);
+#  else // ^^^ _CCCL_BUILTIN_ACOSL ^^^ / vvv !_CCCL_BUILTIN_ACOSL vvv
+  return ::acosl(__x);
+#  endif // !_CCCL_BUILTIN_ACOSL
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double acosl(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_ACOSL)
+  return _CCCL_BUILTIN_ACOSL(__x);
+#  else // ^^^ _CCCL_BUILTIN_ACOSL ^^^ / vvv !_CCCL_BUILTIN_ACOSL vvv
+  return ::acosl(__x);
+#  endif // !_CCCL_BUILTIN_ACOSL
+}
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#if defined(_LIBCUDACXX_HAS_NVFP16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __half acos(__half __x) noexcept
+{
+  return __float2half(_CUDA_VSTD::acosf(__half2float(__x)));
+}
+#endif // _LIBCUDACXX_HAS_NVFP16
+
+#if defined(_LIBCUDACXX_HAS_NVBF16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 acos(__nv_bfloat16 __x) noexcept
+{
+  return __float2bfloat16(_CUDA_VSTD::acosf(__bfloat162float(__x)));
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double acos(_Integer __x) noexcept
+{
+  return _CUDA_VSTD::acos((double) __x);
+}
+
+// asin
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float asin(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_ASINF)
+  return _CCCL_BUILTIN_ASINF(__x);
+#else // ^^^ _CCCL_BUILTIN_ASINF ^^^ / vvv !_CCCL_BUILTIN_ASINF vvv
+  return ::asinf(__x);
+#endif // !_CCCL_BUILTIN_ASINF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float asinf(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_ASINF)
+  return _CCCL_BUILTIN_ASINF(__x);
+#else // ^^^ _CCCL_BUILTIN_ASINF ^^^ / vvv !_CCCL_BUILTIN_ASINF vvv
+  return ::asinf(__x);
+#endif // !_CCCL_BUILTIN_ASINF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double asin(double __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_ASIN)
+  return _CCCL_BUILTIN_ASIN(__x);
+#else // ^^^ _CCCL_BUILTIN_ASIN ^^^ / vvv !_CCCL_BUILTIN_ASIN vvv
+  return ::asin(__x);
+#endif // !_CCCL_BUILTIN_ASIN
+}
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double asin(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_ASINL)
+  return _CCCL_BUILTIN_ASINL(__x);
+#  else // ^^^ _CCCL_BUILTIN_ASINL ^^^ / vvv !_CCCL_BUILTIN_ASINL vvv
+  return ::asinl(__x);
+#  endif // !_CCCL_BUILTIN_ASINL
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double asinl(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_ASINL)
+  return _CCCL_BUILTIN_ASINL(__x);
+#  else // ^^^ _CCCL_BUILTIN_ASINL ^^^ / vvv !_CCCL_BUILTIN_ASINL vvv
+  return ::asinl(__x);
+#  endif // !_CCCL_BUILTIN_ASINL
+}
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#if defined(_LIBCUDACXX_HAS_NVFP16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __half asin(__half __x) noexcept
+{
+  return __float2half(_CUDA_VSTD::asinf(__half2float(__x)));
+}
+#endif // _LIBCUDACXX_HAS_NVFP16
+
+#if defined(_LIBCUDACXX_HAS_NVBF16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 asin(__nv_bfloat16 __x) noexcept
+{
+  return __float2bfloat16(_CUDA_VSTD::asinf(__bfloat162float(__x)));
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double asin(_Integer __x) noexcept
+{
+  return _CUDA_VSTD::asin((double) __x);
+}
+
+// atan
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float atan(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_ATANF)
+  return _CCCL_BUILTIN_ATANF(__x);
+#else // ^^^ _CCCL_BUILTIN_ATANF ^^^ / vvv !_CCCL_BUILTIN_ATANF vvv
+  return ::atanf(__x);
+#endif // !_CCCL_BUILTIN_ATANF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float atanf(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_ATANF)
+  return _CCCL_BUILTIN_ATANF(__x);
+#else // ^^^ _CCCL_BUILTIN_ATANF ^^^ / vvv !_CCCL_BUILTIN_ATANF vvv
+  return ::atanf(__x);
+#endif // !_CCCL_BUILTIN_ATANF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double atan(double __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_ATAN)
+  return _CCCL_BUILTIN_ATAN(__x);
+#else // ^^^ _CCCL_BUILTIN_ATAN ^^^ / vvv !_CCCL_BUILTIN_ATAN vvv
+  return ::atan(__x);
+#endif // !_CCCL_BUILTIN_ATAN
+}
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double atan(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_ATANL)
+  return _CCCL_BUILTIN_ATANL(__x);
+#  else // ^^^ _CCCL_BUILTIN_ATANL ^^^ / vvv !_CCCL_BUILTIN_ATANL vvv
+  return ::atanl(__x);
+#  endif // !_CCCL_BUILTIN_ATANL
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double atanl(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_ATANL)
+  return _CCCL_BUILTIN_ATANL(__x);
+#  else // ^^^ _CCCL_BUILTIN_ATANL ^^^ / vvv !_CCCL_BUILTIN_ATANL vvv
+  return ::atanl(__x);
+#  endif // !_CCCL_BUILTIN_ATANL
+}
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#if defined(_LIBCUDACXX_HAS_NVFP16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __half atan(__half __x) noexcept
+{
+  return __float2half(_CUDA_VSTD::atanf(__half2float(__x)));
+}
+#endif // _LIBCUDACXX_HAS_NVFP16
+
+#if defined(_LIBCUDACXX_HAS_NVBF16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 atan(__nv_bfloat16 __x) noexcept
+{
+  return __float2bfloat16(_CUDA_VSTD::atanf(__bfloat162float(__x)));
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double atan(_Integer __x) noexcept
+{
+  return _CUDA_VSTD::atan((double) __x);
+}
+
+// atan2
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float atan2(float __x, float __y) noexcept
+{
+#if defined(_CCCL_BUILTIN_ATAN2F)
+  return _CCCL_BUILTIN_ATAN2F(__x, __y);
+#else // ^^^ _CCCL_BUILTIN_ATAN2F ^^^ // vvv !_CCCL_BUILTIN_ATAN2F vvv
+  return ::atan2f(__x, __y);
+#endif // !_CCCL_BUILTIN_ATAN2F
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float atan2f(float __x, float __y) noexcept
+{
+#if defined(_CCCL_BUILTIN_ATAN2F)
+  return _CCCL_BUILTIN_ATAN2F(__x, __y);
+#else // ^^^ _CCCL_BUILTIN_ATAN2F ^^^ // vvv !_CCCL_BUILTIN_ATAN2F vvv
+  return ::atan2f(__x, __y);
+#endif // !_CCCL_BUILTIN_ATAN2F
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double atan2(double __x, double __y) noexcept
+{
+#if defined(_CCCL_BUILTIN_ATAN2)
+  return _CCCL_BUILTIN_ATAN2(__x, __y);
+#else // ^^^ _CCCL_BUILTIN_ATAN2 ^^^ // vvv !_CCCL_BUILTIN_ATAN2 vvv
+  return ::atan2(__x, __y);
+#endif // !_CCCL_BUILTIN_ATAN2
+}
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double atan2(long double __x, long double __y) noexcept
+{
+#  if defined(_CCCL_BUILTIN_ATAN2L)
+  return _CCCL_BUILTIN_ATAN2L(__x, __y);
+#  else // ^^^ _CCCL_BUILTIN_ATAN2L ^^^ // vvv !_CCCL_BUILTIN_ATAN2L vvv
+  return ::atan2l(__x, __y);
+#  endif // !_CCCL_BUILTIN_ATAN2L
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double atan2l(long double __x, long double __y) noexcept
+{
+#  if defined(_CCCL_BUILTIN_ATAN2L)
+  return _CCCL_BUILTIN_ATAN2L(__x, __y);
+#  else // ^^^ _CCCL_BUILTIN_ATAN2L ^^^ // vvv !_CCCL_BUILTIN_ATAN2L vvv
+  return ::atan2l(__x, __y);
+#  endif // !_CCCL_BUILTIN_ATAN2L
+}
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#if defined(_LIBCUDACXX_HAS_NVFP16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __half atan2(__half __x, __half __y) noexcept
+{
+  return __float2half(_CUDA_VSTD::atan2f(__half2float(__x), __half2float(__y)));
+}
+#endif // _LIBCUDACXX_HAS_NVFP16
+
+#if defined(_LIBCUDACXX_HAS_NVBF16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 atan2(__nv_bfloat16 __x, __nv_bfloat16 __y) noexcept
+{
+  return __float2bfloat16(_CUDA_VSTD::atan2f(__bfloat162float(__x), __bfloat162float(__y)));
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+template <class _A1, class _A2, enable_if_t<_CCCL_TRAIT(is_arithmetic, _A1) && _CCCL_TRAIT(is_arithmetic, _A2), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __promote_t<_A1, _A2> atan2(_A1 __x, _A2 __y) noexcept
+{
+  using __result_type = __promote_t<_A1, _A2>;
+  static_assert(!(_CCCL_TRAIT(is_same, _A1, __result_type) && _CCCL_TRAIT(is_same, _A2, __result_type)), "");
+  return _CUDA_VSTD::atan2((__result_type) __x, (__result_type) __y);
+}
+
+_LIBCUDACXX_END_NAMESPACE_STD
+
+#endif // _LIBCUDACXX___CMATH_INVERSE_TRIGONOMETRIC_FUNCTIONS_H

--- a/libcudacxx/include/cuda/std/__cmath/nvbf16.h
+++ b/libcudacxx/include/cuda/std/__cmath/nvbf16.h
@@ -34,13 +34,6 @@ _CCCL_DIAG_POP
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-// trigonometric functions
-
-_LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 hypot(__nv_bfloat16 __x, __nv_bfloat16 __y)
-{
-  return __float2bfloat16(::hypotf(__bfloat162float(__x), __bfloat162float(__y)));
-}
-
 // floating point helper
 _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 __constexpr_copysign(__nv_bfloat16 __x, __nv_bfloat16 __y) noexcept
 {

--- a/libcudacxx/include/cuda/std/__cmath/nvbf16.h
+++ b/libcudacxx/include/cuda/std/__cmath/nvbf16.h
@@ -36,16 +36,6 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 // trigonometric functions
 
-_LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 sinh(__nv_bfloat16 __v)
-{
-  return __float2bfloat16(::sinhf(__bfloat162float(__v)));
-}
-
-_LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 cosh(__nv_bfloat16 __v)
-{
-  return __float2bfloat16(::coshf(__bfloat162float(__v)));
-}
-
 _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 hypot(__nv_bfloat16 __x, __nv_bfloat16 __y)
 {
   return __float2bfloat16(::hypotf(__bfloat162float(__x), __bfloat162float(__y)));

--- a/libcudacxx/include/cuda/std/__cmath/nvbf16.h
+++ b/libcudacxx/include/cuda/std/__cmath/nvbf16.h
@@ -41,11 +41,6 @@ _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 hypot(__nv_bfloat16 __x, __nv_bfloat16 _
   return __float2bfloat16(::hypotf(__bfloat162float(__x), __bfloat162float(__y)));
 }
 
-_LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 atan2(__nv_bfloat16 __x, __nv_bfloat16 __y)
-{
-  return __float2bfloat16(::atan2f(__bfloat162float(__x), __bfloat162float(__y)));
-}
-
 // floating point helper
 _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 __constexpr_copysign(__nv_bfloat16 __x, __nv_bfloat16 __y) noexcept
 {

--- a/libcudacxx/include/cuda/std/__cmath/nvbf16.h
+++ b/libcudacxx/include/cuda/std/__cmath/nvbf16.h
@@ -35,19 +35,10 @@ _CCCL_DIAG_POP
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 // trigonometric functions
-_LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 sin(__nv_bfloat16 __v)
-{
-  NV_IF_ELSE_TARGET(NV_IS_DEVICE, (return ::hsin(__v);), (return __float2bfloat16(::sinf(__bfloat162float(__v)));))
-}
 
 _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 sinh(__nv_bfloat16 __v)
 {
   return __float2bfloat16(::sinhf(__bfloat162float(__v)));
-}
-
-_LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 cos(__nv_bfloat16 __v)
-{
-  NV_IF_ELSE_TARGET(NV_IS_DEVICE, (return ::hcos(__v);), (return __float2bfloat16(::cosf(__bfloat162float(__v)));))
 }
 
 _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 cosh(__nv_bfloat16 __v)

--- a/libcudacxx/include/cuda/std/__cmath/nvfp16.h
+++ b/libcudacxx/include/cuda/std/__cmath/nvfp16.h
@@ -32,65 +32,11 @@
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 // trigonometric functions
-_LIBCUDACXX_HIDE_FROM_ABI __half sin(__half __v)
-{
-  NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53, (return ::hsin(__v);), ({
-                      float __vf            = __half2float(__v);
-                      __vf                  = ::sinf(__vf);
-                      __half_raw __ret_repr = ::__float2half_rn(__vf);
-
-                      uint16_t __repr = __half_raw(__v).x;
-                      switch (__repr)
-                      {
-                        case 12979:
-                        case 45747:
-                          __ret_repr.x += 1;
-                          break;
-
-                        case 23728:
-                        case 56496:
-                          __ret_repr.x -= 1;
-                          break;
-
-                        default:;
-                      }
-
-                      return __ret_repr;
-                    }))
-}
 
 _LIBCUDACXX_HIDE_FROM_ABI __half sinh(__half __v)
 {
   return __float2half(::sinhf(__half2float(__v)));
 }
-
-// clang-format off
-_LIBCUDACXX_HIDE_FROM_ABI  __half cos(__half __v)
-{
-  NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53, (
-    return ::hcos(__v);
-  ), (
-    {
-      float __vf            = __half2float(__v);
-      __vf                  = ::cosf(__vf);
-      __half_raw __ret_repr = ::__float2half_rn(__vf);
-
-      uint16_t __repr = __half_raw(__v).x;
-      switch (__repr)
-      {
-        case 11132:
-        case 43900:
-          __ret_repr.x += 1;
-          break;
-
-        default:;
-      }
-
-      return __ret_repr;
-    }
-  ))
-}
-// clang-format on
 
 _LIBCUDACXX_HIDE_FROM_ABI __half cosh(__half __v)
 {

--- a/libcudacxx/include/cuda/std/__cmath/nvfp16.h
+++ b/libcudacxx/include/cuda/std/__cmath/nvfp16.h
@@ -31,13 +31,6 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-// trigonometric functions
-
-_LIBCUDACXX_HIDE_FROM_ABI __half hypot(__half __x, __half __y)
-{
-  return __float2half(::hypotf(__half2float(__x), __half2float(__y)));
-}
-
 // floating point helper
 _LIBCUDACXX_HIDE_FROM_ABI __half __constexpr_copysign(__half __x, __half __y) noexcept
 {

--- a/libcudacxx/include/cuda/std/__cmath/nvfp16.h
+++ b/libcudacxx/include/cuda/std/__cmath/nvfp16.h
@@ -38,11 +38,6 @@ _LIBCUDACXX_HIDE_FROM_ABI __half hypot(__half __x, __half __y)
   return __float2half(::hypotf(__half2float(__x), __half2float(__y)));
 }
 
-_LIBCUDACXX_HIDE_FROM_ABI __half atan2(__half __x, __half __y)
-{
-  return __float2half(::atan2f(__half2float(__x), __half2float(__y)));
-}
-
 // floating point helper
 _LIBCUDACXX_HIDE_FROM_ABI __half __constexpr_copysign(__half __x, __half __y) noexcept
 {

--- a/libcudacxx/include/cuda/std/__cmath/nvfp16.h
+++ b/libcudacxx/include/cuda/std/__cmath/nvfp16.h
@@ -33,16 +33,6 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 // trigonometric functions
 
-_LIBCUDACXX_HIDE_FROM_ABI __half sinh(__half __v)
-{
-  return __float2half(::sinhf(__half2float(__v)));
-}
-
-_LIBCUDACXX_HIDE_FROM_ABI __half cosh(__half __v)
-{
-  return __float2half(::coshf(__half2float(__v)));
-}
-
 _LIBCUDACXX_HIDE_FROM_ABI __half hypot(__half __x, __half __y)
 {
   return __float2half(::hypotf(__half2float(__x), __half2float(__y)));

--- a/libcudacxx/include/cuda/std/__cmath/trigonometric_functions.h
+++ b/libcudacxx/include/cuda/std/__cmath/trigonometric_functions.h
@@ -1,0 +1,283 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___CMATH_TRIGONOMETRIC_FUNCTIONS_H
+#define _LIBCUDACXX___CMATH_TRIGONOMETRIC_FUNCTIONS_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__cmath/common.h>
+#include <cuda/std/__type_traits/enable_if.h>
+#include <cuda/std/__type_traits/is_integral.h>
+#include <cuda/std/cstdint>
+
+#include <nv/target>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_STD
+
+// cos
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float cos(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_COSF)
+  return _CCCL_BUILTIN_COSF(__x);
+#else // ^^^ _CCCL_BUILTIN_COSF ^^^ / vvv !_CCCL_BUILTIN_COSF vvv
+  return ::cosf(__x);
+#endif // !_CCCL_BUILTIN_COSF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float cosf(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_COSF)
+  return _CCCL_BUILTIN_COSF(__x);
+#else // ^^^ _CCCL_BUILTIN_COSF ^^^ / vvv !_CCCL_BUILTIN_COSF vvv
+  return ::cosf(__x);
+#endif // !_CCCL_BUILTIN_COSF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double cos(double __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_COS)
+  return _CCCL_BUILTIN_COS(__x);
+#else // ^^^ _CCCL_BUILTIN_COS ^^^ / vvv !_CCCL_BUILTIN_COS vvv
+  return ::cos(__x);
+#endif // !_CCCL_BUILTIN_COS
+}
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double cos(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_COSL)
+  return _CCCL_BUILTIN_COSL(__x);
+#  else // ^^^ _CCCL_BUILTIN_COSL ^^^ / vvv !_CCCL_BUILTIN_COSL vvv
+  return ::cosl(__x);
+#  endif // !_CCCL_BUILTIN_COSL
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double cosl(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_COSL)
+  return _CCCL_BUILTIN_COSL(__x);
+#  else // ^^^ _CCCL_BUILTIN_COSL ^^^ / vvv !_CCCL_BUILTIN_COSL vvv
+  return ::cosl(__x);
+#  endif // !_CCCL_BUILTIN_COSL
+}
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#if defined(_LIBCUDACXX_HAS_NVFP16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __half cos(__half __x) noexcept
+{
+  NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53, (return ::hcos(__x);), ({
+                      float __xf            = __half2float(__x);
+                      __xf                  = _CUDA_VSTD::cosf(__xf);
+                      __half_raw __ret_repr = ::__float2half_rn(__xf);
+
+                      uint16_t __repr = __half_raw(__x).x;
+                      switch (__repr)
+                      {
+                        case 11132:
+                        case 43900:
+                          __ret_repr.x += 1;
+                          break;
+
+                        default:;
+                      }
+
+                      return __ret_repr;
+                    }))
+}
+#endif // _LIBCUDACXX_HAS_NVFP16
+
+#if defined(_LIBCUDACXX_HAS_NVBF16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 cos(__nv_bfloat16 __x) noexcept
+{
+  NV_IF_ELSE_TARGET(
+    NV_IS_DEVICE, (return ::hcos(__x);), (return __float2bfloat16(_CUDA_VSTD::cosf(__bfloat162float(__x)));))
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double cos(_Integer __x) noexcept
+{
+  return _CUDA_VSTD::cos((double) __x);
+}
+
+// sin
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float sin(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_SINF)
+  return _CCCL_BUILTIN_SINF(__x);
+#else // ^^^ _CCCL_BUILTIN_SINF ^^^ / vvv !_CCCL_BUILTIN_SINF vvv
+  return ::sinf(__x);
+#endif // !_CCCL_BUILTIN_SINF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float sinf(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_SINF)
+  return _CCCL_BUILTIN_SINF(__x);
+#else // ^^^ _CCCL_BUILTIN_SINF ^^^ / vvv !_CCCL_BUILTIN_SINF vvv
+  return ::sinf(__x);
+#endif // !_CCCL_BUILTIN_SINF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double sin(double __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_SIN)
+  return _CCCL_BUILTIN_SIN(__x);
+#else // ^^^ _CCCL_BUILTIN_SIN ^^^ / vvv !_CCCL_BUILTIN_SIN vvv
+  return ::sin(__x);
+#endif // !_CCCL_BUILTIN_SIN
+}
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double sin(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_SINL)
+  return _CCCL_BUILTIN_SINL(__x);
+#  else // ^^^ _CCCL_BUILTIN_SINL ^^^ / vvv !_CCCL_BUILTIN_SINL vvv
+  return ::sinl(__x);
+#  endif // !_CCCL_BUILTIN_SINL
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double sinl(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_SINL)
+  return _CCCL_BUILTIN_SINL(__x);
+#  else // ^^^ _CCCL_BUILTIN_SINL ^^^ / vvv !_CCCL_BUILTIN_SINL vvv
+  return ::sinl(__x);
+#  endif // !_CCCL_BUILTIN_SINL
+}
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#if defined(_LIBCUDACXX_HAS_NVFP16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __half sin(__half __x) noexcept
+{
+  NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53, (return ::hsin(__x);), ({
+                      float __xf            = __half2float(__x);
+                      __xf                  = _CUDA_VSTD::sinf(__xf);
+                      __half_raw __ret_repr = ::__float2half_rn(__xf);
+
+                      uint16_t __repr = __half_raw(__x).x;
+                      switch (__repr)
+                      {
+                        case 12979:
+                        case 45747:
+                          __ret_repr.x += 1;
+                          break;
+
+                        case 23728:
+                        case 56496:
+                          __ret_repr.x -= 1;
+                          break;
+
+                        default:;
+                      }
+
+                      return __ret_repr;
+                    }))
+}
+#endif // _LIBCUDACXX_HAS_NVFP16
+
+#if defined(_LIBCUDACXX_HAS_NVBF16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 sin(__nv_bfloat16 __x) noexcept
+{
+  NV_IF_ELSE_TARGET(
+    NV_IS_DEVICE, (return ::hsin(__x);), (return __float2bfloat16(_CUDA_VSTD::sinf(__bfloat162float(__x)));))
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double sin(_Integer __x) noexcept
+{
+  return _CUDA_VSTD::sin((double) __x);
+}
+
+// tan
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float tan(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_TANF)
+  return _CCCL_BUILTIN_TANF(__x);
+#else // ^^^ _CCCL_BUILTIN_TANF ^^^ / vvv !_CCCL_BUILTIN_TANF vvv
+  return ::tanf(__x);
+#endif // !_CCCL_BUILTIN_TANF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float tanf(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_TANF)
+  return _CCCL_BUILTIN_TANF(__x);
+#else // ^^^ _CCCL_BUILTIN_TANF ^^^ / vvv !_CCCL_BUILTIN_TANF vvv
+  return ::tanf(__x);
+#endif // !_CCCL_BUILTIN_TANF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double tan(double __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_TAN)
+  return _CCCL_BUILTIN_TAN(__x);
+#else // ^^^ _CCCL_BUILTIN_TAN ^^^ / vvv !_CCCL_BUILTIN_TAN vvv
+  return ::tan(__x);
+#endif // !_CCCL_BUILTIN_TAN
+}
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double tan(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_TANL)
+  return _CCCL_BUILTIN_TANL(__x);
+#  else // ^^^ _CCCL_BUILTIN_TANL ^^^ / vvv !_CCCL_BUILTIN_TANL vvv
+  return ::tanl(__x);
+#  endif // !_CCCL_BUILTIN_TANL
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double tanl(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_TANL)
+  return _CCCL_BUILTIN_TANL(__x);
+#  else // ^^^ _CCCL_BUILTIN_TANL ^^^ / vvv !_CCCL_BUILTIN_TANL vvv
+  return ::tanl(__x);
+#  endif // !_CCCL_BUILTIN_TANL
+}
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#if defined(_LIBCUDACXX_HAS_NVFP16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __half tan(__half __x) noexcept
+{
+  return __float2half(_CUDA_VSTD::tanf(__half2float(__x)));
+}
+#endif // _LIBCUDACXX_HAS_NVFP16
+
+#if defined(_LIBCUDACXX_HAS_NVBF16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 tan(__nv_bfloat16 __x) noexcept
+{
+  return __float2bfloat16(_CUDA_VSTD::tanf(__bfloat162float(__x)));
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double tan(_Integer __x) noexcept
+{
+  return _CUDA_VSTD::tan((double) __x);
+}
+
+_LIBCUDACXX_END_NAMESPACE_STD
+
+#endif // _LIBCUDACXX___CMATH_TRIGONOMETRIC_FUNCTIONS_H

--- a/libcudacxx/include/cuda/std/__internal/features.h
+++ b/libcudacxx/include/cuda/std/__internal/features.h
@@ -20,11 +20,6 @@
 #  pragma system_header
 #endif // no system header
 
-// If NVCC is not being used <complex> can safely use `long double` without warnings
-#if !_CCCL_CUDA_COMPILER(NVCC) && !_CCCL_COMPILER(NVRTC)
-#  define _LIBCUDACXX_HAS_COMPLEX_LONG_DOUBLE
-#endif // !_CCCL_CUDA_COMPILER(NVCC) && !_CCCL_COMPILER(NVRTC)
-
 #ifndef _LIBCUDACXX_HAS_EXTERNAL_ATOMIC_IMP
 #  define _LIBCUDACXX_HAS_EXTERNAL_ATOMIC_IMP
 #endif // _LIBCUDACXX_HAS_EXTERNAL_ATOMIC_IMP
@@ -61,9 +56,10 @@
 #endif // _LIBCUDACXX_HAS_NO_INCOMPLETE_RANGES
 
 #ifndef _LIBCUDACXX_HAS_NO_LONG_DOUBLE
-#  if _CCCL_HAS_CUDA_COMPILER
+// FIXME: Enable this for clang-cuda in a followup
+#  if 1 // !_CCCL_CUDA_COMPILER(CLANG)
 #    define _LIBCUDACXX_HAS_NO_LONG_DOUBLE
-#  endif // _CCCL_HAS_CUDA_COMPILER
+#  endif // !_CCCL_CUDA_COMPILER(CLANG)
 #endif // _LIBCUDACXX_HAS_NO_LONG_DOUBLE
 
 #ifndef _LIBCUDACXX_HAS_NO_MONOTONIC_CLOCK

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/cmath
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/cmath
@@ -321,6 +321,7 @@ long double    truncl(long double x);
 #include <cuda/std/__cmath/abs.h>
 #include <cuda/std/__cmath/exponential_functions.h>
 #include <cuda/std/__cmath/fpclassify.h>
+#include <cuda/std/__cmath/hyperbolic_functions.h>
 #include <cuda/std/__cmath/lerp.h>
 #include <cuda/std/__cmath/logarithms.h>
 #include <cuda/std/__cmath/min_max.h>
@@ -358,14 +359,6 @@ using ::atan;
 using ::atan2;
 using ::atan2f;
 using ::atanf;
-using ::cosh;
-using ::coshf;
-
-using ::sinh;
-using ::sinhf;
-
-using ::tanh;
-using ::tanhf;
 
 using ::acosh;
 using ::acoshf;
@@ -387,12 +380,6 @@ using ::fmodf;
 
 using ::modf;
 using ::modff;
-
-using ::sinh;
-using ::sinhf;
-
-using ::tanh;
-using ::tanhf;
 
 using ::acosh;
 using ::acoshf;
@@ -429,15 +416,12 @@ using ::acosl;
 using ::asinl;
 using ::atan2l;
 using ::atanl;
-using ::coshl;
 using ::fmodl;
 using ::modfl;
-using ::sinhl;
 
 using ::acoshl;
 using ::asinhl;
 using ::atanhl;
-using ::tanhl;
 
 using ::copysignl;
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/cmath
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/cmath
@@ -322,6 +322,7 @@ long double    truncl(long double x);
 #include <cuda/std/__cmath/exponential_functions.h>
 #include <cuda/std/__cmath/fpclassify.h>
 #include <cuda/std/__cmath/hyperbolic_functions.h>
+#include <cuda/std/__cmath/inverse_hyperbolic_functions.h>
 #include <cuda/std/__cmath/inverse_trigonometric_functions.h>
 #include <cuda/std/__cmath/lerp.h>
 #include <cuda/std/__cmath/logarithms.h>
@@ -352,13 +353,6 @@ _CCCL_PUSH_MACROS
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-using ::acosh;
-using ::acoshf;
-using ::asinh;
-using ::asinhf;
-using ::atanh;
-using ::atanhf;
-
 using ::hypot;
 using ::hypotf;
 
@@ -372,13 +366,6 @@ using ::fmodf;
 
 using ::modf;
 using ::modff;
-
-using ::acosh;
-using ::acoshf;
-using ::asinh;
-using ::asinhf;
-using ::atanh;
-using ::atanhf;
 
 using ::copysign;
 using ::copysignf;
@@ -406,10 +393,6 @@ using ::tgammaf;
 
 using ::fmodl;
 using ::modfl;
-
-using ::acoshl;
-using ::asinhl;
-using ::atanhl;
 
 using ::copysignl;
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/cmath
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/cmath
@@ -321,6 +321,7 @@ long double    truncl(long double x);
 #include <cuda/std/__cmath/abs.h>
 #include <cuda/std/__cmath/exponential_functions.h>
 #include <cuda/std/__cmath/fpclassify.h>
+#include <cuda/std/__cmath/gamma.h>
 #include <cuda/std/__cmath/hyperbolic_functions.h>
 #include <cuda/std/__cmath/inverse_hyperbolic_functions.h>
 #include <cuda/std/__cmath/inverse_trigonometric_functions.h>
@@ -378,8 +379,6 @@ using ::fdim;
 using ::fdimf;
 using ::fma;
 using ::fmaf;
-using ::lgamma;
-using ::lgammaf;
 
 using ::nan;
 using ::nanf;
@@ -388,8 +387,6 @@ using ::remainder;
 using ::remainderf;
 using ::remquo;
 using ::remquof;
-using ::tgamma;
-using ::tgammaf;
 
 using ::fmodl;
 using ::modfl;
@@ -401,11 +398,9 @@ using ::erfl;
 using ::fdiml;
 using ::fmal;
 using ::hypotl;
-using ::lgammal;
 using ::nanl;
 using ::remainderl;
 using ::remquol;
-using ::tgammal;
 
 #endif // _CCCL_COMPILER(NVRTC)
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/cmath
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/cmath
@@ -322,6 +322,7 @@ long double    truncl(long double x);
 #include <cuda/std/__cmath/exponential_functions.h>
 #include <cuda/std/__cmath/fpclassify.h>
 #include <cuda/std/__cmath/hyperbolic_functions.h>
+#include <cuda/std/__cmath/inverse_trigonometric_functions.h>
 #include <cuda/std/__cmath/lerp.h>
 #include <cuda/std/__cmath/logarithms.h>
 #include <cuda/std/__cmath/min_max.h>
@@ -350,15 +351,6 @@ long double    truncl(long double x);
 _CCCL_PUSH_MACROS
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
-
-using ::acos;
-using ::acosf;
-using ::asin;
-using ::asinf;
-using ::atan;
-using ::atan2;
-using ::atan2f;
-using ::atanf;
 
 using ::acosh;
 using ::acoshf;
@@ -412,10 +404,6 @@ using ::remquof;
 using ::tgamma;
 using ::tgammaf;
 
-using ::acosl;
-using ::asinl;
-using ::atan2l;
-using ::atanl;
 using ::fmodl;
 using ::modfl;
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/cmath
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/cmath
@@ -327,6 +327,7 @@ long double    truncl(long double x);
 #include <cuda/std/__cmath/roots.h>
 #include <cuda/std/__cmath/rounding_functions.h>
 #include <cuda/std/__cmath/traits.h>
+#include <cuda/std/__cmath/trigonometric_functions.h>
 #include <cuda/std/__cstdlib/abs.h>
 #include <cuda/std/limits>
 #include <cuda/std/type_traits>
@@ -357,18 +358,11 @@ using ::atan;
 using ::atan2;
 using ::atan2f;
 using ::atanf;
-using ::cos;
-using ::cosf;
 using ::cosh;
 using ::coshf;
 
-using ::sin;
-using ::sinf;
 using ::sinh;
 using ::sinhf;
-
-using ::tan;
-using ::tanf;
 
 using ::tanh;
 using ::tanhf;
@@ -394,13 +388,8 @@ using ::fmodf;
 using ::modf;
 using ::modff;
 
-using ::sin;
-using ::sinf;
 using ::sinh;
 using ::sinhf;
-
-using ::tan;
-using ::tanf;
 
 using ::tanh;
 using ::tanhf;
@@ -441,12 +430,9 @@ using ::asinl;
 using ::atan2l;
 using ::atanl;
 using ::coshl;
-using ::cosl;
 using ::fmodl;
 using ::modfl;
 using ::sinhl;
-using ::sinl;
-using ::tanl;
 
 using ::acoshl;
 using ::asinhl;

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/cmath
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/cmath
@@ -323,6 +323,7 @@ long double    truncl(long double x);
 #include <cuda/std/__cmath/fpclassify.h>
 #include <cuda/std/__cmath/gamma.h>
 #include <cuda/std/__cmath/hyperbolic_functions.h>
+#include <cuda/std/__cmath/hypot.h>
 #include <cuda/std/__cmath/inverse_hyperbolic_functions.h>
 #include <cuda/std/__cmath/inverse_trigonometric_functions.h>
 #include <cuda/std/__cmath/lerp.h>
@@ -353,9 +354,6 @@ long double    truncl(long double x);
 _CCCL_PUSH_MACROS
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
-
-using ::hypot;
-using ::hypotf;
 
 #if !_CCCL_COMPILER(NVRTC)
 
@@ -397,42 +395,11 @@ using ::erfcl;
 using ::erfl;
 using ::fdiml;
 using ::fmal;
-using ::hypotl;
 using ::nanl;
 using ::remainderl;
 using ::remquol;
 
 #endif // _CCCL_COMPILER(NVRTC)
-
-#ifndef __cuda_std__
-_LIBCUDACXX_HIDE_FROM_ABI float hypot(float x, float y, float z)
-{
-  return _CUDA_VSTD::sqrt(x * x + y * y + z * z);
-}
-_LIBCUDACXX_HIDE_FROM_ABI double hypot(double x, double y, double z)
-{
-  return _CUDA_VSTD::sqrt(x * x + y * y + z * z);
-}
-#  ifdef _LIBCUDACXX_HAS_COMPLEX_LONG_DOUBLE
-_LIBCUDACXX_HIDE_FROM_ABI long double hypot(long double x, long double y, long double z)
-{
-  return _CUDA_VSTD::sqrt(x * x + y * y + z * z);
-}
-#  endif
-
-template <class _A1, class _A2, class _A3>
-_LIBCUDACXX_HIDE_FROM_ABI
-enable_if_t<is_arithmetic<_A1>::value && is_arithmetic<_A2>::value && is_arithmetic<_A3>::value,
-            __promote_t<_A1, _A2, _A3>>
-hypot(_A1 __lcpp_x, _A2 __lcpp_y, _A3 __lcpp_z) noexcept
-{
-  using __result_type = __promote_t<_A1, _A2, _A3>;
-  static_assert(
-    (!(is_same<_A1, __result_type>::value && is_same<_A2, __result_type>::value && is_same<_A3, __result_type>::value)),
-    "");
-  return _CUDA_VSTD::hypot((__result_type) __lcpp_x, (__result_type) __lcpp_y, (__result_type) __lcpp_z);
-}
-#endif // !__cuda_std__
 
 #ifndef _LIBCUDACXX_HAS_NO_CONSTEXPR_COMPLEX_OPERATIONS
 #  define _CCCL_CONSTEXPR_CXX14_COMPLEX constexpr

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/complex
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/complex
@@ -893,13 +893,13 @@ _LIBCUDACXX_HIDE_FROM_ABI _Tp arg(const complex<_Tp>& __c)
   return _CUDA_VSTD::atan2(__c.imag(), __c.real());
 }
 
-#ifdef _LIBCUDACXX_HAS_COMPLEX_LONG_DOUBLE
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
 template <class _Tp>
 _LIBCUDACXX_HIDE_FROM_ABI enable_if_t<is_same<_Tp, long double>::value, long double> arg(_Tp __re)
 {
   return _CUDA_VSTD::atan2l(0.L, __re);
 }
-#endif // _LIBCUDACXX_HAS_COMPLEX_LONG_DOUBLE
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
 
 template <class _Tp>
 _LIBCUDACXX_HIDE_FROM_ABI enable_if_t<is_integral<_Tp>::value || is_same<_Tp, double>::value, double> arg(_Tp __re)
@@ -1512,7 +1512,7 @@ inline namespace literals
 {
 inline namespace complex_literals
 {
-#  ifdef _LIBCUDACXX_HAS_COMPLEX_LONG_DOUBLE
+#  if !_CCCL_CUDA_COMPILER(NVCC) && !_CCCL_COMPILER(NVRTC)
 // NOTE: if you get a warning from GCC <7 here that "literal operator suffixes not preceded by ‘_’ are reserved for
 // future standardization" then we are sorry. The warning was implemented before GCC 7, but can only be disabled since
 // GCC 7. See also: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=69523
@@ -1544,7 +1544,7 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr complex<float> operator""if(unsigned long lo
 {
   return {0.0f, static_cast<float>(__im)};
 }
-#  else // ^^^ _LIBCUDACXX_HAS_COMPLEX_LONG_DOUBLE ^^^ / vvv !_LIBCUDACXX_HAS_COMPLEX_LONG_DOUBLE vvv
+#  else // ^^^ !_CCCL_CUDA_COMPILER(NVCC) && !_CCCL_COMPILER(NVRTC) ^^^ / vvv other compilers vvv
 _LIBCUDACXX_HIDE_FROM_ABI constexpr complex<double> operator""i(double __im)
 {
   return {0.0, static_cast<double>(__im)};
@@ -1564,7 +1564,7 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr complex<float> operator""if(unsigned long lo
 {
   return {0.0f, static_cast<float>(__im)};
 }
-#  endif // !_LIBCUDACXX_HAS_COMPLEX_LONG_DOUBLE
+#  endif // other compilers
 } // namespace complex_literals
 } // namespace literals
 

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/comparison.h
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/comparison.h
@@ -20,7 +20,7 @@ __host__ __device__ bool eq(T lhs, T rhs) noexcept
   return lhs == rhs;
 }
 
-template <typename T, typename U, cuda::std::enable_if_t<cuda::std::is_arithmetic<U>::value, int> = 0>
+template <typename T, typename U, cuda::std::enable_if_t<cuda::std::is_arithmetic_v<U>, int> = 0>
 __host__ __device__ bool eq(T lhs, U rhs) noexcept
 {
   return eq(lhs, T(rhs));

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/comparison.h
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/comparison.h
@@ -1,0 +1,80 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TEST_CMATH_COMPARISON_H
+#define TEST_CMATH_COMPARISON_H
+
+#include <cuda/std/type_traits>
+
+#include "test_macros.h"
+
+template <typename T>
+__host__ __device__ bool eq(T lhs, T rhs) noexcept
+{
+  return lhs == rhs;
+}
+
+template <typename T, typename U, cuda::std::enable_if_t<cuda::std::is_arithmetic<U>::value, int> = 0>
+__host__ __device__ bool eq(T lhs, U rhs) noexcept
+{
+  return eq(lhs, T(rhs));
+}
+
+#ifdef _LIBCUDACXX_HAS_NVFP16
+__host__ __device__ bool eq(__half lhs, __half rhs) noexcept
+{
+  return ::__heq(lhs, rhs);
+}
+#endif // _LIBCUDACXX_HAS_NVFP16
+
+#ifdef _LIBCUDACXX_HAS_NVBF16
+__host__ __device__ bool eq(__nv_bfloat16 lhs, __nv_bfloat16 rhs) noexcept
+{
+  return ::__heq(lhs, rhs);
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+template <class Integer>
+__host__ __device__ bool is_about(Integer x, Integer y)
+{
+  return true;
+}
+
+__host__ __device__ bool is_about(float x, float y)
+{
+  return (cuda::std::abs((x - y) / (x + y)) < 1.e-6);
+}
+
+__host__ __device__ bool is_about(double x, double y)
+{
+  return (cuda::std::abs((x - y) / (x + y)) < 1.e-14);
+}
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+__host__ __device__ bool is_about(long double x, long double y)
+{
+  return (cuda::std::abs((x - y) / (x + y)) < 1.e-14);
+}
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#ifdef _LIBCUDACXX_HAS_NVFP16
+__host__ __device__ bool is_about(__half x, __half y)
+{
+  return (cuda::std::fabs((x - y) / (x + y)) <= __half(1e-3));
+}
+#endif // _LIBCUDACXX_HAS_NVFP16
+
+#ifdef _LIBCUDACXX_HAS_NVBF16
+__host__ __device__ bool is_about(__nv_bfloat16 x, __nv_bfloat16 y)
+{
+  return (cuda::std::fabs((x - y) / (x + y)) <= __nv_bfloat16(5e-3));
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+#endif // TEST_CMATH_COMPARISON_H

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/exponential_functions.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/exponential_functions.pass.cpp
@@ -14,6 +14,7 @@
 #include <cuda/std/limits>
 #include <cuda/std/type_traits>
 
+#include "comparison.h"
 #include "test_macros.h"
 
 #if defined(TEST_COMPILER_MSVC)
@@ -21,68 +22,6 @@
 #  pragma warning(disable : 4305) // 'argument': truncation from 'T' to 'float'
 #  pragma warning(disable : 4146) // unary minus operator applied to unsigned type, result still unsigned
 #endif // TEST_COMPILER_MSVC
-
-template <typename T>
-__host__ __device__ bool eq(T lhs, T rhs) noexcept
-{
-  return lhs == rhs;
-}
-
-template <typename T, typename U, cuda::std::enable_if_t<cuda::std::is_arithmetic<U>::value, int> = 0>
-__host__ __device__ bool eq(T lhs, U rhs) noexcept
-{
-  return eq(lhs, T(rhs));
-}
-
-#ifdef _LIBCUDACXX_HAS_NVFP16
-__host__ __device__ bool eq(__half lhs, __half rhs) noexcept
-{
-  return ::__heq(lhs, rhs);
-}
-#endif // _LIBCUDACXX_HAS_NVFP16
-#ifdef _LIBCUDACXX_HAS_NVBF16
-__host__ __device__ bool eq(__nv_bfloat16 lhs, __nv_bfloat16 rhs) noexcept
-{
-  return ::__heq(lhs, rhs);
-}
-#endif // _LIBCUDACXX_HAS_NVBF16
-
-template <class Integer>
-__host__ __device__ bool is_about(Integer x, Integer y)
-{
-  return true;
-}
-
-__host__ __device__ bool is_about(float x, float y)
-{
-  return (cuda::std::abs((x - y) / (x + y)) < 1.e-6);
-}
-
-__host__ __device__ bool is_about(double x, double y)
-{
-  return (cuda::std::abs((x - y) / (x + y)) < 1.e-14);
-}
-
-#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-__host__ __device__ bool is_about(long double x, long double y)
-{
-  return (cuda::std::abs((x - y) / (x + y)) < 1.e-14);
-}
-#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
-
-#ifdef _LIBCUDACXX_HAS_NVFP16
-__host__ __device__ bool is_about(__half x, __half y)
-{
-  return (cuda::std::fabs((x - y) / (x + y)) <= __half(1e-3));
-}
-#endif // _LIBCUDACXX_HAS_NVFP16
-
-#ifdef _LIBCUDACXX_HAS_NVBF16
-__host__ __device__ bool is_about(__nv_bfloat16 x, __nv_bfloat16 y)
-{
-  return (cuda::std::fabs((x - y) / (x + y)) <= __nv_bfloat16(5e-3));
-}
-#endif // _LIBCUDACXX_HAS_NVBF16
 
 template <typename T>
 __host__ __device__ void test_exp(T val)

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/exponential_functions.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/exponential_functions.pass.cpp
@@ -26,24 +26,24 @@
 template <typename T>
 __host__ __device__ void test_exp(T val)
 {
-  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
-  static_assert(cuda::std::is_same<decltype(cuda::std::exp(T{})), ret>::value, "");
+  using ret = cuda::std::conditional_t<cuda::std::is_integral_v<T>, double, T>;
+  static_assert(cuda::std::is_same_v<decltype(cuda::std::exp(T{})), ret>, "");
 
   const T euler = T(2.718281828459045);
   assert(eq(cuda::std::exp(T(-0.0)), T(1.0)));
-  if (!cuda::std::is_integral<T>::value)
+  if constexpr (!cuda::std::is_integral_v<T>)
   {
     assert(eq(cuda::std::exp(val), euler));
     assert(eq(cuda::std::exp(T(-cuda::std::numeric_limits<T>::infinity())), T(0.0)));
   }
-  if (cuda::std::is_same<T, float>::value)
+  if constexpr (cuda::std::is_same_v<T, float>)
   {
     assert(eq(cuda::std::expf(val), euler));
     assert(eq(cuda::std::expf(T(-0.0)), T(1.0)));
     assert(eq(cuda::std::expf(T(-cuda::std::numeric_limits<T>::infinity())), T(0.0)));
   }
 #if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  else if (cuda::std::is_same<T, long double>::value)
+  else if constexpr (cuda::std::is_same_v<T, long double>)
   {
     assert(eq(cuda::std::expl(val), euler));
     assert(eq(cuda::std::expl(T(-0.0)), T(1.0)));
@@ -55,18 +55,18 @@ __host__ __device__ void test_exp(T val)
 template <typename T>
 __host__ __device__ void test_exp2(T val)
 {
-  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
-  static_assert(cuda::std::is_same<decltype(cuda::std::exp2(T{})), ret>::value, "");
+  using ret = cuda::std::conditional_t<cuda::std::is_integral_v<T>, double, T>;
+  static_assert(cuda::std::is_same_v<decltype(cuda::std::exp2(T{})), ret>, "");
 
   assert(eq(cuda::std::exp2(val), T(2.0)));
   assert(eq(cuda::std::exp2(val * T(4)), T(16.0)));
   assert(eq(cuda::std::exp2(T(-0.0)), T(1.0)));
-  if (!cuda::std::is_integral<T>::value)
+  if constexpr (!cuda::std::is_integral_v<T>)
   {
     assert(eq(cuda::std::exp2(val * T(-4)), T(0.0625)));
     assert(eq(cuda::std::exp2(T(-cuda::std::numeric_limits<T>::infinity())), T(0.0)));
   }
-  if (cuda::std::is_same<T, float>::value)
+  if constexpr (cuda::std::is_same_v<T, float>)
   {
     assert(eq(cuda::std::exp2f(val), T(2.0)));
     assert(eq(cuda::std::exp2f(val * T(4)), T(16.0)));
@@ -75,7 +75,7 @@ __host__ __device__ void test_exp2(T val)
     assert(eq(cuda::std::exp2f(T(-cuda::std::numeric_limits<T>::infinity())), T(0.0)));
   }
 #if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  else if (cuda::std::is_same<T, long double>::value)
+  else if constexpr (cuda::std::is_same_v<T, long double>)
   {
     assert(eq(cuda::std::exp2l(val), T(2.0)));
     assert(eq(cuda::std::exp2l(val * T(4)), T(16.0)));
@@ -89,18 +89,18 @@ __host__ __device__ void test_exp2(T val)
 template <typename T>
 __host__ __device__ void test_expm1(T val)
 {
-  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
-  static_assert(cuda::std::is_same<decltype(cuda::std::expm1(T{})), ret>::value, "");
+  using ret = cuda::std::conditional_t<cuda::std::is_integral_v<T>, double, T>;
+  static_assert(cuda::std::is_same_v<decltype(cuda::std::expm1(T{})), ret>, "");
 
   const T eulerm1 = T(1.718281828459045);
   assert(eq(cuda::std::expm1(T(-0.0)), T(-0.0)));
-  if (!cuda::std::is_integral<T>::value)
+  if constexpr (!cuda::std::is_integral_v<T>)
   {
     assert(is_about(T(cuda::std::expm1(val)), eulerm1));
     assert(eq(cuda::std::expm1(800), cuda::std::numeric_limits<T>::infinity()));
     assert(eq(cuda::std::expm1(T(-cuda::std::numeric_limits<T>::infinity())), T(-1)));
   }
-  if (cuda::std::is_same<T, float>::value)
+  if constexpr (cuda::std::is_same_v<T, float>)
   {
     assert(is_about(T(cuda::std::expm1f(val)), eulerm1));
     assert(eq(cuda::std::expm1f(T(-0.0)), T(-0.0)));
@@ -108,7 +108,7 @@ __host__ __device__ void test_expm1(T val)
     assert(eq(cuda::std::expm1f(T(-cuda::std::numeric_limits<T>::infinity())), T(-1)));
   }
 #if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  else if (cuda::std::is_same<T, long double>::value)
+  else if constexpr (cuda::std::is_same_v<T, long double>)
   {
     assert(is_about(T(cuda::std::expm1l(val)), eulerm1));
     assert(eq(cuda::std::expm1l(T(-0.0)), T(-0.0)));
@@ -121,8 +121,8 @@ __host__ __device__ void test_expm1(T val)
 template <typename T>
 __host__ __device__ void test_frexp(T val)
 {
-  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
-  static_assert(cuda::std::is_same<decltype(cuda::std::frexp(T{}, nullptr)), ret>::value, "");
+  using ret = cuda::std::conditional_t<cuda::std::is_integral_v<T>, double, T>;
+  static_assert(cuda::std::is_same_v<decltype(cuda::std::frexp(T{}, nullptr)), ret>, "");
 
   int exponent = -1;
   assert(eq(cuda::std::frexp(T(0.0), &exponent), T(0.0)));
@@ -130,7 +130,7 @@ __host__ __device__ void test_frexp(T val)
   exponent = -1;
   assert(eq(cuda::std::frexp(T(-0.0), &exponent), T(0.0)));
   assert(exponent == 0);
-  if (!cuda::std::is_integral<T>::value)
+  if constexpr (!cuda::std::is_integral_v<T>)
   {
     exponent = -1;
     assert(eq(cuda::std::frexp(val, &exponent), T(0.5)));
@@ -142,7 +142,7 @@ __host__ __device__ void test_frexp(T val)
               T(-cuda::std::numeric_limits<T>::infinity())));
     assert(cuda::std::isnan(cuda::std::frexp(T(cuda::std::numeric_limits<T>::quiet_NaN()), &exponent)));
   }
-  if (cuda::std::is_same<T, float>::value)
+  if constexpr (cuda::std::is_same_v<T, float>)
   {
     exponent = -1;
     assert(eq(cuda::std::frexpf(val, &exponent), T(0.5)));
@@ -163,7 +163,7 @@ __host__ __device__ void test_frexp(T val)
     assert(cuda::std::isnan(cuda::std::frexpf(T(cuda::std::numeric_limits<T>::quiet_NaN()), &exponent)));
   }
 #if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  else if (cuda::std::is_same<T, long double>::value)
+  else if constexpr (cuda::std::is_same_v<T, long double>)
   {
     exponent = -1;
     assert(eq(cuda::std::frexpl(val, &exponent), T(0.5)));
@@ -188,14 +188,14 @@ __host__ __device__ void test_frexp(T val)
 template <typename T>
 __host__ __device__ void test_ldexp(T val)
 {
-  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
-  static_assert(cuda::std::is_same<decltype(cuda::std::ldexp(T{}, int{})), ret>::value, "");
+  using ret = cuda::std::conditional_t<cuda::std::is_integral_v<T>, double, T>;
+  static_assert(cuda::std::is_same_v<decltype(cuda::std::ldexp(T{}, int{})), ret>, "");
 
   assert(eq(cuda::std::ldexp(T(0.0), 800), T(0.0)));
   assert(eq(cuda::std::ldexp(T(-0.0), 800), T(0.0)));
   assert(eq(cuda::std::ldexp(val, 5), T(32.0)));
   assert(eq(cuda::std::ldexp(val, 0), val));
-  if (!cuda::std::is_integral<T>::value)
+  if constexpr (!cuda::std::is_integral_v<T>)
   {
     assert(eq(cuda::std::ldexp(T(cuda::std::numeric_limits<T>::infinity()), 1),
               T(cuda::std::numeric_limits<T>::infinity())));
@@ -203,7 +203,7 @@ __host__ __device__ void test_ldexp(T val)
               T(-cuda::std::numeric_limits<T>::infinity())));
     assert(cuda::std::isnan(cuda::std::ldexp(T(cuda::std::numeric_limits<T>::quiet_NaN()), 1)));
   }
-  if (cuda::std::is_same<T, float>::value)
+  if constexpr (cuda::std::is_same_v<T, float>)
   {
     assert(eq(cuda::std::ldexpf(T(0.0), 800), T(0.0)));
     assert(eq(cuda::std::ldexpf(T(-0.0), 800), T(0.0)));
@@ -216,7 +216,7 @@ __host__ __device__ void test_ldexp(T val)
     assert(cuda::std::isnan(cuda::std::ldexpf(T(cuda::std::numeric_limits<T>::quiet_NaN()), 1)));
   }
 #if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  else if (cuda::std::is_same<T, long double>::value)
+  else if constexpr (cuda::std::is_same_v<T, long double>)
   {
     assert(eq(cuda::std::ldexpl(T(0.0), 800), T(0.0)));
     assert(eq(cuda::std::ldexpl(T(-0.0), 800), T(0.0)));
@@ -234,14 +234,14 @@ __host__ __device__ void test_ldexp(T val)
 template <typename T>
 __host__ __device__ void test_scalbln(T val)
 {
-  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
-  static_assert(cuda::std::is_same<decltype(cuda::std::scalbln(T{}, long{})), ret>::value, "");
+  using ret = cuda::std::conditional_t<cuda::std::is_integral_v<T>, double, T>;
+  static_assert(cuda::std::is_same_v<decltype(cuda::std::scalbln(T{}, long{})), ret>, "");
 
   assert(eq(cuda::std::scalbln(T(0.0), 800), T(0.0)));
   assert(eq(cuda::std::scalbln(T(-0.0), 800), T(0.0)));
   assert(eq(cuda::std::scalbln(val, 5), T(32.0)));
   assert(eq(cuda::std::scalbln(val, 0), val));
-  if (!cuda::std::is_integral<T>::value)
+  if constexpr (!cuda::std::is_integral_v<T>)
   {
     assert(eq(cuda::std::scalbln(T(cuda::std::numeric_limits<T>::infinity()), 1),
               T(cuda::std::numeric_limits<T>::infinity())));
@@ -249,7 +249,7 @@ __host__ __device__ void test_scalbln(T val)
               T(-cuda::std::numeric_limits<T>::infinity())));
     assert(cuda::std::isnan(cuda::std::scalbln(T(cuda::std::numeric_limits<T>::quiet_NaN()), 1)));
   }
-  if (cuda::std::is_same<T, float>::value)
+  if constexpr (cuda::std::is_same_v<T, float>)
   {
     assert(eq(cuda::std::scalblnf(T(0.0), 800), T(0.0)));
     assert(eq(cuda::std::scalblnf(T(-0.0), 800), T(0.0)));
@@ -262,7 +262,7 @@ __host__ __device__ void test_scalbln(T val)
     assert(cuda::std::isnan(cuda::std::scalblnf(T(cuda::std::numeric_limits<T>::quiet_NaN()), 1)));
   }
 #if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  else if (cuda::std::is_same<T, long double>::value)
+  else if constexpr (cuda::std::is_same_v<T, long double>)
   {
     assert(eq(cuda::std::scalblnl(T(0.0), 800), T(0.0)));
     assert(eq(cuda::std::scalblnl(T(-0.0), 800), T(0.0)));
@@ -280,14 +280,14 @@ __host__ __device__ void test_scalbln(T val)
 template <typename T>
 __host__ __device__ void test_scalbn(T val)
 {
-  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
-  static_assert(cuda::std::is_same<decltype(cuda::std::scalbn(T{}, int{})), ret>::value, "");
+  using ret = cuda::std::conditional_t<cuda::std::is_integral_v<T>, double, T>;
+  static_assert(cuda::std::is_same_v<decltype(cuda::std::scalbn(T{}, int{})), ret>, "");
 
   assert(eq(cuda::std::scalbn(T(0.0), 800), T(0.0)));
   assert(eq(cuda::std::scalbn(T(-0.0), 800), T(0.0)));
   assert(eq(cuda::std::scalbn(val, 5), T(32.0)));
   assert(eq(cuda::std::scalbn(val, 0), val));
-  if (!cuda::std::is_integral<T>::value)
+  if constexpr (!cuda::std::is_integral_v<T>)
   {
     assert(eq(cuda::std::scalbn(T(cuda::std::numeric_limits<T>::infinity()), 1),
               T(cuda::std::numeric_limits<T>::infinity())));
@@ -295,7 +295,7 @@ __host__ __device__ void test_scalbn(T val)
               T(-cuda::std::numeric_limits<T>::infinity())));
     assert(cuda::std::isnan(cuda::std::scalbn(T(cuda::std::numeric_limits<T>::quiet_NaN()), 1)));
   }
-  if (cuda::std::is_same<T, float>::value)
+  if constexpr (cuda::std::is_same_v<T, float>)
   {
     assert(eq(cuda::std::scalbnf(T(0.0), 800), T(0.0)));
     assert(eq(cuda::std::scalbnf(T(-0.0), 800), T(0.0)));
@@ -308,7 +308,7 @@ __host__ __device__ void test_scalbn(T val)
     assert(cuda::std::isnan(cuda::std::scalbnf(T(cuda::std::numeric_limits<T>::quiet_NaN()), 1)));
   }
 #if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  else if (cuda::std::is_same<T, long double>::value)
+  else if constexpr (cuda::std::is_same_v<T, long double>)
   {
     assert(eq(cuda::std::scalbnl(T(0.0), 800), T(0.0)));
     assert(eq(cuda::std::scalbnl(T(-0.0), 800), T(0.0)));
@@ -326,15 +326,15 @@ __host__ __device__ void test_scalbn(T val)
 template <typename T>
 __host__ __device__ void test_pow(T val)
 {
-  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
-  static_assert(cuda::std::is_same<decltype(cuda::std::pow(T{}, T{})), ret>::value, "");
+  using ret = cuda::std::conditional_t<cuda::std::is_integral_v<T>, double, T>;
+  static_assert(cuda::std::is_same_v<decltype(cuda::std::pow(T{}, T{})), ret>, "");
 
   assert(eq(cuda::std::pow(T(2.0), T(10.0)), T(1024.0)));
   assert(eq(cuda::std::pow(val, cuda::std::numeric_limits<T>::infinity()), val));
   assert(eq(cuda::std::pow(-val, cuda::std::numeric_limits<T>::infinity()), val));
   assert(eq(cuda::std::pow(T(0.0), val), T(0.0)));
   assert(eq(cuda::std::pow(T(-0.0), val), T(-0.0)));
-  if (!cuda::std::is_integral<T>::value)
+  if constexpr (!cuda::std::is_integral_v<T>)
   {
     assert(eq(cuda::std::pow(T(2), T(-3)), T(0.125)));
 
@@ -349,7 +349,7 @@ __host__ __device__ void test_pow(T val)
     assert(
       eq(cuda::std::pow(T(0.5), -cuda::std::numeric_limits<T>::infinity()), cuda::std::numeric_limits<T>::infinity()));
   }
-  if (cuda::std::is_same<T, float>::value)
+  if constexpr (cuda::std::is_same_v<T, float>)
   {
     assert(eq(cuda::std::powf(T(2), T(-3)), T(0.125)));
 
@@ -365,7 +365,7 @@ __host__ __device__ void test_pow(T val)
       eq(cuda::std::powf(T(0.5), -cuda::std::numeric_limits<T>::infinity()), cuda::std::numeric_limits<T>::infinity()));
   }
 #if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  else if (cuda::std::is_same<T, long double>::value)
+  else if constexpr (cuda::std::is_same_v<T, long double>)
   {
     assert(eq(cuda::std::powl(T(2), T(-3)), T(0.125)));
 

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/exponential_functions.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/exponential_functions.pass.cpp
@@ -29,8 +29,9 @@ __host__ __device__ void test_exp(T val)
   using ret = cuda::std::conditional_t<cuda::std::is_integral_v<T>, double, T>;
   static_assert(cuda::std::is_same_v<decltype(cuda::std::exp(T{})), ret>, "");
 
-  const T euler = T(2.718281828459045);
+  [[maybe_unused]] const T euler = T(2.718281828459045);
   assert(eq(cuda::std::exp(T(-0.0)), T(1.0)));
+  unused(val);
   if constexpr (!cuda::std::is_integral_v<T>)
   {
     assert(eq(cuda::std::exp(val), euler));
@@ -93,13 +94,14 @@ __host__ __device__ void test_expm1(T val)
   static_assert(cuda::std::is_same_v<decltype(cuda::std::expm1(T{})), ret>, "");
 
   const T eulerm1 = T(1.718281828459045);
+  assert(is_about(T(cuda::std::expm1(val)), eulerm1));
   assert(eq(cuda::std::expm1(T(-0.0)), T(-0.0)));
   if constexpr (!cuda::std::is_integral_v<T>)
   {
-    assert(is_about(T(cuda::std::expm1(val)), eulerm1));
     assert(eq(cuda::std::expm1(800), cuda::std::numeric_limits<T>::infinity()));
     assert(eq(cuda::std::expm1(T(-cuda::std::numeric_limits<T>::infinity())), T(-1)));
   }
+
   if constexpr (cuda::std::is_same_v<T, float>)
   {
     assert(is_about(T(cuda::std::expm1f(val)), eulerm1));
@@ -130,6 +132,7 @@ __host__ __device__ void test_frexp(T val)
   exponent = -1;
   assert(eq(cuda::std::frexp(T(-0.0), &exponent), T(0.0)));
   assert(exponent == 0);
+  unused(val);
   if constexpr (!cuda::std::is_integral_v<T>)
   {
     exponent = -1;

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/fp_abs.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/fp_abs.pass.cpp
@@ -44,7 +44,7 @@ template <class T, class = void>
 struct OverloadTester;
 
 template <class T>
-struct OverloadTester<T, cuda::std::enable_if_t<!cuda::std::__is_extended_floating_point<T>::value>>
+struct OverloadTester<T, cuda::std::enable_if_t<!cuda::std::__is_extended_floating_point_v<T>>>
 {
   __host__ __device__ static bool test_fabs(T in, T ref, T zero_value)
   {
@@ -62,7 +62,7 @@ struct OverloadTester<T, cuda::std::enable_if_t<!cuda::std::__is_extended_floati
 };
 
 template <class T>
-struct OverloadTester<T, cuda::std::enable_if_t<cuda::std::__is_extended_floating_point<T>::value>>
+struct OverloadTester<T, cuda::std::enable_if_t<cuda::std::__is_extended_floating_point_v<T>>>
 {
   __host__ __device__ static bool test_fabs(T in, T ref, T zero_value)
   {
@@ -111,7 +111,7 @@ __host__ __device__ bool test_fabs(T zero_value)
   test_fabs(-cuda::std::numeric_limits<T>::infinity(), cuda::std::numeric_limits<T>::infinity(), zero_value);
 
   // __half and __nvbfloat have precision issues here
-  if (!cuda::std::__is_extended_floating_point<T>::value)
+  if constexpr (!cuda::std::__is_extended_floating_point_v<T>)
   {
     test_fabs_nan(zero_value);
   }

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/fp_min_max.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/fp_min_max.pass.cpp
@@ -18,11 +18,11 @@
 template <class T>
 __host__ __device__ void test_fmax(T value)
 {
-  static_assert((cuda::std::is_same<decltype(cuda::std::fmax((T) 0, (T) 0)), T>::value), "");
-  static_assert(
-    (cuda::std::is_same<decltype(cuda::std::fmax((float) 0, (T) 0)), cuda::std::__promote_t<float, T>>::value), "");
-  static_assert(
-    (cuda::std::is_same<decltype(cuda::std::fmax((double) 0, (T) 0)), cuda::std::__promote_t<double, T>>::value), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::fmax((T) 0, (T) 0)), T>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::fmax((float) 0, (T) 0)), cuda::std::__promote_t<float, T>>),
+                "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::fmax((double) 0, (T) 0)), cuda::std::__promote_t<double, T>>),
+                "");
   assert(cuda::std::fmax(value, (T) 0) == value);
 }
 
@@ -40,31 +40,30 @@ __host__ __device__ void test_fmax(float value)
   test_fmax<__nv_bfloat16>(__float2bfloat16(value));
 #endif // _LIBCUDACXX_HAS_NVBF16
 
-  static_assert((cuda::std::is_same<decltype(cuda::std::fmax((int) 0, (int) 0)), double>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::fmax((int) 0, (long long) 0)), double>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::fmax((int) 0, (unsigned long long) 0)), double>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::fmax((float) 0, (unsigned int) 0)), double>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::fmax((double) 0, (long) 0)), double>::value), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::fmax((int) 0, (int) 0)), double>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::fmax((int) 0, (long long) 0)), double>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::fmax((int) 0, (unsigned long long) 0)), double>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::fmax((float) 0, (unsigned int) 0)), double>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::fmax((double) 0, (long) 0)), double>), "");
 
-  static_assert((cuda::std::is_same<decltype(cuda::std::fmax((bool) 0, (float) 0)), double>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::fmax((unsigned short) 0, (double) 0)), double>::value), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::fmax((bool) 0, (float) 0)), double>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::fmax((unsigned short) 0, (double) 0)), double>), "");
 
-  static_assert((cuda::std::is_same<decltype(cuda::std::fmaxf(0, 0)), float>::value), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::fmaxf(0, 0)), float>), "");
 #if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  static_assert((cuda::std::is_same<decltype(cuda::std::fmax((long double) 0, (unsigned long) 0)), long double>::value),
-                "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::fmaxl(0, 0)), long double>::value), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::fmax((long double) 0, (unsigned long) 0)), long double>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::fmaxl(0, 0)), long double>), "");
 #endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
 }
 
 template <class T>
 __host__ __device__ void test_fmin(T value)
 {
-  static_assert((cuda::std::is_same<decltype(cuda::std::fmin((T) 0, (T) 0)), T>::value), "");
-  static_assert(
-    (cuda::std::is_same<decltype(cuda::std::fmin((float) 0, (T) 0)), cuda::std::__promote_t<float, T>>::value), "");
-  static_assert(
-    (cuda::std::is_same<decltype(cuda::std::fmin((double) 0, (T) 0)), cuda::std::__promote_t<double, T>>::value), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::fmin((T) 0, (T) 0)), T>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::fmin((float) 0, (T) 0)), cuda::std::__promote_t<float, T>>),
+                "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::fmin((double) 0, (T) 0)), cuda::std::__promote_t<double, T>>),
+                "");
   assert(cuda::std::fmin(value, (T) 0) == T(0));
 }
 
@@ -82,20 +81,19 @@ __host__ __device__ void test_fmin(float value)
   test_fmax<__nv_bfloat16>(__float2bfloat16(value));
 #endif // _LIBCUDACXX_HAS_NVBF16
 
-  static_assert((cuda::std::is_same<decltype(cuda::std::fmin((int) 0, (int) 0)), double>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::fmin((int) 0, (long long) 0)), double>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::fmin((int) 0, (unsigned long long) 0)), double>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::fmin((float) 0, (unsigned int) 0)), double>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::fmin((double) 0, (long) 0)), double>::value), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::fmin((int) 0, (int) 0)), double>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::fmin((int) 0, (long long) 0)), double>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::fmin((int) 0, (unsigned long long) 0)), double>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::fmin((float) 0, (unsigned int) 0)), double>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::fmin((double) 0, (long) 0)), double>), "");
 
-  static_assert((cuda::std::is_same<decltype(cuda::std::fmin((bool) 0, (float) 0)), double>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::fmin((unsigned short) 0, (double) 0)), double>::value), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::fmin((bool) 0, (float) 0)), double>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::fmin((unsigned short) 0, (double) 0)), double>), "");
 
-  static_assert((cuda::std::is_same<decltype(cuda::std::fminf(0, 0)), float>::value), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::fminf(0, 0)), float>), "");
 #if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  static_assert((cuda::std::is_same<decltype(cuda::std::fmin((long double) 0, (unsigned long) 0)), long double>::value),
-                "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::fminl(0, 0)), long double>::value), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::fmin((long double) 0, (unsigned long) 0)), long double>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::fminl(0, 0)), long double>), "");
 #endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
 }
 

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/fp_traits.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/fp_traits.pass.cpp
@@ -20,14 +20,14 @@
 template <class T>
 __host__ __device__ void test_fpclassify(float val)
 {
-  static_assert((cuda::std::is_same<decltype(cuda::std::fpclassify(T(val))), int>::value), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::fpclassify(T(val))), int>), "");
   assert(cuda::std::fpclassify(T(val)) == FP_NORMAL);
   assert(cuda::std::fpclassify(T(1.0)) == FP_NORMAL);
   assert(cuda::std::fpclassify(T(0.0)) == FP_ZERO);
   assert(cuda::std::fpclassify(T(-1.0)) == FP_NORMAL);
   assert(cuda::std::fpclassify(T(-0.0)) == FP_ZERO);
   // extended floating point types have issues here
-  if (!cuda::std::__is_extended_floating_point<T>::value)
+  if constexpr (!cuda::std::__is_extended_floating_point_v<T>)
   {
     assert(cuda::std::fpclassify(T(cuda::std::numeric_limits<T>::quiet_NaN())) == FP_NAN);
     assert(cuda::std::fpclassify(T(cuda::std::numeric_limits<T>::infinity())) == FP_INFINITE);
@@ -67,7 +67,7 @@ __host__ __device__ void test_fpclassify(float val)
 template <class T>
 __host__ __device__ void test_signbit(float val)
 {
-  static_assert((cuda::std::is_same<decltype(cuda::std::signbit((T) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::signbit((T) 0)), bool>), "");
   assert(cuda::std::signbit(T(val)) == false);
   assert(cuda::std::signbit(T(-1.0)) == true);
   assert(cuda::std::signbit(T(0.0)) == false);
@@ -98,7 +98,7 @@ __host__ __device__ void test_signbit(float val)
 template <class T>
 __host__ __device__ void test_isfinite(float val)
 {
-  static_assert((cuda::std::is_same<decltype(cuda::std::isfinite((T) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isfinite((T) 0)), bool>), "");
   assert(cuda::std::isfinite(T(val)) == true);
   assert(cuda::std::isfinite(T(-1.0f)) == true);
   assert(cuda::std::isfinite(T(1.0f)) == true);
@@ -136,7 +136,7 @@ __host__ __device__ _CCCL_CONSTEXPR_ISFINITE bool test_constexpr_isfinite(float 
 template <class T>
 __host__ __device__ void test_isnormal(float val)
 {
-  static_assert((cuda::std::is_same<decltype(cuda::std::isnormal((T) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isnormal((T) 0)), bool>), "");
   assert(cuda::std::isnormal(T(val)) == true);
   assert(cuda::std::isnormal(T(-1.0f)) == true);
   assert(cuda::std::isnormal(T(1.0f)) == true);
@@ -169,85 +169,79 @@ __host__ __device__ void test_isnormal(float val)
 
 __host__ __device__ void test_isgreater(float val)
 {
-  static_assert((cuda::std::is_same<decltype(cuda::std::isgreater((float) 0, (float) 0)), bool>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::isgreater((float) 0, (double) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isgreater((float) 0, (float) 0)), bool>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isgreater((float) 0, (double) 0)), bool>), "");
 #if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  static_assert((cuda::std::is_same<decltype(cuda::std::isgreater((float) 0, (long double) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isgreater((float) 0, (long double) 0)), bool>), "");
 #endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
-  static_assert((cuda::std::is_same<decltype(cuda::std::isgreater((double) 0, (float) 0)), bool>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::isgreater((double) 0, (double) 0)), bool>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::isgreater(0, (double) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isgreater((double) 0, (float) 0)), bool>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isgreater((double) 0, (double) 0)), bool>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isgreater(0, (double) 0)), bool>), "");
 #if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  static_assert((cuda::std::is_same<decltype(cuda::std::isgreater((double) 0, (long double) 0)), bool>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::isgreater((long double) 0, (float) 0)), bool>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::isgreater((long double) 0, (double) 0)), bool>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::isgreater((long double) 0, (long double) 0)), bool>::value),
-                "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isgreater((double) 0, (long double) 0)), bool>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isgreater((long double) 0, (float) 0)), bool>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isgreater((long double) 0, (double) 0)), bool>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isgreater((long double) 0, (long double) 0)), bool>), "");
 #endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
 #ifdef _LIBCUDACXX_HAS_NVFP16
-  static_assert((cuda::std::is_same<decltype(cuda::std::isgreater((__half) 0, (__half) 0)), bool>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::isgreater((__half) 0, (float) 0)), bool>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::isgreater((__half) 0, (double) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isgreater((__half) 0, (__half) 0)), bool>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isgreater((__half) 0, (float) 0)), bool>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isgreater((__half) 0, (double) 0)), bool>), "");
 #endif // _LIBCUDACXX_HAS_NVFP16
 #ifdef _LIBCUDACXX_HAS_NVBF16
-  static_assert((cuda::std::is_same<decltype(cuda::std::isgreater((__nv_bfloat16) 0, (__nv_bfloat16) 0)), bool>::value),
-                "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::isgreater((__nv_bfloat16) 0, (float) 0)), bool>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::isgreater((__nv_bfloat16) 0, (double) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isgreater((__nv_bfloat16) 0, (__nv_bfloat16) 0)), bool>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isgreater((__nv_bfloat16) 0, (float) 0)), bool>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isgreater((__nv_bfloat16) 0, (double) 0)), bool>), "");
 #endif // _LIBCUDACXX_HAS_NVBF16
   assert(cuda::std::isgreater(-1.0, 0.F) == false);
 }
 
 __host__ __device__ void test_isgreaterequal(float val)
 {
-  static_assert((cuda::std::is_same<decltype(cuda::std::isgreaterequal((float) 0, (float) 0)), bool>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::isgreaterequal((float) 0, (double) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isgreaterequal((float) 0, (float) 0)), bool>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isgreaterequal((float) 0, (double) 0)), bool>), "");
 #if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  static_assert((cuda::std::is_same<decltype(cuda::std::isgreaterequal((float) 0, (long double) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isgreaterequal((float) 0, (long double) 0)), bool>), "");
 #endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
-  static_assert((cuda::std::is_same<decltype(cuda::std::isgreaterequal((double) 0, (float) 0)), bool>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::isgreaterequal((double) 0, (double) 0)), bool>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::isgreaterequal(0, (double) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isgreaterequal((double) 0, (float) 0)), bool>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isgreaterequal((double) 0, (double) 0)), bool>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isgreaterequal(0, (double) 0)), bool>), "");
 #if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  static_assert((cuda::std::is_same<decltype(cuda::std::isgreaterequal((double) 0, (long double) 0)), bool>::value),
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isgreaterequal((double) 0, (long double) 0)), bool>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isgreaterequal((long double) 0, (float) 0)), bool>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isgreaterequal((long double) 0, (double) 0)), bool>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isgreaterequal((long double) 0, (long double) 0)), bool>),
                 "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::isgreaterequal((long double) 0, (float) 0)), bool>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::isgreaterequal((long double) 0, (double) 0)), bool>::value),
-                "");
-  static_assert(
-    (cuda::std::is_same<decltype(cuda::std::isgreaterequal((long double) 0, (long double) 0)), bool>::value), "");
 #endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
 #ifdef _LIBCUDACXX_HAS_NVFP16
-  static_assert((cuda::std::is_same<decltype(cuda::std::isgreaterequal((__half) 0, (__half) 0)), bool>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::isgreaterequal((__half) 0, (float) 0)), bool>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::isgreaterequal((__half) 0, (double) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isgreaterequal((__half) 0, (__half) 0)), bool>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isgreaterequal((__half) 0, (float) 0)), bool>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isgreaterequal((__half) 0, (double) 0)), bool>), "");
 #endif // _LIBCUDACXX_HAS_NVFP16
 #ifdef _LIBCUDACXX_HAS_NVBF16
-  static_assert(
-    (cuda::std::is_same<decltype(cuda::std::isgreaterequal((__nv_bfloat16) 0, (__nv_bfloat16) 0)), bool>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::isgreaterequal((__nv_bfloat16) 0, (float) 0)), bool>::value),
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isgreaterequal((__nv_bfloat16) 0, (__nv_bfloat16) 0)), bool>),
                 "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::isgreaterequal((__nv_bfloat16) 0, (double) 0)), bool>::value),
-                "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isgreaterequal((__nv_bfloat16) 0, (float) 0)), bool>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isgreaterequal((__nv_bfloat16) 0, (double) 0)), bool>), "");
 #endif // _LIBCUDACXX_HAS_NVBF16
   assert(cuda::std::isgreaterequal(-1.0, 0.F) == false);
 }
 
 __host__ __device__ void test_isinf(float val)
 {
-  static_assert((cuda::std::is_same<decltype(cuda::std::isinf((float) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isinf((float) 0)), bool>), "");
 
   typedef decltype(cuda::std::isinf((double) 0)) DoubleRetType;
-  static_assert((cuda::std::is_same<DoubleRetType, bool>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::isinf(0)), bool>::value), "");
+  static_assert((cuda::std::is_same_v<DoubleRetType, bool>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isinf(0)), bool>), "");
 #if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  static_assert((cuda::std::is_same<decltype(cuda::std::isinf((long double) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isinf((long double) 0)), bool>), "");
 #endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
 #ifdef _LIBCUDACXX_HAS_NVFP16
-  static_assert((cuda::std::is_same<decltype(cuda::std::isinf((__half) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isinf((__half) 0)), bool>), "");
 #endif // _LIBCUDACXX_HAS_NVFP16
 #ifdef _LIBCUDACXX_HAS_NVBF16
-  static_assert((cuda::std::is_same<decltype(cuda::std::isinf((__nv_bfloat16) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isinf((__nv_bfloat16) 0)), bool>), "");
 #endif // _LIBCUDACXX_HAS_NVBF16
   assert(cuda::std::isinf(-1.0) == false);
   assert(cuda::std::isinf(0) == false);
@@ -264,113 +258,108 @@ __host__ __device__ _CCCL_CONSTEXPR_ISINF bool test_constexpr_isinf(float val)
 
 __host__ __device__ void test_isless(float val)
 {
-  static_assert((cuda::std::is_same<decltype(cuda::std::isless((float) 0, (float) 0)), bool>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::isless((float) 0, (double) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isless((float) 0, (float) 0)), bool>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isless((float) 0, (double) 0)), bool>), "");
 #if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  static_assert((cuda::std::is_same<decltype(cuda::std::isless((float) 0, (long double) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isless((float) 0, (long double) 0)), bool>), "");
 #endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
-  static_assert((cuda::std::is_same<decltype(cuda::std::isless((double) 0, (float) 0)), bool>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::isless((double) 0, (double) 0)), bool>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::isless(0, (double) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isless((double) 0, (float) 0)), bool>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isless((double) 0, (double) 0)), bool>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isless(0, (double) 0)), bool>), "");
 #if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  static_assert((cuda::std::is_same<decltype(cuda::std::isless((double) 0, (long double) 0)), bool>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::isless((long double) 0, (float) 0)), bool>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::isless((long double) 0, (double) 0)), bool>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::isless((long double) 0, (long double) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isless((double) 0, (long double) 0)), bool>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isless((long double) 0, (float) 0)), bool>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isless((long double) 0, (double) 0)), bool>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isless((long double) 0, (long double) 0)), bool>), "");
 #endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
 #ifdef _LIBCUDACXX_HAS_NVFP16
-  static_assert((cuda::std::is_same<decltype(cuda::std::isless((__half) 0, (__half) 0)), bool>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::isless((__half) 0, (float) 0)), bool>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::isless((__half) 0, (double) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isless((__half) 0, (__half) 0)), bool>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isless((__half) 0, (float) 0)), bool>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isless((__half) 0, (double) 0)), bool>), "");
 #endif // _LIBCUDACXX_HAS_NVFP16
 #ifdef _LIBCUDACXX_HAS_NVBF16
-  static_assert((cuda::std::is_same<decltype(cuda::std::isless((__nv_bfloat16) 0, (__nv_bfloat16) 0)), bool>::value),
-                "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::isless((__nv_bfloat16) 0, (float) 0)), bool>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::isless((__nv_bfloat16) 0, (double) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isless((__nv_bfloat16) 0, (__nv_bfloat16) 0)), bool>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isless((__nv_bfloat16) 0, (float) 0)), bool>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isless((__nv_bfloat16) 0, (double) 0)), bool>), "");
 #endif // _LIBCUDACXX_HAS_NVBF16
   assert(cuda::std::isless(-1.0, 0.F) == true);
 }
 
 __host__ __device__ void test_islessequal(float val)
 {
-  static_assert((cuda::std::is_same<decltype(cuda::std::islessequal((float) 0, (float) 0)), bool>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::islessequal((float) 0, (double) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::islessequal((float) 0, (float) 0)), bool>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::islessequal((float) 0, (double) 0)), bool>), "");
 #if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  static_assert((cuda::std::is_same<decltype(cuda::std::islessequal((float) 0, (long double) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::islessequal((float) 0, (long double) 0)), bool>), "");
 #endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
-  static_assert((cuda::std::is_same<decltype(cuda::std::islessequal((double) 0, (float) 0)), bool>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::islessequal((double) 0, (double) 0)), bool>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::islessequal(0, (double) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::islessequal((double) 0, (float) 0)), bool>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::islessequal((double) 0, (double) 0)), bool>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::islessequal(0, (double) 0)), bool>), "");
 #if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  static_assert((cuda::std::is_same<decltype(cuda::std::islessequal((double) 0, (long double) 0)), bool>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::islessequal((long double) 0, (float) 0)), bool>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::islessequal((long double) 0, (double) 0)), bool>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::islessequal((long double) 0, (long double) 0)), bool>::value),
-                "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::islessequal((double) 0, (long double) 0)), bool>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::islessequal((long double) 0, (float) 0)), bool>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::islessequal((long double) 0, (double) 0)), bool>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::islessequal((long double) 0, (long double) 0)), bool>), "");
 #endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
 #ifdef _LIBCUDACXX_HAS_NVFP16
-  static_assert((cuda::std::is_same<decltype(cuda::std::islessequal((__half) 0, (__half) 0)), bool>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::islessequal((__half) 0, (float) 0)), bool>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::islessequal((__half) 0, (double) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::islessequal((__half) 0, (__half) 0)), bool>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::islessequal((__half) 0, (float) 0)), bool>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::islessequal((__half) 0, (double) 0)), bool>), "");
 #endif // _LIBCUDACXX_HAS_NVFP16
 #ifdef _LIBCUDACXX_HAS_NVBF16
-  static_assert(
-    (cuda::std::is_same<decltype(cuda::std::islessequal((__nv_bfloat16) 0, (__nv_bfloat16) 0)), bool>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::islessequal((__nv_bfloat16) 0, (float) 0)), bool>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::islessequal((__nv_bfloat16) 0, (double) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::islessequal((__nv_bfloat16) 0, (__nv_bfloat16) 0)), bool>),
+                "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::islessequal((__nv_bfloat16) 0, (float) 0)), bool>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::islessequal((__nv_bfloat16) 0, (double) 0)), bool>), "");
 #endif // _LIBCUDACXX_HAS_NVBF16
   assert(cuda::std::islessequal(-1.0, 0.F) == true);
 }
 
 __host__ __device__ void test_islessgreater(float val)
 {
-  static_assert((cuda::std::is_same<decltype(cuda::std::islessgreater((float) 0, (float) 0)), bool>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::islessgreater((float) 0, (double) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::islessgreater((float) 0, (float) 0)), bool>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::islessgreater((float) 0, (double) 0)), bool>), "");
 #if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  static_assert((cuda::std::is_same<decltype(cuda::std::islessgreater((float) 0, (long double) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::islessgreater((float) 0, (long double) 0)), bool>), "");
 #endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
-  static_assert((cuda::std::is_same<decltype(cuda::std::islessgreater((double) 0, (float) 0)), bool>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::islessgreater((double) 0, (double) 0)), bool>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::islessgreater(0, (double) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::islessgreater((double) 0, (float) 0)), bool>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::islessgreater((double) 0, (double) 0)), bool>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::islessgreater(0, (double) 0)), bool>), "");
 #if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  static_assert((cuda::std::is_same<decltype(cuda::std::islessgreater((double) 0, (long double) 0)), bool>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::islessgreater((long double) 0, (float) 0)), bool>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::islessgreater((long double) 0, (double) 0)), bool>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::islessgreater((long double) 0, (long double) 0)), bool>::value),
-                "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::islessgreater((double) 0, (long double) 0)), bool>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::islessgreater((long double) 0, (float) 0)), bool>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::islessgreater((long double) 0, (double) 0)), bool>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::islessgreater((long double) 0, (long double) 0)), bool>), "");
 #endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
 #ifdef _LIBCUDACXX_HAS_NVFP16
-  static_assert((cuda::std::is_same<decltype(cuda::std::islessgreater((__half) 0, (__half) 0)), bool>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::islessgreater((__half) 0, (float) 0)), bool>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::islessgreater((__half) 0, (double) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::islessgreater((__half) 0, (__half) 0)), bool>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::islessgreater((__half) 0, (float) 0)), bool>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::islessgreater((__half) 0, (double) 0)), bool>), "");
 #endif // _LIBCUDACXX_HAS_NVFP16
 #ifdef _LIBCUDACXX_HAS_NVBF16
-  static_assert(
-    (cuda::std::is_same<decltype(cuda::std::islessgreater((__nv_bfloat16) 0, (__nv_bfloat16) 0)), bool>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::islessgreater((__nv_bfloat16) 0, (float) 0)), bool>::value),
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::islessgreater((__nv_bfloat16) 0, (__nv_bfloat16) 0)), bool>),
                 "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::islessgreater((__nv_bfloat16) 0, (double) 0)), bool>::value),
-                "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::islessgreater((__nv_bfloat16) 0, (float) 0)), bool>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::islessgreater((__nv_bfloat16) 0, (double) 0)), bool>), "");
 #endif // _LIBCUDACXX_HAS_NVBF16
   assert(cuda::std::islessgreater(-1.0, 0.F) == true);
 }
 
 __host__ __device__ void test_isnan(float val)
 {
-  static_assert((cuda::std::is_same<decltype(cuda::std::isnan((float) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isnan((float) 0)), bool>), "");
 
   typedef decltype(cuda::std::isnan((double) 0)) DoubleRetType;
-  static_assert((cuda::std::is_same<DoubleRetType, bool>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::isnan(0)), bool>::value), "");
+  static_assert((cuda::std::is_same_v<DoubleRetType, bool>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isnan(0)), bool>), "");
 #if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  static_assert((cuda::std::is_same<decltype(cuda::std::isnan((long double) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isnan((long double) 0)), bool>), "");
 #endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
 #ifdef _LIBCUDACXX_HAS_NVFP16
-  static_assert((cuda::std::is_same<decltype(cuda::std::isnan((__half) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isnan((__half) 0)), bool>), "");
 #endif // _LIBCUDACXX_HAS_NVFP16
 #ifdef _LIBCUDACXX_HAS_NVBF16
-  static_assert((cuda::std::is_same<decltype(cuda::std::isnan((__nv_bfloat16) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isnan((__nv_bfloat16) 0)), bool>), "");
 #endif // _LIBCUDACXX_HAS_NVBF16
   assert(cuda::std::isnan(-1.0) == false);
   assert(cuda::std::isnan(0) == false);
@@ -387,31 +376,30 @@ __host__ __device__ _CCCL_CONSTEXPR_ISNAN bool test_constexpr_isnan(float val)
 
 __host__ __device__ void test_isunordered(float val)
 {
-  static_assert((cuda::std::is_same<decltype(cuda::std::isunordered((float) 0, (float) 0)), bool>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::isunordered((float) 0, (double) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isunordered((float) 0, (float) 0)), bool>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isunordered((float) 0, (double) 0)), bool>), "");
 #if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  static_assert((cuda::std::is_same<decltype(cuda::std::isunordered((float) 0, (long double) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isunordered((float) 0, (long double) 0)), bool>), "");
 #endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
-  static_assert((cuda::std::is_same<decltype(cuda::std::isunordered((double) 0, (float) 0)), bool>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::isunordered((double) 0, (double) 0)), bool>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::isunordered(0, (double) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isunordered((double) 0, (float) 0)), bool>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isunordered((double) 0, (double) 0)), bool>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isunordered(0, (double) 0)), bool>), "");
 #if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  static_assert((cuda::std::is_same<decltype(cuda::std::isunordered((double) 0, (long double) 0)), bool>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::isunordered((long double) 0, (float) 0)), bool>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::isunordered((long double) 0, (double) 0)), bool>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::isunordered((long double) 0, (long double) 0)), bool>::value),
-                "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isunordered((double) 0, (long double) 0)), bool>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isunordered((long double) 0, (float) 0)), bool>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isunordered((long double) 0, (double) 0)), bool>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isunordered((long double) 0, (long double) 0)), bool>), "");
 #endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
 #ifdef _LIBCUDACXX_HAS_NVFP16
-  static_assert((cuda::std::is_same<decltype(cuda::std::isunordered((__half) 0, (__half) 0)), bool>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::isunordered((__half) 0, (float) 0)), bool>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::isunordered((__half) 0, (double) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isunordered((__half) 0, (__half) 0)), bool>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isunordered((__half) 0, (float) 0)), bool>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isunordered((__half) 0, (double) 0)), bool>), "");
 #endif // _LIBCUDACXX_HAS_NVFP16
 #ifdef _LIBCUDACXX_HAS_NVBF16
-  static_assert(
-    (cuda::std::is_same<decltype(cuda::std::isunordered((__nv_bfloat16) 0, (__nv_bfloat16) 0)), bool>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::isunordered((__nv_bfloat16) 0, (float) 0)), bool>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::isunordered((__nv_bfloat16) 0, (double) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isunordered((__nv_bfloat16) 0, (__nv_bfloat16) 0)), bool>),
+                "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isunordered((__nv_bfloat16) 0, (float) 0)), bool>), "");
+  static_assert((cuda::std::is_same_v<decltype(cuda::std::isunordered((__nv_bfloat16) 0, (double) 0)), bool>), "");
 #endif // _LIBCUDACXX_HAS_NVBF16
   assert(cuda::std::isunordered(-1.0, 0.F) == false);
 }

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/gamma.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/gamma.pass.cpp
@@ -1,0 +1,246 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cmath>
+
+#include <cuda/std/cassert>
+#include <cuda/std/cmath>
+#include <cuda/std/limits>
+#include <cuda/std/type_traits>
+
+#include "comparison.h"
+#include "test_macros.h"
+
+#if defined(TEST_COMPILER_MSVC)
+#  pragma warning(disable : 4244) // conversion from 'double' to 'float', possible loss of data
+#  pragma warning(disable : 4305) // 'argument': truncation from 'T' to 'float'
+#  pragma warning(disable : 4146) // unary minus operator applied to unsigned type, result still unsigned
+#endif // TEST_COMPILER_MSVC
+
+template <typename T>
+__host__ __device__ void test_lgamma(T val)
+{
+  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
+  static_assert(cuda::std::is_same<decltype(cuda::std::lgamma(T{})), ret>::value, "");
+
+  // If the argument is 1, +0 is returned.
+  assert(eq(cuda::std::lgamma(T(1.0)), val));
+
+  // If the argument is 2, +0 is returned.
+  assert(eq(cuda::std::lgamma(T(2.0)), val));
+
+  // If the argument is a negative integer, +∞ is returned.
+  assert(eq(cuda::std::lgamma(-2), cuda::std::numeric_limits<double>::infinity()));
+
+  // If the argument is ±0, +∞ is returned.
+  assert(eq(cuda::std::lgamma(val), cuda::std::numeric_limits<ret>::infinity()));
+
+  if constexpr (!cuda::std::is_integral_v<T>)
+  {
+    // If the argument is ±0, +∞ is returned.
+    assert(eq(cuda::std::lgamma(-val), cuda::std::numeric_limits<T>::infinity()));
+
+    // If the argument is ±∞, +∞ is returned.
+    assert(eq(cuda::std::lgamma(cuda::std::numeric_limits<T>::infinity()), cuda::std::numeric_limits<T>::infinity()));
+    assert(eq(cuda::std::lgamma(-cuda::std::numeric_limits<T>::infinity()), cuda::std::numeric_limits<T>::infinity()));
+
+    // If the argument is NaN, NaN is returned.
+    assert(cuda::std::isnan(cuda::std::lgamma(cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::lgamma(cuda::std::numeric_limits<T>::quiet_NaN())));
+    assert(cuda::std::isnan(cuda::std::lgamma(-cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::lgamma(-cuda::std::numeric_limits<T>::quiet_NaN())));
+
+    // Some random value
+    const T expected = T(0.5723649429247000819387380943226162);
+    assert(is_about(cuda::std::lgamma(T(0.5)), expected));
+  }
+
+  if constexpr (cuda::std::is_same<T, float>::value)
+  {
+    // If the argument is 1, +0 is returned.
+    assert(eq(cuda::std::lgammaf(T(1.0)), val));
+
+    // If the argument is 2, +0 is returned.
+    assert(eq(cuda::std::lgammaf(T(2.0)), val));
+
+    // If the argument is ±0, +∞ is returned.
+    assert(eq(cuda::std::lgammaf(val), cuda::std::numeric_limits<T>::infinity()));
+    assert(eq(cuda::std::lgammaf(-val), cuda::std::numeric_limits<T>::infinity()));
+
+    // If the argument is ±∞, +∞ is returned.
+    assert(eq(cuda::std::lgammaf(cuda::std::numeric_limits<T>::infinity()), cuda::std::numeric_limits<T>::infinity()));
+    assert(eq(cuda::std::lgammaf(-cuda::std::numeric_limits<T>::infinity()), cuda::std::numeric_limits<T>::infinity()));
+
+    // If the argument is NaN, NaN is returned.
+    assert(cuda::std::isnan(cuda::std::lgammaf(cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::lgammaf(cuda::std::numeric_limits<T>::quiet_NaN())));
+    assert(cuda::std::isnan(cuda::std::lgammaf(-cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::lgammaf(-cuda::std::numeric_limits<T>::quiet_NaN())));
+
+    // Some random value
+    const T expected = T(0.5723649429247000819387380943226162);
+    assert(is_about(cuda::std::lgammaf(T(0.5)), expected));
+  }
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  else if constexpr (cuda::std::is_same<T, long double>::value)
+  {
+    // If the argument is 1, +0 is returned.
+    assert(eq(cuda::std::lgammal(T(1.0)), val));
+
+    // If the argument is 2, +0 is returned.
+    assert(eq(cuda::std::lgammal(T(2.0)), val));
+
+    // If the argument is ±0, +∞ is returned.
+    assert(eq(cuda::std::lgammal(val), cuda::std::numeric_limits<T>::infinity()));
+    assert(eq(cuda::std::lgammal(-val), cuda::std::numeric_limits<T>::infinity()));
+
+    // If the argument is ±∞, +∞ is returned.
+    assert(eq(cuda::std::lgammal(cuda::std::numeric_limits<T>::infinity()), cuda::std::numeric_limits<T>::infinity()));
+    assert(eq(cuda::std::lgammal(-cuda::std::numeric_limits<T>::infinity()), cuda::std::numeric_limits<T>::infinity()));
+
+    // If the argument is NaN, NaN is returned.
+    assert(cuda::std::isnan(cuda::std::lgammal(cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::lgammal(cuda::std::numeric_limits<T>::quiet_NaN())));
+    assert(cuda::std::isnan(cuda::std::lgammal(-cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::lgammal(-cuda::std::numeric_limits<T>::quiet_NaN())));
+
+    // Some random value
+    const T expected = T(0.5723649429247000819387380943226162);
+    assert(is_about(cuda::std::lgammal(T(0.5)), expected));
+  }
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+}
+
+template <typename T>
+__host__ __device__ void test_tgamma(T val)
+{
+  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
+  static_assert(cuda::std::is_same<decltype(cuda::std::tgamma(T{})), ret>::value, "");
+
+  // If the argument is a negative integer.
+  assert(cuda::std::isnan(cuda::std::tgamma(-2)));
+
+  // Some characteristic value
+  assert(eq(cuda::std::tgamma(T(2.0)), T(1.0)));
+
+  // If the argument is ±0, ±∞ is returned.
+  assert(eq(cuda::std::tgamma(val), cuda::std::numeric_limits<ret>::infinity()));
+
+  if constexpr (!cuda::std::is_integral_v<T>)
+  {
+    // If the argument is ±0, ±∞ is returned.
+    assert(eq(cuda::std::tgamma(-val), -cuda::std::numeric_limits<ret>::infinity()));
+
+    // If the argument is -∞, NaN is returned.
+    assert(cuda::std::isnan(cuda::std::tgamma(-cuda::std::numeric_limits<T>::infinity())));
+
+    // If the argument is +∞, +∞ is returned.
+    assert(eq(cuda::std::tgamma(cuda::std::numeric_limits<T>::infinity()), cuda::std::numeric_limits<T>::infinity()));
+
+    // If the argument is NaN, NaN is returned.
+    assert(cuda::std::isnan(cuda::std::tgamma(cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::tgamma(-cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::tgamma(cuda::std::numeric_limits<T>::quiet_NaN())));
+    assert(cuda::std::isnan(cuda::std::tgamma(-cuda::std::numeric_limits<T>::quiet_NaN())));
+
+    // Some random value
+    const T expected = T(1.772453850905516103964032481599133);
+    assert(is_about(cuda::std::tgamma(T(0.5)), expected));
+  }
+
+  if constexpr (cuda::std::is_same<T, float>::value)
+  {
+    // If the argument is ±0, ±∞ is returned.
+    assert(eq(cuda::std::tgammaf(val), cuda::std::numeric_limits<T>::infinity()));
+    assert(eq(cuda::std::tgammaf(-val), -cuda::std::numeric_limits<T>::infinity()));
+
+    // If the argument is -∞, NaN is returned.
+    assert(cuda::std::isnan(cuda::std::tgammaf(-cuda::std::numeric_limits<T>::infinity())));
+
+    // If the argument is +∞, +∞ is returned.
+    assert(eq(cuda::std::tgammaf(cuda::std::numeric_limits<T>::infinity()), cuda::std::numeric_limits<T>::infinity()));
+
+    // If the argument is NaN, NaN is returned.
+    assert(cuda::std::isnan(cuda::std::tgammaf(cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::tgammaf(-cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::tgammaf(cuda::std::numeric_limits<T>::quiet_NaN())));
+    assert(cuda::std::isnan(cuda::std::tgammaf(-cuda::std::numeric_limits<T>::quiet_NaN())));
+
+    // Some random value
+    const T expected = T(1.772453850905516103964032481599133);
+    assert(is_about(cuda::std::tgammaf(T(0.5)), expected));
+  }
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  else if constexpr (cuda::std::is_same<T, long double>::value)
+  {
+    // If the argument is ±0, ±∞ is returned.
+    assert(eq(cuda::std::tgammal(val), cuda::std::numeric_limits<T>::infinity()));
+    assert(eq(cuda::std::tgammal(-val), -cuda::std::numeric_limits<T>::infinity()));
+
+    // If the argument is -∞, NaN is returned.
+    assert(cuda::std::isnan(cuda::std::tgammal(-cuda::std::numeric_limits<T>::infinity())));
+
+    // If the argument is +∞, +∞ is returned.
+    assert(eq(cuda::std::tgammal(cuda::std::numeric_limits<T>::infinity()), cuda::std::numeric_limits<T>::infinity()));
+
+    // If the argument is NaN, NaN is returned.
+    assert(cuda::std::isnan(cuda::std::tgammal(cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::tgammal(-cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::tgammal(cuda::std::numeric_limits<T>::quiet_NaN())));
+    assert(cuda::std::isnan(cuda::std::tgammal(-cuda::std::numeric_limits<T>::quiet_NaN())));
+
+    // Some random value
+    const T expected = T(1.772453850905516103964032481599133);
+    assert(is_about(cuda::std::tgammal(T(0.5)), expected));
+  }
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+}
+
+template <typename T>
+__host__ __device__ void test(const T val)
+{
+  test_lgamma<T>(val);
+  test_tgamma<T>(val);
+}
+
+__host__ __device__ void test(const float val)
+{
+  test<float>(val);
+  test<double>(val);
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  test<long double>();
+#endif //!_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#ifdef _LIBCUDACXX_HAS_NVFP16
+  test<__half>(val);
+#endif // _LIBCUDACXX_HAS_NVFP16
+#ifdef _LIBCUDACXX_HAS_NVBF16
+  test<__nv_bfloat16>(val);
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+  test<unsigned short>(static_cast<unsigned short>(val));
+  test<int>(static_cast<int>(val));
+  test<unsigned int>(static_cast<unsigned int>(val));
+  test<long>(static_cast<long>(val));
+  test<unsigned long>(static_cast<unsigned long>(val));
+  test<long long>(static_cast<long long>(val));
+  test<unsigned long long>(static_cast<unsigned long long>(val));
+}
+
+__global__ void test_global_kernel(float* val)
+{
+  test(*val);
+}
+
+int main(int, char**)
+{
+  volatile float val = 0.0f;
+  test(val);
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/gamma.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/gamma.pass.cpp
@@ -26,8 +26,8 @@
 template <typename T>
 __host__ __device__ void test_lgamma(T val)
 {
-  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
-  static_assert(cuda::std::is_same<decltype(cuda::std::lgamma(T{})), ret>::value, "");
+  using ret = cuda::std::conditional_t<cuda::std::is_integral_v<T>, double, T>;
+  static_assert(cuda::std::is_same_v<decltype(cuda::std::lgamma(T{})), ret>, "");
 
   // If the argument is 1, +0 is returned.
   assert(eq(cuda::std::lgamma(T(1.0)), val));
@@ -61,7 +61,7 @@ __host__ __device__ void test_lgamma(T val)
     assert(is_about(cuda::std::lgamma(T(0.5)), expected));
   }
 
-  if constexpr (cuda::std::is_same<T, float>::value)
+  if constexpr (cuda::std::is_same_v<T, float>)
   {
     // If the argument is 1, +0 is returned.
     assert(eq(cuda::std::lgammaf(T(1.0)), val));
@@ -88,7 +88,7 @@ __host__ __device__ void test_lgamma(T val)
     assert(is_about(cuda::std::lgammaf(T(0.5)), expected));
   }
 #if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  else if constexpr (cuda::std::is_same<T, long double>::value)
+  else if constexpr (cuda::std::is_same_v<T, long double>)
   {
     // If the argument is 1, +0 is returned.
     assert(eq(cuda::std::lgammal(T(1.0)), val));
@@ -120,8 +120,8 @@ __host__ __device__ void test_lgamma(T val)
 template <typename T>
 __host__ __device__ void test_tgamma(T val)
 {
-  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
-  static_assert(cuda::std::is_same<decltype(cuda::std::tgamma(T{})), ret>::value, "");
+  using ret = cuda::std::conditional_t<cuda::std::is_integral_v<T>, double, T>;
+  static_assert(cuda::std::is_same_v<decltype(cuda::std::tgamma(T{})), ret>, "");
 
   // If the argument is a negative integer.
   assert(cuda::std::isnan(cuda::std::tgamma(-2)));
@@ -154,7 +154,7 @@ __host__ __device__ void test_tgamma(T val)
     assert(is_about(cuda::std::tgamma(T(0.5)), expected));
   }
 
-  if constexpr (cuda::std::is_same<T, float>::value)
+  if constexpr (cuda::std::is_same_v<T, float>)
   {
     // If the argument is ±0, ±∞ is returned.
     assert(eq(cuda::std::tgammaf(val), cuda::std::numeric_limits<T>::infinity()));
@@ -177,7 +177,7 @@ __host__ __device__ void test_tgamma(T val)
     assert(is_about(cuda::std::tgammaf(T(0.5)), expected));
   }
 #if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  else if constexpr (cuda::std::is_same<T, long double>::value)
+  else if constexpr (cuda::std::is_same_v<T, long double>)
   {
     // If the argument is ±0, ±∞ is returned.
     assert(eq(cuda::std::tgammal(val), cuda::std::numeric_limits<T>::infinity()));

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/hyperbolic_functions.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/hyperbolic_functions.pass.cpp
@@ -1,0 +1,219 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cmath>
+
+#include <cuda/std/cassert>
+#include <cuda/std/cmath>
+#include <cuda/std/limits>
+#include <cuda/std/type_traits>
+
+#include "comparison.h"
+#include "test_macros.h"
+
+#if defined(TEST_COMPILER_MSVC)
+#  pragma warning(disable : 4244) // conversion from 'double' to 'float', possible loss of data
+#  pragma warning(disable : 4305) // 'argument': truncation from 'T' to 'float'
+#  pragma warning(disable : 4146) // unary minus operator applied to unsigned type, result still unsigned
+#endif // TEST_COMPILER_MSVC
+
+template <typename T>
+__host__ __device__ void test_cosh(T val)
+{
+  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
+  static_assert(cuda::std::is_same<decltype(cuda::std::cosh(T{})), ret>::value, "");
+
+  // 0 is returned unmodified
+  assert(eq(cuda::std::cosh(val), T(1.0)));
+  assert(eq(cuda::std::cosh(-val), T(1.0)));
+  if constexpr (!cuda::std::is_integral<T>::value)
+  {
+    assert(cuda::std::isinf(cuda::std::cosh(cuda::std::numeric_limits<T>::infinity())));
+    assert(cuda::std::isinf(cuda::std::cosh(-cuda::std::numeric_limits<T>::infinity())));
+    assert(cuda::std::isnan(cuda::std::cosh(-cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::cosh(-cuda::std::numeric_limits<T>::quiet_NaN())));
+
+    const T expected = T(1.543080634815243712409937870688736);
+    assert(is_about(cuda::std::cosh(T(1.0)), expected));
+    assert(is_about(cuda::std::cosh(T(-1.0)), expected));
+  }
+
+  if constexpr (cuda::std::is_same<T, float>::value)
+  {
+    assert(cuda::std::isinf(cuda::std::coshf(cuda::std::numeric_limits<T>::infinity())));
+    assert(cuda::std::isinf(cuda::std::coshf(-cuda::std::numeric_limits<T>::infinity())));
+    assert(cuda::std::isnan(cuda::std::coshf(-cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::coshf(-cuda::std::numeric_limits<T>::quiet_NaN())));
+
+    const T expected = T(1.543080634815243712409937870688736);
+    assert(is_about(cuda::std::coshf(T(1.0)), expected));
+    assert(is_about(cuda::std::coshf(T(-1.0)), expected));
+  }
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  else if constexpr (cuda::std::is_same<T, long double>::value)
+  {
+    assert(cuda::std::isinf(cuda::std::coshl(cuda::std::numeric_limits<T>::infinity())));
+    assert(cuda::std::isinf(cuda::std::coshl(-cuda::std::numeric_limits<T>::infinity())));
+    assert(cuda::std::isnan(cuda::std::coshl(-cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::coshl(-cuda::std::numeric_limits<T>::quiet_NaN())));
+
+    const T expected = T(1.543080634815243712409937870688736);
+    assert(is_about(cuda::std::coshl(T(1.0)), expected));
+    assert(is_about(cuda::std::coshl(T(-1.0)), expected));
+  }
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+}
+
+template <typename T>
+__host__ __device__ void test_sinh(T val)
+{
+  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
+  static_assert(cuda::std::is_same<decltype(cuda::std::sinh(T{})), ret>::value, "");
+
+  // 0 is returned unmodified
+  assert(eq(cuda::std::sinh(val), val));
+  assert(eq(cuda::std::sinh(-val), -val));
+  if constexpr (!cuda::std::is_integral<T>::value)
+  {
+    assert(eq(cuda::std::sinh(cuda::std::numeric_limits<T>::infinity()), cuda::std::numeric_limits<T>::infinity()));
+    assert(eq(cuda::std::sinh(-cuda::std::numeric_limits<T>::infinity()), -cuda::std::numeric_limits<T>::infinity()));
+    assert(cuda::std::isnan(cuda::std::sinh(-cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::sinh(-cuda::std::numeric_limits<T>::quiet_NaN())));
+
+    const T expected = T(1.175201193643801378385660427738912);
+    assert(is_about(cuda::std::sinh(T(1.0)), expected));
+    assert(is_about(cuda::std::sinh(T(-1.0)), -expected));
+  }
+
+  if constexpr (cuda::std::is_same<T, float>::value)
+  {
+    assert(eq(cuda::std::sinhf(cuda::std::numeric_limits<T>::infinity()), cuda::std::numeric_limits<T>::infinity()));
+    assert(eq(cuda::std::sinhf(-cuda::std::numeric_limits<T>::infinity()), -cuda::std::numeric_limits<T>::infinity()));
+    assert(cuda::std::isnan(cuda::std::sinhf(-cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::sinhf(-cuda::std::numeric_limits<T>::quiet_NaN())));
+
+    const T expected = T(1.175201193643801378385660427738912);
+    assert(is_about(cuda::std::sinhf(T(1.0)), expected));
+    assert(is_about(cuda::std::sinhf(T(-1.0)), -expected));
+  }
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  else if constexpr (cuda::std::is_same<T, long double>::value)
+  {
+    assert(eq(cuda::std::sinhl(cuda::std::numeric_limits<T>::infinity()), cuda::std::numeric_limits<T>::infinity()));
+    assert(eq(cuda::std::sinhl(-cuda::std::numeric_limits<T>::infinity()), -cuda::std::numeric_limits<T>::infinity()));
+    assert(cuda::std::isnan(cuda::std::sinhl(-cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::sinhl(-cuda::std::numeric_limits<T>::quiet_NaN())));
+
+    const T expected = T(1.175201193643801378385660427738912);
+    assert(is_about(cuda::std::sinhl(T(1.0)), expected));
+    assert(is_about(cuda::std::sinhl(T(-1.0)), -expected));
+  }
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+}
+
+template <typename T>
+__host__ __device__ void test_tanh(T val)
+{
+  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
+  static_assert(cuda::std::is_same<decltype(cuda::std::tanh(T{})), ret>::value, "");
+
+  // 0 is returned unmodified
+  assert(eq(cuda::std::tanh(val), val));
+  assert(eq(cuda::std::tanh(-val), -val));
+  if constexpr (!cuda::std::is_integral<T>::value)
+  {
+    assert(eq(cuda::std::tanh(cuda::std::numeric_limits<T>::infinity()), T(1.0)));
+    assert(eq(cuda::std::tanh(-cuda::std::numeric_limits<T>::infinity()), T(-1.0)));
+    assert(cuda::std::isnan(cuda::std::tanh(-cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::tanh(-cuda::std::numeric_limits<T>::quiet_NaN())));
+
+    // We have precision issues with tanh because ... its tanh
+    if constexpr (cuda::std::is_same<T, double>::value)
+    {
+      const T expected = T(0.7615941559557648510292438004398718);
+      assert(is_about(cuda::std::tanh(T(1.0)), expected));
+      assert(is_about(cuda::std::tanh(T(-1.0)), -expected));
+    }
+    else
+    {
+      const T expected = T(0.76159417629241943359375);
+      assert(is_about(cuda::std::tanh(T(1.0)), expected));
+      assert(is_about(cuda::std::tanh(T(-1.0)), -expected));
+    }
+  }
+
+  if constexpr (cuda::std::is_same<T, float>::value)
+  {
+    assert(eq(cuda::std::tanhf(cuda::std::numeric_limits<T>::infinity()), T(1.0)));
+    assert(eq(cuda::std::tanhf(-cuda::std::numeric_limits<T>::infinity()), T(-1.0)));
+    assert(cuda::std::isnan(cuda::std::tanhf(-cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::tanhf(-cuda::std::numeric_limits<T>::quiet_NaN())));
+
+    const T expected = T(0.76159417629241943359375);
+    assert(is_about(cuda::std::tanhf(T(1.0)), expected));
+    assert(is_about(cuda::std::tanhf(T(-1.0)), -expected));
+  }
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  else if constexpr (cuda::std::is_same<T, long double>::value)
+  {
+    assert(eq(cuda::std::tanhl(cuda::std::numeric_limits<T>::infinity()), T(1.0)));
+    assert(eq(cuda::std::tanhl(-cuda::std::numeric_limits<T>::infinity()), T(-1.0)));
+    assert(cuda::std::isnan(cuda::std::tanhl(-cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::tanhl(-cuda::std::numeric_limits<T>::quiet_NaN())));
+
+    const T expected = T(0.7615941559557648510292438004398718);
+    assert(is_about(cuda::std::tanhl(T(1.0)), expected));
+    assert(is_about(cuda::std::tanhl(T(-1.0)), expected));
+  }
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+}
+
+template <typename T>
+__host__ __device__ void test(const T val)
+{
+  test_cosh<T>(val);
+  test_sinh<T>(val);
+  test_tanh<T>(val);
+}
+
+__host__ __device__ void test(const float val)
+{
+  test<float>(val);
+  test<double>(val);
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  test<long double>();
+#endif //!_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#ifdef _LIBCUDACXX_HAS_NVFP16
+  test<__half>(val);
+#endif // _LIBCUDACXX_HAS_NVFP16
+#ifdef _LIBCUDACXX_HAS_NVBF16
+  test<__nv_bfloat16>(val);
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+  test<unsigned short>(static_cast<unsigned short>(val));
+  test<int>(static_cast<int>(val));
+  test<unsigned int>(static_cast<unsigned int>(val));
+  test<long>(static_cast<long>(val));
+  test<unsigned long>(static_cast<unsigned long>(val));
+  test<long long>(static_cast<long long>(val));
+  test<unsigned long long>(static_cast<unsigned long long>(val));
+}
+
+__global__ void test_global_kernel(float* val)
+{
+  test(*val);
+}
+
+int main(int, char**)
+{
+  volatile float val = 0.0f;
+  test(val);
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/hyperbolic_functions.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/hyperbolic_functions.pass.cpp
@@ -26,13 +26,13 @@
 template <typename T>
 __host__ __device__ void test_cosh(T val)
 {
-  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
-  static_assert(cuda::std::is_same<decltype(cuda::std::cosh(T{})), ret>::value, "");
+  using ret = cuda::std::conditional_t<cuda::std::is_integral_v<T>, double, T>;
+  static_assert(cuda::std::is_same_v<decltype(cuda::std::cosh(T{})), ret>, "");
 
   // 0 is returned unmodified
   assert(eq(cuda::std::cosh(val), T(1.0)));
   assert(eq(cuda::std::cosh(-val), T(1.0)));
-  if constexpr (!cuda::std::is_integral<T>::value)
+  if constexpr (!cuda::std::is_integral_v<T>)
   {
     assert(cuda::std::isinf(cuda::std::cosh(cuda::std::numeric_limits<T>::infinity())));
     assert(cuda::std::isinf(cuda::std::cosh(-cuda::std::numeric_limits<T>::infinity())));
@@ -44,7 +44,7 @@ __host__ __device__ void test_cosh(T val)
     assert(is_about(cuda::std::cosh(T(-1.0)), expected));
   }
 
-  if constexpr (cuda::std::is_same<T, float>::value)
+  if constexpr (cuda::std::is_same_v<T, float>)
   {
     assert(cuda::std::isinf(cuda::std::coshf(cuda::std::numeric_limits<T>::infinity())));
     assert(cuda::std::isinf(cuda::std::coshf(-cuda::std::numeric_limits<T>::infinity())));
@@ -56,7 +56,7 @@ __host__ __device__ void test_cosh(T val)
     assert(is_about(cuda::std::coshf(T(-1.0)), expected));
   }
 #if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  else if constexpr (cuda::std::is_same<T, long double>::value)
+  else if constexpr (cuda::std::is_same_v<T, long double>)
   {
     assert(cuda::std::isinf(cuda::std::coshl(cuda::std::numeric_limits<T>::infinity())));
     assert(cuda::std::isinf(cuda::std::coshl(-cuda::std::numeric_limits<T>::infinity())));
@@ -73,13 +73,13 @@ __host__ __device__ void test_cosh(T val)
 template <typename T>
 __host__ __device__ void test_sinh(T val)
 {
-  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
-  static_assert(cuda::std::is_same<decltype(cuda::std::sinh(T{})), ret>::value, "");
+  using ret = cuda::std::conditional_t<cuda::std::is_integral_v<T>, double, T>;
+  static_assert(cuda::std::is_same_v<decltype(cuda::std::sinh(T{})), ret>, "");
 
   // 0 is returned unmodified
   assert(eq(cuda::std::sinh(val), val));
   assert(eq(cuda::std::sinh(-val), -val));
-  if constexpr (!cuda::std::is_integral<T>::value)
+  if constexpr (!cuda::std::is_integral_v<T>)
   {
     assert(eq(cuda::std::sinh(cuda::std::numeric_limits<T>::infinity()), cuda::std::numeric_limits<T>::infinity()));
     assert(eq(cuda::std::sinh(-cuda::std::numeric_limits<T>::infinity()), -cuda::std::numeric_limits<T>::infinity()));
@@ -91,7 +91,7 @@ __host__ __device__ void test_sinh(T val)
     assert(is_about(cuda::std::sinh(T(-1.0)), -expected));
   }
 
-  if constexpr (cuda::std::is_same<T, float>::value)
+  if constexpr (cuda::std::is_same_v<T, float>)
   {
     assert(eq(cuda::std::sinhf(cuda::std::numeric_limits<T>::infinity()), cuda::std::numeric_limits<T>::infinity()));
     assert(eq(cuda::std::sinhf(-cuda::std::numeric_limits<T>::infinity()), -cuda::std::numeric_limits<T>::infinity()));
@@ -103,7 +103,7 @@ __host__ __device__ void test_sinh(T val)
     assert(is_about(cuda::std::sinhf(T(-1.0)), -expected));
   }
 #if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  else if constexpr (cuda::std::is_same<T, long double>::value)
+  else if constexpr (cuda::std::is_same_v<T, long double>)
   {
     assert(eq(cuda::std::sinhl(cuda::std::numeric_limits<T>::infinity()), cuda::std::numeric_limits<T>::infinity()));
     assert(eq(cuda::std::sinhl(-cuda::std::numeric_limits<T>::infinity()), -cuda::std::numeric_limits<T>::infinity()));
@@ -120,13 +120,13 @@ __host__ __device__ void test_sinh(T val)
 template <typename T>
 __host__ __device__ void test_tanh(T val)
 {
-  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
-  static_assert(cuda::std::is_same<decltype(cuda::std::tanh(T{})), ret>::value, "");
+  using ret = cuda::std::conditional_t<cuda::std::is_integral_v<T>, double, T>;
+  static_assert(cuda::std::is_same_v<decltype(cuda::std::tanh(T{})), ret>, "");
 
   // 0 is returned unmodified
   assert(eq(cuda::std::tanh(val), val));
   assert(eq(cuda::std::tanh(-val), -val));
-  if constexpr (!cuda::std::is_integral<T>::value)
+  if constexpr (!cuda::std::is_integral_v<T>)
   {
     assert(eq(cuda::std::tanh(cuda::std::numeric_limits<T>::infinity()), T(1.0)));
     assert(eq(cuda::std::tanh(-cuda::std::numeric_limits<T>::infinity()), T(-1.0)));
@@ -134,7 +134,7 @@ __host__ __device__ void test_tanh(T val)
     assert(cuda::std::isnan(cuda::std::tanh(-cuda::std::numeric_limits<T>::quiet_NaN())));
 
     // We have precision issues with tanh because ... its tanh
-    if constexpr (cuda::std::is_same<T, double>::value)
+    if constexpr (cuda::std::is_same_v<T, double>)
     {
       const T expected = T(0.7615941559557648510292438004398718);
       assert(is_about(cuda::std::tanh(T(1.0)), expected));
@@ -148,7 +148,7 @@ __host__ __device__ void test_tanh(T val)
     }
   }
 
-  if constexpr (cuda::std::is_same<T, float>::value)
+  if constexpr (cuda::std::is_same_v<T, float>)
   {
     assert(eq(cuda::std::tanhf(cuda::std::numeric_limits<T>::infinity()), T(1.0)));
     assert(eq(cuda::std::tanhf(-cuda::std::numeric_limits<T>::infinity()), T(-1.0)));
@@ -160,7 +160,7 @@ __host__ __device__ void test_tanh(T val)
     assert(is_about(cuda::std::tanhf(T(-1.0)), -expected));
   }
 #if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  else if constexpr (cuda::std::is_same<T, long double>::value)
+  else if constexpr (cuda::std::is_same_v<T, long double>)
   {
     assert(eq(cuda::std::tanhl(cuda::std::numeric_limits<T>::infinity()), T(1.0)));
     assert(eq(cuda::std::tanhl(-cuda::std::numeric_limits<T>::infinity()), T(-1.0)));

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/hypot.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/hypot.pass.cpp
@@ -26,8 +26,8 @@
 template <typename T>
 __host__ __device__ void test_hypot(T val)
 {
-  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
-  static_assert(cuda::std::is_same<decltype(cuda::std::hypot(T{}, T{})), ret>::value, "");
+  using ret = cuda::std::conditional_t<cuda::std::is_integral_v<T>, double, T>;
+  static_assert(cuda::std::is_same_v<decltype(cuda::std::hypot(T{}, T{})), ret>, "");
 
   // hypot(x, y), hypot(y, x), and hypot(x, -y) are equivalent.
   assert(eq(cuda::std::hypot(T(1.0), T(0.25)), cuda::std::hypot(T(0.25), T(1.0))));
@@ -47,7 +47,7 @@ __host__ __device__ void test_hypot(T val)
     assert(eq(cuda::std::hypot(-val, T(-0.25)), T(0.25)));
   }
 
-  if constexpr (!cuda::std::is_integral<T>::value)
+  if constexpr (!cuda::std::is_integral_v<T>)
   {
     // If one of the arguments is ±∞, std::hypot(x, y) returns +∞ even if the other argument is NaN.
     assert(eq(cuda::std::hypot(cuda::std::numeric_limits<T>::infinity(), cuda::std::numeric_limits<T>::quiet_NaN()),
@@ -74,7 +74,7 @@ __host__ __device__ void test_hypot(T val)
     assert(is_about(cuda::std::hypot(T(1.0), T(2.0)), expected));
   }
 
-  if constexpr (cuda::std::is_same<T, float>::value)
+  if constexpr (cuda::std::is_same_v<T, float>)
   {
     // If one of the arguments is ±∞, std::hypot(x, y) returns +∞ even if the other argument is NaN.
     assert(eq(cuda::std::hypotf(cuda::std::numeric_limits<T>::infinity(), cuda::std::numeric_limits<T>::quiet_NaN()),
@@ -102,7 +102,7 @@ __host__ __device__ void test_hypot(T val)
     assert(is_about(cuda::std::hypotf(T(3.0), T(4.0)), T(5.0)));
   }
 #if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  else if constexpr (cuda::std::is_same<T, long double>::value)
+  else if constexpr (cuda::std::is_same_v<T, long double>)
   {
     // If one of the arguments is ±∞, std::hypot(x, y) returns +∞ even if the other argument is NaN.
     assert(eq(cuda::std::hypotl(cuda::std::numeric_limits<T>::infinity(), cuda::std::numeric_limits<T>::quiet_NaN()),
@@ -135,8 +135,8 @@ __host__ __device__ void test_hypot(T val)
 template <typename T>
 __host__ __device__ void test_hypot3(T val)
 {
-  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
-  static_assert(cuda::std::is_same<decltype(cuda::std::hypot(T{}, T{}, T{})), ret>::value, "");
+  using ret = cuda::std::conditional_t<cuda::std::is_integral_v<T>, double, T>;
+  static_assert(cuda::std::is_same_v<decltype(cuda::std::hypot(T{}, T{}, T{})), ret>, "");
 
   // hypot(x, y), hypot(y, x), and hypot(x, -y) are equivalent.
   assert(eq(cuda::std::hypot(T(1.0), T(0.25), T(2.0)), cuda::std::hypot(T(0.25), T(1.0), T(2.0))));
@@ -154,7 +154,7 @@ __host__ __device__ void test_hypot3(T val)
     assert(eq(cuda::std::hypot(-val, T(-0.25), T(2.0)), cuda::std::hypot(T(0.25), T(2.0))));
   }
 
-  if constexpr (!cuda::std::is_integral<T>::value)
+  if constexpr (!cuda::std::is_integral_v<T>)
   {
     // If any of the arguments is NaN, NaN is returned.
     assert(cuda::std::isnan(cuda::std::hypot(cuda::std::numeric_limits<T>::quiet_NaN(), T(0.25), T(3.0))));
@@ -174,7 +174,7 @@ __host__ __device__ void test_hypot3(T val)
     assert(is_about(cuda::std::hypot(T(2.0), T(3.0), T(6.0)), T(7.0)));
   }
 
-  if constexpr (cuda::std::is_same<T, float>::value)
+  if constexpr (cuda::std::is_same_v<T, float>)
   {
     // If any of the arguments is NaN, NaN is returned.
     assert(cuda::std::isnan(cuda::std::hypotf(cuda::std::numeric_limits<T>::quiet_NaN(), T(0.25), T(3.0))));
@@ -194,7 +194,7 @@ __host__ __device__ void test_hypot3(T val)
     assert(is_about(cuda::std::hypotf(T(2.0), T(3.0), T(6.0)), T(7.0)));
   }
 #if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  else if constexpr (cuda::std::is_same<T, long double>::value)
+  else if constexpr (cuda::std::is_same_v<T, long double>)
   {
     // If any of the arguments is NaN, NaN is returned.
     assert(cuda::std::isnan(cuda::std::hypotl(cuda::std::numeric_limits<T>::quiet_NaN(), T(0.25), T(3.0))));

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/hypot.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/hypot.pass.cpp
@@ -1,0 +1,260 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cmath>
+
+#include <cuda/std/cassert>
+#include <cuda/std/cmath>
+#include <cuda/std/limits>
+#include <cuda/std/type_traits>
+
+#include "comparison.h"
+#include "test_macros.h"
+
+#if defined(TEST_COMPILER_MSVC)
+#  pragma warning(disable : 4244) // conversion from 'double' to 'float', possible loss of data
+#  pragma warning(disable : 4305) // 'argument': truncation from 'T' to 'float'
+#  pragma warning(disable : 4146) // unary minus operator applied to unsigned type, result still unsigned
+#endif // TEST_COMPILER_MSVC
+
+template <typename T>
+__host__ __device__ void test_hypot(T val)
+{
+  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
+  static_assert(cuda::std::is_same<decltype(cuda::std::hypot(T{}, T{})), ret>::value, "");
+
+  // hypot(x, y), hypot(y, x), and hypot(x, -y) are equivalent.
+  assert(eq(cuda::std::hypot(T(1.0), T(0.25)), cuda::std::hypot(T(0.25), T(1.0))));
+  if constexpr (cuda::std::is_signed_v<T>)
+  {
+    assert(eq(cuda::std::hypot(T(1.0), T(0.25)), cuda::std::hypot(T(1.0), T(-0.25))));
+  }
+
+  // If one of the arguments is ±0, std::hypot(x, y) is equivalent to std::fabs called with the non-zero argument.
+  assert(eq(cuda::std::hypot(val, T(0.25)), T(0.25)));
+  assert(eq(cuda::std::hypot(-val, T(0.25)), T(0.25)));
+
+  assert(is_about(cuda::std::hypot(T(3.0), T(4.0)), T(5.0)));
+  if constexpr (cuda::std::is_signed_v<T>)
+  {
+    assert(eq(cuda::std::hypot(val, T(-0.25)), T(0.25)));
+    assert(eq(cuda::std::hypot(-val, T(-0.25)), T(0.25)));
+  }
+
+  if constexpr (!cuda::std::is_integral<T>::value)
+  {
+    // If one of the arguments is ±∞, std::hypot(x, y) returns +∞ even if the other argument is NaN.
+    assert(eq(cuda::std::hypot(cuda::std::numeric_limits<T>::infinity(), cuda::std::numeric_limits<T>::quiet_NaN()),
+              cuda::std::numeric_limits<T>::infinity()));
+    assert(eq(cuda::std::hypot(-cuda::std::numeric_limits<T>::infinity(), cuda::std::numeric_limits<T>::quiet_NaN()),
+              cuda::std::numeric_limits<T>::infinity()));
+    assert(eq(cuda::std::hypot(cuda::std::numeric_limits<T>::quiet_NaN(), cuda::std::numeric_limits<T>::infinity()),
+              cuda::std::numeric_limits<T>::infinity()));
+    assert(eq(cuda::std::hypot(cuda::std::numeric_limits<T>::quiet_NaN(), -cuda::std::numeric_limits<T>::infinity()),
+              cuda::std::numeric_limits<T>::infinity()));
+
+    // Otherwise, if any of the arguments is NaN, NaN is returned.
+    assert(cuda::std::isnan(cuda::std::hypot(T(3.0), cuda::std::numeric_limits<T>::quiet_NaN())));
+    assert(cuda::std::isnan(cuda::std::hypot(T(3.0), -cuda::std::numeric_limits<T>::quiet_NaN())));
+    assert(cuda::std::isnan(cuda::std::hypot(T(3.0), cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::hypot(T(3.0), -cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::hypot(cuda::std::numeric_limits<T>::quiet_NaN(), T(3.0))));
+    assert(cuda::std::isnan(cuda::std::hypot(-cuda::std::numeric_limits<T>::quiet_NaN(), T(3.0))));
+    assert(cuda::std::isnan(cuda::std::hypot(cuda::std::numeric_limits<T>::signaling_NaN(), T(3.0))));
+    assert(cuda::std::isnan(cuda::std::hypot(-cuda::std::numeric_limits<T>::signaling_NaN(), T(3.0))));
+
+    // Some random value
+    const T expected = T(2.236067977499789805051477742381394);
+    assert(is_about(cuda::std::hypot(T(1.0), T(2.0)), expected));
+  }
+
+  if constexpr (cuda::std::is_same<T, float>::value)
+  {
+    // If one of the arguments is ±∞, std::hypot(x, y) returns +∞ even if the other argument is NaN.
+    assert(eq(cuda::std::hypotf(cuda::std::numeric_limits<T>::infinity(), cuda::std::numeric_limits<T>::quiet_NaN()),
+              cuda::std::numeric_limits<T>::infinity()));
+    assert(eq(cuda::std::hypotf(-cuda::std::numeric_limits<T>::infinity(), cuda::std::numeric_limits<T>::quiet_NaN()),
+              cuda::std::numeric_limits<T>::infinity()));
+    assert(eq(cuda::std::hypotf(cuda::std::numeric_limits<T>::quiet_NaN(), cuda::std::numeric_limits<T>::infinity()),
+              cuda::std::numeric_limits<T>::infinity()));
+    assert(eq(cuda::std::hypotf(cuda::std::numeric_limits<T>::quiet_NaN(), -cuda::std::numeric_limits<T>::infinity()),
+              cuda::std::numeric_limits<T>::infinity()));
+
+    // Otherwise, if any of the arguments is NaN, NaN is returned.
+    assert(cuda::std::isnan(cuda::std::hypotf(T(3.0), cuda::std::numeric_limits<T>::quiet_NaN())));
+    assert(cuda::std::isnan(cuda::std::hypotf(T(3.0), -cuda::std::numeric_limits<T>::quiet_NaN())));
+    assert(cuda::std::isnan(cuda::std::hypotf(T(3.0), cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::hypotf(T(3.0), -cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::hypotf(cuda::std::numeric_limits<T>::quiet_NaN(), T(3.0))));
+    assert(cuda::std::isnan(cuda::std::hypotf(-cuda::std::numeric_limits<T>::quiet_NaN(), T(3.0))));
+    assert(cuda::std::isnan(cuda::std::hypotf(cuda::std::numeric_limits<T>::signaling_NaN(), T(3.0))));
+    assert(cuda::std::isnan(cuda::std::hypotf(-cuda::std::numeric_limits<T>::signaling_NaN(), T(3.0))));
+
+    // Some random value
+    const T expected = T(2.236067977499789805051477742381394);
+    assert(is_about(cuda::std::hypotf(T(1.0), T(2.0)), expected));
+    assert(is_about(cuda::std::hypotf(T(3.0), T(4.0)), T(5.0)));
+  }
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  else if constexpr (cuda::std::is_same<T, long double>::value)
+  {
+    // If one of the arguments is ±∞, std::hypot(x, y) returns +∞ even if the other argument is NaN.
+    assert(eq(cuda::std::hypotl(cuda::std::numeric_limits<T>::infinity(), cuda::std::numeric_limits<T>::quiet_NaN()),
+              cuda::std::numeric_limits<T>::infinity()));
+    assert(eq(cuda::std::hypotl(-cuda::std::numeric_limits<T>::infinity(), cuda::std::numeric_limits<T>::quiet_NaN()),
+              cuda::std::numeric_limits<T>::infinity()));
+    assert(eq(cuda::std::hypotl(cuda::std::numeric_limits<T>::quiet_NaN(), cuda::std::numeric_limits<T>::infinity()),
+              cuda::std::numeric_limits<T>::infinity()));
+    assert(eq(cuda::std::hypotl(cuda::std::numeric_limits<T>::quiet_NaN(), -cuda::std::numeric_limits<T>::infinity()),
+              cuda::std::numeric_limits<T>::infinity()));
+
+    // Otherwise, if any of the arguments is NaN, NaN is returned.
+    assert(cuda::std::isnan(cuda::std::hypotl(T(3.0), cuda::std::numeric_limits<T>::quiet_NaN())));
+    assert(cuda::std::isnan(cuda::std::hypotl(T(3.0), -cuda::std::numeric_limits<T>::quiet_NaN())));
+    assert(cuda::std::isnan(cuda::std::hypotl(T(3.0), cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::hypotl(T(3.0), -cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::hypotl(cuda::std::numeric_limits<T>::quiet_NaN(), T(3.0))));
+    assert(cuda::std::isnan(cuda::std::hypotl(-cuda::std::numeric_limits<T>::quiet_NaN(), T(3.0))));
+    assert(cuda::std::isnan(cuda::std::hypotl(cuda::std::numeric_limits<T>::signaling_NaN(), T(3.0))));
+    assert(cuda::std::isnan(cuda::std::hypotl(-cuda::std::numeric_limits<T>::signaling_NaN(), T(3.0))));
+
+    // Some random value
+    const T expected = T(2.236067977499789805051477742381394);
+    assert(is_about(cuda::std::hypotl(T(1.0), T(2.0)), expected));
+    assert(is_about(cuda::std::hypotl(T(3.0), T(4.0)), T(5.0)));
+  }
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+}
+
+template <typename T>
+__host__ __device__ void test_hypot3(T val)
+{
+  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
+  static_assert(cuda::std::is_same<decltype(cuda::std::hypot(T{}, T{}, T{})), ret>::value, "");
+
+  // hypot(x, y), hypot(y, x), and hypot(x, -y) are equivalent.
+  assert(eq(cuda::std::hypot(T(1.0), T(0.25), T(2.0)), cuda::std::hypot(T(0.25), T(1.0), T(2.0))));
+  if constexpr (cuda::std::is_signed_v<T>)
+  {
+    assert(eq(cuda::std::hypot(T(1.0), T(0.25), T(2.0)), cuda::std::hypot(T(1.0), T(-0.25), T(2.0))));
+  }
+
+  // If one of the arguments is ±0, std::hypot(x, y) is equivalent to std::fabs called with the non-zero argument.
+  assert(eq(cuda::std::hypot(val, T(0.25), T(2.0)), cuda::std::hypot(T(0.25), T(2.0))));
+  assert(eq(cuda::std::hypot(-val, T(0.25), T(2.0)), cuda::std::hypot(T(0.25), T(2.0))));
+  if constexpr (cuda::std::is_signed_v<T>)
+  {
+    assert(eq(cuda::std::hypot(val, T(-0.25), T(2.0)), cuda::std::hypot(T(0.25), T(2.0))));
+    assert(eq(cuda::std::hypot(-val, T(-0.25), T(2.0)), cuda::std::hypot(T(0.25), T(2.0))));
+  }
+
+  if constexpr (!cuda::std::is_integral<T>::value)
+  {
+    // If any of the arguments is NaN, NaN is returned.
+    assert(cuda::std::isnan(cuda::std::hypot(cuda::std::numeric_limits<T>::quiet_NaN(), T(0.25), T(3.0))));
+    assert(cuda::std::isnan(cuda::std::hypot(-cuda::std::numeric_limits<T>::quiet_NaN(), T(0.25), T(3.0))));
+    assert(cuda::std::isnan(cuda::std::hypot(cuda::std::numeric_limits<T>::signaling_NaN(), T(0.25), T(3.0))));
+    assert(cuda::std::isnan(cuda::std::hypot(-cuda::std::numeric_limits<T>::signaling_NaN(), T(0.25), T(3.0))));
+    assert(cuda::std::isnan(cuda::std::hypot(T(0.25), cuda::std::numeric_limits<T>::quiet_NaN(), T(3.0))));
+    assert(cuda::std::isnan(cuda::std::hypot(T(0.25), -cuda::std::numeric_limits<T>::quiet_NaN(), T(3.0))));
+    assert(cuda::std::isnan(cuda::std::hypot(T(0.25), cuda::std::numeric_limits<T>::signaling_NaN(), T(3.0))));
+    assert(cuda::std::isnan(cuda::std::hypot(T(0.25), -cuda::std::numeric_limits<T>::signaling_NaN(), T(3.0))));
+    assert(cuda::std::isnan(cuda::std::hypot(T(0.25), T(3.0), cuda::std::numeric_limits<T>::quiet_NaN())));
+    assert(cuda::std::isnan(cuda::std::hypot(T(0.25), T(3.0), -cuda::std::numeric_limits<T>::quiet_NaN())));
+    assert(cuda::std::isnan(cuda::std::hypot(T(0.25), T(3.0), cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::hypot(T(0.25), T(3.0), -cuda::std::numeric_limits<T>::signaling_NaN())));
+
+    // Some random value
+    assert(is_about(cuda::std::hypot(T(2.0), T(3.0), T(6.0)), T(7.0)));
+  }
+
+  if constexpr (cuda::std::is_same<T, float>::value)
+  {
+    // If any of the arguments is NaN, NaN is returned.
+    assert(cuda::std::isnan(cuda::std::hypotf(cuda::std::numeric_limits<T>::quiet_NaN(), T(0.25), T(3.0))));
+    assert(cuda::std::isnan(cuda::std::hypotf(-cuda::std::numeric_limits<T>::quiet_NaN(), T(0.25), T(3.0))));
+    assert(cuda::std::isnan(cuda::std::hypotf(cuda::std::numeric_limits<T>::signaling_NaN(), T(0.25), T(3.0))));
+    assert(cuda::std::isnan(cuda::std::hypotf(-cuda::std::numeric_limits<T>::signaling_NaN(), T(0.25), T(3.0))));
+    assert(cuda::std::isnan(cuda::std::hypotf(T(0.25), cuda::std::numeric_limits<T>::quiet_NaN(), T(3.0))));
+    assert(cuda::std::isnan(cuda::std::hypotf(T(0.25), -cuda::std::numeric_limits<T>::quiet_NaN(), T(3.0))));
+    assert(cuda::std::isnan(cuda::std::hypotf(T(0.25), cuda::std::numeric_limits<T>::signaling_NaN(), T(3.0))));
+    assert(cuda::std::isnan(cuda::std::hypotf(T(0.25), -cuda::std::numeric_limits<T>::signaling_NaN(), T(3.0))));
+    assert(cuda::std::isnan(cuda::std::hypotf(T(0.25), T(3.0), cuda::std::numeric_limits<T>::quiet_NaN())));
+    assert(cuda::std::isnan(cuda::std::hypotf(T(0.25), T(3.0), -cuda::std::numeric_limits<T>::quiet_NaN())));
+    assert(cuda::std::isnan(cuda::std::hypotf(T(0.25), T(3.0), cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::hypotf(T(0.25), T(3.0), -cuda::std::numeric_limits<T>::signaling_NaN())));
+
+    // Some random value
+    assert(is_about(cuda::std::hypotf(T(2.0), T(3.0), T(6.0)), T(7.0)));
+  }
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  else if constexpr (cuda::std::is_same<T, long double>::value)
+  {
+    // If any of the arguments is NaN, NaN is returned.
+    assert(cuda::std::isnan(cuda::std::hypotl(cuda::std::numeric_limits<T>::quiet_NaN(), T(0.25), T(3.0))));
+    assert(cuda::std::isnan(cuda::std::hypotl(-cuda::std::numeric_limits<T>::quiet_NaN(), T(0.25), T(3.0))));
+    assert(cuda::std::isnan(cuda::std::hypotl(cuda::std::numeric_limits<T>::signaling_NaN(), T(0.25), T(3.0))));
+    assert(cuda::std::isnan(cuda::std::hypotl(-cuda::std::numeric_limits<T>::signaling_NaN(), T(0.25), T(3.0))));
+    assert(cuda::std::isnan(cuda::std::hypotl(T(0.25), cuda::std::numeric_limits<T>::quiet_NaN(), T(3.0))));
+    assert(cuda::std::isnan(cuda::std::hypotl(T(0.25), -cuda::std::numeric_limits<T>::quiet_NaN(), T(3.0))));
+    assert(cuda::std::isnan(cuda::std::hypotl(T(0.25), cuda::std::numeric_limits<T>::signaling_NaN(), T(3.0))));
+    assert(cuda::std::isnan(cuda::std::hypotl(T(0.25), -cuda::std::numeric_limits<T>::signaling_NaN(), T(3.0))));
+    assert(cuda::std::isnan(cuda::std::hypotl(T(0.25), T(3.0), cuda::std::numeric_limits<T>::quiet_NaN())));
+    assert(cuda::std::isnan(cuda::std::hypotl(T(0.25), T(3.0), -cuda::std::numeric_limits<T>::quiet_NaN())));
+    assert(cuda::std::isnan(cuda::std::hypotl(T(0.25), T(3.0), cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::hypotl(T(0.25), T(3.0), -cuda::std::numeric_limits<T>::signaling_NaN())));
+
+    // Some random value
+    assert(is_about(cuda::std::hypotl(T(2.0), T(3.0), T(6.0)), T(7.0)));
+  }
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+}
+
+template <typename T>
+__host__ __device__ void test(const T val)
+{
+  test_hypot<T>(val);
+  test_hypot3<T>(val);
+}
+
+__host__ __device__ void test(const float val)
+{
+  test<float>(val);
+  test<double>(val);
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  test<long double>();
+#endif //!_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#ifdef _LIBCUDACXX_HAS_NVFP16
+  test<__half>(val);
+#endif // _LIBCUDACXX_HAS_NVFP16
+#ifdef _LIBCUDACXX_HAS_NVBF16
+  test<__nv_bfloat16>(val);
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+  test<unsigned short>(static_cast<unsigned short>(val));
+  test<int>(static_cast<int>(val));
+  test<unsigned int>(static_cast<unsigned int>(val));
+  test<long>(static_cast<long>(val));
+  test<unsigned long>(static_cast<unsigned long>(val));
+  test<long long>(static_cast<long long>(val));
+  test<unsigned long long>(static_cast<unsigned long long>(val));
+}
+
+__global__ void test_global_kernel(float* val)
+{
+  test(*val);
+}
+
+int main(int, char**)
+{
+  volatile float val = 0.0f;
+  test(val);
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/inverse_hyperbolic_functions.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/inverse_hyperbolic_functions.pass.cpp
@@ -1,0 +1,273 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cmath>
+
+#include <cuda/std/cassert>
+#include <cuda/std/cmath>
+#include <cuda/std/limits>
+#include <cuda/std/type_traits>
+
+#include "comparison.h"
+#include "test_macros.h"
+
+#if defined(TEST_COMPILER_MSVC)
+#  pragma warning(disable : 4244) // conversion from 'double' to 'float', possible loss of data
+#  pragma warning(disable : 4305) // 'argument': truncation from 'T' to 'float'
+#  pragma warning(disable : 4146) // unary minus operator applied to unsigned type, result still unsigned
+#endif // TEST_COMPILER_MSVC
+
+template <typename T>
+__host__ __device__ void test_acosh(T val)
+{
+  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
+  static_assert(cuda::std::is_same<decltype(cuda::std::acosh(T{})), ret>::value, "");
+
+  // If the argument is less than 1
+  assert(cuda::std::isnan(cuda::std::acosh(val)));
+  assert(cuda::std::isnan(cuda::std::acosh(-val)));
+  assert(cuda::std::isnan(cuda::std::acosh(-cuda::std::numeric_limits<T>::infinity())));
+
+  // If the argument is 1, +0 is returned.
+  assert(eq(cuda::std::acosh(T(1.0)), val));
+
+  if constexpr (!cuda::std::is_integral<T>::value)
+  {
+    assert(eq(cuda::std::acosh(cuda::std::numeric_limits<T>::infinity()), cuda::std::numeric_limits<T>::infinity()));
+    assert(cuda::std::isnan(cuda::std::acosh(cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::acosh(cuda::std::numeric_limits<T>::quiet_NaN())));
+    assert(cuda::std::isnan(cuda::std::acosh(-cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::acosh(-cuda::std::numeric_limits<T>::quiet_NaN())));
+
+    // Some random value
+    const T expected = T(1.316957896924816795447554795828182);
+    assert(is_about(cuda::std::acosh(T(2.0)), expected));
+  }
+
+  if constexpr (cuda::std::is_same<T, float>::value)
+  {
+    assert(eq(cuda::std::acoshf(cuda::std::numeric_limits<T>::infinity()), cuda::std::numeric_limits<T>::infinity()));
+    assert(cuda::std::isnan(cuda::std::acoshf(cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::acoshf(cuda::std::numeric_limits<T>::quiet_NaN())));
+    assert(cuda::std::isnan(cuda::std::acoshf(-cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::acoshf(-cuda::std::numeric_limits<T>::quiet_NaN())));
+
+    // Some random value
+    const T expected = T(1.316957896924816795447554795828182);
+    assert(is_about(cuda::std::acoshf(T(2.0)), expected));
+  }
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  else if constexpr (cuda::std::is_same<T, long double>::value)
+  {
+    assert(eq(cuda::std::acoshl(cuda::std::numeric_limits<T>::infinity()), cuda::std::numeric_limits<T>::infinity()));
+    assert(cuda::std::isnan(cuda::std::acoshl(cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::acoshl(cuda::std::numeric_limits<T>::quiet_NaN())));
+    assert(cuda::std::isnan(cuda::std::acoshl(-cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::acoshl(-cuda::std::numeric_limits<T>::quiet_NaN())));
+
+    // Some random value
+    const T expected = T(1.316957896924816795447554795828182);
+    assert(is_about(cuda::std::acoshl(T(2.0)), expected));
+  }
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+}
+
+template <typename T>
+__host__ __device__ void test_asinh(T val)
+{
+  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
+  static_assert(cuda::std::is_same<decltype(cuda::std::asinh(T{})), ret>::value, "");
+
+  // If  the argument is ±0 or ±∞, it is returned unmodified.
+  assert(eq(cuda::std::asinh(val), val));
+  assert(eq(cuda::std::asinh(-val), -val));
+  if constexpr (!cuda::std::is_integral<T>::value)
+  {
+    // If  the argument is ±0 or ±∞, it is returned unmodified.
+    assert(eq(cuda::std::asinh(cuda::std::numeric_limits<T>::infinity()), cuda::std::numeric_limits<T>::infinity()));
+    assert(eq(cuda::std::asinh(-cuda::std::numeric_limits<T>::infinity()), -cuda::std::numeric_limits<T>::infinity()));
+
+    // If the argument is NaN, NaN is returned.
+    assert(cuda::std::isnan(cuda::std::asinh(cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::asinh(-cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::asinh(cuda::std::numeric_limits<T>::quiet_NaN())));
+    assert(cuda::std::isnan(cuda::std::asinh(-cuda::std::numeric_limits<T>::quiet_NaN())));
+
+    // Is symmetric
+    assert(eq(cuda::std::asinh(T(0.5)), -cuda::std::asinh(T(-0.5))));
+    assert(eq(cuda::std::asinh(T(0.25)), -cuda::std::asinh(T(-0.25))));
+
+    // Some random value
+    const T expected = T(0.8813735870195430477380682532384526);
+    assert(is_about(cuda::std::asinh(T(1.0)), expected));
+    assert(is_about(cuda::std::asinh(T(-1.0)), -expected));
+  }
+
+  if constexpr (cuda::std::is_same<T, float>::value)
+  {
+    // If  the argument is ±0 or ±∞, it is returned unmodified.
+    assert(eq(cuda::std::asinhf(cuda::std::numeric_limits<T>::infinity()), cuda::std::numeric_limits<T>::infinity()));
+    assert(eq(cuda::std::asinhf(-cuda::std::numeric_limits<T>::infinity()), -cuda::std::numeric_limits<T>::infinity()));
+
+    // If the argument is NaN, NaN is returned.
+    assert(cuda::std::isnan(cuda::std::asinhf(cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::asinhf(-cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::asinhf(cuda::std::numeric_limits<T>::quiet_NaN())));
+    assert(cuda::std::isnan(cuda::std::asinhf(-cuda::std::numeric_limits<T>::quiet_NaN())));
+
+    // Is symmetric
+    assert(eq(cuda::std::asinhf(T(0.5)), -cuda::std::asinhf(T(-0.5))));
+    assert(eq(cuda::std::asinhf(T(0.25)), -cuda::std::asinhf(T(-0.25))));
+
+    // Some random value
+    const T expected = T(0.8813735870195430477380682532384526);
+    assert(is_about(cuda::std::asinhf(T(1.0)), expected));
+    assert(is_about(cuda::std::asinhf(T(-1.0)), -expected));
+  }
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  else if constexpr (cuda::std::is_same<T, long double>::value)
+  {
+    // If  the argument is ±0 or ±∞, it is returned unmodified.
+    assert(eq(cuda::std::asinhl(cuda::std::numeric_limits<T>::infinity()), cuda::std::numeric_limits<T>::infinity()));
+    assert(eq(cuda::std::asinhl(-cuda::std::numeric_limits<T>::infinity()), -cuda::std::numeric_limits<T>::infinity()));
+
+    // If the argument is NaN, NaN is returned.
+    assert(cuda::std::isnan(cuda::std::asinhl(cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::asinhl(-cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::asinhl(cuda::std::numeric_limits<T>::quiet_NaN())));
+    assert(cuda::std::isnan(cuda::std::asinhl(-cuda::std::numeric_limits<T>::quiet_NaN())));
+
+    // Is symmetric
+    assert(eq(cuda::std::asinhl(T(0.5)), -cuda::std::asinhl(T(-0.5))));
+    assert(eq(cuda::std::asinhl(T(0.25)), -cuda::std::asinhl(T(-0.25))));
+
+    // Some random value
+    const T expected = T(0.8813735870195430477380682532384526);
+    assert(is_about(cuda::std::asinhl(T(1.0)), expected));
+    assert(is_about(cuda::std::asinhl(T(-1.0)), -expected));
+  }
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+}
+
+template <typename T>
+__host__ __device__ void test_atanh(T val)
+{
+  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
+  static_assert(cuda::std::is_same<decltype(cuda::std::atanh(T{})), ret>::value, "");
+
+  // 0 is returned unmodified
+  assert(eq(cuda::std::atanh(val), val));
+  assert(eq(cuda::std::atanh(-val), -val));
+  if constexpr (!cuda::std::is_integral<T>::value)
+  {
+    assert(eq(cuda::std::atanh(T(1.0)), cuda::std::numeric_limits<T>::infinity()));
+    assert(eq(cuda::std::atanh(T(-1.0)), -cuda::std::numeric_limits<T>::infinity()));
+    assert(cuda::std::isnan(cuda::std::atanh(-cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::atanh(-cuda::std::numeric_limits<T>::quiet_NaN())));
+
+    // If |x| > 1, NaN is returned
+    assert(cuda::std::isnan(cuda::std::atanh(T(2.0))));
+    assert(cuda::std::isnan(cuda::std::atanh(T(-2.0))));
+
+    // Is symmetric
+    assert(eq(cuda::std::atanh(T(0.25)), -cuda::std::atanh(T(-0.25))));
+    assert(eq(cuda::std::atanh(T(0.5)), -cuda::std::atanh(T(-0.5))));
+
+    const T expected =
+      cuda::std::is_same_v<T, double> ? T(0.5493061443340548910541087934689131) : T(0.5493061542510986328125);
+    assert(is_about(cuda::std::atanh(T(0.5)), expected));
+    assert(is_about(cuda::std::atanh(T(-0.5)), -expected));
+  }
+
+  if constexpr (cuda::std::is_same<T, float>::value)
+  {
+    assert(eq(cuda::std::atanhf(T(1.0)), cuda::std::numeric_limits<T>::infinity()));
+    assert(eq(cuda::std::atanhf(T(-1.0)), -cuda::std::numeric_limits<T>::infinity()));
+    assert(cuda::std::isnan(cuda::std::atanhf(-cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::atanhf(-cuda::std::numeric_limits<T>::quiet_NaN())));
+
+    // If |x| > 1, NaN is returned
+    assert(cuda::std::isnan(cuda::std::atanhf(T(2.0))));
+    assert(cuda::std::isnan(cuda::std::atanhf(T(-2.0))));
+
+    // Is symmetric
+    assert(eq(cuda::std::atanhf(T(0.25)), -cuda::std::atanhf(T(-0.25))));
+    assert(eq(cuda::std::atanhf(T(0.5)), -cuda::std::atanhf(T(-0.5))));
+
+    // Some random value
+    const T expected = T(0.5493061542510986328125);
+    assert(is_about(cuda::std::atanhf(T(0.5)), expected));
+    assert(is_about(cuda::std::atanhf(T(-0.5)), -expected));
+  }
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  else if constexpr (cuda::std::is_same<T, long double>::value)
+  {
+    assert(eq(cuda::std::atanhl(T(1.0)), cuda::std::numeric_limits<T>::infinity()));
+    assert(eq(cuda::std::atanhl(T(-1.0)), -cuda::std::numeric_limits<T>::infinity()));
+    assert(cuda::std::isnan(cuda::std::atanhl(-cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::atanhl(-cuda::std::numeric_limits<T>::quiet_NaN())));
+
+    // If |x| > 1, NaN is returned
+    assert(cuda::std::isnan(cuda::std::atanhl(T(2.0))));
+    assert(cuda::std::isnan(cuda::std::atanhl(T(-2.0))));
+
+    // Is symmetric
+    assert(eq(cuda::std::atanhl(T(0.25)), -cuda::std::atanhl(T(-0.25))));
+    assert(eq(cuda::std::atanhl(T(0.5)), -cuda::std::atanhl(T(-0.5))));
+
+    const T expected = T(0.5493061443340548910541087934689131);
+    assert(is_about(cuda::std::atanhl(T(0.5)), expected));
+    assert(is_about(cuda::std::atanhl(T(-0.5)), -expected));
+  }
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+}
+
+template <typename T>
+__host__ __device__ void test(const T val)
+{
+  test_acosh<T>(val);
+  test_asinh<T>(val);
+  test_atanh<T>(val);
+}
+
+__host__ __device__ void test(const float val)
+{
+  test<float>(val);
+  test<double>(val);
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  test<long double>();
+#endif //!_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#ifdef _LIBCUDACXX_HAS_NVFP16
+  test<__half>(val);
+#endif // _LIBCUDACXX_HAS_NVFP16
+#ifdef _LIBCUDACXX_HAS_NVBF16
+  test<__nv_bfloat16>(val);
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+  test<unsigned short>(static_cast<unsigned short>(val));
+  test<int>(static_cast<int>(val));
+  test<unsigned int>(static_cast<unsigned int>(val));
+  test<long>(static_cast<long>(val));
+  test<unsigned long>(static_cast<unsigned long>(val));
+  test<long long>(static_cast<long long>(val));
+  test<unsigned long long>(static_cast<unsigned long long>(val));
+}
+
+__global__ void test_global_kernel(float* val)
+{
+  test(*val);
+}
+
+int main(int, char**)
+{
+  volatile float val = 0.0f;
+  test(val);
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/inverse_hyperbolic_functions.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/inverse_hyperbolic_functions.pass.cpp
@@ -26,8 +26,8 @@
 template <typename T>
 __host__ __device__ void test_acosh(T val)
 {
-  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
-  static_assert(cuda::std::is_same<decltype(cuda::std::acosh(T{})), ret>::value, "");
+  using ret = cuda::std::conditional_t<cuda::std::is_integral_v<T>, double, T>;
+  static_assert(cuda::std::is_same_v<decltype(cuda::std::acosh(T{})), ret>, "");
 
   // If the argument is less than 1
   assert(cuda::std::isnan(cuda::std::acosh(val)));
@@ -37,7 +37,7 @@ __host__ __device__ void test_acosh(T val)
   // If the argument is 1, +0 is returned.
   assert(eq(cuda::std::acosh(T(1.0)), val));
 
-  if constexpr (!cuda::std::is_integral<T>::value)
+  if constexpr (!cuda::std::is_integral_v<T>)
   {
     assert(eq(cuda::std::acosh(cuda::std::numeric_limits<T>::infinity()), cuda::std::numeric_limits<T>::infinity()));
     assert(cuda::std::isnan(cuda::std::acosh(cuda::std::numeric_limits<T>::signaling_NaN())));
@@ -50,7 +50,7 @@ __host__ __device__ void test_acosh(T val)
     assert(is_about(cuda::std::acosh(T(2.0)), expected));
   }
 
-  if constexpr (cuda::std::is_same<T, float>::value)
+  if constexpr (cuda::std::is_same_v<T, float>)
   {
     assert(eq(cuda::std::acoshf(cuda::std::numeric_limits<T>::infinity()), cuda::std::numeric_limits<T>::infinity()));
     assert(cuda::std::isnan(cuda::std::acoshf(cuda::std::numeric_limits<T>::signaling_NaN())));
@@ -63,7 +63,7 @@ __host__ __device__ void test_acosh(T val)
     assert(is_about(cuda::std::acoshf(T(2.0)), expected));
   }
 #if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  else if constexpr (cuda::std::is_same<T, long double>::value)
+  else if constexpr (cuda::std::is_same_v<T, long double>)
   {
     assert(eq(cuda::std::acoshl(cuda::std::numeric_limits<T>::infinity()), cuda::std::numeric_limits<T>::infinity()));
     assert(cuda::std::isnan(cuda::std::acoshl(cuda::std::numeric_limits<T>::signaling_NaN())));
@@ -81,13 +81,13 @@ __host__ __device__ void test_acosh(T val)
 template <typename T>
 __host__ __device__ void test_asinh(T val)
 {
-  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
-  static_assert(cuda::std::is_same<decltype(cuda::std::asinh(T{})), ret>::value, "");
+  using ret = cuda::std::conditional_t<cuda::std::is_integral_v<T>, double, T>;
+  static_assert(cuda::std::is_same_v<decltype(cuda::std::asinh(T{})), ret>, "");
 
   // If  the argument is ±0 or ±∞, it is returned unmodified.
   assert(eq(cuda::std::asinh(val), val));
   assert(eq(cuda::std::asinh(-val), -val));
-  if constexpr (!cuda::std::is_integral<T>::value)
+  if constexpr (!cuda::std::is_integral_v<T>)
   {
     // If  the argument is ±0 or ±∞, it is returned unmodified.
     assert(eq(cuda::std::asinh(cuda::std::numeric_limits<T>::infinity()), cuda::std::numeric_limits<T>::infinity()));
@@ -109,7 +109,7 @@ __host__ __device__ void test_asinh(T val)
     assert(is_about(cuda::std::asinh(T(-1.0)), -expected));
   }
 
-  if constexpr (cuda::std::is_same<T, float>::value)
+  if constexpr (cuda::std::is_same_v<T, float>)
   {
     // If  the argument is ±0 or ±∞, it is returned unmodified.
     assert(eq(cuda::std::asinhf(cuda::std::numeric_limits<T>::infinity()), cuda::std::numeric_limits<T>::infinity()));
@@ -131,7 +131,7 @@ __host__ __device__ void test_asinh(T val)
     assert(is_about(cuda::std::asinhf(T(-1.0)), -expected));
   }
 #if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  else if constexpr (cuda::std::is_same<T, long double>::value)
+  else if constexpr (cuda::std::is_same_v<T, long double>)
   {
     // If  the argument is ±0 or ±∞, it is returned unmodified.
     assert(eq(cuda::std::asinhl(cuda::std::numeric_limits<T>::infinity()), cuda::std::numeric_limits<T>::infinity()));
@@ -158,13 +158,13 @@ __host__ __device__ void test_asinh(T val)
 template <typename T>
 __host__ __device__ void test_atanh(T val)
 {
-  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
-  static_assert(cuda::std::is_same<decltype(cuda::std::atanh(T{})), ret>::value, "");
+  using ret = cuda::std::conditional_t<cuda::std::is_integral_v<T>, double, T>;
+  static_assert(cuda::std::is_same_v<decltype(cuda::std::atanh(T{})), ret>, "");
 
   // 0 is returned unmodified
   assert(eq(cuda::std::atanh(val), val));
   assert(eq(cuda::std::atanh(-val), -val));
-  if constexpr (!cuda::std::is_integral<T>::value)
+  if constexpr (!cuda::std::is_integral_v<T>)
   {
     assert(eq(cuda::std::atanh(T(1.0)), cuda::std::numeric_limits<T>::infinity()));
     assert(eq(cuda::std::atanh(T(-1.0)), -cuda::std::numeric_limits<T>::infinity()));
@@ -185,7 +185,7 @@ __host__ __device__ void test_atanh(T val)
     assert(is_about(cuda::std::atanh(T(-0.5)), -expected));
   }
 
-  if constexpr (cuda::std::is_same<T, float>::value)
+  if constexpr (cuda::std::is_same_v<T, float>)
   {
     assert(eq(cuda::std::atanhf(T(1.0)), cuda::std::numeric_limits<T>::infinity()));
     assert(eq(cuda::std::atanhf(T(-1.0)), -cuda::std::numeric_limits<T>::infinity()));
@@ -206,7 +206,7 @@ __host__ __device__ void test_atanh(T val)
     assert(is_about(cuda::std::atanhf(T(-0.5)), -expected));
   }
 #if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  else if constexpr (cuda::std::is_same<T, long double>::value)
+  else if constexpr (cuda::std::is_same_v<T, long double>)
   {
     assert(eq(cuda::std::atanhl(T(1.0)), cuda::std::numeric_limits<T>::infinity()));
     assert(eq(cuda::std::atanhl(T(-1.0)), -cuda::std::numeric_limits<T>::infinity()));

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/inverse_trigonometric_functions.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/inverse_trigonometric_functions.pass.cpp
@@ -26,12 +26,12 @@
 template <typename T>
 __host__ __device__ void test_acos(T val)
 {
-  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
-  static_assert(cuda::std::is_same<decltype(cuda::std::acos(T{})), ret>::value, "");
+  using ret = cuda::std::conditional_t<cuda::std::is_integral_v<T>, double, T>;
+  static_assert(cuda::std::is_same_v<decltype(cuda::std::acos(T{})), ret>, "");
 
   assert(eq(cuda::std::acos(T(1.0)), val));
   assert(cuda::std::isnan(cuda::std::acos(T(2.0))));
-  if constexpr (!cuda::std::is_integral<T>::value)
+  if constexpr (!cuda::std::is_integral_v<T>)
   {
     assert(cuda::std::isnan(cuda::std::acos(cuda::std::numeric_limits<T>::infinity())));
     assert(cuda::std::isnan(cuda::std::acos(-cuda::std::numeric_limits<T>::infinity())));
@@ -42,7 +42,7 @@ __host__ __device__ void test_acos(T val)
     assert(is_about(cuda::std::acos(T(0.5)), pi / T(3.0)));
   }
 
-  if constexpr (cuda::std::is_same<T, float>::value)
+  if constexpr (cuda::std::is_same_v<T, float>)
   {
     assert(cuda::std::isnan(cuda::std::acosf(cuda::std::numeric_limits<T>::infinity())));
     assert(cuda::std::isnan(cuda::std::acosf(-cuda::std::numeric_limits<T>::infinity())));
@@ -53,7 +53,7 @@ __host__ __device__ void test_acos(T val)
     assert(is_about(cuda::std::acosf(T(0.5)), pi / T(3.0)));
   }
 #if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  else if constexpr (cuda::std::is_same<T, long double>::value)
+  else if constexpr (cuda::std::is_same_v<T, long double>)
   {
     assert(cuda::std::isnan(cuda::std::acosl(cuda::std::numeric_limits<T>::infinity())));
     assert(cuda::std::isnan(cuda::std::acosl(-cuda::std::numeric_limits<T>::infinity())));
@@ -69,14 +69,14 @@ __host__ __device__ void test_acos(T val)
 template <typename T>
 __host__ __device__ void test_asin(T val)
 {
-  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
-  static_assert(cuda::std::is_same<decltype(cuda::std::asin(T{})), ret>::value, "");
+  using ret = cuda::std::conditional_t<cuda::std::is_integral_v<T>, double, T>;
+  static_assert(cuda::std::is_same_v<decltype(cuda::std::asin(T{})), ret>, "");
 
   // 0 is returned unmodified
   assert(eq(cuda::std::asin(val), val));
   assert(eq(cuda::std::asin(-val), -val));
   assert(cuda::std::isnan(cuda::std::asin(T(2.0))));
-  if constexpr (!cuda::std::is_integral<T>::value)
+  if constexpr (!cuda::std::is_integral_v<T>)
   {
     assert(cuda::std::isnan(cuda::std::asin(cuda::std::numeric_limits<T>::infinity())));
     assert(cuda::std::isnan(cuda::std::asin(-cuda::std::numeric_limits<T>::infinity())));
@@ -88,7 +88,7 @@ __host__ __device__ void test_asin(T val)
     assert(is_about(cuda::std::asin(T(-0.5)), -pi / T(6.0)));
   }
 
-  if constexpr (cuda::std::is_same<T, float>::value)
+  if constexpr (cuda::std::is_same_v<T, float>)
   {
     assert(cuda::std::isnan(cuda::std::asinf(cuda::std::numeric_limits<T>::infinity())));
     assert(cuda::std::isnan(cuda::std::asinf(-cuda::std::numeric_limits<T>::infinity())));
@@ -100,7 +100,7 @@ __host__ __device__ void test_asin(T val)
     assert(is_about(cuda::std::asinf(T(-0.5)), -pi / T(6.0)));
   }
 #if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  else if constexpr (cuda::std::is_same<T, long double>::value)
+  else if constexpr (cuda::std::is_same_v<T, long double>)
   {
     assert(cuda::std::isnan(cuda::std::asinl(cuda::std::numeric_limits<T>::infinity())));
     assert(cuda::std::isnan(cuda::std::asinl(-cuda::std::numeric_limits<T>::infinity())));
@@ -117,13 +117,13 @@ __host__ __device__ void test_asin(T val)
 template <typename T>
 __host__ __device__ void test_atan(T val)
 {
-  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
-  static_assert(cuda::std::is_same<decltype(cuda::std::atan(T{})), ret>::value, "");
+  using ret = cuda::std::conditional_t<cuda::std::is_integral_v<T>, double, T>;
+  static_assert(cuda::std::is_same_v<decltype(cuda::std::atan(T{})), ret>, "");
 
   // 0 is returned unmodified
   assert(eq(cuda::std::atan(val), val));
   assert(eq(cuda::std::atan(-val), -val));
-  if constexpr (!cuda::std::is_integral<T>::value)
+  if constexpr (!cuda::std::is_integral_v<T>)
   {
     const T pi = T(3.141592653589793238462643383279502);
     assert(eq(cuda::std::atan(cuda::std::numeric_limits<T>::infinity()), pi / T(2.0)));
@@ -134,7 +134,7 @@ __host__ __device__ void test_atan(T val)
     assert(is_about(cuda::std::atan(T(1.0)), pi / T(4.0)));
   }
 
-  if constexpr (cuda::std::is_same<T, float>::value)
+  if constexpr (cuda::std::is_same_v<T, float>)
   {
     const T pi = T(3.141592653589793238462643383279502);
     assert(eq(cuda::std::atanf(cuda::std::numeric_limits<T>::infinity()), pi / T(2.0)));
@@ -145,7 +145,7 @@ __host__ __device__ void test_atan(T val)
     assert(is_about(cuda::std::atanf(T(1.0)), pi / T(4.0)));
   }
 #if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  else if constexpr (cuda::std::is_same<T, long double>::value)
+  else if constexpr (cuda::std::is_same_v<T, long double>)
   {
     const T pi = T(3.141592653589793238462643383279502);
     assert(eq(cuda::std::atanl(cuda::std::numeric_limits<T>::infinity()), pi / T(2.0)));
@@ -161,15 +161,15 @@ __host__ __device__ void test_atan(T val)
 template <typename T>
 __host__ __device__ void test_atan2(T val)
 {
-  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
-  static_assert(cuda::std::is_same<decltype(cuda::std::atan2(T{}, T{})), ret>::value, "");
+  using ret = cuda::std::conditional_t<cuda::std::is_integral_v<T>, double, T>;
+  static_assert(cuda::std::is_same_v<decltype(cuda::std::atan2(T{}, T{})), ret>, "");
 
   // If y is ±0 and x is positive or +0, ±0 is returned.
   assert(eq(cuda::std::atan2(val, val), val));
   assert(eq(cuda::std::atan2(-val, val), -val));
   assert(eq(cuda::std::atan2(val, T(2.0)), val));
   assert(eq(cuda::std::atan2(-val, T(2.0)), val));
-  if constexpr (!cuda::std::is_integral<T>::value)
+  if constexpr (!cuda::std::is_integral_v<T>)
   {
     const T pi = T(3.141592653589793238462643383279502);
     assert(cuda::std::isnan(cuda::std::atan2(val, cuda::std::numeric_limits<T>::signaling_NaN())));
@@ -226,7 +226,7 @@ __host__ __device__ void test_atan2(T val)
     assert(eq(cuda::std::atan2(T(-2.0), cuda::std::numeric_limits<T>::infinity()), -val));
   }
 
-  if constexpr (cuda::std::is_same<T, float>::value)
+  if constexpr (cuda::std::is_same_v<T, float>)
   {
     const T pi = T(3.141592653589793238462643383279502);
     assert(cuda::std::isnan(cuda::std::atan2f(val, cuda::std::numeric_limits<T>::signaling_NaN())));
@@ -283,7 +283,7 @@ __host__ __device__ void test_atan2(T val)
     assert(eq(cuda::std::atan2f(T(-2.0), cuda::std::numeric_limits<T>::infinity()), -val));
   }
 #if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  else if constexpr (cuda::std::is_same<T, long double>::value)
+  else if constexpr (cuda::std::is_same_v<T, long double>)
   {
     const T pi = T(3.141592653589793238462643383279502);
     assert(cuda::std::isnan(cuda::std::atan2l(val, cuda::std::numeric_limits<T>::signaling_NaN())));

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/inverse_trigonometric_functions.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/inverse_trigonometric_functions.pass.cpp
@@ -1,0 +1,388 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cmath>
+
+#include <cuda/std/cassert>
+#include <cuda/std/cmath>
+#include <cuda/std/limits>
+#include <cuda/std/type_traits>
+
+#include "comparison.h"
+#include "test_macros.h"
+
+#if defined(TEST_COMPILER_MSVC)
+#  pragma warning(disable : 4244) // conversion from 'double' to 'float', possible loss of data
+#  pragma warning(disable : 4305) // 'argument': truncation from 'T' to 'float'
+#  pragma warning(disable : 4146) // unary minus operator applied to unsigned type, result still unsigned
+#endif // TEST_COMPILER_MSVC
+
+template <typename T>
+__host__ __device__ void test_acos(T val)
+{
+  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
+  static_assert(cuda::std::is_same<decltype(cuda::std::acos(T{})), ret>::value, "");
+
+  assert(eq(cuda::std::acos(T(1.0)), val));
+  assert(cuda::std::isnan(cuda::std::acos(T(2.0))));
+  if constexpr (!cuda::std::is_integral<T>::value)
+  {
+    assert(cuda::std::isnan(cuda::std::acos(cuda::std::numeric_limits<T>::infinity())));
+    assert(cuda::std::isnan(cuda::std::acos(-cuda::std::numeric_limits<T>::infinity())));
+    assert(cuda::std::isnan(cuda::std::acos(-cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::acos(-cuda::std::numeric_limits<T>::quiet_NaN())));
+
+    const T pi = T(3.141592653589793238462643383279502);
+    assert(is_about(cuda::std::acos(T(0.5)), pi / T(3.0)));
+  }
+
+  if constexpr (cuda::std::is_same<T, float>::value)
+  {
+    assert(cuda::std::isnan(cuda::std::acosf(cuda::std::numeric_limits<T>::infinity())));
+    assert(cuda::std::isnan(cuda::std::acosf(-cuda::std::numeric_limits<T>::infinity())));
+    assert(cuda::std::isnan(cuda::std::acosf(-cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::acosf(-cuda::std::numeric_limits<T>::quiet_NaN())));
+
+    const T pi = T(3.141592653589793238462643383279502);
+    assert(is_about(cuda::std::acosf(T(0.5)), pi / T(3.0)));
+  }
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  else if constexpr (cuda::std::is_same<T, long double>::value)
+  {
+    assert(cuda::std::isnan(cuda::std::acosl(cuda::std::numeric_limits<T>::infinity())));
+    assert(cuda::std::isnan(cuda::std::acosl(-cuda::std::numeric_limits<T>::infinity())));
+    assert(cuda::std::isnan(cuda::std::acosl(-cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::acosl(-cuda::std::numeric_limits<T>::quiet_NaN())));
+
+    const T pi = T(3.141592653589793238462643383279502);
+    assert(is_about(cuda::std::acosl(T(0.5)), pi / T(3.0)));
+  }
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+}
+
+template <typename T>
+__host__ __device__ void test_asin(T val)
+{
+  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
+  static_assert(cuda::std::is_same<decltype(cuda::std::asin(T{})), ret>::value, "");
+
+  // 0 is returned unmodified
+  assert(eq(cuda::std::asin(val), val));
+  assert(eq(cuda::std::asin(-val), -val));
+  assert(cuda::std::isnan(cuda::std::asin(T(2.0))));
+  if constexpr (!cuda::std::is_integral<T>::value)
+  {
+    assert(cuda::std::isnan(cuda::std::asin(cuda::std::numeric_limits<T>::infinity())));
+    assert(cuda::std::isnan(cuda::std::asin(-cuda::std::numeric_limits<T>::infinity())));
+    assert(cuda::std::isnan(cuda::std::asin(-cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::asin(-cuda::std::numeric_limits<T>::quiet_NaN())));
+
+    const T pi = T(3.141592653589793238462643383279502);
+    assert(is_about(cuda::std::asin(T(1.0)), pi / T(2.0)));
+    assert(is_about(cuda::std::asin(T(-0.5)), -pi / T(6.0)));
+  }
+
+  if constexpr (cuda::std::is_same<T, float>::value)
+  {
+    assert(cuda::std::isnan(cuda::std::asinf(cuda::std::numeric_limits<T>::infinity())));
+    assert(cuda::std::isnan(cuda::std::asinf(-cuda::std::numeric_limits<T>::infinity())));
+    assert(cuda::std::isnan(cuda::std::asinf(-cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::asinf(-cuda::std::numeric_limits<T>::quiet_NaN())));
+
+    const T pi = T(3.141592653589793238462643383279502);
+    assert(is_about(cuda::std::asinf(T(1.0)), pi / T(2.0)));
+    assert(is_about(cuda::std::asinf(T(-0.5)), -pi / T(6.0)));
+  }
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  else if constexpr (cuda::std::is_same<T, long double>::value)
+  {
+    assert(cuda::std::isnan(cuda::std::asinl(cuda::std::numeric_limits<T>::infinity())));
+    assert(cuda::std::isnan(cuda::std::asinl(-cuda::std::numeric_limits<T>::infinity())));
+    assert(cuda::std::isnan(cuda::std::asinl(-cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::asinl(-cuda::std::numeric_limits<T>::quiet_NaN())));
+
+    const T pi = T(3.141592653589793238462643383279502);
+    assert(is_about(cuda::std::asinl(T(1.0)), pi / T(2.0)));
+    assert(is_about(cuda::std::asinl(T(-0.5)), -pi / T(6.0)));
+  }
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+}
+
+template <typename T>
+__host__ __device__ void test_atan(T val)
+{
+  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
+  static_assert(cuda::std::is_same<decltype(cuda::std::atan(T{})), ret>::value, "");
+
+  // 0 is returned unmodified
+  assert(eq(cuda::std::atan(val), val));
+  assert(eq(cuda::std::atan(-val), -val));
+  if constexpr (!cuda::std::is_integral<T>::value)
+  {
+    const T pi = T(3.141592653589793238462643383279502);
+    assert(eq(cuda::std::atan(cuda::std::numeric_limits<T>::infinity()), pi / T(2.0)));
+    assert(eq(cuda::std::atan(-cuda::std::numeric_limits<T>::infinity()), -pi / T(2.0)));
+    assert(cuda::std::isnan(cuda::std::atan(-cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::atan(-cuda::std::numeric_limits<T>::quiet_NaN())));
+
+    assert(is_about(cuda::std::atan(T(1.0)), pi / T(4.0)));
+  }
+
+  if constexpr (cuda::std::is_same<T, float>::value)
+  {
+    const T pi = T(3.141592653589793238462643383279502);
+    assert(eq(cuda::std::atanf(cuda::std::numeric_limits<T>::infinity()), pi / T(2.0)));
+    assert(eq(cuda::std::atanf(-cuda::std::numeric_limits<T>::infinity()), -pi / T(2.0)));
+    assert(cuda::std::isnan(cuda::std::atanf(-cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::atanf(-cuda::std::numeric_limits<T>::quiet_NaN())));
+
+    assert(is_about(cuda::std::atanf(T(1.0)), pi / T(4.0)));
+  }
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  else if constexpr (cuda::std::is_same<T, long double>::value)
+  {
+    const T pi = T(3.141592653589793238462643383279502);
+    assert(eq(cuda::std::atanl(cuda::std::numeric_limits<T>::infinity()), pi / T(2.0)));
+    assert(eq(cuda::std::atanl(-cuda::std::numeric_limits<T>::infinity()), -pi / T(2.0)));
+    assert(cuda::std::isnan(cuda::std::atanl(-cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::atanl(-cuda::std::numeric_limits<T>::quiet_NaN())));
+
+    assert(is_about(cuda::std::atanl(T(1.0)), pi / T(4.0)));
+  }
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+}
+
+template <typename T>
+__host__ __device__ void test_atan2(T val)
+{
+  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
+  static_assert(cuda::std::is_same<decltype(cuda::std::atan2(T{}, T{})), ret>::value, "");
+
+  // If y is ±0 and x is positive or +0, ±0 is returned.
+  assert(eq(cuda::std::atan2(val, val), val));
+  assert(eq(cuda::std::atan2(-val, val), -val));
+  assert(eq(cuda::std::atan2(val, T(2.0)), val));
+  assert(eq(cuda::std::atan2(-val, T(2.0)), val));
+  if constexpr (!cuda::std::is_integral<T>::value)
+  {
+    const T pi = T(3.141592653589793238462643383279502);
+    assert(cuda::std::isnan(cuda::std::atan2(val, cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::atan2(val, cuda::std::numeric_limits<T>::quiet_NaN())));
+    assert(cuda::std::isnan(cuda::std::atan2(cuda::std::numeric_limits<T>::signaling_NaN(), val)));
+    assert(cuda::std::isnan(cuda::std::atan2(cuda::std::numeric_limits<T>::quiet_NaN(), val)));
+
+    // If y is ±0 and x is negative or -0, ±π is returned.
+    assert(eq(cuda::std::atan2(-val, -val), -pi));
+    assert(eq(cuda::std::atan2(-val, T(-2.0)), -pi));
+    assert(eq(cuda::std::atan2(val, -val), pi));
+    assert(eq(cuda::std::atan2(val, T(-2.0)), pi));
+
+    // If y is ±∞ and x is finite, ±π/2 is returned.
+    assert(eq(cuda::std::atan2(cuda::std::numeric_limits<T>::infinity(), T(2.0)), pi / T(2.0)));
+    assert(eq(cuda::std::atan2(cuda::std::numeric_limits<T>::infinity(), T(-2.0)), pi / T(2.0)));
+    assert(eq(cuda::std::atan2(-cuda::std::numeric_limits<T>::infinity(), T(2.0)), -pi / T(2.0)));
+    assert(eq(cuda::std::atan2(-cuda::std::numeric_limits<T>::infinity(), T(-2.0)), -pi / T(2.0)));
+
+    // If y is ±∞ and x is -∞, ±3π/4 is returned.
+    assert(eq(cuda::std::atan2(cuda::std::numeric_limits<T>::infinity(), -cuda::std::numeric_limits<T>::infinity()),
+              pi * T(0.75)));
+    assert(eq(cuda::std::atan2(-cuda::std::numeric_limits<T>::infinity(), -cuda::std::numeric_limits<T>::infinity()),
+              -pi * T(0.75)));
+
+    // If y is ±∞ and x is +∞, ±π/4 is returned.
+    assert(eq(cuda::std::atan2(cuda::std::numeric_limits<T>::infinity(), cuda::std::numeric_limits<T>::infinity()),
+              pi / T(4.0)));
+    assert(eq(cuda::std::atan2(-cuda::std::numeric_limits<T>::infinity(), cuda::std::numeric_limits<T>::infinity()),
+              -pi / T(4.0)));
+
+    // If x is ±0 and y is negative, -π/2 is returned.
+    assert(eq(cuda::std::atan2(T(-2.0), val), -pi / T(2.0)));
+    assert(eq(cuda::std::atan2(T(-2.0), -val), -pi / T(2.0)));
+
+    // If x is ±0 and y is positive, +π/2 is returned.
+    assert(eq(cuda::std::atan2(T(2.0), val), pi / T(2.0)));
+    assert(eq(cuda::std::atan2(T(2.0), -val), pi / T(2.0)));
+
+    // If x is -∞ and y is finite and positive, +π is returned.
+    assert(eq(cuda::std::atan2(T(2.0), -cuda::std::numeric_limits<T>::infinity()), pi));
+    assert(eq(cuda::std::atan2(T(2.0), -cuda::std::numeric_limits<T>::infinity()), pi));
+
+    // If x is -∞ and y is finite and negative, -π is returned.
+    assert(eq(cuda::std::atan2(T(-2.0), -cuda::std::numeric_limits<T>::infinity()), -pi));
+    assert(eq(cuda::std::atan2(T(-2.0), -cuda::std::numeric_limits<T>::infinity()), -pi));
+
+    // If x is +∞ and y is finite and positive, +0 is returned.
+    assert(eq(cuda::std::atan2(T(2.0), cuda::std::numeric_limits<T>::infinity()), val));
+    assert(eq(cuda::std::atan2(T(2.0), cuda::std::numeric_limits<T>::infinity()), val));
+
+    // If x is +∞ and y is finite and negative, -0 is returned.
+    assert(eq(cuda::std::atan2(T(-2.0), cuda::std::numeric_limits<T>::infinity()), -val));
+    assert(eq(cuda::std::atan2(T(-2.0), cuda::std::numeric_limits<T>::infinity()), -val));
+  }
+
+  if constexpr (cuda::std::is_same<T, float>::value)
+  {
+    const T pi = T(3.141592653589793238462643383279502);
+    assert(cuda::std::isnan(cuda::std::atan2f(val, cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::atan2f(val, cuda::std::numeric_limits<T>::quiet_NaN())));
+    assert(cuda::std::isnan(cuda::std::atan2f(cuda::std::numeric_limits<T>::signaling_NaN(), val)));
+    assert(cuda::std::isnan(cuda::std::atan2f(cuda::std::numeric_limits<T>::quiet_NaN(), val)));
+
+    // If y is ±0 and x is negative or -0, ±π is returned.
+    assert(eq(cuda::std::atan2f(-val, -val), -pi));
+    assert(eq(cuda::std::atan2f(-val, T(-2.0)), -pi));
+    assert(eq(cuda::std::atan2f(val, -val), pi));
+    assert(eq(cuda::std::atan2f(val, T(-2.0)), pi));
+
+    // If y is ±∞ and x is finite, ±π/2 is returned.
+    assert(eq(cuda::std::atan2f(cuda::std::numeric_limits<T>::infinity(), T(2.0)), pi / T(2.0)));
+    assert(eq(cuda::std::atan2f(cuda::std::numeric_limits<T>::infinity(), T(-2.0)), pi / T(2.0)));
+    assert(eq(cuda::std::atan2f(-cuda::std::numeric_limits<T>::infinity(), T(2.0)), -pi / T(2.0)));
+    assert(eq(cuda::std::atan2f(-cuda::std::numeric_limits<T>::infinity(), T(-2.0)), -pi / T(2.0)));
+
+    // If y is ±∞ and x is -∞, ±3π/4 is returned.
+    assert(eq(cuda::std::atan2f(cuda::std::numeric_limits<T>::infinity(), -cuda::std::numeric_limits<T>::infinity()),
+              pi * T(0.75)));
+    assert(eq(cuda::std::atan2f(-cuda::std::numeric_limits<T>::infinity(), -cuda::std::numeric_limits<T>::infinity()),
+              -pi * T(0.75)));
+
+    // If y is ±∞ and x is +∞, ±π/4 is returned.
+    assert(eq(cuda::std::atan2f(cuda::std::numeric_limits<T>::infinity(), cuda::std::numeric_limits<T>::infinity()),
+              pi / T(4.0)));
+    assert(eq(cuda::std::atan2f(-cuda::std::numeric_limits<T>::infinity(), cuda::std::numeric_limits<T>::infinity()),
+              -pi / T(4.0)));
+
+    // If x is ±0 and y is negative, -π/2 is returned.
+    assert(eq(cuda::std::atan2f(T(-2.0), val), -pi / T(2.0)));
+    assert(eq(cuda::std::atan2f(T(-2.0), -val), -pi / T(2.0)));
+
+    // If x is ±0 and y is positive, +π/2 is returned.
+    assert(eq(cuda::std::atan2f(T(2.0), val), pi / T(2.0)));
+    assert(eq(cuda::std::atan2f(T(2.0), -val), pi / T(2.0)));
+
+    // If x is -∞ and y is finite and positive, +π is returned.
+    assert(eq(cuda::std::atan2f(T(2.0), -cuda::std::numeric_limits<T>::infinity()), pi));
+    assert(eq(cuda::std::atan2f(T(2.0), -cuda::std::numeric_limits<T>::infinity()), pi));
+
+    // If x is -∞ and y is finite and negative, -π is returned.
+    assert(eq(cuda::std::atan2f(T(-2.0), -cuda::std::numeric_limits<T>::infinity()), -pi));
+    assert(eq(cuda::std::atan2f(T(-2.0), -cuda::std::numeric_limits<T>::infinity()), -pi));
+
+    // If x is +∞ and y is finite and positive, +0 is returned.
+    assert(eq(cuda::std::atan2f(T(2.0), cuda::std::numeric_limits<T>::infinity()), val));
+    assert(eq(cuda::std::atan2f(T(2.0), cuda::std::numeric_limits<T>::infinity()), val));
+
+    // If x is +∞ and y is finite and negative, -0 is returned.
+    assert(eq(cuda::std::atan2f(T(-2.0), cuda::std::numeric_limits<T>::infinity()), -val));
+    assert(eq(cuda::std::atan2f(T(-2.0), cuda::std::numeric_limits<T>::infinity()), -val));
+  }
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  else if constexpr (cuda::std::is_same<T, long double>::value)
+  {
+    const T pi = T(3.141592653589793238462643383279502);
+    assert(cuda::std::isnan(cuda::std::atan2l(val, cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::atan2l(val, cuda::std::numeric_limits<T>::quiet_NaN())));
+    assert(cuda::std::isnan(cuda::std::atan2l(cuda::std::numeric_limits<T>::signaling_NaN(), val)));
+    assert(cuda::std::isnan(cuda::std::atan2l(cuda::std::numeric_limits<T>::quiet_NaN(), val)));
+
+    // If y is ±0 and x is negative or -0, ±π is returned.
+    assert(eq(cuda::std::atan2l(-val, -val), -pi));
+    assert(eq(cuda::std::atan2l(-val, T(-2.0)), -pi));
+    assert(eq(cuda::std::atan2l(val, -val), pi));
+    assert(eq(cuda::std::atan2l(val, T(-2.0)), pi));
+
+    // If y is ±∞ and x is finite, ±π/2 is returned.
+    assert(eq(cuda::std::atan2l(cuda::std::numeric_limits<T>::infinity(), T(2.0)), pi / T(2.0)));
+    assert(eq(cuda::std::atan2l(cuda::std::numeric_limits<T>::infinity(), T(-2.0)), pi / T(2.0)));
+    assert(eq(cuda::std::atan2l(-cuda::std::numeric_limits<T>::infinity(), T(2.0)), -pi / T(2.0)));
+    assert(eq(cuda::std::atan2l(-cuda::std::numeric_limits<T>::infinity(), T(-2.0)), -pi / T(2.0)));
+
+    // If y is ±∞ and x is -∞, ±3π/4 is returned.
+    assert(eq(cuda::std::atan2l(cuda::std::numeric_limits<T>::infinity(), -cuda::std::numeric_limits<T>::infinity()),
+              pi * T(0.75)));
+    assert(eq(cuda::std::atan2l(-cuda::std::numeric_limits<T>::infinity(), -cuda::std::numeric_limits<T>::infinity()),
+              -pi * T(0.75)));
+
+    // If y is ±∞ and x is +∞, ±π/4 is returned.
+    assert(eq(cuda::std::atan2l(cuda::std::numeric_limits<T>::infinity(), cuda::std::numeric_limits<T>::infinity()),
+              pi / T(4.0)));
+    assert(eq(cuda::std::atan2l(-cuda::std::numeric_limits<T>::infinity(), cuda::std::numeric_limits<T>::infinity()),
+              -pi / T(4.0)));
+
+    // If x is ±0 and y is negative, -π/2 is returned.
+    assert(eq(cuda::std::atan2l(T(-2.0), val), -pi / T(2.0)));
+    assert(eq(cuda::std::atan2l(T(-2.0), -val), -pi / T(2.0)));
+
+    // If x is ±0 and y is positive, +π/2 is returned.
+    assert(eq(cuda::std::atan2l(T(2.0), val), pi / T(2.0)));
+    assert(eq(cuda::std::atan2l(T(2.0), -val), pi / T(2.0)));
+
+    // If x is -∞ and y is finite and positive, +π is returned.
+    assert(eq(cuda::std::atan2l(T(2.0), -cuda::std::numeric_limits<T>::infinity()), pi));
+    assert(eq(cuda::std::atan2l(T(2.0), -cuda::std::numeric_limits<T>::infinity()), pi));
+
+    // If x is -∞ and y is finite and negative, -π is returned.
+    assert(eq(cuda::std::atan2l(T(-2.0), -cuda::std::numeric_limits<T>::infinity()), -pi));
+    assert(eq(cuda::std::atan2l(T(-2.0), -cuda::std::numeric_limits<T>::infinity()), -pi));
+
+    // If x is +∞ and y is finite and positive, +0 is returned.
+    assert(eq(cuda::std::atan2l(T(2.0), cuda::std::numeric_limits<T>::infinity()), val));
+    assert(eq(cuda::std::atan2l(T(2.0), cuda::std::numeric_limits<T>::infinity()), val));
+
+    // If x is +∞ and y is finite and negative, -0 is returned.
+    assert(eq(cuda::std::atan2l(T(-2.0), cuda::std::numeric_limits<T>::infinity()), -val));
+    assert(eq(cuda::std::atan2l(T(-2.0), cuda::std::numeric_limits<T>::infinity()), -val));
+  }
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+}
+
+template <typename T>
+__host__ __device__ void test(const T val)
+{
+  test_acos<T>(val);
+  test_asin<T>(val);
+  test_atan<T>(val);
+  test_atan2<T>(val);
+}
+
+__host__ __device__ void test(const float val)
+{
+  test<float>(val);
+  test<double>(val);
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  test<long double>();
+#endif //!_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#ifdef _LIBCUDACXX_HAS_NVFP16
+  test<__half>(val);
+#endif // _LIBCUDACXX_HAS_NVFP16
+#ifdef _LIBCUDACXX_HAS_NVBF16
+  test<__nv_bfloat16>(val);
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+  test<unsigned short>(static_cast<unsigned short>(val));
+  test<int>(static_cast<int>(val));
+  test<unsigned int>(static_cast<unsigned int>(val));
+  test<long>(static_cast<long>(val));
+  test<unsigned long>(static_cast<unsigned long>(val));
+  test<long long>(static_cast<long long>(val));
+  test<unsigned long long>(static_cast<unsigned long long>(val));
+}
+
+__global__ void test_global_kernel(float* val)
+{
+  test(*val);
+}
+
+int main(int, char**)
+{
+  volatile float val = 0.0f;
+  test(val);
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/lerp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/lerp.pass.cpp
@@ -56,7 +56,7 @@ __host__ __device__ void test()
   assert(cuda::std::lerp(T(0.0), T(0.0), T(23)) == T(0.0));
 
   // __half and __nvbfloat have precision issues here
-  if (!cuda::std::__is_extended_floating_point<T>::value)
+  if constexpr (!cuda::std::__is_extended_floating_point_v<T>)
   {
     assert(cuda::std::isnan(cuda::std::lerp(T(0.0), T(0.0), T(inf))));
   }

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/logarithms.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/logarithms.pass.cpp
@@ -18,47 +18,47 @@
 template <class T>
 __host__ __device__ void test_log(T value)
 {
-  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
-  static_assert(cuda::std::is_same<decltype(cuda::std::log(value)), ret>::value, "");
+  using ret = cuda::std::conditional_t<cuda::std::is_integral_v<T>, double, T>;
+  static_assert(cuda::std::is_same_v<decltype(cuda::std::log(value)), ret>, "");
   assert(cuda::std::log(value) == ret{0});
 }
 
 template <class T>
 __host__ __device__ void test_log10(T value)
 {
-  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
-  static_assert(cuda::std::is_same<decltype(cuda::std::log10(value)), ret>::value, "");
+  using ret = cuda::std::conditional_t<cuda::std::is_integral_v<T>, double, T>;
+  static_assert(cuda::std::is_same_v<decltype(cuda::std::log10(value)), ret>, "");
   assert(cuda::std::log10(value) == ret{0});
 }
 
 template <class T>
 __host__ __device__ void test_ilogb(T value)
 {
-  static_assert(cuda::std::is_same<decltype(cuda::std::ilogb(value)), int>::value, "");
+  static_assert(cuda::std::is_same_v<decltype(cuda::std::ilogb(value)), int>, "");
   assert(cuda::std::ilogb(value) == 0);
 }
 
 template <class T>
 __host__ __device__ void test_log1p(T value)
 {
-  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
-  static_assert(cuda::std::is_same<decltype(cuda::std::log1p(value)), ret>::value, "");
+  using ret = cuda::std::conditional_t<cuda::std::is_integral_v<T>, double, T>;
+  static_assert(cuda::std::is_same_v<decltype(cuda::std::log1p(value)), ret>, "");
   assert(cuda::std::log1p(value - value) == ret{0});
 }
 
 template <class T>
 __host__ __device__ void test_log2(T value)
 {
-  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
-  static_assert(cuda::std::is_same<decltype(cuda::std::log2(value)), ret>::value, "");
+  using ret = cuda::std::conditional_t<cuda::std::is_integral_v<T>, double, T>;
+  static_assert(cuda::std::is_same_v<decltype(cuda::std::log2(value)), ret>, "");
   assert(cuda::std::log2(value) == ret{0});
 }
 
 template <class T>
 __host__ __device__ void test_logb(T value)
 {
-  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
-  static_assert(cuda::std::is_same<decltype(cuda::std::logb(value)), ret>::value, "");
+  using ret = cuda::std::conditional_t<cuda::std::is_integral_v<T>, double, T>;
+  static_assert(cuda::std::is_same_v<decltype(cuda::std::logb(value)), ret>, "");
   assert(cuda::std::logb(value) == ret{0});
 }
 

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/roots.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/roots.pass.cpp
@@ -26,19 +26,19 @@
 template <typename T>
 __host__ __device__ void test_sqrt(T val)
 {
-  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
-  static_assert(cuda::std::is_same<decltype(cuda::std::sqrt(T{})), ret>::value, "");
+  using ret = cuda::std::conditional_t<cuda::std::is_integral_v<T>, double, T>;
+  static_assert(cuda::std::is_same_v<decltype(cuda::std::sqrt(T{})), ret>, "");
 
   assert(eq(cuda::std::sqrt(val), T(8.0)));
   assert(eq(cuda::std::sqrt(T(0.0)), T(0.0)));
   assert(eq(cuda::std::sqrt(T(cuda::std::numeric_limits<T>::infinity())), cuda::std::numeric_limits<T>::infinity()));
-  if (cuda::std::is_same<T, float>::value)
+  if constexpr (cuda::std::is_same_v<T, float>)
   {
     assert(eq(cuda::std::sqrtf(val), T(8.0)));
     assert(eq(cuda::std::sqrtf(T(0.0)), T(0.0)));
   }
 #if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  else if (cuda::std::is_same<T, long double>::value)
+  else if constexpr (cuda::std::is_same_v<T, long double>)
   {
     assert(eq(cuda::std::sqrtl(val), T(8)));
     assert(eq(cuda::std::sqrtl(T(0.0)), T(0.0)));
@@ -49,20 +49,20 @@ __host__ __device__ void test_sqrt(T val)
 template <typename T>
 __host__ __device__ void test_cbrt(T val)
 {
-  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
-  static_assert(cuda::std::is_same<decltype(cuda::std::cbrt(T{})), ret>::value, "");
+  using ret = cuda::std::conditional_t<cuda::std::is_integral_v<T>, double, T>;
+  static_assert(cuda::std::is_same_v<decltype(cuda::std::cbrt(T{})), ret>, "");
 
   assert(eq(cuda::std::cbrt(val), T(2)));
   assert(eq(cuda::std::cbrt(T(0.0)), T(0.0)));
   assert(eq(cuda::std::cbrt(-T(0.0)), -T(0.0)));
   assert(eq(cuda::std::cbrt(T(cuda::std::numeric_limits<T>::infinity())), cuda::std::numeric_limits<T>::infinity()));
-  if (cuda::std::is_same<T, float>::value)
+  if constexpr (cuda::std::is_same_v<T, float>)
   {
     assert(eq(cuda::std::cbrtf(val), T(2)));
     assert(eq(cuda::std::cbrtf(T(0.0)), T(0.0)));
   }
 #if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  else if (cuda::std::is_same<T, long double>::value)
+  else if constexpr (cuda::std::is_same_v<T, long double>)
   {
     assert(eq(cuda::std::cbrtl(val), T(2)));
     assert(eq(cuda::std::cbrtl(T(0.0)), T(0.0)));

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/roots.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/roots.pass.cpp
@@ -14,6 +14,7 @@
 #include <cuda/std/limits>
 #include <cuda/std/type_traits>
 
+#include "comparison.h"
 #include "fp_compare.h"
 #include "test_macros.h"
 
@@ -21,31 +22,6 @@
 #  pragma warning(disable : 4244) // conversion from 'double' to 'float', possible loss of data
 #  pragma warning(disable : 4146) // unary minus operator applied to unsigned type, result still unsigned
 #endif // TEST_COMPILER_MSVC
-
-template <typename T>
-__host__ __device__ bool eq(T lhs, T rhs) noexcept
-{
-  return lhs == rhs;
-}
-
-template <typename T, typename U, cuda::std::enable_if_t<cuda::std::is_arithmetic<U>::value, int> = 0>
-__host__ __device__ bool eq(T lhs, U rhs) noexcept
-{
-  return eq(lhs, T(rhs));
-}
-
-#ifdef _LIBCUDACXX_HAS_NVFP16
-__host__ __device__ bool eq(__half lhs, __half rhs) noexcept
-{
-  return ::__heq(lhs, rhs);
-}
-#endif // _LIBCUDACXX_HAS_NVFP16
-#ifdef _LIBCUDACXX_HAS_NVBF16
-__host__ __device__ bool eq(__nv_bfloat16 lhs, __nv_bfloat16 rhs) noexcept
-{
-  return ::__heq(lhs, rhs);
-}
-#endif // _LIBCUDACXX_HAS_NVBF16
 
 template <typename T>
 __host__ __device__ void test_sqrt(T val)

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/rounding.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/rounding.pass.cpp
@@ -27,10 +27,10 @@
 template <typename T>
 __host__ __device__ void test_ceil(T val)
 {
-  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
-  static_assert(cuda::std::is_same<decltype(cuda::std::ceil(T{})), ret>::value, "");
+  using ret = cuda::std::conditional_t<cuda::std::is_integral_v<T>, double, T>;
+  static_assert(cuda::std::is_same_v<decltype(cuda::std::ceil(T{})), ret>, "");
 
-  if (cuda::std::is_integral<T>::value)
+  if constexpr (cuda::std::is_integral_v<T>)
   {
     assert(eq(cuda::std::ceil(val), val));
     assert(eq(cuda::std::ceil(-val), -val));
@@ -43,7 +43,7 @@ __host__ __device__ void test_ceil(T val)
   assert(eq(cuda::std::ceil(T(-0.0)), T(-0.0)));
   assert(eq(cuda::std::ceil(T(0.0)), T(0.0)));
   assert(eq(cuda::std::ceil(T(-cuda::std::numeric_limits<T>::infinity())), -cuda::std::numeric_limits<T>::infinity()));
-  if (cuda::std::is_same<T, float>::value)
+  if constexpr (cuda::std::is_same_v<T, float>)
   {
     assert(eq(cuda::std::ceilf(val), T(2)));
     assert(eq(cuda::std::ceilf(-val), T(-1)));
@@ -51,7 +51,7 @@ __host__ __device__ void test_ceil(T val)
     assert(eq(cuda::std::ceilf(T(0.0)), T(0.0)));
   }
 #if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  else if (cuda::std::is_same<T, long double>::value)
+  else if constexpr (cuda::std::is_same_v<T, long double>)
   {
     assert(eq(cuda::std::ceill(val), T(2)));
     assert(eq(cuda::std::ceill(-val), T(-1)));
@@ -64,10 +64,10 @@ __host__ __device__ void test_ceil(T val)
 template <typename T>
 __host__ __device__ void test_floor(T val)
 {
-  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
-  static_assert(cuda::std::is_same<decltype(cuda::std::floor(T{})), ret>::value, "");
+  using ret = cuda::std::conditional_t<cuda::std::is_integral_v<T>, double, T>;
+  static_assert(cuda::std::is_same_v<decltype(cuda::std::floor(T{})), ret>, "");
 
-  if (cuda::std::is_integral<T>::value)
+  if constexpr (cuda::std::is_integral_v<T>)
   {
     assert(eq(cuda::std::floor(val), val));
     assert(eq(cuda::std::floor(-val), -val));
@@ -80,7 +80,7 @@ __host__ __device__ void test_floor(T val)
   assert(eq(cuda::std::floor(T(-0.0)), T(-0.0)));
   assert(eq(cuda::std::floor(T(0.0)), T(0.0)));
   assert(eq(cuda::std::floor(T(-cuda::std::numeric_limits<T>::infinity())), -cuda::std::numeric_limits<T>::infinity()));
-  if (cuda::std::is_same<T, float>::value)
+  if constexpr (cuda::std::is_same_v<T, float>)
   {
     assert(eq(cuda::std::floorf(val), T(1)));
     assert(eq(cuda::std::floorf(-val), T(-2)));
@@ -88,7 +88,7 @@ __host__ __device__ void test_floor(T val)
     assert(eq(cuda::std::floorf(T(0.0)), T(0.0)));
   }
 #if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  else if (cuda::std::is_same<T, long double>::value)
+  else if constexpr (cuda::std::is_same_v<T, long double>)
   {
     assert(eq(cuda::std::floorl(val), T(1)));
     assert(eq(cuda::std::floorl(-val), T(-2)));
@@ -101,9 +101,9 @@ __host__ __device__ void test_floor(T val)
 template <typename T>
 __host__ __device__ void test_llrint(T val)
 {
-  static_assert(cuda::std::is_same<decltype(cuda::std::llrint(T{})), long long>::value, "");
+  static_assert(cuda::std::is_same_v<decltype(cuda::std::llrint(T{})), long long>, "");
 
-  if (cuda::std::is_integral<T>::value)
+  if constexpr (cuda::std::is_integral_v<T>)
   {
     assert(eq(cuda::std::llrint(val), val));
   }
@@ -116,7 +116,7 @@ __host__ __device__ void test_llrint(T val)
   }
   assert(cuda::std::llrint(T(-0.0)) == -0);
   assert(cuda::std::llrint(T(0.0)) == 0);
-  if (cuda::std::is_same<T, float>::value)
+  if constexpr (cuda::std::is_same_v<T, float>)
   {
     assert(cuda::std::llrintf(val) == 2);
     assert(cuda::std::llrintf(-val) == -2);
@@ -124,7 +124,7 @@ __host__ __device__ void test_llrint(T val)
     assert(cuda::std::llrintf(-val + T(0.2)) == -1);
   }
 #if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  else if (cuda::std::is_same<T, long double>::value)
+  else if constexpr (cuda::std::is_same_v<T, long double>)
   {
     assert(cuda::std::llrintl(val) == 2);
     assert(cuda::std::llrintl(-val) == -2);
@@ -137,9 +137,9 @@ __host__ __device__ void test_llrint(T val)
 template <typename T>
 __host__ __device__ void test_llround(T val)
 {
-  static_assert(cuda::std::is_same<decltype(cuda::std::llround(T{})), long long>::value, "");
+  static_assert(cuda::std::is_same_v<decltype(cuda::std::llround(T{})), long long>, "");
 
-  if (cuda::std::is_integral<T>::value)
+  if constexpr (cuda::std::is_integral_v<T>)
   {
     assert(eq(cuda::std::llround(val), val));
   }
@@ -152,7 +152,7 @@ __host__ __device__ void test_llround(T val)
   }
   assert(cuda::std::llround(T(-0.0)) == -0);
   assert(cuda::std::llround(T(0.0)) == 0);
-  if (cuda::std::is_same<T, float>::value)
+  if constexpr (cuda::std::is_same_v<T, float>)
   {
     assert(cuda::std::llroundf(val) == 2);
     assert(cuda::std::llroundf(-val) == -2);
@@ -160,7 +160,7 @@ __host__ __device__ void test_llround(T val)
     assert(cuda::std::llroundf(-val + T(0.2)) == -1);
   }
 #if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  else if (cuda::std::is_same<T, long double>::value)
+  else if constexpr (cuda::std::is_same_v<T, long double>)
   {
     assert(cuda::std::llroundl(val) == 2);
     assert(cuda::std::llroundl(-val) == -2);
@@ -173,9 +173,9 @@ __host__ __device__ void test_llround(T val)
 template <typename T>
 __host__ __device__ void test_lrint(T val)
 {
-  static_assert(cuda::std::is_same<decltype(cuda::std::lrint(T{})), long>::value, "");
+  static_assert(cuda::std::is_same_v<decltype(cuda::std::lrint(T{})), long>, "");
 
-  if (cuda::std::is_integral<T>::value)
+  if constexpr (cuda::std::is_integral_v<T>)
   {
     assert(eq(cuda::std::lrint(val), val));
   }
@@ -188,7 +188,7 @@ __host__ __device__ void test_lrint(T val)
   }
   assert(cuda::std::lrint(T(-0.0)) == -0);
   assert(cuda::std::lrint(T(0.0)) == 0);
-  if (cuda::std::is_same<T, float>::value)
+  if constexpr (cuda::std::is_same_v<T, float>)
   {
     assert(cuda::std::lrintf(val) == 2);
     assert(cuda::std::lrintf(-val) == -2);
@@ -196,7 +196,7 @@ __host__ __device__ void test_lrint(T val)
     assert(cuda::std::lrintf(-val + T(0.2)) == -1);
   }
 #if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  else if (cuda::std::is_same<T, long double>::value)
+  else if constexpr (cuda::std::is_same_v<T, long double>)
   {
     assert(cuda::std::lrintl(val) == 2);
     assert(cuda::std::lrintl(-val) == -2);
@@ -209,9 +209,9 @@ __host__ __device__ void test_lrint(T val)
 template <typename T>
 __host__ __device__ void test_lround(T val)
 {
-  static_assert(cuda::std::is_same<decltype(cuda::std::lround(T{})), long>::value, "");
+  static_assert(cuda::std::is_same_v<decltype(cuda::std::lround(T{})), long>, "");
 
-  if (cuda::std::is_integral<T>::value)
+  if constexpr (cuda::std::is_integral_v<T>)
   {
     assert(eq(cuda::std::lround(val), val));
   }
@@ -224,7 +224,7 @@ __host__ __device__ void test_lround(T val)
   }
   assert(cuda::std::lround(T(-0.0)) == -0);
   assert(cuda::std::lround(T(0.0)) == 0);
-  if (cuda::std::is_same<T, float>::value)
+  if constexpr (cuda::std::is_same_v<T, float>)
   {
     assert(cuda::std::lroundf(val) == 2);
     assert(cuda::std::lroundf(-val) == -2);
@@ -232,7 +232,7 @@ __host__ __device__ void test_lround(T val)
     assert(cuda::std::lroundf(-val + T(0.2)) == -1);
   }
 #if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  else if (cuda::std::is_same<T, long double>::value)
+  else if constexpr (cuda::std::is_same_v<T, long double>)
   {
     assert(cuda::std::lroundl(val) == 2);
     assert(cuda::std::lroundl(-val) == -2);
@@ -245,10 +245,10 @@ __host__ __device__ void test_lround(T val)
 template <typename T>
 __host__ __device__ void test_nearbyint(T val)
 {
-  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
-  static_assert(cuda::std::is_same<decltype(cuda::std::nearbyint(T{})), ret>::value, "");
+  using ret = cuda::std::conditional_t<cuda::std::is_integral_v<T>, double, T>;
+  static_assert(cuda::std::is_same_v<decltype(cuda::std::nearbyint(T{})), ret>, "");
 
-  if (cuda::std::is_integral<T>::value)
+  if constexpr (cuda::std::is_integral_v<T>)
   {
     assert(eq(cuda::std::nearbyint(val), val));
     assert(eq(cuda::std::nearbyint(-val), -val));
@@ -262,7 +262,7 @@ __host__ __device__ void test_nearbyint(T val)
   }
   assert(eq(cuda::std::nearbyint(T(-0.0)), T(-0.0)));
   assert(eq(cuda::std::nearbyint(T(0.0)), T(0.0)));
-  if (cuda::std::is_same<T, float>::value)
+  if constexpr (cuda::std::is_same_v<T, float>)
   {
     assert(eq(cuda::std::nearbyintf(val), T(2)));
     assert(eq(cuda::std::nearbyintf(-val), T(-2)));
@@ -270,7 +270,7 @@ __host__ __device__ void test_nearbyint(T val)
     assert(eq(cuda::std::nearbyintf(-val + T(0.2)), T(-1)));
   }
 #if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  else if (cuda::std::is_same<T, long double>::value)
+  else if constexpr (cuda::std::is_same_v<T, long double>)
   {
     assert(eq(cuda::std::nearbyintl(val), T(2)));
     assert(eq(cuda::std::nearbyintl(-val), T(-2)));
@@ -283,16 +283,16 @@ __host__ __device__ void test_nearbyint(T val)
 template <typename T>
 __host__ __device__ void test_nextafter(T val)
 {
-  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
-  static_assert(cuda::std::is_same<decltype(cuda::std::nextafter(T{}, T{})), ret>::value, "");
+  using ret = cuda::std::conditional_t<cuda::std::is_integral_v<T>, double, T>;
+  static_assert(cuda::std::is_same_v<decltype(cuda::std::nextafter(T{}, T{})), ret>, "");
 
   // assert(eq(cuda::std::nextafter(cuda::std::nextafter(val, T(10)), T(-10)), val));
-  if (cuda::std::is_same<T, float>::value)
+  if constexpr (cuda::std::is_same_v<T, float>)
   {
     assert(eq(cuda::std::nextafterf(cuda::std::nextafterf(val, T(10)), T(-10)), val));
   }
 #if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  else if (cuda::std::is_same<T, long double>::value)
+  else if constexpr (cuda::std::is_same_v<T, long double>)
   {
     assert(eq(cuda::std::nextafterl(cuda::std::nextafterl(val, T(10)), T(-10)), val));
   }
@@ -303,15 +303,15 @@ __host__ __device__ void test_nextafter(T val)
 template <typename T>
 __host__ __device__ void test_nexttoward(T val)
 {
-  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
-  static_assert(cuda::std::is_same<decltype(cuda::std::nexttoward(T{}, long double{})), ret>::value, "");
+  using ret = cuda::std::conditional_t<cuda::std::is_integral_v<T>, double, T>;
+  static_assert(cuda::std::is_same_v<decltype(cuda::std::nexttoward(T{}, long double{})), ret>, "");
 
   assert(eq(cuda::std::nexttoward(cuda::std::nexttoward(val, long double(10.0)), long double(-10.0)), val));
-  if (cuda::std::is_same<T, float>::value)
+  if constexpr (cuda::std::is_same_v<T, float>)
   {
     assert(eq(cuda::std::nexttowardf(cuda::std::nexttowardf(val, long double(10.0)), long double(-10.0)), val));
   }
-  else if (cuda::std::is_same<T, float>::value)
+  else if constexpr (cuda::std::is_same_v<T, float>)
   {
     assert(eq(cuda::std::nexttowardl(cuda::std::nexttowardl(val, long double(10.0)), long double(-10.0)), val));
   }
@@ -321,10 +321,10 @@ __host__ __device__ void test_nexttoward(T val)
 template <typename T>
 __host__ __device__ void test_rint(T val)
 {
-  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
-  static_assert(cuda::std::is_same<decltype(cuda::std::rint(T{})), ret>::value, "");
+  using ret = cuda::std::conditional_t<cuda::std::is_integral_v<T>, double, T>;
+  static_assert(cuda::std::is_same_v<decltype(cuda::std::rint(T{})), ret>, "");
 
-  if (cuda::std::is_integral<T>::value)
+  if constexpr (cuda::std::is_integral_v<T>)
   {
     assert(eq(cuda::std::rint(val), val));
     assert(eq(cuda::std::rint(-val), -val));
@@ -338,7 +338,7 @@ __host__ __device__ void test_rint(T val)
   }
   assert(eq(cuda::std::rint(T(-0.0)), T(-0.0)));
   assert(eq(cuda::std::rint(T(0.0)), T(0.0)));
-  if (cuda::std::is_same<T, float>::value)
+  if constexpr (cuda::std::is_same_v<T, float>)
   {
     assert(eq(cuda::std::rintf(val), T(2)));
     assert(eq(cuda::std::rintf(-val), T(-2)));
@@ -346,7 +346,7 @@ __host__ __device__ void test_rint(T val)
     assert(eq(cuda::std::rintf(-val + T(0.2)), T(-1)));
   }
 #if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  else if (cuda::std::is_same<T, long double>::value)
+  else if constexpr (cuda::std::is_same_v<T, long double>)
   {
     assert(eq(cuda::std::rintl(val), T(2)));
     assert(eq(cuda::std::rintl(-val), T(-2)));
@@ -359,10 +359,10 @@ __host__ __device__ void test_rint(T val)
 template <typename T>
 __host__ __device__ void test_round(T val)
 {
-  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
-  static_assert(cuda::std::is_same<decltype(cuda::std::round(T{})), ret>::value, "");
+  using ret = cuda::std::conditional_t<cuda::std::is_integral_v<T>, double, T>;
+  static_assert(cuda::std::is_same_v<decltype(cuda::std::round(T{})), ret>, "");
 
-  if (cuda::std::is_integral<T>::value)
+  if constexpr (cuda::std::is_integral_v<T>)
   {
     assert(eq(cuda::std::round(val), val));
     assert(eq(cuda::std::round(-val), -val));
@@ -376,7 +376,7 @@ __host__ __device__ void test_round(T val)
   }
   assert(eq(cuda::std::round(T(-0.0)), T(-0.0)));
   assert(eq(cuda::std::round(T(0.0)), T(0.0)));
-  if (cuda::std::is_same<T, float>::value)
+  if constexpr (cuda::std::is_same_v<T, float>)
   {
     assert(eq(cuda::std::roundf(val), T(2)));
     assert(eq(cuda::std::roundf(-val), T(-2)));
@@ -384,7 +384,7 @@ __host__ __device__ void test_round(T val)
     assert(eq(cuda::std::roundf(-val + T(0.2)), T(-1)));
   }
 #if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  else if (cuda::std::is_same<T, long double>::value)
+  else if constexpr (cuda::std::is_same_v<T, long double>)
   {
     assert(eq(cuda::std::roundl(val), T(2)));
     assert(eq(cuda::std::roundl(-val), T(-2)));
@@ -397,9 +397,9 @@ __host__ __device__ void test_round(T val)
 template <typename T>
 __host__ __device__ void test_trunc(T val)
 {
-  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
-  static_assert(cuda::std::is_same<decltype(cuda::std::trunc(T{})), ret>::value, "");
-  if (cuda::std::is_integral<T>::value)
+  using ret = cuda::std::conditional_t<cuda::std::is_integral_v<T>, double, T>;
+  static_assert(cuda::std::is_same_v<decltype(cuda::std::trunc(T{})), ret>, "");
+  if constexpr (cuda::std::is_integral_v<T>)
   {
     assert(eq(cuda::std::trunc(val), val));
     assert(eq(cuda::std::trunc(-val), -val));
@@ -412,13 +412,13 @@ __host__ __device__ void test_trunc(T val)
   assert(eq(cuda::std::trunc(T(-0.0)), T(-0.0)));
   assert(eq(cuda::std::trunc(T(0.0)), T(0.0)));
   assert(eq(cuda::std::trunc(T(-cuda::std::numeric_limits<T>::infinity())), -cuda::std::numeric_limits<T>::infinity()));
-  if (cuda::std::is_same<T, float>::value)
+  if constexpr (cuda::std::is_same_v<T, float>)
   {
     assert(eq(cuda::std::truncf(val), T(1)));
     assert(eq(cuda::std::truncf(-val), T(-1)));
   }
 #if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  else if (cuda::std::is_same<T, long double>::value)
+  else if constexpr (cuda::std::is_same_v<T, long double>)
   {
     assert(eq(cuda::std::truncl(val), T(1)));
     assert(eq(cuda::std::truncl(-val), T(-1)));

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/rounding.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/rounding.pass.cpp
@@ -14,6 +14,7 @@
 #include <cuda/std/limits>
 #include <cuda/std/type_traits>
 
+#include "comparison.h"
 #include "fp_compare.h"
 #include "test_macros.h"
 
@@ -22,31 +23,6 @@
 #  pragma warning(disable : 4305) // 'argument': truncation from 'T' to 'float'
 #  pragma warning(disable : 4146) // unary minus operator applied to unsigned type, result still unsigned
 #endif // TEST_COMPILER_MSVC
-
-template <typename T>
-__host__ __device__ bool eq(T lhs, T rhs) noexcept
-{
-  return lhs == rhs;
-}
-
-template <typename T, typename U, cuda::std::enable_if_t<cuda::std::is_arithmetic<U>::value, int> = 0>
-__host__ __device__ bool eq(T lhs, U rhs) noexcept
-{
-  return eq(lhs, T(rhs));
-}
-
-#ifdef _LIBCUDACXX_HAS_NVFP16
-__host__ __device__ bool eq(__half lhs, __half rhs) noexcept
-{
-  return ::__heq(lhs, rhs);
-}
-#endif // _LIBCUDACXX_HAS_NVFP16
-#ifdef _LIBCUDACXX_HAS_NVBF16
-__host__ __device__ bool eq(__nv_bfloat16 lhs, __nv_bfloat16 rhs) noexcept
-{
-  return ::__heq(lhs, rhs);
-}
-#endif // _LIBCUDACXX_HAS_NVBF16
 
 template <typename T>
 __host__ __device__ void test_ceil(T val)

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/rounding.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/rounding.pass.cpp
@@ -286,7 +286,7 @@ __host__ __device__ void test_nextafter(T val)
   using ret = cuda::std::conditional_t<cuda::std::is_integral_v<T>, double, T>;
   static_assert(cuda::std::is_same_v<decltype(cuda::std::nextafter(T{}, T{})), ret>, "");
 
-  // assert(eq(cuda::std::nextafter(cuda::std::nextafter(val, T(10)), T(-10)), val));
+  unused(val);
   if constexpr (cuda::std::is_same_v<T, float>)
   {
     assert(eq(cuda::std::nextafterf(cuda::std::nextafterf(val, T(10)), T(-10)), val));

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/trigonometric_functions.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/trigonometric_functions.pass.cpp
@@ -1,0 +1,226 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cmath>
+
+#include <cuda/std/cassert>
+#include <cuda/std/cmath>
+#include <cuda/std/limits>
+#include <cuda/std/type_traits>
+
+#include "comparison.h"
+#include "test_macros.h"
+
+#if defined(TEST_COMPILER_MSVC)
+#  pragma warning(disable : 4244) // conversion from 'double' to 'float', possible loss of data
+#  pragma warning(disable : 4305) // 'argument': truncation from 'T' to 'float'
+#  pragma warning(disable : 4146) // unary minus operator applied to unsigned type, result still unsigned
+#endif // TEST_COMPILER_MSVC
+
+template <typename T>
+__host__ __device__ void test_cos(T val)
+{
+  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
+  static_assert(cuda::std::is_same<decltype(cuda::std::cos(T{})), ret>::value, "");
+
+  // 0 is returned unmodified
+  assert(eq(cuda::std::cos(val), T(1.0)));
+  assert(eq(cuda::std::cos(-val), T(1.0)));
+  if constexpr (!cuda::std::is_integral<T>::value)
+  {
+    assert(cuda::std::isnan(cuda::std::cos(cuda::std::numeric_limits<T>::infinity())));
+    assert(cuda::std::isnan(cuda::std::cos(-cuda::std::numeric_limits<T>::infinity())));
+    assert(cuda::std::isnan(cuda::std::cos(-cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::cos(-cuda::std::numeric_limits<T>::quiet_NaN())));
+
+    const T pi = T(3.141592653589793238462643383279502);
+    assert(is_about(cuda::std::cos(pi * T(0.25)), -cuda::std::cos(pi * T(0.75))));
+    assert(is_about(cuda::std::cos(pi / T(2.0)), cuda::std::cos(-pi / T(2.0))));
+  }
+
+  if constexpr (cuda::std::is_same<T, float>::value)
+  {
+    assert(cuda::std::isnan(cuda::std::cosf(cuda::std::numeric_limits<T>::infinity())));
+    assert(cuda::std::isnan(cuda::std::cosf(-cuda::std::numeric_limits<T>::infinity())));
+    assert(cuda::std::isnan(cuda::std::cosf(-cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::cosf(-cuda::std::numeric_limits<T>::quiet_NaN())));
+
+    const T pi = T(3.141592653589793238462643383279502);
+    assert(eq(cuda::std::cosf(pi * T(0.25)), -cuda::std::cosf(pi * T(0.75))));
+    assert(eq(cuda::std::cosf(pi / T(2.0)), cuda::std::cosf(-pi / T(2.0))));
+  }
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  else if constexpr (cuda::std::is_same<T, long double>::value)
+  {
+    assert(cuda::std::isnan(cuda::std::cosl(cuda::std::numeric_limits<T>::infinity())));
+    assert(cuda::std::isnan(cuda::std::cosl(-cuda::std::numeric_limits<T>::infinity())));
+    assert(cuda::std::isnan(cuda::std::cosl(-cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::cosl(-cuda::std::numeric_limits<T>::quiet_NaN())));
+
+    const T pi = T(3.141592653589793238462643383279502);
+    assert(eq(cuda::std::cosl(pi * T(0.25)), -cuda::std::cosl(pi * T(0.75))));
+    assert(eq(cuda::std::cosl(pi / T(2.0)), cuda::std::cosl(-pi / T(2.0))));
+  }
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+}
+
+template <typename T>
+__host__ __device__ void test_sin(T val)
+{
+  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
+  static_assert(cuda::std::is_same<decltype(cuda::std::sin(T{})), ret>::value, "");
+
+  // 0 is returned unmodified
+  assert(eq(cuda::std::sin(val), val));
+  assert(eq(cuda::std::sin(-val), -val));
+  if constexpr (!cuda::std::is_integral<T>::value)
+  {
+    assert(cuda::std::isnan(cuda::std::sin(cuda::std::numeric_limits<T>::infinity())));
+    assert(cuda::std::isnan(cuda::std::sin(-cuda::std::numeric_limits<T>::infinity())));
+    assert(cuda::std::isnan(cuda::std::sin(-cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::sin(-cuda::std::numeric_limits<T>::quiet_NaN())));
+
+    const T pi = T(3.141592653589793238462643383279502);
+    assert(is_about(cuda::std::sin(pi / T(6.0)), T(0.5)));
+    assert(is_about(cuda::std::sin(-pi / T(6.0)), T(-0.5)));
+    assert(is_about(cuda::std::sin(pi / T(2.0)), T(1.0)));
+    assert(is_about(cuda::std::sin(-pi / T(2.0)), T(-1.0)));
+  }
+
+  if constexpr (cuda::std::is_same<T, float>::value)
+  {
+    assert(cuda::std::isnan(cuda::std::sinf(cuda::std::numeric_limits<T>::infinity())));
+    assert(cuda::std::isnan(cuda::std::sinf(-cuda::std::numeric_limits<T>::infinity())));
+    assert(cuda::std::isnan(cuda::std::sinf(-cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::sinf(-cuda::std::numeric_limits<T>::quiet_NaN())));
+
+    const T pi = T(3.141592653589793238462643383279502);
+    assert(eq(cuda::std::sinf(pi / T(6.0)), T(0.5)));
+    assert(eq(cuda::std::sinf(-pi / T(6.0)), T(-0.5)));
+    assert(eq(cuda::std::sinf(pi / T(2.0)), T(1.0)));
+    assert(eq(cuda::std::sinf(-pi / T(2.0)), T(-1.0)));
+  }
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  else if constexpr (cuda::std::is_same<T, long double>::value)
+  {
+    assert(cuda::std::isnan(cuda::std::sinl(cuda::std::numeric_limits<T>::infinity())));
+    assert(cuda::std::isnan(cuda::std::sinl(-cuda::std::numeric_limits<T>::infinity())));
+    assert(cuda::std::isnan(cuda::std::sinl(-cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::sinl(-cuda::std::numeric_limits<T>::quiet_NaN())));
+
+    const T pi = T(3.141592653589793238462643383279502);
+    assert(eq(cuda::std::sinl(pi / T(6.0)), T(0.5)));
+    assert(eq(cuda::std::sinl(-pi / T(6.0)), T(-0.5)));
+    assert(eq(cuda::std::sinl(pi / T(2.0)), T(1.0)));
+    assert(eq(cuda::std::sinl(-pi / T(2.0)), T(-1.0)));
+  }
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+}
+
+template <typename T>
+__host__ __device__ void test_tan(T val)
+{
+  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
+  static_assert(cuda::std::is_same<decltype(cuda::std::tan(T{})), ret>::value, "");
+
+  // 0 is returned unmodified
+  assert(eq(cuda::std::tan(val), val));
+  assert(eq(cuda::std::tan(-val), -val));
+  if constexpr (!cuda::std::is_integral<T>::value)
+  {
+    assert(cuda::std::isnan(cuda::std::tan(cuda::std::numeric_limits<T>::infinity())));
+    assert(cuda::std::isnan(cuda::std::tan(-cuda::std::numeric_limits<T>::infinity())));
+    assert(cuda::std::isnan(cuda::std::tan(-cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::tan(-cuda::std::numeric_limits<T>::quiet_NaN())));
+
+    const T pi = T(3.141592653589793238462643383279502);
+    assert(is_about(cuda::std::tan(pi * T(0.25)), T(1.0)));
+    assert(is_about(cuda::std::tan(pi * T(0.75)), T(-1.0)));
+
+    // half and bfloat suffer from precision here
+    if constexpr (cuda::std::is_floating_point_v<T>)
+    {
+      assert(is_about(cuda::std::tan(pi * T(1.25)), T(1.0)));
+      assert(is_about(cuda::std::tan(pi * T(1.75)), T(-1.0)));
+    }
+  }
+
+  if constexpr (cuda::std::is_same<T, float>::value)
+  {
+    assert(cuda::std::isnan(cuda::std::tanf(cuda::std::numeric_limits<T>::infinity())));
+    assert(cuda::std::isnan(cuda::std::tanf(-cuda::std::numeric_limits<T>::infinity())));
+    assert(cuda::std::isnan(cuda::std::tanf(-cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::tanf(-cuda::std::numeric_limits<T>::quiet_NaN())));
+
+    const T pi = T(3.141592653589793238462643383279502);
+    assert(is_about(cuda::std::tanf(pi * T(0.25)), T(1.0)));
+    assert(is_about(cuda::std::tanf(pi * T(0.75)), T(-1.0)));
+    assert(is_about(cuda::std::tanf(pi * T(1.25)), T(1.0)));
+    assert(is_about(cuda::std::tanf(pi * T(1.75)), T(-1.0)));
+  }
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  else if constexpr (cuda::std::is_same<T, long double>::value)
+  {
+    assert(cuda::std::isnan(cuda::std::tanl(cuda::std::numeric_limits<T>::infinity())));
+    assert(cuda::std::isnan(cuda::std::tanl(-cuda::std::numeric_limits<T>::infinity())));
+    assert(cuda::std::isnan(cuda::std::tanl(-cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::tanl(-cuda::std::numeric_limits<T>::quiet_NaN())));
+
+    const T pi = T(3.141592653589793238462643383279502);
+    assert(is_about(cuda::std::tanl(pi * T(0.25)), T(1.0)));
+    assert(is_about(cuda::std::tanl(pi * T(0.75)), T(-1.0)));
+    assert(is_about(cuda::std::tanl(pi * T(1.25)), T(1.0)));
+    assert(is_about(cuda::std::tanl(pi * T(1.75)), T(-1.0)));
+  }
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+}
+
+template <typename T>
+__host__ __device__ void test(const T val)
+{
+  test_cos<T>(val);
+  test_sin<T>(val);
+  test_tan<T>(val);
+}
+
+__host__ __device__ void test(const float val)
+{
+  test<float>(val);
+  test<double>(val);
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  test<long double>();
+#endif //!_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#ifdef _LIBCUDACXX_HAS_NVFP16
+  test<__half>(val);
+#endif // _LIBCUDACXX_HAS_NVFP16
+#ifdef _LIBCUDACXX_HAS_NVBF16
+  test<__nv_bfloat16>(val);
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+  test<unsigned short>(static_cast<unsigned short>(val));
+  test<int>(static_cast<int>(val));
+  test<unsigned int>(static_cast<unsigned int>(val));
+  test<long>(static_cast<long>(val));
+  test<unsigned long>(static_cast<unsigned long>(val));
+  test<long long>(static_cast<long long>(val));
+  test<unsigned long long>(static_cast<unsigned long long>(val));
+}
+
+__global__ void test_global_kernel(float* val)
+{
+  test(*val);
+}
+
+int main(int, char**)
+{
+  volatile float val = 0.0f;
+  test(val);
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/trigonometric_functions.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/trigonometric_functions.pass.cpp
@@ -26,13 +26,13 @@
 template <typename T>
 __host__ __device__ void test_cos(T val)
 {
-  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
-  static_assert(cuda::std::is_same<decltype(cuda::std::cos(T{})), ret>::value, "");
+  using ret = cuda::std::conditional_t<cuda::std::is_integral_v<T>, double, T>;
+  static_assert(cuda::std::is_same_v<decltype(cuda::std::cos(T{})), ret>, "");
 
   // 0 is returned unmodified
   assert(eq(cuda::std::cos(val), T(1.0)));
   assert(eq(cuda::std::cos(-val), T(1.0)));
-  if constexpr (!cuda::std::is_integral<T>::value)
+  if constexpr (!cuda::std::is_integral_v<T>)
   {
     assert(cuda::std::isnan(cuda::std::cos(cuda::std::numeric_limits<T>::infinity())));
     assert(cuda::std::isnan(cuda::std::cos(-cuda::std::numeric_limits<T>::infinity())));
@@ -44,7 +44,7 @@ __host__ __device__ void test_cos(T val)
     assert(is_about(cuda::std::cos(pi / T(2.0)), cuda::std::cos(-pi / T(2.0))));
   }
 
-  if constexpr (cuda::std::is_same<T, float>::value)
+  if constexpr (cuda::std::is_same_v<T, float>)
   {
     assert(cuda::std::isnan(cuda::std::cosf(cuda::std::numeric_limits<T>::infinity())));
     assert(cuda::std::isnan(cuda::std::cosf(-cuda::std::numeric_limits<T>::infinity())));
@@ -56,7 +56,7 @@ __host__ __device__ void test_cos(T val)
     assert(eq(cuda::std::cosf(pi / T(2.0)), cuda::std::cosf(-pi / T(2.0))));
   }
 #if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  else if constexpr (cuda::std::is_same<T, long double>::value)
+  else if constexpr (cuda::std::is_same_v<T, long double>)
   {
     assert(cuda::std::isnan(cuda::std::cosl(cuda::std::numeric_limits<T>::infinity())));
     assert(cuda::std::isnan(cuda::std::cosl(-cuda::std::numeric_limits<T>::infinity())));
@@ -73,13 +73,13 @@ __host__ __device__ void test_cos(T val)
 template <typename T>
 __host__ __device__ void test_sin(T val)
 {
-  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
-  static_assert(cuda::std::is_same<decltype(cuda::std::sin(T{})), ret>::value, "");
+  using ret = cuda::std::conditional_t<cuda::std::is_integral_v<T>, double, T>;
+  static_assert(cuda::std::is_same_v<decltype(cuda::std::sin(T{})), ret>, "");
 
   // 0 is returned unmodified
   assert(eq(cuda::std::sin(val), val));
   assert(eq(cuda::std::sin(-val), -val));
-  if constexpr (!cuda::std::is_integral<T>::value)
+  if constexpr (!cuda::std::is_integral_v<T>)
   {
     assert(cuda::std::isnan(cuda::std::sin(cuda::std::numeric_limits<T>::infinity())));
     assert(cuda::std::isnan(cuda::std::sin(-cuda::std::numeric_limits<T>::infinity())));
@@ -93,7 +93,7 @@ __host__ __device__ void test_sin(T val)
     assert(is_about(cuda::std::sin(-pi / T(2.0)), T(-1.0)));
   }
 
-  if constexpr (cuda::std::is_same<T, float>::value)
+  if constexpr (cuda::std::is_same_v<T, float>)
   {
     assert(cuda::std::isnan(cuda::std::sinf(cuda::std::numeric_limits<T>::infinity())));
     assert(cuda::std::isnan(cuda::std::sinf(-cuda::std::numeric_limits<T>::infinity())));
@@ -107,7 +107,7 @@ __host__ __device__ void test_sin(T val)
     assert(eq(cuda::std::sinf(-pi / T(2.0)), T(-1.0)));
   }
 #if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  else if constexpr (cuda::std::is_same<T, long double>::value)
+  else if constexpr (cuda::std::is_same_v<T, long double>)
   {
     assert(cuda::std::isnan(cuda::std::sinl(cuda::std::numeric_limits<T>::infinity())));
     assert(cuda::std::isnan(cuda::std::sinl(-cuda::std::numeric_limits<T>::infinity())));
@@ -126,13 +126,13 @@ __host__ __device__ void test_sin(T val)
 template <typename T>
 __host__ __device__ void test_tan(T val)
 {
-  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
-  static_assert(cuda::std::is_same<decltype(cuda::std::tan(T{})), ret>::value, "");
+  using ret = cuda::std::conditional_t<cuda::std::is_integral_v<T>, double, T>;
+  static_assert(cuda::std::is_same_v<decltype(cuda::std::tan(T{})), ret>, "");
 
   // 0 is returned unmodified
   assert(eq(cuda::std::tan(val), val));
   assert(eq(cuda::std::tan(-val), -val));
-  if constexpr (!cuda::std::is_integral<T>::value)
+  if constexpr (!cuda::std::is_integral_v<T>)
   {
     assert(cuda::std::isnan(cuda::std::tan(cuda::std::numeric_limits<T>::infinity())));
     assert(cuda::std::isnan(cuda::std::tan(-cuda::std::numeric_limits<T>::infinity())));
@@ -151,7 +151,7 @@ __host__ __device__ void test_tan(T val)
     }
   }
 
-  if constexpr (cuda::std::is_same<T, float>::value)
+  if constexpr (cuda::std::is_same_v<T, float>)
   {
     assert(cuda::std::isnan(cuda::std::tanf(cuda::std::numeric_limits<T>::infinity())));
     assert(cuda::std::isnan(cuda::std::tanf(-cuda::std::numeric_limits<T>::infinity())));
@@ -165,7 +165,7 @@ __host__ __device__ void test_tan(T val)
     assert(is_about(cuda::std::tanf(pi * T(1.75)), T(-1.0)));
   }
 #if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  else if constexpr (cuda::std::is_same<T, long double>::value)
+  else if constexpr (cuda::std::is_same_v<T, long double>)
   {
     assert(cuda::std::isnan(cuda::std::tanl(cuda::std::numeric_limits<T>::infinity())));
     assert(cuda::std::isnan(cuda::std::tanl(-cuda::std::numeric_limits<T>::infinity())));

--- a/libcudacxx/test/libcudacxx/std/numerics/complex.number/cases.h
+++ b/libcudacxx/test/libcudacxx/std/numerics/complex.number/cases.h
@@ -311,13 +311,12 @@ __host__ __device__ void is_about(double x, double y)
   assert(cuda::std::abs((x - y) / (x + y)) < 1.e-14);
 }
 
-// CUDA treats long double as double
-/*
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
 __host__ __device__ void is_about(long double x, long double y)
 {
-    assert(cuda::std::abs((x-y)/(x+y)) < 1.e-14);
+  assert(cuda::std::abs((x - y) / (x + y)) < 1.e-14);
 }
-*/
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
 
 #ifdef _LIBCUDACXX_HAS_NVFP16
 __host__ __device__ void is_about(__half x, __half y)


### PR DESCRIPTION
This properly implements more of the functions in `<cuda/std/cmath>`

I did not port more functions because those are conflictig with the ongoing work on extended floating point types