### PR TITLE
Refactor uses of thrust::iterator_traversal

### DIFF
--- a/thrust/thrust/detail/vector_base.h
+++ b/thrust/thrust/detail/vector_base.h
@@ -501,12 +501,6 @@ private:
   template <typename InputIterator>
   void range_init(InputIterator first, InputIterator last);
 
-  template <typename InputIterator>
-  void range_init(InputIterator first, InputIterator last, thrust::incrementable_traversal_tag);
-
-  template <typename ForwardIterator>
-  void range_init(ForwardIterator first, ForwardIterator last, thrust::random_access_traversal_tag);
-
   void value_init(size_type n);
 
   void fill_init(size_type n, const T& x);
@@ -541,14 +535,6 @@ private:
   // this method performs assignment from a range
   template <typename InputIterator>
   void range_assign(InputIterator first, InputIterator last);
-
-  // this method performs assignment from a range of RandomAccessIterators
-  template <typename RandomAccessIterator>
-  void range_assign(RandomAccessIterator first, RandomAccessIterator last, thrust::random_access_traversal_tag);
-
-  // this method performs assignment from a range of InputIterators
-  template <typename InputIterator>
-  void range_assign(InputIterator first, InputIterator last, thrust::incrementable_traversal_tag);
 
   // this method performs assignment from a fill value
   void fill_assign(size_type n, const T& x);

--- a/thrust/thrust/detail/vector_base.inl
+++ b/thrust/thrust/detail/vector_base.inl
@@ -25,6 +25,7 @@
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
 #  pragma system_header
 #endif // no system header
+
 #include <thrust/advance.h>
 #include <thrust/detail/copy.h>
 #include <thrust/detail/overlapped_copy.h>
@@ -37,6 +38,7 @@
 
 #include <cuda/std/__algorithm/max.h>
 #include <cuda/std/__algorithm/min.h>
+#include <cuda/std/type_traits>
 
 #include <stdexcept>
 
@@ -248,27 +250,21 @@ template <typename T, typename Alloc>
 template <typename InputIterator>
 void vector_base<T, Alloc>::range_init(InputIterator first, InputIterator last)
 {
-  range_init(first, last, typename thrust::iterator_traversal<InputIterator>::type());
-} // end vector_base::range_init()
-
-template <typename T, typename Alloc>
-template <typename InputIterator>
-void vector_base<T, Alloc>::range_init(InputIterator first, InputIterator last, thrust::incrementable_traversal_tag)
-{
-  for (; first != last; ++first)
+  using traversal = typename iterator_traversal<InputIterator>::type;
+  if constexpr (::cuda::std::is_convertible_v<traversal, random_access_traversal_tag>)
   {
-    push_back(*first);
+    size_type new_size = thrust::distance(first, last);
+
+    allocate_and_copy(new_size, first, last, m_storage);
+    m_size = new_size;
   }
-} // end vector_base::range_init()
-
-template <typename T, typename Alloc>
-template <typename ForwardIterator>
-void vector_base<T, Alloc>::range_init(ForwardIterator first, ForwardIterator last, thrust::random_access_traversal_tag)
-{
-  size_type new_size = thrust::distance(first, last);
-
-  allocate_and_copy(new_size, first, last, m_storage);
-  m_size = new_size;
+  else
+  {
+    for (; first != last; ++first)
+    {
+      push_back(*first);
+    }
+  }
 } // end vector_base::range_init()
 
 template <typename T, typename Alloc>
