### PR TITLE
[cuda::ptx] Fix .cta_group::2 definition

### DIFF
--- a/docs/libcudacxx/ptx/instructions/generated/tcgen05_mma.rst
+++ b/docs/libcudacxx/ptx/instructions/generated/tcgen05_mma.rst
@@ -7,30 +7,11 @@ tcgen05.mma.cta_group::1.kind::f16
 
    // tcgen05.mma.cta_group.kind [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d, scale_input_d; // PTX ISA 86, SM_100a
    // .kind      = { .kind::f16, .kind::tf32 }
-   // .cta_group = { .cta_group::1, .cta_group::2 }
-   template <int N32, cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
+   // .cta_group = { .cta_group::1 }
+   template <int N32, cuda::ptx::dot_kind Kind>
    __device__ static inline void tcgen05_mma(
      cuda::ptx::kind_t<Kind> kind,
-     cuda::ptx::cta_group_t<Cta_Group> cta_group,
-     uint32_t d_tmem,
-     uint64_t a_desc,
-     uint64_t b_desc,
-     uint32_t idesc,
-     const uint32_t (&disable_output_lane)[4],
-     bool enable_input_d,
-     cuda::ptx::n32_t<N32> scale_input_d);
-
-tcgen05.mma.cta_group::2.kind::f16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // tcgen05.mma.cta_group.kind [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d, scale_input_d; // PTX ISA 86, SM_100a
-   // .kind      = { .kind::f16, .kind::tf32 }
-   // .cta_group = { .cta_group::1, .cta_group::2 }
-   template <int N32, cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
-   __device__ static inline void tcgen05_mma(
-     cuda::ptx::kind_t<Kind> kind,
-     cuda::ptx::cta_group_t<Cta_Group> cta_group,
+     cuda::ptx::cta_group_1_t,
      uint32_t d_tmem,
      uint64_t a_desc,
      uint64_t b_desc,
@@ -45,16 +26,35 @@ tcgen05.mma.cta_group::1.kind::tf32
 
    // tcgen05.mma.cta_group.kind [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d, scale_input_d; // PTX ISA 86, SM_100a
    // .kind      = { .kind::f16, .kind::tf32 }
-   // .cta_group = { .cta_group::1, .cta_group::2 }
-   template <int N32, cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
+   // .cta_group = { .cta_group::1 }
+   template <int N32, cuda::ptx::dot_kind Kind>
    __device__ static inline void tcgen05_mma(
      cuda::ptx::kind_t<Kind> kind,
-     cuda::ptx::cta_group_t<Cta_Group> cta_group,
+     cuda::ptx::cta_group_1_t,
      uint32_t d_tmem,
      uint64_t a_desc,
      uint64_t b_desc,
      uint32_t idesc,
      const uint32_t (&disable_output_lane)[4],
+     bool enable_input_d,
+     cuda::ptx::n32_t<N32> scale_input_d);
+
+tcgen05.mma.cta_group::2.kind::f16
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // tcgen05.mma.cta_group.kind [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d, scale_input_d; // PTX ISA 86, SM_100a
+   // .kind      = { .kind::f16, .kind::tf32 }
+   // .cta_group = { .cta_group::2 }
+   template <int N32, cuda::ptx::dot_kind Kind>
+   __device__ static inline void tcgen05_mma(
+     cuda::ptx::kind_t<Kind> kind,
+     cuda::ptx::cta_group_2_t,
+     uint32_t d_tmem,
+     uint64_t a_desc,
+     uint64_t b_desc,
+     uint32_t idesc,
+     const uint32_t (&disable_output_lane)[8],
      bool enable_input_d,
      cuda::ptx::n32_t<N32> scale_input_d);
 
@@ -64,16 +64,16 @@ tcgen05.mma.cta_group::2.kind::tf32
 
    // tcgen05.mma.cta_group.kind [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d, scale_input_d; // PTX ISA 86, SM_100a
    // .kind      = { .kind::f16, .kind::tf32 }
-   // .cta_group = { .cta_group::1, .cta_group::2 }
-   template <int N32, cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
+   // .cta_group = { .cta_group::2 }
+   template <int N32, cuda::ptx::dot_kind Kind>
    __device__ static inline void tcgen05_mma(
      cuda::ptx::kind_t<Kind> kind,
-     cuda::ptx::cta_group_t<Cta_Group> cta_group,
+     cuda::ptx::cta_group_2_t,
      uint32_t d_tmem,
      uint64_t a_desc,
      uint64_t b_desc,
      uint32_t idesc,
-     const uint32_t (&disable_output_lane)[4],
+     const uint32_t (&disable_output_lane)[8],
      bool enable_input_d,
      cuda::ptx::n32_t<N32> scale_input_d);
 
@@ -83,29 +83,11 @@ tcgen05.mma.cta_group::1.kind::f16
 
    // tcgen05.mma.cta_group.kind [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
-   // .cta_group = { .cta_group::1, .cta_group::2 }
-   template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
+   // .cta_group = { .cta_group::1 }
+   template <cuda::ptx::dot_kind Kind>
    __device__ static inline void tcgen05_mma(
      cuda::ptx::kind_t<Kind> kind,
-     cuda::ptx::cta_group_t<Cta_Group> cta_group,
-     uint32_t d_tmem,
-     uint64_t a_desc,
-     uint64_t b_desc,
-     uint32_t idesc,
-     const uint32_t (&disable_output_lane)[4],
-     bool enable_input_d);
-
-tcgen05.mma.cta_group::2.kind::f16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // tcgen05.mma.cta_group.kind [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
-   // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
-   // .cta_group = { .cta_group::1, .cta_group::2 }
-   template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
-   __device__ static inline void tcgen05_mma(
-     cuda::ptx::kind_t<Kind> kind,
-     cuda::ptx::cta_group_t<Cta_Group> cta_group,
+     cuda::ptx::cta_group_1_t,
      uint32_t d_tmem,
      uint64_t a_desc,
      uint64_t b_desc,
@@ -119,29 +101,11 @@ tcgen05.mma.cta_group::1.kind::tf32
 
    // tcgen05.mma.cta_group.kind [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
-   // .cta_group = { .cta_group::1, .cta_group::2 }
-   template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
+   // .cta_group = { .cta_group::1 }
+   template <cuda::ptx::dot_kind Kind>
    __device__ static inline void tcgen05_mma(
      cuda::ptx::kind_t<Kind> kind,
-     cuda::ptx::cta_group_t<Cta_Group> cta_group,
-     uint32_t d_tmem,
-     uint64_t a_desc,
-     uint64_t b_desc,
-     uint32_t idesc,
-     const uint32_t (&disable_output_lane)[4],
-     bool enable_input_d);
-
-tcgen05.mma.cta_group::2.kind::tf32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // tcgen05.mma.cta_group.kind [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
-   // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
-   // .cta_group = { .cta_group::1, .cta_group::2 }
-   template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
-   __device__ static inline void tcgen05_mma(
-     cuda::ptx::kind_t<Kind> kind,
-     cuda::ptx::cta_group_t<Cta_Group> cta_group,
+     cuda::ptx::cta_group_1_t,
      uint32_t d_tmem,
      uint64_t a_desc,
      uint64_t b_desc,
@@ -155,29 +119,11 @@ tcgen05.mma.cta_group::1.kind::f8f6f4
 
    // tcgen05.mma.cta_group.kind [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
-   // .cta_group = { .cta_group::1, .cta_group::2 }
-   template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
+   // .cta_group = { .cta_group::1 }
+   template <cuda::ptx::dot_kind Kind>
    __device__ static inline void tcgen05_mma(
      cuda::ptx::kind_t<Kind> kind,
-     cuda::ptx::cta_group_t<Cta_Group> cta_group,
-     uint32_t d_tmem,
-     uint64_t a_desc,
-     uint64_t b_desc,
-     uint32_t idesc,
-     const uint32_t (&disable_output_lane)[4],
-     bool enable_input_d);
-
-tcgen05.mma.cta_group::2.kind::f8f6f4
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // tcgen05.mma.cta_group.kind [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
-   // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
-   // .cta_group = { .cta_group::1, .cta_group::2 }
-   template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
-   __device__ static inline void tcgen05_mma(
-     cuda::ptx::kind_t<Kind> kind,
-     cuda::ptx::cta_group_t<Cta_Group> cta_group,
+     cuda::ptx::cta_group_1_t,
      uint32_t d_tmem,
      uint64_t a_desc,
      uint64_t b_desc,
@@ -191,16 +137,70 @@ tcgen05.mma.cta_group::1.kind::i8
 
    // tcgen05.mma.cta_group.kind [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
-   // .cta_group = { .cta_group::1, .cta_group::2 }
-   template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
+   // .cta_group = { .cta_group::1 }
+   template <cuda::ptx::dot_kind Kind>
    __device__ static inline void tcgen05_mma(
      cuda::ptx::kind_t<Kind> kind,
-     cuda::ptx::cta_group_t<Cta_Group> cta_group,
+     cuda::ptx::cta_group_1_t,
      uint32_t d_tmem,
      uint64_t a_desc,
      uint64_t b_desc,
      uint32_t idesc,
      const uint32_t (&disable_output_lane)[4],
+     bool enable_input_d);
+
+tcgen05.mma.cta_group::2.kind::f16
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // tcgen05.mma.cta_group.kind [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
+   // .cta_group = { .cta_group::2 }
+   template <cuda::ptx::dot_kind Kind>
+   __device__ static inline void tcgen05_mma(
+     cuda::ptx::kind_t<Kind> kind,
+     cuda::ptx::cta_group_2_t,
+     uint32_t d_tmem,
+     uint64_t a_desc,
+     uint64_t b_desc,
+     uint32_t idesc,
+     const uint32_t (&disable_output_lane)[8],
+     bool enable_input_d);
+
+tcgen05.mma.cta_group::2.kind::tf32
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // tcgen05.mma.cta_group.kind [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
+   // .cta_group = { .cta_group::2 }
+   template <cuda::ptx::dot_kind Kind>
+   __device__ static inline void tcgen05_mma(
+     cuda::ptx::kind_t<Kind> kind,
+     cuda::ptx::cta_group_2_t,
+     uint32_t d_tmem,
+     uint64_t a_desc,
+     uint64_t b_desc,
+     uint32_t idesc,
+     const uint32_t (&disable_output_lane)[8],
+     bool enable_input_d);
+
+tcgen05.mma.cta_group::2.kind::f8f6f4
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // tcgen05.mma.cta_group.kind [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
+   // .cta_group = { .cta_group::2 }
+   template <cuda::ptx::dot_kind Kind>
+   __device__ static inline void tcgen05_mma(
+     cuda::ptx::kind_t<Kind> kind,
+     cuda::ptx::cta_group_2_t,
+     uint32_t d_tmem,
+     uint64_t a_desc,
+     uint64_t b_desc,
+     uint32_t idesc,
+     const uint32_t (&disable_output_lane)[8],
      bool enable_input_d);
 
 tcgen05.mma.cta_group::2.kind::i8
@@ -209,16 +209,16 @@ tcgen05.mma.cta_group::2.kind::i8
 
    // tcgen05.mma.cta_group.kind [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
-   // .cta_group = { .cta_group::1, .cta_group::2 }
-   template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
+   // .cta_group = { .cta_group::2 }
+   template <cuda::ptx::dot_kind Kind>
    __device__ static inline void tcgen05_mma(
      cuda::ptx::kind_t<Kind> kind,
-     cuda::ptx::cta_group_t<Cta_Group> cta_group,
+     cuda::ptx::cta_group_2_t,
      uint32_t d_tmem,
      uint64_t a_desc,
      uint64_t b_desc,
      uint32_t idesc,
-     const uint32_t (&disable_output_lane)[4],
+     const uint32_t (&disable_output_lane)[8],
      bool enable_input_d);
 
 tcgen05.mma.cta_group::1.kind::f16
@@ -435,30 +435,11 @@ tcgen05.mma.cta_group::1.kind::f16
 
    // tcgen05.mma.cta_group.kind [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d, scale_input_d; // PTX ISA 86, SM_100a
    // .kind      = { .kind::f16, .kind::tf32 }
-   // .cta_group = { .cta_group::1, .cta_group::2 }
-   template <int N32, cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
+   // .cta_group = { .cta_group::1 }
+   template <int N32, cuda::ptx::dot_kind Kind>
    __device__ static inline void tcgen05_mma_tmem_a(
      cuda::ptx::kind_t<Kind> kind,
-     cuda::ptx::cta_group_t<Cta_Group> cta_group,
-     uint32_t d_tmem,
-     uint32_t a_tmem,
-     uint64_t b_desc,
-     uint32_t idesc,
-     const uint32_t (&disable_output_lane)[4],
-     bool enable_input_d,
-     cuda::ptx::n32_t<N32> scale_input_d);
-
-tcgen05.mma.cta_group::2.kind::f16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // tcgen05.mma.cta_group.kind [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d, scale_input_d; // PTX ISA 86, SM_100a
-   // .kind      = { .kind::f16, .kind::tf32 }
-   // .cta_group = { .cta_group::1, .cta_group::2 }
-   template <int N32, cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
-   __device__ static inline void tcgen05_mma_tmem_a(
-     cuda::ptx::kind_t<Kind> kind,
-     cuda::ptx::cta_group_t<Cta_Group> cta_group,
+     cuda::ptx::cta_group_1_t,
      uint32_t d_tmem,
      uint32_t a_tmem,
      uint64_t b_desc,
@@ -473,16 +454,35 @@ tcgen05.mma.cta_group::1.kind::tf32
 
    // tcgen05.mma.cta_group.kind [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d, scale_input_d; // PTX ISA 86, SM_100a
    // .kind      = { .kind::f16, .kind::tf32 }
-   // .cta_group = { .cta_group::1, .cta_group::2 }
-   template <int N32, cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
+   // .cta_group = { .cta_group::1 }
+   template <int N32, cuda::ptx::dot_kind Kind>
    __device__ static inline void tcgen05_mma_tmem_a(
      cuda::ptx::kind_t<Kind> kind,
-     cuda::ptx::cta_group_t<Cta_Group> cta_group,
+     cuda::ptx::cta_group_1_t,
      uint32_t d_tmem,
      uint32_t a_tmem,
      uint64_t b_desc,
      uint32_t idesc,
      const uint32_t (&disable_output_lane)[4],
+     bool enable_input_d,
+     cuda::ptx::n32_t<N32> scale_input_d);
+
+tcgen05.mma.cta_group::2.kind::f16
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // tcgen05.mma.cta_group.kind [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d, scale_input_d; // PTX ISA 86, SM_100a
+   // .kind      = { .kind::f16, .kind::tf32 }
+   // .cta_group = { .cta_group::2 }
+   template <int N32, cuda::ptx::dot_kind Kind>
+   __device__ static inline void tcgen05_mma_tmem_a(
+     cuda::ptx::kind_t<Kind> kind,
+     cuda::ptx::cta_group_2_t,
+     uint32_t d_tmem,
+     uint32_t a_tmem,
+     uint64_t b_desc,
+     uint32_t idesc,
+     const uint32_t (&disable_output_lane)[8],
      bool enable_input_d,
      cuda::ptx::n32_t<N32> scale_input_d);
 
@@ -492,16 +492,16 @@ tcgen05.mma.cta_group::2.kind::tf32
 
    // tcgen05.mma.cta_group.kind [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d, scale_input_d; // PTX ISA 86, SM_100a
    // .kind      = { .kind::f16, .kind::tf32 }
-   // .cta_group = { .cta_group::1, .cta_group::2 }
-   template <int N32, cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
+   // .cta_group = { .cta_group::2 }
+   template <int N32, cuda::ptx::dot_kind Kind>
    __device__ static inline void tcgen05_mma_tmem_a(
      cuda::ptx::kind_t<Kind> kind,
-     cuda::ptx::cta_group_t<Cta_Group> cta_group,
+     cuda::ptx::cta_group_2_t,
      uint32_t d_tmem,
      uint32_t a_tmem,
      uint64_t b_desc,
      uint32_t idesc,
-     const uint32_t (&disable_output_lane)[4],
+     const uint32_t (&disable_output_lane)[8],
      bool enable_input_d,
      cuda::ptx::n32_t<N32> scale_input_d);
 
@@ -511,29 +511,11 @@ tcgen05.mma.cta_group::1.kind::f16
 
    // tcgen05.mma.cta_group.kind [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
-   // .cta_group = { .cta_group::1, .cta_group::2 }
-   template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
+   // .cta_group = { .cta_group::1 }
+   template <cuda::ptx::dot_kind Kind>
    __device__ static inline void tcgen05_mma_tmem_a(
      cuda::ptx::kind_t<Kind> kind,
-     cuda::ptx::cta_group_t<Cta_Group> cta_group,
-     uint32_t d_tmem,
-     uint32_t a_tmem,
-     uint64_t b_desc,
-     uint32_t idesc,
-     const uint32_t (&disable_output_lane)[4],
-     bool enable_input_d);
-
-tcgen05.mma.cta_group::2.kind::f16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // tcgen05.mma.cta_group.kind [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
-   // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
-   // .cta_group = { .cta_group::1, .cta_group::2 }
-   template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
-   __device__ static inline void tcgen05_mma_tmem_a(
-     cuda::ptx::kind_t<Kind> kind,
-     cuda::ptx::cta_group_t<Cta_Group> cta_group,
+     cuda::ptx::cta_group_1_t,
      uint32_t d_tmem,
      uint32_t a_tmem,
      uint64_t b_desc,
@@ -547,29 +529,11 @@ tcgen05.mma.cta_group::1.kind::tf32
 
    // tcgen05.mma.cta_group.kind [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
-   // .cta_group = { .cta_group::1, .cta_group::2 }
-   template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
+   // .cta_group = { .cta_group::1 }
+   template <cuda::ptx::dot_kind Kind>
    __device__ static inline void tcgen05_mma_tmem_a(
      cuda::ptx::kind_t<Kind> kind,
-     cuda::ptx::cta_group_t<Cta_Group> cta_group,
-     uint32_t d_tmem,
-     uint32_t a_tmem,
-     uint64_t b_desc,
-     uint32_t idesc,
-     const uint32_t (&disable_output_lane)[4],
-     bool enable_input_d);
-
-tcgen05.mma.cta_group::2.kind::tf32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // tcgen05.mma.cta_group.kind [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
-   // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
-   // .cta_group = { .cta_group::1, .cta_group::2 }
-   template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
-   __device__ static inline void tcgen05_mma_tmem_a(
-     cuda::ptx::kind_t<Kind> kind,
-     cuda::ptx::cta_group_t<Cta_Group> cta_group,
+     cuda::ptx::cta_group_1_t,
      uint32_t d_tmem,
      uint32_t a_tmem,
      uint64_t b_desc,
@@ -583,29 +547,11 @@ tcgen05.mma.cta_group::1.kind::f8f6f4
 
    // tcgen05.mma.cta_group.kind [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
-   // .cta_group = { .cta_group::1, .cta_group::2 }
-   template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
+   // .cta_group = { .cta_group::1 }
+   template <cuda::ptx::dot_kind Kind>
    __device__ static inline void tcgen05_mma_tmem_a(
      cuda::ptx::kind_t<Kind> kind,
-     cuda::ptx::cta_group_t<Cta_Group> cta_group,
-     uint32_t d_tmem,
-     uint32_t a_tmem,
-     uint64_t b_desc,
-     uint32_t idesc,
-     const uint32_t (&disable_output_lane)[4],
-     bool enable_input_d);
-
-tcgen05.mma.cta_group::2.kind::f8f6f4
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // tcgen05.mma.cta_group.kind [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
-   // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
-   // .cta_group = { .cta_group::1, .cta_group::2 }
-   template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
-   __device__ static inline void tcgen05_mma_tmem_a(
-     cuda::ptx::kind_t<Kind> kind,
-     cuda::ptx::cta_group_t<Cta_Group> cta_group,
+     cuda::ptx::cta_group_1_t,
      uint32_t d_tmem,
      uint32_t a_tmem,
      uint64_t b_desc,
@@ -619,16 +565,70 @@ tcgen05.mma.cta_group::1.kind::i8
 
    // tcgen05.mma.cta_group.kind [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
-   // .cta_group = { .cta_group::1, .cta_group::2 }
-   template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
+   // .cta_group = { .cta_group::1 }
+   template <cuda::ptx::dot_kind Kind>
    __device__ static inline void tcgen05_mma_tmem_a(
      cuda::ptx::kind_t<Kind> kind,
-     cuda::ptx::cta_group_t<Cta_Group> cta_group,
+     cuda::ptx::cta_group_1_t,
      uint32_t d_tmem,
      uint32_t a_tmem,
      uint64_t b_desc,
      uint32_t idesc,
      const uint32_t (&disable_output_lane)[4],
+     bool enable_input_d);
+
+tcgen05.mma.cta_group::2.kind::f16
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // tcgen05.mma.cta_group.kind [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
+   // .cta_group = { .cta_group::2 }
+   template <cuda::ptx::dot_kind Kind>
+   __device__ static inline void tcgen05_mma_tmem_a(
+     cuda::ptx::kind_t<Kind> kind,
+     cuda::ptx::cta_group_2_t,
+     uint32_t d_tmem,
+     uint32_t a_tmem,
+     uint64_t b_desc,
+     uint32_t idesc,
+     const uint32_t (&disable_output_lane)[8],
+     bool enable_input_d);
+
+tcgen05.mma.cta_group::2.kind::tf32
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // tcgen05.mma.cta_group.kind [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
+   // .cta_group = { .cta_group::2 }
+   template <cuda::ptx::dot_kind Kind>
+   __device__ static inline void tcgen05_mma_tmem_a(
+     cuda::ptx::kind_t<Kind> kind,
+     cuda::ptx::cta_group_2_t,
+     uint32_t d_tmem,
+     uint32_t a_tmem,
+     uint64_t b_desc,
+     uint32_t idesc,
+     const uint32_t (&disable_output_lane)[8],
+     bool enable_input_d);
+
+tcgen05.mma.cta_group::2.kind::f8f6f4
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // tcgen05.mma.cta_group.kind [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
+   // .cta_group = { .cta_group::2 }
+   template <cuda::ptx::dot_kind Kind>
+   __device__ static inline void tcgen05_mma_tmem_a(
+     cuda::ptx::kind_t<Kind> kind,
+     cuda::ptx::cta_group_2_t,
+     uint32_t d_tmem,
+     uint32_t a_tmem,
+     uint64_t b_desc,
+     uint32_t idesc,
+     const uint32_t (&disable_output_lane)[8],
      bool enable_input_d);
 
 tcgen05.mma.cta_group::2.kind::i8
@@ -637,16 +637,16 @@ tcgen05.mma.cta_group::2.kind::i8
 
    // tcgen05.mma.cta_group.kind [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
-   // .cta_group = { .cta_group::1, .cta_group::2 }
-   template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
+   // .cta_group = { .cta_group::2 }
+   template <cuda::ptx::dot_kind Kind>
    __device__ static inline void tcgen05_mma_tmem_a(
      cuda::ptx::kind_t<Kind> kind,
-     cuda::ptx::cta_group_t<Cta_Group> cta_group,
+     cuda::ptx::cta_group_2_t,
      uint32_t d_tmem,
      uint32_t a_tmem,
      uint64_t b_desc,
      uint32_t idesc,
-     const uint32_t (&disable_output_lane)[4],
+     const uint32_t (&disable_output_lane)[8],
      bool enable_input_d);
 
 tcgen05.mma.cta_group::1.kind::f16

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/tcgen05_mma.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/tcgen05_mma.h
@@ -4,14 +4,13 @@
 #define _CUDA_PTX_GENERATED_TCGEN05_MMA_H_
 
 /*
-// tcgen05.mma.cta_group.kind [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d, scale_input_d; //
-PTX ISA 86, SM_100a
+// tcgen05.mma.cta_group.kind [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d, scale_input_d; // PTX ISA 86, SM_100a
 // .kind      = { .kind::f16, .kind::tf32 }
-// .cta_group = { .cta_group::1, .cta_group::2 }
-template <int N32, cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
+// .cta_group = { .cta_group::1 }
+template <int N32, cuda::ptx::dot_kind Kind>
 __device__ static inline void tcgen05_mma(
   cuda::ptx::kind_t<Kind> kind,
-  cuda::ptx::cta_group_t<Cta_Group> cta_group,
+  cuda::ptx::cta_group_1_t,
   uint32_t d_tmem,
   uint64_t a_desc,
   uint64_t b_desc,
@@ -22,10 +21,10 @@ __device__ static inline void tcgen05_mma(
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_is_not_supported_before_SM_100a__();
-template <int _N32, dot_kind _Kind, dot_cta_group _Cta_Group>
+template <int _N32, dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma(
   kind_t<_Kind> __kind,
-  cta_group_t<_Cta_Group> __cta_group,
+  cta_group_1_t,
   _CUDA_VSTD::uint32_t __d_tmem,
   _CUDA_VSTD::uint64_t __a_desc,
   _CUDA_VSTD::uint64_t __b_desc,
@@ -35,104 +34,149 @@ _CCCL_DEVICE static inline void tcgen05_mma(
   n32_t<_N32> __scale_input_d)
 {
   static_assert(__kind == kind_f16 || __kind == kind_tf32, "");
-  static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL
-  if constexpr (__kind == kind_f16 && __cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %8, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::f16 [%0], %1, %2, %3, {%4, %5, %6, %7}, PRED_enable_input_d, %9;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__disable_output_lane[0]),
-        "r"(__disable_output_lane[1]),
-        "r"(__disable_output_lane[2]),
-        "r"(__disable_output_lane[3]),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d)),
-        "n"(__scale_input_d.value)
-      : "memory");
-  }
-  else if constexpr (__kind == kind_f16 && __cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %8, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::f16 [%0], %1, %2, %3, {%4, %5, %6, %7}, PRED_enable_input_d, %9;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__disable_output_lane[0]),
-        "r"(__disable_output_lane[1]),
-        "r"(__disable_output_lane[2]),
-        "r"(__disable_output_lane[3]),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d)),
-        "n"(__scale_input_d.value)
-      : "memory");
-  }
-  else if constexpr (__kind == kind_tf32 && __cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %8, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::tf32 [%0], %1, %2, %3, {%4, %5, %6, %7}, PRED_enable_input_d, %9;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__disable_output_lane[0]),
-        "r"(__disable_output_lane[1]),
-        "r"(__disable_output_lane[2]),
-        "r"(__disable_output_lane[3]),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d)),
-        "n"(__scale_input_d.value)
-      : "memory");
-  }
-  else if constexpr (__kind == kind_tf32 && __cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %8, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::tf32 [%0], %1, %2, %3, {%4, %5, %6, %7}, PRED_enable_input_d, %9;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__disable_output_lane[0]),
-        "r"(__disable_output_lane[1]),
-        "r"(__disable_output_lane[2]),
-        "r"(__disable_output_lane[3]),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d)),
-        "n"(__scale_input_d.value)
-      : "memory");
-  }
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_is_not_supported_before_SM_100a__();
-#  endif
+  // __cta_group == cta_group_1 (due to parameter type constraint)
+  #if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL
+    if constexpr (__kind == kind_f16) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %8, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::f16 [%0], %1, %2, %3, {%4, %5, %6, %7}, PRED_enable_input_d, %9;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__disable_output_lane[0]),
+          "r"(__disable_output_lane[1]),
+          "r"(__disable_output_lane[2]),
+          "r"(__disable_output_lane[3]),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d)),
+          "n"(__scale_input_d.value)
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_tf32) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %8, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::tf32 [%0], %1, %2, %3, {%4, %5, %6, %7}, PRED_enable_input_d, %9;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__disable_output_lane[0]),
+          "r"(__disable_output_lane[1]),
+          "r"(__disable_output_lane[2]),
+          "r"(__disable_output_lane[3]),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d)),
+          "n"(__scale_input_d.value)
+        : "memory"
+      );
+    }
+  #else
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_tcgen05_mma_is_not_supported_before_SM_100a__();
+  #endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.mma.cta_group.kind [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86,
-SM_100a, SM_101a
-// .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
-// .cta_group = { .cta_group::1, .cta_group::2 }
-template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
+// tcgen05.mma.cta_group.kind [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d, scale_input_d; // PTX ISA 86, SM_100a
+// .kind      = { .kind::f16, .kind::tf32 }
+// .cta_group = { .cta_group::2 }
+template <int N32, cuda::ptx::dot_kind Kind>
 __device__ static inline void tcgen05_mma(
   cuda::ptx::kind_t<Kind> kind,
-  cuda::ptx::cta_group_t<Cta_Group> cta_group,
+  cuda::ptx::cta_group_2_t,
+  uint32_t d_tmem,
+  uint64_t a_desc,
+  uint64_t b_desc,
+  uint32_t idesc,
+  const uint32_t (&disable_output_lane)[8],
+  bool enable_input_d,
+  cuda::ptx::n32_t<N32> scale_input_d);
+*/
+#if __cccl_ptx_isa >= 860
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_is_not_supported_before_SM_100a__();
+template <int _N32, dot_kind _Kind>
+_CCCL_DEVICE static inline void tcgen05_mma(
+  kind_t<_Kind> __kind,
+  cta_group_2_t,
+  _CUDA_VSTD::uint32_t __d_tmem,
+  _CUDA_VSTD::uint64_t __a_desc,
+  _CUDA_VSTD::uint64_t __b_desc,
+  _CUDA_VSTD::uint32_t __idesc,
+  const _CUDA_VSTD::uint32_t (&__disable_output_lane)[8],
+  bool __enable_input_d,
+  n32_t<_N32> __scale_input_d)
+{
+  static_assert(__kind == kind_f16 || __kind == kind_tf32, "");
+  // __cta_group == cta_group_2 (due to parameter type constraint)
+  #if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL
+    if constexpr (__kind == kind_f16) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %12, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::f16 [%0], %1, %2, %3, {%4, %5, %6, %7, %8, %9, %10, %11}, PRED_enable_input_d, %13;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__disable_output_lane[0]),
+          "r"(__disable_output_lane[1]),
+          "r"(__disable_output_lane[2]),
+          "r"(__disable_output_lane[3]),
+          "r"(__disable_output_lane[4]),
+          "r"(__disable_output_lane[5]),
+          "r"(__disable_output_lane[6]),
+          "r"(__disable_output_lane[7]),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d)),
+          "n"(__scale_input_d.value)
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_tf32) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %12, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::tf32 [%0], %1, %2, %3, {%4, %5, %6, %7, %8, %9, %10, %11}, PRED_enable_input_d, %13;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__disable_output_lane[0]),
+          "r"(__disable_output_lane[1]),
+          "r"(__disable_output_lane[2]),
+          "r"(__disable_output_lane[3]),
+          "r"(__disable_output_lane[4]),
+          "r"(__disable_output_lane[5]),
+          "r"(__disable_output_lane[6]),
+          "r"(__disable_output_lane[7]),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d)),
+          "n"(__scale_input_d.value)
+        : "memory"
+      );
+    }
+  #else
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_tcgen05_mma_is_not_supported_before_SM_100a__();
+  #endif
+}
+#endif // __cccl_ptx_isa >= 860
+
+/*
+// tcgen05.mma.cta_group.kind [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+// .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
+// .cta_group = { .cta_group::1 }
+template <cuda::ptx::dot_kind Kind>
+__device__ static inline void tcgen05_mma(
+  cuda::ptx::kind_t<Kind> kind,
+  cuda::ptx::cta_group_1_t,
   uint32_t d_tmem,
   uint64_t a_desc,
   uint64_t b_desc,
@@ -142,10 +186,10 @@ __device__ static inline void tcgen05_mma(
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_is_not_supported_before_SM_100a_SM_101a__();
-template <dot_kind _Kind, dot_cta_group _Cta_Group>
+template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma(
   kind_t<_Kind> __kind,
-  cta_group_t<_Cta_Group> __cta_group,
+  cta_group_1_t,
   _CUDA_VSTD::uint32_t __d_tmem,
   _CUDA_VSTD::uint64_t __a_desc,
   _CUDA_VSTD::uint64_t __b_desc,
@@ -154,164 +198,212 @@ _CCCL_DEVICE static inline void tcgen05_mma(
   bool __enable_input_d)
 {
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-  static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
-  if constexpr (__kind == kind_f16 && __cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %8, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::f16 [%0], %1, %2, %3, {%4, %5, %6, %7}, PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__disable_output_lane[0]),
-        "r"(__disable_output_lane[1]),
-        "r"(__disable_output_lane[2]),
-        "r"(__disable_output_lane[3]),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__kind == kind_f16 && __cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %8, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::f16 [%0], %1, %2, %3, {%4, %5, %6, %7}, PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__disable_output_lane[0]),
-        "r"(__disable_output_lane[1]),
-        "r"(__disable_output_lane[2]),
-        "r"(__disable_output_lane[3]),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__kind == kind_tf32 && __cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %8, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::tf32 [%0], %1, %2, %3, {%4, %5, %6, %7}, PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__disable_output_lane[0]),
-        "r"(__disable_output_lane[1]),
-        "r"(__disable_output_lane[2]),
-        "r"(__disable_output_lane[3]),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__kind == kind_tf32 && __cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %8, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::tf32 [%0], %1, %2, %3, {%4, %5, %6, %7}, PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__disable_output_lane[0]),
-        "r"(__disable_output_lane[1]),
-        "r"(__disable_output_lane[2]),
-        "r"(__disable_output_lane[3]),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__kind == kind_f8f6f4 && __cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %8, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::f8f6f4 [%0], %1, %2, %3, {%4, %5, %6, %7}, PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__disable_output_lane[0]),
-        "r"(__disable_output_lane[1]),
-        "r"(__disable_output_lane[2]),
-        "r"(__disable_output_lane[3]),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__kind == kind_f8f6f4 && __cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %8, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::f8f6f4 [%0], %1, %2, %3, {%4, %5, %6, %7}, PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__disable_output_lane[0]),
-        "r"(__disable_output_lane[1]),
-        "r"(__disable_output_lane[2]),
-        "r"(__disable_output_lane[3]),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__kind == kind_i8 && __cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %8, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::i8 [%0], %1, %2, %3, {%4, %5, %6, %7}, PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__disable_output_lane[0]),
-        "r"(__disable_output_lane[1]),
-        "r"(__disable_output_lane[2]),
-        "r"(__disable_output_lane[3]),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__kind == kind_i8 && __cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %8, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::i8 [%0], %1, %2, %3, {%4, %5, %6, %7}, PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__disable_output_lane[0]),
-        "r"(__disable_output_lane[1]),
-        "r"(__disable_output_lane[2]),
-        "r"(__disable_output_lane[3]),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_is_not_supported_before_SM_100a_SM_101a__();
-#  endif
+  // __cta_group == cta_group_1 (due to parameter type constraint)
+  #if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL|| __CUDA_ARCH_FEAT_SM101_ALL
+    if constexpr (__kind == kind_f16) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %8, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::f16 [%0], %1, %2, %3, {%4, %5, %6, %7}, PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__disable_output_lane[0]),
+          "r"(__disable_output_lane[1]),
+          "r"(__disable_output_lane[2]),
+          "r"(__disable_output_lane[3]),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_tf32) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %8, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::tf32 [%0], %1, %2, %3, {%4, %5, %6, %7}, PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__disable_output_lane[0]),
+          "r"(__disable_output_lane[1]),
+          "r"(__disable_output_lane[2]),
+          "r"(__disable_output_lane[3]),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_f8f6f4) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %8, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::f8f6f4 [%0], %1, %2, %3, {%4, %5, %6, %7}, PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__disable_output_lane[0]),
+          "r"(__disable_output_lane[1]),
+          "r"(__disable_output_lane[2]),
+          "r"(__disable_output_lane[3]),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_i8) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %8, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::i8 [%0], %1, %2, %3, {%4, %5, %6, %7}, PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__disable_output_lane[0]),
+          "r"(__disable_output_lane[1]),
+          "r"(__disable_output_lane[2]),
+          "r"(__disable_output_lane[3]),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    }
+  #else
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_tcgen05_mma_is_not_supported_before_SM_100a_SM_101a__();
+  #endif
+}
+#endif // __cccl_ptx_isa >= 860
+
+/*
+// tcgen05.mma.cta_group.kind [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+// .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
+// .cta_group = { .cta_group::2 }
+template <cuda::ptx::dot_kind Kind>
+__device__ static inline void tcgen05_mma(
+  cuda::ptx::kind_t<Kind> kind,
+  cuda::ptx::cta_group_2_t,
+  uint32_t d_tmem,
+  uint64_t a_desc,
+  uint64_t b_desc,
+  uint32_t idesc,
+  const uint32_t (&disable_output_lane)[8],
+  bool enable_input_d);
+*/
+#if __cccl_ptx_isa >= 860
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_is_not_supported_before_SM_100a_SM_101a__();
+template <dot_kind _Kind>
+_CCCL_DEVICE static inline void tcgen05_mma(
+  kind_t<_Kind> __kind,
+  cta_group_2_t,
+  _CUDA_VSTD::uint32_t __d_tmem,
+  _CUDA_VSTD::uint64_t __a_desc,
+  _CUDA_VSTD::uint64_t __b_desc,
+  _CUDA_VSTD::uint32_t __idesc,
+  const _CUDA_VSTD::uint32_t (&__disable_output_lane)[8],
+  bool __enable_input_d)
+{
+  static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
+  // __cta_group == cta_group_2 (due to parameter type constraint)
+  #if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL|| __CUDA_ARCH_FEAT_SM101_ALL
+    if constexpr (__kind == kind_f16) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %12, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::f16 [%0], %1, %2, %3, {%4, %5, %6, %7, %8, %9, %10, %11}, PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__disable_output_lane[0]),
+          "r"(__disable_output_lane[1]),
+          "r"(__disable_output_lane[2]),
+          "r"(__disable_output_lane[3]),
+          "r"(__disable_output_lane[4]),
+          "r"(__disable_output_lane[5]),
+          "r"(__disable_output_lane[6]),
+          "r"(__disable_output_lane[7]),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_tf32) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %12, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::tf32 [%0], %1, %2, %3, {%4, %5, %6, %7, %8, %9, %10, %11}, PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__disable_output_lane[0]),
+          "r"(__disable_output_lane[1]),
+          "r"(__disable_output_lane[2]),
+          "r"(__disable_output_lane[3]),
+          "r"(__disable_output_lane[4]),
+          "r"(__disable_output_lane[5]),
+          "r"(__disable_output_lane[6]),
+          "r"(__disable_output_lane[7]),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_f8f6f4) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %12, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::f8f6f4 [%0], %1, %2, %3, {%4, %5, %6, %7, %8, %9, %10, %11}, PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__disable_output_lane[0]),
+          "r"(__disable_output_lane[1]),
+          "r"(__disable_output_lane[2]),
+          "r"(__disable_output_lane[3]),
+          "r"(__disable_output_lane[4]),
+          "r"(__disable_output_lane[5]),
+          "r"(__disable_output_lane[6]),
+          "r"(__disable_output_lane[7]),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_i8) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %12, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::i8 [%0], %1, %2, %3, {%4, %5, %6, %7, %8, %9, %10, %11}, PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__disable_output_lane[0]),
+          "r"(__disable_output_lane[1]),
+          "r"(__disable_output_lane[2]),
+          "r"(__disable_output_lane[3]),
+          "r"(__disable_output_lane[4]),
+          "r"(__disable_output_lane[5]),
+          "r"(__disable_output_lane[6]),
+          "r"(__disable_output_lane[7]),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    }
+  #else
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_tcgen05_mma_is_not_supported_before_SM_100a_SM_101a__();
+  #endif
 }
 #endif // __cccl_ptx_isa >= 860
 
