### PR TITLE
Change to apply utilities added in gh-3906 in algorithms

### DIFF
--- a/python/cuda_parallel/cuda/parallel/experimental/algorithms/scan.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/algorithms/scan.py
@@ -10,11 +10,10 @@ from typing import Callable
 
 import numba
 import numpy as np
-from numba import cuda
 from numba.cuda.cudadrv import enums
 
 from .. import _cccl as cccl
-from .._bindings import get_bindings, get_paths
+from .._bindings import call_build, get_bindings
 from .._caching import CachableFunction, cache_with_key
 from .._utils import protocols
 from ..iterators._iterators import IteratorBase
@@ -36,8 +35,6 @@ class _Scan:
         self.d_in_cccl = cccl.to_cccl_iter(d_in)
         self.d_out_cccl = cccl.to_cccl_iter(d_out)
         self.h_init_cccl = cccl.to_cccl_value(h_init)
-        cc_major, cc_minor = cuda.get_current_device().compute_capability
-        cub_path, thrust_path, libcudacxx_path, cuda_include_path = get_paths()
         if isinstance(h_init, np.ndarray):
             value_type = numba.from_dtype(h_init.dtype)
         else:
@@ -46,18 +43,13 @@ class _Scan:
         self.op_wrapper = cccl.to_cccl_op(op, sig)
         self.build_result = cccl.DeviceScanBuildResult()
         self.bindings = get_bindings()
-        error = self.bindings.cccl_device_scan_build(
+        error = call_build(
+            self.bindings.cccl_device_scan_build,
             ctypes.byref(self.build_result),
             self.d_in_cccl,
             self.d_out_cccl,
             self.op_wrapper,
             cccl.to_cccl_value(h_init),
-            cc_major,
-            cc_minor,
-            ctypes.c_char_p(cub_path),
-            ctypes.c_char_p(thrust_path),
-            ctypes.c_char_p(libcudacxx_path),
-            ctypes.c_char_p(cuda_include_path),
         )
         if error != enums.CUDA_SUCCESS:
             raise ValueError("Error building scan")
@@ -71,15 +63,9 @@ class _Scan:
         h_init: np.ndarray | GpuStruct,
         stream=None,
     ):
-        if self.d_in_cccl.type.value == cccl.IteratorKind.POINTER:
-            self.d_in_cccl.state = protocols.get_data_pointer(d_in)
-        else:
-            self.d_in_cccl.state = d_in.state
-
-        if self.d_out_cccl.type.value == cccl.IteratorKind.POINTER:
-            self.d_out_cccl.state = protocols.get_data_pointer(d_out)
-        else:
-            self.d_out_cccl.state = d_out.state
+        set_state_fn = cccl.set_cccl_iterator_state
+        set_state_fn(self.d_in_cccl, d_in)
+        set_state_fn(self.d_out_cccl, d_out)
 
         self.h_init_cccl.state = h_init.__array_interface__["data"][0]
 


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes gh-3967

<!-- Provide a standalone description of changes in this PR. -->

This PR removes repeated code to set state in `cccl.Iterator` throughout algorithms. It also applies `call_build` utility to call algorithm's build function while passing along compute capability of the current device and include paths, eliminating copy-pasted identical code.

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