@@ -951,86 +947,77 @@ template <typename T, typename Alloc>
 template <typename InputIterator>
 void vector_base<T, Alloc>::range_assign(InputIterator first, InputIterator last)
 {
-  // dispatch on traversal
-  range_assign(first, last, typename thrust::iterator_traversal<InputIterator>::type());
+  using traversal = typename iterator_traversal<InputIterator>::type;
+  if constexpr (::cuda::std::is_convertible_v<traversal, random_access_traversal_tag>)
+  {
+    const size_type n = thrust::distance(first, last);
+    if (n > capacity())
+    {
+      storage_type new_storage(copy_allocator_t(), m_storage);
+      allocate_and_copy(n, first, last, new_storage);
+
+      // call destructors on the elements in the old storage
+      m_storage.destroy(begin(), end());
+
+      // record the vector's new state
+      m_storage.swap(new_storage);
+      m_size = n;
+    } // end if
+    else if (size() >= n)
+    {
+      // we can already accommodate the new range
+      iterator new_end = thrust::copy(first, last, begin());
+
+      // destroy the elements we don't need
+      m_storage.destroy(new_end, end());
+
+      // update size
+      m_size = n;
+    } // end else if
+    else
+    {
+      // range fits inside allocated storage, but some elements
+      // have not been constructed yet
+
+      // XXX TODO we could possibly implement this with one call
+      // to transform rather than copy + uninitialized_copy
+
+      // copy to elements which already exist
+      InputIterator mid = first;
+      thrust::advance(mid, size());
+      thrust::copy(first, mid, begin());
+
+      // uninitialize_copy to elements which must be constructed
+      m_storage.uninitialized_copy(mid, last, end());
+
+      // update size
+      m_size = n;
+    } // end else
+  }
+  else // for less than random access iterators
+  {
+    iterator current(begin());
+
+    // assign to elements which already exist
+    for (; first != last && current != end(); ++current, ++first)
+    {
+      *current = *first;
+    } // end for
+
+    // either just the input was exhausted or both
+    // the input and vector elements were exhausted
+    if (first == last)
+    {
+      // if we exhausted the input, erase leftover elements
+      erase(current, end());
+    } // end if
+    else
+    {
+      // insert the rest of the input at the end of the vector
+      insert(end(), first, last);
+    } // end else
+  }
 } // end range_assign()
-
-template <typename T, typename Alloc>
-template <typename InputIterator>
-void vector_base<T, Alloc>::range_assign(InputIterator first, InputIterator last, thrust::incrementable_traversal_tag)
-{
-  iterator current(begin());
-
-  // assign to elements which already exist
-  for (; first != last && current != end(); ++current, ++first)
-  {
-    *current = *first;
-  } // end for
-
-  // either just the input was exhausted or both
-  // the input and vector elements were exhausted
-  if (first == last)
-  {
-    // if we exhausted the input, erase leftover elements
-    erase(current, end());
-  } // end if
-  else
-  {
-    // insert the rest of the input at the end of the vector
-    insert(end(), first, last);
-  } // end else
-} // end vector_base::range_assign()
-
-template <typename T, typename Alloc>
-template <typename RandomAccessIterator>
-void vector_base<T, Alloc>::range_assign(
-  RandomAccessIterator first, RandomAccessIterator last, thrust::random_access_traversal_tag)
-{
-  const size_type n = thrust::distance(first, last);
-
-  if (n > capacity())
-  {
-    storage_type new_storage(copy_allocator_t(), m_storage);
-    allocate_and_copy(n, first, last, new_storage);
-
-    // call destructors on the elements in the old storage
-    m_storage.destroy(begin(), end());
-
-    // record the vector's new state
-    m_storage.swap(new_storage);
-    m_size = n;
-  } // end if
-  else if (size() >= n)
-  {
-    // we can already accommodate the new range
-    iterator new_end = thrust::copy(first, last, begin());
-
-    // destroy the elements we don't need
-    m_storage.destroy(new_end, end());
-
-    // update size
-    m_size = n;
-  } // end else if
-  else
-  {
-    // range fits inside allocated storage, but some elements
-    // have not been constructed yet
-
-    // XXX TODO we could possibly implement this with one call
-    // to transform rather than copy + uninitialized_copy
-
-    // copy to elements which already exist
-    RandomAccessIterator mid = first;
-    thrust::advance(mid, size());
-    thrust::copy(first, mid, begin());
-
-    // uninitialize_copy to elements which must be constructed
-    m_storage.uninitialized_copy(mid, last, end());
-
-    // update size
-    m_size = n;
-  } // end else
-} // end vector_base::assign()
 
 template <typename T, typename Alloc>
 void vector_base<T, Alloc>::fill_assign(size_type n, const T& x)

--- a/thrust/thrust/iterator/detail/iterator_category_to_system.h
+++ b/thrust/thrust/iterator/detail/iterator_category_to_system.h
@@ -29,7 +29,6 @@
 #include <thrust/iterator/detail/any_system_tag.h>
 #include <thrust/iterator/detail/device_system_tag.h>
 #include <thrust/iterator/detail/host_system_tag.h>
-#include <thrust/iterator/detail/iterator_traversal_tags.h>
 #include <thrust/iterator/iterator_categories.h>
 
 THRUST_NAMESPACE_BEGIN

--- a/thrust/thrust/system/detail/generic/advance.inl
+++ b/thrust/thrust/system/detail/generic/advance.inl
@@ -25,47 +25,31 @@
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
 #  pragma system_header
 #endif // no system header