@@ -345,75 +437,72 @@ _CCCL_DEVICE static inline void tcgen05_mma(
 {
   static_assert(__kind == kind_f16 || __kind == kind_tf32, "");
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL
-  if constexpr (__kind == kind_f16 && __cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %4, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::f16 [%0], %1, %2, %3, PRED_enable_input_d, %5;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d)),
-        "n"(__scale_input_d.value)
-      : "memory");
-  }
-  else if constexpr (__kind == kind_f16 && __cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %4, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::f16 [%0], %1, %2, %3, PRED_enable_input_d, %5;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d)),
-        "n"(__scale_input_d.value)
-      : "memory");
-  }
-  else if constexpr (__kind == kind_tf32 && __cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %4, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::tf32 [%0], %1, %2, %3, PRED_enable_input_d, %5;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d)),
-        "n"(__scale_input_d.value)
-      : "memory");
-  }
-  else if constexpr (__kind == kind_tf32 && __cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %4, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::tf32 [%0], %1, %2, %3, PRED_enable_input_d, %5;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d)),
-        "n"(__scale_input_d.value)
-      : "memory");
-  }
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_is_not_supported_before_SM_100a__();
-#  endif
+  #if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL
+    if constexpr (__kind == kind_f16 && __cta_group == cta_group_1) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %4, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::f16 [%0], %1, %2, %3, PRED_enable_input_d, %5;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d)),
+          "n"(__scale_input_d.value)
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_f16 && __cta_group == cta_group_2) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %4, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::f16 [%0], %1, %2, %3, PRED_enable_input_d, %5;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d)),
+          "n"(__scale_input_d.value)
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_tf32 && __cta_group == cta_group_1) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %4, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::tf32 [%0], %1, %2, %3, PRED_enable_input_d, %5;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d)),
+          "n"(__scale_input_d.value)
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_tf32 && __cta_group == cta_group_2) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %4, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::tf32 [%0], %1, %2, %3, PRED_enable_input_d, %5;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d)),
+          "n"(__scale_input_d.value)
+        : "memory"
+      );
+    }
+  #else
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_tcgen05_mma_is_not_supported_before_SM_100a__();
+  #endif
 }
 #endif // __cccl_ptx_isa >= 860
 
