### PR TITLE
Add multi-dimensional support to block_radix_sort routines.

### DIFF
--- a/python/cuda_cooperative/cuda/cooperative/experimental/_common.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/_common.py
@@ -19,6 +19,13 @@ symbol = namedtuple("symbol", ("kind", "name"))
 dim3 = namedtuple("dim3", ("x", "y", "z"))
 
 
+CUB_BLOCK_SCAN_ALGOS = {
+    "raking": "::cub::BlockScanAlgorithm::BLOCK_SCAN_RAKING",
+    "raking_memoize": "::cub::BlockScanAlgorithm::BLOCK_SCAN_RAKING_MEMOIZE",
+    "warp_scans": "::cub::BlockScanAlgorithm::BLOCK_SCAN_WARP_SCANS",
+}
+
+
 class CudaSharedMemConfig(Enum):
     """
     CUDA shared memory configuration.  This is intended to mirror the C++

--- a/python/cuda_cooperative/cuda/cooperative/experimental/_common.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/_common.py
@@ -5,6 +5,7 @@
 import re
 import tempfile
 from collections import namedtuple
+from enum import Enum
 from typing import TYPE_CHECKING, Union
 
 # Import for type checking only
@@ -16,6 +17,20 @@ version = namedtuple("version", ("major", "minor"))
 code = namedtuple("code", ("kind", "version", "data"))
 symbol = namedtuple("symbol", ("kind", "name"))
 dim3 = namedtuple("dim3", ("x", "y", "z"))
+
+
+class CudaSharedMemConfig(Enum):
+    """
+    CUDA shared memory configuration.  This is intended to mirror the C++
+    equivalent `cudaSharedMemConfig` enum.
+    """
+
+    BankSizeDefault = 0
+    BankSizeFourByte = 1
+    BankSizeEightByte = 2
+
+    def __str__(self):
+        return f"cudaSharedMem{self.name}"
 
 
 def make_binary_tempfile(content, suffix):

--- a/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_scan.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_scan.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Callable, Literal, Union
 import numba
 
 from cuda.cooperative.experimental._common import (
+    CUB_BLOCK_SCAN_ALGOS,
     make_binary_tempfile,
     normalize_dtype_param,
 )
@@ -23,12 +24,6 @@ from cuda.cooperative.experimental._types import (
 
 if TYPE_CHECKING:
     import numpy as np
-
-CUB_BLOCK_SCAN_ALGOS = {
-    "raking": "::cub::BlockScanAlgorithm::BLOCK_SCAN_RAKING",
-    "raking_memoize": "::cub::BlockScanAlgorithm::BLOCK_SCAN_RAKING_MEMOIZE",
-    "warp_scans": "::cub::BlockScanAlgorithm::BLOCK_SCAN_WARP_SCANS",
-}
 
 
 def _scan(

--- a/python/cuda_cooperative/tests/test_block_radix_sort.py
+++ b/python/cuda_cooperative/tests/test_block_radix_sort.py
@@ -2,9 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+from functools import reduce
+from operator import mul
+
 import numba
 import pytest
-from helpers import NUMBA_TYPES_TO_NP, random_int
+from helpers import NUMBA_TYPES_TO_NP, random_int, row_major_tid
 from numba import cuda, types
 from pynvjitlink import patch
 
@@ -15,11 +18,18 @@ numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
 
 
 @pytest.mark.parametrize("T", [types.int8, types.int16, types.uint32, types.uint64])
-@pytest.mark.parametrize("threads_per_block", [32, 128, 256, 1024])
+@pytest.mark.parametrize("threads_per_block", [32, 128, 256, 1024, (4, 8), (2, 4, 8)])
 @pytest.mark.parametrize("items_per_thread", [1, 3])
 def test_block_radix_sort_descending(T, threads_per_block, items_per_thread):
     begin_bit = numba.int32(0)
     end_bit = numba.int32(T.bitwidth)
+
+    num_threads_per_block = (
+        threads_per_block
+        if type(threads_per_block) is int
+        else reduce(mul, threads_per_block)
+    )
+
     block_radix_sort = cudax.block.radix_sort_keys_descending(
         dtype=T, threads_per_block=threads_per_block, items_per_thread=items_per_thread
     )
@@ -27,7 +37,7 @@ def test_block_radix_sort_descending(T, threads_per_block, items_per_thread):
 
     @cuda.jit(link=block_radix_sort.files)
     def kernel(input, output):
-        tid = cuda.threadIdx.x
+        tid = row_major_tid()
         temp_storage = cuda.shared.array(shape=temp_storage_bytes, dtype="uint8")
         thread_data = cuda.local.array(shape=items_per_thread, dtype=dtype)
         for i in range(items_per_thread):
@@ -37,7 +47,7 @@ def test_block_radix_sort_descending(T, threads_per_block, items_per_thread):
             output[tid * items_per_thread + i] = thread_data[i]
 
     dtype = NUMBA_TYPES_TO_NP[T]
-    items_per_tile = threads_per_block * items_per_thread
+    items_per_tile = num_threads_per_block * items_per_thread
     input = random_int(items_per_tile, dtype)
     d_input = cuda.to_device(input)
     d_output = cuda.device_array(items_per_tile, dtype=dtype)
@@ -57,10 +67,14 @@ def test_block_radix_sort_descending(T, threads_per_block, items_per_thread):
 
 
 @pytest.mark.parametrize("T", [types.int8, types.int16, types.uint32, types.uint64])
-@pytest.mark.parametrize("threads_per_block", [32, 128, 256, 1024])
+@pytest.mark.parametrize("threads_per_block", [32, 128, 256, 1024, (4, 8), (2, 4, 8)])
 @pytest.mark.parametrize("items_per_thread", [1, 3])
 def test_block_radix_sort(T, threads_per_block, items_per_thread):
-    items_per_tile = threads_per_block * items_per_thread
+    items_per_tile = (
+        threads_per_block * items_per_thread
+        if type(threads_per_block) is int
+        else reduce(mul, threads_per_block) * items_per_thread
+    )
 
     block_radix_sort = cudax.block.radix_sort_keys(
         dtype=T, threads_per_block=threads_per_block, items_per_thread=items_per_thread
@@ -69,7 +83,7 @@ def test_block_radix_sort(T, threads_per_block, items_per_thread):
 
     @cuda.jit(link=block_radix_sort.files)
     def kernel(input, output):
-        tid = cuda.threadIdx.x
+        tid = row_major_tid()
         temp_storage = cuda.shared.array(shape=temp_storage_bytes, dtype="uint8")
         thread_data = cuda.local.array(shape=items_per_thread, dtype=dtype)
         for i in range(items_per_thread):

--- a/python/cuda_cooperative/tests/test_common.py
+++ b/python/cuda_cooperative/tests/test_common.py
@@ -6,7 +6,10 @@ import numba
 import numpy as np
 import pytest
 
-from cuda.cooperative.experimental._common import normalize_dtype_param
+from cuda.cooperative.experimental._common import (
+    CudaSharedMemConfig,
+    normalize_dtype_param,
+)
 
 
 class TestNormalizeDtypeParam:
@@ -138,3 +141,74 @@ class TestNormalizeDtypeParam:
         with pytest.raises(ValueError) as excinfo:
             normalize_dtype_param(dtype)
         assert "Unrecognized dtype format:" in str(excinfo.value)
+
+
+class TestCudaSharedMemConfig:
+    @pytest.mark.parametrize(
+        "enum_member, expected_value",
+        [
+            (CudaSharedMemConfig.BankSizeDefault, 0),
+            (CudaSharedMemConfig.BankSizeFourByte, 1),
+            (CudaSharedMemConfig.BankSizeEightByte, 2),
+        ],
+    )
+    def test_enum_values(self, enum_member, expected_value):
+        """Test that enum values are correctly defined."""
+        assert enum_member.value == expected_value
+
+    @pytest.mark.parametrize(
+        "enum_member, expected_name",
+        [
+            (CudaSharedMemConfig.BankSizeDefault, "BankSizeDefault"),
+            (CudaSharedMemConfig.BankSizeFourByte, "BankSizeFourByte"),
+            (CudaSharedMemConfig.BankSizeEightByte, "BankSizeEightByte"),
+        ],
+    )
+    def test_enum_names(self, enum_member, expected_name):
+        """Test that enum names are correctly defined."""
+        assert enum_member.name == expected_name
+
+    @pytest.mark.parametrize(
+        "enum_member, expected_str",
+        [
+            (CudaSharedMemConfig.BankSizeDefault, "cudaSharedMemBankSizeDefault"),
+            (CudaSharedMemConfig.BankSizeFourByte, "cudaSharedMemBankSizeFourByte"),
+            (CudaSharedMemConfig.BankSizeEightByte, "cudaSharedMemBankSizeEightByte"),
+        ],
+    )
+    def test_string_representation(self, enum_member, expected_str):
+        """Test the string representation of enum values."""
+        assert str(enum_member) == expected_str
+
+    def test_enum_iteration(self):
+        """Test that we can iterate through all enum values."""
+        expected_values = [
+            CudaSharedMemConfig.BankSizeDefault,
+            CudaSharedMemConfig.BankSizeFourByte,
+            CudaSharedMemConfig.BankSizeEightByte,
+        ]
+        assert list(CudaSharedMemConfig) == expected_values
+
+    @pytest.mark.parametrize(
+        "name, expected_enum",
+        [
+            ("BankSizeDefault", CudaSharedMemConfig.BankSizeDefault),
+            ("BankSizeFourByte", CudaSharedMemConfig.BankSizeFourByte),
+            ("BankSizeEightByte", CudaSharedMemConfig.BankSizeEightByte),
+        ],
+    )
+    def test_enum_lookup_by_name(self, name, expected_enum):
+        """Test that we can look up enum values by name."""
+        assert CudaSharedMemConfig[name] == expected_enum
+
+    @pytest.mark.parametrize(
+        "value, expected_enum",
+        [
+            (0, CudaSharedMemConfig.BankSizeDefault),
+            (1, CudaSharedMemConfig.BankSizeFourByte),
+            (2, CudaSharedMemConfig.BankSizeEightByte),
+        ],
+    )
+    def test_enum_lookup_by_value(self, value, expected_enum):
+        """Test that we can look up enum values by value."""
+        assert CudaSharedMemConfig(value) == expected_enum


### PR DESCRIPTION
Tests have been updated and gave the `_block_radix_sort.py` module some general spring cleaning.

N.B. I created this off #4028; I'll rebase once that's merged.  Only review the third commit onward.