+
 #include <thrust/iterator/iterator_traits.h>
 #include <thrust/system/detail/generic/advance.h>
 
+#include <cuda/std/type_traits>
+
 THRUST_NAMESPACE_BEGIN
-namespace system
+namespace system::detail::generic
 {
-namespace detail
-{
-namespace generic
-{
-namespace detail
-{
-
-_CCCL_EXEC_CHECK_DISABLE
-template <typename InputIterator, typename Distance>
-_CCCL_HOST_DEVICE void advance(InputIterator& i, Distance n, thrust::incrementable_traversal_tag)
-{
-  while (n)
-  {
-    ++i;
-    --n;
-  } // end while
-} // end advance()
-
-_CCCL_EXEC_CHECK_DISABLE
-template <typename InputIterator, typename Distance>
-_CCCL_HOST_DEVICE void advance(InputIterator& i, Distance n, thrust::random_access_traversal_tag)
-{
-  i += n;
-} // end advance()
-
-} // namespace detail
-
 template <typename InputIterator, typename Distance>
 _CCCL_HOST_DEVICE void advance(InputIterator& i, Distance n)
 {
-  // dispatch on iterator traversal
-  thrust::system::detail::generic::detail::advance(i, n, typename thrust::iterator_traversal<InputIterator>::type());
-} // end advance()
-
-} // namespace generic
-} // namespace detail
-} // end namespace system
+  using traversal = typename iterator_traversal<InputIterator>::type;
+  if constexpr (::cuda::std::is_convertible_v<traversal, random_access_traversal_tag>)
+  {
+    i += n;
+  }
+  else
+  {
+    while (n)
+    {
+      ++i;
+      --n;
+    }
+  }
+}
+} // namespace system::detail::generic
 THRUST_NAMESPACE_END

