### PR TITLE
Assert offset type in `DispatchScan[ByKey]` to be unsigned and at least 4 bytes

### DIFF
--- a/cub/benchmarks/bench/scan/exclusive/by_key.cu
+++ b/cub/benchmarks/bench/scan/exclusive/by_key.cu
@@ -84,7 +84,7 @@ static void scan(nvbench::state& state, nvbench::type_list<KeyT, ValueT, OffsetT
   using val_input_it_t  = const ValueT*;
   using val_output_it_t = ValueT*;
   using equality_op_t   = ::cuda::std::equal_to<>;
-  using offset_t        = ::cuda::std::make_unsigned_t<OffsetT>;
+  using offset_t        = cub::detail::choose_offset_t<OffsetT>;
 
 #if !TUNE_BASE
   using policy_t   = policy_hub_t;

--- a/cub/benchmarks/bench/scan/exclusive/by_key.cu
+++ b/cub/benchmarks/bench/scan/exclusive/by_key.cu
@@ -27,6 +27,8 @@
 
 #include <cub/device/device_scan.cuh>
 
+#include <cuda/std/type_traits>
+
 #include <look_back_helper.cuh>
 #include <nvbench_helper.cuh>
 
@@ -82,7 +84,7 @@ static void scan(nvbench::state& state, nvbench::type_list<KeyT, ValueT, OffsetT
   using val_input_it_t  = const ValueT*;
   using val_output_it_t = ValueT*;
   using equality_op_t   = ::cuda::std::equal_to<>;
-  using offset_t        = OffsetT;
+  using offset_t        = ::cuda::std::make_unsigned_t<OffsetT>;
 
 #if !TUNE_BASE
   using policy_t   = policy_hub_t;

--- a/cub/benchmarks/bench/scan/exclusive/by_key.cu
+++ b/cub/benchmarks/bench/scan/exclusive/by_key.cu
@@ -25,9 +25,8 @@
  *
  ******************************************************************************/
 
+#include <cub/detail/choose_offset.cuh>
 #include <cub/device/device_scan.cuh>
-
-#include <cuda/std/type_traits>
 
 #include <look_back_helper.cuh>
 #include <nvbench_helper.cuh>

--- a/cub/cub/device/dispatch/dispatch_scan.cuh
+++ b/cub/cub/device/dispatch/dispatch_scan.cuh
@@ -165,6 +165,8 @@ template <
   typename KernelLauncherFactory = detail::TripleChevronFactory>
 struct DispatchScan
 {
+  static_assert(::cuda::std::is_unsigned_v<OffsetT>, "DispatchScan only supports unsigned offset types");
+
   //---------------------------------------------------------------------
   // Constants and Types
   //---------------------------------------------------------------------

--- a/cub/cub/device/dispatch/dispatch_scan.cuh
+++ b/cub/cub/device/dispatch/dispatch_scan.cuh
@@ -165,7 +165,8 @@ template <
   typename KernelLauncherFactory = detail::TripleChevronFactory>
 struct DispatchScan
 {
-  static_assert(::cuda::std::is_unsigned_v<OffsetT>, "DispatchScan only supports unsigned offset types");
+  static_assert(::cuda::std::is_unsigned_v<OffsetT> && sizeof(OffsetT) >= 4,
+                "DispatchScan only supports unsigned offset types of at least 4-bytes");
 
   //---------------------------------------------------------------------
   // Constants and Types

--- a/cub/cub/device/dispatch/dispatch_scan_by_key.cuh
+++ b/cub/cub/device/dispatch/dispatch_scan_by_key.cuh
@@ -241,6 +241,8 @@ template <
     detail::scan_by_key::policy_hub<KeysInputIteratorT, AccumT, cub::detail::it_value_t<ValuesInputIteratorT>, ScanOpT>>
 struct DispatchScanByKey
 {
+  static_assert(::cuda::std::is_unsigned_v<OffsetT>, "DispatchScanByKey only supports unsigned offset types");
+
   //---------------------------------------------------------------------
   // Constants and Types
   //---------------------------------------------------------------------

--- a/cub/cub/device/dispatch/dispatch_scan_by_key.cuh
+++ b/cub/cub/device/dispatch/dispatch_scan_by_key.cuh
@@ -241,7 +241,8 @@ template <
     detail::scan_by_key::policy_hub<KeysInputIteratorT, AccumT, cub::detail::it_value_t<ValuesInputIteratorT>, ScanOpT>>
 struct DispatchScanByKey
 {
-  static_assert(::cuda::std::is_unsigned_v<OffsetT>, "DispatchScanByKey only supports unsigned offset types");
+  static_assert(::cuda::std::is_unsigned_v<OffsetT> && sizeof(OffsetT) >= 4,
+                "DispatchScan only supports unsigned offset types of at least 4-bytes");
 
   //---------------------------------------------------------------------
   // Constants and Types


### PR DESCRIPTION
`DispatchScan[ByKey]` should only be instanted with unsigned types. This was a result of the large offset support benchmarking by @elstehle. #3111 updated the documentation accordingly, but we could not add an assertion ensuring it, because users may instantiate the dispatcher themselves.