@@ -445,143 +534,135 @@ _CCCL_DEVICE static inline void tcgen05_mma(
 {
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
-  if constexpr (__kind == kind_f16 && __cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %4, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::f16 [%0], %1, %2, %3, PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__kind == kind_f16 && __cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %4, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::f16 [%0], %1, %2, %3, PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__kind == kind_tf32 && __cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %4, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::tf32 [%0], %1, %2, %3, PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__kind == kind_tf32 && __cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %4, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::tf32 [%0], %1, %2, %3, PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__kind == kind_f8f6f4 && __cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %4, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::f8f6f4 [%0], %1, %2, %3, PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__kind == kind_f8f6f4 && __cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %4, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::f8f6f4 [%0], %1, %2, %3, PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__kind == kind_i8 && __cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %4, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::i8 [%0], %1, %2, %3, PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__kind == kind_i8 && __cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %4, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::i8 [%0], %1, %2, %3, PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_is_not_supported_before_SM_100a_SM_101a__();
-#  endif
+  #if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL|| __CUDA_ARCH_FEAT_SM101_ALL
+    if constexpr (__kind == kind_f16 && __cta_group == cta_group_1) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %4, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::f16 [%0], %1, %2, %3, PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_f16 && __cta_group == cta_group_2) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %4, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::f16 [%0], %1, %2, %3, PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_tf32 && __cta_group == cta_group_1) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %4, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::tf32 [%0], %1, %2, %3, PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_tf32 && __cta_group == cta_group_2) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %4, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::tf32 [%0], %1, %2, %3, PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_f8f6f4 && __cta_group == cta_group_1) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %4, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::f8f6f4 [%0], %1, %2, %3, PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_f8f6f4 && __cta_group == cta_group_2) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %4, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::f8f6f4 [%0], %1, %2, %3, PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_i8 && __cta_group == cta_group_1) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %4, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::i8 [%0], %1, %2, %3, PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_i8 && __cta_group == cta_group_2) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %4, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::i8 [%0], %1, %2, %3, PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    }
+  #else
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_tcgen05_mma_is_not_supported_before_SM_100a_SM_101a__();
+  #endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.mma.cta_group.kind [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d, scale_input_d; //
-PTX ISA 86, SM_100a
+// tcgen05.mma.cta_group.kind [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d, scale_input_d; // PTX ISA 86, SM_100a
 // .kind      = { .kind::f16, .kind::tf32 }
-// .cta_group = { .cta_group::1, .cta_group::2 }
-template <int N32, cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
+// .cta_group = { .cta_group::1 }
+template <int N32, cuda::ptx::dot_kind Kind>
 __device__ static inline void tcgen05_mma_tmem_a(
   cuda::ptx::kind_t<Kind> kind,
-  cuda::ptx::cta_group_t<Cta_Group> cta_group,
+  cuda::ptx::cta_group_1_t,
   uint32_t d_tmem,
   uint32_t a_tmem,
   uint64_t b_desc,
@@ -592,10 +673,10 @@ __device__ static inline void tcgen05_mma_tmem_a(
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_tmem_a_is_not_supported_before_SM_100a__();
-template <int _N32, dot_kind _Kind, dot_cta_group _Cta_Group>
+template <int _N32, dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_tmem_a(
   kind_t<_Kind> __kind,
-  cta_group_t<_Cta_Group> __cta_group,
+  cta_group_1_t,
   _CUDA_VSTD::uint32_t __d_tmem,
   _CUDA_VSTD::uint32_t __a_tmem,
   _CUDA_VSTD::uint64_t __b_desc,
@@ -605,104 +686,149 @@ _CCCL_DEVICE static inline void tcgen05_mma_tmem_a(
   n32_t<_N32> __scale_input_d)
 {
   static_assert(__kind == kind_f16 || __kind == kind_tf32, "");
-  static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL
-  if constexpr (__kind == kind_f16 && __cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %8, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::f16 [%0], [%1], %2, %3, {%4, %5, %6, %7}, PRED_enable_input_d, %9;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "r"(__a_tmem),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__disable_output_lane[0]),
-        "r"(__disable_output_lane[1]),
-        "r"(__disable_output_lane[2]),
-        "r"(__disable_output_lane[3]),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d)),
-        "n"(__scale_input_d.value)
-      : "memory");
-  }
-  else if constexpr (__kind == kind_f16 && __cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %8, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::f16 [%0], [%1], %2, %3, {%4, %5, %6, %7}, PRED_enable_input_d, %9;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "r"(__a_tmem),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__disable_output_lane[0]),
-        "r"(__disable_output_lane[1]),
-        "r"(__disable_output_lane[2]),
-        "r"(__disable_output_lane[3]),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d)),
-        "n"(__scale_input_d.value)
-      : "memory");
-  }
-  else if constexpr (__kind == kind_tf32 && __cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %8, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::tf32 [%0], [%1], %2, %3, {%4, %5, %6, %7}, PRED_enable_input_d, %9;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "r"(__a_tmem),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__disable_output_lane[0]),
-        "r"(__disable_output_lane[1]),
-        "r"(__disable_output_lane[2]),
-        "r"(__disable_output_lane[3]),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d)),
-        "n"(__scale_input_d.value)
-      : "memory");
-  }
-  else if constexpr (__kind == kind_tf32 && __cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %8, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::tf32 [%0], [%1], %2, %3, {%4, %5, %6, %7}, PRED_enable_input_d, %9;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "r"(__a_tmem),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__disable_output_lane[0]),
-        "r"(__disable_output_lane[1]),
-        "r"(__disable_output_lane[2]),
-        "r"(__disable_output_lane[3]),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d)),
-        "n"(__scale_input_d.value)
-      : "memory");
-  }
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_tmem_a_is_not_supported_before_SM_100a__();
-#  endif
+  // __cta_group == cta_group_1 (due to parameter type constraint)
+  #if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL
+    if constexpr (__kind == kind_f16) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %8, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::f16 [%0], [%1], %2, %3, {%4, %5, %6, %7}, PRED_enable_input_d, %9;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "r"(__a_tmem),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__disable_output_lane[0]),
+          "r"(__disable_output_lane[1]),
+          "r"(__disable_output_lane[2]),
+          "r"(__disable_output_lane[3]),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d)),
+          "n"(__scale_input_d.value)
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_tf32) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %8, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::tf32 [%0], [%1], %2, %3, {%4, %5, %6, %7}, PRED_enable_input_d, %9;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "r"(__a_tmem),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__disable_output_lane[0]),
+          "r"(__disable_output_lane[1]),
+          "r"(__disable_output_lane[2]),
+          "r"(__disable_output_lane[3]),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d)),
+          "n"(__scale_input_d.value)
+        : "memory"
+      );
+    }
+  #else
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_tcgen05_mma_tmem_a_is_not_supported_before_SM_100a__();
+  #endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.mma.cta_group.kind [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86,
-SM_100a, SM_101a
-// .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
-// .cta_group = { .cta_group::1, .cta_group::2 }
-template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
+// tcgen05.mma.cta_group.kind [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d, scale_input_d; // PTX ISA 86, SM_100a
+// .kind      = { .kind::f16, .kind::tf32 }
+// .cta_group = { .cta_group::2 }
+template <int N32, cuda::ptx::dot_kind Kind>
 __device__ static inline void tcgen05_mma_tmem_a(
   cuda::ptx::kind_t<Kind> kind,
-  cuda::ptx::cta_group_t<Cta_Group> cta_group,
+  cuda::ptx::cta_group_2_t,
+  uint32_t d_tmem,
+  uint32_t a_tmem,
+  uint64_t b_desc,
+  uint32_t idesc,
+  const uint32_t (&disable_output_lane)[8],
+  bool enable_input_d,
+  cuda::ptx::n32_t<N32> scale_input_d);
+*/
+#if __cccl_ptx_isa >= 860
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_tmem_a_is_not_supported_before_SM_100a__();
+template <int _N32, dot_kind _Kind>
+_CCCL_DEVICE static inline void tcgen05_mma_tmem_a(
+  kind_t<_Kind> __kind,
+  cta_group_2_t,
+  _CUDA_VSTD::uint32_t __d_tmem,
+  _CUDA_VSTD::uint32_t __a_tmem,
+  _CUDA_VSTD::uint64_t __b_desc,
+  _CUDA_VSTD::uint32_t __idesc,
+  const _CUDA_VSTD::uint32_t (&__disable_output_lane)[8],
+  bool __enable_input_d,
+  n32_t<_N32> __scale_input_d)
+{
+  static_assert(__kind == kind_f16 || __kind == kind_tf32, "");
+  // __cta_group == cta_group_2 (due to parameter type constraint)
+  #if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL
+    if constexpr (__kind == kind_f16) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %12, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::f16 [%0], [%1], %2, %3, {%4, %5, %6, %7, %8, %9, %10, %11}, PRED_enable_input_d, %13;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "r"(__a_tmem),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__disable_output_lane[0]),
+          "r"(__disable_output_lane[1]),
+          "r"(__disable_output_lane[2]),
+          "r"(__disable_output_lane[3]),
+          "r"(__disable_output_lane[4]),
+          "r"(__disable_output_lane[5]),
+          "r"(__disable_output_lane[6]),
+          "r"(__disable_output_lane[7]),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d)),
+          "n"(__scale_input_d.value)
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_tf32) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %12, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::tf32 [%0], [%1], %2, %3, {%4, %5, %6, %7, %8, %9, %10, %11}, PRED_enable_input_d, %13;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "r"(__a_tmem),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__disable_output_lane[0]),
+          "r"(__disable_output_lane[1]),
+          "r"(__disable_output_lane[2]),
+          "r"(__disable_output_lane[3]),
+          "r"(__disable_output_lane[4]),
+          "r"(__disable_output_lane[5]),
+          "r"(__disable_output_lane[6]),
+          "r"(__disable_output_lane[7]),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d)),
+          "n"(__scale_input_d.value)
+        : "memory"
+      );
+    }
+  #else
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_tcgen05_mma_tmem_a_is_not_supported_before_SM_100a__();
+  #endif
+}
+#endif // __cccl_ptx_isa >= 860
+
+/*
+// tcgen05.mma.cta_group.kind [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+// .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
+// .cta_group = { .cta_group::1 }
+template <cuda::ptx::dot_kind Kind>
+__device__ static inline void tcgen05_mma_tmem_a(
+  cuda::ptx::kind_t<Kind> kind,
+  cuda::ptx::cta_group_1_t,
   uint32_t d_tmem,
   uint32_t a_tmem,
   uint64_t b_desc,
@@ -712,10 +838,10 @@ __device__ static inline void tcgen05_mma_tmem_a(
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_tmem_a_is_not_supported_before_SM_100a_SM_101a__();
-template <dot_kind _Kind, dot_cta_group _Cta_Group>
+template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_tmem_a(
   kind_t<_Kind> __kind,
-  cta_group_t<_Cta_Group> __cta_group,
+  cta_group_1_t,
   _CUDA_VSTD::uint32_t __d_tmem,
   _CUDA_VSTD::uint32_t __a_tmem,
   _CUDA_VSTD::uint64_t __b_desc,
@@ -724,164 +850,212 @@ _CCCL_DEVICE static inline void tcgen05_mma_tmem_a(
   bool __enable_input_d)
 {
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-  static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
-  if constexpr (__kind == kind_f16 && __cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %8, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::f16 [%0], [%1], %2, %3, {%4, %5, %6, %7}, PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "r"(__a_tmem),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__disable_output_lane[0]),
-        "r"(__disable_output_lane[1]),
-        "r"(__disable_output_lane[2]),
-        "r"(__disable_output_lane[3]),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__kind == kind_f16 && __cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %8, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::f16 [%0], [%1], %2, %3, {%4, %5, %6, %7}, PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "r"(__a_tmem),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__disable_output_lane[0]),
-        "r"(__disable_output_lane[1]),
-        "r"(__disable_output_lane[2]),
-        "r"(__disable_output_lane[3]),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__kind == kind_tf32 && __cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %8, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::tf32 [%0], [%1], %2, %3, {%4, %5, %6, %7}, PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "r"(__a_tmem),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__disable_output_lane[0]),
-        "r"(__disable_output_lane[1]),
-        "r"(__disable_output_lane[2]),
-        "r"(__disable_output_lane[3]),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__kind == kind_tf32 && __cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %8, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::tf32 [%0], [%1], %2, %3, {%4, %5, %6, %7}, PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "r"(__a_tmem),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__disable_output_lane[0]),
-        "r"(__disable_output_lane[1]),
-        "r"(__disable_output_lane[2]),
-        "r"(__disable_output_lane[3]),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__kind == kind_f8f6f4 && __cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %8, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::f8f6f4 [%0], [%1], %2, %3, {%4, %5, %6, %7}, PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "r"(__a_tmem),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__disable_output_lane[0]),
-        "r"(__disable_output_lane[1]),
-        "r"(__disable_output_lane[2]),
-        "r"(__disable_output_lane[3]),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__kind == kind_f8f6f4 && __cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %8, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::f8f6f4 [%0], [%1], %2, %3, {%4, %5, %6, %7}, PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "r"(__a_tmem),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__disable_output_lane[0]),
-        "r"(__disable_output_lane[1]),
-        "r"(__disable_output_lane[2]),
-        "r"(__disable_output_lane[3]),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__kind == kind_i8 && __cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %8, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::i8 [%0], [%1], %2, %3, {%4, %5, %6, %7}, PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "r"(__a_tmem),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__disable_output_lane[0]),
-        "r"(__disable_output_lane[1]),
-        "r"(__disable_output_lane[2]),
-        "r"(__disable_output_lane[3]),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__kind == kind_i8 && __cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %8, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::i8 [%0], [%1], %2, %3, {%4, %5, %6, %7}, PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "r"(__a_tmem),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__disable_output_lane[0]),
-        "r"(__disable_output_lane[1]),
-        "r"(__disable_output_lane[2]),
-        "r"(__disable_output_lane[3]),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_tmem_a_is_not_supported_before_SM_100a_SM_101a__();
-#  endif
+  // __cta_group == cta_group_1 (due to parameter type constraint)
+  #if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL|| __CUDA_ARCH_FEAT_SM101_ALL
+    if constexpr (__kind == kind_f16) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %8, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::f16 [%0], [%1], %2, %3, {%4, %5, %6, %7}, PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "r"(__a_tmem),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__disable_output_lane[0]),
+          "r"(__disable_output_lane[1]),
+          "r"(__disable_output_lane[2]),
+          "r"(__disable_output_lane[3]),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_tf32) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %8, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::tf32 [%0], [%1], %2, %3, {%4, %5, %6, %7}, PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "r"(__a_tmem),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__disable_output_lane[0]),
+          "r"(__disable_output_lane[1]),
+          "r"(__disable_output_lane[2]),
+          "r"(__disable_output_lane[3]),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_f8f6f4) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %8, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::f8f6f4 [%0], [%1], %2, %3, {%4, %5, %6, %7}, PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "r"(__a_tmem),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__disable_output_lane[0]),
+          "r"(__disable_output_lane[1]),
+          "r"(__disable_output_lane[2]),
+          "r"(__disable_output_lane[3]),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_i8) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %8, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::i8 [%0], [%1], %2, %3, {%4, %5, %6, %7}, PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "r"(__a_tmem),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__disable_output_lane[0]),
+          "r"(__disable_output_lane[1]),
+          "r"(__disable_output_lane[2]),
+          "r"(__disable_output_lane[3]),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    }
+  #else
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_tcgen05_mma_tmem_a_is_not_supported_before_SM_100a_SM_101a__();
+  #endif
+}
+#endif // __cccl_ptx_isa >= 860
+
+/*
+// tcgen05.mma.cta_group.kind [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+// .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
+// .cta_group = { .cta_group::2 }
+template <cuda::ptx::dot_kind Kind>
+__device__ static inline void tcgen05_mma_tmem_a(
+  cuda::ptx::kind_t<Kind> kind,
+  cuda::ptx::cta_group_2_t,
+  uint32_t d_tmem,
+  uint32_t a_tmem,
+  uint64_t b_desc,
+  uint32_t idesc,
+  const uint32_t (&disable_output_lane)[8],
+  bool enable_input_d);
+*/
+#if __cccl_ptx_isa >= 860
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_tmem_a_is_not_supported_before_SM_100a_SM_101a__();
+template <dot_kind _Kind>
+_CCCL_DEVICE static inline void tcgen05_mma_tmem_a(
+  kind_t<_Kind> __kind,
+  cta_group_2_t,
+  _CUDA_VSTD::uint32_t __d_tmem,
+  _CUDA_VSTD::uint32_t __a_tmem,
+  _CUDA_VSTD::uint64_t __b_desc,
+  _CUDA_VSTD::uint32_t __idesc,
+  const _CUDA_VSTD::uint32_t (&__disable_output_lane)[8],
+  bool __enable_input_d)
+{
+  static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
+  // __cta_group == cta_group_2 (due to parameter type constraint)
+  #if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL|| __CUDA_ARCH_FEAT_SM101_ALL
+    if constexpr (__kind == kind_f16) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %12, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::f16 [%0], [%1], %2, %3, {%4, %5, %6, %7, %8, %9, %10, %11}, PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "r"(__a_tmem),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__disable_output_lane[0]),
+          "r"(__disable_output_lane[1]),
+          "r"(__disable_output_lane[2]),
+          "r"(__disable_output_lane[3]),
+          "r"(__disable_output_lane[4]),
+          "r"(__disable_output_lane[5]),
+          "r"(__disable_output_lane[6]),
+          "r"(__disable_output_lane[7]),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_tf32) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %12, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::tf32 [%0], [%1], %2, %3, {%4, %5, %6, %7, %8, %9, %10, %11}, PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "r"(__a_tmem),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__disable_output_lane[0]),
+          "r"(__disable_output_lane[1]),
+          "r"(__disable_output_lane[2]),
+          "r"(__disable_output_lane[3]),
+          "r"(__disable_output_lane[4]),
+          "r"(__disable_output_lane[5]),
+          "r"(__disable_output_lane[6]),
+          "r"(__disable_output_lane[7]),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_f8f6f4) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %12, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::f8f6f4 [%0], [%1], %2, %3, {%4, %5, %6, %7, %8, %9, %10, %11}, PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "r"(__a_tmem),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__disable_output_lane[0]),
+          "r"(__disable_output_lane[1]),
+          "r"(__disable_output_lane[2]),
+          "r"(__disable_output_lane[3]),
+          "r"(__disable_output_lane[4]),
+          "r"(__disable_output_lane[5]),
+          "r"(__disable_output_lane[6]),
+          "r"(__disable_output_lane[7]),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_i8) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %12, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::i8 [%0], [%1], %2, %3, {%4, %5, %6, %7, %8, %9, %10, %11}, PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "r"(__a_tmem),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__disable_output_lane[0]),
+          "r"(__disable_output_lane[1]),
+          "r"(__disable_output_lane[2]),
+          "r"(__disable_output_lane[3]),
+          "r"(__disable_output_lane[4]),
+          "r"(__disable_output_lane[5]),
+          "r"(__disable_output_lane[6]),
+          "r"(__disable_output_lane[7]),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    }
+  #else
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_tcgen05_mma_tmem_a_is_not_supported_before_SM_100a_SM_101a__();
+  #endif
 }
 #endif // __cccl_ptx_isa >= 860
 
