### PR TITLE
Drop CUB_MIN|MAX in warp_scan_shfl

### DIFF
--- a/cub/cub/warp/specializations/warp_scan_shfl.cuh
+++ b/cub/cub/warp/specializations/warp_scan_shfl.cuh
@@ -551,7 +551,7 @@ struct WarpScanShfl
     ballot = ballot & ::cuda::ptx::get_sreg_lanemask_le();
 
     // Find index of first set bit
-    int segment_first_lane = CUB_MAX(0, 31 - __clz(ballot));
+    int segment_first_lane = _CUDA_VSTD::max(0, 31 - __clz(ballot));
 
     // Iterate scan steps
 #pragma unroll


### PR DESCRIPTION
- [x] No SASS diff of `cub.bench.scan.exclusive.sum.base` for SM100.