### PR TITLE
Drop CUB_MIN|MAX in MergePathSearch and deprecate it

### DIFF
--- a/cub/cub/thread/thread_search.cuh
+++ b/cub/cub/thread/thread_search.cuh
@@ -52,16 +52,18 @@ CUB_NAMESPACE_BEGIN
 
 /**
  * Computes the begin offsets into A and B for the specific diagonal
+ *
+ * Deprecated [Since 3.0]
  */
 template <typename AIteratorT, typename BIteratorT, typename OffsetT, typename CoordinateT>
-_CCCL_HOST_DEVICE _CCCL_FORCEINLINE void MergePathSearch(
+CCCL_DEPRECATED _CCCL_HOST_DEVICE _CCCL_FORCEINLINE void MergePathSearch(
   OffsetT diagonal, AIteratorT a, BIteratorT b, OffsetT a_len, OffsetT b_len, CoordinateT& path_coordinate)
 {
   /// The value type of the input iterator
   using T = cub::detail::it_value_t<AIteratorT>;
 
-  OffsetT split_min = CUB_MAX(diagonal - b_len, 0);
-  OffsetT split_max = CUB_MIN(diagonal, a_len);
+  OffsetT split_min = _CUDA_VSTD::max(diagonal - b_len, 0);
+  OffsetT split_max = _CUDA_VSTD::min(diagonal, a_len);
 
   while (split_min < split_max)
   {
@@ -78,7 +80,7 @@ _CCCL_HOST_DEVICE _CCCL_FORCEINLINE void MergePathSearch(
     }
   }
 
-  path_coordinate.x = CUB_MIN(split_min, a_len);
+  path_coordinate.x = _CUDA_VSTD::min(split_min, a_len);
   path_coordinate.y = diagonal - split_min;
 }
 


### PR DESCRIPTION
It turns out this `cub::MergePathSearch` is not used, so this refactoring should be fine. Furthermore, we can also deprecate the function.