@@ -915,75 +1089,72 @@ _CCCL_DEVICE static inline void tcgen05_mma_tmem_a(
 {
   static_assert(__kind == kind_f16 || __kind == kind_tf32, "");
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL
-  if constexpr (__kind == kind_f16 && __cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %4, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::f16 [%0], [%1], %2, %3, PRED_enable_input_d, %5;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "r"(__a_tmem),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d)),
-        "n"(__scale_input_d.value)
-      : "memory");
-  }
-  else if constexpr (__kind == kind_f16 && __cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %4, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::f16 [%0], [%1], %2, %3, PRED_enable_input_d, %5;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "r"(__a_tmem),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d)),
-        "n"(__scale_input_d.value)
-      : "memory");
-  }
-  else if constexpr (__kind == kind_tf32 && __cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %4, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::tf32 [%0], [%1], %2, %3, PRED_enable_input_d, %5;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "r"(__a_tmem),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d)),
-        "n"(__scale_input_d.value)
-      : "memory");
-  }
-  else if constexpr (__kind == kind_tf32 && __cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %4, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::tf32 [%0], [%1], %2, %3, PRED_enable_input_d, %5;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "r"(__a_tmem),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d)),
-        "n"(__scale_input_d.value)
-      : "memory");
-  }
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_tmem_a_is_not_supported_before_SM_100a__();
-#  endif
+  #if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL
+    if constexpr (__kind == kind_f16 && __cta_group == cta_group_1) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %4, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::f16 [%0], [%1], %2, %3, PRED_enable_input_d, %5;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "r"(__a_tmem),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d)),
+          "n"(__scale_input_d.value)
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_f16 && __cta_group == cta_group_2) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %4, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::f16 [%0], [%1], %2, %3, PRED_enable_input_d, %5;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "r"(__a_tmem),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d)),
+          "n"(__scale_input_d.value)
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_tf32 && __cta_group == cta_group_1) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %4, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::tf32 [%0], [%1], %2, %3, PRED_enable_input_d, %5;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "r"(__a_tmem),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d)),
+          "n"(__scale_input_d.value)
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_tf32 && __cta_group == cta_group_2) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %4, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::tf32 [%0], [%1], %2, %3, PRED_enable_input_d, %5;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "r"(__a_tmem),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d)),
+          "n"(__scale_input_d.value)
+        : "memory"
+      );
+    }
+  #else
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_tcgen05_mma_tmem_a_is_not_supported_before_SM_100a__();
+  #endif
 }
 #endif // __cccl_ptx_isa >= 860
 
@@ -1015,137 +1186,129 @@ _CCCL_DEVICE static inline void tcgen05_mma_tmem_a(
 {
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
-  if constexpr (__kind == kind_f16 && __cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %4, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::f16 [%0], [%1], %2, %3, PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "r"(__a_tmem),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__kind == kind_f16 && __cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %4, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::f16 [%0], [%1], %2, %3, PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "r"(__a_tmem),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__kind == kind_tf32 && __cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %4, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::tf32 [%0], [%1], %2, %3, PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "r"(__a_tmem),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__kind == kind_tf32 && __cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %4, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::tf32 [%0], [%1], %2, %3, PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "r"(__a_tmem),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__kind == kind_f8f6f4 && __cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %4, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::f8f6f4 [%0], [%1], %2, %3, PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "r"(__a_tmem),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__kind == kind_f8f6f4 && __cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %4, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::f8f6f4 [%0], [%1], %2, %3, PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "r"(__a_tmem),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__kind == kind_i8 && __cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %4, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::i8 [%0], [%1], %2, %3, PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "r"(__a_tmem),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__kind == kind_i8 && __cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %4, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::i8 [%0], [%1], %2, %3, PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "r"(__a_tmem),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_tmem_a_is_not_supported_before_SM_100a_SM_101a__();
-#  endif
+  #if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL|| __CUDA_ARCH_FEAT_SM101_ALL
+    if constexpr (__kind == kind_f16 && __cta_group == cta_group_1) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %4, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::f16 [%0], [%1], %2, %3, PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "r"(__a_tmem),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_f16 && __cta_group == cta_group_2) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %4, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::f16 [%0], [%1], %2, %3, PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "r"(__a_tmem),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_tf32 && __cta_group == cta_group_1) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %4, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::tf32 [%0], [%1], %2, %3, PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "r"(__a_tmem),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_tf32 && __cta_group == cta_group_2) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %4, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::tf32 [%0], [%1], %2, %3, PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "r"(__a_tmem),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_f8f6f4 && __cta_group == cta_group_1) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %4, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::f8f6f4 [%0], [%1], %2, %3, PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "r"(__a_tmem),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_f8f6f4 && __cta_group == cta_group_2) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %4, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::f8f6f4 [%0], [%1], %2, %3, PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "r"(__a_tmem),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_i8 && __cta_group == cta_group_1) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %4, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::i8 [%0], [%1], %2, %3, PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "r"(__a_tmem),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_i8 && __cta_group == cta_group_2) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %4, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::i8 [%0], [%1], %2, %3, PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "r"(__a_tmem),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    }
+  #else
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_tcgen05_mma_tmem_a_is_not_supported_before_SM_100a_SM_101a__();
+  #endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem],
-enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
 // .kind      = { .kind::mxf8f6f4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
@@ -1176,53 +1339,49 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x(
 {
   // __kind == kind_mxf8f6f4 (due to parameter type constraint)
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
-  if constexpr (__cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X [%0], %1, %2, %3, [%4], [%5], "
-      "PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X [%0], %1, %2, %3, [%4], [%5], "
-      "PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_1x_is_not_supported_before_SM_100a_SM_101a__();
-#  endif
+  #if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL|| __CUDA_ARCH_FEAT_SM101_ALL
+    if constexpr (__cta_group == cta_group_1) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__cta_group == cta_group_2) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    }
+  #else
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_tcgen05_mma_block_scale_vec_1x_is_not_supported_before_SM_100a_SM_101a__();
+  #endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem],
-enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
 // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -1253,89 +1412,81 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_2x(
 {
   static_assert(__kind == kind_mxf4 || __kind == kind_mxf4nvf4, "");
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
-  if constexpr (__kind == kind_mxf4 && __cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X [%0], %1, %2, %3, [%4], [%5], "
-      "PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__kind == kind_mxf4 && __cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X [%0], %1, %2, %3, [%4], [%5], "
-      "PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__kind == kind_mxf4nvf4 && __cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X [%0], %1, %2, %3, [%4], [%5], "
-      "PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__kind == kind_mxf4nvf4 && __cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X [%0], %1, %2, %3, [%4], [%5], "
-      "PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_2x_is_not_supported_before_SM_100a_SM_101a__();
-#  endif
+  #if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL|| __CUDA_ARCH_FEAT_SM101_ALL
+    if constexpr (__kind == kind_mxf4 && __cta_group == cta_group_1) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_mxf4 && __cta_group == cta_group_2) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_mxf4nvf4 && __cta_group == cta_group_1) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_mxf4nvf4 && __cta_group == cta_group_2) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    }
+  #else
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_tcgen05_mma_block_scale_vec_2x_is_not_supported_before_SM_100a_SM_101a__();
+  #endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem],
-enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
 // .kind      = { .kind::mxf4nvf4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