--- a/thrust/thrust/system/detail/generic/advance.inl
+++ b/thrust/thrust/system/detail/generic/advance.inl
@@ -34,6 +34,7 @@
 THRUST_NAMESPACE_BEGIN
 namespace system::detail::generic
 {
+_CCCL_EXEC_CHECK_DISABLE
 template <typename InputIterator, typename Distance>
 _CCCL_HOST_DEVICE void advance(InputIterator& i, Distance n)
 {

--- a/thrust/thrust/system/omp/detail/copy.inl
+++ b/thrust/thrust/system/omp/detail/copy.inl
@@ -47,11 +47,11 @@ copy(execution_policy<DerivedPolicy>& exec, InputIterator first, InputIterator l
 
   if constexpr (::cuda::std::is_convertible_v<traversal, random_access_traversal_tag>)
   {
-    return system::detail::generic::copy_n(exec, first, last, result);
+    return system::detail::generic::copy(exec, first, last, result);
   }
   else
   {
-    return system::detail::sequential::copy_n(exec, first, last, result);
+    return system::detail::sequential::copy(exec, first, last, result);
   }
 }
 

--- a/thrust/thrust/system/omp/detail/copy.inl
+++ b/thrust/thrust/system/omp/detail/copy.inl
@@ -25,93 +25,50 @@
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
 #  pragma system_header
 #endif // no system header
+
 #include <thrust/detail/type_traits/minimum_type.h>
 #include <thrust/system/detail/generic/copy.h>
 #include <thrust/system/detail/sequential/copy.h>
 #include <thrust/system/omp/detail/copy.h>
 
+#include <cuda/std/type_traits>
+
 THRUST_NAMESPACE_BEGIN
-namespace system
+namespace system::omp::detail
 {
-namespace omp
-{
-namespace detail
-{
-namespace dispatch
-{
-
-template <typename DerivedPolicy, typename InputIterator, typename OutputIterator>
-OutputIterator
-copy(execution_policy<DerivedPolicy>& exec,
-     InputIterator first,
-     InputIterator last,
-     OutputIterator result,
-     thrust::incrementable_traversal_tag)
-{
-  return thrust::system::detail::sequential::copy(exec, first, last, result);
-} // end copy()
-
-template <typename DerivedPolicy, typename InputIterator, typename OutputIterator>
-OutputIterator
-copy(execution_policy<DerivedPolicy>& exec,
-     InputIterator first,
-     InputIterator last,
-     OutputIterator result,
-     thrust::random_access_traversal_tag)
-{
-  return thrust::system::detail::generic::copy(exec, first, last, result);
-} // end copy()
-
-template <typename DerivedPolicy, typename InputIterator, typename Size, typename OutputIterator>
-OutputIterator
-copy_n(execution_policy<DerivedPolicy>& exec,
-       InputIterator first,
-       Size n,
-       OutputIterator result,
-       thrust::incrementable_traversal_tag)
-{
-  return thrust::system::detail::sequential::copy_n(exec, first, n, result);
-} // end copy_n()
-
-template <typename DerivedPolicy, typename InputIterator, typename Size, typename OutputIterator>
-OutputIterator
-copy_n(execution_policy<DerivedPolicy>& exec,
-       InputIterator first,
-       Size n,
-       OutputIterator result,
-       thrust::random_access_traversal_tag)
-{
-  return thrust::system::detail::generic::copy_n(exec, first, n, result);
-} // end copy_n()
-
-} // namespace dispatch
-
 template <typename DerivedPolicy, typename InputIterator, typename OutputIterator>
 OutputIterator
 copy(execution_policy<DerivedPolicy>& exec, InputIterator first, InputIterator last, OutputIterator result)
 {
-  using traversal1 = typename thrust::iterator_traversal<InputIterator>::type;
-  using traversal2 = typename thrust::iterator_traversal<OutputIterator>::type;
+  using traversal1 = typename iterator_traversal<InputIterator>::type;
+  using traversal2 = typename iterator_traversal<OutputIterator>::type;
 
   using traversal = typename thrust::detail::minimum_type<traversal1, traversal2>::type;
 
-  // dispatch on minimum traversal
-  return thrust::system::omp::detail::dispatch::copy(exec, first, last, result, traversal());
-} // end copy()
+  if constexpr (::cuda::std::is_convertible_v<traversal, random_access_traversal_tag>)
+  {
+    return system::detail::generic::copy_n(exec, first, last, result);
+  }
+  else
+  {
+    return system::detail::sequential::copy_n(exec, first, last, result);
+  }
+}
 
 template <typename DerivedPolicy, typename InputIterator, typename Size, typename OutputIterator>
 OutputIterator copy_n(execution_policy<DerivedPolicy>& exec, InputIterator first, Size n, OutputIterator result)
 {
-  using traversal1 = typename thrust::iterator_traversal<InputIterator>::type;
-  using traversal2 = typename thrust::iterator_traversal<OutputIterator>::type;
-
-  using traversal = typename thrust::detail::minimum_type<traversal1, traversal2>::type;
-
-  // dispatch on minimum traversal
-  return thrust::system::omp::detail::dispatch::copy_n(exec, first, n, result, traversal());
-} // end copy_n()
-
-} // end namespace detail
-} // end namespace omp
-} // end namespace system
+  using traversal1 = typename iterator_traversal<InputIterator>::type;
+  using traversal2 = typename iterator_traversal<OutputIterator>::type;
+  using traversal  = typename thrust::detail::minimum_type<traversal1, traversal2>::type;
+  if constexpr (::cuda::std::is_convertible_v<traversal, random_access_traversal_tag>)
+  {
+    return system::detail::generic::copy_n(exec, first, n, result);
+  }
+  else
+  {
+    return system::detail::sequential::copy_n(exec, first, n, result);
+  }
+}
+} // namespace system::omp::detail
 THRUST_NAMESPACE_END

--- a/thrust/thrust/system/tbb/detail/copy.inl
+++ b/thrust/thrust/system/tbb/detail/copy.inl
@@ -46,11 +46,11 @@ copy(execution_policy<DerivedPolicy>& exec, InputIterator first, InputIterator l
   using traversal  = typename thrust::detail::minimum_type<traversal1, traversal2>::type;
   if constexpr (::cuda::std::is_convertible_v<traversal, random_access_traversal_tag>)
   {
-    return system::detail::generic::copy_n(exec, first, last, result);
+    return system::detail::generic::copy(exec, first, last, result);
   }
   else
   {
-    return system::detail::sequential::copy_n(exec, first, last, result);
+    return system::detail::sequential::copy(exec, first, last, result);
   }
 }
 

--- a/thrust/thrust/system/tbb/detail/copy.inl
+++ b/thrust/thrust/system/tbb/detail/copy.inl
@@ -25,94 +25,49 @@
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
 #  pragma system_header
 #endif // no system header
+
 #include <thrust/detail/copy.h>
 #include <thrust/detail/type_traits/minimum_type.h>
 #include <thrust/system/detail/generic/copy.h>
 #include <thrust/system/detail/sequential/copy.h>
 #include <thrust/system/tbb/detail/copy.h>
 
