### PR TITLE
Added `release.yml` to automatically categorize release notes.

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,16 +1,16 @@
 changelog:
   categories:
-    - title: 💻 C++ - 🚀 Thrust / CUB
+    - title: 🚀 Thrust / CUB
       labels:
         - "thrust"
         - "cub"
-    - title: 💻 C++ - 📚 Libcudacxx
+    - title: 📚 Libcudacxx
       labels:
         - "libcu++"
-    - title: 🐍 Python - 🤝 cuda.cooperative
+    - title: 🤝 cuda.cooperative
       labels:
         - "cuda.cooperative"
-    - title: 🐍 Python - ⚡ cuda.parallel
+    - title: ⚡ cuda.parallel
       labels:
         - "cuda.parallel"
     - title: 📝 Documentation

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -10,7 +10,7 @@ changelog:
     - title: 🐍 Python - 🤝 cuda.cooperative
       labels:
         - "cuda.cooperative"
-    - title: 🐍 Python - ⚡ cuda.parallel 
+    - title: 🐍 Python - ⚡ cuda.parallel
       labels:
         - "cuda.parallel"
     - title: 📝 Documentation

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,24 +1,18 @@
 changelog:
   categories:
-    - title: 💻 C++
-      labels: []
-      sections:
-        - title: 🚀 Thrust / CUB
-          labels:
-            - "thrust"
-            - "cub"
-        - title: 📚 Libcudacxx
-          labels:
-            - "libcu++"
-    - title: 🐍 Python
-      labels: []
-      sections:
-        - title: 🤝 cuda.cooperative
-          labels:
-            - "cuda.cooperative"
-        - title: ⚡ cuda.parallel
-          labels:
-            - "cuda.parallel"
+    - title: 💻 C++ - 🚀 Thrust / CUB
+      labels:
+        - "thrust"
+        - "cub"
+    - title: 💻 C++ - 📚 Libcudacxx
+      labels:
+        - "libcu++"
+    - title: 🐍 Python - 🤝 cuda.cooperative
+      labels:
+        - "cuda.cooperative"
+    - title: 🐍 Python - ⚡ cuda.parallel 
+      labels:
+        - "cuda.parallel"
     - title: 📝 Documentation
       labels:
         - "doc"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,27 @@
+changelog:
+  categories:
+    - title: 💻 C++
+      labels: []
+      sections:
+        - title: 🚀 Thrust / CUB
+          labels:
+            - "thrust"
+            - "cub"
+        - title: 📚 Libcudacxx
+          labels:
+            - "libcu++"
+    - title: 🐍 Python
+      labels: []
+      sections:
+        - title: 🤝 cuda.cooperative
+          labels:
+            - "cuda.cooperative"
+        - title: ⚡ cuda.parallel
+          labels:
+            - "cuda.parallel"
+    - title: 📝 Documentation
+      labels:
+        - "doc"
+    - title: 🔄 Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
## Description
Makes progress on #3191

<!-- Provide a standalone description of changes in this PR. -->
Adds `release.yml` file to the `.github` directory. 

As mentioned in #3191, the structure of a future release document will likely depend on #2841.  To provide a short-term solution, I mimicked the [previous release's layout](https://github.com/NVIDIA/cccl/releases/tag/v2.7.0). An addition to this structure I made was adding a Documentation section that the `doc` label will fall under, and an Other Changes section that acts as a "catch all" to PRs that don't fit into labels specified in `release.yml`

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
