### PR TITLE
Enable mdspan for all MSVC versions

### DIFF
--- a/cub/cub/device/dispatch/kernels/for_each_in_extents_kernel.cuh
+++ b/cub/cub/device/dispatch/kernels/for_each_in_extents_kernel.cuh
@@ -55,35 +55,33 @@ namespace detail
 namespace for_each_in_extents
 {
 
-_CCCL_TEMPLATE(int Rank, typename ExtendType, typename FastDivModType)
-_CCCL_REQUIRES((ExtendType::static_extent(Rank) != ::cuda::std::dynamic_extent))
+template <int Rank, typename ExtendType, typename FastDivModType>
 _CCCL_DEVICE _CCCL_FORCEINLINE auto get_extent_size(ExtendType ext, FastDivModType extent_size)
 {
-  using extent_index_type   = typename ExtendType::index_type;
-  using index_type          = implicit_prom_t<extent_index_type>;
-  using unsigned_index_type = ::cuda::std::make_unsigned_t<index_type>;
-  return static_cast<unsigned_index_type>(ext.static_extent(Rank));
+  if constexpr (ExtendType::static_extent(Rank) != ::cuda::std::dynamic_extent)
+  {
+    using extent_index_type   = typename ExtendType::index_type;
+    using index_type          = implicit_prom_t<extent_index_type>;
+    using unsigned_index_type = ::cuda::std::make_unsigned_t<index_type>;
+    return static_cast<unsigned_index_type>(ext.static_extent(Rank));
+  }
+  else
+  {
+    return extent_size;
+  }
 }
 
-_CCCL_TEMPLATE(int Rank, typename ExtendType, typename FastDivModType)
-_CCCL_REQUIRES((ExtendType::static_extent(Rank) == ::cuda::std::dynamic_extent))
-_CCCL_DEVICE _CCCL_FORCEINLINE auto get_extent_size(ExtendType ext, FastDivModType extent_size)
-{
-  return extent_size;
-}
-
-_CCCL_TEMPLATE(int Rank, typename ExtendType, typename FastDivModType)
-_CCCL_REQUIRES((cub::detail::is_sub_size_static<Rank + 1, ExtendType>()))
+template <int Rank, typename ExtendType, typename FastDivModType>
 _CCCL_DEVICE _CCCL_FORCEINLINE auto get_extents_sub_size(ExtendType ext, FastDivModType extents_sub_size)
 {
-  return sub_size<Rank + 1>(ext);
-}
-
-_CCCL_TEMPLATE(int Rank, typename ExtendType, typename FastDivModType)
-_CCCL_REQUIRES((!cub::detail::is_sub_size_static<Rank + 1, ExtendType>()))
-_CCCL_DEVICE _CCCL_FORCEINLINE auto get_extents_sub_size(ExtendType ext, FastDivModType extents_sub_size)
-{
-  return extents_sub_size;
+  if constexpr (cub::detail::is_sub_size_static<Rank + 1, ExtendType>())
+  {
+    return sub_size<Rank + 1>(ext);
+  }
+  else
+  {
+    return extents_sub_size;
+  }
 }
 
 template <int Rank, typename IndexType, typename ExtendType, typename FastDivModType>
@@ -100,29 +98,29 @@ template <typename IndexType,
           typename ExtendType,
           typename FastDivModArrayType, //
           ::cuda::std::size_t... Ranks>
-_CCCL_DEVICE _CCCL_FORCEINLINE ::cuda::std::enable_if_t<(ExtendType::rank() > 0)> computation(
+_CCCL_DEVICE _CCCL_FORCEINLINE void computation(
   IndexType id,
-  IndexType stride,
+  [[maybe_unused]] IndexType stride,
   Func func,
-  ExtendType ext,
-  FastDivModArrayType sub_sizes_div_array,
-  FastDivModArrayType extents_mod_array)
+  [[maybe_unused]] ExtendType ext,
+  [[maybe_unused]] FastDivModArrayType sub_sizes_div_array,
+  [[maybe_unused]] FastDivModArrayType extents_mod_array)
 {
   using extent_index_type = typename ExtendType::index_type;
-  for (auto i = id; i < cub::detail::size(ext); i += stride)
+  if constexpr (ExtendType::rank() > 0)
   {
-    func(i, coordinate_at<Ranks>(i, ext, sub_sizes_div_array[Ranks], extents_mod_array[Ranks])...);
+    for (auto i = id; i < cub::detail::size(ext); i += stride)
+    {
+      func(i, coordinate_at<Ranks>(i, ext, sub_sizes_div_array[Ranks], extents_mod_array[Ranks])...);
+    }
   }
-}
-
-template <typename IndexType, typename Func, typename ExtendType, typename FastDivModArrayType>
-_CCCL_DEVICE _CCCL_FORCEINLINE ::cuda::std::enable_if_t<ExtendType::rank() == 0>
-computation(IndexType id, IndexType, Func func, ExtendType, FastDivModArrayType, FastDivModArrayType)
-{
-  using extent_index_type = typename ExtendType::index_type;
-  if (id == 0)
+  else
   {
-    func(0);
+    using extent_index_type = typename ExtendType::index_type;
+    if (id == 0)
+    {
+      func(0);
+    }
   }
 }
 
@@ -130,24 +128,17 @@ computation(IndexType id, IndexType, Func func, ExtendType, FastDivModArrayType,
  * Kernel entry points
  **********************************************************************************************************************/
 
-// GCC6/7/8/9 raises unused parameter warning
-#  if _CCCL_COMPILER(GCC, <, 10)
-#    define _CUB_UNUSED_ATTRIBUTE __attribute__((unused))
-#  else
-#    define _CUB_UNUSED_ATTRIBUTE
-#  endif
-
 template <typename ChainedPolicyT,
           typename Func,
           typename ExtendType,
           typename FastDivModArrayType,
           ::cuda::std::size_t... Ranks>
-__launch_bounds__(ChainedPolicyT::ActivePolicy::for_policy_t::block_threads) //
+__launch_bounds__(ChainedPolicyT::ActivePolicy::for_policy_t::block_threads)
   CUB_DETAIL_KERNEL_ATTRIBUTES void static_kernel(
-    Func func _CUB_UNUSED_ATTRIBUTE,
-    _CCCL_GRID_CONSTANT const ExtendType ext _CUB_UNUSED_ATTRIBUTE,
-    _CCCL_GRID_CONSTANT const FastDivModArrayType sub_sizes_div_array _CUB_UNUSED_ATTRIBUTE,
-    _CCCL_GRID_CONSTANT const FastDivModArrayType extents_mod_array _CUB_UNUSED_ATTRIBUTE)
+    [[maybe_unused]] Func func,
+    [[maybe_unused]] _CCCL_GRID_CONSTANT const ExtendType ext,
+    [[maybe_unused]] _CCCL_GRID_CONSTANT const FastDivModArrayType sub_sizes_div_array,
+    [[maybe_unused]] _CCCL_GRID_CONSTANT const FastDivModArrayType extents_mod_array)
 {
   using active_policy_t        = typename ChainedPolicyT::ActivePolicy::for_policy_t;
   using extent_index_type      = typename ExtendType::index_type;

--- a/libcudacxx/include/cuda/std/__linalg/conj_if_needed.h
+++ b/libcudacxx/include/cuda/std/__linalg/conj_if_needed.h
@@ -29,13 +29,9 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/std/version>
-
-#if defined(__cccl_lib_mdspan)
-
-#  include <cuda/std/__concepts/concept_macros.h>
-#  include <cuda/std/__type_traits/is_arithmetic.h>
-#  include <cuda/std/complex>
+#include <cuda/std/__concepts/concept_macros.h>
+#include <cuda/std/__type_traits/is_arithmetic.h>
+#include <cuda/std/complex>
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
@@ -75,5 +71,4 @@ _CCCL_GLOBAL_CONSTANT auto conj_if_needed = __conj_if_needed::__conj_if_needed{}
 
 _LIBCUDACXX_END_NAMESPACE_STD
 
-#endif // defined(__cccl_lib_mdspan)
 #endif // _LIBCUDACXX___LINALG_CONJUGATED_HPP

--- a/libcudacxx/include/cuda/std/__linalg/conjugate_transposed.h
+++ b/libcudacxx/include/cuda/std/__linalg/conjugate_transposed.h
@@ -29,12 +29,8 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/std/version>
-
-#if defined(__cccl_lib_mdspan)
-
-#  include <cuda/std/__linalg/conjugated.h>
-#  include <cuda/std/__linalg/transposed.h>
+#include <cuda/std/__linalg/conjugated.h>
+#include <cuda/std/__linalg/transposed.h>
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
@@ -52,5 +48,4 @@ conjugate_transposed(mdspan<_ElementType, _Extents, _Layout, _Accessor> __a)
 
 _LIBCUDACXX_END_NAMESPACE_STD
 
-#endif // defined(__cccl_lib_mdspan)
 #endif // _LIBCUDACXX___LINALG_CONJUGATE_TRANSPOSED_HPP

--- a/libcudacxx/include/cuda/std/__linalg/conjugated.h
+++ b/libcudacxx/include/cuda/std/__linalg/conjugated.h
@@ -29,16 +29,12 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/std/version>
-
-#if defined(__cccl_lib_mdspan)
-
-#  include <cuda/std/__linalg/conj_if_needed.h>
-#  include <cuda/std/__type_traits/add_const.h>
-#  include <cuda/std/__type_traits/is_arithmetic.h>
-#  include <cuda/std/__type_traits/remove_const.h>
-#  include <cuda/std/__utility/declval.h>
-#  include <cuda/std/mdspan>
+#include <cuda/std/__linalg/conj_if_needed.h>
+#include <cuda/std/__type_traits/add_const.h>
+#include <cuda/std/__type_traits/is_arithmetic.h>
+#include <cuda/std/__type_traits/remove_const.h>
+#include <cuda/std/__utility/declval.h>
+#include <cuda/std/mdspan>
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
@@ -138,5 +134,4 @@ conjugated(mdspan<_ElementType, _Extents, _Layout, conjugated_accessor<_NestedAc
 
 _LIBCUDACXX_END_NAMESPACE_STD
 
-#endif // defined(__cccl_lib_mdspan)
 #endif // _LIBCUDACXX___LINALG_CONJUGATED_HPP

--- a/libcudacxx/include/cuda/std/__linalg/scaled.h
+++ b/libcudacxx/include/cuda/std/__linalg/scaled.h
@@ -83,7 +83,7 @@ public:
   }
 
   _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI
-    typename offset_policy::data_handle_type constexpr offset(data_handle_type __p, size_t __i) const
+  typename offset_policy::data_handle_type constexpr offset(data_handle_type __p, size_t __i) const
   {
     return __nested_accessor_.offset(__p, __i);
   }
@@ -112,10 +112,11 @@ using __scaled_element_type = add_const_t<typename scaled_accessor<_ScalingFacto
 } // namespace __detail
 
 template <class _ScalingFactor, class _ElementType, class _Extents, class _Layout, class _Accessor>
-_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr mdspan<__detail::__scaled_element_type<_ScalingFactor, _Accessor>,
-                                                           _Extents,
-                                                           _Layout,
-                                                           scaled_accessor<_ScalingFactor, _Accessor>>
+_CCCL_NODISCARD
+_LIBCUDACXX_HIDE_FROM_ABI constexpr mdspan<__detail::__scaled_element_type<_ScalingFactor, _Accessor>,
+                                           _Extents,
+                                           _Layout,
+                                           scaled_accessor<_ScalingFactor, _Accessor>>
 scaled(_ScalingFactor __scaling_factor, mdspan<_ElementType, _Extents, _Layout, _Accessor> __x)
 {
   using __acc_type = scaled_accessor<_ScalingFactor, _Accessor>;

--- a/libcudacxx/include/cuda/std/__linalg/scaled.h
+++ b/libcudacxx/include/cuda/std/__linalg/scaled.h
@@ -29,15 +29,11 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/std/version>
-
-#if defined(__cccl_lib_mdspan)
-
-#  include <cuda/std/__concepts/concept_macros.h>
-#  include <cuda/std/__type_traits/add_const.h>
-#  include <cuda/std/__type_traits/remove_const.h>
-#  include <cuda/std/__utility/declval.h>
-#  include <cuda/std/mdspan>
+#include <cuda/std/__concepts/concept_macros.h>
+#include <cuda/std/__type_traits/add_const.h>
+#include <cuda/std/__type_traits/remove_const.h>
+#include <cuda/std/__utility/declval.h>
+#include <cuda/std/mdspan>
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
@@ -87,7 +83,7 @@ public:
   }
 
   _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI
-  typename offset_policy::data_handle_type constexpr offset(data_handle_type __p, size_t __i) const
+    typename offset_policy::data_handle_type constexpr offset(data_handle_type __p, size_t __i) const
   {
     return __nested_accessor_.offset(__p, __i);
   }
@@ -116,11 +112,10 @@ using __scaled_element_type = add_const_t<typename scaled_accessor<_ScalingFacto
 } // namespace __detail
 
 template <class _ScalingFactor, class _ElementType, class _Extents, class _Layout, class _Accessor>