+#include <cuda/std/type_traits>
+
 THRUST_NAMESPACE_BEGIN
-namespace system
+namespace system::tbb::detail
 {
-namespace tbb
-{
-namespace detail
-{
-namespace dispatch
-{
-
-template <typename DerivedPolicy, typename InputIterator, typename OutputIterator>
-OutputIterator
-copy(execution_policy<DerivedPolicy>& exec,
-     InputIterator first,
-     InputIterator last,
-     OutputIterator result,
-     thrust::incrementable_traversal_tag)
-{
-  return thrust::system::detail::sequential::copy(exec, first, last, result);
-} // end copy()
-
-template <typename DerivedPolicy, typename InputIterator, typename OutputIterator>
-OutputIterator
-copy(execution_policy<DerivedPolicy>& exec,
-     InputIterator first,
-     InputIterator last,
-     OutputIterator result,
-     thrust::random_access_traversal_tag)
-{
-  return thrust::system::detail::generic::copy(exec, first, last, result);
-} // end copy()
-
-template <typename DerivedPolicy, typename InputIterator, typename Size, typename OutputIterator>
-OutputIterator
-copy_n(execution_policy<DerivedPolicy>& exec,
-       InputIterator first,
-       Size n,
-       OutputIterator result,
-       thrust::incrementable_traversal_tag)
-{
-  return thrust::system::detail::sequential::copy_n(exec, first, n, result);
-} // end copy_n()
-
-template <typename DerivedPolicy, typename InputIterator, typename Size, typename OutputIterator>
-OutputIterator
-copy_n(execution_policy<DerivedPolicy>& exec,
-       InputIterator first,
-       Size n,
-       OutputIterator result,
-       thrust::random_access_traversal_tag)
-{
-  return thrust::system::detail::generic::copy_n(exec, first, n, result);
-} // end copy_n()
-
-} // namespace dispatch
-
 template <typename DerivedPolicy, typename InputIterator, typename OutputIterator>
 OutputIterator
 copy(execution_policy<DerivedPolicy>& exec, InputIterator first, InputIterator last, OutputIterator result)
 {
-  using traversal1 = typename thrust::iterator_traversal<InputIterator>::type;
-  using traversal2 = typename thrust::iterator_traversal<OutputIterator>::type;
-
-  using traversal = typename thrust::detail::minimum_type<traversal1, traversal2>::type;
-
-  // dispatch on minimum traversal
-  return thrust::system::tbb::detail::dispatch::copy(exec, first, last, result, traversal());
-} // end copy()
+  using traversal1 = typename iterator_traversal<InputIterator>::type;
+  using traversal2 = typename iterator_traversal<OutputIterator>::type;
+  using traversal  = typename thrust::detail::minimum_type<traversal1, traversal2>::type;
+  if constexpr (::cuda::std::is_convertible_v<traversal, random_access_traversal_tag>)
+  {
+    return system::detail::generic::copy_n(exec, first, last, result);
+  }
+  else
+  {
+    return system::detail::sequential::copy_n(exec, first, last, result);
+  }
+}
 
 template <typename DerivedPolicy, typename InputIterator, typename Size, typename OutputIterator>
 OutputIterator copy_n(execution_policy<DerivedPolicy>& exec, InputIterator first, Size n, OutputIterator result)
 {
-  using traversal1 = typename thrust::iterator_traversal<InputIterator>::type;
-  using traversal2 = typename thrust::iterator_traversal<OutputIterator>::type;
-
-  using traversal = typename thrust::detail::minimum_type<traversal1, traversal2>::type;
-
-  // dispatch on minimum traversal
-  return thrust::system::tbb::detail::dispatch::copy_n(exec, first, n, result, traversal());
-} // end copy_n()
-
-} // end namespace detail
-} // end namespace tbb
-} // end namespace system
+  using traversal1 = typename iterator_traversal<InputIterator>::type;
+  using traversal2 = typename iterator_traversal<OutputIterator>::type;
+  using traversal  = typename thrust::detail::minimum_type<traversal1, traversal2>::type;
+  if constexpr (::cuda::std::is_convertible_v<traversal, random_access_traversal_tag>)
+  {
+    return system::detail::generic::copy_n(exec, first, n, result);
+  }
+  else
+  {
+    return system::detail::sequential::copy_n(exec, first, n, result);
+  }
+}
+} // namespace system::tbb::detail
 THRUST_NAMESPACE_END


### PR DESCRIPTION
This PR replaces some tag dispatching on iterator traversals by `if constexpr` .