@@ -1366,53 +1517,49 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x(
 {
   // __kind == kind_mxf4nvf4 (due to parameter type constraint)
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
-  if constexpr (__cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X [%0], %1, %2, %3, [%4], [%5], "
-      "PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X [%0], %1, %2, %3, [%4], [%5], "
-      "PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_4x_is_not_supported_before_SM_100a_SM_101a__();
-#  endif
+  #if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL|| __CUDA_ARCH_FEAT_SM101_ALL
+    if constexpr (__cta_group == cta_group_1) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__cta_group == cta_group_2) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    }
+  #else
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_tcgen05_mma_block_scale_vec_4x_is_not_supported_before_SM_100a_SM_101a__();
+  #endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem],
-enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
 // .kind      = { .kind::mxf8f6f4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
@@ -1428,8 +1575,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_1x_tmem_a(
   bool enable_input_d);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_block_scale_vec_1x_tmem_a_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_block_scale_vec_1x_tmem_a_is_not_supported_before_SM_100a_SM_101a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x_tmem_a(
   kind_mxf8f6f4_t,
@@ -1444,53 +1590,49 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x_tmem_a(
 {
   // __kind == kind_mxf8f6f4 (due to parameter type constraint)
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
-  if constexpr (__cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X [%0], %1, %2, %3, [%4], [%5], "
-      "PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X [%0], %1, %2, %3, [%4], [%5], "
-      "PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_1x_tmem_a_is_not_supported_before_SM_100a_SM_101a__();
-#  endif
+  #if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL|| __CUDA_ARCH_FEAT_SM101_ALL
+    if constexpr (__cta_group == cta_group_1) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__cta_group == cta_group_2) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    }
+  #else
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_tcgen05_mma_block_scale_vec_1x_tmem_a_is_not_supported_before_SM_100a_SM_101a__();
+  #endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem],
-enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
 // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -1521,89 +1663,81 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_2_tmem_a(
 {
   static_assert(__kind == kind_mxf4 || __kind == kind_mxf4nvf4, "");
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
-  if constexpr (__kind == kind_mxf4 && __cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X [%0], %1, %2, %3, [%4], [%5], "
-      "PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__kind == kind_mxf4 && __cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X [%0], %1, %2, %3, [%4], [%5], "
-      "PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__kind == kind_mxf4nvf4 && __cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X [%0], %1, %2, %3, [%4], [%5], "
-      "PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__kind == kind_mxf4nvf4 && __cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X [%0], %1, %2, %3, [%4], [%5], "
-      "PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_2_tmem_a_is_not_supported_before_SM_100a_SM_101a__();
-#  endif
+  #if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL|| __CUDA_ARCH_FEAT_SM101_ALL
+    if constexpr (__kind == kind_mxf4 && __cta_group == cta_group_1) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_mxf4 && __cta_group == cta_group_2) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_mxf4nvf4 && __cta_group == cta_group_1) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_mxf4nvf4 && __cta_group == cta_group_2) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    }
+  #else
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_tcgen05_mma_block_scale_vec_2_tmem_a_is_not_supported_before_SM_100a_SM_101a__();
+  #endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem],
-enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
 // .kind      = { .kind::mxf4nvf4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
@@ -1619,8 +1753,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_4x_tmem_a(
   bool enable_input_d);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_block_scale_vec_4x_tmem_a_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_block_scale_vec_4x_tmem_a_is_not_supported_before_SM_100a_SM_101a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x_tmem_a(
   kind_mxf4nvf4_t,
@@ -1635,53 +1768,49 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x_tmem_a(
 {
   // __kind == kind_mxf4nvf4 (due to parameter type constraint)
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
-  if constexpr (__cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X [%0], %1, %2, %3, [%4], [%5], "
-      "PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X [%0], %1, %2, %3, [%4], [%5], "
-      "PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_4x_tmem_a_is_not_supported_before_SM_100a_SM_101a__();
-#  endif
+  #if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL|| __CUDA_ARCH_FEAT_SM101_ALL
+    if constexpr (__cta_group == cta_group_1) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__cta_group == cta_group_2) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    }
+  #else
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_tcgen05_mma_block_scale_vec_4x_tmem_a_is_not_supported_before_SM_100a_SM_101a__();
+  #endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X.collector::a::fill [d_tmem], a_desc, b_desc, idesc,
-[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
 // .kind      = { .kind::mxf8f6f4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
@@ -1697,8 +1826,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_1x_collector_a_fill(
   bool enable_input_d);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_block_scale_vec_1x_collector_a_fill_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_block_scale_vec_1x_collector_a_fill_is_not_supported_before_SM_100a_SM_101a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x_collector_a_fill(
   kind_mxf8f6f4_t,
@@ -1713,53 +1841,49 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x_collector_a_fill(
 {
   // __kind == kind_mxf8f6f4 (due to parameter type constraint)
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
-  if constexpr (__cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::fill [%0], %1, %2, %3, [%4], "
-      "[%5], PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::fill [%0], %1, %2, %3, [%4], "
-      "[%5], PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_1x_collector_a_fill_is_not_supported_before_SM_100a_SM_101a__();
-#  endif
+  #if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL|| __CUDA_ARCH_FEAT_SM101_ALL
+    if constexpr (__cta_group == cta_group_1) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::fill [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__cta_group == cta_group_2) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::fill [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    }
+  #else
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_tcgen05_mma_block_scale_vec_1x_collector_a_fill_is_not_supported_before_SM_100a_SM_101a__();
+  #endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc, b_desc, idesc,
-[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
 // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -1775,8 +1899,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_2x_collector_a_fill(
   bool enable_input_d);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_block_scale_vec_2x_collector_a_fill_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_block_scale_vec_2x_collector_a_fill_is_not_supported_before_SM_100a_SM_101a__();
 template <dot_kind _Kind, dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_2x_collector_a_fill(
   kind_t<_Kind> __kind,
@@ -1791,89 +1914,81 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_2x_collector_a_fill(
 {
   static_assert(__kind == kind_mxf4 || __kind == kind_mxf4nvf4, "");
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
-  if constexpr (__kind == kind_mxf4 && __cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::fill [%0], %1, %2, %3, [%4], [%5], "
-      "PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__kind == kind_mxf4 && __cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::fill [%0], %1, %2, %3, [%4], [%5], "
-      "PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__kind == kind_mxf4nvf4 && __cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::fill [%0], %1, %2, %3, [%4], "
-      "[%5], PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__kind == kind_mxf4nvf4 && __cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::fill [%0], %1, %2, %3, [%4], "
-      "[%5], PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_2x_collector_a_fill_is_not_supported_before_SM_100a_SM_101a__();
-#  endif
+  #if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL|| __CUDA_ARCH_FEAT_SM101_ALL
+    if constexpr (__kind == kind_mxf4 && __cta_group == cta_group_1) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::fill [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_mxf4 && __cta_group == cta_group_2) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::fill [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_mxf4nvf4 && __cta_group == cta_group_1) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::fill [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_mxf4nvf4 && __cta_group == cta_group_2) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::fill [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    }
+  #else
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_tcgen05_mma_block_scale_vec_2x_collector_a_fill_is_not_supported_before_SM_100a_SM_101a__();
+  #endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X.collector::a::fill [d_tmem], a_desc, b_desc, idesc,
-[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
 // .kind      = { .kind::mxf4nvf4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
@@ -1889,8 +2004,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_4x_collector_a_fill(
   bool enable_input_d);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_block_scale_vec_4x_collector_a_fill_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_block_scale_vec_4x_collector_a_fill_is_not_supported_before_SM_100a_SM_101a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x_collector_a_fill(
   kind_mxf4nvf4_t,
@@ -1905,53 +2019,49 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x_collector_a_fill(
 {
   // __kind == kind_mxf4nvf4 (due to parameter type constraint)
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
-  if constexpr (__cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::fill [%0], %1, %2, %3, [%4], "
-      "[%5], PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::fill [%0], %1, %2, %3, [%4], "
-      "[%5], PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_4x_collector_a_fill_is_not_supported_before_SM_100a_SM_101a__();
-#  endif
+  #if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL|| __CUDA_ARCH_FEAT_SM101_ALL
+    if constexpr (__cta_group == cta_group_1) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::fill [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__cta_group == cta_group_2) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::fill [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    }
+  #else
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_tcgen05_mma_block_scale_vec_4x_collector_a_fill_is_not_supported_before_SM_100a_SM_101a__();
+  #endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X.collector::a::fill [d_tmem], a_desc, b_desc, idesc,
-[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
 // .kind      = { .kind::mxf8f6f4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
@@ -1967,8 +2077,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_
   bool enable_input_d);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_fill_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_fill_is_not_supported_before_SM_100a_SM_101a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_fill(
   kind_mxf8f6f4_t,
@@ -1983,53 +2092,49 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x_tmem_a_collector_
 {
   // __kind == kind_mxf8f6f4 (due to parameter type constraint)
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
-  if constexpr (__cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::fill [%0], %1, %2, %3, [%4], "
-      "[%5], PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::fill [%0], %1, %2, %3, [%4], "
-      "[%5], PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_fill_is_not_supported_before_SM_100a_SM_101a__();
-#  endif
+  #if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL|| __CUDA_ARCH_FEAT_SM101_ALL
+    if constexpr (__cta_group == cta_group_1) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::fill [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__cta_group == cta_group_2) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::fill [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    }
+  #else
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_fill_is_not_supported_before_SM_100a_SM_101a__();
+  #endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc, b_desc, idesc,
-[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
 // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -2045,8 +2150,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_f
   bool enable_input_d);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_fill_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_fill_is_not_supported_before_SM_100a_SM_101a__();
 template <dot_kind _Kind, dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_fill(
   kind_t<_Kind> __kind,
@@ -2061,89 +2165,81 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_2_tmem_a_collector_a
 {
   static_assert(__kind == kind_mxf4 || __kind == kind_mxf4nvf4, "");
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
-  if constexpr (__kind == kind_mxf4 && __cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::fill [%0], %1, %2, %3, [%4], [%5], "
-      "PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__kind == kind_mxf4 && __cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::fill [%0], %1, %2, %3, [%4], [%5], "
-      "PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__kind == kind_mxf4nvf4 && __cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::fill [%0], %1, %2, %3, [%4], "
-      "[%5], PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__kind == kind_mxf4nvf4 && __cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::fill [%0], %1, %2, %3, [%4], "
-      "[%5], PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_fill_is_not_supported_before_SM_100a_SM_101a__();
-#  endif
+  #if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL|| __CUDA_ARCH_FEAT_SM101_ALL
+    if constexpr (__kind == kind_mxf4 && __cta_group == cta_group_1) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::fill [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_mxf4 && __cta_group == cta_group_2) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::fill [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_mxf4nvf4 && __cta_group == cta_group_1) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::fill [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_mxf4nvf4 && __cta_group == cta_group_2) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::fill [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    }
+  #else
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_fill_is_not_supported_before_SM_100a_SM_101a__();
+  #endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X.collector::a::fill [d_tmem], a_desc, b_desc, idesc,
-[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
 // .kind      = { .kind::mxf4nvf4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
@@ -2159,8 +2255,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_
   bool enable_input_d);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_fill_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_fill_is_not_supported_before_SM_100a_SM_101a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_fill(
   kind_mxf4nvf4_t,
@@ -2175,53 +2270,49 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x_tmem_a_collector_
 {
   // __kind == kind_mxf4nvf4 (due to parameter type constraint)
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
-  if constexpr (__cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::fill [%0], %1, %2, %3, [%4], "
-      "[%5], PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::fill [%0], %1, %2, %3, [%4], "
-      "[%5], PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_fill_is_not_supported_before_SM_100a_SM_101a__();
-#  endif
+  #if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL|| __CUDA_ARCH_FEAT_SM101_ALL
+    if constexpr (__cta_group == cta_group_1) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::fill [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__cta_group == cta_group_2) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::fill [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    }
+  #else
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_fill_is_not_supported_before_SM_100a_SM_101a__();
+  #endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X.collector::a::use [d_tmem], a_desc, b_desc, idesc,
-[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
 // .kind      = { .kind::mxf8f6f4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
@@ -2237,8 +2328,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_1x_collector_a_use(
   bool enable_input_d);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_block_scale_vec_1x_collector_a_use_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_block_scale_vec_1x_collector_a_use_is_not_supported_before_SM_100a_SM_101a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x_collector_a_use(
   kind_mxf8f6f4_t,
@@ -2253,53 +2343,49 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x_collector_a_use(
 {
   // __kind == kind_mxf8f6f4 (due to parameter type constraint)
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
-  if constexpr (__cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::use [%0], %1, %2, %3, [%4], "
-      "[%5], PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::use [%0], %1, %2, %3, [%4], "
-      "[%5], PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_1x_collector_a_use_is_not_supported_before_SM_100a_SM_101a__();
-#  endif
+  #if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL|| __CUDA_ARCH_FEAT_SM101_ALL
+    if constexpr (__cta_group == cta_group_1) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::use [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__cta_group == cta_group_2) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::use [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    }
+  #else
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_tcgen05_mma_block_scale_vec_1x_collector_a_use_is_not_supported_before_SM_100a_SM_101a__();
+  #endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc, idesc,
-[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
 // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -2315,8 +2401,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_2x_collector_a_use(
   bool enable_input_d);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_block_scale_vec_2x_collector_a_use_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_block_scale_vec_2x_collector_a_use_is_not_supported_before_SM_100a_SM_101a__();
 template <dot_kind _Kind, dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_2x_collector_a_use(
   kind_t<_Kind> __kind,
@@ -2331,89 +2416,81 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_2x_collector_a_use(
 {
   static_assert(__kind == kind_mxf4 || __kind == kind_mxf4nvf4, "");
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
-  if constexpr (__kind == kind_mxf4 && __cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::use [%0], %1, %2, %3, [%4], [%5], "
-      "PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__kind == kind_mxf4 && __cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::use [%0], %1, %2, %3, [%4], [%5], "
-      "PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__kind == kind_mxf4nvf4 && __cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::use [%0], %1, %2, %3, [%4], "
-      "[%5], PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__kind == kind_mxf4nvf4 && __cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::use [%0], %1, %2, %3, [%4], "
-      "[%5], PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_2x_collector_a_use_is_not_supported_before_SM_100a_SM_101a__();
-#  endif
+  #if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL|| __CUDA_ARCH_FEAT_SM101_ALL
+    if constexpr (__kind == kind_mxf4 && __cta_group == cta_group_1) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::use [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_mxf4 && __cta_group == cta_group_2) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::use [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_mxf4nvf4 && __cta_group == cta_group_1) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::use [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_mxf4nvf4 && __cta_group == cta_group_2) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::use [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    }
+  #else
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_tcgen05_mma_block_scale_vec_2x_collector_a_use_is_not_supported_before_SM_100a_SM_101a__();
+  #endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X.collector::a::use [d_tmem], a_desc, b_desc, idesc,
-[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
 // .kind      = { .kind::mxf4nvf4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
@@ -2429,8 +2506,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_4x_collector_a_use(
   bool enable_input_d);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_block_scale_vec_4x_collector_a_use_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_block_scale_vec_4x_collector_a_use_is_not_supported_before_SM_100a_SM_101a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x_collector_a_use(
   kind_mxf4nvf4_t,
@@ -2445,53 +2521,49 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x_collector_a_use(
 {
   // __kind == kind_mxf4nvf4 (due to parameter type constraint)
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
-  if constexpr (__cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::use [%0], %1, %2, %3, [%4], "
-      "[%5], PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::use [%0], %1, %2, %3, [%4], "
-      "[%5], PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_4x_collector_a_use_is_not_supported_before_SM_100a_SM_101a__();
-#  endif
+  #if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL|| __CUDA_ARCH_FEAT_SM101_ALL
+    if constexpr (__cta_group == cta_group_1) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::use [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__cta_group == cta_group_2) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::use [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    }
+  #else
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_tcgen05_mma_block_scale_vec_4x_collector_a_use_is_not_supported_before_SM_100a_SM_101a__();
+  #endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X.collector::a::use [d_tmem], a_desc, b_desc, idesc,
-[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
 // .kind      = { .kind::mxf8f6f4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
@@ -2507,8 +2579,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_
   bool enable_input_d);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_use_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_use_is_not_supported_before_SM_100a_SM_101a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_use(
   kind_mxf8f6f4_t,
@@ -2523,53 +2594,49 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x_tmem_a_collector_
 {
   // __kind == kind_mxf8f6f4 (due to parameter type constraint)
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
-  if constexpr (__cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::use [%0], %1, %2, %3, [%4], "
-      "[%5], PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::use [%0], %1, %2, %3, [%4], "
-      "[%5], PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_use_is_not_supported_before_SM_100a_SM_101a__();
-#  endif
+  #if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL|| __CUDA_ARCH_FEAT_SM101_ALL
+    if constexpr (__cta_group == cta_group_1) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::use [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__cta_group == cta_group_2) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::use [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    }
+  #else
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_use_is_not_supported_before_SM_100a_SM_101a__();
+  #endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc, idesc,
-[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
 // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -2585,8 +2652,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_u
   bool enable_input_d);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_use_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_use_is_not_supported_before_SM_100a_SM_101a__();
 template <dot_kind _Kind, dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_use(
   kind_t<_Kind> __kind,
@@ -2601,89 +2667,81 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_2_tmem_a_collector_a
 {
   static_assert(__kind == kind_mxf4 || __kind == kind_mxf4nvf4, "");
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
-  if constexpr (__kind == kind_mxf4 && __cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::use [%0], %1, %2, %3, [%4], [%5], "
-      "PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__kind == kind_mxf4 && __cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::use [%0], %1, %2, %3, [%4], [%5], "
-      "PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__kind == kind_mxf4nvf4 && __cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::use [%0], %1, %2, %3, [%4], "
-      "[%5], PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__kind == kind_mxf4nvf4 && __cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::use [%0], %1, %2, %3, [%4], "
-      "[%5], PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_use_is_not_supported_before_SM_100a_SM_101a__();
-#  endif
+  #if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL|| __CUDA_ARCH_FEAT_SM101_ALL
+    if constexpr (__kind == kind_mxf4 && __cta_group == cta_group_1) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::use [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_mxf4 && __cta_group == cta_group_2) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::use [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_mxf4nvf4 && __cta_group == cta_group_1) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::use [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_mxf4nvf4 && __cta_group == cta_group_2) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::use [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    }
+  #else
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_use_is_not_supported_before_SM_100a_SM_101a__();
+  #endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X.collector::a::use [d_tmem], a_desc, b_desc, idesc,
-[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
 // .kind      = { .kind::mxf4nvf4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
@@ -2699,8 +2757,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_
   bool enable_input_d);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_use_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_use_is_not_supported_before_SM_100a_SM_101a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_use(
   kind_mxf4nvf4_t,
@@ -2715,53 +2772,49 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x_tmem_a_collector_
 {
   // __kind == kind_mxf4nvf4 (due to parameter type constraint)
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
-  if constexpr (__cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::use [%0], %1, %2, %3, [%4], "
-      "[%5], PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::use [%0], %1, %2, %3, [%4], "
-      "[%5], PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_use_is_not_supported_before_SM_100a_SM_101a__();
-#  endif
+  #if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL|| __CUDA_ARCH_FEAT_SM101_ALL
+    if constexpr (__cta_group == cta_group_1) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::use [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__cta_group == cta_group_2) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::use [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    }
+  #else
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_use_is_not_supported_before_SM_100a_SM_101a__();
+  #endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc,
-[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
 // .kind      = { .kind::mxf8f6f4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
@@ -2777,8 +2830,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_1x_collector_a_lastuse
   bool enable_input_d);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_block_scale_vec_1x_collector_a_lastuse_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_block_scale_vec_1x_collector_a_lastuse_is_not_supported_before_SM_100a_SM_101a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x_collector_a_lastuse(
   kind_mxf8f6f4_t,
@@ -2793,53 +2845,49 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x_collector_a_lastu
 {
   // __kind == kind_mxf8f6f4 (due to parameter type constraint)
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
-  if constexpr (__cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::lastuse [%0], %1, %2, %3, [%4], "
-      "[%5], PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::lastuse [%0], %1, %2, %3, [%4], "
-      "[%5], PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_1x_collector_a_lastuse_is_not_supported_before_SM_100a_SM_101a__();
-#  endif
+  #if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL|| __CUDA_ARCH_FEAT_SM101_ALL
+    if constexpr (__cta_group == cta_group_1) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::lastuse [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__cta_group == cta_group_2) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::lastuse [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    }
+  #else
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_tcgen05_mma_block_scale_vec_1x_collector_a_lastuse_is_not_supported_before_SM_100a_SM_101a__();
+  #endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc,
-[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
 // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -2855,8 +2903,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_2x_collector_a_lastuse
   bool enable_input_d);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_block_scale_vec_2x_collector_a_lastuse_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_block_scale_vec_2x_collector_a_lastuse_is_not_supported_before_SM_100a_SM_101a__();
 template <dot_kind _Kind, dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_2x_collector_a_lastuse(
   kind_t<_Kind> __kind,
@@ -2871,89 +2918,81 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_2x_collector_a_lastu
 {
   static_assert(__kind == kind_mxf4 || __kind == kind_mxf4nvf4, "");
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
-  if constexpr (__kind == kind_mxf4 && __cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::lastuse [%0], %1, %2, %3, [%4], "
-      "[%5], PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__kind == kind_mxf4 && __cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::lastuse [%0], %1, %2, %3, [%4], "
-      "[%5], PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__kind == kind_mxf4nvf4 && __cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::lastuse [%0], %1, %2, %3, [%4], "
-      "[%5], PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__kind == kind_mxf4nvf4 && __cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::lastuse [%0], %1, %2, %3, [%4], "
-      "[%5], PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_2x_collector_a_lastuse_is_not_supported_before_SM_100a_SM_101a__();
-#  endif
+  #if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL|| __CUDA_ARCH_FEAT_SM101_ALL
+    if constexpr (__kind == kind_mxf4 && __cta_group == cta_group_1) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::lastuse [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_mxf4 && __cta_group == cta_group_2) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::lastuse [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_mxf4nvf4 && __cta_group == cta_group_1) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::lastuse [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_mxf4nvf4 && __cta_group == cta_group_2) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::lastuse [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    }
+  #else
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_tcgen05_mma_block_scale_vec_2x_collector_a_lastuse_is_not_supported_before_SM_100a_SM_101a__();
+  #endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc,
-[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
 // .kind      = { .kind::mxf4nvf4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
@@ -2969,8 +3008,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_4x_collector_a_lastuse
   bool enable_input_d);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_block_scale_vec_4x_collector_a_lastuse_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_block_scale_vec_4x_collector_a_lastuse_is_not_supported_before_SM_100a_SM_101a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x_collector_a_lastuse(
   kind_mxf4nvf4_t,
@@ -2985,53 +3023,49 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x_collector_a_lastu
 {
   // __kind == kind_mxf4nvf4 (due to parameter type constraint)
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
-  if constexpr (__cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::lastuse [%0], %1, %2, %3, [%4], "
-      "[%5], PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::lastuse [%0], %1, %2, %3, [%4], "
-      "[%5], PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_4x_collector_a_lastuse_is_not_supported_before_SM_100a_SM_101a__();
-#  endif
+  #if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL|| __CUDA_ARCH_FEAT_SM101_ALL
+    if constexpr (__cta_group == cta_group_1) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::lastuse [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__cta_group == cta_group_2) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::lastuse [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    }
+  #else
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_tcgen05_mma_block_scale_vec_4x_collector_a_lastuse_is_not_supported_before_SM_100a_SM_101a__();
+  #endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc,
-[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
 // .kind      = { .kind::mxf8f6f4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
@@ -3047,8 +3081,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_
   bool enable_input_d);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_lastuse_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_lastuse_is_not_supported_before_SM_100a_SM_101a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_lastuse(
   kind_mxf8f6f4_t,
@@ -3063,53 +3096,49 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x_tmem_a_collector_
 {
   // __kind == kind_mxf8f6f4 (due to parameter type constraint)
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
-  if constexpr (__cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::lastuse [%0], %1, %2, %3, [%4], "
-      "[%5], PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::lastuse [%0], %1, %2, %3, [%4], "
-      "[%5], PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_lastuse_is_not_supported_before_SM_100a_SM_101a__();
-#  endif
+  #if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL|| __CUDA_ARCH_FEAT_SM101_ALL
+    if constexpr (__cta_group == cta_group_1) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::lastuse [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__cta_group == cta_group_2) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::lastuse [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    }
+  #else
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_lastuse_is_not_supported_before_SM_100a_SM_101a__();
+  #endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc,
-[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
 // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -3125,8 +3154,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_l
   bool enable_input_d);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_lastuse_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_lastuse_is_not_supported_before_SM_100a_SM_101a__();
 template <dot_kind _Kind, dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_lastuse(
   kind_t<_Kind> __kind,
@@ -3141,89 +3169,81 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_2_tmem_a_collector_a
 {
   static_assert(__kind == kind_mxf4 || __kind == kind_mxf4nvf4, "");
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
-  if constexpr (__kind == kind_mxf4 && __cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::lastuse [%0], %1, %2, %3, [%4], "
-      "[%5], PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__kind == kind_mxf4 && __cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::lastuse [%0], %1, %2, %3, [%4], "
-      "[%5], PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__kind == kind_mxf4nvf4 && __cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::lastuse [%0], %1, %2, %3, [%4], "
-      "[%5], PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__kind == kind_mxf4nvf4 && __cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::lastuse [%0], %1, %2, %3, [%4], "
-      "[%5], PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_lastuse_is_not_supported_before_SM_100a_SM_101a__();
-#  endif
+  #if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL|| __CUDA_ARCH_FEAT_SM101_ALL
+    if constexpr (__kind == kind_mxf4 && __cta_group == cta_group_1) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::lastuse [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_mxf4 && __cta_group == cta_group_2) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::lastuse [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_mxf4nvf4 && __cta_group == cta_group_1) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::lastuse [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_mxf4nvf4 && __cta_group == cta_group_2) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::lastuse [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    }
+  #else
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_lastuse_is_not_supported_before_SM_100a_SM_101a__();
+  #endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc,
-[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
 // .kind      = { .kind::mxf4nvf4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
@@ -3239,8 +3259,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_
   bool enable_input_d);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_lastuse_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_lastuse_is_not_supported_before_SM_100a_SM_101a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_lastuse(
   kind_mxf4nvf4_t,
@@ -3255,53 +3274,49 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x_tmem_a_collector_
 {
   // __kind == kind_mxf4nvf4 (due to parameter type constraint)
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
-  if constexpr (__cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::lastuse [%0], %1, %2, %3, [%4], "
-      "[%5], PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::lastuse [%0], %1, %2, %3, [%4], "
-      "[%5], PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_lastuse_is_not_supported_before_SM_100a_SM_101a__();
-#  endif
+  #if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL|| __CUDA_ARCH_FEAT_SM101_ALL
+    if constexpr (__cta_group == cta_group_1) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::lastuse [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__cta_group == cta_group_2) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::lastuse [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    }
+  #else
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_lastuse_is_not_supported_before_SM_100a_SM_101a__();
+  #endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X.collector::a::discard [d_tmem], a_desc, b_desc, idesc,
-[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
 // .kind      = { .kind::mxf8f6f4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
@@ -3317,8 +3332,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_1x_collector_a_discard
   bool enable_input_d);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_block_scale_vec_1x_collector_a_discard_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_block_scale_vec_1x_collector_a_discard_is_not_supported_before_SM_100a_SM_101a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x_collector_a_discard(
   kind_mxf8f6f4_t,
@@ -3333,53 +3347,49 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x_collector_a_disca
 {
   // __kind == kind_mxf8f6f4 (due to parameter type constraint)
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
-  if constexpr (__cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::discard [%0], %1, %2, %3, [%4], "
-      "[%5], PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::discard [%0], %1, %2, %3, [%4], "
-      "[%5], PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_1x_collector_a_discard_is_not_supported_before_SM_100a_SM_101a__();
-#  endif
+  #if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL|| __CUDA_ARCH_FEAT_SM101_ALL
+    if constexpr (__cta_group == cta_group_1) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::discard [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__cta_group == cta_group_2) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::discard [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    }
+  #else
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_tcgen05_mma_block_scale_vec_1x_collector_a_discard_is_not_supported_before_SM_100a_SM_101a__();
+  #endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc, b_desc, idesc,
-[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
 // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -3395,8 +3405,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_2x_collector_a_discard
   bool enable_input_d);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_block_scale_vec_2x_collector_a_discard_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_block_scale_vec_2x_collector_a_discard_is_not_supported_before_SM_100a_SM_101a__();
 template <dot_kind _Kind, dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_2x_collector_a_discard(
   kind_t<_Kind> __kind,
@@ -3411,89 +3420,81 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_2x_collector_a_disca
 {
   static_assert(__kind == kind_mxf4 || __kind == kind_mxf4nvf4, "");
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
-  if constexpr (__kind == kind_mxf4 && __cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::discard [%0], %1, %2, %3, [%4], "
-      "[%5], PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__kind == kind_mxf4 && __cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::discard [%0], %1, %2, %3, [%4], "
-      "[%5], PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__kind == kind_mxf4nvf4 && __cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::discard [%0], %1, %2, %3, [%4], "
-      "[%5], PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__kind == kind_mxf4nvf4 && __cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::discard [%0], %1, %2, %3, [%4], "
-      "[%5], PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_2x_collector_a_discard_is_not_supported_before_SM_100a_SM_101a__();
-#  endif
+  #if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL|| __CUDA_ARCH_FEAT_SM101_ALL
+    if constexpr (__kind == kind_mxf4 && __cta_group == cta_group_1) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::discard [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_mxf4 && __cta_group == cta_group_2) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::discard [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_mxf4nvf4 && __cta_group == cta_group_1) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::discard [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_mxf4nvf4 && __cta_group == cta_group_2) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::discard [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    }
+  #else
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_tcgen05_mma_block_scale_vec_2x_collector_a_discard_is_not_supported_before_SM_100a_SM_101a__();
+  #endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X.collector::a::discard [d_tmem], a_desc, b_desc, idesc,
-[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
 // .kind      = { .kind::mxf4nvf4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
@@ -3509,8 +3510,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_4x_collector_a_discard
   bool enable_input_d);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_block_scale_vec_4x_collector_a_discard_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_block_scale_vec_4x_collector_a_discard_is_not_supported_before_SM_100a_SM_101a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x_collector_a_discard(
   kind_mxf4nvf4_t,
@@ -3525,53 +3525,49 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x_collector_a_disca
 {
   // __kind == kind_mxf4nvf4 (due to parameter type constraint)
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
-  if constexpr (__cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::discard [%0], %1, %2, %3, [%4], "
-      "[%5], PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::discard [%0], %1, %2, %3, [%4], "
-      "[%5], PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_4x_collector_a_discard_is_not_supported_before_SM_100a_SM_101a__();
-#  endif
+  #if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL|| __CUDA_ARCH_FEAT_SM101_ALL
+    if constexpr (__cta_group == cta_group_1) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::discard [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__cta_group == cta_group_2) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::discard [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    }
+  #else
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_tcgen05_mma_block_scale_vec_4x_collector_a_discard_is_not_supported_before_SM_100a_SM_101a__();
+  #endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X.collector::a::discard [d_tmem], a_desc, b_desc, idesc,
-[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
 // .kind      = { .kind::mxf8f6f4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
@@ -3587,8 +3583,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_
   bool enable_input_d);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_discard_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_discard_is_not_supported_before_SM_100a_SM_101a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_discard(
   kind_mxf8f6f4_t,
@@ -3603,53 +3598,49 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x_tmem_a_collector_
 {
   // __kind == kind_mxf8f6f4 (due to parameter type constraint)
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
-  if constexpr (__cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::discard [%0], %1, %2, %3, [%4], "
-      "[%5], PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::discard [%0], %1, %2, %3, [%4], "
-      "[%5], PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_discard_is_not_supported_before_SM_100a_SM_101a__();
-#  endif
+  #if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL|| __CUDA_ARCH_FEAT_SM101_ALL
+    if constexpr (__cta_group == cta_group_1) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::discard [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__cta_group == cta_group_2) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::discard [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    }
+  #else
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_discard_is_not_supported_before_SM_100a_SM_101a__();
+  #endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc, b_desc, idesc,
-[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
 // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -3665,8 +3656,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_d
   bool enable_input_d);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_discard_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_discard_is_not_supported_before_SM_100a_SM_101a__();
 template <dot_kind _Kind, dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_discard(
   kind_t<_Kind> __kind,
@@ -3681,89 +3671,81 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_2_tmem_a_collector_a
 {
   static_assert(__kind == kind_mxf4 || __kind == kind_mxf4nvf4, "");
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
-  if constexpr (__kind == kind_mxf4 && __cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::discard [%0], %1, %2, %3, [%4], "
-      "[%5], PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__kind == kind_mxf4 && __cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::discard [%0], %1, %2, %3, [%4], "
-      "[%5], PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__kind == kind_mxf4nvf4 && __cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::discard [%0], %1, %2, %3, [%4], "
-      "[%5], PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__kind == kind_mxf4nvf4 && __cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::discard [%0], %1, %2, %3, [%4], "
-      "[%5], PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_discard_is_not_supported_before_SM_100a_SM_101a__();
-#  endif
+  #if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL|| __CUDA_ARCH_FEAT_SM101_ALL
+    if constexpr (__kind == kind_mxf4 && __cta_group == cta_group_1) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::discard [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_mxf4 && __cta_group == cta_group_2) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::discard [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_mxf4nvf4 && __cta_group == cta_group_1) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::discard [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__kind == kind_mxf4nvf4 && __cta_group == cta_group_2) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::discard [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    }
+  #else
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_discard_is_not_supported_before_SM_100a_SM_101a__();
+  #endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X.collector::a::discard [d_tmem], a_desc, b_desc, idesc,
-[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
 // .kind      = { .kind::mxf4nvf4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
@@ -3779,8 +3761,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_
   bool enable_input_d);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_discard_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_discard_is_not_supported_before_SM_100a_SM_101a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_discard(
   kind_mxf4nvf4_t,
@@ -3795,47 +3776,44 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x_tmem_a_collector_
 {
   // __kind == kind_mxf4nvf4 (due to parameter type constraint)
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
-  if constexpr (__cta_group == cta_group_1)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::discard [%0], %1, %2, %3, [%4], "
-      "[%5], PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-  else if constexpr (__cta_group == cta_group_2)
-  {
-    asm volatile(
-      "{\n\t .reg .pred PRED_enable_input_d; \n\t"
-      "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
-      "tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::discard [%0], %1, %2, %3, [%4], "
-      "[%5], PRED_enable_input_d;\n\t"
-      "}"
-      :
-      : "r"(__d_tmem),
-        "l"(__a_desc),
-        "l"(__b_desc),
-        "r"(__idesc),
-        "r"(__scale_A_tmem),
-        "r"(__scale_B_tmem),
-        "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
-      : "memory");
-  }
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_discard_is_not_supported_before_SM_100a_SM_101a__();
-#  endif
+  #if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL|| __CUDA_ARCH_FEAT_SM101_ALL
+    if constexpr (__cta_group == cta_group_1) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::discard [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    } else if constexpr (__cta_group == cta_group_2) {
+      asm volatile (
+        "{\n\t .reg .pred PRED_enable_input_d; \n\t"
+        "setp.ne.b32 PRED_enable_input_d, %6, 0;\n\t"
+        "tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::discard [%0], %1, %2, %3, [%4], [%5], PRED_enable_input_d;\n\t"
+        "}"
+        :
+        : "r"(__d_tmem),
+          "l"(__a_desc),
+          "l"(__b_desc),
+          "r"(__idesc),
+          "r"(__scale_A_tmem),
+          "r"(__scale_B_tmem),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__enable_input_d))
+        : "memory"
+      );
+    }
+  #else
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_discard_is_not_supported_before_SM_100a_SM_101a__();
+  #endif
 }
 #endif // __cccl_ptx_isa >= 860
 

--- a/libcudacxx/include/cuda/__ptx/ptx_dot_variants.h
+++ b/libcudacxx/include/cuda/__ptx/ptx_dot_variants.h
@@ -195,7 +195,7 @@ static constexpr op_exch_t op_exch{};
 template <dot_cta_group __cta_group>
 using cta_group_t   = _CUDA_VSTD::integral_constant<dot_cta_group, __cta_group>;
 using cta_group_1_t = cta_group_t<dot_cta_group::cta_group_1>;
-using cta_group_2_t = cta_group_t<dot_cta_group::cta_group_1>;
+using cta_group_2_t = cta_group_t<dot_cta_group::cta_group_2>;
 
 static constexpr cta_group_1_t cta_group_1{};
 static constexpr cta_group_2_t cta_group_2{};

--- a/libcudacxx/test/libcudacxx/cuda/ptx/generated/tcgen05_mma.h
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/generated/tcgen05_mma.h
@@ -1,5 +1,5 @@
 // This file was automatically generated. Do not edit.
-
+            
 // We use a special strategy to force the generation of the PTX. This is mainly
 // a fight against dead-code-elimination in the NVVM layer.
 //
@@ -14,2915 +14,766 @@
 // Because `fn_ptr` is possibly visible outside this translation unit, the
 // compiler must compile all the functions which are stored.
 
-__global__ void test_tcgen05_mma(void** fn_ptr)
-{
+__global__ void test_tcgen05_mma(void ** fn_ptr) {
 #if __cccl_ptx_isa >= 860
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::f16 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d,
-        // scale_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f16_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               const uint32_t(&)[4],
-                               bool,
-                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma));
-          // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d,
-          // scale_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_f16_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   const uint32_t(&)[4],
-                                   bool,
-                                   cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma));
-          // tcgen05.mma.cta_group::1.kind::tf32 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d,
-          // scale_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_tf32_t,
-                                   cuda::ptx::cta_group_1_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   const uint32_t(&)[4],
-                                   bool,
-                                   cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma));
-          // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d,
-          // scale_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_tf32_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   const uint32_t(&)[4],
-                                   bool,
-                                   cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma));));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_100a, (
+    // tcgen05.mma.cta_group::1.kind::f16 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d, scale_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_f16_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , const uint32_t (&)[4], bool , cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma));
+    // tcgen05.mma.cta_group::1.kind::tf32 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d, scale_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_tf32_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , const uint32_t (&)[4], bool , cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma));
+  ));
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 860
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::f16 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f16_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               const uint32_t(&)[4],
-                               bool)>(cuda::ptx::tcgen05_mma));
-          // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_f16_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   const uint32_t(&)[4],
-                                   bool)>(cuda::ptx::tcgen05_mma));
-          // tcgen05.mma.cta_group::1.kind::tf32 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_tf32_t,
-                                   cuda::ptx::cta_group_1_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   const uint32_t(&)[4],
-                                   bool)>(cuda::ptx::tcgen05_mma));
-          // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_tf32_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   const uint32_t(&)[4],
-                                   bool)>(cuda::ptx::tcgen05_mma));
-          // tcgen05.mma.cta_group::1.kind::f8f6f4 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_f8f6f4_t,
-                                   cuda::ptx::cta_group_1_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   const uint32_t(&)[4],
-                                   bool)>(cuda::ptx::tcgen05_mma));
-          // tcgen05.mma.cta_group::2.kind::f8f6f4 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_f8f6f4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   const uint32_t(&)[4],
-                                   bool)>(cuda::ptx::tcgen05_mma));
-          // tcgen05.mma.cta_group::1.kind::i8 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_i8_t,
-                                   cuda::ptx::cta_group_1_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   const uint32_t(&)[4],
-                                   bool)>(cuda::ptx::tcgen05_mma));
-          // tcgen05.mma.cta_group::2.kind::i8 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_i8_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   const uint32_t(&)[4],
-                                   bool)>(cuda::ptx::tcgen05_mma));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
-    (
-        // tcgen05.mma.cta_group::1.kind::f16 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f16_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               const uint32_t(&)[4],
-                               bool)>(cuda::ptx::tcgen05_mma));
-          // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_f16_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   const uint32_t(&)[4],
-                                   bool)>(cuda::ptx::tcgen05_mma));
-          // tcgen05.mma.cta_group::1.kind::tf32 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_tf32_t,
-                                   cuda::ptx::cta_group_1_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   const uint32_t(&)[4],
-                                   bool)>(cuda::ptx::tcgen05_mma));
-          // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_tf32_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   const uint32_t(&)[4],
-                                   bool)>(cuda::ptx::tcgen05_mma));
-          // tcgen05.mma.cta_group::1.kind::f8f6f4 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_f8f6f4_t,
-                                   cuda::ptx::cta_group_1_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   const uint32_t(&)[4],
-                                   bool)>(cuda::ptx::tcgen05_mma));
-          // tcgen05.mma.cta_group::2.kind::f8f6f4 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_f8f6f4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   const uint32_t(&)[4],
-                                   bool)>(cuda::ptx::tcgen05_mma));
-          // tcgen05.mma.cta_group::1.kind::i8 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_i8_t,
-                                   cuda::ptx::cta_group_1_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   const uint32_t(&)[4],
-                                   bool)>(cuda::ptx::tcgen05_mma));
-          // tcgen05.mma.cta_group::2.kind::i8 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_i8_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   const uint32_t(&)[4],
-                                   bool)>(cuda::ptx::tcgen05_mma));));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_100a, (
+    // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d, scale_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_f16_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , const uint32_t (&)[8], bool , cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma));
+    // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d, scale_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_tf32_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , const uint32_t (&)[8], bool , cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma));
+  ));
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 860
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::f16 [d_tmem], a_desc, b_desc, idesc, enable_input_d, scale_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f16_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               bool,
-                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma));
-          // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], a_desc, b_desc, idesc, enable_input_d, scale_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_f16_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   bool,
-                                   cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma));
-          // tcgen05.mma.cta_group::1.kind::tf32 [d_tmem], a_desc, b_desc, idesc, enable_input_d, scale_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_tf32_t,
-                                   cuda::ptx::cta_group_1_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   bool,
-                                   cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma));
-          // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], a_desc, b_desc, idesc, enable_input_d, scale_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_tf32_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   bool,
-                                   cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma));));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_100a, (
+    // tcgen05.mma.cta_group::1.kind::f16 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_f16_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , const uint32_t (&)[4], bool )>(cuda::ptx::tcgen05_mma));
+    // tcgen05.mma.cta_group::1.kind::tf32 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_tf32_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , const uint32_t (&)[4], bool )>(cuda::ptx::tcgen05_mma));
+    // tcgen05.mma.cta_group::1.kind::f8f6f4 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_f8f6f4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , const uint32_t (&)[4], bool )>(cuda::ptx::tcgen05_mma));
+    // tcgen05.mma.cta_group::1.kind::i8 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_i8_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , const uint32_t (&)[4], bool )>(cuda::ptx::tcgen05_mma));
+  ));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a, (
+    // tcgen05.mma.cta_group::1.kind::f16 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_f16_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , const uint32_t (&)[4], bool )>(cuda::ptx::tcgen05_mma));
+    // tcgen05.mma.cta_group::1.kind::tf32 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_tf32_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , const uint32_t (&)[4], bool )>(cuda::ptx::tcgen05_mma));
+    // tcgen05.mma.cta_group::1.kind::f8f6f4 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_f8f6f4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , const uint32_t (&)[4], bool )>(cuda::ptx::tcgen05_mma));
+    // tcgen05.mma.cta_group::1.kind::i8 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_i8_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , const uint32_t (&)[4], bool )>(cuda::ptx::tcgen05_mma));
+  ));
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 860
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::f16 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(
-            cuda::ptx::kind_f16_t, cuda::ptx::cta_group_1_t, uint32_t, uint64_t, uint64_t, uint32_t, bool)>(
-            cuda::ptx::tcgen05_mma));
-          // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(
-                cuda::ptx::kind_f16_t, cuda::ptx::cta_group_2_t, uint32_t, uint64_t, uint64_t, uint32_t, bool)>(
-                cuda::ptx::tcgen05_mma));
-          // tcgen05.mma.cta_group::1.kind::tf32 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(
-                cuda::ptx::kind_tf32_t, cuda::ptx::cta_group_1_t, uint32_t, uint64_t, uint64_t, uint32_t, bool)>(
-                cuda::ptx::tcgen05_mma));
-          // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(
-                cuda::ptx::kind_tf32_t, cuda::ptx::cta_group_2_t, uint32_t, uint64_t, uint64_t, uint32_t, bool)>(
-                cuda::ptx::tcgen05_mma));
-          // tcgen05.mma.cta_group::1.kind::f8f6f4 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(
-                cuda::ptx::kind_f8f6f4_t, cuda::ptx::cta_group_1_t, uint32_t, uint64_t, uint64_t, uint32_t, bool)>(
-                cuda::ptx::tcgen05_mma));
-          // tcgen05.mma.cta_group::2.kind::f8f6f4 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(
-                cuda::ptx::kind_f8f6f4_t, cuda::ptx::cta_group_2_t, uint32_t, uint64_t, uint64_t, uint32_t, bool)>(
-                cuda::ptx::tcgen05_mma));
-          // tcgen05.mma.cta_group::1.kind::i8 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(
-                cuda::ptx::kind_i8_t, cuda::ptx::cta_group_1_t, uint32_t, uint64_t, uint64_t, uint32_t, bool)>(
-                cuda::ptx::tcgen05_mma));
-          // tcgen05.mma.cta_group::2.kind::i8 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(
-                cuda::ptx::kind_i8_t, cuda::ptx::cta_group_2_t, uint32_t, uint64_t, uint64_t, uint32_t, bool)>(
-                cuda::ptx::tcgen05_mma));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
-    (
-        // tcgen05.mma.cta_group::1.kind::f16 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(
-            cuda::ptx::kind_f16_t, cuda::ptx::cta_group_1_t, uint32_t, uint64_t, uint64_t, uint32_t, bool)>(
-            cuda::ptx::tcgen05_mma));
-          // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(
-                cuda::ptx::kind_f16_t, cuda::ptx::cta_group_2_t, uint32_t, uint64_t, uint64_t, uint32_t, bool)>(
-                cuda::ptx::tcgen05_mma));
-          // tcgen05.mma.cta_group::1.kind::tf32 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(
-                cuda::ptx::kind_tf32_t, cuda::ptx::cta_group_1_t, uint32_t, uint64_t, uint64_t, uint32_t, bool)>(
-                cuda::ptx::tcgen05_mma));
-          // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(
-                cuda::ptx::kind_tf32_t, cuda::ptx::cta_group_2_t, uint32_t, uint64_t, uint64_t, uint32_t, bool)>(
-                cuda::ptx::tcgen05_mma));
-          // tcgen05.mma.cta_group::1.kind::f8f6f4 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(
-                cuda::ptx::kind_f8f6f4_t, cuda::ptx::cta_group_1_t, uint32_t, uint64_t, uint64_t, uint32_t, bool)>(
-                cuda::ptx::tcgen05_mma));
-          // tcgen05.mma.cta_group::2.kind::f8f6f4 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(
-                cuda::ptx::kind_f8f6f4_t, cuda::ptx::cta_group_2_t, uint32_t, uint64_t, uint64_t, uint32_t, bool)>(
-                cuda::ptx::tcgen05_mma));
-          // tcgen05.mma.cta_group::1.kind::i8 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(
-                cuda::ptx::kind_i8_t, cuda::ptx::cta_group_1_t, uint32_t, uint64_t, uint64_t, uint32_t, bool)>(
-                cuda::ptx::tcgen05_mma));
-          // tcgen05.mma.cta_group::2.kind::i8 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(
-                cuda::ptx::kind_i8_t, cuda::ptx::cta_group_2_t, uint32_t, uint64_t, uint64_t, uint32_t, bool)>(
-                cuda::ptx::tcgen05_mma));));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_100a, (
+    // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_f16_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , const uint32_t (&)[8], bool )>(cuda::ptx::tcgen05_mma));
+    // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_tf32_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , const uint32_t (&)[8], bool )>(cuda::ptx::tcgen05_mma));
+    // tcgen05.mma.cta_group::2.kind::f8f6f4 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_f8f6f4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , const uint32_t (&)[8], bool )>(cuda::ptx::tcgen05_mma));
+    // tcgen05.mma.cta_group::2.kind::i8 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_i8_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , const uint32_t (&)[8], bool )>(cuda::ptx::tcgen05_mma));
+  ));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a, (
+    // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_f16_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , const uint32_t (&)[8], bool )>(cuda::ptx::tcgen05_mma));
+    // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_tf32_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , const uint32_t (&)[8], bool )>(cuda::ptx::tcgen05_mma));
+    // tcgen05.mma.cta_group::2.kind::f8f6f4 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_f8f6f4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , const uint32_t (&)[8], bool )>(cuda::ptx::tcgen05_mma));
+    // tcgen05.mma.cta_group::2.kind::i8 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_i8_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , const uint32_t (&)[8], bool )>(cuda::ptx::tcgen05_mma));
+  ));
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 860
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::f16 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d,
-        // scale_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f16_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint32_t,
-                               uint64_t,
-                               uint32_t,
-                               const uint32_t(&)[4],
-                               bool,
-                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma_tmem_a));
-          // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane,
-          // enable_input_d, scale_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_f16_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   const uint32_t(&)[4],
-                                   bool,
-                                   cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma_tmem_a));
-          // tcgen05.mma.cta_group::1.kind::tf32 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane,
-          // enable_input_d, scale_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_tf32_t,
-                                   cuda::ptx::cta_group_1_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   const uint32_t(&)[4],
-                                   bool,
-                                   cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma_tmem_a));
-          // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane,
-          // enable_input_d, scale_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_tf32_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   const uint32_t(&)[4],
-                                   bool,
-                                   cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma_tmem_a));));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_100a, (
+    // tcgen05.mma.cta_group::1.kind::f16 [d_tmem], a_desc, b_desc, idesc, enable_input_d, scale_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_f16_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , bool , cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma));
+    // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], a_desc, b_desc, idesc, enable_input_d, scale_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_f16_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , bool , cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma));
+    // tcgen05.mma.cta_group::1.kind::tf32 [d_tmem], a_desc, b_desc, idesc, enable_input_d, scale_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_tf32_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , bool , cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma));
+    // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], a_desc, b_desc, idesc, enable_input_d, scale_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_tf32_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , bool , cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma));
+  ));
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 860
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::f16 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f16_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint32_t,
-                               uint64_t,
-                               uint32_t,
-                               const uint32_t(&)[4],
-                               bool)>(cuda::ptx::tcgen05_mma_tmem_a));
-          // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_f16_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   const uint32_t(&)[4],
-                                   bool)>(cuda::ptx::tcgen05_mma_tmem_a));
-          // tcgen05.mma.cta_group::1.kind::tf32 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_tf32_t,
-                                   cuda::ptx::cta_group_1_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   const uint32_t(&)[4],
-                                   bool)>(cuda::ptx::tcgen05_mma_tmem_a));
-          // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_tf32_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   const uint32_t(&)[4],
-                                   bool)>(cuda::ptx::tcgen05_mma_tmem_a));
-          // tcgen05.mma.cta_group::1.kind::f8f6f4 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane,
-          // enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_f8f6f4_t,
-                                   cuda::ptx::cta_group_1_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   const uint32_t(&)[4],
-                                   bool)>(cuda::ptx::tcgen05_mma_tmem_a));
-          // tcgen05.mma.cta_group::2.kind::f8f6f4 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane,
-          // enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_f8f6f4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   const uint32_t(&)[4],
-                                   bool)>(cuda::ptx::tcgen05_mma_tmem_a));
-          // tcgen05.mma.cta_group::1.kind::i8 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_i8_t,
-                                   cuda::ptx::cta_group_1_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   const uint32_t(&)[4],
-                                   bool)>(cuda::ptx::tcgen05_mma_tmem_a));
-          // tcgen05.mma.cta_group::2.kind::i8 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_i8_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   const uint32_t(&)[4],
-                                   bool)>(cuda::ptx::tcgen05_mma_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
-    (
-        // tcgen05.mma.cta_group::1.kind::f16 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f16_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint32_t,
-                               uint64_t,
-                               uint32_t,
-                               const uint32_t(&)[4],
-                               bool)>(cuda::ptx::tcgen05_mma_tmem_a));
-          // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_f16_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   const uint32_t(&)[4],
-                                   bool)>(cuda::ptx::tcgen05_mma_tmem_a));
-          // tcgen05.mma.cta_group::1.kind::tf32 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_tf32_t,
-                                   cuda::ptx::cta_group_1_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   const uint32_t(&)[4],
-                                   bool)>(cuda::ptx::tcgen05_mma_tmem_a));
-          // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_tf32_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   const uint32_t(&)[4],
-                                   bool)>(cuda::ptx::tcgen05_mma_tmem_a));
-          // tcgen05.mma.cta_group::1.kind::f8f6f4 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane,
-          // enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_f8f6f4_t,
-                                   cuda::ptx::cta_group_1_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   const uint32_t(&)[4],
-                                   bool)>(cuda::ptx::tcgen05_mma_tmem_a));
-          // tcgen05.mma.cta_group::2.kind::f8f6f4 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane,
-          // enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_f8f6f4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   const uint32_t(&)[4],
-                                   bool)>(cuda::ptx::tcgen05_mma_tmem_a));
-          // tcgen05.mma.cta_group::1.kind::i8 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_i8_t,
-                                   cuda::ptx::cta_group_1_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   const uint32_t(&)[4],
-                                   bool)>(cuda::ptx::tcgen05_mma_tmem_a));
-          // tcgen05.mma.cta_group::2.kind::i8 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_i8_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   const uint32_t(&)[4],
-                                   bool)>(cuda::ptx::tcgen05_mma_tmem_a));));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_100a, (
+    // tcgen05.mma.cta_group::1.kind::f16 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_f16_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma));
+    // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_f16_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma));
+    // tcgen05.mma.cta_group::1.kind::tf32 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_tf32_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma));
+    // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_tf32_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma));
+    // tcgen05.mma.cta_group::1.kind::f8f6f4 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_f8f6f4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma));
+    // tcgen05.mma.cta_group::2.kind::f8f6f4 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_f8f6f4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma));
+    // tcgen05.mma.cta_group::1.kind::i8 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_i8_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma));
+    // tcgen05.mma.cta_group::2.kind::i8 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_i8_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma));
+  ));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a, (
+    // tcgen05.mma.cta_group::1.kind::f16 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_f16_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma));
+    // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_f16_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma));
+    // tcgen05.mma.cta_group::1.kind::tf32 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_tf32_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma));
+    // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_tf32_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma));
+    // tcgen05.mma.cta_group::1.kind::f8f6f4 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_f8f6f4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma));
+    // tcgen05.mma.cta_group::2.kind::f8f6f4 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_f8f6f4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma));
+    // tcgen05.mma.cta_group::1.kind::i8 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_i8_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma));
+    // tcgen05.mma.cta_group::2.kind::i8 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_i8_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma));
+  ));
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 860
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::f16 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, scale_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f16_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint32_t,
-                               uint64_t,
-                               uint32_t,
-                               bool,
-                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma_tmem_a));
-          // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, scale_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_f16_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   bool,
-                                   cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma_tmem_a));
-          // tcgen05.mma.cta_group::1.kind::tf32 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, scale_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_tf32_t,
-                                   cuda::ptx::cta_group_1_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   bool,
-                                   cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma_tmem_a));
-          // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, scale_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_tf32_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   bool,
-                                   cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma_tmem_a));));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_100a, (
+    // tcgen05.mma.cta_group::1.kind::f16 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d, scale_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_f16_t, cuda::ptx::cta_group_1_t, uint32_t , uint32_t , uint64_t , uint32_t , const uint32_t (&)[4], bool , cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma_tmem_a));
+    // tcgen05.mma.cta_group::1.kind::tf32 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d, scale_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_tf32_t, cuda::ptx::cta_group_1_t, uint32_t , uint32_t , uint64_t , uint32_t , const uint32_t (&)[4], bool , cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma_tmem_a));
+  ));
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 860
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::f16 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(
-            cuda::ptx::kind_f16_t, cuda::ptx::cta_group_1_t, uint32_t, uint32_t, uint64_t, uint32_t, bool)>(
-            cuda::ptx::tcgen05_mma_tmem_a));
-          // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(
-                cuda::ptx::kind_f16_t, cuda::ptx::cta_group_2_t, uint32_t, uint32_t, uint64_t, uint32_t, bool)>(
-                cuda::ptx::tcgen05_mma_tmem_a));
-          // tcgen05.mma.cta_group::1.kind::tf32 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(
-                cuda::ptx::kind_tf32_t, cuda::ptx::cta_group_1_t, uint32_t, uint32_t, uint64_t, uint32_t, bool)>(
-                cuda::ptx::tcgen05_mma_tmem_a));
-          // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(
-                cuda::ptx::kind_tf32_t, cuda::ptx::cta_group_2_t, uint32_t, uint32_t, uint64_t, uint32_t, bool)>(
-                cuda::ptx::tcgen05_mma_tmem_a));
-          // tcgen05.mma.cta_group::1.kind::f8f6f4 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(
-                cuda::ptx::kind_f8f6f4_t, cuda::ptx::cta_group_1_t, uint32_t, uint32_t, uint64_t, uint32_t, bool)>(
-                cuda::ptx::tcgen05_mma_tmem_a));
-          // tcgen05.mma.cta_group::2.kind::f8f6f4 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(
-                cuda::ptx::kind_f8f6f4_t, cuda::ptx::cta_group_2_t, uint32_t, uint32_t, uint64_t, uint32_t, bool)>(
-                cuda::ptx::tcgen05_mma_tmem_a));
-          // tcgen05.mma.cta_group::1.kind::i8 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(
-                cuda::ptx::kind_i8_t, cuda::ptx::cta_group_1_t, uint32_t, uint32_t, uint64_t, uint32_t, bool)>(
-                cuda::ptx::tcgen05_mma_tmem_a));
-          // tcgen05.mma.cta_group::2.kind::i8 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(
-                cuda::ptx::kind_i8_t, cuda::ptx::cta_group_2_t, uint32_t, uint32_t, uint64_t, uint32_t, bool)>(
-                cuda::ptx::tcgen05_mma_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
-    (
-        // tcgen05.mma.cta_group::1.kind::f16 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(
-            cuda::ptx::kind_f16_t, cuda::ptx::cta_group_1_t, uint32_t, uint32_t, uint64_t, uint32_t, bool)>(
-            cuda::ptx::tcgen05_mma_tmem_a));
-          // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(
-                cuda::ptx::kind_f16_t, cuda::ptx::cta_group_2_t, uint32_t, uint32_t, uint64_t, uint32_t, bool)>(
-                cuda::ptx::tcgen05_mma_tmem_a));
-          // tcgen05.mma.cta_group::1.kind::tf32 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(
-                cuda::ptx::kind_tf32_t, cuda::ptx::cta_group_1_t, uint32_t, uint32_t, uint64_t, uint32_t, bool)>(
-                cuda::ptx::tcgen05_mma_tmem_a));
-          // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(
-                cuda::ptx::kind_tf32_t, cuda::ptx::cta_group_2_t, uint32_t, uint32_t, uint64_t, uint32_t, bool)>(
-                cuda::ptx::tcgen05_mma_tmem_a));
-          // tcgen05.mma.cta_group::1.kind::f8f6f4 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(
-                cuda::ptx::kind_f8f6f4_t, cuda::ptx::cta_group_1_t, uint32_t, uint32_t, uint64_t, uint32_t, bool)>(
-                cuda::ptx::tcgen05_mma_tmem_a));
-          // tcgen05.mma.cta_group::2.kind::f8f6f4 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(
-                cuda::ptx::kind_f8f6f4_t, cuda::ptx::cta_group_2_t, uint32_t, uint32_t, uint64_t, uint32_t, bool)>(
-                cuda::ptx::tcgen05_mma_tmem_a));
-          // tcgen05.mma.cta_group::1.kind::i8 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(
-                cuda::ptx::kind_i8_t, cuda::ptx::cta_group_1_t, uint32_t, uint32_t, uint64_t, uint32_t, bool)>(
-                cuda::ptx::tcgen05_mma_tmem_a));
-          // tcgen05.mma.cta_group::2.kind::i8 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(
-                cuda::ptx::kind_i8_t, cuda::ptx::cta_group_2_t, uint32_t, uint32_t, uint64_t, uint32_t, bool)>(
-                cuda::ptx::tcgen05_mma_tmem_a));));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_100a, (
+    // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d, scale_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_f16_t, cuda::ptx::cta_group_2_t, uint32_t , uint32_t , uint64_t , uint32_t , const uint32_t (&)[8], bool , cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma_tmem_a));
+    // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d, scale_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_tf32_t, cuda::ptx::cta_group_2_t, uint32_t , uint32_t , uint64_t , uint32_t , const uint32_t (&)[8], bool , cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma_tmem_a));
+  ));
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 860
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X [d_tmem], a_desc, b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x));
-          // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X [d_tmem], a_desc, b_desc, idesc,
-          // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X [d_tmem], a_desc, b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x));
-          // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X [d_tmem], a_desc, b_desc, idesc,
-          // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x));));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_100a, (
+    // tcgen05.mma.cta_group::1.kind::f16 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_f16_t, cuda::ptx::cta_group_1_t, uint32_t , uint32_t , uint64_t , uint32_t , const uint32_t (&)[4], bool )>(cuda::ptx::tcgen05_mma_tmem_a));
+    // tcgen05.mma.cta_group::1.kind::tf32 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_tf32_t, cuda::ptx::cta_group_1_t, uint32_t , uint32_t , uint64_t , uint32_t , const uint32_t (&)[4], bool )>(cuda::ptx::tcgen05_mma_tmem_a));
+    // tcgen05.mma.cta_group::1.kind::f8f6f4 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_f8f6f4_t, cuda::ptx::cta_group_1_t, uint32_t , uint32_t , uint64_t , uint32_t , const uint32_t (&)[4], bool )>(cuda::ptx::tcgen05_mma_tmem_a));
+    // tcgen05.mma.cta_group::1.kind::i8 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_i8_t, cuda::ptx::cta_group_1_t, uint32_t , uint32_t , uint64_t , uint32_t , const uint32_t (&)[4], bool )>(cuda::ptx::tcgen05_mma_tmem_a));
+  ));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a, (
+    // tcgen05.mma.cta_group::1.kind::f16 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_f16_t, cuda::ptx::cta_group_1_t, uint32_t , uint32_t , uint64_t , uint32_t , const uint32_t (&)[4], bool )>(cuda::ptx::tcgen05_mma_tmem_a));
+    // tcgen05.mma.cta_group::1.kind::tf32 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_tf32_t, cuda::ptx::cta_group_1_t, uint32_t , uint32_t , uint64_t , uint32_t , const uint32_t (&)[4], bool )>(cuda::ptx::tcgen05_mma_tmem_a));
+    // tcgen05.mma.cta_group::1.kind::f8f6f4 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_f8f6f4_t, cuda::ptx::cta_group_1_t, uint32_t , uint32_t , uint64_t , uint32_t , const uint32_t (&)[4], bool )>(cuda::ptx::tcgen05_mma_tmem_a));
+    // tcgen05.mma.cta_group::1.kind::i8 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_i8_t, cuda::ptx::cta_group_1_t, uint32_t , uint32_t , uint64_t , uint32_t , const uint32_t (&)[4], bool )>(cuda::ptx::tcgen05_mma_tmem_a));
+  ));
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 860
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x));
-          // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc,
-          // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x));
-          // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc,
-          // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_1_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x));
-          // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc,
-          // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x));
-          // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc,
-          // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x));
-          // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc,
-          // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_1_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x));
-          // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc,
-          // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x));));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_100a, (
+    // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_f16_t, cuda::ptx::cta_group_2_t, uint32_t , uint32_t , uint64_t , uint32_t , const uint32_t (&)[8], bool )>(cuda::ptx::tcgen05_mma_tmem_a));
+    // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_tf32_t, cuda::ptx::cta_group_2_t, uint32_t , uint32_t , uint64_t , uint32_t , const uint32_t (&)[8], bool )>(cuda::ptx::tcgen05_mma_tmem_a));
+    // tcgen05.mma.cta_group::2.kind::f8f6f4 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_f8f6f4_t, cuda::ptx::cta_group_2_t, uint32_t , uint32_t , uint64_t , uint32_t , const uint32_t (&)[8], bool )>(cuda::ptx::tcgen05_mma_tmem_a));
+    // tcgen05.mma.cta_group::2.kind::i8 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_i8_t, cuda::ptx::cta_group_2_t, uint32_t , uint32_t , uint64_t , uint32_t , const uint32_t (&)[8], bool )>(cuda::ptx::tcgen05_mma_tmem_a));
+  ));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a, (
+    // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_f16_t, cuda::ptx::cta_group_2_t, uint32_t , uint32_t , uint64_t , uint32_t , const uint32_t (&)[8], bool )>(cuda::ptx::tcgen05_mma_tmem_a));
+    // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_tf32_t, cuda::ptx::cta_group_2_t, uint32_t , uint32_t , uint64_t , uint32_t , const uint32_t (&)[8], bool )>(cuda::ptx::tcgen05_mma_tmem_a));
+    // tcgen05.mma.cta_group::2.kind::f8f6f4 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_f8f6f4_t, cuda::ptx::cta_group_2_t, uint32_t , uint32_t , uint64_t , uint32_t , const uint32_t (&)[8], bool )>(cuda::ptx::tcgen05_mma_tmem_a));
+    // tcgen05.mma.cta_group::2.kind::i8 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_i8_t, cuda::ptx::cta_group_2_t, uint32_t , uint32_t , uint64_t , uint32_t , const uint32_t (&)[8], bool )>(cuda::ptx::tcgen05_mma_tmem_a));
+  ));
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 860
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X [d_tmem], a_desc, b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x));
-          // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X [d_tmem], a_desc, b_desc, idesc,
-          // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X [d_tmem], a_desc, b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x));
-          // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X [d_tmem], a_desc, b_desc, idesc,
-          // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x));));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_100a, (
+    // tcgen05.mma.cta_group::1.kind::f16 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, scale_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_f16_t, cuda::ptx::cta_group_1_t, uint32_t , uint32_t , uint64_t , uint32_t , bool , cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma_tmem_a));
+    // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, scale_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_f16_t, cuda::ptx::cta_group_2_t, uint32_t , uint32_t , uint64_t , uint32_t , bool , cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma_tmem_a));
+    // tcgen05.mma.cta_group::1.kind::tf32 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, scale_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_tf32_t, cuda::ptx::cta_group_1_t, uint32_t , uint32_t , uint64_t , uint32_t , bool , cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma_tmem_a));
+    // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, scale_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_tf32_t, cuda::ptx::cta_group_2_t, uint32_t , uint32_t , uint64_t , uint32_t , bool , cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma_tmem_a));
+  ));
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 860
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X [d_tmem], a_desc, b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a));
-          // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X [d_tmem], a_desc, b_desc, idesc,
-          // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X [d_tmem], a_desc, b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a));
-          // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X [d_tmem], a_desc, b_desc, idesc,
-          // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a));));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_100a, (
+    // tcgen05.mma.cta_group::1.kind::f16 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_f16_t, cuda::ptx::cta_group_1_t, uint32_t , uint32_t , uint64_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_tmem_a));
+    // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_f16_t, cuda::ptx::cta_group_2_t, uint32_t , uint32_t , uint64_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_tmem_a));
+    // tcgen05.mma.cta_group::1.kind::tf32 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_tf32_t, cuda::ptx::cta_group_1_t, uint32_t , uint32_t , uint64_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_tmem_a));
+    // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_tf32_t, cuda::ptx::cta_group_2_t, uint32_t , uint32_t , uint64_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_tmem_a));
+    // tcgen05.mma.cta_group::1.kind::f8f6f4 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_f8f6f4_t, cuda::ptx::cta_group_1_t, uint32_t , uint32_t , uint64_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_tmem_a));
+    // tcgen05.mma.cta_group::2.kind::f8f6f4 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_f8f6f4_t, cuda::ptx::cta_group_2_t, uint32_t , uint32_t , uint64_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_tmem_a));
+    // tcgen05.mma.cta_group::1.kind::i8 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_i8_t, cuda::ptx::cta_group_1_t, uint32_t , uint32_t , uint64_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_tmem_a));
+    // tcgen05.mma.cta_group::2.kind::i8 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_i8_t, cuda::ptx::cta_group_2_t, uint32_t , uint32_t , uint64_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_tmem_a));
+  ));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a, (
+    // tcgen05.mma.cta_group::1.kind::f16 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_f16_t, cuda::ptx::cta_group_1_t, uint32_t , uint32_t , uint64_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_tmem_a));
+    // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_f16_t, cuda::ptx::cta_group_2_t, uint32_t , uint32_t , uint64_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_tmem_a));
+    // tcgen05.mma.cta_group::1.kind::tf32 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_tf32_t, cuda::ptx::cta_group_1_t, uint32_t , uint32_t , uint64_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_tmem_a));
+    // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_tf32_t, cuda::ptx::cta_group_2_t, uint32_t , uint32_t , uint64_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_tmem_a));
+    // tcgen05.mma.cta_group::1.kind::f8f6f4 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_f8f6f4_t, cuda::ptx::cta_group_1_t, uint32_t , uint32_t , uint64_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_tmem_a));
+    // tcgen05.mma.cta_group::2.kind::f8f6f4 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_f8f6f4_t, cuda::ptx::cta_group_2_t, uint32_t , uint32_t , uint64_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_tmem_a));
+    // tcgen05.mma.cta_group::1.kind::i8 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_i8_t, cuda::ptx::cta_group_1_t, uint32_t , uint32_t , uint64_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_tmem_a));
+    // tcgen05.mma.cta_group::2.kind::i8 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_i8_t, cuda::ptx::cta_group_2_t, uint32_t , uint32_t , uint64_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_tmem_a));
+  ));
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 860
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a));
-          // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc,
-          // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a));
-          // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc,
-          // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_1_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a));
-          // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc,
-          // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a));
-          // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc,
-          // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a));
-          // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc,
-          // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_1_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a));
-          // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc,
-          // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a));));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_100a, (
+    // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_1x));
+    // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_1x));
+  ));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a, (
+    // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_1x));
+    // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_1x));
+  ));
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 860
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X [d_tmem], a_desc, b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a));
-          // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X [d_tmem], a_desc, b_desc, idesc,
-          // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X [d_tmem], a_desc, b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a));
-          // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X [d_tmem], a_desc, b_desc, idesc,
-          // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a));));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_100a, (
+    // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2x));
+    // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2x));
+    // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2x));
+    // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2x));
+  ));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a, (
+    // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2x));
+    // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2x));
+    // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2x));
+    // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2x));
+  ));
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 860
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::fill [d_tmem], a_desc,
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_fill));
-          // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::fill [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::fill [d_tmem], a_desc,
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_fill));
-          // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::fill [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_fill));));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_100a, (
+    // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_4x));
+    // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_4x));
+  ));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a, (
+    // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_4x));
+    // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_4x));
+  ));
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 860
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_fill));
-          // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_fill));
-          // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_1_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_fill));
-          // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_fill));
-          // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_fill));
-          // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_1_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_fill));
-          // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_fill));));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_100a, (
+    // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a));
+    // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a));
+  ));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a, (
+    // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a));
+    // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a));
+  ));
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 860
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::fill [d_tmem], a_desc,
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_fill));
-          // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::fill [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::fill [d_tmem], a_desc,
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_fill));
-          // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::fill [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_fill));));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_100a, (
+    // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a));
+    // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a));
+    // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a));
+    // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a));
+  ));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a, (
+    // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a));
+    // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a));
+    // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a));
+    // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a));
+  ));
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 860
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::fill [d_tmem], a_desc,
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_fill));
-          // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::fill [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::fill [d_tmem], a_desc,
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_fill));
-          // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::fill [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_fill));));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_100a, (
+    // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a));
+    // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a));
+  ));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a, (
+    // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a));
+    // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a));
+  ));
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 860
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_fill));
-          // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_fill));
-          // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_1_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_fill));
-          // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_fill));
-          // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_fill));
-          // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_1_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_fill));
-          // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_fill));));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_100a, (
+    // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_fill));
+    // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_fill));
+  ));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a, (
+    // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_fill));
+    // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_fill));
+  ));
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 860
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::fill [d_tmem], a_desc,
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_fill));
-          // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::fill [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::fill [d_tmem], a_desc,
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_fill));
-          // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::fill [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_fill));));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_100a, (
+    // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_fill));
+    // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_fill));
+    // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_fill));
+    // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_fill));
+  ));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a, (
+    // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_fill));
+    // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_fill));
+    // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_fill));
+    // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_fill));
+  ));
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 860
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::use [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_use));
-          // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::use [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::use [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_use));
-          // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::use [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_use));));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_100a, (
+    // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_fill));
+    // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_fill));
+  ));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a, (
+    // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_fill));
+    // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_fill));
+  ));
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 860
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_use));
-          // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc,
-          // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_use));
-          // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_1_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_use));
-          // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_use));
-          // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc,
-          // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_use));
-          // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_1_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_use));
-          // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_use));));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_100a, (
+    // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_fill));
+    // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_fill));
+  ));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a, (
+    // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_fill));
+    // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_fill));
+  ));
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 860
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::use [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_use));
-          // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::use [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::use [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_use));
-          // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::use [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_use));));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_100a, (
+    // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_fill));
+    // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_fill));
+    // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_fill));
+    // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_fill));
+  ));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a, (
+    // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_fill));
+    // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_fill));
+    // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_fill));
+    // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_fill));
+  ));
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 860
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::use [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_use));
-          // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::use [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::use [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_use));
-          // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::use [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_use));));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_100a, (
+    // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_fill));
+    // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_fill));
+  ));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a, (
+    // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_fill));
+    // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_fill));
+  ));
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 860
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_use));
-          // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc,
-          // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_use));
-          // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_1_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_use));
-          // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_use));
-          // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc,
-          // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_use));
-          // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_1_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_use));
-          // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_use));));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_100a, (
+    // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_use));
+    // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_use));
+  ));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a, (
+    // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_use));
+    // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_use));
+  ));
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 860
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::use [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_use));
-          // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::use [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::use [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_use));
-          // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::use [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_use));));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_100a, (
+    // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_use));
+    // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_use));
+    // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_use));
+    // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_use));
+  ));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a, (
+    // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_use));
+    // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_use));
+    // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_use));
+    // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_use));
+  ));
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 860
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::lastuse [d_tmem], a_desc,
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_lastuse));
-          // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::lastuse [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::lastuse [d_tmem], a_desc,
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_lastuse));
-          // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::lastuse [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_lastuse));));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_100a, (
+    // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_use));
+    // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_use));
+  ));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a, (
+    // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_use));
+    // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_use));
+  ));
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 860
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_lastuse));
-          // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_lastuse));
-          // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_1_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_lastuse));
-          // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_lastuse));
-          // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_lastuse));
-          // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_1_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_lastuse));
-          // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_lastuse));));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_100a, (
+    // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_use));
+    // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_use));
+  ));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a, (
+    // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_use));
+    // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_use));
+  ));
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 860
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::lastuse [d_tmem], a_desc,
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_lastuse));
-          // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::lastuse [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::lastuse [d_tmem], a_desc,
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_lastuse));
-          // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::lastuse [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_lastuse));));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_100a, (
+    // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_use));
+    // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_use));
+    // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_use));
+    // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_use));
+  ));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a, (
+    // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_use));
+    // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_use));
+    // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_use));
+    // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_use));
+  ));
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 860
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::lastuse [d_tmem], a_desc,
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_lastuse));
-          // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::lastuse [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::lastuse [d_tmem], a_desc,
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_lastuse));
-          // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::lastuse [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_lastuse));));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_100a, (
+    // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_use));
+    // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_use));
+  ));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a, (
+    // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_use));
+    // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_use));
+  ));
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 860
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_lastuse));
-          // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_lastuse));
-          // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_1_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_lastuse));
-          // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_lastuse));
-          // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_lastuse));
-          // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_1_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_lastuse));
-          // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_lastuse));));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_100a, (
+    // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_lastuse));
+    // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_lastuse));
+  ));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a, (
+    // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_lastuse));
+    // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_lastuse));
+  ));
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 860
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::lastuse [d_tmem], a_desc,
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_lastuse));
-          // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::lastuse [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::lastuse [d_tmem], a_desc,
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_lastuse));
-          // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::lastuse [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_lastuse));));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_100a, (
+    // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_lastuse));
+    // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_lastuse));
+    // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_lastuse));
+    // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_lastuse));
+  ));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a, (
+    // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_lastuse));
+    // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_lastuse));
+    // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_lastuse));
+    // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_lastuse));
+  ));
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 860
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::discard [d_tmem], a_desc,
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_discard));
-          // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::discard [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::discard [d_tmem], a_desc,
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_discard));
-          // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::discard [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_discard));));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_100a, (
+    // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_lastuse));
+    // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_lastuse));
+  ));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a, (
+    // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_lastuse));
+    // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_lastuse));
+  ));
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 860
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_discard));
-          // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_discard));
-          // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_1_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_discard));
-          // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_discard));
-          // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_discard));
-          // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_1_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_discard));
-          // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_discard));));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_100a, (
+    // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_lastuse));
+    // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_lastuse));
+  ));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a, (
+    // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_lastuse));
+    // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_lastuse));
+  ));
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 860
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::discard [d_tmem], a_desc,
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_discard));
-          // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::discard [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::discard [d_tmem], a_desc,
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_discard));
-          // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::discard [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_discard));));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_100a, (
+    // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_lastuse));
+    // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_lastuse));
+    // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_lastuse));
+    // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_lastuse));
+  ));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a, (
+    // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_lastuse));
+    // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_lastuse));
+    // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_lastuse));
+    // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_lastuse));
+  ));
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 860
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::discard [d_tmem], a_desc,
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_discard));
-          // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::discard [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::discard [d_tmem], a_desc,
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_discard));
-          // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::discard [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_discard));));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_100a, (
+    // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_lastuse));
+    // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_lastuse));
+  ));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a, (
+    // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_lastuse));
+    // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_lastuse));
+  ));
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 860
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_discard));
-          // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_discard));
-          // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_1_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_discard));
-          // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_discard));
-          // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_discard));
-          // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_1_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_discard));
-          // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_discard));));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_100a, (
+    // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_discard));
+    // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_discard));
+  ));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a, (
+    // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_discard));
+    // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_discard));
+  ));
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 860
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::discard [d_tmem], a_desc,
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_discard));
-          // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::discard [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::discard [d_tmem], a_desc,
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               uint32_t,
-                               uint64_t,
-                               uint64_t,
-                               uint32_t,
-                               uint32_t,
-                               uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_discard));
-          // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::discard [d_tmem], a_desc,
-          // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-            * fn_ptr++ = reinterpret_cast<void*>(
-              static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                                   cuda::ptx::cta_group_2_t,
-                                   uint32_t,
-                                   uint64_t,
-                                   uint64_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   uint32_t,
-                                   bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_discard));));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_100a, (
+    // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_discard));
+    // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_discard));
+    // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_discard));
+    // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_discard));
+  ));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a, (
+    // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_discard));
+    // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_discard));
+    // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_discard));
+    // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_discard));
+  ));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_100a, (
+    // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_discard));
+    // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_discard));
+  ));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a, (
+    // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_discard));
+    // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_discard));
+  ));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_100a, (
+    // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_discard));
+    // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_discard));
+  ));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a, (
+    // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_discard));
+    // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_discard));
+  ));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_100a, (
+    // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_discard));
+    // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_discard));
+    // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_discard));
+    // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_discard));
+  ));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a, (
+    // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_discard));
+    // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_discard));
+    // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_discard));
+    // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_discard));
+  ));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_100a, (
+    // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_discard));
+    // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_discard));
+  ));
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a, (
+    // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_1_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_discard));
+    // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t, cuda::ptx::cta_group_2_t, uint32_t , uint64_t , uint64_t , uint32_t , uint32_t , uint32_t , bool )>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_discard));
+  ));
 #endif // __cccl_ptx_isa >= 860
 }


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes https://github.com/NVIDIA/cccl/issues/4037

<!-- Provide a standalone description of changes in this PR. -->
Fix cta_group::2 definition, and fix `tcgen05.mma.cta_group::2` with `disable_output_lane` parameter. This parameter is wider when it uses 2 CTAs. 

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
