### PR TITLE
Fix `cuda::std::assume_aligned` assertion

### DIFF
--- a/libcudacxx/include/cuda/std/__memory/assume_aligned.h
+++ b/libcudacxx/include/cuda/std/__memory/assume_aligned.h
@@ -34,7 +34,7 @@ template <size_t _Align, class _Tp>
 _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp* assume_aligned(_Tp* __ptr) noexcept
 {
   static_assert(_CUDA_VSTD::has_single_bit(_Align), "std::assume_aligned requires the alignment to be a power of 2");
-  static_assert(_Align >= sizeof(_Tp), "Alignment must be greater than or equal to the size of the input type");
+  static_assert(_Align >= alignof(_Tp), "Alignment must be greater than or equal to the size of the input type");
 #if !defined(_CCCL_BUILTIN_IS_CONSTANT_EVALUATED)
   return __ptr;
 #else

--- a/libcudacxx/include/cuda/std/__memory/assume_aligned.h
+++ b/libcudacxx/include/cuda/std/__memory/assume_aligned.h
@@ -34,7 +34,7 @@ template <size_t _Align, class _Tp>
 _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp* assume_aligned(_Tp* __ptr) noexcept
 {
   static_assert(_CUDA_VSTD::has_single_bit(_Align), "std::assume_aligned requires the alignment to be a power of 2");
-  static_assert(_Align >= alignof(_Tp), "Alignment must be greater than or equal to the size of the input type");
+  static_assert(_Align >= alignof(_Tp), "Alignment must be greater than or equal to the alignment of the input type");
 #if !defined(_CCCL_BUILTIN_IS_CONSTANT_EVALUATED)
   return __ptr;
 #else


### PR DESCRIPTION
## Description

`static_assert` needs to check the alignment not the size of the input type