### PR TITLE
Drop CUB_MIN in radix sort agent

### DIFF
--- a/cub/cub/agent/agent_radix_sort_histogram.cuh
+++ b/cub/cub/agent/agent_radix_sort_histogram.cuh
@@ -208,9 +208,7 @@ struct AgentRadixSortHistogram
 #pragma unroll
     for (int current_bit = begin_bit, pass = 0; current_bit < end_bit; current_bit += RADIX_BITS, ++pass)
     {
-      // FIXME(bgruber): the following replacement changes SASS for cub.test.device_radix_sort_pairs.lid_0
-      // const int num_bits = _CUDA_VSTD::min(+RADIX_BITS, end_bit - current_bit);
-      const int num_bits = CUB_MIN(+RADIX_BITS, end_bit - current_bit);
+      const int num_bits = _CUDA_VSTD::min(+RADIX_BITS, end_bit - current_bit);
 #pragma unroll
       for (int u = 0; u < ITEMS_PER_THREAD; ++u)
       {


### PR DESCRIPTION
Benchmark of `cub.bench.radix_sort.keys.base` on B200 looks good:

```
|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |  Entropy  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |       Diff |   %Diff |  Status  |
|---------|---------------|----------------|-----------|------------|-------------|------------|-------------|------------|---------|----------|
|   I8    |      I32      |      2^16      |     1     |  30.017 us |       4.08% |  30.057 us |       3.89% |   0.041 us |   0.14% |   SAME   |
|   I8    |      I32      |      2^20      |     1     |  37.537 us |       2.66% |  37.591 us |       2.68% |   0.054 us |   0.14% |   SAME   |
|   I8    |      I32      |      2^24      |     1     | 126.926 us |       1.13% | 126.838 us |       1.04% |  -0.088 us |  -0.07% |   SAME   |
|   I8    |      I32      |      2^28      |     1     |   1.319 ms |       0.24% |   1.319 ms |       0.24% |  -0.033 us |  -0.00% |   SAME   |
|   I8    |      I32      |      2^16      |   0.544   |  30.904 us |       4.54% |  30.929 us |       4.57% |   0.024 us |   0.08% |   SAME   |
|   I8    |      I32      |      2^20      |   0.544   |  38.174 us |       3.16% |  38.137 us |       3.30% |  -0.037 us |  -0.10% |   SAME   |
|   I8    |      I32      |      2^24      |   0.544   | 129.988 us |       1.02% | 129.914 us |       1.07% |  -0.074 us |  -0.06% |   SAME   |
|   I8    |      I32      |      2^28      |   0.544   |   1.337 ms |       0.24% |   1.337 ms |       0.26% |   0.053 us |   0.00% |   SAME   |
|   I8    |      I32      |      2^16      |   0.201   |  30.258 us |       4.13% |  30.296 us |       4.16% |   0.038 us |   0.12% |   SAME   |
|   I8    |      I32      |      2^20      |   0.201   |  36.241 us |       2.88% |  36.222 us |       2.88% |  -0.019 us |  -0.05% |   SAME   |
|   I8    |      I32      |      2^24      |   0.201   | 120.184 us |       1.03% | 120.166 us |       1.02% |  -0.018 us |  -0.01% |   SAME   |
|   I8    |      I32      |      2^28      |   0.201   |   1.261 ms |       0.30% |   1.261 ms |       0.31% |   0.170 us |   0.01% |   SAME   |
|   I8    |      I64      |      2^16      |     1     |  30.127 us |       4.27% |  30.244 us |       4.24% |   0.117 us |   0.39% |   SAME   |
|   I8    |      I64      |      2^20      |     1     |  37.227 us |       1.73% |  37.291 us |       2.04% |   0.064 us |   0.17% |   SAME   |
|   I8    |      I64      |      2^24      |     1     | 121.249 us |       0.67% | 121.151 us |       0.63% |  -0.098 us |  -0.08% |   SAME   |
|   I8    |      I64      |      2^28      |     1     |   1.316 ms |       0.27% |   1.316 ms |       0.25% |  -0.090 us |  -0.01% |   SAME   |
|   I8    |      I64      |      2^16      |   0.544   |  30.260 us |       4.28% |  30.081 us |       4.10% |  -0.179 us |  -0.59% |   SAME   |
|   I8    |      I64      |      2^20      |   0.544   |  37.666 us |       2.65% |  37.633 us |       2.71% |  -0.034 us |  -0.09% |   SAME   |
|   I8    |      I64      |      2^24      |   0.544   | 123.107 us |       0.92% | 123.053 us |       0.97% |  -0.054 us |  -0.04% |   SAME   |
|   I8    |      I64      |      2^28      |   0.544   |   1.334 ms |       0.26% |   1.334 ms |       0.24% |   0.058 us |   0.00% |   SAME   |
|   I8    |      I64      |      2^16      |   0.201   |  29.543 us |       3.11% |  29.568 us |       3.27% |   0.025 us |   0.09% |   SAME   |
|   I8    |      I64      |      2^20      |   0.201   |  36.231 us |       3.33% |  36.232 us |       3.21% |   0.001 us |   0.00% |   SAME   |
|   I8    |      I64      |      2^24      |   0.201   | 116.115 us |       1.07% | 116.197 us |       1.04% |   0.082 us |   0.07% |   SAME   |
|   I8    |      I64      |      2^28      |   0.201   |   1.255 ms |       0.29% |   1.254 ms |       0.28% |  -0.292 us |  -0.02% |   SAME   |
|   I16   |      I32      |      2^16      |     1     |  46.168 us |       2.18% |  46.204 us |       2.21% |   0.036 us |   0.08% |   SAME   |
|   I16   |      I32      |      2^20      |     1     |  56.710 us |       1.61% |  56.683 us |       1.51% |  -0.027 us |  -0.05% |   SAME   |
|   I16   |      I32      |      2^24      |     1     | 212.010 us |       0.34% | 211.961 us |       0.34% |  -0.049 us |  -0.02% |   SAME   |
|   I16   |      I32      |      2^28      |     1     |   2.551 ms |       0.10% |   2.551 ms |       0.10% |   0.044 us |   0.00% |   SAME   |
|   I16   |      I32      |      2^16      |   0.544   |  45.474 us |       1.94% |  45.563 us |       1.99% |   0.089 us |   0.19% |   SAME   |
|   I16   |      I32      |      2^20      |   0.544   |  58.242 us |       1.57% |  58.210 us |       1.54% |  -0.032 us |  -0.05% |   SAME   |
|   I16   |      I32      |      2^24      |   0.544   | 217.672 us |       0.43% | 217.591 us |       0.45% |  -0.081 us |  -0.04% |   SAME   |
|   I16   |      I32      |      2^28      |   0.544   |   2.605 ms |       0.09% |   2.606 ms |       0.09% |   0.216 us |   0.01% |   SAME   |
|   I16   |      I32      |      2^16      |   0.201   |  45.450 us |       2.07% |  45.453 us |       2.01% |   0.003 us |   0.01% |   SAME   |
|   I16   |      I32      |      2^20      |   0.201   |  56.197 us |       1.56% |  56.228 us |       1.42% |   0.031 us |   0.05% |   SAME   |
|   I16   |      I32      |      2^24      |   0.201   | 203.431 us |       0.54% | 203.434 us |       0.49% |   0.003 us |   0.00% |   SAME   |
|   I16   |      I32      |      2^28      |   0.201   |   2.434 ms |       0.12% |   2.434 ms |       0.12% |   0.255 us |   0.01% |   SAME   |
|   I16   |      I64      |      2^16      |     1     |  45.554 us |       1.88% |  45.466 us |       2.02% |  -0.089 us |  -0.19% |   SAME   |
|   I16   |      I64      |      2^20      |     1     |  56.772 us |       1.76% |  56.734 us |       1.85% |  -0.038 us |  -0.07% |   SAME   |
|   I16   |      I64      |      2^24      |     1     | 211.615 us |       0.58% | 211.652 us |       0.59% |   0.037 us |   0.02% |   SAME   |
|   I16   |      I64      |      2^28      |     1     |   2.471 ms |       0.20% |   2.471 ms |       0.19% |  -0.188 us |  -0.01% |   SAME   |
|   I16   |      I64      |      2^16      |   0.544   |  45.463 us |       2.07% |  45.452 us |       2.02% |  -0.011 us |  -0.02% |   SAME   |
|   I16   |      I64      |      2^20      |   0.544   |  57.473 us |       2.10% |  57.353 us |       2.12% |  -0.120 us |  -0.21% |   SAME   |
|   I16   |      I64      |      2^24      |   0.544   | 213.720 us |       0.31% | 213.726 us |       0.27% |   0.005 us |   0.00% |   SAME   |
|   I16   |      I64      |      2^28      |   0.544   |   2.526 ms |       0.18% |   2.526 ms |       0.18% |  -0.101 us |  -0.00% |   SAME   |
|   I16   |      I64      |      2^16      |   0.201   |  45.919 us |       1.28% |  45.858 us |       1.48% |  -0.061 us |  -0.13% |   SAME   |
|   I16   |      I64      |      2^20      |   0.201   |  56.336 us |       0.92% |  56.170 us |       0.89% |  -0.166 us |  -0.30% |   SAME   |
|   I16   |      I64      |      2^24      |   0.201   | 202.611 us |       0.65% | 202.584 us |       0.67% |  -0.027 us |  -0.01% |   SAME   |
|   I16   |      I64      |      2^28      |   0.201   |   2.366 ms |       0.19% |   2.367 ms |       0.18% |   0.234 us |   0.01% |   SAME   |
|   I32   |      I32      |      2^16      |     1     |  75.014 us |       0.90% |  74.977 us |       0.81% |  -0.037 us |  -0.05% |   SAME   |
|   I32   |      I32      |      2^20      |     1     |  95.917 us |       1.08% |  95.981 us |       1.18% |   0.064 us |   0.07% |   SAME   |
|   I32   |      I32      |      2^24      |     1     | 390.209 us |       0.40% | 390.294 us |       0.38% |   0.085 us |   0.02% |   SAME   |
|   I32   |      I32      |      2^28      |     1     |   4.940 ms |       0.06% |   4.940 ms |       0.06% |   0.280 us |   0.01% |   SAME   |
|   I32   |      I32      |      2^16      |   0.544   |  75.044 us |       0.75% |  75.025 us |       0.80% |  -0.019 us |  -0.03% |   SAME   |
|   I32   |      I32      |      2^20      |   0.544   |  95.927 us |       1.12% |  95.822 us |       0.98% |  -0.104 us |  -0.11% |   SAME   |
|   I32   |      I32      |      2^24      |   0.544   | 397.464 us |       0.43% | 396.585 us |       0.42% |  -0.880 us |  -0.22% |   SAME   |
|   I32   |      I32      |      2^28      |   0.544   |   5.093 ms |       0.08% |   5.093 ms |       0.08% |  -0.054 us |  -0.00% |   SAME   |
|   I32   |      I32      |      2^16      |   0.201   |  75.506 us |       1.02% |  74.928 us |       0.87% |  -0.578 us |  -0.77% |   SAME   |
|   I32   |      I32      |      2^20      |   0.201   |  94.747 us |       1.16% |  93.822 us |       1.12% |  -0.925 us |  -0.98% |   SAME   |
|   I32   |      I32      |      2^24      |   0.201   | 378.917 us |       0.29% | 378.334 us |       0.31% |  -0.583 us |  -0.15% |   SAME   |
|   I32   |      I32      |      2^28      |   0.201   |   4.743 ms |       0.07% |   4.742 ms |       0.07% |  -0.408 us |  -0.01% |   SAME   |
|   I32   |      I64      |      2^16      |     1     |  77.489 us |       1.18% |  77.222 us |       0.88% |  -0.267 us |  -0.34% |   SAME   |
|   I32   |      I64      |      2^20      |     1     |  97.936 us |       1.09% |  97.638 us |       1.01% |  -0.298 us |  -0.30% |   SAME   |
|   I32   |      I64      |      2^24      |     1     | 404.161 us |       0.34% | 403.892 us |       0.35% |  -0.269 us |  -0.07% |   SAME   |
|   I32   |      I64      |      2^28      |     1     |   5.104 ms |       0.06% |   5.103 ms |       0.06% |  -0.654 us |  -0.01% |   SAME   |
|   I32   |      I64      |      2^16      |   0.544   |  77.733 us |       0.96% |  77.262 us |       0.84% |  -0.471 us |  -0.61% |   SAME   |
|   I32   |      I64      |      2^20      |   0.544   |  98.095 us |       1.16% |  97.858 us |       1.17% |  -0.237 us |  -0.24% |   SAME   |
|   I32   |      I64      |      2^24      |   0.544   | 408.297 us |       0.35% | 407.886 us |       0.36% |  -0.411 us |  -0.10% |   SAME   |
|   I32   |      I64      |      2^28      |   0.544   |   5.244 ms |       0.15% |   5.244 ms |       0.14% |   0.264 us |   0.01% |   SAME   |
|   I32   |      I64      |      2^16      |   0.201   |  77.541 us |       1.03% |  77.252 us |       0.91% |  -0.289 us |  -0.37% |   SAME   |
|   I32   |      I64      |      2^20      |   0.201   |  95.849 us |       0.97% |  95.641 us |       0.90% |  -0.207 us |  -0.22% |   SAME   |
|   I32   |      I64      |      2^24      |   0.201   | 388.728 us |       0.33% | 388.149 us |       0.33% |  -0.578 us |  -0.15% |   SAME   |
|   I32   |      I64      |      2^28      |   0.201   |   4.894 ms |       0.10% |   4.894 ms |       0.11% |  -0.516 us |  -0.01% |   SAME   |
|   I64   |      I32      |      2^16      |     1     | 132.758 us |       0.63% | 132.485 us |       0.55% |  -0.273 us |  -0.21% |   SAME   |
|   I64   |      I32      |      2^20      |     1     | 201.348 us |       0.72% | 201.073 us |       0.60% |  -0.275 us |  -0.14% |   SAME   |
|   I64   |      I32      |      2^24      |     1     |   1.441 ms |       0.21% |   1.441 ms |       0.22% |  -0.354 us |  -0.02% |   SAME   |
|   I64   |      I32      |      2^28      |     1     |  21.109 ms |       0.22% |  21.102 ms |       0.21% |  -7.049 us |  -0.03% |   SAME   |
|   I64   |      I32      |      2^16      |   0.544   | 132.593 us |       0.54% | 132.567 us |       0.52% |  -0.026 us |  -0.02% |   SAME   |
|   I64   |      I32      |      2^20      |   0.544   | 201.309 us |       0.56% | 201.211 us |       0.57% |  -0.098 us |  -0.05% |   SAME   |
|   I64   |      I32      |      2^24      |   0.544   |   1.440 ms |       0.18% |   1.440 ms |       0.18% |  -0.063 us |  -0.00% |   SAME   |
|   I64   |      I32      |      2^28      |   0.544   |  21.066 ms |       0.20% |  21.069 ms |       0.19% |   2.513 us |   0.01% |   SAME   |
|   I64   |      I32      |      2^16      |   0.201   | 132.586 us |       0.53% | 132.587 us |       0.52% |   0.001 us |   0.00% |   SAME   |
|   I64   |      I32      |      2^20      |   0.201   | 191.580 us |       0.70% | 191.595 us |       0.68% |   0.015 us |   0.01% |   SAME   |
|   I64   |      I32      |      2^24      |   0.201   |   1.391 ms |       0.17% |   1.391 ms |       0.19% |   0.023 us |   0.00% |   SAME   |
|   I64   |      I32      |      2^28      |   0.201   |  20.288 ms |       0.21% |  20.290 ms |       0.20% |   1.919 us |   0.01% |   SAME   |
|   I64   |      I64      |      2^16      |     1     | 132.764 us |       0.64% | 132.470 us |       0.52% |  -0.294 us |  -0.22% |   SAME   |
|   I64   |      I64      |      2^20      |     1     | 201.232 us |       0.71% | 200.963 us |       0.67% |  -0.269 us |  -0.13% |   SAME   |
|   I64   |      I64      |      2^24      |     1     |   1.446 ms |       0.16% |   1.446 ms |       0.15% |  -0.277 us |  -0.02% |   SAME   |
|   I64   |      I64      |      2^28      |     1     |  21.184 ms |       0.24% |  21.185 ms |       0.23% |   0.615 us |   0.00% |   SAME   |
|   I64   |      I64      |      2^16      |   0.544   | 132.585 us |       0.59% | 132.577 us |       0.54% |  -0.008 us |  -0.01% |   SAME   |
|   I64   |      I64      |      2^20      |   0.544   | 199.405 us |       0.93% | 199.708 us |       0.90% |   0.304 us |   0.15% |   SAME   |
|   I64   |      I64      |      2^24      |   0.544   |   1.447 ms |       0.19% |   1.446 ms |       0.19% |  -0.616 us |  -0.04% |   SAME   |
|   I64   |      I64      |      2^28      |   0.544   |  21.141 ms |       0.22% |  21.142 ms |       0.21% |   1.335 us |   0.01% |   SAME   |
|   I64   |      I64      |      2^16      |   0.201   | 131.737 us |       1.06% | 131.778 us |       0.98% |   0.041 us |   0.03% |   SAME   |
|   I64   |      I64      |      2^20      |   0.201   | 191.874 us |       0.38% | 191.941 us |       0.41% |   0.067 us |   0.04% |   SAME   |
|   I64   |      I64      |      2^24      |   0.201   |   1.392 ms |       0.18% |   1.392 ms |       0.18% |   0.106 us |   0.01% |   SAME   |
|   I64   |      I64      |      2^28      |   0.201   |  20.348 ms |       0.22% |  20.346 ms |       0.23% |  -2.380 us |  -0.01% |   SAME   |
|  I128   |      I32      |      2^16      |     1     | 233.030 us |       0.32% | 232.871 us |       0.29% |  -0.159 us |  -0.07% |   SAME   |
|  I128   |      I32      |      2^20      |     1     | 418.186 us |       0.42% | 418.004 us |       0.43% |  -0.181 us |  -0.04% |   SAME   |
|  I128   |      I32      |      2^24      |     1     |   3.521 ms |       0.10% |   3.521 ms |       0.10% |  -0.077 us |  -0.00% |   SAME   |
|  I128   |      I32      |      2^28      |     1     |  52.690 ms |       0.07% |  52.698 ms |       0.07% |   7.649 us |   0.01% |   SAME   |
|  I128   |      I32      |      2^16      |   0.544   | 231.915 us |       0.59% | 231.961 us |       0.58% |   0.046 us |   0.02% |   SAME   |
|  I128   |      I32      |      2^20      |   0.544   | 415.521 us |       0.56% | 415.676 us |       0.59% |   0.156 us |   0.04% |   SAME   |
|  I128   |      I32      |      2^24      |   0.544   |   3.499 ms |       0.10% |   3.499 ms |       0.11% |  -0.390 us |  -0.01% |   SAME   |
|  I128   |      I32      |      2^28      |   0.544   |  52.334 ms |       0.07% |  52.339 ms |       0.07% |   4.523 us |   0.01% |   SAME   |
|  I128   |      I32      |      2^16      |   0.201   | 227.486 us |       0.84% | 227.500 us |       0.86% |   0.014 us |   0.01% |   SAME   |
|  I128   |      I32      |      2^20      |   0.201   | 404.798 us |       0.50% | 404.759 us |       0.50% |  -0.038 us |  -0.01% |   SAME   |
|  I128   |      I32      |      2^24      |   0.201   |   3.455 ms |       0.11% |   3.454 ms |       0.10% |  -0.058 us |  -0.00% |   SAME   |
|  I128   |      I32      |      2^28      |   0.201   |  51.494 ms |       0.07% |  51.495 ms |       0.07% |   1.277 us |   0.00% |   SAME   |
|  I128   |      I64      |      2^16      |     1     | 232.850 us |       0.25% | 232.787 us |       0.27% |  -0.064 us |  -0.03% |   SAME   |
|  I128   |      I64      |      2^20      |     1     | 419.108 us |       0.37% | 419.086 us |       0.34% |  -0.022 us |  -0.01% |   SAME   |
|  I128   |      I64      |      2^24      |     1     |   3.539 ms |       0.11% |   3.539 ms |       0.12% |   0.010 us |   0.00% |   SAME   |
|  I128   |      I64      |      2^28      |     1     |  53.716 ms |       0.02% |  53.711 ms |       0.02% |  -5.280 us |  -0.01% |   SAME   |
|  I128   |      I64      |      2^16      |   0.544   | 228.291 us |       0.79% | 228.231 us |       0.81% |  -0.060 us |  -0.03% |   SAME   |
|  I128   |      I64      |      2^20      |   0.544   | 417.898 us |       0.46% | 417.785 us |       0.51% |  -0.114 us |  -0.03% |   SAME   |
|  I128   |      I64      |      2^24      |   0.544   |   3.519 ms |       0.10% |   3.519 ms |       0.10% |  -0.011 us |  -0.00% |   SAME   |
|  I128   |      I64      |      2^28      |   0.544   |  53.362 ms |       0.03% |  53.367 ms |       0.03% |   5.211 us |   0.01% |   SAME   |
|  I128   |      I64      |      2^16      |   0.201   | 227.311 us |       0.87% | 227.184 us |       0.74% |  -0.127 us |  -0.06% |   SAME   |
|  I128   |      I64      |      2^20      |   0.201   | 409.160 us |       0.62% | 408.855 us |       0.68% |  -0.305 us |  -0.07% |   SAME   |
|  I128   |      I64      |      2^24      |   0.201   |   3.472 ms |       0.11% |   3.472 ms |       0.11% |   0.020 us |   0.00% |   SAME   |
|  I128   |      I64      |      2^28      |   0.201   |  52.544 ms |       0.03% |  52.531 ms |       0.03% | -12.696 us |  -0.02% |   SAME   |
|   F32   |      I32      |      2^16      |     1     |  75.067 us |       0.89% |  75.025 us |       0.91% |  -0.042 us |  -0.06% |   SAME   |
|   F32   |      I32      |      2^20      |     1     |  96.402 us |       1.30% |  96.440 us |       1.26% |   0.038 us |   0.04% |   SAME   |
|   F32   |      I32      |      2^24      |     1     | 452.484 us |       0.29% | 452.635 us |       0.28% |   0.151 us |   0.03% |   SAME   |
|   F32   |      I32      |      2^28      |     1     |   6.094 ms |       0.06% |   6.093 ms |       0.05% |  -0.852 us |  -0.01% |   SAME   |
|   F32   |      I32      |      2^16      |   0.544   |  75.710 us |       0.90% |  75.062 us |       0.87% |  -0.648 us |  -0.86% |   SAME   |
|   F32   |      I32      |      2^20      |   0.544   |  98.258 us |       0.69% |  97.563 us |       0.66% |  -0.695 us |  -0.71% |   FAST   |
|   F32   |      I32      |      2^24      |   0.544   | 459.843 us |       0.41% | 459.184 us |       0.36% |  -0.659 us |  -0.14% |   SAME   |
|   F32   |      I32      |      2^28      |   0.544   |   6.176 ms |       0.05% |   6.175 ms |       0.05% |  -0.425 us |  -0.01% |   SAME   |
|   F32   |      I32      |      2^16      |   0.201   |  75.526 us |       0.99% |  74.915 us |       0.86% |  -0.611 us |  -0.81% |   SAME   |
|   F32   |      I32      |      2^20      |   0.201   |  95.444 us |       1.21% |  94.606 us |       1.23% |  -0.838 us |  -0.88% |   SAME   |
|   F32   |      I32      |      2^24      |   0.201   | 444.352 us |       0.43% | 444.026 us |       0.49% |  -0.326 us |  -0.07% |   SAME   |
|   F32   |      I32      |      2^28      |   0.201   |   5.950 ms |       0.06% |   5.949 ms |       0.06% |  -0.438 us |  -0.01% |   SAME   |
|   F32   |      I64      |      2^16      |     1     |  77.369 us |       0.85% |  77.296 us |       0.84% |  -0.073 us |  -0.09% |   SAME   |
|   F32   |      I64      |      2^20      |     1     |  99.724 us |       1.70% |  99.537 us |       1.77% |  -0.186 us |  -0.19% |   SAME   |
|   F32   |      I64      |      2^24      |     1     | 415.597 us |       0.28% | 415.464 us |       0.25% |  -0.133 us |  -0.03% |   SAME   |
|   F32   |      I64      |      2^28      |     1     |   5.303 ms |       0.09% |   5.303 ms |       0.09% |   0.259 us |   0.00% |   SAME   |
|   F32   |      I64      |      2^16      |   0.544   |  77.263 us |       0.96% |  77.274 us |       0.90% |   0.011 us |   0.01% |   SAME   |
|   F32   |      I64      |      2^20      |   0.544   |  99.831 us |       1.63% |  99.913 us |       1.66% |   0.082 us |   0.08% |   SAME   |
|   F32   |      I64      |      2^24      |   0.544   | 421.287 us |       0.41% | 421.461 us |       0.41% |   0.174 us |   0.04% |   SAME   |
|   F32   |      I64      |      2^28      |   0.544   |   5.388 ms |       0.09% |   5.389 ms |       0.08% |   0.254 us |   0.00% |   SAME   |
|   F32   |      I64      |      2^16      |   0.201   |  77.366 us |       0.89% |  77.257 us |       0.78% |  -0.109 us |  -0.14% |   SAME   |
|   F32   |      I64      |      2^20      |   0.201   |  97.584 us |       1.57% |  97.680 us |       1.50% |   0.096 us |   0.10% |   SAME   |
|   F32   |      I64      |      2^24      |   0.201   | 406.163 us |       0.35% | 406.205 us |       0.35% |   0.043 us |   0.01% |   SAME   |
|   F32   |      I64      |      2^28      |   0.201   |   5.157 ms |       0.08% |   5.157 ms |       0.08% |  -0.226 us |  -0.00% |   SAME   |
|   F64   |      I32      |      2^16      |     1     | 132.925 us |       0.73% | 132.719 us |       0.69% |  -0.205 us |  -0.15% |   SAME   |
|   F64   |      I32      |      2^20      |     1     | 187.509 us |       0.83% | 187.411 us |       0.80% |  -0.098 us |  -0.05% |   SAME   |
|   F64   |      I32      |      2^24      |     1     |   1.085 ms |       0.21% |   1.085 ms |       0.21% |  -0.079 us |  -0.01% |   SAME   |
|   F64   |      I32      |      2^28      |     1     |  15.346 ms |       0.04% |  15.346 ms |       0.04% |   0.085 us |   0.00% |   SAME   |
|   F64   |      I32      |      2^16      |   0.544   | 133.247 us |       0.99% | 133.253 us |       0.98% |   0.006 us |   0.00% |   SAME   |
|   F64   |      I32      |      2^20      |   0.544   | 188.198 us |       0.59% | 188.226 us |       0.65% |   0.028 us |   0.02% |   SAME   |
|   F64   |      I32      |      2^24      |   0.544   |   1.101 ms |       0.22% |   1.101 ms |       0.22% |  -0.096 us |  -0.01% |   SAME   |
|   F64   |      I32      |      2^28      |   0.544   |  15.581 ms |       0.03% |  15.581 ms |       0.03% |   0.169 us |   0.00% |   SAME   |
|   F64   |      I32      |      2^16      |   0.201   | 133.983 us |       1.07% | 133.627 us |       1.01% |  -0.356 us |  -0.27% |   SAME   |
|   F64   |      I32      |      2^20      |   0.201   | 186.263 us |       0.57% | 185.910 us |       0.46% |  -0.353 us |  -0.19% |   SAME   |
|   F64   |      I32      |      2^24      |   0.201   |   1.070 ms |       0.24% |   1.070 ms |       0.22% |  -0.618 us |  -0.06% |   SAME   |
|   F64   |      I32      |      2^28      |   0.201   |  15.026 ms |       0.05% |  15.025 ms |       0.04% |  -0.690 us |  -0.00% |   SAME   |
|   F64   |      I64      |      2^16      |     1     | 132.796 us |       0.74% | 132.591 us |       0.59% |  -0.205 us |  -0.15% |   SAME   |
|   F64   |      I64      |      2^20      |     1     | 188.369 us |       0.78% | 188.295 us |       0.75% |  -0.074 us |  -0.04% |   SAME   |
|   F64   |      I64      |      2^24      |     1     |   1.070 ms |       0.16% |   1.069 ms |       0.16% |  -0.284 us |  -0.03% |   SAME   |
|   F64   |      I64      |      2^28      |     1     |  15.293 ms |       0.04% |  15.293 ms |       0.04% |  -0.436 us |  -0.00% |   SAME   |
|   F64   |      I64      |      2^16      |   0.544   | 132.745 us |       0.64% | 132.715 us |       0.66% |  -0.030 us |  -0.02% |   SAME   |
|   F64   |      I64      |      2^20      |   0.544   | 187.849 us |       0.52% | 187.943 us |       0.49% |   0.094 us |   0.05% |   SAME   |
|   F64   |      I64      |      2^24      |   0.544   |   1.088 ms |       0.16% |   1.088 ms |       0.16% |  -0.066 us |  -0.01% |   SAME   |
|   F64   |      I64      |      2^28      |   0.544   |  15.525 ms |       0.04% |  15.525 ms |       0.04% |  -0.623 us |  -0.00% |   SAME   |
|   F64   |      I64      |      2^16      |   0.201   | 132.574 us |       0.61% | 132.599 us |       0.62% |   0.025 us |   0.02% |   SAME   |
|   F64   |      I64      |      2^20      |   0.201   | 185.706 us |       0.53% | 185.733 us |       0.51% |   0.027 us |   0.01% |   SAME   |
|   F64   |      I64      |      2^24      |   0.201   |   1.057 ms |       0.23% |   1.057 ms |       0.21% |   0.215 us |   0.02% |   SAME   |
|   F64   |      I64      |      2^28      |   0.201   |  14.948 ms |       0.10% |  14.948 ms |       0.10% |   0.287 us |   0.00% |   SAME   |
```