-_CCCL_NODISCARD
-_LIBCUDACXX_HIDE_FROM_ABI constexpr mdspan<__detail::__scaled_element_type<_ScalingFactor, _Accessor>,
-                                           _Extents,
-                                           _Layout,
-                                           scaled_accessor<_ScalingFactor, _Accessor>>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr mdspan<__detail::__scaled_element_type<_ScalingFactor, _Accessor>,
+                                                           _Extents,
+                                                           _Layout,
+                                                           scaled_accessor<_ScalingFactor, _Accessor>>
 scaled(_ScalingFactor __scaling_factor, mdspan<_ElementType, _Extents, _Layout, _Accessor> __x)
 {
   using __acc_type = scaled_accessor<_ScalingFactor, _Accessor>;
@@ -131,5 +126,4 @@ scaled(_ScalingFactor __scaling_factor, mdspan<_ElementType, _Extents, _Layout, 
 
 _LIBCUDACXX_END_NAMESPACE_STD
 
-#endif // defined(__cccl_lib_mdspan)
 #endif // _LIBCUDACXX___LINALG_SCALED_HPP

--- a/libcudacxx/include/cuda/std/__linalg/transposed.h
+++ b/libcudacxx/include/cuda/std/__linalg/transposed.h
@@ -29,15 +29,11 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/std/version>
-
-#if defined(__cccl_lib_mdspan)
-
-#  include <cuda/std/__concepts/concept_macros.h>
-#  include <cuda/std/__type_traits/is_convertible.h>
-#  include <cuda/std/__type_traits/is_same.h>
-#  include <cuda/std/array>
-#  include <cuda/std/mdspan>
+#include <cuda/std/__concepts/concept_macros.h>
+#include <cuda/std/__type_traits/is_convertible.h>
+#include <cuda/std/__type_traits/is_same.h>
+#include <cuda/std/array>
+#include <cuda/std/mdspan>
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
@@ -326,5 +322,4 @@ transposed(mdspan<_ElementType, _Extents, _Layout, _Accessor> __a)
 
 _LIBCUDACXX_END_NAMESPACE_STD
 
-#endif // defined(__cccl_lib_mdspan)
 #endif // _LIBCUDACXX___LINALG_TRANSPOSED_HPP

--- a/libcudacxx/include/cuda/std/__linalg/transposed.h
+++ b/libcudacxx/include/cuda/std/__linalg/transposed.h
@@ -152,7 +152,7 @@ public:
 
     _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI static constexpr bool is_always_exhaustive() noexcept
     {
-      return __nested_mapping_type::is_always_contiguous();
+      return __nested_mapping_type::is_always_exhaustive();
     }
 
     _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI static constexpr bool is_always_strided() noexcept

--- a/libcudacxx/include/cuda/std/__mdspan/aligned_accessor.h
+++ b/libcudacxx/include/cuda/std/__mdspan/aligned_accessor.h
@@ -29,18 +29,14 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/std/version>
-
-#if defined(__cccl_lib_mdspan)
-
-#  include <cuda/std/__bit/has_single_bit.h>
-#  include <cuda/std/__concepts/concept_macros.h>
-#  include <cuda/std/__mdspan/default_accessor.h>
-#  include <cuda/std/__memory/assume_aligned.h>
-#  include <cuda/std/__type_traits/is_abstract.h>
-#  include <cuda/std/__type_traits/is_array.h>
-#  include <cuda/std/__type_traits/is_convertible.h>
-#  include <cuda/std/__type_traits/is_object.h>
+#include <cuda/std/__bit/has_single_bit.h>
+#include <cuda/std/__concepts/concept_macros.h>
+#include <cuda/std/__mdspan/default_accessor.h>
+#include <cuda/std/__memory/assume_aligned.h>
+#include <cuda/std/__type_traits/is_abstract.h>
+#include <cuda/std/__type_traits/is_array.h>
+#include <cuda/std/__type_traits/is_convertible.h>
+#include <cuda/std/__type_traits/is_object.h>
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
@@ -97,5 +93,4 @@ public:
 
 _LIBCUDACXX_END_NAMESPACE_STD
 
-#endif // defined(__cccl_lib_mdspan)
 #endif // _LIBCUDACXX___MDSPAN_ALIGNED_ACCESSOR_H

--- a/libcudacxx/include/cuda/std/version
+++ b/libcudacxx/include/cuda/std/version
@@ -85,9 +85,7 @@
 #define __cccl_lib_is_invocable          201703L
 #define __cccl_lib_make_reverse_iterator 201402L
 // # define __cccl_lib_make_unique                          201304L
-#if !_CCCL_COMPILER(MSVC) || _CCCL_STD_VER >= 2020
 #  define __cccl_lib_mdspan 202207L
-#endif // _CCCL_COMPILER(MSVC) && _CCCL_STD_VER >= 2020
 #define __cccl_lib_null_iterators 201304L
 #define __cccl_lib_optional       202110L
 #ifdef CCCL_ENABLE_OPTIONAL_REF

--- a/libcudacxx/include/cuda/std/version
+++ b/libcudacxx/include/cuda/std/version
@@ -85,7 +85,7 @@
 #define __cccl_lib_is_invocable          201703L
 #define __cccl_lib_make_reverse_iterator 201402L
 // # define __cccl_lib_make_unique                          201304L
-#  define __cccl_lib_mdspan 202207L
+#define __cccl_lib_mdspan         202207L
 #define __cccl_lib_null_iterators 201304L
 #define __cccl_lib_optional       202110L
 #ifdef CCCL_ENABLE_OPTIONAL_REF

--- a/libcudacxx/test/libcudacxx/std/linalg/accessors/conjugate_transposed.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/linalg/accessors/conjugate_transposed.pass.cpp
@@ -7,8 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: msvc && c++17
-
 #include <cuda/std/cassert>
 #include <cuda/std/complex>
 #include <cuda/std/linalg>

--- a/libcudacxx/test/libcudacxx/std/linalg/accessors/conjugated.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/linalg/accessors/conjugated.pass.cpp
@@ -7,8 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: msvc && c++17
-
 #include <cuda/std/cassert>
 #include <cuda/std/complex>
 #include <cuda/std/linalg>

--- a/libcudacxx/test/libcudacxx/std/linalg/accessors/scaled.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/linalg/accessors/scaled.pass.cpp
@@ -7,8 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: msvc && c++17
-
 #include <cuda/std/cassert>
 #include <cuda/std/linalg>
 #include <cuda/std/type_traits>

--- a/libcudacxx/test/libcudacxx/std/linalg/layouts/transposed.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/linalg/layouts/transposed.pass.cpp
@@ -7,8 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: msvc && c++17
-
 #include <cuda/std/cassert>
 #include <cuda/std/cstddef>
 #include <cuda/std/linalg>


### PR DESCRIPTION
With the recent refactor of `mdspan` we can enable linalg for all compilers
