### PR TITLE
Fix typo in `_LIBCUDACXX_HAS_NVFP16` macro.

### DIFF
--- a/libcudacxx/include/cuda/__ptx/instructions/cp_reduce_async_bulk.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/cp_reduce_async_bulk.h
@@ -32,9 +32,9 @@
 // expensive to include. The APIs use only pointers, so we do not have to define
 // the types. If the user wants to use these types, it is their responsibility
 // to include the headers.
-#ifdef _LIBCUDACXX_HAS_NVF16
+#ifdef _LIBCUDACXX_HAS_NVFP16
 struct __half;
-#endif // _LIBCUDACXX_HAS_NVF16
+#endif // _LIBCUDACXX_HAS_NVFP16
 #ifdef _LIBCUDACXX_HAS_NVBF16
 struct __nv_bfloat16;
 #endif // _LIBCUDACXX_HAS_NVBF16
@@ -44,9 +44,9 @@ _LIBCUDACXX_BEGIN_NAMESPACE_CUDA_PTX
 // 9.7.8.24.7. Data Movement and Conversion Instructions: cp.reduce.async.bulk
 // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#data-movement-and-conversion-instructions-cp-reduce-async-bulk
 #include <cuda/__ptx/instructions/generated/cp_reduce_async_bulk.h>
-#ifdef _LIBCUDACXX_HAS_NVF16
+#ifdef _LIBCUDACXX_HAS_NVFP16
 #  include <cuda/__ptx/instructions/generated/cp_reduce_async_bulk_f16.h>
-#endif // _LIBCUDACXX_HAS_NVF16
+#endif // _LIBCUDACXX_HAS_NVFP16
 #ifdef _LIBCUDACXX_HAS_NVBF16
 #  include <cuda/__ptx/instructions/generated/cp_reduce_async_bulk_bf16.h>
 #endif // _LIBCUDACXX_HAS_NVBF16

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.cp.reduce.async.bulk.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.cp.reduce.async.bulk.compile.pass.cpp
@@ -18,9 +18,9 @@
 // above header needs to be included before the generated test header
 #include "generated/cp_reduce_async_bulk.h"
 
-#ifdef _LIBCUDACXX_HAS_NVF16
+#ifdef _LIBCUDACXX_HAS_NVFP16
 #  include "generated/cp_reduce_async_bulk_f16.h"
-#endif // _LIBCUDACXX_HAS_NVF16
+#endif // _LIBCUDACXX_HAS_NVFP16
 
 #ifdef _LIBCUDACXX_HAS_NVBF16
 #  include "generated/cp_reduce_async_bulk_bf16.h"


### PR DESCRIPTION
Fix typo in `_LIBCUDACXX_HAS_NVFP16` macro.
