### PR TITLE
Update RAPIDS and Matx CI builds to indicate they are optional

### DIFF
--- a/.github/workflows/ci-workflow-pull-request.yml
+++ b/.github/workflows/ci-workflow-pull-request.yml
@@ -191,7 +191,7 @@ jobs:
           upload_pages_artifact: "false"
 
   build-rapids:
-    name: Build RAPIDS
+    name: Build RAPIDS (optional)
     if: ${{ !contains(github.event.head_commit.message, '[skip-rapids]') }}
     secrets: inherit
     permissions:
@@ -203,7 +203,7 @@ jobs:
     uses: ./.github/workflows/build-rapids.yml
 
   build-matx:
-    name: Build MatX
+    name: Build MatX (optional)
     if: ${{ !contains(github.event.head_commit.message, '[skip-matx]') }}
     secrets: inherit
     permissions:


### PR DESCRIPTION
## Description

Updates the name of the RAPIDS and Matx jobs to better indicate that these are optional and do not block merging a PR. 
