### PR TITLE
Fix PTX `ld/st`

### DIFF
--- a/docs/libcudacxx/ptx/instructions/generated/ld.rst
+++ b/docs/libcudacxx/ptx/instructions/generated/ld.rst
@@ -1,7 +1,5 @@
-ld
-=============
-
--  PTX ISA: ```ld`` <https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#data-movement-and-conversion-instructions-ld>`__
+..
+   This file was automatically generated. Do not edit.
 
 ld.global.b8
 ^^^^^^^^^^^^

--- a/docs/libcudacxx/ptx/instructions/generated/ld.rst
+++ b/docs/libcudacxx/ptx/instructions/generated/ld.rst
@@ -187,7 +187,7 @@ ld.global.L1::evict_normal.b8
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // ld.global.L1::evict_normal.b8 dest, [addr]; // PTX ISA 74, SM_75
+   // ld.global.L1::evict_normal.b8 dest, [addr]; // PTX ISA 74, SM_70
    template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
    __device__ static inline B8 ld_global_L1_evict_normal(
      const B8* addr);
@@ -196,7 +196,7 @@ ld.global.L1::evict_normal.b16
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // ld.global.L1::evict_normal.b16 dest, [addr]; // PTX ISA 74, SM_75
+   // ld.global.L1::evict_normal.b16 dest, [addr]; // PTX ISA 74, SM_70
    template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
    __device__ static inline B16 ld_global_L1_evict_normal(
      const B16* addr);
@@ -205,7 +205,7 @@ ld.global.L1::evict_normal.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // ld.global.L1::evict_normal.b32 dest, [addr]; // PTX ISA 74, SM_75
+   // ld.global.L1::evict_normal.b32 dest, [addr]; // PTX ISA 74, SM_70
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline B32 ld_global_L1_evict_normal(
      const B32* addr);
@@ -214,7 +214,7 @@ ld.global.L1::evict_normal.b64
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // ld.global.L1::evict_normal.b64 dest, [addr]; // PTX ISA 74, SM_75
+   // ld.global.L1::evict_normal.b64 dest, [addr]; // PTX ISA 74, SM_70
    template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
    __device__ static inline B64 ld_global_L1_evict_normal(
      const B64* addr);
@@ -223,7 +223,7 @@ ld.global.L1::evict_normal.b128
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // ld.global.L1::evict_normal.b128 dest, [addr]; // PTX ISA 83, SM_75
+   // ld.global.L1::evict_normal.b128 dest, [addr]; // PTX ISA 83, SM_70
    template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
    __device__ static inline B128 ld_global_L1_evict_normal(
      const B128* addr);
@@ -367,7 +367,7 @@ ld.global.L1::evict_unchanged.b8
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // ld.global.L1::evict_unchanged.b8 dest, [addr]; // PTX ISA 74, SM_75
+   // ld.global.L1::evict_unchanged.b8 dest, [addr]; // PTX ISA 74, SM_70
    template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
    __device__ static inline B8 ld_global_L1_evict_unchanged(
      const B8* addr);
@@ -376,7 +376,7 @@ ld.global.L1::evict_unchanged.b16
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // ld.global.L1::evict_unchanged.b16 dest, [addr]; // PTX ISA 74, SM_75
+   // ld.global.L1::evict_unchanged.b16 dest, [addr]; // PTX ISA 74, SM_70
    template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
    __device__ static inline B16 ld_global_L1_evict_unchanged(
      const B16* addr);
@@ -385,7 +385,7 @@ ld.global.L1::evict_unchanged.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // ld.global.L1::evict_unchanged.b32 dest, [addr]; // PTX ISA 74, SM_75
+   // ld.global.L1::evict_unchanged.b32 dest, [addr]; // PTX ISA 74, SM_70
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline B32 ld_global_L1_evict_unchanged(
      const B32* addr);
@@ -394,7 +394,7 @@ ld.global.L1::evict_unchanged.b64
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // ld.global.L1::evict_unchanged.b64 dest, [addr]; // PTX ISA 74, SM_75
+   // ld.global.L1::evict_unchanged.b64 dest, [addr]; // PTX ISA 74, SM_70
    template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
    __device__ static inline B64 ld_global_L1_evict_unchanged(
      const B64* addr);
@@ -403,7 +403,7 @@ ld.global.L1::evict_unchanged.b128
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // ld.global.L1::evict_unchanged.b128 dest, [addr]; // PTX ISA 83, SM_75
+   // ld.global.L1::evict_unchanged.b128 dest, [addr]; // PTX ISA 83, SM_70
    template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
    __device__ static inline B128 ld_global_L1_evict_unchanged(
      const B128* addr);
@@ -547,7 +547,7 @@ ld.global.L1::evict_first.b8
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // ld.global.L1::evict_first.b8 dest, [addr]; // PTX ISA 74, SM_75
+   // ld.global.L1::evict_first.b8 dest, [addr]; // PTX ISA 74, SM_70
    template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
    __device__ static inline B8 ld_global_L1_evict_first(
      const B8* addr);
@@ -556,7 +556,7 @@ ld.global.L1::evict_first.b16
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // ld.global.L1::evict_first.b16 dest, [addr]; // PTX ISA 74, SM_75
+   // ld.global.L1::evict_first.b16 dest, [addr]; // PTX ISA 74, SM_70
    template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
    __device__ static inline B16 ld_global_L1_evict_first(
      const B16* addr);
@@ -565,7 +565,7 @@ ld.global.L1::evict_first.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // ld.global.L1::evict_first.b32 dest, [addr]; // PTX ISA 74, SM_75
+   // ld.global.L1::evict_first.b32 dest, [addr]; // PTX ISA 74, SM_70
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline B32 ld_global_L1_evict_first(
      const B32* addr);
@@ -574,7 +574,7 @@ ld.global.L1::evict_first.b64
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // ld.global.L1::evict_first.b64 dest, [addr]; // PTX ISA 74, SM_75
+   // ld.global.L1::evict_first.b64 dest, [addr]; // PTX ISA 74, SM_70
    template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
    __device__ static inline B64 ld_global_L1_evict_first(
      const B64* addr);
@@ -583,7 +583,7 @@ ld.global.L1::evict_first.b128
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // ld.global.L1::evict_first.b128 dest, [addr]; // PTX ISA 83, SM_75
+   // ld.global.L1::evict_first.b128 dest, [addr]; // PTX ISA 83, SM_70
    template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
    __device__ static inline B128 ld_global_L1_evict_first(
      const B128* addr);
@@ -727,7 +727,7 @@ ld.global.L1::evict_last.b8
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // ld.global.L1::evict_last.b8 dest, [addr]; // PTX ISA 74, SM_75
+   // ld.global.L1::evict_last.b8 dest, [addr]; // PTX ISA 74, SM_70
    template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
    __device__ static inline B8 ld_global_L1_evict_last(
      const B8* addr);
@@ -736,7 +736,7 @@ ld.global.L1::evict_last.b16
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // ld.global.L1::evict_last.b16 dest, [addr]; // PTX ISA 74, SM_75
+   // ld.global.L1::evict_last.b16 dest, [addr]; // PTX ISA 74, SM_70
    template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
    __device__ static inline B16 ld_global_L1_evict_last(
      const B16* addr);
@@ -745,7 +745,7 @@ ld.global.L1::evict_last.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // ld.global.L1::evict_last.b32 dest, [addr]; // PTX ISA 74, SM_75
+   // ld.global.L1::evict_last.b32 dest, [addr]; // PTX ISA 74, SM_70
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline B32 ld_global_L1_evict_last(
      const B32* addr);
@@ -754,7 +754,7 @@ ld.global.L1::evict_last.b64
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // ld.global.L1::evict_last.b64 dest, [addr]; // PTX ISA 74, SM_75
+   // ld.global.L1::evict_last.b64 dest, [addr]; // PTX ISA 74, SM_70
    template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
    __device__ static inline B64 ld_global_L1_evict_last(
      const B64* addr);
@@ -763,7 +763,7 @@ ld.global.L1::evict_last.b128
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // ld.global.L1::evict_last.b128 dest, [addr]; // PTX ISA 83, SM_75
+   // ld.global.L1::evict_last.b128 dest, [addr]; // PTX ISA 83, SM_70
    template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
    __device__ static inline B128 ld_global_L1_evict_last(
      const B128* addr);
@@ -907,7 +907,7 @@ ld.global.L1::no_allocate.b8
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // ld.global.L1::no_allocate.b8 dest, [addr]; // PTX ISA 74, SM_75
+   // ld.global.L1::no_allocate.b8 dest, [addr]; // PTX ISA 74, SM_70
    template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
    __device__ static inline B8 ld_global_L1_no_allocate(
      const B8* addr);
@@ -916,7 +916,7 @@ ld.global.L1::no_allocate.b16
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // ld.global.L1::no_allocate.b16 dest, [addr]; // PTX ISA 74, SM_75
+   // ld.global.L1::no_allocate.b16 dest, [addr]; // PTX ISA 74, SM_70
    template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
    __device__ static inline B16 ld_global_L1_no_allocate(
      const B16* addr);
@@ -925,7 +925,7 @@ ld.global.L1::no_allocate.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // ld.global.L1::no_allocate.b32 dest, [addr]; // PTX ISA 74, SM_75
+   // ld.global.L1::no_allocate.b32 dest, [addr]; // PTX ISA 74, SM_70
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline B32 ld_global_L1_no_allocate(
      const B32* addr);
@@ -934,7 +934,7 @@ ld.global.L1::no_allocate.b64
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // ld.global.L1::no_allocate.b64 dest, [addr]; // PTX ISA 74, SM_75
+   // ld.global.L1::no_allocate.b64 dest, [addr]; // PTX ISA 74, SM_70
    template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
    __device__ static inline B64 ld_global_L1_no_allocate(
      const B64* addr);
@@ -943,7 +943,7 @@ ld.global.L1::no_allocate.b128
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // ld.global.L1::no_allocate.b128 dest, [addr]; // PTX ISA 83, SM_75
+   // ld.global.L1::no_allocate.b128 dest, [addr]; // PTX ISA 83, SM_70
    template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
    __device__ static inline B128 ld_global_L1_no_allocate(
      const B128* addr);
@@ -1267,7 +1267,7 @@ ld.global.nc.L1::evict_normal.b8
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // ld.global.nc.L1::evict_normal.b8 dest, [addr]; // PTX ISA 74, SM_75
+   // ld.global.nc.L1::evict_normal.b8 dest, [addr]; // PTX ISA 74, SM_70
    template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
    __device__ static inline B8 ld_global_nc_L1_evict_normal(
      const B8* addr);
@@ -1276,7 +1276,7 @@ ld.global.nc.L1::evict_normal.b16
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // ld.global.nc.L1::evict_normal.b16 dest, [addr]; // PTX ISA 74, SM_75
+   // ld.global.nc.L1::evict_normal.b16 dest, [addr]; // PTX ISA 74, SM_70
    template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
    __device__ static inline B16 ld_global_nc_L1_evict_normal(
      const B16* addr);
@@ -1285,7 +1285,7 @@ ld.global.nc.L1::evict_normal.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // ld.global.nc.L1::evict_normal.b32 dest, [addr]; // PTX ISA 74, SM_75
+   // ld.global.nc.L1::evict_normal.b32 dest, [addr]; // PTX ISA 74, SM_70
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline B32 ld_global_nc_L1_evict_normal(
      const B32* addr);
@@ -1294,7 +1294,7 @@ ld.global.nc.L1::evict_normal.b64
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // ld.global.nc.L1::evict_normal.b64 dest, [addr]; // PTX ISA 74, SM_75
+   // ld.global.nc.L1::evict_normal.b64 dest, [addr]; // PTX ISA 74, SM_70
    template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
    __device__ static inline B64 ld_global_nc_L1_evict_normal(
      const B64* addr);
@@ -1303,7 +1303,7 @@ ld.global.nc.L1::evict_normal.b128
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // ld.global.nc.L1::evict_normal.b128 dest, [addr]; // PTX ISA 83, SM_75
+   // ld.global.nc.L1::evict_normal.b128 dest, [addr]; // PTX ISA 83, SM_70
    template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
    __device__ static inline B128 ld_global_nc_L1_evict_normal(
      const B128* addr);
@@ -1447,7 +1447,7 @@ ld.global.nc.L1::evict_unchanged.b8
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // ld.global.nc.L1::evict_unchanged.b8 dest, [addr]; // PTX ISA 74, SM_75
+   // ld.global.nc.L1::evict_unchanged.b8 dest, [addr]; // PTX ISA 74, SM_70
    template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
    __device__ static inline B8 ld_global_nc_L1_evict_unchanged(
      const B8* addr);
@@ -1456,7 +1456,7 @@ ld.global.nc.L1::evict_unchanged.b16
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // ld.global.nc.L1::evict_unchanged.b16 dest, [addr]; // PTX ISA 74, SM_75
+   // ld.global.nc.L1::evict_unchanged.b16 dest, [addr]; // PTX ISA 74, SM_70
    template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
    __device__ static inline B16 ld_global_nc_L1_evict_unchanged(
      const B16* addr);
@@ -1465,7 +1465,7 @@ ld.global.nc.L1::evict_unchanged.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // ld.global.nc.L1::evict_unchanged.b32 dest, [addr]; // PTX ISA 74, SM_75
+   // ld.global.nc.L1::evict_unchanged.b32 dest, [addr]; // PTX ISA 74, SM_70
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline B32 ld_global_nc_L1_evict_unchanged(
      const B32* addr);
@@ -1474,7 +1474,7 @@ ld.global.nc.L1::evict_unchanged.b64
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // ld.global.nc.L1::evict_unchanged.b64 dest, [addr]; // PTX ISA 74, SM_75
+   // ld.global.nc.L1::evict_unchanged.b64 dest, [addr]; // PTX ISA 74, SM_70
    template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
    __device__ static inline B64 ld_global_nc_L1_evict_unchanged(
      const B64* addr);
@@ -1483,7 +1483,7 @@ ld.global.nc.L1::evict_unchanged.b128
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // ld.global.nc.L1::evict_unchanged.b128 dest, [addr]; // PTX ISA 83, SM_75
+   // ld.global.nc.L1::evict_unchanged.b128 dest, [addr]; // PTX ISA 83, SM_70
    template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
    __device__ static inline B128 ld_global_nc_L1_evict_unchanged(
      const B128* addr);
@@ -1627,7 +1627,7 @@ ld.global.nc.L1::evict_first.b8
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // ld.global.nc.L1::evict_first.b8 dest, [addr]; // PTX ISA 74, SM_75
+   // ld.global.nc.L1::evict_first.b8 dest, [addr]; // PTX ISA 74, SM_70
    template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
    __device__ static inline B8 ld_global_nc_L1_evict_first(
      const B8* addr);
@@ -1636,7 +1636,7 @@ ld.global.nc.L1::evict_first.b16
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // ld.global.nc.L1::evict_first.b16 dest, [addr]; // PTX ISA 74, SM_75
+   // ld.global.nc.L1::evict_first.b16 dest, [addr]; // PTX ISA 74, SM_70
    template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
    __device__ static inline B16 ld_global_nc_L1_evict_first(
      const B16* addr);
@@ -1645,7 +1645,7 @@ ld.global.nc.L1::evict_first.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // ld.global.nc.L1::evict_first.b32 dest, [addr]; // PTX ISA 74, SM_75
+   // ld.global.nc.L1::evict_first.b32 dest, [addr]; // PTX ISA 74, SM_70
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline B32 ld_global_nc_L1_evict_first(
      const B32* addr);
@@ -1654,7 +1654,7 @@ ld.global.nc.L1::evict_first.b64
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // ld.global.nc.L1::evict_first.b64 dest, [addr]; // PTX ISA 74, SM_75
+   // ld.global.nc.L1::evict_first.b64 dest, [addr]; // PTX ISA 74, SM_70
    template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
    __device__ static inline B64 ld_global_nc_L1_evict_first(
      const B64* addr);
@@ -1663,7 +1663,7 @@ ld.global.nc.L1::evict_first.b128
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // ld.global.nc.L1::evict_first.b128 dest, [addr]; // PTX ISA 83, SM_75
+   // ld.global.nc.L1::evict_first.b128 dest, [addr]; // PTX ISA 83, SM_70
    template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
    __device__ static inline B128 ld_global_nc_L1_evict_first(
      const B128* addr);
@@ -1807,7 +1807,7 @@ ld.global.nc.L1::evict_last.b8
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // ld.global.nc.L1::evict_last.b8 dest, [addr]; // PTX ISA 74, SM_75
+   // ld.global.nc.L1::evict_last.b8 dest, [addr]; // PTX ISA 74, SM_70
    template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
    __device__ static inline B8 ld_global_nc_L1_evict_last(
      const B8* addr);
@@ -1816,7 +1816,7 @@ ld.global.nc.L1::evict_last.b16
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // ld.global.nc.L1::evict_last.b16 dest, [addr]; // PTX ISA 74, SM_75
+   // ld.global.nc.L1::evict_last.b16 dest, [addr]; // PTX ISA 74, SM_70
    template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
    __device__ static inline B16 ld_global_nc_L1_evict_last(
      const B16* addr);
@@ -1825,7 +1825,7 @@ ld.global.nc.L1::evict_last.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // ld.global.nc.L1::evict_last.b32 dest, [addr]; // PTX ISA 74, SM_75
+   // ld.global.nc.L1::evict_last.b32 dest, [addr]; // PTX ISA 74, SM_70
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline B32 ld_global_nc_L1_evict_last(
      const B32* addr);
@@ -1834,7 +1834,7 @@ ld.global.nc.L1::evict_last.b64
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // ld.global.nc.L1::evict_last.b64 dest, [addr]; // PTX ISA 74, SM_75
+   // ld.global.nc.L1::evict_last.b64 dest, [addr]; // PTX ISA 74, SM_70
    template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
    __device__ static inline B64 ld_global_nc_L1_evict_last(
      const B64* addr);
@@ -1843,7 +1843,7 @@ ld.global.nc.L1::evict_last.b128
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // ld.global.nc.L1::evict_last.b128 dest, [addr]; // PTX ISA 83, SM_75
+   // ld.global.nc.L1::evict_last.b128 dest, [addr]; // PTX ISA 83, SM_70
    template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
    __device__ static inline B128 ld_global_nc_L1_evict_last(
      const B128* addr);
@@ -1987,7 +1987,7 @@ ld.global.nc.L1::no_allocate.b8
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // ld.global.nc.L1::no_allocate.b8 dest, [addr]; // PTX ISA 74, SM_75
+   // ld.global.nc.L1::no_allocate.b8 dest, [addr]; // PTX ISA 74, SM_70
    template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
    __device__ static inline B8 ld_global_nc_L1_no_allocate(
      const B8* addr);
@@ -1996,7 +1996,7 @@ ld.global.nc.L1::no_allocate.b16
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // ld.global.nc.L1::no_allocate.b16 dest, [addr]; // PTX ISA 74, SM_75
+   // ld.global.nc.L1::no_allocate.b16 dest, [addr]; // PTX ISA 74, SM_70
    template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
    __device__ static inline B16 ld_global_nc_L1_no_allocate(
      const B16* addr);
@@ -2005,7 +2005,7 @@ ld.global.nc.L1::no_allocate.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // ld.global.nc.L1::no_allocate.b32 dest, [addr]; // PTX ISA 74, SM_75
+   // ld.global.nc.L1::no_allocate.b32 dest, [addr]; // PTX ISA 74, SM_70
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline B32 ld_global_nc_L1_no_allocate(
      const B32* addr);
@@ -2014,7 +2014,7 @@ ld.global.nc.L1::no_allocate.b64
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // ld.global.nc.L1::no_allocate.b64 dest, [addr]; // PTX ISA 74, SM_75
+   // ld.global.nc.L1::no_allocate.b64 dest, [addr]; // PTX ISA 74, SM_70
    template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
    __device__ static inline B64 ld_global_nc_L1_no_allocate(
      const B64* addr);
@@ -2023,7 +2023,7 @@ ld.global.nc.L1::no_allocate.b128
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // ld.global.nc.L1::no_allocate.b128 dest, [addr]; // PTX ISA 83, SM_75
+   // ld.global.nc.L1::no_allocate.b128 dest, [addr]; // PTX ISA 83, SM_70
    template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
    __device__ static inline B128 ld_global_nc_L1_no_allocate(
      const B128* addr);

--- a/docs/libcudacxx/ptx/instructions/generated/st.rst
+++ b/docs/libcudacxx/ptx/instructions/generated/st.rst
@@ -57,7 +57,7 @@ st.global.L1::evict_normal.b8
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // st.global.L1::evict_normal.b8 [addr], src; // PTX ISA 74, SM_75
+   // st.global.L1::evict_normal.b8 [addr], src; // PTX ISA 74, SM_70
    template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
    __device__ static inline void st_global_L1_evict_normal(
      B8* addr,
@@ -67,7 +67,7 @@ st.global.L1::evict_normal.b16
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // st.global.L1::evict_normal.b16 [addr], src; // PTX ISA 74, SM_75
+   // st.global.L1::evict_normal.b16 [addr], src; // PTX ISA 74, SM_70
    template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
    __device__ static inline void st_global_L1_evict_normal(
      B16* addr,
@@ -77,7 +77,7 @@ st.global.L1::evict_normal.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // st.global.L1::evict_normal.b32 [addr], src; // PTX ISA 74, SM_75
+   // st.global.L1::evict_normal.b32 [addr], src; // PTX ISA 74, SM_70
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void st_global_L1_evict_normal(
      B32* addr,
@@ -87,7 +87,7 @@ st.global.L1::evict_normal.b64
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // st.global.L1::evict_normal.b64 [addr], src; // PTX ISA 74, SM_75
+   // st.global.L1::evict_normal.b64 [addr], src; // PTX ISA 74, SM_70
    template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
    __device__ static inline void st_global_L1_evict_normal(
      B64* addr,
@@ -97,7 +97,7 @@ st.global.L1::evict_normal.b128
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // st.global.L1::evict_normal.b128 [addr], src; // PTX ISA 83, SM_75
+   // st.global.L1::evict_normal.b128 [addr], src; // PTX ISA 83, SM_70
    template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
    __device__ static inline void st_global_L1_evict_normal(
      B128* addr,
@@ -107,7 +107,7 @@ st.global.L1::evict_unchanged.b8
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // st.global.L1::evict_unchanged.b8 [addr], src; // PTX ISA 74, SM_75
+   // st.global.L1::evict_unchanged.b8 [addr], src; // PTX ISA 74, SM_70
    template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
    __device__ static inline void st_global_L1_evict_unchanged(
      B8* addr,
@@ -117,7 +117,7 @@ st.global.L1::evict_unchanged.b16
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // st.global.L1::evict_unchanged.b16 [addr], src; // PTX ISA 74, SM_75
+   // st.global.L1::evict_unchanged.b16 [addr], src; // PTX ISA 74, SM_70
    template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
    __device__ static inline void st_global_L1_evict_unchanged(
      B16* addr,
@@ -127,7 +127,7 @@ st.global.L1::evict_unchanged.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // st.global.L1::evict_unchanged.b32 [addr], src; // PTX ISA 74, SM_75
+   // st.global.L1::evict_unchanged.b32 [addr], src; // PTX ISA 74, SM_70
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void st_global_L1_evict_unchanged(
      B32* addr,
@@ -137,7 +137,7 @@ st.global.L1::evict_unchanged.b64
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // st.global.L1::evict_unchanged.b64 [addr], src; // PTX ISA 74, SM_75
+   // st.global.L1::evict_unchanged.b64 [addr], src; // PTX ISA 74, SM_70
    template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
    __device__ static inline void st_global_L1_evict_unchanged(
      B64* addr,
@@ -147,7 +147,7 @@ st.global.L1::evict_unchanged.b128
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // st.global.L1::evict_unchanged.b128 [addr], src; // PTX ISA 83, SM_75
+   // st.global.L1::evict_unchanged.b128 [addr], src; // PTX ISA 83, SM_70
    template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
    __device__ static inline void st_global_L1_evict_unchanged(
      B128* addr,
@@ -157,7 +157,7 @@ st.global.L1::evict_first.b8
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // st.global.L1::evict_first.b8 [addr], src; // PTX ISA 74, SM_75
+   // st.global.L1::evict_first.b8 [addr], src; // PTX ISA 74, SM_70
    template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
    __device__ static inline void st_global_L1_evict_first(
      B8* addr,
@@ -167,7 +167,7 @@ st.global.L1::evict_first.b16
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // st.global.L1::evict_first.b16 [addr], src; // PTX ISA 74, SM_75
+   // st.global.L1::evict_first.b16 [addr], src; // PTX ISA 74, SM_70
    template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
    __device__ static inline void st_global_L1_evict_first(
      B16* addr,
@@ -177,7 +177,7 @@ st.global.L1::evict_first.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // st.global.L1::evict_first.b32 [addr], src; // PTX ISA 74, SM_75
+   // st.global.L1::evict_first.b32 [addr], src; // PTX ISA 74, SM_70
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void st_global_L1_evict_first(
      B32* addr,
@@ -187,7 +187,7 @@ st.global.L1::evict_first.b64
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // st.global.L1::evict_first.b64 [addr], src; // PTX ISA 74, SM_75
+   // st.global.L1::evict_first.b64 [addr], src; // PTX ISA 74, SM_70
    template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
    __device__ static inline void st_global_L1_evict_first(
      B64* addr,
@@ -197,7 +197,7 @@ st.global.L1::evict_first.b128
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // st.global.L1::evict_first.b128 [addr], src; // PTX ISA 83, SM_75
+   // st.global.L1::evict_first.b128 [addr], src; // PTX ISA 83, SM_70
    template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
    __device__ static inline void st_global_L1_evict_first(
      B128* addr,
@@ -207,7 +207,7 @@ st.global.L1::evict_last.b8
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // st.global.L1::evict_last.b8 [addr], src; // PTX ISA 74, SM_75
+   // st.global.L1::evict_last.b8 [addr], src; // PTX ISA 74, SM_70
    template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
    __device__ static inline void st_global_L1_evict_last(
      B8* addr,
@@ -217,7 +217,7 @@ st.global.L1::evict_last.b16
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // st.global.L1::evict_last.b16 [addr], src; // PTX ISA 74, SM_75
+   // st.global.L1::evict_last.b16 [addr], src; // PTX ISA 74, SM_70
    template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
    __device__ static inline void st_global_L1_evict_last(
      B16* addr,
@@ -227,7 +227,7 @@ st.global.L1::evict_last.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // st.global.L1::evict_last.b32 [addr], src; // PTX ISA 74, SM_75
+   // st.global.L1::evict_last.b32 [addr], src; // PTX ISA 74, SM_70
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void st_global_L1_evict_last(
      B32* addr,
@@ -237,7 +237,7 @@ st.global.L1::evict_last.b64
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // st.global.L1::evict_last.b64 [addr], src; // PTX ISA 74, SM_75
+   // st.global.L1::evict_last.b64 [addr], src; // PTX ISA 74, SM_70
    template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
    __device__ static inline void st_global_L1_evict_last(
      B64* addr,
@@ -247,7 +247,7 @@ st.global.L1::evict_last.b128
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // st.global.L1::evict_last.b128 [addr], src; // PTX ISA 83, SM_75
+   // st.global.L1::evict_last.b128 [addr], src; // PTX ISA 83, SM_70
    template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
    __device__ static inline void st_global_L1_evict_last(
      B128* addr,
@@ -257,7 +257,7 @@ st.global.L1::no_allocate.b8
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // st.global.L1::no_allocate.b8 [addr], src; // PTX ISA 74, SM_75
+   // st.global.L1::no_allocate.b8 [addr], src; // PTX ISA 74, SM_70
    template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
    __device__ static inline void st_global_L1_no_allocate(
      B8* addr,
@@ -267,7 +267,7 @@ st.global.L1::no_allocate.b16
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // st.global.L1::no_allocate.b16 [addr], src; // PTX ISA 74, SM_75
+   // st.global.L1::no_allocate.b16 [addr], src; // PTX ISA 74, SM_70
    template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
    __device__ static inline void st_global_L1_no_allocate(
      B16* addr,
@@ -277,7 +277,7 @@ st.global.L1::no_allocate.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // st.global.L1::no_allocate.b32 [addr], src; // PTX ISA 74, SM_75
+   // st.global.L1::no_allocate.b32 [addr], src; // PTX ISA 74, SM_70
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void st_global_L1_no_allocate(
      B32* addr,
@@ -287,7 +287,7 @@ st.global.L1::no_allocate.b64
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // st.global.L1::no_allocate.b64 [addr], src; // PTX ISA 74, SM_75
+   // st.global.L1::no_allocate.b64 [addr], src; // PTX ISA 74, SM_70
    template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
    __device__ static inline void st_global_L1_no_allocate(
      B64* addr,
@@ -297,7 +297,7 @@ st.global.L1::no_allocate.b128
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // st.global.L1::no_allocate.b128 [addr], src; // PTX ISA 83, SM_75
+   // st.global.L1::no_allocate.b128 [addr], src; // PTX ISA 83, SM_70
    template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
    __device__ static inline void st_global_L1_no_allocate(
      B128* addr,

--- a/docs/libcudacxx/ptx/instructions/generated/st.rst
+++ b/docs/libcudacxx/ptx/instructions/generated/st.rst
@@ -1,7 +1,5 @@
-st
-=============
-
--  PTX ISA: ```st`` <https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#data-movement-and-conversion-instructions-st>`__
+..
+   This file was automatically generated. Do not edit.
 
 st.global.b8
 ^^^^^^^^^^^^

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/ld.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/ld.h
@@ -5,9 +5,9 @@
 
 /*
 // ld.global.b8 dest, [addr]; // PTX ISA 10, SM_50
-template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
-__device__ static inline _B8 ld_global(
-  const _B8* addr);
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_global(
+  const B8* addr);
 */
 #if __cccl_ptx_isa >= 100
 extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_is_not_supported_before_SM_50__();
@@ -137,9 +137,9 @@ _CCCL_DEVICE static inline _B128 ld_global(const _B128* __addr)
 
 /*
 // ld.global.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
-template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
-__device__ static inline _B8 ld_global_L2_64B(
-  const _B8* addr);
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_global_L2_64B(
+  const B8* addr);
 */
 #if __cccl_ptx_isa >= 740
 extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L2_64B_is_not_supported_before_SM_75__();
@@ -269,9 +269,9 @@ _CCCL_DEVICE static inline _B128 ld_global_L2_64B(const _B128* __addr)
 
 /*
 // ld.global.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
-template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
-__device__ static inline _B8 ld_global_L2_128B(
-  const _B8* addr);
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_global_L2_128B(
+  const B8* addr);
 */
 #if __cccl_ptx_isa >= 740
 extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L2_128B_is_not_supported_before_SM_75__();
@@ -401,9 +401,9 @@ _CCCL_DEVICE static inline _B128 ld_global_L2_128B(const _B128* __addr)
 
 /*
 // ld.global.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
-template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
-__device__ static inline _B8 ld_global_L2_256B(
-  const _B8* addr);
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_global_L2_256B(
+  const B8* addr);
 */
 #if __cccl_ptx_isa >= 740
 extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L2_256B_is_not_supported_before_SM_80__();
@@ -533,9 +533,9 @@ _CCCL_DEVICE static inline _B128 ld_global_L2_256B(const _B128* __addr)
 
 /*
 // ld.global.L1::evict_normal.b8 dest, [addr]; // PTX ISA 74, SM_70
-template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
-__device__ static inline _B8 ld_global_L1_evict_normal(
-  const _B8* addr);
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_global_L1_evict_normal(
+  const B8* addr);
 */
 #if __cccl_ptx_isa >= 740
 extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_normal_is_not_supported_before_SM_70__();
@@ -665,9 +665,9 @@ _CCCL_DEVICE static inline _B128 ld_global_L1_evict_normal(const _B128* __addr)
 
 /*
 // ld.global.L1::evict_normal.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
-template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
-__device__ static inline _B8 ld_global_L1_evict_normal_L2_64B(
-  const _B8* addr);
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_global_L1_evict_normal_L2_64B(
+  const B8* addr);
 */
 #if __cccl_ptx_isa >= 740
 extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
@@ -809,9 +809,9 @@ _CCCL_DEVICE static inline _B128 ld_global_L1_evict_normal_L2_64B(const _B128* _
 
 /*
 // ld.global.L1::evict_normal.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
-template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
-__device__ static inline _B8 ld_global_L1_evict_normal_L2_128B(
-  const _B8* addr);
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_global_L1_evict_normal_L2_128B(
+  const B8* addr);
 */
 #if __cccl_ptx_isa >= 740
 extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
@@ -953,9 +953,9 @@ _CCCL_DEVICE static inline _B128 ld_global_L1_evict_normal_L2_128B(const _B128* 
 
 /*
 // ld.global.L1::evict_normal.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
-template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
-__device__ static inline _B8 ld_global_L1_evict_normal_L2_256B(
-  const _B8* addr);
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_global_L1_evict_normal_L2_256B(
+  const B8* addr);
 */
 #if __cccl_ptx_isa >= 740
 extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
@@ -1097,9 +1097,9 @@ _CCCL_DEVICE static inline _B128 ld_global_L1_evict_normal_L2_256B(const _B128* 
 
 /*
 // ld.global.L1::evict_unchanged.b8 dest, [addr]; // PTX ISA 74, SM_70
-template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
-__device__ static inline _B8 ld_global_L1_evict_unchanged(
-  const _B8* addr);
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_global_L1_evict_unchanged(
+  const B8* addr);
 */
 #if __cccl_ptx_isa >= 740
 extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_unchanged_is_not_supported_before_SM_70__();
@@ -1229,9 +1229,9 @@ _CCCL_DEVICE static inline _B128 ld_global_L1_evict_unchanged(const _B128* __add
 
 /*
 // ld.global.L1::evict_unchanged.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
-template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
-__device__ static inline _B8 ld_global_L1_evict_unchanged_L2_64B(
-  const _B8* addr);
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_global_L1_evict_unchanged_L2_64B(
+  const B8* addr);
 */
 #if __cccl_ptx_isa >= 740
 extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
@@ -1373,9 +1373,9 @@ _CCCL_DEVICE static inline _B128 ld_global_L1_evict_unchanged_L2_64B(const _B128
 
 /*
 // ld.global.L1::evict_unchanged.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
-template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
-__device__ static inline _B8 ld_global_L1_evict_unchanged_L2_128B(
-  const _B8* addr);
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_global_L1_evict_unchanged_L2_128B(
+  const B8* addr);
 */
 #if __cccl_ptx_isa >= 740
 extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
@@ -1517,9 +1517,9 @@ _CCCL_DEVICE static inline _B128 ld_global_L1_evict_unchanged_L2_128B(const _B12
 
 /*
 // ld.global.L1::evict_unchanged.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
-template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
-__device__ static inline _B8 ld_global_L1_evict_unchanged_L2_256B(
-  const _B8* addr);
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_global_L1_evict_unchanged_L2_256B(
+  const B8* addr);
 */
 #if __cccl_ptx_isa >= 740
 extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
@@ -1661,9 +1661,9 @@ _CCCL_DEVICE static inline _B128 ld_global_L1_evict_unchanged_L2_256B(const _B12
 
 /*
 // ld.global.L1::evict_first.b8 dest, [addr]; // PTX ISA 74, SM_70
-template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
-__device__ static inline _B8 ld_global_L1_evict_first(
-  const _B8* addr);
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_global_L1_evict_first(
+  const B8* addr);
 */
 #if __cccl_ptx_isa >= 740
 extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_first_is_not_supported_before_SM_70__();
@@ -1793,9 +1793,9 @@ _CCCL_DEVICE static inline _B128 ld_global_L1_evict_first(const _B128* __addr)
 
 /*
 // ld.global.L1::evict_first.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
-template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
-__device__ static inline _B8 ld_global_L1_evict_first_L2_64B(
-  const _B8* addr);
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_global_L1_evict_first_L2_64B(
+  const B8* addr);
 */
 #if __cccl_ptx_isa >= 740
 extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
@@ -1934,9 +1934,9 @@ _CCCL_DEVICE static inline _B128 ld_global_L1_evict_first_L2_64B(const _B128* __
 
 /*
 // ld.global.L1::evict_first.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
-template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
-__device__ static inline _B8 ld_global_L1_evict_first_L2_128B(
-  const _B8* addr);
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_global_L1_evict_first_L2_128B(
+  const B8* addr);
 */
 #if __cccl_ptx_isa >= 740
 extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
@@ -2078,9 +2078,9 @@ _CCCL_DEVICE static inline _B128 ld_global_L1_evict_first_L2_128B(const _B128* _
 
 /*
 // ld.global.L1::evict_first.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
-template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
-__device__ static inline _B8 ld_global_L1_evict_first_L2_256B(
-  const _B8* addr);
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_global_L1_evict_first_L2_256B(
+  const B8* addr);
 */
 #if __cccl_ptx_isa >= 740
 extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
@@ -2222,9 +2222,9 @@ _CCCL_DEVICE static inline _B128 ld_global_L1_evict_first_L2_256B(const _B128* _
 
 /*
 // ld.global.L1::evict_last.b8 dest, [addr]; // PTX ISA 74, SM_70
-template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
-__device__ static inline _B8 ld_global_L1_evict_last(
-  const _B8* addr);
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_global_L1_evict_last(
+  const B8* addr);
 */
 #if __cccl_ptx_isa >= 740
 extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_last_is_not_supported_before_SM_70__();
@@ -2354,9 +2354,9 @@ _CCCL_DEVICE static inline _B128 ld_global_L1_evict_last(const _B128* __addr)
 
 /*
 // ld.global.L1::evict_last.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
-template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
-__device__ static inline _B8 ld_global_L1_evict_last_L2_64B(
-  const _B8* addr);
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_global_L1_evict_last_L2_64B(
+  const B8* addr);
 */
 #if __cccl_ptx_isa >= 740
 extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
@@ -2486,9 +2486,9 @@ _CCCL_DEVICE static inline _B128 ld_global_L1_evict_last_L2_64B(const _B128* __a
 
 /*
 // ld.global.L1::evict_last.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
-template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
-__device__ static inline _B8 ld_global_L1_evict_last_L2_128B(
-  const _B8* addr);
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_global_L1_evict_last_L2_128B(
+  const B8* addr);
 */
 #if __cccl_ptx_isa >= 740
 extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
@@ -2627,9 +2627,9 @@ _CCCL_DEVICE static inline _B128 ld_global_L1_evict_last_L2_128B(const _B128* __
 
 /*
 // ld.global.L1::evict_last.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
-template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
-__device__ static inline _B8 ld_global_L1_evict_last_L2_256B(
-  const _B8* addr);
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_global_L1_evict_last_L2_256B(
+  const B8* addr);
 */
 #if __cccl_ptx_isa >= 740
 extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
@@ -2768,9 +2768,9 @@ _CCCL_DEVICE static inline _B128 ld_global_L1_evict_last_L2_256B(const _B128* __
 
 /*
 // ld.global.L1::no_allocate.b8 dest, [addr]; // PTX ISA 74, SM_70
-template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
-__device__ static inline _B8 ld_global_L1_no_allocate(
-  const _B8* addr);
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_global_L1_no_allocate(
+  const B8* addr);
 */
 #if __cccl_ptx_isa >= 740
 extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_no_allocate_is_not_supported_before_SM_70__();
@@ -2900,9 +2900,9 @@ _CCCL_DEVICE static inline _B128 ld_global_L1_no_allocate(const _B128* __addr)
 
 /*
 // ld.global.L1::no_allocate.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
-template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
-__device__ static inline _B8 ld_global_L1_no_allocate_L2_64B(
-  const _B8* addr);
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_global_L1_no_allocate_L2_64B(
+  const B8* addr);
 */
 #if __cccl_ptx_isa >= 740
 extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
@@ -3041,9 +3041,9 @@ _CCCL_DEVICE static inline _B128 ld_global_L1_no_allocate_L2_64B(const _B128* __
 
 /*
 // ld.global.L1::no_allocate.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
-template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
-__device__ static inline _B8 ld_global_L1_no_allocate_L2_128B(
-  const _B8* addr);
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_global_L1_no_allocate_L2_128B(
+  const B8* addr);
 */
 #if __cccl_ptx_isa >= 740
 extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
@@ -3185,9 +3185,9 @@ _CCCL_DEVICE static inline _B128 ld_global_L1_no_allocate_L2_128B(const _B128* _
 
 /*
 // ld.global.L1::no_allocate.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
-template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
-__device__ static inline _B8 ld_global_L1_no_allocate_L2_256B(
-  const _B8* addr);
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_global_L1_no_allocate_L2_256B(
+  const B8* addr);
 */
 #if __cccl_ptx_isa >= 740
 extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
@@ -3329,9 +3329,9 @@ _CCCL_DEVICE static inline _B128 ld_global_L1_no_allocate_L2_256B(const _B128* _
 
 /*
 // ld.global.nc.b8 dest, [addr]; // PTX ISA 10, SM_50
-template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
-__device__ static inline _B8 ld_global_nc(
-  const _B8* addr);
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_global_nc(
+  const B8* addr);
 */
 #if __cccl_ptx_isa >= 100
 extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_is_not_supported_before_SM_50__();
@@ -3461,9 +3461,9 @@ _CCCL_DEVICE static inline _B128 ld_global_nc(const _B128* __addr)
 
 /*
 // ld.global.nc.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
-template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
-__device__ static inline _B8 ld_global_nc_L2_64B(
-  const _B8* addr);
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_global_nc_L2_64B(
+  const B8* addr);
 */
 #if __cccl_ptx_isa >= 740
 extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L2_64B_is_not_supported_before_SM_75__();
@@ -3593,9 +3593,9 @@ _CCCL_DEVICE static inline _B128 ld_global_nc_L2_64B(const _B128* __addr)
 
 /*
 // ld.global.nc.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
-template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
-__device__ static inline _B8 ld_global_nc_L2_128B(
-  const _B8* addr);
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_global_nc_L2_128B(
+  const B8* addr);
 */
 #if __cccl_ptx_isa >= 740
 extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L2_128B_is_not_supported_before_SM_75__();
@@ -3725,9 +3725,9 @@ _CCCL_DEVICE static inline _B128 ld_global_nc_L2_128B(const _B128* __addr)
 
 /*
 // ld.global.nc.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
-template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
-__device__ static inline _B8 ld_global_nc_L2_256B(
-  const _B8* addr);
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_global_nc_L2_256B(
+  const B8* addr);
 */
 #if __cccl_ptx_isa >= 740
 extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L2_256B_is_not_supported_before_SM_80__();
@@ -3857,9 +3857,9 @@ _CCCL_DEVICE static inline _B128 ld_global_nc_L2_256B(const _B128* __addr)
 
 /*
 // ld.global.nc.L1::evict_normal.b8 dest, [addr]; // PTX ISA 74, SM_70
-template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
-__device__ static inline _B8 ld_global_nc_L1_evict_normal(
-  const _B8* addr);
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_global_nc_L1_evict_normal(
+  const B8* addr);
 */
 #if __cccl_ptx_isa >= 740
 extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_normal_is_not_supported_before_SM_70__();
@@ -3989,9 +3989,9 @@ _CCCL_DEVICE static inline _B128 ld_global_nc_L1_evict_normal(const _B128* __add
 
 /*
 // ld.global.nc.L1::evict_normal.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
-template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
-__device__ static inline _B8 ld_global_nc_L1_evict_normal_L2_64B(
-  const _B8* addr);
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_global_nc_L1_evict_normal_L2_64B(
+  const B8* addr);
 */
 #if __cccl_ptx_isa >= 740
 extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
@@ -4133,9 +4133,9 @@ _CCCL_DEVICE static inline _B128 ld_global_nc_L1_evict_normal_L2_64B(const _B128
 
 /*
 // ld.global.nc.L1::evict_normal.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
-template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
-__device__ static inline _B8 ld_global_nc_L1_evict_normal_L2_128B(
-  const _B8* addr);
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_global_nc_L1_evict_normal_L2_128B(
+  const B8* addr);
 */
 #if __cccl_ptx_isa >= 740
 extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
@@ -4277,9 +4277,9 @@ _CCCL_DEVICE static inline _B128 ld_global_nc_L1_evict_normal_L2_128B(const _B12
 
 /*
 // ld.global.nc.L1::evict_normal.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
-template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
-__device__ static inline _B8 ld_global_nc_L1_evict_normal_L2_256B(
-  const _B8* addr);
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_global_nc_L1_evict_normal_L2_256B(
+  const B8* addr);
 */
 #if __cccl_ptx_isa >= 740
 extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
@@ -4421,9 +4421,9 @@ _CCCL_DEVICE static inline _B128 ld_global_nc_L1_evict_normal_L2_256B(const _B12
 
 /*
 // ld.global.nc.L1::evict_unchanged.b8 dest, [addr]; // PTX ISA 74, SM_70
-template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
-__device__ static inline _B8 ld_global_nc_L1_evict_unchanged(
-  const _B8* addr);
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_global_nc_L1_evict_unchanged(
+  const B8* addr);
 */
 #if __cccl_ptx_isa >= 740
 extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_unchanged_is_not_supported_before_SM_70__();
@@ -4553,9 +4553,9 @@ _CCCL_DEVICE static inline _B128 ld_global_nc_L1_evict_unchanged(const _B128* __
 
 /*
 // ld.global.nc.L1::evict_unchanged.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
-template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
-__device__ static inline _B8 ld_global_nc_L1_evict_unchanged_L2_64B(
-  const _B8* addr);
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_global_nc_L1_evict_unchanged_L2_64B(
+  const B8* addr);
 */
 #if __cccl_ptx_isa >= 740
 extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
@@ -4697,9 +4697,9 @@ _CCCL_DEVICE static inline _B128 ld_global_nc_L1_evict_unchanged_L2_64B(const _B
 
 /*
 // ld.global.nc.L1::evict_unchanged.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
-template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
-__device__ static inline _B8 ld_global_nc_L1_evict_unchanged_L2_128B(
-  const _B8* addr);
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_global_nc_L1_evict_unchanged_L2_128B(
+  const B8* addr);
 */
 #if __cccl_ptx_isa >= 740
 extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
@@ -4841,9 +4841,9 @@ _CCCL_DEVICE static inline _B128 ld_global_nc_L1_evict_unchanged_L2_128B(const _
 
 /*
 // ld.global.nc.L1::evict_unchanged.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
-template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
-__device__ static inline _B8 ld_global_nc_L1_evict_unchanged_L2_256B(
-  const _B8* addr);
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_global_nc_L1_evict_unchanged_L2_256B(
+  const B8* addr);
 */
 #if __cccl_ptx_isa >= 740
 extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
@@ -4985,9 +4985,9 @@ _CCCL_DEVICE static inline _B128 ld_global_nc_L1_evict_unchanged_L2_256B(const _
 
 /*
 // ld.global.nc.L1::evict_first.b8 dest, [addr]; // PTX ISA 74, SM_70
-template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
-__device__ static inline _B8 ld_global_nc_L1_evict_first(
-  const _B8* addr);
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_global_nc_L1_evict_first(
+  const B8* addr);
 */
 #if __cccl_ptx_isa >= 740
 extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_first_is_not_supported_before_SM_70__();
@@ -5117,9 +5117,9 @@ _CCCL_DEVICE static inline _B128 ld_global_nc_L1_evict_first(const _B128* __addr
 
 /*
 // ld.global.nc.L1::evict_first.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
-template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
-__device__ static inline _B8 ld_global_nc_L1_evict_first_L2_64B(
-  const _B8* addr);
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_global_nc_L1_evict_first_L2_64B(
+  const B8* addr);
 */
 #if __cccl_ptx_isa >= 740
 extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
@@ -5261,9 +5261,9 @@ _CCCL_DEVICE static inline _B128 ld_global_nc_L1_evict_first_L2_64B(const _B128*
 
 /*
 // ld.global.nc.L1::evict_first.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
-template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
-__device__ static inline _B8 ld_global_nc_L1_evict_first_L2_128B(
-  const _B8* addr);
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_global_nc_L1_evict_first_L2_128B(
+  const B8* addr);
 */
 #if __cccl_ptx_isa >= 740
 extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
@@ -5405,9 +5405,9 @@ _CCCL_DEVICE static inline _B128 ld_global_nc_L1_evict_first_L2_128B(const _B128
 
 /*
 // ld.global.nc.L1::evict_first.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
-template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
-__device__ static inline _B8 ld_global_nc_L1_evict_first_L2_256B(
-  const _B8* addr);
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_global_nc_L1_evict_first_L2_256B(
+  const B8* addr);
 */
 #if __cccl_ptx_isa >= 740
 extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
@@ -5549,9 +5549,9 @@ _CCCL_DEVICE static inline _B128 ld_global_nc_L1_evict_first_L2_256B(const _B128
 
 /*
 // ld.global.nc.L1::evict_last.b8 dest, [addr]; // PTX ISA 74, SM_70
-template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
-__device__ static inline _B8 ld_global_nc_L1_evict_last(
-  const _B8* addr);
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_global_nc_L1_evict_last(
+  const B8* addr);
 */
 #if __cccl_ptx_isa >= 740
 extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_last_is_not_supported_before_SM_70__();
@@ -5681,9 +5681,9 @@ _CCCL_DEVICE static inline _B128 ld_global_nc_L1_evict_last(const _B128* __addr)
 
 /*
 // ld.global.nc.L1::evict_last.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
-template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
-__device__ static inline _B8 ld_global_nc_L1_evict_last_L2_64B(
-  const _B8* addr);
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_global_nc_L1_evict_last_L2_64B(
+  const B8* addr);
 */
 #if __cccl_ptx_isa >= 740
 extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
@@ -5825,9 +5825,9 @@ _CCCL_DEVICE static inline _B128 ld_global_nc_L1_evict_last_L2_64B(const _B128* 
 
 /*
 // ld.global.nc.L1::evict_last.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
-template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
-__device__ static inline _B8 ld_global_nc_L1_evict_last_L2_128B(
-  const _B8* addr);
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_global_nc_L1_evict_last_L2_128B(
+  const B8* addr);
 */
 #if __cccl_ptx_isa >= 740
 extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
@@ -5969,9 +5969,9 @@ _CCCL_DEVICE static inline _B128 ld_global_nc_L1_evict_last_L2_128B(const _B128*
 
 /*
 // ld.global.nc.L1::evict_last.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
-template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
-__device__ static inline _B8 ld_global_nc_L1_evict_last_L2_256B(
-  const _B8* addr);
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_global_nc_L1_evict_last_L2_256B(
+  const B8* addr);
 */
 #if __cccl_ptx_isa >= 740
 extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
@@ -6113,9 +6113,9 @@ _CCCL_DEVICE static inline _B128 ld_global_nc_L1_evict_last_L2_256B(const _B128*
 
 /*
 // ld.global.nc.L1::no_allocate.b8 dest, [addr]; // PTX ISA 74, SM_70
-template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
-__device__ static inline _B8 ld_global_nc_L1_no_allocate(
-  const _B8* addr);
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_global_nc_L1_no_allocate(
+  const B8* addr);
 */
 #if __cccl_ptx_isa >= 740
 extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_no_allocate_is_not_supported_before_SM_70__();
@@ -6245,9 +6245,9 @@ _CCCL_DEVICE static inline _B128 ld_global_nc_L1_no_allocate(const _B128* __addr
 
 /*
 // ld.global.nc.L1::no_allocate.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
-template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
-__device__ static inline _B8 ld_global_nc_L1_no_allocate_L2_64B(
-  const _B8* addr);
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_global_nc_L1_no_allocate_L2_64B(
+  const B8* addr);
 */
 #if __cccl_ptx_isa >= 740
 extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
@@ -6389,9 +6389,9 @@ _CCCL_DEVICE static inline _B128 ld_global_nc_L1_no_allocate_L2_64B(const _B128*
 
 /*
 // ld.global.nc.L1::no_allocate.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
-template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
-__device__ static inline _B8 ld_global_nc_L1_no_allocate_L2_128B(
-  const _B8* addr);
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_global_nc_L1_no_allocate_L2_128B(
+  const B8* addr);
 */
 #if __cccl_ptx_isa >= 740
 extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
@@ -6533,9 +6533,9 @@ _CCCL_DEVICE static inline _B128 ld_global_nc_L1_no_allocate_L2_128B(const _B128
 
 /*
 // ld.global.nc.L1::no_allocate.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
-template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
-__device__ static inline _B8 ld_global_nc_L1_no_allocate_L2_256B(
-  const _B8* addr);
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_global_nc_L1_no_allocate_L2_256B(
+  const B8* addr);
 */
 #if __cccl_ptx_isa >= 740
 extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/ld.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/ld.h
@@ -1,6480 +1,6678 @@
 // This file was automatically generated. Do not edit.
 
-#ifndef _CUDA_PTX_GENERATED_INSTRUCTIONS_LD_H
-#define _CUDA_PTX_GENERATED_INSTRUCTIONS_LD_H
+#ifndef _CUDA_PTX_GENERATED_LD_H_
+#define _CUDA_PTX_GENERATED_LD_H_
 
 /*
 // ld.global.b8 dest, [addr]; // PTX ISA 10, SM_50
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global(
-  const B8* addr);
+template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
+__device__ static inline _B8 ld_global(
+  const _B8* addr);
 */
 #if __cccl_ptx_isa >= 100
-extern "C" __device__ void __cuda_ptx_ld_global_is_not_supported_before_SM_50__();
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global(const B8* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_is_not_supported_before_SM_50__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8 ld_global(const _B8* __addr)
 {
-  static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 500
-  std::uint32_t dest;
-  asm volatile("ld.global.b8 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return __u32_as_b8<B8>(dest);
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 500
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return __u32_as_b8<_B8>(__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_is_not_supported_before_SM_50__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B8*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 100
 
 /*
 // ld.global.b16 dest, [addr]; // PTX ISA 10, SM_50
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global(
   const B16* addr);
 */
 #if __cccl_ptx_isa >= 100
-extern "C" __device__ void __cuda_ptx_ld_global_is_not_supported_before_SM_50__();
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_global(const B16* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_is_not_supported_before_SM_50__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16 ld_global(const _B16* __addr)
 {
-  static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 500
-  std::uint16_t dest;
-  asm volatile("ld.global.b16 %0, [%1];" : "=h"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B16*>(&dest);
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 500
+  _CUDA_VSTD::uint16_t __dest;
+  asm volatile("ld.global.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B16*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_is_not_supported_before_SM_50__();
-  std::uint16_t err_out_var = 0;
-  return *reinterpret_cast<B16*>(&err_out_var);
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 100
 
 /*
 // ld.global.b32 dest, [addr]; // PTX ISA 10, SM_50
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global(
   const B32* addr);
 */
 #if __cccl_ptx_isa >= 100
-extern "C" __device__ void __cuda_ptx_ld_global_is_not_supported_before_SM_50__();
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_global(const B32* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_is_not_supported_before_SM_50__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32 ld_global(const _B32* __addr)
 {
-  static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 500
-  std::uint32_t dest;
-  asm volatile("ld.global.b32 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B32*>(&dest);
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 500
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B32*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_is_not_supported_before_SM_50__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B32*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 100
 
 /*
 // ld.global.b64 dest, [addr]; // PTX ISA 10, SM_50
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global(
   const B64* addr);
 */
 #if __cccl_ptx_isa >= 100
-extern "C" __device__ void __cuda_ptx_ld_global_is_not_supported_before_SM_50__();
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_global(const B64* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_is_not_supported_before_SM_50__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64 ld_global(const _B64* __addr)
 {
-  static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 500
-  std::uint64_t dest;
-  asm volatile("ld.global.b64 %0, [%1];" : "=l"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B64*>(&dest);
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 500
+  _CUDA_VSTD::uint64_t __dest;
+  asm volatile("ld.global.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B64*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_is_not_supported_before_SM_50__();
-  std::uint64_t err_out_var = 0;
-  return *reinterpret_cast<B64*>(&err_out_var);
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 100
 
 /*
 // ld.global.b128 dest, [addr]; // PTX ISA 83, SM_70
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
+template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global(
   const B128* addr);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_ld_global_is_not_supported_before_SM_70__();
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_global(const B128* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_is_not_supported_before_SM_70__();
+template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
+_CCCL_DEVICE static inline _B128 ld_global(const _B128* __addr)
 {
-  static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
-  longlong2 dest;
+  static_assert(sizeof(_B128) == 16, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
+  longlong2 __dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.b128 B128_dest, [%2];\n\t"
     "mov.b128 {%0, %1}, B128_dest; \n"
     "}"
-    : "=l"(dest.x), "=l"(dest.y)
-    : "l"(__as_ptr_gmem(addr))
+    : "=l"(__dest.x), "=l"(__dest.y)
+    : "l"(__as_ptr_gmem(__addr))
     : "memory");
-  return *reinterpret_cast<B128*>(&dest);
+  return *reinterpret_cast<_B128*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_is_not_supported_before_SM_70__();
-  longlong2 err_out_var{0, 0};
-  return *reinterpret_cast<B128*>(&err_out_var);
+  longlong2 __err_out_var{0, 0};
+  return *reinterpret_cast<_B128*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_L2_64B(
-  const B8* addr);
+template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
+__device__ static inline _B8 ld_global_L2_64B(
+  const _B8* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L2_64B_is_not_supported_before_SM_75__();
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_L2_64B(const B8* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8 ld_global_L2_64B(const _B8* __addr)
 {
-  static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint32_t dest;
-  asm volatile("ld.global.L2::64B.b8 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return __u32_as_b8<B8>(dest);
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.L2::64B.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return __u32_as_b8<_B8>(__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L2_64B_is_not_supported_before_SM_75__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B8*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L2::64B.b16 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L2_64B(
   const B16* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L2_64B_is_not_supported_before_SM_75__();
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_global_L2_64B(const B16* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16 ld_global_L2_64B(const _B16* __addr)
 {
-  static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint16_t dest;
-  asm volatile("ld.global.L2::64B.b16 %0, [%1];" : "=h"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B16*>(&dest);
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint16_t __dest;
+  asm volatile("ld.global.L2::64B.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B16*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L2_64B_is_not_supported_before_SM_75__();
-  std::uint16_t err_out_var = 0;
-  return *reinterpret_cast<B16*>(&err_out_var);
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L2::64B.b32 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L2_64B(
   const B32* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L2_64B_is_not_supported_before_SM_75__();
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_global_L2_64B(const B32* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32 ld_global_L2_64B(const _B32* __addr)
 {
-  static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint32_t dest;
-  asm volatile("ld.global.L2::64B.b32 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B32*>(&dest);
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.L2::64B.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B32*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L2_64B_is_not_supported_before_SM_75__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B32*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L2::64B.b64 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L2_64B(
   const B64* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L2_64B_is_not_supported_before_SM_75__();
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_global_L2_64B(const B64* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64 ld_global_L2_64B(const _B64* __addr)
 {
-  static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint64_t dest;
-  asm volatile("ld.global.L2::64B.b64 %0, [%1];" : "=l"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B64*>(&dest);
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint64_t __dest;
+  asm volatile("ld.global.L2::64B.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B64*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L2_64B_is_not_supported_before_SM_75__();
-  std::uint64_t err_out_var = 0;
-  return *reinterpret_cast<B64*>(&err_out_var);
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L2::64B.b128 dest, [addr]; // PTX ISA 83, SM_75
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
+template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L2_64B(
   const B128* addr);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_ld_global_L2_64B_is_not_supported_before_SM_75__();
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_global_L2_64B(const B128* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
+_CCCL_DEVICE static inline _B128 ld_global_L2_64B(const _B128* __addr)
 {
-  static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  longlong2 dest;
+  static_assert(sizeof(_B128) == 16, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  longlong2 __dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.L2::64B.b128 B128_dest, [%2];\n\t"
     "mov.b128 {%0, %1}, B128_dest; \n"
     "}"
-    : "=l"(dest.x), "=l"(dest.y)
-    : "l"(__as_ptr_gmem(addr))
+    : "=l"(__dest.x), "=l"(__dest.y)
+    : "l"(__as_ptr_gmem(__addr))
     : "memory");
-  return *reinterpret_cast<B128*>(&dest);
+  return *reinterpret_cast<_B128*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L2_64B_is_not_supported_before_SM_75__();
-  longlong2 err_out_var{0, 0};
-  return *reinterpret_cast<B128*>(&err_out_var);
+  longlong2 __err_out_var{0, 0};
+  return *reinterpret_cast<_B128*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_L2_128B(
-  const B8* addr);
+template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
+__device__ static inline _B8 ld_global_L2_128B(
+  const _B8* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L2_128B_is_not_supported_before_SM_75__();
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_L2_128B(const B8* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8 ld_global_L2_128B(const _B8* __addr)
 {
-  static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint32_t dest;
-  asm volatile("ld.global.L2::128B.b8 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return __u32_as_b8<B8>(dest);
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.L2::128B.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return __u32_as_b8<_B8>(__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L2_128B_is_not_supported_before_SM_75__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B8*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L2::128B.b16 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L2_128B(
   const B16* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L2_128B_is_not_supported_before_SM_75__();
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_global_L2_128B(const B16* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16 ld_global_L2_128B(const _B16* __addr)
 {
-  static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint16_t dest;
-  asm volatile("ld.global.L2::128B.b16 %0, [%1];" : "=h"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B16*>(&dest);
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint16_t __dest;
+  asm volatile("ld.global.L2::128B.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B16*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L2_128B_is_not_supported_before_SM_75__();
-  std::uint16_t err_out_var = 0;
-  return *reinterpret_cast<B16*>(&err_out_var);
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L2::128B.b32 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L2_128B(
   const B32* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L2_128B_is_not_supported_before_SM_75__();
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_global_L2_128B(const B32* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32 ld_global_L2_128B(const _B32* __addr)
 {
-  static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint32_t dest;
-  asm volatile("ld.global.L2::128B.b32 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B32*>(&dest);
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.L2::128B.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B32*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L2_128B_is_not_supported_before_SM_75__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B32*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L2::128B.b64 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L2_128B(
   const B64* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L2_128B_is_not_supported_before_SM_75__();
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_global_L2_128B(const B64* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64 ld_global_L2_128B(const _B64* __addr)
 {
-  static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint64_t dest;
-  asm volatile("ld.global.L2::128B.b64 %0, [%1];" : "=l"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B64*>(&dest);
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint64_t __dest;
+  asm volatile("ld.global.L2::128B.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B64*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L2_128B_is_not_supported_before_SM_75__();
-  std::uint64_t err_out_var = 0;
-  return *reinterpret_cast<B64*>(&err_out_var);
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L2::128B.b128 dest, [addr]; // PTX ISA 83, SM_75
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
+template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L2_128B(
   const B128* addr);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_ld_global_L2_128B_is_not_supported_before_SM_75__();
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_global_L2_128B(const B128* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
+_CCCL_DEVICE static inline _B128 ld_global_L2_128B(const _B128* __addr)
 {
-  static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  longlong2 dest;
+  static_assert(sizeof(_B128) == 16, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  longlong2 __dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.L2::128B.b128 B128_dest, [%2];\n\t"
     "mov.b128 {%0, %1}, B128_dest; \n"
     "}"
-    : "=l"(dest.x), "=l"(dest.y)
-    : "l"(__as_ptr_gmem(addr))
+    : "=l"(__dest.x), "=l"(__dest.y)
+    : "l"(__as_ptr_gmem(__addr))
     : "memory");
-  return *reinterpret_cast<B128*>(&dest);
+  return *reinterpret_cast<_B128*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L2_128B_is_not_supported_before_SM_75__();
-  longlong2 err_out_var{0, 0};
-  return *reinterpret_cast<B128*>(&err_out_var);
+  longlong2 __err_out_var{0, 0};
+  return *reinterpret_cast<_B128*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_L2_256B(
-  const B8* addr);
+template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
+__device__ static inline _B8 ld_global_L2_256B(
+  const _B8* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L2_256B_is_not_supported_before_SM_80__();
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_L2_256B(const B8* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8 ld_global_L2_256B(const _B8* __addr)
 {
-  static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  std::uint32_t dest;
-  asm volatile("ld.global.L2::256B.b8 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return __u32_as_b8<B8>(dest);
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.L2::256B.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return __u32_as_b8<_B8>(__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L2_256B_is_not_supported_before_SM_80__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B8*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L2_256B(
   const B16* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L2_256B_is_not_supported_before_SM_80__();
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_global_L2_256B(const B16* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16 ld_global_L2_256B(const _B16* __addr)
 {
-  static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  std::uint16_t dest;
-  asm volatile("ld.global.L2::256B.b16 %0, [%1];" : "=h"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B16*>(&dest);
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint16_t __dest;
+  asm volatile("ld.global.L2::256B.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B16*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L2_256B_is_not_supported_before_SM_80__();
-  std::uint16_t err_out_var = 0;
-  return *reinterpret_cast<B16*>(&err_out_var);
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L2_256B(
   const B32* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L2_256B_is_not_supported_before_SM_80__();
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_global_L2_256B(const B32* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32 ld_global_L2_256B(const _B32* __addr)
 {
-  static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  std::uint32_t dest;
-  asm volatile("ld.global.L2::256B.b32 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B32*>(&dest);
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.L2::256B.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B32*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L2_256B_is_not_supported_before_SM_80__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B32*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L2::256B.b64 dest, [addr]; // PTX ISA 74, SM_80
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L2_256B(
   const B64* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L2_256B_is_not_supported_before_SM_80__();
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_global_L2_256B(const B64* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64 ld_global_L2_256B(const _B64* __addr)
 {
-  static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  std::uint64_t dest;
-  asm volatile("ld.global.L2::256B.b64 %0, [%1];" : "=l"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B64*>(&dest);
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint64_t __dest;
+  asm volatile("ld.global.L2::256B.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B64*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L2_256B_is_not_supported_before_SM_80__();
-  std::uint64_t err_out_var = 0;
-  return *reinterpret_cast<B64*>(&err_out_var);
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L2::256B.b128 dest, [addr]; // PTX ISA 83, SM_80
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
+template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L2_256B(
   const B128* addr);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_ld_global_L2_256B_is_not_supported_before_SM_80__();
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_global_L2_256B(const B128* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
+_CCCL_DEVICE static inline _B128 ld_global_L2_256B(const _B128* __addr)
 {
-  static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  longlong2 dest;
+  static_assert(sizeof(_B128) == 16, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  longlong2 __dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.L2::256B.b128 B128_dest, [%2];\n\t"
     "mov.b128 {%0, %1}, B128_dest; \n"
     "}"
-    : "=l"(dest.x), "=l"(dest.y)
-    : "l"(__as_ptr_gmem(addr))
+    : "=l"(__dest.x), "=l"(__dest.y)
+    : "l"(__as_ptr_gmem(__addr))
     : "memory");
-  return *reinterpret_cast<B128*>(&dest);
+  return *reinterpret_cast<_B128*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L2_256B_is_not_supported_before_SM_80__();
-  longlong2 err_out_var{0, 0};
-  return *reinterpret_cast<B128*>(&err_out_var);
+  longlong2 __err_out_var{0, 0};
+  return *reinterpret_cast<_B128*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.L1::evict_normal.b8 dest, [addr]; // PTX ISA 74, SM_70
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_L1_evict_normal(
-  const B8* addr);
+template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
+__device__ static inline _B8 ld_global_L1_evict_normal(
+  const _B8* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_normal_is_not_supported_before_SM_70__();
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_L1_evict_normal(const B8* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_normal_is_not_supported_before_SM_70__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8 ld_global_L1_evict_normal(const _B8* __addr)
 {
-  static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
-  std::uint32_t dest;
-  asm volatile("ld.global.L1::evict_normal.b8 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return __u32_as_b8<B8>(dest);
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.L1::evict_normal.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return __u32_as_b8<_B8>(__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_normal_is_not_supported_before_SM_70__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B8*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_normal.b16 dest, [addr]; // PTX ISA 74, SM_70
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_evict_normal(
   const B16* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_normal_is_not_supported_before_SM_70__();
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_global_L1_evict_normal(const B16* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_normal_is_not_supported_before_SM_70__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16 ld_global_L1_evict_normal(const _B16* __addr)
 {
-  static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
-  std::uint16_t dest;
-  asm volatile("ld.global.L1::evict_normal.b16 %0, [%1];" : "=h"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B16*>(&dest);
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
+  _CUDA_VSTD::uint16_t __dest;
+  asm volatile("ld.global.L1::evict_normal.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B16*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_normal_is_not_supported_before_SM_70__();
-  std::uint16_t err_out_var = 0;
-  return *reinterpret_cast<B16*>(&err_out_var);
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_normal.b32 dest, [addr]; // PTX ISA 74, SM_70
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_evict_normal(
   const B32* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_normal_is_not_supported_before_SM_70__();
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_global_L1_evict_normal(const B32* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_normal_is_not_supported_before_SM_70__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32 ld_global_L1_evict_normal(const _B32* __addr)
 {
-  static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
-  std::uint32_t dest;
-  asm volatile("ld.global.L1::evict_normal.b32 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B32*>(&dest);
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.L1::evict_normal.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B32*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_normal_is_not_supported_before_SM_70__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B32*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_normal.b64 dest, [addr]; // PTX ISA 74, SM_70
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_evict_normal(
   const B64* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_normal_is_not_supported_before_SM_70__();
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_global_L1_evict_normal(const B64* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_normal_is_not_supported_before_SM_70__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64 ld_global_L1_evict_normal(const _B64* __addr)
 {
-  static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
-  std::uint64_t dest;
-  asm volatile("ld.global.L1::evict_normal.b64 %0, [%1];" : "=l"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B64*>(&dest);
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
+  _CUDA_VSTD::uint64_t __dest;
+  asm volatile("ld.global.L1::evict_normal.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B64*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_normal_is_not_supported_before_SM_70__();
-  std::uint64_t err_out_var = 0;
-  return *reinterpret_cast<B64*>(&err_out_var);
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_normal.b128 dest, [addr]; // PTX ISA 83, SM_70
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
+template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_evict_normal(
   const B128* addr);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_normal_is_not_supported_before_SM_70__();
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_global_L1_evict_normal(const B128* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_normal_is_not_supported_before_SM_70__();
+template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
+_CCCL_DEVICE static inline _B128 ld_global_L1_evict_normal(const _B128* __addr)
 {
-  static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
-  longlong2 dest;
+  static_assert(sizeof(_B128) == 16, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
+  longlong2 __dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.L1::evict_normal.b128 B128_dest, [%2];\n\t"
     "mov.b128 {%0, %1}, B128_dest; \n"
     "}"
-    : "=l"(dest.x), "=l"(dest.y)
-    : "l"(__as_ptr_gmem(addr))
+    : "=l"(__dest.x), "=l"(__dest.y)
+    : "l"(__as_ptr_gmem(__addr))
     : "memory");
-  return *reinterpret_cast<B128*>(&dest);
+  return *reinterpret_cast<_B128*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_normal_is_not_supported_before_SM_70__();
-  longlong2 err_out_var{0, 0};
-  return *reinterpret_cast<B128*>(&err_out_var);
+  longlong2 __err_out_var{0, 0};
+  return *reinterpret_cast<_B128*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.L1::evict_normal.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_L1_evict_normal_L2_64B(
-  const B8* addr);
+template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
+__device__ static inline _B8 ld_global_L1_evict_normal_L2_64B(
+  const _B8* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_L1_evict_normal_L2_64B(const B8* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8 ld_global_L1_evict_normal_L2_64B(const _B8* __addr)
 {
-  static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint32_t dest;
-  asm volatile("ld.global.L1::evict_normal.L2::64B.b8 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return __u32_as_b8<B8>(dest);
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.L1::evict_normal.L2::64B.b8 %0, [%1];"
+               : "=r"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return __u32_as_b8<_B8>(__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B8*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_normal.L2::64B.b16 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_evict_normal_L2_64B(
   const B16* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_global_L1_evict_normal_L2_64B(const B16* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16 ld_global_L1_evict_normal_L2_64B(const _B16* __addr)
 {
-  static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint16_t dest;
-  asm volatile("ld.global.L1::evict_normal.L2::64B.b16 %0, [%1];" : "=h"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B16*>(&dest);
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint16_t __dest;
+  asm volatile("ld.global.L1::evict_normal.L2::64B.b16 %0, [%1];"
+               : "=h"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return *reinterpret_cast<_B16*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
-  std::uint16_t err_out_var = 0;
-  return *reinterpret_cast<B16*>(&err_out_var);
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_normal.L2::64B.b32 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_evict_normal_L2_64B(
   const B32* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_global_L1_evict_normal_L2_64B(const B32* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32 ld_global_L1_evict_normal_L2_64B(const _B32* __addr)
 {
-  static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint32_t dest;
-  asm volatile("ld.global.L1::evict_normal.L2::64B.b32 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B32*>(&dest);
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.L1::evict_normal.L2::64B.b32 %0, [%1];"
+               : "=r"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return *reinterpret_cast<_B32*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B32*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_normal.L2::64B.b64 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_evict_normal_L2_64B(
   const B64* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_global_L1_evict_normal_L2_64B(const B64* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64 ld_global_L1_evict_normal_L2_64B(const _B64* __addr)
 {
-  static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint64_t dest;
-  asm volatile("ld.global.L1::evict_normal.L2::64B.b64 %0, [%1];" : "=l"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B64*>(&dest);
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint64_t __dest;
+  asm volatile("ld.global.L1::evict_normal.L2::64B.b64 %0, [%1];"
+               : "=l"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return *reinterpret_cast<_B64*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
-  std::uint64_t err_out_var = 0;
-  return *reinterpret_cast<B64*>(&err_out_var);
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_normal.L2::64B.b128 dest, [addr]; // PTX ISA 83, SM_75
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
+template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_evict_normal_L2_64B(
   const B128* addr);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_global_L1_evict_normal_L2_64B(const B128* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
+_CCCL_DEVICE static inline _B128 ld_global_L1_evict_normal_L2_64B(const _B128* __addr)
 {
-  static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  longlong2 dest;
+  static_assert(sizeof(_B128) == 16, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  longlong2 __dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.L1::evict_normal.L2::64B.b128 B128_dest, [%2];\n\t"
     "mov.b128 {%0, %1}, B128_dest; \n"
     "}"
-    : "=l"(dest.x), "=l"(dest.y)
-    : "l"(__as_ptr_gmem(addr))
+    : "=l"(__dest.x), "=l"(__dest.y)
+    : "l"(__as_ptr_gmem(__addr))
     : "memory");
-  return *reinterpret_cast<B128*>(&dest);
+  return *reinterpret_cast<_B128*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
-  longlong2 err_out_var{0, 0};
-  return *reinterpret_cast<B128*>(&err_out_var);
+  longlong2 __err_out_var{0, 0};
+  return *reinterpret_cast<_B128*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.L1::evict_normal.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_L1_evict_normal_L2_128B(
-  const B8* addr);
+template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
+__device__ static inline _B8 ld_global_L1_evict_normal_L2_128B(
+  const _B8* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_L1_evict_normal_L2_128B(const B8* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8 ld_global_L1_evict_normal_L2_128B(const _B8* __addr)
 {
-  static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint32_t dest;
-  asm volatile("ld.global.L1::evict_normal.L2::128B.b8 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return __u32_as_b8<B8>(dest);
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.L1::evict_normal.L2::128B.b8 %0, [%1];"
+               : "=r"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return __u32_as_b8<_B8>(__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B8*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_normal.L2::128B.b16 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_evict_normal_L2_128B(
   const B16* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_global_L1_evict_normal_L2_128B(const B16* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16 ld_global_L1_evict_normal_L2_128B(const _B16* __addr)
 {
-  static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint16_t dest;
-  asm volatile("ld.global.L1::evict_normal.L2::128B.b16 %0, [%1];" : "=h"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B16*>(&dest);
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint16_t __dest;
+  asm volatile("ld.global.L1::evict_normal.L2::128B.b16 %0, [%1];"
+               : "=h"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return *reinterpret_cast<_B16*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
-  std::uint16_t err_out_var = 0;
-  return *reinterpret_cast<B16*>(&err_out_var);
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_normal.L2::128B.b32 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_evict_normal_L2_128B(
   const B32* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_global_L1_evict_normal_L2_128B(const B32* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32 ld_global_L1_evict_normal_L2_128B(const _B32* __addr)
 {
-  static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint32_t dest;
-  asm volatile("ld.global.L1::evict_normal.L2::128B.b32 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B32*>(&dest);
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.L1::evict_normal.L2::128B.b32 %0, [%1];"
+               : "=r"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return *reinterpret_cast<_B32*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B32*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_normal.L2::128B.b64 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_evict_normal_L2_128B(
   const B64* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_global_L1_evict_normal_L2_128B(const B64* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64 ld_global_L1_evict_normal_L2_128B(const _B64* __addr)
 {
-  static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint64_t dest;
-  asm volatile("ld.global.L1::evict_normal.L2::128B.b64 %0, [%1];" : "=l"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B64*>(&dest);
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint64_t __dest;
+  asm volatile("ld.global.L1::evict_normal.L2::128B.b64 %0, [%1];"
+               : "=l"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return *reinterpret_cast<_B64*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
-  std::uint64_t err_out_var = 0;
-  return *reinterpret_cast<B64*>(&err_out_var);
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_normal.L2::128B.b128 dest, [addr]; // PTX ISA 83, SM_75
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
+template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_evict_normal_L2_128B(
   const B128* addr);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_global_L1_evict_normal_L2_128B(const B128* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
+_CCCL_DEVICE static inline _B128 ld_global_L1_evict_normal_L2_128B(const _B128* __addr)
 {
-  static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  longlong2 dest;
+  static_assert(sizeof(_B128) == 16, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  longlong2 __dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.L1::evict_normal.L2::128B.b128 B128_dest, [%2];\n\t"
     "mov.b128 {%0, %1}, B128_dest; \n"
     "}"
-    : "=l"(dest.x), "=l"(dest.y)
-    : "l"(__as_ptr_gmem(addr))
+    : "=l"(__dest.x), "=l"(__dest.y)
+    : "l"(__as_ptr_gmem(__addr))
     : "memory");
-  return *reinterpret_cast<B128*>(&dest);
+  return *reinterpret_cast<_B128*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
-  longlong2 err_out_var{0, 0};
-  return *reinterpret_cast<B128*>(&err_out_var);
+  longlong2 __err_out_var{0, 0};
+  return *reinterpret_cast<_B128*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.L1::evict_normal.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_L1_evict_normal_L2_256B(
-  const B8* addr);
+template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
+__device__ static inline _B8 ld_global_L1_evict_normal_L2_256B(
+  const _B8* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_L1_evict_normal_L2_256B(const B8* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8 ld_global_L1_evict_normal_L2_256B(const _B8* __addr)
 {
-  static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  std::uint32_t dest;
-  asm volatile("ld.global.L1::evict_normal.L2::256B.b8 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return __u32_as_b8<B8>(dest);
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.L1::evict_normal.L2::256B.b8 %0, [%1];"
+               : "=r"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return __u32_as_b8<_B8>(__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B8*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_normal.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_evict_normal_L2_256B(
   const B16* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_global_L1_evict_normal_L2_256B(const B16* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16 ld_global_L1_evict_normal_L2_256B(const _B16* __addr)
 {
-  static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  std::uint16_t dest;
-  asm volatile("ld.global.L1::evict_normal.L2::256B.b16 %0, [%1];" : "=h"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B16*>(&dest);
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint16_t __dest;
+  asm volatile("ld.global.L1::evict_normal.L2::256B.b16 %0, [%1];"
+               : "=h"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return *reinterpret_cast<_B16*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
-  std::uint16_t err_out_var = 0;
-  return *reinterpret_cast<B16*>(&err_out_var);
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_normal.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_evict_normal_L2_256B(
   const B32* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_global_L1_evict_normal_L2_256B(const B32* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32 ld_global_L1_evict_normal_L2_256B(const _B32* __addr)
 {
-  static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  std::uint32_t dest;
-  asm volatile("ld.global.L1::evict_normal.L2::256B.b32 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B32*>(&dest);
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.L1::evict_normal.L2::256B.b32 %0, [%1];"
+               : "=r"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return *reinterpret_cast<_B32*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B32*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_normal.L2::256B.b64 dest, [addr]; // PTX ISA 74, SM_80
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_evict_normal_L2_256B(
   const B64* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_global_L1_evict_normal_L2_256B(const B64* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64 ld_global_L1_evict_normal_L2_256B(const _B64* __addr)
 {
-  static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  std::uint64_t dest;
-  asm volatile("ld.global.L1::evict_normal.L2::256B.b64 %0, [%1];" : "=l"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B64*>(&dest);
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint64_t __dest;
+  asm volatile("ld.global.L1::evict_normal.L2::256B.b64 %0, [%1];"
+               : "=l"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return *reinterpret_cast<_B64*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
-  std::uint64_t err_out_var = 0;
-  return *reinterpret_cast<B64*>(&err_out_var);
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_normal.L2::256B.b128 dest, [addr]; // PTX ISA 83, SM_80
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
+template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_evict_normal_L2_256B(
   const B128* addr);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_global_L1_evict_normal_L2_256B(const B128* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
+_CCCL_DEVICE static inline _B128 ld_global_L1_evict_normal_L2_256B(const _B128* __addr)
 {
-  static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  longlong2 dest;
+  static_assert(sizeof(_B128) == 16, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  longlong2 __dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.L1::evict_normal.L2::256B.b128 B128_dest, [%2];\n\t"
     "mov.b128 {%0, %1}, B128_dest; \n"
     "}"
-    : "=l"(dest.x), "=l"(dest.y)
-    : "l"(__as_ptr_gmem(addr))
+    : "=l"(__dest.x), "=l"(__dest.y)
+    : "l"(__as_ptr_gmem(__addr))
     : "memory");
-  return *reinterpret_cast<B128*>(&dest);
+  return *reinterpret_cast<_B128*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
-  longlong2 err_out_var{0, 0};
-  return *reinterpret_cast<B128*>(&err_out_var);
+  longlong2 __err_out_var{0, 0};
+  return *reinterpret_cast<_B128*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.L1::evict_unchanged.b8 dest, [addr]; // PTX ISA 74, SM_70
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_L1_evict_unchanged(
-  const B8* addr);
+template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
+__device__ static inline _B8 ld_global_L1_evict_unchanged(
+  const _B8* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_unchanged_is_not_supported_before_SM_70__();
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_L1_evict_unchanged(const B8* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_unchanged_is_not_supported_before_SM_70__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8 ld_global_L1_evict_unchanged(const _B8* __addr)
 {
-  static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
-  std::uint32_t dest;
-  asm volatile("ld.global.L1::evict_unchanged.b8 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return __u32_as_b8<B8>(dest);
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.L1::evict_unchanged.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return __u32_as_b8<_B8>(__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_unchanged_is_not_supported_before_SM_70__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B8*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_unchanged.b16 dest, [addr]; // PTX ISA 74, SM_70
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_evict_unchanged(
   const B16* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_unchanged_is_not_supported_before_SM_70__();
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_global_L1_evict_unchanged(const B16* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_unchanged_is_not_supported_before_SM_70__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16 ld_global_L1_evict_unchanged(const _B16* __addr)
 {
-  static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
-  std::uint16_t dest;
-  asm volatile("ld.global.L1::evict_unchanged.b16 %0, [%1];" : "=h"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B16*>(&dest);
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
+  _CUDA_VSTD::uint16_t __dest;
+  asm volatile("ld.global.L1::evict_unchanged.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B16*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_unchanged_is_not_supported_before_SM_70__();
-  std::uint16_t err_out_var = 0;
-  return *reinterpret_cast<B16*>(&err_out_var);
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_unchanged.b32 dest, [addr]; // PTX ISA 74, SM_70
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_evict_unchanged(
   const B32* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_unchanged_is_not_supported_before_SM_70__();
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_global_L1_evict_unchanged(const B32* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_unchanged_is_not_supported_before_SM_70__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32 ld_global_L1_evict_unchanged(const _B32* __addr)
 {
-  static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
-  std::uint32_t dest;
-  asm volatile("ld.global.L1::evict_unchanged.b32 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B32*>(&dest);
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.L1::evict_unchanged.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B32*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_unchanged_is_not_supported_before_SM_70__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B32*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_unchanged.b64 dest, [addr]; // PTX ISA 74, SM_70
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_evict_unchanged(
   const B64* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_unchanged_is_not_supported_before_SM_70__();
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_global_L1_evict_unchanged(const B64* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_unchanged_is_not_supported_before_SM_70__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64 ld_global_L1_evict_unchanged(const _B64* __addr)
 {
-  static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
-  std::uint64_t dest;
-  asm volatile("ld.global.L1::evict_unchanged.b64 %0, [%1];" : "=l"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B64*>(&dest);
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
+  _CUDA_VSTD::uint64_t __dest;
+  asm volatile("ld.global.L1::evict_unchanged.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B64*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_unchanged_is_not_supported_before_SM_70__();
-  std::uint64_t err_out_var = 0;
-  return *reinterpret_cast<B64*>(&err_out_var);
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_unchanged.b128 dest, [addr]; // PTX ISA 83, SM_70
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
+template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_evict_unchanged(
   const B128* addr);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_unchanged_is_not_supported_before_SM_70__();
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_global_L1_evict_unchanged(const B128* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_unchanged_is_not_supported_before_SM_70__();
+template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
+_CCCL_DEVICE static inline _B128 ld_global_L1_evict_unchanged(const _B128* __addr)
 {
-  static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
-  longlong2 dest;
+  static_assert(sizeof(_B128) == 16, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
+  longlong2 __dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.L1::evict_unchanged.b128 B128_dest, [%2];\n\t"
     "mov.b128 {%0, %1}, B128_dest; \n"
     "}"
-    : "=l"(dest.x), "=l"(dest.y)
-    : "l"(__as_ptr_gmem(addr))
+    : "=l"(__dest.x), "=l"(__dest.y)
+    : "l"(__as_ptr_gmem(__addr))
     : "memory");
-  return *reinterpret_cast<B128*>(&dest);
+  return *reinterpret_cast<_B128*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_unchanged_is_not_supported_before_SM_70__();
-  longlong2 err_out_var{0, 0};
-  return *reinterpret_cast<B128*>(&err_out_var);
+  longlong2 __err_out_var{0, 0};
+  return *reinterpret_cast<_B128*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.L1::evict_unchanged.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_L1_evict_unchanged_L2_64B(
-  const B8* addr);
+template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
+__device__ static inline _B8 ld_global_L1_evict_unchanged_L2_64B(
+  const _B8* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_L1_evict_unchanged_L2_64B(const B8* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8 ld_global_L1_evict_unchanged_L2_64B(const _B8* __addr)
 {
-  static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint32_t dest;
-  asm volatile("ld.global.L1::evict_unchanged.L2::64B.b8 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return __u32_as_b8<B8>(dest);
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.L1::evict_unchanged.L2::64B.b8 %0, [%1];"
+               : "=r"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return __u32_as_b8<_B8>(__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B8*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_unchanged.L2::64B.b16 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_evict_unchanged_L2_64B(
   const B16* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_global_L1_evict_unchanged_L2_64B(const B16* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16 ld_global_L1_evict_unchanged_L2_64B(const _B16* __addr)
 {
-  static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint16_t dest;
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint16_t __dest;
   asm volatile("ld.global.L1::evict_unchanged.L2::64B.b16 %0, [%1];"
-               : "=h"(dest)
-               : "l"(__as_ptr_gmem(addr))
+               : "=h"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
                : "memory");
-  return *reinterpret_cast<B16*>(&dest);
+  return *reinterpret_cast<_B16*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
-  std::uint16_t err_out_var = 0;
-  return *reinterpret_cast<B16*>(&err_out_var);
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_unchanged.L2::64B.b32 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_evict_unchanged_L2_64B(
   const B32* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_global_L1_evict_unchanged_L2_64B(const B32* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32 ld_global_L1_evict_unchanged_L2_64B(const _B32* __addr)
 {
-  static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint32_t dest;
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint32_t __dest;
   asm volatile("ld.global.L1::evict_unchanged.L2::64B.b32 %0, [%1];"
-               : "=r"(dest)
-               : "l"(__as_ptr_gmem(addr))
+               : "=r"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
                : "memory");
-  return *reinterpret_cast<B32*>(&dest);
+  return *reinterpret_cast<_B32*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B32*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_unchanged.L2::64B.b64 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_evict_unchanged_L2_64B(
   const B64* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_global_L1_evict_unchanged_L2_64B(const B64* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64 ld_global_L1_evict_unchanged_L2_64B(const _B64* __addr)
 {
-  static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint64_t dest;
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint64_t __dest;
   asm volatile("ld.global.L1::evict_unchanged.L2::64B.b64 %0, [%1];"
-               : "=l"(dest)
-               : "l"(__as_ptr_gmem(addr))
+               : "=l"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
                : "memory");
-  return *reinterpret_cast<B64*>(&dest);
+  return *reinterpret_cast<_B64*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
-  std::uint64_t err_out_var = 0;
-  return *reinterpret_cast<B64*>(&err_out_var);
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_unchanged.L2::64B.b128 dest, [addr]; // PTX ISA 83, SM_75
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
+template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_evict_unchanged_L2_64B(
   const B128* addr);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_global_L1_evict_unchanged_L2_64B(const B128* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
+_CCCL_DEVICE static inline _B128 ld_global_L1_evict_unchanged_L2_64B(const _B128* __addr)
 {
-  static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  longlong2 dest;
+  static_assert(sizeof(_B128) == 16, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  longlong2 __dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.L1::evict_unchanged.L2::64B.b128 B128_dest, [%2];\n\t"
     "mov.b128 {%0, %1}, B128_dest; \n"
     "}"
-    : "=l"(dest.x), "=l"(dest.y)
-    : "l"(__as_ptr_gmem(addr))
+    : "=l"(__dest.x), "=l"(__dest.y)
+    : "l"(__as_ptr_gmem(__addr))
     : "memory");
-  return *reinterpret_cast<B128*>(&dest);
+  return *reinterpret_cast<_B128*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
-  longlong2 err_out_var{0, 0};
-  return *reinterpret_cast<B128*>(&err_out_var);
+  longlong2 __err_out_var{0, 0};
+  return *reinterpret_cast<_B128*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.L1::evict_unchanged.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_L1_evict_unchanged_L2_128B(
-  const B8* addr);
+template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
+__device__ static inline _B8 ld_global_L1_evict_unchanged_L2_128B(
+  const _B8* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_L1_evict_unchanged_L2_128B(const B8* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8 ld_global_L1_evict_unchanged_L2_128B(const _B8* __addr)
 {
-  static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint32_t dest;
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint32_t __dest;
   asm volatile("ld.global.L1::evict_unchanged.L2::128B.b8 %0, [%1];"
-               : "=r"(dest)
-               : "l"(__as_ptr_gmem(addr))
+               : "=r"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
                : "memory");
-  return __u32_as_b8<B8>(dest);
+  return __u32_as_b8<_B8>(__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B8*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_unchanged.L2::128B.b16 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_evict_unchanged_L2_128B(
   const B16* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_global_L1_evict_unchanged_L2_128B(const B16* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16 ld_global_L1_evict_unchanged_L2_128B(const _B16* __addr)
 {
-  static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint16_t dest;
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint16_t __dest;
   asm volatile("ld.global.L1::evict_unchanged.L2::128B.b16 %0, [%1];"
-               : "=h"(dest)
-               : "l"(__as_ptr_gmem(addr))
+               : "=h"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
                : "memory");
-  return *reinterpret_cast<B16*>(&dest);
+  return *reinterpret_cast<_B16*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
-  std::uint16_t err_out_var = 0;
-  return *reinterpret_cast<B16*>(&err_out_var);
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_unchanged.L2::128B.b32 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_evict_unchanged_L2_128B(
   const B32* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_global_L1_evict_unchanged_L2_128B(const B32* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32 ld_global_L1_evict_unchanged_L2_128B(const _B32* __addr)
 {
-  static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint32_t dest;
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint32_t __dest;
   asm volatile("ld.global.L1::evict_unchanged.L2::128B.b32 %0, [%1];"
-               : "=r"(dest)
-               : "l"(__as_ptr_gmem(addr))
+               : "=r"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
                : "memory");
-  return *reinterpret_cast<B32*>(&dest);
+  return *reinterpret_cast<_B32*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B32*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_unchanged.L2::128B.b64 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_evict_unchanged_L2_128B(
   const B64* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_global_L1_evict_unchanged_L2_128B(const B64* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64 ld_global_L1_evict_unchanged_L2_128B(const _B64* __addr)
 {
-  static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint64_t dest;
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint64_t __dest;
   asm volatile("ld.global.L1::evict_unchanged.L2::128B.b64 %0, [%1];"
-               : "=l"(dest)
-               : "l"(__as_ptr_gmem(addr))
+               : "=l"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
                : "memory");
-  return *reinterpret_cast<B64*>(&dest);
+  return *reinterpret_cast<_B64*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
-  std::uint64_t err_out_var = 0;
-  return *reinterpret_cast<B64*>(&err_out_var);
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_unchanged.L2::128B.b128 dest, [addr]; // PTX ISA 83, SM_75
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
+template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_evict_unchanged_L2_128B(
   const B128* addr);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_global_L1_evict_unchanged_L2_128B(const B128* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
+_CCCL_DEVICE static inline _B128 ld_global_L1_evict_unchanged_L2_128B(const _B128* __addr)
 {
-  static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  longlong2 dest;
+  static_assert(sizeof(_B128) == 16, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  longlong2 __dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.L1::evict_unchanged.L2::128B.b128 B128_dest, [%2];\n\t"
     "mov.b128 {%0, %1}, B128_dest; \n"
     "}"
-    : "=l"(dest.x), "=l"(dest.y)
-    : "l"(__as_ptr_gmem(addr))
+    : "=l"(__dest.x), "=l"(__dest.y)
+    : "l"(__as_ptr_gmem(__addr))
     : "memory");
-  return *reinterpret_cast<B128*>(&dest);
+  return *reinterpret_cast<_B128*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
-  longlong2 err_out_var{0, 0};
-  return *reinterpret_cast<B128*>(&err_out_var);
+  longlong2 __err_out_var{0, 0};
+  return *reinterpret_cast<_B128*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.L1::evict_unchanged.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_L1_evict_unchanged_L2_256B(
-  const B8* addr);
+template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
+__device__ static inline _B8 ld_global_L1_evict_unchanged_L2_256B(
+  const _B8* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_L1_evict_unchanged_L2_256B(const B8* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8 ld_global_L1_evict_unchanged_L2_256B(const _B8* __addr)
 {
-  static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  std::uint32_t dest;
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint32_t __dest;
   asm volatile("ld.global.L1::evict_unchanged.L2::256B.b8 %0, [%1];"
-               : "=r"(dest)
-               : "l"(__as_ptr_gmem(addr))
+               : "=r"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
                : "memory");
-  return __u32_as_b8<B8>(dest);
+  return __u32_as_b8<_B8>(__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B8*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_unchanged.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_evict_unchanged_L2_256B(
   const B16* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_global_L1_evict_unchanged_L2_256B(const B16* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16 ld_global_L1_evict_unchanged_L2_256B(const _B16* __addr)
 {
-  static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  std::uint16_t dest;
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint16_t __dest;
   asm volatile("ld.global.L1::evict_unchanged.L2::256B.b16 %0, [%1];"
-               : "=h"(dest)
-               : "l"(__as_ptr_gmem(addr))
+               : "=h"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
                : "memory");
-  return *reinterpret_cast<B16*>(&dest);
+  return *reinterpret_cast<_B16*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
-  std::uint16_t err_out_var = 0;
-  return *reinterpret_cast<B16*>(&err_out_var);
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_unchanged.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_evict_unchanged_L2_256B(
   const B32* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_global_L1_evict_unchanged_L2_256B(const B32* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32 ld_global_L1_evict_unchanged_L2_256B(const _B32* __addr)
 {
-  static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  std::uint32_t dest;
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint32_t __dest;
   asm volatile("ld.global.L1::evict_unchanged.L2::256B.b32 %0, [%1];"
-               : "=r"(dest)
-               : "l"(__as_ptr_gmem(addr))
+               : "=r"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
                : "memory");
-  return *reinterpret_cast<B32*>(&dest);
+  return *reinterpret_cast<_B32*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B32*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_unchanged.L2::256B.b64 dest, [addr]; // PTX ISA 74, SM_80
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_evict_unchanged_L2_256B(
   const B64* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_global_L1_evict_unchanged_L2_256B(const B64* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64 ld_global_L1_evict_unchanged_L2_256B(const _B64* __addr)
 {
-  static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  std::uint64_t dest;
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint64_t __dest;
   asm volatile("ld.global.L1::evict_unchanged.L2::256B.b64 %0, [%1];"
-               : "=l"(dest)
-               : "l"(__as_ptr_gmem(addr))
+               : "=l"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
                : "memory");
-  return *reinterpret_cast<B64*>(&dest);
+  return *reinterpret_cast<_B64*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
-  std::uint64_t err_out_var = 0;
-  return *reinterpret_cast<B64*>(&err_out_var);
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_unchanged.L2::256B.b128 dest, [addr]; // PTX ISA 83, SM_80
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
+template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_evict_unchanged_L2_256B(
   const B128* addr);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_global_L1_evict_unchanged_L2_256B(const B128* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
+_CCCL_DEVICE static inline _B128 ld_global_L1_evict_unchanged_L2_256B(const _B128* __addr)
 {
-  static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  longlong2 dest;
+  static_assert(sizeof(_B128) == 16, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  longlong2 __dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.L1::evict_unchanged.L2::256B.b128 B128_dest, [%2];\n\t"
     "mov.b128 {%0, %1}, B128_dest; \n"
     "}"
-    : "=l"(dest.x), "=l"(dest.y)
-    : "l"(__as_ptr_gmem(addr))
+    : "=l"(__dest.x), "=l"(__dest.y)
+    : "l"(__as_ptr_gmem(__addr))
     : "memory");
-  return *reinterpret_cast<B128*>(&dest);
+  return *reinterpret_cast<_B128*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
-  longlong2 err_out_var{0, 0};
-  return *reinterpret_cast<B128*>(&err_out_var);
+  longlong2 __err_out_var{0, 0};
+  return *reinterpret_cast<_B128*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.L1::evict_first.b8 dest, [addr]; // PTX ISA 74, SM_70
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_L1_evict_first(
-  const B8* addr);
+template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
+__device__ static inline _B8 ld_global_L1_evict_first(
+  const _B8* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_first_is_not_supported_before_SM_70__();
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_L1_evict_first(const B8* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_first_is_not_supported_before_SM_70__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8 ld_global_L1_evict_first(const _B8* __addr)
 {
-  static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
-  std::uint32_t dest;
-  asm volatile("ld.global.L1::evict_first.b8 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return __u32_as_b8<B8>(dest);
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.L1::evict_first.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return __u32_as_b8<_B8>(__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_first_is_not_supported_before_SM_70__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B8*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_first.b16 dest, [addr]; // PTX ISA 74, SM_70
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_evict_first(
   const B16* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_first_is_not_supported_before_SM_70__();
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_global_L1_evict_first(const B16* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_first_is_not_supported_before_SM_70__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16 ld_global_L1_evict_first(const _B16* __addr)
 {
-  static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
-  std::uint16_t dest;
-  asm volatile("ld.global.L1::evict_first.b16 %0, [%1];" : "=h"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B16*>(&dest);
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
+  _CUDA_VSTD::uint16_t __dest;
+  asm volatile("ld.global.L1::evict_first.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B16*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_first_is_not_supported_before_SM_70__();
-  std::uint16_t err_out_var = 0;
-  return *reinterpret_cast<B16*>(&err_out_var);
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_first.b32 dest, [addr]; // PTX ISA 74, SM_70
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_evict_first(
   const B32* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_first_is_not_supported_before_SM_70__();
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_global_L1_evict_first(const B32* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_first_is_not_supported_before_SM_70__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32 ld_global_L1_evict_first(const _B32* __addr)
 {
-  static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
-  std::uint32_t dest;
-  asm volatile("ld.global.L1::evict_first.b32 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B32*>(&dest);
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.L1::evict_first.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B32*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_first_is_not_supported_before_SM_70__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B32*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_first.b64 dest, [addr]; // PTX ISA 74, SM_70
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_evict_first(
   const B64* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_first_is_not_supported_before_SM_70__();
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_global_L1_evict_first(const B64* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_first_is_not_supported_before_SM_70__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64 ld_global_L1_evict_first(const _B64* __addr)
 {
-  static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
-  std::uint64_t dest;
-  asm volatile("ld.global.L1::evict_first.b64 %0, [%1];" : "=l"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B64*>(&dest);
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
+  _CUDA_VSTD::uint64_t __dest;
+  asm volatile("ld.global.L1::evict_first.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B64*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_first_is_not_supported_before_SM_70__();
-  std::uint64_t err_out_var = 0;
-  return *reinterpret_cast<B64*>(&err_out_var);
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_first.b128 dest, [addr]; // PTX ISA 83, SM_70
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
+template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_evict_first(
   const B128* addr);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_first_is_not_supported_before_SM_70__();
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_global_L1_evict_first(const B128* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_first_is_not_supported_before_SM_70__();
+template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
+_CCCL_DEVICE static inline _B128 ld_global_L1_evict_first(const _B128* __addr)
 {
-  static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
-  longlong2 dest;
+  static_assert(sizeof(_B128) == 16, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
+  longlong2 __dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.L1::evict_first.b128 B128_dest, [%2];\n\t"
     "mov.b128 {%0, %1}, B128_dest; \n"
     "}"
-    : "=l"(dest.x), "=l"(dest.y)
-    : "l"(__as_ptr_gmem(addr))
+    : "=l"(__dest.x), "=l"(__dest.y)
+    : "l"(__as_ptr_gmem(__addr))
     : "memory");
-  return *reinterpret_cast<B128*>(&dest);
+  return *reinterpret_cast<_B128*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_first_is_not_supported_before_SM_70__();
-  longlong2 err_out_var{0, 0};
-  return *reinterpret_cast<B128*>(&err_out_var);
+  longlong2 __err_out_var{0, 0};
+  return *reinterpret_cast<_B128*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.L1::evict_first.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_L1_evict_first_L2_64B(
-  const B8* addr);
+template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
+__device__ static inline _B8 ld_global_L1_evict_first_L2_64B(
+  const _B8* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_L1_evict_first_L2_64B(const B8* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8 ld_global_L1_evict_first_L2_64B(const _B8* __addr)
 {
-  static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint32_t dest;
-  asm volatile("ld.global.L1::evict_first.L2::64B.b8 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return __u32_as_b8<B8>(dest);
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.L1::evict_first.L2::64B.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return __u32_as_b8<_B8>(__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B8*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_first.L2::64B.b16 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_evict_first_L2_64B(
   const B16* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_global_L1_evict_first_L2_64B(const B16* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16 ld_global_L1_evict_first_L2_64B(const _B16* __addr)
 {
-  static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint16_t dest;
-  asm volatile("ld.global.L1::evict_first.L2::64B.b16 %0, [%1];" : "=h"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B16*>(&dest);
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint16_t __dest;
+  asm volatile("ld.global.L1::evict_first.L2::64B.b16 %0, [%1];"
+               : "=h"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return *reinterpret_cast<_B16*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
-  std::uint16_t err_out_var = 0;
-  return *reinterpret_cast<B16*>(&err_out_var);
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_first.L2::64B.b32 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_evict_first_L2_64B(
   const B32* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_global_L1_evict_first_L2_64B(const B32* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32 ld_global_L1_evict_first_L2_64B(const _B32* __addr)
 {
-  static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint32_t dest;
-  asm volatile("ld.global.L1::evict_first.L2::64B.b32 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B32*>(&dest);
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.L1::evict_first.L2::64B.b32 %0, [%1];"
+               : "=r"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return *reinterpret_cast<_B32*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B32*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_first.L2::64B.b64 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_evict_first_L2_64B(
   const B64* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_global_L1_evict_first_L2_64B(const B64* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64 ld_global_L1_evict_first_L2_64B(const _B64* __addr)
 {
-  static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint64_t dest;
-  asm volatile("ld.global.L1::evict_first.L2::64B.b64 %0, [%1];" : "=l"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B64*>(&dest);
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint64_t __dest;
+  asm volatile("ld.global.L1::evict_first.L2::64B.b64 %0, [%1];"
+               : "=l"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return *reinterpret_cast<_B64*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
-  std::uint64_t err_out_var = 0;
-  return *reinterpret_cast<B64*>(&err_out_var);
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_first.L2::64B.b128 dest, [addr]; // PTX ISA 83, SM_75
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
+template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_evict_first_L2_64B(
   const B128* addr);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_global_L1_evict_first_L2_64B(const B128* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
+_CCCL_DEVICE static inline _B128 ld_global_L1_evict_first_L2_64B(const _B128* __addr)
 {
-  static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  longlong2 dest;
+  static_assert(sizeof(_B128) == 16, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  longlong2 __dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.L1::evict_first.L2::64B.b128 B128_dest, [%2];\n\t"
     "mov.b128 {%0, %1}, B128_dest; \n"
     "}"
-    : "=l"(dest.x), "=l"(dest.y)
-    : "l"(__as_ptr_gmem(addr))
+    : "=l"(__dest.x), "=l"(__dest.y)
+    : "l"(__as_ptr_gmem(__addr))
     : "memory");
-  return *reinterpret_cast<B128*>(&dest);
+  return *reinterpret_cast<_B128*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
-  longlong2 err_out_var{0, 0};
-  return *reinterpret_cast<B128*>(&err_out_var);
+  longlong2 __err_out_var{0, 0};
+  return *reinterpret_cast<_B128*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.L1::evict_first.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_L1_evict_first_L2_128B(
-  const B8* addr);
+template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
+__device__ static inline _B8 ld_global_L1_evict_first_L2_128B(
+  const _B8* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_L1_evict_first_L2_128B(const B8* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8 ld_global_L1_evict_first_L2_128B(const _B8* __addr)
 {
-  static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint32_t dest;
-  asm volatile("ld.global.L1::evict_first.L2::128B.b8 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return __u32_as_b8<B8>(dest);
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.L1::evict_first.L2::128B.b8 %0, [%1];"
+               : "=r"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return __u32_as_b8<_B8>(__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B8*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_first.L2::128B.b16 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_evict_first_L2_128B(
   const B16* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_global_L1_evict_first_L2_128B(const B16* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16 ld_global_L1_evict_first_L2_128B(const _B16* __addr)
 {
-  static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint16_t dest;
-  asm volatile("ld.global.L1::evict_first.L2::128B.b16 %0, [%1];" : "=h"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B16*>(&dest);
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint16_t __dest;
+  asm volatile("ld.global.L1::evict_first.L2::128B.b16 %0, [%1];"
+               : "=h"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return *reinterpret_cast<_B16*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
-  std::uint16_t err_out_var = 0;
-  return *reinterpret_cast<B16*>(&err_out_var);
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_first.L2::128B.b32 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_evict_first_L2_128B(
   const B32* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_global_L1_evict_first_L2_128B(const B32* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32 ld_global_L1_evict_first_L2_128B(const _B32* __addr)
 {
-  static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint32_t dest;
-  asm volatile("ld.global.L1::evict_first.L2::128B.b32 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B32*>(&dest);
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.L1::evict_first.L2::128B.b32 %0, [%1];"
+               : "=r"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return *reinterpret_cast<_B32*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B32*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_first.L2::128B.b64 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_evict_first_L2_128B(
   const B64* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_global_L1_evict_first_L2_128B(const B64* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64 ld_global_L1_evict_first_L2_128B(const _B64* __addr)
 {
-  static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint64_t dest;
-  asm volatile("ld.global.L1::evict_first.L2::128B.b64 %0, [%1];" : "=l"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B64*>(&dest);
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint64_t __dest;
+  asm volatile("ld.global.L1::evict_first.L2::128B.b64 %0, [%1];"
+               : "=l"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return *reinterpret_cast<_B64*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
-  std::uint64_t err_out_var = 0;
-  return *reinterpret_cast<B64*>(&err_out_var);
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_first.L2::128B.b128 dest, [addr]; // PTX ISA 83, SM_75
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
+template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_evict_first_L2_128B(
   const B128* addr);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_global_L1_evict_first_L2_128B(const B128* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
+_CCCL_DEVICE static inline _B128 ld_global_L1_evict_first_L2_128B(const _B128* __addr)
 {
-  static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  longlong2 dest;
+  static_assert(sizeof(_B128) == 16, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  longlong2 __dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.L1::evict_first.L2::128B.b128 B128_dest, [%2];\n\t"
     "mov.b128 {%0, %1}, B128_dest; \n"
     "}"
-    : "=l"(dest.x), "=l"(dest.y)
-    : "l"(__as_ptr_gmem(addr))
+    : "=l"(__dest.x), "=l"(__dest.y)
+    : "l"(__as_ptr_gmem(__addr))
     : "memory");
-  return *reinterpret_cast<B128*>(&dest);
+  return *reinterpret_cast<_B128*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
-  longlong2 err_out_var{0, 0};
-  return *reinterpret_cast<B128*>(&err_out_var);
+  longlong2 __err_out_var{0, 0};
+  return *reinterpret_cast<_B128*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.L1::evict_first.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_L1_evict_first_L2_256B(
-  const B8* addr);
+template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
+__device__ static inline _B8 ld_global_L1_evict_first_L2_256B(
+  const _B8* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_L1_evict_first_L2_256B(const B8* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8 ld_global_L1_evict_first_L2_256B(const _B8* __addr)
 {
-  static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  std::uint32_t dest;
-  asm volatile("ld.global.L1::evict_first.L2::256B.b8 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return __u32_as_b8<B8>(dest);
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.L1::evict_first.L2::256B.b8 %0, [%1];"
+               : "=r"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return __u32_as_b8<_B8>(__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B8*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_first.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_evict_first_L2_256B(
   const B16* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_global_L1_evict_first_L2_256B(const B16* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16 ld_global_L1_evict_first_L2_256B(const _B16* __addr)
 {
-  static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  std::uint16_t dest;
-  asm volatile("ld.global.L1::evict_first.L2::256B.b16 %0, [%1];" : "=h"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B16*>(&dest);
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint16_t __dest;
+  asm volatile("ld.global.L1::evict_first.L2::256B.b16 %0, [%1];"
+               : "=h"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return *reinterpret_cast<_B16*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
-  std::uint16_t err_out_var = 0;
-  return *reinterpret_cast<B16*>(&err_out_var);
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_first.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_evict_first_L2_256B(
   const B32* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_global_L1_evict_first_L2_256B(const B32* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32 ld_global_L1_evict_first_L2_256B(const _B32* __addr)
 {
-  static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  std::uint32_t dest;
-  asm volatile("ld.global.L1::evict_first.L2::256B.b32 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B32*>(&dest);
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.L1::evict_first.L2::256B.b32 %0, [%1];"
+               : "=r"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return *reinterpret_cast<_B32*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B32*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_first.L2::256B.b64 dest, [addr]; // PTX ISA 74, SM_80
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_evict_first_L2_256B(
   const B64* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_global_L1_evict_first_L2_256B(const B64* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64 ld_global_L1_evict_first_L2_256B(const _B64* __addr)
 {
-  static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  std::uint64_t dest;
-  asm volatile("ld.global.L1::evict_first.L2::256B.b64 %0, [%1];" : "=l"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B64*>(&dest);
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint64_t __dest;
+  asm volatile("ld.global.L1::evict_first.L2::256B.b64 %0, [%1];"
+               : "=l"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return *reinterpret_cast<_B64*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
-  std::uint64_t err_out_var = 0;
-  return *reinterpret_cast<B64*>(&err_out_var);
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_first.L2::256B.b128 dest, [addr]; // PTX ISA 83, SM_80
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
+template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_evict_first_L2_256B(
   const B128* addr);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_global_L1_evict_first_L2_256B(const B128* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
+_CCCL_DEVICE static inline _B128 ld_global_L1_evict_first_L2_256B(const _B128* __addr)
 {
-  static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  longlong2 dest;
+  static_assert(sizeof(_B128) == 16, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  longlong2 __dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.L1::evict_first.L2::256B.b128 B128_dest, [%2];\n\t"
     "mov.b128 {%0, %1}, B128_dest; \n"
     "}"
-    : "=l"(dest.x), "=l"(dest.y)
-    : "l"(__as_ptr_gmem(addr))
+    : "=l"(__dest.x), "=l"(__dest.y)
+    : "l"(__as_ptr_gmem(__addr))
     : "memory");
-  return *reinterpret_cast<B128*>(&dest);
+  return *reinterpret_cast<_B128*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
-  longlong2 err_out_var{0, 0};
-  return *reinterpret_cast<B128*>(&err_out_var);
+  longlong2 __err_out_var{0, 0};
+  return *reinterpret_cast<_B128*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.L1::evict_last.b8 dest, [addr]; // PTX ISA 74, SM_70
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_L1_evict_last(
-  const B8* addr);
+template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
+__device__ static inline _B8 ld_global_L1_evict_last(
+  const _B8* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_last_is_not_supported_before_SM_70__();
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_L1_evict_last(const B8* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_last_is_not_supported_before_SM_70__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8 ld_global_L1_evict_last(const _B8* __addr)
 {
-  static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
-  std::uint32_t dest;
-  asm volatile("ld.global.L1::evict_last.b8 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return __u32_as_b8<B8>(dest);
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.L1::evict_last.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return __u32_as_b8<_B8>(__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_last_is_not_supported_before_SM_70__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B8*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_last.b16 dest, [addr]; // PTX ISA 74, SM_70
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_evict_last(
   const B16* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_last_is_not_supported_before_SM_70__();
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_global_L1_evict_last(const B16* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_last_is_not_supported_before_SM_70__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16 ld_global_L1_evict_last(const _B16* __addr)
 {
-  static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
-  std::uint16_t dest;
-  asm volatile("ld.global.L1::evict_last.b16 %0, [%1];" : "=h"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B16*>(&dest);
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
+  _CUDA_VSTD::uint16_t __dest;
+  asm volatile("ld.global.L1::evict_last.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B16*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_last_is_not_supported_before_SM_70__();
-  std::uint16_t err_out_var = 0;
-  return *reinterpret_cast<B16*>(&err_out_var);
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_last.b32 dest, [addr]; // PTX ISA 74, SM_70
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_evict_last(
   const B32* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_last_is_not_supported_before_SM_70__();
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_global_L1_evict_last(const B32* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_last_is_not_supported_before_SM_70__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32 ld_global_L1_evict_last(const _B32* __addr)
 {
-  static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
-  std::uint32_t dest;
-  asm volatile("ld.global.L1::evict_last.b32 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B32*>(&dest);
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.L1::evict_last.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B32*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_last_is_not_supported_before_SM_70__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B32*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_last.b64 dest, [addr]; // PTX ISA 74, SM_70
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_evict_last(
   const B64* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_last_is_not_supported_before_SM_70__();
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_global_L1_evict_last(const B64* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_last_is_not_supported_before_SM_70__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64 ld_global_L1_evict_last(const _B64* __addr)
 {
-  static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
-  std::uint64_t dest;
-  asm volatile("ld.global.L1::evict_last.b64 %0, [%1];" : "=l"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B64*>(&dest);
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
+  _CUDA_VSTD::uint64_t __dest;
+  asm volatile("ld.global.L1::evict_last.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B64*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_last_is_not_supported_before_SM_70__();
-  std::uint64_t err_out_var = 0;
-  return *reinterpret_cast<B64*>(&err_out_var);
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_last.b128 dest, [addr]; // PTX ISA 83, SM_70
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
+template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_evict_last(
   const B128* addr);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_last_is_not_supported_before_SM_70__();
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_global_L1_evict_last(const B128* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_last_is_not_supported_before_SM_70__();
+template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
+_CCCL_DEVICE static inline _B128 ld_global_L1_evict_last(const _B128* __addr)
 {
-  static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
-  longlong2 dest;
+  static_assert(sizeof(_B128) == 16, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
+  longlong2 __dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.L1::evict_last.b128 B128_dest, [%2];\n\t"
     "mov.b128 {%0, %1}, B128_dest; \n"
     "}"
-    : "=l"(dest.x), "=l"(dest.y)
-    : "l"(__as_ptr_gmem(addr))
+    : "=l"(__dest.x), "=l"(__dest.y)
+    : "l"(__as_ptr_gmem(__addr))
     : "memory");
-  return *reinterpret_cast<B128*>(&dest);
+  return *reinterpret_cast<_B128*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_last_is_not_supported_before_SM_70__();
-  longlong2 err_out_var{0, 0};
-  return *reinterpret_cast<B128*>(&err_out_var);
+  longlong2 __err_out_var{0, 0};
+  return *reinterpret_cast<_B128*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.L1::evict_last.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_L1_evict_last_L2_64B(
-  const B8* addr);
+template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
+__device__ static inline _B8 ld_global_L1_evict_last_L2_64B(
+  const _B8* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_L1_evict_last_L2_64B(const B8* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8 ld_global_L1_evict_last_L2_64B(const _B8* __addr)
 {
-  static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint32_t dest;
-  asm volatile("ld.global.L1::evict_last.L2::64B.b8 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return __u32_as_b8<B8>(dest);
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.L1::evict_last.L2::64B.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return __u32_as_b8<_B8>(__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B8*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_last.L2::64B.b16 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_evict_last_L2_64B(
   const B16* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_global_L1_evict_last_L2_64B(const B16* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16 ld_global_L1_evict_last_L2_64B(const _B16* __addr)
 {
-  static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint16_t dest;
-  asm volatile("ld.global.L1::evict_last.L2::64B.b16 %0, [%1];" : "=h"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B16*>(&dest);
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint16_t __dest;
+  asm volatile("ld.global.L1::evict_last.L2::64B.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B16*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
-  std::uint16_t err_out_var = 0;
-  return *reinterpret_cast<B16*>(&err_out_var);
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_last.L2::64B.b32 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_evict_last_L2_64B(
   const B32* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_global_L1_evict_last_L2_64B(const B32* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32 ld_global_L1_evict_last_L2_64B(const _B32* __addr)
 {
-  static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint32_t dest;
-  asm volatile("ld.global.L1::evict_last.L2::64B.b32 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B32*>(&dest);
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.L1::evict_last.L2::64B.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B32*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B32*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_last.L2::64B.b64 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_evict_last_L2_64B(
   const B64* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_global_L1_evict_last_L2_64B(const B64* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64 ld_global_L1_evict_last_L2_64B(const _B64* __addr)
 {
-  static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint64_t dest;
-  asm volatile("ld.global.L1::evict_last.L2::64B.b64 %0, [%1];" : "=l"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B64*>(&dest);
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint64_t __dest;
+  asm volatile("ld.global.L1::evict_last.L2::64B.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B64*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
-  std::uint64_t err_out_var = 0;
-  return *reinterpret_cast<B64*>(&err_out_var);
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_last.L2::64B.b128 dest, [addr]; // PTX ISA 83, SM_75
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
+template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_evict_last_L2_64B(
   const B128* addr);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_global_L1_evict_last_L2_64B(const B128* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
+_CCCL_DEVICE static inline _B128 ld_global_L1_evict_last_L2_64B(const _B128* __addr)
 {
-  static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  longlong2 dest;
+  static_assert(sizeof(_B128) == 16, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  longlong2 __dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.L1::evict_last.L2::64B.b128 B128_dest, [%2];\n\t"
     "mov.b128 {%0, %1}, B128_dest; \n"
     "}"
-    : "=l"(dest.x), "=l"(dest.y)
-    : "l"(__as_ptr_gmem(addr))
+    : "=l"(__dest.x), "=l"(__dest.y)
+    : "l"(__as_ptr_gmem(__addr))
     : "memory");
-  return *reinterpret_cast<B128*>(&dest);
+  return *reinterpret_cast<_B128*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
-  longlong2 err_out_var{0, 0};
-  return *reinterpret_cast<B128*>(&err_out_var);
+  longlong2 __err_out_var{0, 0};
+  return *reinterpret_cast<_B128*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.L1::evict_last.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_L1_evict_last_L2_128B(
-  const B8* addr);
+template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
+__device__ static inline _B8 ld_global_L1_evict_last_L2_128B(
+  const _B8* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_L1_evict_last_L2_128B(const B8* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8 ld_global_L1_evict_last_L2_128B(const _B8* __addr)
 {
-  static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint32_t dest;
-  asm volatile("ld.global.L1::evict_last.L2::128B.b8 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return __u32_as_b8<B8>(dest);
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.L1::evict_last.L2::128B.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return __u32_as_b8<_B8>(__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B8*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_last.L2::128B.b16 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_evict_last_L2_128B(
   const B16* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_global_L1_evict_last_L2_128B(const B16* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16 ld_global_L1_evict_last_L2_128B(const _B16* __addr)
 {
-  static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint16_t dest;
-  asm volatile("ld.global.L1::evict_last.L2::128B.b16 %0, [%1];" : "=h"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B16*>(&dest);
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint16_t __dest;
+  asm volatile("ld.global.L1::evict_last.L2::128B.b16 %0, [%1];"
+               : "=h"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return *reinterpret_cast<_B16*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
-  std::uint16_t err_out_var = 0;
-  return *reinterpret_cast<B16*>(&err_out_var);
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_last.L2::128B.b32 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_evict_last_L2_128B(
   const B32* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_global_L1_evict_last_L2_128B(const B32* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32 ld_global_L1_evict_last_L2_128B(const _B32* __addr)
 {
-  static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint32_t dest;
-  asm volatile("ld.global.L1::evict_last.L2::128B.b32 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B32*>(&dest);
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.L1::evict_last.L2::128B.b32 %0, [%1];"
+               : "=r"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return *reinterpret_cast<_B32*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B32*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_last.L2::128B.b64 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_evict_last_L2_128B(
   const B64* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_global_L1_evict_last_L2_128B(const B64* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64 ld_global_L1_evict_last_L2_128B(const _B64* __addr)
 {
-  static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint64_t dest;
-  asm volatile("ld.global.L1::evict_last.L2::128B.b64 %0, [%1];" : "=l"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B64*>(&dest);
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint64_t __dest;
+  asm volatile("ld.global.L1::evict_last.L2::128B.b64 %0, [%1];"
+               : "=l"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return *reinterpret_cast<_B64*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
-  std::uint64_t err_out_var = 0;
-  return *reinterpret_cast<B64*>(&err_out_var);
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_last.L2::128B.b128 dest, [addr]; // PTX ISA 83, SM_75
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
+template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_evict_last_L2_128B(
   const B128* addr);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_global_L1_evict_last_L2_128B(const B128* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
+_CCCL_DEVICE static inline _B128 ld_global_L1_evict_last_L2_128B(const _B128* __addr)
 {
-  static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  longlong2 dest;
+  static_assert(sizeof(_B128) == 16, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  longlong2 __dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.L1::evict_last.L2::128B.b128 B128_dest, [%2];\n\t"
     "mov.b128 {%0, %1}, B128_dest; \n"
     "}"
-    : "=l"(dest.x), "=l"(dest.y)
-    : "l"(__as_ptr_gmem(addr))
+    : "=l"(__dest.x), "=l"(__dest.y)
+    : "l"(__as_ptr_gmem(__addr))
     : "memory");
-  return *reinterpret_cast<B128*>(&dest);
+  return *reinterpret_cast<_B128*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
-  longlong2 err_out_var{0, 0};
-  return *reinterpret_cast<B128*>(&err_out_var);
+  longlong2 __err_out_var{0, 0};
+  return *reinterpret_cast<_B128*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.L1::evict_last.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_L1_evict_last_L2_256B(
-  const B8* addr);
+template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
+__device__ static inline _B8 ld_global_L1_evict_last_L2_256B(
+  const _B8* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_L1_evict_last_L2_256B(const B8* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8 ld_global_L1_evict_last_L2_256B(const _B8* __addr)
 {
-  static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  std::uint32_t dest;
-  asm volatile("ld.global.L1::evict_last.L2::256B.b8 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return __u32_as_b8<B8>(dest);
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.L1::evict_last.L2::256B.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return __u32_as_b8<_B8>(__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B8*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_last.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_evict_last_L2_256B(
   const B16* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_global_L1_evict_last_L2_256B(const B16* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16 ld_global_L1_evict_last_L2_256B(const _B16* __addr)
 {
-  static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  std::uint16_t dest;
-  asm volatile("ld.global.L1::evict_last.L2::256B.b16 %0, [%1];" : "=h"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B16*>(&dest);
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint16_t __dest;
+  asm volatile("ld.global.L1::evict_last.L2::256B.b16 %0, [%1];"
+               : "=h"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return *reinterpret_cast<_B16*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
-  std::uint16_t err_out_var = 0;
-  return *reinterpret_cast<B16*>(&err_out_var);
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_last.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_evict_last_L2_256B(
   const B32* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_global_L1_evict_last_L2_256B(const B32* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32 ld_global_L1_evict_last_L2_256B(const _B32* __addr)
 {
-  static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  std::uint32_t dest;
-  asm volatile("ld.global.L1::evict_last.L2::256B.b32 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B32*>(&dest);
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.L1::evict_last.L2::256B.b32 %0, [%1];"
+               : "=r"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return *reinterpret_cast<_B32*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B32*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_last.L2::256B.b64 dest, [addr]; // PTX ISA 74, SM_80
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_evict_last_L2_256B(
   const B64* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_global_L1_evict_last_L2_256B(const B64* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64 ld_global_L1_evict_last_L2_256B(const _B64* __addr)
 {
-  static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  std::uint64_t dest;
-  asm volatile("ld.global.L1::evict_last.L2::256B.b64 %0, [%1];" : "=l"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B64*>(&dest);
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint64_t __dest;
+  asm volatile("ld.global.L1::evict_last.L2::256B.b64 %0, [%1];"
+               : "=l"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return *reinterpret_cast<_B64*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
-  std::uint64_t err_out_var = 0;
-  return *reinterpret_cast<B64*>(&err_out_var);
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_last.L2::256B.b128 dest, [addr]; // PTX ISA 83, SM_80
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
+template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_evict_last_L2_256B(
   const B128* addr);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_global_L1_evict_last_L2_256B(const B128* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
+_CCCL_DEVICE static inline _B128 ld_global_L1_evict_last_L2_256B(const _B128* __addr)
 {
-  static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  longlong2 dest;
+  static_assert(sizeof(_B128) == 16, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  longlong2 __dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.L1::evict_last.L2::256B.b128 B128_dest, [%2];\n\t"
     "mov.b128 {%0, %1}, B128_dest; \n"
     "}"
-    : "=l"(dest.x), "=l"(dest.y)
-    : "l"(__as_ptr_gmem(addr))
+    : "=l"(__dest.x), "=l"(__dest.y)
+    : "l"(__as_ptr_gmem(__addr))
     : "memory");
-  return *reinterpret_cast<B128*>(&dest);
+  return *reinterpret_cast<_B128*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
-  longlong2 err_out_var{0, 0};
-  return *reinterpret_cast<B128*>(&err_out_var);
+  longlong2 __err_out_var{0, 0};
+  return *reinterpret_cast<_B128*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.L1::no_allocate.b8 dest, [addr]; // PTX ISA 74, SM_70
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_L1_no_allocate(
-  const B8* addr);
+template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
+__device__ static inline _B8 ld_global_L1_no_allocate(
+  const _B8* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_no_allocate_is_not_supported_before_SM_70__();
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_L1_no_allocate(const B8* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_no_allocate_is_not_supported_before_SM_70__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8 ld_global_L1_no_allocate(const _B8* __addr)
 {
-  static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
-  std::uint32_t dest;
-  asm volatile("ld.global.L1::no_allocate.b8 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return __u32_as_b8<B8>(dest);
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.L1::no_allocate.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return __u32_as_b8<_B8>(__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_no_allocate_is_not_supported_before_SM_70__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B8*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::no_allocate.b16 dest, [addr]; // PTX ISA 74, SM_70
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_no_allocate(
   const B16* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_no_allocate_is_not_supported_before_SM_70__();
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_global_L1_no_allocate(const B16* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_no_allocate_is_not_supported_before_SM_70__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16 ld_global_L1_no_allocate(const _B16* __addr)
 {
-  static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
-  std::uint16_t dest;
-  asm volatile("ld.global.L1::no_allocate.b16 %0, [%1];" : "=h"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B16*>(&dest);
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
+  _CUDA_VSTD::uint16_t __dest;
+  asm volatile("ld.global.L1::no_allocate.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B16*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_no_allocate_is_not_supported_before_SM_70__();
-  std::uint16_t err_out_var = 0;
-  return *reinterpret_cast<B16*>(&err_out_var);
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::no_allocate.b32 dest, [addr]; // PTX ISA 74, SM_70
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_no_allocate(
   const B32* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_no_allocate_is_not_supported_before_SM_70__();
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_global_L1_no_allocate(const B32* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_no_allocate_is_not_supported_before_SM_70__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32 ld_global_L1_no_allocate(const _B32* __addr)
 {
-  static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
-  std::uint32_t dest;
-  asm volatile("ld.global.L1::no_allocate.b32 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B32*>(&dest);
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.L1::no_allocate.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B32*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_no_allocate_is_not_supported_before_SM_70__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B32*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::no_allocate.b64 dest, [addr]; // PTX ISA 74, SM_70
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_no_allocate(
   const B64* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_no_allocate_is_not_supported_before_SM_70__();
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_global_L1_no_allocate(const B64* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_no_allocate_is_not_supported_before_SM_70__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64 ld_global_L1_no_allocate(const _B64* __addr)
 {
-  static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
-  std::uint64_t dest;
-  asm volatile("ld.global.L1::no_allocate.b64 %0, [%1];" : "=l"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B64*>(&dest);
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
+  _CUDA_VSTD::uint64_t __dest;
+  asm volatile("ld.global.L1::no_allocate.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B64*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_no_allocate_is_not_supported_before_SM_70__();
-  std::uint64_t err_out_var = 0;
-  return *reinterpret_cast<B64*>(&err_out_var);
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::no_allocate.b128 dest, [addr]; // PTX ISA 83, SM_70
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
+template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_no_allocate(
   const B128* addr);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_ld_global_L1_no_allocate_is_not_supported_before_SM_70__();
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_global_L1_no_allocate(const B128* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_no_allocate_is_not_supported_before_SM_70__();
+template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
+_CCCL_DEVICE static inline _B128 ld_global_L1_no_allocate(const _B128* __addr)
 {
-  static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
-  longlong2 dest;
+  static_assert(sizeof(_B128) == 16, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
+  longlong2 __dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.L1::no_allocate.b128 B128_dest, [%2];\n\t"
     "mov.b128 {%0, %1}, B128_dest; \n"
     "}"
-    : "=l"(dest.x), "=l"(dest.y)
-    : "l"(__as_ptr_gmem(addr))
+    : "=l"(__dest.x), "=l"(__dest.y)
+    : "l"(__as_ptr_gmem(__addr))
     : "memory");
-  return *reinterpret_cast<B128*>(&dest);
+  return *reinterpret_cast<_B128*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_no_allocate_is_not_supported_before_SM_70__();
-  longlong2 err_out_var{0, 0};
-  return *reinterpret_cast<B128*>(&err_out_var);
+  longlong2 __err_out_var{0, 0};
+  return *reinterpret_cast<_B128*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.L1::no_allocate.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_L1_no_allocate_L2_64B(
-  const B8* addr);
+template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
+__device__ static inline _B8 ld_global_L1_no_allocate_L2_64B(
+  const _B8* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_L1_no_allocate_L2_64B(const B8* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8 ld_global_L1_no_allocate_L2_64B(const _B8* __addr)
 {
-  static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint32_t dest;
-  asm volatile("ld.global.L1::no_allocate.L2::64B.b8 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return __u32_as_b8<B8>(dest);
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.L1::no_allocate.L2::64B.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return __u32_as_b8<_B8>(__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B8*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::no_allocate.L2::64B.b16 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_no_allocate_L2_64B(
   const B16* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_global_L1_no_allocate_L2_64B(const B16* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16 ld_global_L1_no_allocate_L2_64B(const _B16* __addr)
 {
-  static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint16_t dest;
-  asm volatile("ld.global.L1::no_allocate.L2::64B.b16 %0, [%1];" : "=h"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B16*>(&dest);
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint16_t __dest;
+  asm volatile("ld.global.L1::no_allocate.L2::64B.b16 %0, [%1];"
+               : "=h"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return *reinterpret_cast<_B16*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
-  std::uint16_t err_out_var = 0;
-  return *reinterpret_cast<B16*>(&err_out_var);
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::no_allocate.L2::64B.b32 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_no_allocate_L2_64B(
   const B32* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_global_L1_no_allocate_L2_64B(const B32* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32 ld_global_L1_no_allocate_L2_64B(const _B32* __addr)
 {
-  static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint32_t dest;
-  asm volatile("ld.global.L1::no_allocate.L2::64B.b32 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B32*>(&dest);
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.L1::no_allocate.L2::64B.b32 %0, [%1];"
+               : "=r"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return *reinterpret_cast<_B32*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B32*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::no_allocate.L2::64B.b64 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_no_allocate_L2_64B(
   const B64* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_global_L1_no_allocate_L2_64B(const B64* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64 ld_global_L1_no_allocate_L2_64B(const _B64* __addr)
 {
-  static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint64_t dest;
-  asm volatile("ld.global.L1::no_allocate.L2::64B.b64 %0, [%1];" : "=l"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B64*>(&dest);
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint64_t __dest;
+  asm volatile("ld.global.L1::no_allocate.L2::64B.b64 %0, [%1];"
+               : "=l"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return *reinterpret_cast<_B64*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
-  std::uint64_t err_out_var = 0;
-  return *reinterpret_cast<B64*>(&err_out_var);
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::no_allocate.L2::64B.b128 dest, [addr]; // PTX ISA 83, SM_75
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
+template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_no_allocate_L2_64B(
   const B128* addr);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_ld_global_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_global_L1_no_allocate_L2_64B(const B128* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
+_CCCL_DEVICE static inline _B128 ld_global_L1_no_allocate_L2_64B(const _B128* __addr)
 {
-  static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  longlong2 dest;
+  static_assert(sizeof(_B128) == 16, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  longlong2 __dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.L1::no_allocate.L2::64B.b128 B128_dest, [%2];\n\t"
     "mov.b128 {%0, %1}, B128_dest; \n"
     "}"
-    : "=l"(dest.x), "=l"(dest.y)
-    : "l"(__as_ptr_gmem(addr))
+    : "=l"(__dest.x), "=l"(__dest.y)
+    : "l"(__as_ptr_gmem(__addr))
     : "memory");
-  return *reinterpret_cast<B128*>(&dest);
+  return *reinterpret_cast<_B128*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
-  longlong2 err_out_var{0, 0};
-  return *reinterpret_cast<B128*>(&err_out_var);
+  longlong2 __err_out_var{0, 0};
+  return *reinterpret_cast<_B128*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.L1::no_allocate.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_L1_no_allocate_L2_128B(
-  const B8* addr);
+template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
+__device__ static inline _B8 ld_global_L1_no_allocate_L2_128B(
+  const _B8* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_L1_no_allocate_L2_128B(const B8* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8 ld_global_L1_no_allocate_L2_128B(const _B8* __addr)
 {
-  static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint32_t dest;
-  asm volatile("ld.global.L1::no_allocate.L2::128B.b8 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return __u32_as_b8<B8>(dest);
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.L1::no_allocate.L2::128B.b8 %0, [%1];"
+               : "=r"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return __u32_as_b8<_B8>(__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B8*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::no_allocate.L2::128B.b16 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_no_allocate_L2_128B(
   const B16* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_global_L1_no_allocate_L2_128B(const B16* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16 ld_global_L1_no_allocate_L2_128B(const _B16* __addr)
 {
-  static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint16_t dest;
-  asm volatile("ld.global.L1::no_allocate.L2::128B.b16 %0, [%1];" : "=h"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B16*>(&dest);
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint16_t __dest;
+  asm volatile("ld.global.L1::no_allocate.L2::128B.b16 %0, [%1];"
+               : "=h"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return *reinterpret_cast<_B16*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
-  std::uint16_t err_out_var = 0;
-  return *reinterpret_cast<B16*>(&err_out_var);
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::no_allocate.L2::128B.b32 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_no_allocate_L2_128B(
   const B32* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_global_L1_no_allocate_L2_128B(const B32* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32 ld_global_L1_no_allocate_L2_128B(const _B32* __addr)
 {
-  static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint32_t dest;
-  asm volatile("ld.global.L1::no_allocate.L2::128B.b32 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B32*>(&dest);
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.L1::no_allocate.L2::128B.b32 %0, [%1];"
+               : "=r"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return *reinterpret_cast<_B32*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B32*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::no_allocate.L2::128B.b64 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_no_allocate_L2_128B(
   const B64* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_global_L1_no_allocate_L2_128B(const B64* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64 ld_global_L1_no_allocate_L2_128B(const _B64* __addr)
 {
-  static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint64_t dest;
-  asm volatile("ld.global.L1::no_allocate.L2::128B.b64 %0, [%1];" : "=l"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B64*>(&dest);
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint64_t __dest;
+  asm volatile("ld.global.L1::no_allocate.L2::128B.b64 %0, [%1];"
+               : "=l"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return *reinterpret_cast<_B64*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
-  std::uint64_t err_out_var = 0;
-  return *reinterpret_cast<B64*>(&err_out_var);
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::no_allocate.L2::128B.b128 dest, [addr]; // PTX ISA 83, SM_75
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
+template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_no_allocate_L2_128B(
   const B128* addr);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_ld_global_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_global_L1_no_allocate_L2_128B(const B128* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
+_CCCL_DEVICE static inline _B128 ld_global_L1_no_allocate_L2_128B(const _B128* __addr)
 {
-  static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  longlong2 dest;
+  static_assert(sizeof(_B128) == 16, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  longlong2 __dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.L1::no_allocate.L2::128B.b128 B128_dest, [%2];\n\t"
     "mov.b128 {%0, %1}, B128_dest; \n"
     "}"
-    : "=l"(dest.x), "=l"(dest.y)
-    : "l"(__as_ptr_gmem(addr))
+    : "=l"(__dest.x), "=l"(__dest.y)
+    : "l"(__as_ptr_gmem(__addr))
     : "memory");
-  return *reinterpret_cast<B128*>(&dest);
+  return *reinterpret_cast<_B128*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
-  longlong2 err_out_var{0, 0};
-  return *reinterpret_cast<B128*>(&err_out_var);
+  longlong2 __err_out_var{0, 0};
+  return *reinterpret_cast<_B128*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.L1::no_allocate.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_L1_no_allocate_L2_256B(
-  const B8* addr);
+template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
+__device__ static inline _B8 ld_global_L1_no_allocate_L2_256B(
+  const _B8* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_L1_no_allocate_L2_256B(const B8* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8 ld_global_L1_no_allocate_L2_256B(const _B8* __addr)
 {
-  static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  std::uint32_t dest;
-  asm volatile("ld.global.L1::no_allocate.L2::256B.b8 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return __u32_as_b8<B8>(dest);
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.L1::no_allocate.L2::256B.b8 %0, [%1];"
+               : "=r"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return __u32_as_b8<_B8>(__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B8*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::no_allocate.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_no_allocate_L2_256B(
   const B16* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_global_L1_no_allocate_L2_256B(const B16* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16 ld_global_L1_no_allocate_L2_256B(const _B16* __addr)
 {
-  static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  std::uint16_t dest;
-  asm volatile("ld.global.L1::no_allocate.L2::256B.b16 %0, [%1];" : "=h"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B16*>(&dest);
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint16_t __dest;
+  asm volatile("ld.global.L1::no_allocate.L2::256B.b16 %0, [%1];"
+               : "=h"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return *reinterpret_cast<_B16*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
-  std::uint16_t err_out_var = 0;
-  return *reinterpret_cast<B16*>(&err_out_var);
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::no_allocate.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_no_allocate_L2_256B(
   const B32* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_global_L1_no_allocate_L2_256B(const B32* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32 ld_global_L1_no_allocate_L2_256B(const _B32* __addr)
 {
-  static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  std::uint32_t dest;
-  asm volatile("ld.global.L1::no_allocate.L2::256B.b32 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B32*>(&dest);
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.L1::no_allocate.L2::256B.b32 %0, [%1];"
+               : "=r"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return *reinterpret_cast<_B32*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B32*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::no_allocate.L2::256B.b64 dest, [addr]; // PTX ISA 74, SM_80
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_no_allocate_L2_256B(
   const B64* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_global_L1_no_allocate_L2_256B(const B64* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64 ld_global_L1_no_allocate_L2_256B(const _B64* __addr)
 {
-  static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  std::uint64_t dest;
-  asm volatile("ld.global.L1::no_allocate.L2::256B.b64 %0, [%1];" : "=l"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B64*>(&dest);
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint64_t __dest;
+  asm volatile("ld.global.L1::no_allocate.L2::256B.b64 %0, [%1];"
+               : "=l"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return *reinterpret_cast<_B64*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
-  std::uint64_t err_out_var = 0;
-  return *reinterpret_cast<B64*>(&err_out_var);
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::no_allocate.L2::256B.b128 dest, [addr]; // PTX ISA 83, SM_80
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
+template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_no_allocate_L2_256B(
   const B128* addr);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_ld_global_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_global_L1_no_allocate_L2_256B(const B128* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
+_CCCL_DEVICE static inline _B128 ld_global_L1_no_allocate_L2_256B(const _B128* __addr)
 {
-  static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  longlong2 dest;
+  static_assert(sizeof(_B128) == 16, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  longlong2 __dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.L1::no_allocate.L2::256B.b128 B128_dest, [%2];\n\t"
     "mov.b128 {%0, %1}, B128_dest; \n"
     "}"
-    : "=l"(dest.x), "=l"(dest.y)
-    : "l"(__as_ptr_gmem(addr))
+    : "=l"(__dest.x), "=l"(__dest.y)
+    : "l"(__as_ptr_gmem(__addr))
     : "memory");
-  return *reinterpret_cast<B128*>(&dest);
+  return *reinterpret_cast<_B128*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
-  longlong2 err_out_var{0, 0};
-  return *reinterpret_cast<B128*>(&err_out_var);
+  longlong2 __err_out_var{0, 0};
+  return *reinterpret_cast<_B128*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.nc.b8 dest, [addr]; // PTX ISA 10, SM_50
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_nc(
-  const B8* addr);
+template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
+__device__ static inline _B8 ld_global_nc(
+  const _B8* addr);
 */
 #if __cccl_ptx_isa >= 100
-extern "C" __device__ void __cuda_ptx_ld_global_nc_is_not_supported_before_SM_50__();
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_nc(const B8* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_is_not_supported_before_SM_50__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8 ld_global_nc(const _B8* __addr)
 {
-  static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 500
-  std::uint32_t dest;
-  asm volatile("ld.global.nc.b8 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return __u32_as_b8<B8>(dest);
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 500
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.nc.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return __u32_as_b8<_B8>(__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_is_not_supported_before_SM_50__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B8*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 100
 
 /*
 // ld.global.nc.b16 dest, [addr]; // PTX ISA 10, SM_50
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc(
   const B16* addr);
 */
 #if __cccl_ptx_isa >= 100
-extern "C" __device__ void __cuda_ptx_ld_global_nc_is_not_supported_before_SM_50__();
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_global_nc(const B16* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_is_not_supported_before_SM_50__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16 ld_global_nc(const _B16* __addr)
 {
-  static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 500
-  std::uint16_t dest;
-  asm volatile("ld.global.nc.b16 %0, [%1];" : "=h"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B16*>(&dest);
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 500
+  _CUDA_VSTD::uint16_t __dest;
+  asm volatile("ld.global.nc.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B16*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_is_not_supported_before_SM_50__();
-  std::uint16_t err_out_var = 0;
-  return *reinterpret_cast<B16*>(&err_out_var);
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 100
 
 /*
 // ld.global.nc.b32 dest, [addr]; // PTX ISA 10, SM_50
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc(
   const B32* addr);
 */
 #if __cccl_ptx_isa >= 100
-extern "C" __device__ void __cuda_ptx_ld_global_nc_is_not_supported_before_SM_50__();
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_global_nc(const B32* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_is_not_supported_before_SM_50__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32 ld_global_nc(const _B32* __addr)
 {
-  static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 500
-  std::uint32_t dest;
-  asm volatile("ld.global.nc.b32 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B32*>(&dest);
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 500
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.nc.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B32*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_is_not_supported_before_SM_50__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B32*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 100
 
 /*
 // ld.global.nc.b64 dest, [addr]; // PTX ISA 10, SM_50
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc(
   const B64* addr);
 */
 #if __cccl_ptx_isa >= 100
-extern "C" __device__ void __cuda_ptx_ld_global_nc_is_not_supported_before_SM_50__();
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_global_nc(const B64* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_is_not_supported_before_SM_50__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64 ld_global_nc(const _B64* __addr)
 {
-  static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 500
-  std::uint64_t dest;
-  asm volatile("ld.global.nc.b64 %0, [%1];" : "=l"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B64*>(&dest);
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 500
+  _CUDA_VSTD::uint64_t __dest;
+  asm volatile("ld.global.nc.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B64*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_is_not_supported_before_SM_50__();
-  std::uint64_t err_out_var = 0;
-  return *reinterpret_cast<B64*>(&err_out_var);
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 100
 
 /*
 // ld.global.nc.b128 dest, [addr]; // PTX ISA 83, SM_70
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
+template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc(
   const B128* addr);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_ld_global_nc_is_not_supported_before_SM_70__();
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_global_nc(const B128* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_is_not_supported_before_SM_70__();
+template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
+_CCCL_DEVICE static inline _B128 ld_global_nc(const _B128* __addr)
 {
-  static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
-  longlong2 dest;
+  static_assert(sizeof(_B128) == 16, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
+  longlong2 __dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.nc.b128 B128_dest, [%2];\n\t"
     "mov.b128 {%0, %1}, B128_dest; \n"
     "}"
-    : "=l"(dest.x), "=l"(dest.y)
-    : "l"(__as_ptr_gmem(addr))
+    : "=l"(__dest.x), "=l"(__dest.y)
+    : "l"(__as_ptr_gmem(__addr))
     : "memory");
-  return *reinterpret_cast<B128*>(&dest);
+  return *reinterpret_cast<_B128*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_is_not_supported_before_SM_70__();
-  longlong2 err_out_var{0, 0};
-  return *reinterpret_cast<B128*>(&err_out_var);
+  longlong2 __err_out_var{0, 0};
+  return *reinterpret_cast<_B128*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.nc.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_nc_L2_64B(
-  const B8* addr);
+template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
+__device__ static inline _B8 ld_global_nc_L2_64B(
+  const _B8* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L2_64B_is_not_supported_before_SM_75__();
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_nc_L2_64B(const B8* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8 ld_global_nc_L2_64B(const _B8* __addr)
 {
-  static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint32_t dest;
-  asm volatile("ld.global.nc.L2::64B.b8 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return __u32_as_b8<B8>(dest);
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.nc.L2::64B.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return __u32_as_b8<_B8>(__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L2_64B_is_not_supported_before_SM_75__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B8*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L2::64B.b16 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L2_64B(
   const B16* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L2_64B_is_not_supported_before_SM_75__();
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_global_nc_L2_64B(const B16* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16 ld_global_nc_L2_64B(const _B16* __addr)
 {
-  static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint16_t dest;
-  asm volatile("ld.global.nc.L2::64B.b16 %0, [%1];" : "=h"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B16*>(&dest);
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint16_t __dest;
+  asm volatile("ld.global.nc.L2::64B.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B16*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L2_64B_is_not_supported_before_SM_75__();
-  std::uint16_t err_out_var = 0;
-  return *reinterpret_cast<B16*>(&err_out_var);
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L2::64B.b32 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L2_64B(
   const B32* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L2_64B_is_not_supported_before_SM_75__();
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_global_nc_L2_64B(const B32* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32 ld_global_nc_L2_64B(const _B32* __addr)
 {
-  static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint32_t dest;
-  asm volatile("ld.global.nc.L2::64B.b32 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B32*>(&dest);
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.nc.L2::64B.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B32*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L2_64B_is_not_supported_before_SM_75__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B32*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L2::64B.b64 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L2_64B(
   const B64* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L2_64B_is_not_supported_before_SM_75__();
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_global_nc_L2_64B(const B64* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64 ld_global_nc_L2_64B(const _B64* __addr)
 {
-  static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint64_t dest;
-  asm volatile("ld.global.nc.L2::64B.b64 %0, [%1];" : "=l"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B64*>(&dest);
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint64_t __dest;
+  asm volatile("ld.global.nc.L2::64B.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B64*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L2_64B_is_not_supported_before_SM_75__();
-  std::uint64_t err_out_var = 0;
-  return *reinterpret_cast<B64*>(&err_out_var);
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L2::64B.b128 dest, [addr]; // PTX ISA 83, SM_75
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
+template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L2_64B(
   const B128* addr);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L2_64B_is_not_supported_before_SM_75__();
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_global_nc_L2_64B(const B128* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
+_CCCL_DEVICE static inline _B128 ld_global_nc_L2_64B(const _B128* __addr)
 {
-  static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  longlong2 dest;
+  static_assert(sizeof(_B128) == 16, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  longlong2 __dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.nc.L2::64B.b128 B128_dest, [%2];\n\t"
     "mov.b128 {%0, %1}, B128_dest; \n"
     "}"
-    : "=l"(dest.x), "=l"(dest.y)
-    : "l"(__as_ptr_gmem(addr))
+    : "=l"(__dest.x), "=l"(__dest.y)
+    : "l"(__as_ptr_gmem(__addr))
     : "memory");
-  return *reinterpret_cast<B128*>(&dest);
+  return *reinterpret_cast<_B128*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L2_64B_is_not_supported_before_SM_75__();
-  longlong2 err_out_var{0, 0};
-  return *reinterpret_cast<B128*>(&err_out_var);
+  longlong2 __err_out_var{0, 0};
+  return *reinterpret_cast<_B128*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.nc.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_nc_L2_128B(
-  const B8* addr);
+template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
+__device__ static inline _B8 ld_global_nc_L2_128B(
+  const _B8* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L2_128B_is_not_supported_before_SM_75__();
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_nc_L2_128B(const B8* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8 ld_global_nc_L2_128B(const _B8* __addr)
 {
-  static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint32_t dest;
-  asm volatile("ld.global.nc.L2::128B.b8 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return __u32_as_b8<B8>(dest);
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.nc.L2::128B.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return __u32_as_b8<_B8>(__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L2_128B_is_not_supported_before_SM_75__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B8*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L2::128B.b16 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L2_128B(
   const B16* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L2_128B_is_not_supported_before_SM_75__();
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_global_nc_L2_128B(const B16* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16 ld_global_nc_L2_128B(const _B16* __addr)
 {
-  static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint16_t dest;
-  asm volatile("ld.global.nc.L2::128B.b16 %0, [%1];" : "=h"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B16*>(&dest);
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint16_t __dest;
+  asm volatile("ld.global.nc.L2::128B.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B16*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L2_128B_is_not_supported_before_SM_75__();
-  std::uint16_t err_out_var = 0;
-  return *reinterpret_cast<B16*>(&err_out_var);
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L2::128B.b32 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L2_128B(
   const B32* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L2_128B_is_not_supported_before_SM_75__();
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_global_nc_L2_128B(const B32* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32 ld_global_nc_L2_128B(const _B32* __addr)
 {
-  static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint32_t dest;
-  asm volatile("ld.global.nc.L2::128B.b32 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B32*>(&dest);
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.nc.L2::128B.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B32*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L2_128B_is_not_supported_before_SM_75__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B32*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L2::128B.b64 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L2_128B(
   const B64* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L2_128B_is_not_supported_before_SM_75__();
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_global_nc_L2_128B(const B64* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64 ld_global_nc_L2_128B(const _B64* __addr)
 {
-  static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint64_t dest;
-  asm volatile("ld.global.nc.L2::128B.b64 %0, [%1];" : "=l"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B64*>(&dest);
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint64_t __dest;
+  asm volatile("ld.global.nc.L2::128B.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B64*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L2_128B_is_not_supported_before_SM_75__();
-  std::uint64_t err_out_var = 0;
-  return *reinterpret_cast<B64*>(&err_out_var);
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L2::128B.b128 dest, [addr]; // PTX ISA 83, SM_75
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
+template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L2_128B(
   const B128* addr);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L2_128B_is_not_supported_before_SM_75__();
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_global_nc_L2_128B(const B128* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
+_CCCL_DEVICE static inline _B128 ld_global_nc_L2_128B(const _B128* __addr)
 {
-  static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  longlong2 dest;
+  static_assert(sizeof(_B128) == 16, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  longlong2 __dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.nc.L2::128B.b128 B128_dest, [%2];\n\t"
     "mov.b128 {%0, %1}, B128_dest; \n"
     "}"
-    : "=l"(dest.x), "=l"(dest.y)
-    : "l"(__as_ptr_gmem(addr))
+    : "=l"(__dest.x), "=l"(__dest.y)
+    : "l"(__as_ptr_gmem(__addr))
     : "memory");
-  return *reinterpret_cast<B128*>(&dest);
+  return *reinterpret_cast<_B128*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L2_128B_is_not_supported_before_SM_75__();
-  longlong2 err_out_var{0, 0};
-  return *reinterpret_cast<B128*>(&err_out_var);
+  longlong2 __err_out_var{0, 0};
+  return *reinterpret_cast<_B128*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.nc.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_nc_L2_256B(
-  const B8* addr);
+template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
+__device__ static inline _B8 ld_global_nc_L2_256B(
+  const _B8* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L2_256B_is_not_supported_before_SM_80__();
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_nc_L2_256B(const B8* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8 ld_global_nc_L2_256B(const _B8* __addr)
 {
-  static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  std::uint32_t dest;
-  asm volatile("ld.global.nc.L2::256B.b8 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return __u32_as_b8<B8>(dest);
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.nc.L2::256B.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return __u32_as_b8<_B8>(__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L2_256B_is_not_supported_before_SM_80__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B8*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L2_256B(
   const B16* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L2_256B_is_not_supported_before_SM_80__();
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_global_nc_L2_256B(const B16* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16 ld_global_nc_L2_256B(const _B16* __addr)
 {
-  static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  std::uint16_t dest;
-  asm volatile("ld.global.nc.L2::256B.b16 %0, [%1];" : "=h"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B16*>(&dest);
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint16_t __dest;
+  asm volatile("ld.global.nc.L2::256B.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B16*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L2_256B_is_not_supported_before_SM_80__();
-  std::uint16_t err_out_var = 0;
-  return *reinterpret_cast<B16*>(&err_out_var);
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L2_256B(
   const B32* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L2_256B_is_not_supported_before_SM_80__();
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_global_nc_L2_256B(const B32* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32 ld_global_nc_L2_256B(const _B32* __addr)
 {
-  static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  std::uint32_t dest;
-  asm volatile("ld.global.nc.L2::256B.b32 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B32*>(&dest);
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.nc.L2::256B.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B32*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L2_256B_is_not_supported_before_SM_80__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B32*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L2::256B.b64 dest, [addr]; // PTX ISA 74, SM_80
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L2_256B(
   const B64* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L2_256B_is_not_supported_before_SM_80__();
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_global_nc_L2_256B(const B64* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64 ld_global_nc_L2_256B(const _B64* __addr)
 {
-  static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  std::uint64_t dest;
-  asm volatile("ld.global.nc.L2::256B.b64 %0, [%1];" : "=l"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B64*>(&dest);
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint64_t __dest;
+  asm volatile("ld.global.nc.L2::256B.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B64*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L2_256B_is_not_supported_before_SM_80__();
-  std::uint64_t err_out_var = 0;
-  return *reinterpret_cast<B64*>(&err_out_var);
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L2::256B.b128 dest, [addr]; // PTX ISA 83, SM_80
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
+template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L2_256B(
   const B128* addr);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L2_256B_is_not_supported_before_SM_80__();
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_global_nc_L2_256B(const B128* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
+_CCCL_DEVICE static inline _B128 ld_global_nc_L2_256B(const _B128* __addr)
 {
-  static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  longlong2 dest;
+  static_assert(sizeof(_B128) == 16, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  longlong2 __dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.nc.L2::256B.b128 B128_dest, [%2];\n\t"
     "mov.b128 {%0, %1}, B128_dest; \n"
     "}"
-    : "=l"(dest.x), "=l"(dest.y)
-    : "l"(__as_ptr_gmem(addr))
+    : "=l"(__dest.x), "=l"(__dest.y)
+    : "l"(__as_ptr_gmem(__addr))
     : "memory");
-  return *reinterpret_cast<B128*>(&dest);
+  return *reinterpret_cast<_B128*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L2_256B_is_not_supported_before_SM_80__();
-  longlong2 err_out_var{0, 0};
-  return *reinterpret_cast<B128*>(&err_out_var);
+  longlong2 __err_out_var{0, 0};
+  return *reinterpret_cast<_B128*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.nc.L1::evict_normal.b8 dest, [addr]; // PTX ISA 74, SM_70
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_nc_L1_evict_normal(
-  const B8* addr);
+template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
+__device__ static inline _B8 ld_global_nc_L1_evict_normal(
+  const _B8* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_normal_is_not_supported_before_SM_70__();
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_nc_L1_evict_normal(const B8* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_normal_is_not_supported_before_SM_70__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8 ld_global_nc_L1_evict_normal(const _B8* __addr)
 {
-  static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
-  std::uint32_t dest;
-  asm volatile("ld.global.nc.L1::evict_normal.b8 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return __u32_as_b8<B8>(dest);
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.nc.L1::evict_normal.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return __u32_as_b8<_B8>(__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_normal_is_not_supported_before_SM_70__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B8*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_normal.b16 dest, [addr]; // PTX ISA 74, SM_70
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_evict_normal(
   const B16* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_normal_is_not_supported_before_SM_70__();
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_global_nc_L1_evict_normal(const B16* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_normal_is_not_supported_before_SM_70__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16 ld_global_nc_L1_evict_normal(const _B16* __addr)
 {
-  static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
-  std::uint16_t dest;
-  asm volatile("ld.global.nc.L1::evict_normal.b16 %0, [%1];" : "=h"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B16*>(&dest);
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
+  _CUDA_VSTD::uint16_t __dest;
+  asm volatile("ld.global.nc.L1::evict_normal.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B16*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_normal_is_not_supported_before_SM_70__();
-  std::uint16_t err_out_var = 0;
-  return *reinterpret_cast<B16*>(&err_out_var);
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_normal.b32 dest, [addr]; // PTX ISA 74, SM_70
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_evict_normal(
   const B32* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_normal_is_not_supported_before_SM_70__();
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_global_nc_L1_evict_normal(const B32* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_normal_is_not_supported_before_SM_70__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32 ld_global_nc_L1_evict_normal(const _B32* __addr)
 {
-  static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
-  std::uint32_t dest;
-  asm volatile("ld.global.nc.L1::evict_normal.b32 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B32*>(&dest);
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.nc.L1::evict_normal.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B32*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_normal_is_not_supported_before_SM_70__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B32*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_normal.b64 dest, [addr]; // PTX ISA 74, SM_70
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_evict_normal(
   const B64* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_normal_is_not_supported_before_SM_70__();
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_global_nc_L1_evict_normal(const B64* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_normal_is_not_supported_before_SM_70__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64 ld_global_nc_L1_evict_normal(const _B64* __addr)
 {
-  static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
-  std::uint64_t dest;
-  asm volatile("ld.global.nc.L1::evict_normal.b64 %0, [%1];" : "=l"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B64*>(&dest);
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
+  _CUDA_VSTD::uint64_t __dest;
+  asm volatile("ld.global.nc.L1::evict_normal.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B64*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_normal_is_not_supported_before_SM_70__();
-  std::uint64_t err_out_var = 0;
-  return *reinterpret_cast<B64*>(&err_out_var);
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_normal.b128 dest, [addr]; // PTX ISA 83, SM_70
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
+template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_evict_normal(
   const B128* addr);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_normal_is_not_supported_before_SM_70__();
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_global_nc_L1_evict_normal(const B128* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_normal_is_not_supported_before_SM_70__();
+template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
+_CCCL_DEVICE static inline _B128 ld_global_nc_L1_evict_normal(const _B128* __addr)
 {
-  static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
-  longlong2 dest;
+  static_assert(sizeof(_B128) == 16, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
+  longlong2 __dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.nc.L1::evict_normal.b128 B128_dest, [%2];\n\t"
     "mov.b128 {%0, %1}, B128_dest; \n"
     "}"
-    : "=l"(dest.x), "=l"(dest.y)
-    : "l"(__as_ptr_gmem(addr))
+    : "=l"(__dest.x), "=l"(__dest.y)
+    : "l"(__as_ptr_gmem(__addr))
     : "memory");
-  return *reinterpret_cast<B128*>(&dest);
+  return *reinterpret_cast<_B128*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_normal_is_not_supported_before_SM_70__();
-  longlong2 err_out_var{0, 0};
-  return *reinterpret_cast<B128*>(&err_out_var);
+  longlong2 __err_out_var{0, 0};
+  return *reinterpret_cast<_B128*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.nc.L1::evict_normal.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_nc_L1_evict_normal_L2_64B(
-  const B8* addr);
+template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
+__device__ static inline _B8 ld_global_nc_L1_evict_normal_L2_64B(
+  const _B8* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_nc_L1_evict_normal_L2_64B(const B8* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8 ld_global_nc_L1_evict_normal_L2_64B(const _B8* __addr)
 {
-  static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint32_t dest;
-  asm volatile("ld.global.nc.L1::evict_normal.L2::64B.b8 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return __u32_as_b8<B8>(dest);
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.nc.L1::evict_normal.L2::64B.b8 %0, [%1];"
+               : "=r"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return __u32_as_b8<_B8>(__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B8*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_normal.L2::64B.b16 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_evict_normal_L2_64B(
   const B16* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_global_nc_L1_evict_normal_L2_64B(const B16* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16 ld_global_nc_L1_evict_normal_L2_64B(const _B16* __addr)
 {
-  static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint16_t dest;
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint16_t __dest;
   asm volatile("ld.global.nc.L1::evict_normal.L2::64B.b16 %0, [%1];"
-               : "=h"(dest)
-               : "l"(__as_ptr_gmem(addr))
+               : "=h"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
                : "memory");
-  return *reinterpret_cast<B16*>(&dest);
+  return *reinterpret_cast<_B16*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
-  std::uint16_t err_out_var = 0;
-  return *reinterpret_cast<B16*>(&err_out_var);
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_normal.L2::64B.b32 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_evict_normal_L2_64B(
   const B32* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_global_nc_L1_evict_normal_L2_64B(const B32* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32 ld_global_nc_L1_evict_normal_L2_64B(const _B32* __addr)
 {
-  static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint32_t dest;
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint32_t __dest;
   asm volatile("ld.global.nc.L1::evict_normal.L2::64B.b32 %0, [%1];"
-               : "=r"(dest)
-               : "l"(__as_ptr_gmem(addr))
+               : "=r"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
                : "memory");
-  return *reinterpret_cast<B32*>(&dest);
+  return *reinterpret_cast<_B32*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B32*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_normal.L2::64B.b64 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_evict_normal_L2_64B(
   const B64* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_global_nc_L1_evict_normal_L2_64B(const B64* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64 ld_global_nc_L1_evict_normal_L2_64B(const _B64* __addr)
 {
-  static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint64_t dest;
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint64_t __dest;
   asm volatile("ld.global.nc.L1::evict_normal.L2::64B.b64 %0, [%1];"
-               : "=l"(dest)
-               : "l"(__as_ptr_gmem(addr))
+               : "=l"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
                : "memory");
-  return *reinterpret_cast<B64*>(&dest);
+  return *reinterpret_cast<_B64*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
-  std::uint64_t err_out_var = 0;
-  return *reinterpret_cast<B64*>(&err_out_var);
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_normal.L2::64B.b128 dest, [addr]; // PTX ISA 83, SM_75
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
+template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_evict_normal_L2_64B(
   const B128* addr);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_global_nc_L1_evict_normal_L2_64B(const B128* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
+_CCCL_DEVICE static inline _B128 ld_global_nc_L1_evict_normal_L2_64B(const _B128* __addr)
 {
-  static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  longlong2 dest;
+  static_assert(sizeof(_B128) == 16, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  longlong2 __dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.nc.L1::evict_normal.L2::64B.b128 B128_dest, [%2];\n\t"
     "mov.b128 {%0, %1}, B128_dest; \n"
     "}"
-    : "=l"(dest.x), "=l"(dest.y)
-    : "l"(__as_ptr_gmem(addr))
+    : "=l"(__dest.x), "=l"(__dest.y)
+    : "l"(__as_ptr_gmem(__addr))
     : "memory");
-  return *reinterpret_cast<B128*>(&dest);
+  return *reinterpret_cast<_B128*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
-  longlong2 err_out_var{0, 0};
-  return *reinterpret_cast<B128*>(&err_out_var);
+  longlong2 __err_out_var{0, 0};
+  return *reinterpret_cast<_B128*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.nc.L1::evict_normal.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_nc_L1_evict_normal_L2_128B(
-  const B8* addr);
+template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
+__device__ static inline _B8 ld_global_nc_L1_evict_normal_L2_128B(
+  const _B8* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_nc_L1_evict_normal_L2_128B(const B8* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8 ld_global_nc_L1_evict_normal_L2_128B(const _B8* __addr)
 {
-  static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint32_t dest;
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint32_t __dest;
   asm volatile("ld.global.nc.L1::evict_normal.L2::128B.b8 %0, [%1];"
-               : "=r"(dest)
-               : "l"(__as_ptr_gmem(addr))
+               : "=r"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
                : "memory");
-  return __u32_as_b8<B8>(dest);
+  return __u32_as_b8<_B8>(__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B8*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_normal.L2::128B.b16 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_evict_normal_L2_128B(
   const B16* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_global_nc_L1_evict_normal_L2_128B(const B16* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16 ld_global_nc_L1_evict_normal_L2_128B(const _B16* __addr)
 {
-  static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint16_t dest;
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint16_t __dest;
   asm volatile("ld.global.nc.L1::evict_normal.L2::128B.b16 %0, [%1];"
-               : "=h"(dest)
-               : "l"(__as_ptr_gmem(addr))
+               : "=h"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
                : "memory");
-  return *reinterpret_cast<B16*>(&dest);
+  return *reinterpret_cast<_B16*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
-  std::uint16_t err_out_var = 0;
-  return *reinterpret_cast<B16*>(&err_out_var);
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_normal.L2::128B.b32 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_evict_normal_L2_128B(
   const B32* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_global_nc_L1_evict_normal_L2_128B(const B32* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32 ld_global_nc_L1_evict_normal_L2_128B(const _B32* __addr)
 {
-  static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint32_t dest;
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint32_t __dest;
   asm volatile("ld.global.nc.L1::evict_normal.L2::128B.b32 %0, [%1];"
-               : "=r"(dest)
-               : "l"(__as_ptr_gmem(addr))
+               : "=r"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
                : "memory");
-  return *reinterpret_cast<B32*>(&dest);
+  return *reinterpret_cast<_B32*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B32*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_normal.L2::128B.b64 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_evict_normal_L2_128B(
   const B64* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_global_nc_L1_evict_normal_L2_128B(const B64* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64 ld_global_nc_L1_evict_normal_L2_128B(const _B64* __addr)
 {
-  static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint64_t dest;
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint64_t __dest;
   asm volatile("ld.global.nc.L1::evict_normal.L2::128B.b64 %0, [%1];"
-               : "=l"(dest)
-               : "l"(__as_ptr_gmem(addr))
+               : "=l"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
                : "memory");
-  return *reinterpret_cast<B64*>(&dest);
+  return *reinterpret_cast<_B64*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
-  std::uint64_t err_out_var = 0;
-  return *reinterpret_cast<B64*>(&err_out_var);
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_normal.L2::128B.b128 dest, [addr]; // PTX ISA 83, SM_75
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
+template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_evict_normal_L2_128B(
   const B128* addr);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_global_nc_L1_evict_normal_L2_128B(const B128* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
+_CCCL_DEVICE static inline _B128 ld_global_nc_L1_evict_normal_L2_128B(const _B128* __addr)
 {
-  static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  longlong2 dest;
+  static_assert(sizeof(_B128) == 16, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  longlong2 __dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.nc.L1::evict_normal.L2::128B.b128 B128_dest, [%2];\n\t"
     "mov.b128 {%0, %1}, B128_dest; \n"
     "}"
-    : "=l"(dest.x), "=l"(dest.y)
-    : "l"(__as_ptr_gmem(addr))
+    : "=l"(__dest.x), "=l"(__dest.y)
+    : "l"(__as_ptr_gmem(__addr))
     : "memory");
-  return *reinterpret_cast<B128*>(&dest);
+  return *reinterpret_cast<_B128*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
-  longlong2 err_out_var{0, 0};
-  return *reinterpret_cast<B128*>(&err_out_var);
+  longlong2 __err_out_var{0, 0};
+  return *reinterpret_cast<_B128*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.nc.L1::evict_normal.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_nc_L1_evict_normal_L2_256B(
-  const B8* addr);
+template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
+__device__ static inline _B8 ld_global_nc_L1_evict_normal_L2_256B(
+  const _B8* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_nc_L1_evict_normal_L2_256B(const B8* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8 ld_global_nc_L1_evict_normal_L2_256B(const _B8* __addr)
 {
-  static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  std::uint32_t dest;
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint32_t __dest;
   asm volatile("ld.global.nc.L1::evict_normal.L2::256B.b8 %0, [%1];"
-               : "=r"(dest)
-               : "l"(__as_ptr_gmem(addr))
+               : "=r"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
                : "memory");
-  return __u32_as_b8<B8>(dest);
+  return __u32_as_b8<_B8>(__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B8*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_normal.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_evict_normal_L2_256B(
   const B16* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_global_nc_L1_evict_normal_L2_256B(const B16* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16 ld_global_nc_L1_evict_normal_L2_256B(const _B16* __addr)
 {
-  static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  std::uint16_t dest;
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint16_t __dest;
   asm volatile("ld.global.nc.L1::evict_normal.L2::256B.b16 %0, [%1];"
-               : "=h"(dest)
-               : "l"(__as_ptr_gmem(addr))
+               : "=h"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
                : "memory");
-  return *reinterpret_cast<B16*>(&dest);
+  return *reinterpret_cast<_B16*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
-  std::uint16_t err_out_var = 0;
-  return *reinterpret_cast<B16*>(&err_out_var);
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_normal.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_evict_normal_L2_256B(
   const B32* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_global_nc_L1_evict_normal_L2_256B(const B32* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32 ld_global_nc_L1_evict_normal_L2_256B(const _B32* __addr)
 {
-  static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  std::uint32_t dest;
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint32_t __dest;
   asm volatile("ld.global.nc.L1::evict_normal.L2::256B.b32 %0, [%1];"
-               : "=r"(dest)
-               : "l"(__as_ptr_gmem(addr))
+               : "=r"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
                : "memory");
-  return *reinterpret_cast<B32*>(&dest);
+  return *reinterpret_cast<_B32*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B32*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_normal.L2::256B.b64 dest, [addr]; // PTX ISA 74, SM_80
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_evict_normal_L2_256B(
   const B64* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_global_nc_L1_evict_normal_L2_256B(const B64* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64 ld_global_nc_L1_evict_normal_L2_256B(const _B64* __addr)
 {
-  static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  std::uint64_t dest;
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint64_t __dest;
   asm volatile("ld.global.nc.L1::evict_normal.L2::256B.b64 %0, [%1];"
-               : "=l"(dest)
-               : "l"(__as_ptr_gmem(addr))
+               : "=l"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
                : "memory");
-  return *reinterpret_cast<B64*>(&dest);
+  return *reinterpret_cast<_B64*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
-  std::uint64_t err_out_var = 0;
-  return *reinterpret_cast<B64*>(&err_out_var);
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_normal.L2::256B.b128 dest, [addr]; // PTX ISA 83, SM_80
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
+template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_evict_normal_L2_256B(
   const B128* addr);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_global_nc_L1_evict_normal_L2_256B(const B128* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
+_CCCL_DEVICE static inline _B128 ld_global_nc_L1_evict_normal_L2_256B(const _B128* __addr)
 {
-  static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  longlong2 dest;
+  static_assert(sizeof(_B128) == 16, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  longlong2 __dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.nc.L1::evict_normal.L2::256B.b128 B128_dest, [%2];\n\t"
     "mov.b128 {%0, %1}, B128_dest; \n"
     "}"
-    : "=l"(dest.x), "=l"(dest.y)
-    : "l"(__as_ptr_gmem(addr))
+    : "=l"(__dest.x), "=l"(__dest.y)
+    : "l"(__as_ptr_gmem(__addr))
     : "memory");
-  return *reinterpret_cast<B128*>(&dest);
+  return *reinterpret_cast<_B128*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
-  longlong2 err_out_var{0, 0};
-  return *reinterpret_cast<B128*>(&err_out_var);
+  longlong2 __err_out_var{0, 0};
+  return *reinterpret_cast<_B128*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.nc.L1::evict_unchanged.b8 dest, [addr]; // PTX ISA 74, SM_70
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_nc_L1_evict_unchanged(
-  const B8* addr);
+template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
+__device__ static inline _B8 ld_global_nc_L1_evict_unchanged(
+  const _B8* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_unchanged_is_not_supported_before_SM_70__();
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_nc_L1_evict_unchanged(const B8* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_unchanged_is_not_supported_before_SM_70__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8 ld_global_nc_L1_evict_unchanged(const _B8* __addr)
 {
-  static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
-  std::uint32_t dest;
-  asm volatile("ld.global.nc.L1::evict_unchanged.b8 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return __u32_as_b8<B8>(dest);
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.nc.L1::evict_unchanged.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return __u32_as_b8<_B8>(__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_unchanged_is_not_supported_before_SM_70__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B8*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_unchanged.b16 dest, [addr]; // PTX ISA 74, SM_70
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_evict_unchanged(
   const B16* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_unchanged_is_not_supported_before_SM_70__();
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_global_nc_L1_evict_unchanged(const B16* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_unchanged_is_not_supported_before_SM_70__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16 ld_global_nc_L1_evict_unchanged(const _B16* __addr)
 {
-  static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
-  std::uint16_t dest;
-  asm volatile("ld.global.nc.L1::evict_unchanged.b16 %0, [%1];" : "=h"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B16*>(&dest);
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
+  _CUDA_VSTD::uint16_t __dest;
+  asm volatile("ld.global.nc.L1::evict_unchanged.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B16*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_unchanged_is_not_supported_before_SM_70__();
-  std::uint16_t err_out_var = 0;
-  return *reinterpret_cast<B16*>(&err_out_var);
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_unchanged.b32 dest, [addr]; // PTX ISA 74, SM_70
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_evict_unchanged(
   const B32* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_unchanged_is_not_supported_before_SM_70__();
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_global_nc_L1_evict_unchanged(const B32* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_unchanged_is_not_supported_before_SM_70__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32 ld_global_nc_L1_evict_unchanged(const _B32* __addr)
 {
-  static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
-  std::uint32_t dest;
-  asm volatile("ld.global.nc.L1::evict_unchanged.b32 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B32*>(&dest);
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.nc.L1::evict_unchanged.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B32*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_unchanged_is_not_supported_before_SM_70__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B32*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_unchanged.b64 dest, [addr]; // PTX ISA 74, SM_70
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_evict_unchanged(
   const B64* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_unchanged_is_not_supported_before_SM_70__();
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_global_nc_L1_evict_unchanged(const B64* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_unchanged_is_not_supported_before_SM_70__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64 ld_global_nc_L1_evict_unchanged(const _B64* __addr)
 {
-  static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
-  std::uint64_t dest;
-  asm volatile("ld.global.nc.L1::evict_unchanged.b64 %0, [%1];" : "=l"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B64*>(&dest);
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
+  _CUDA_VSTD::uint64_t __dest;
+  asm volatile("ld.global.nc.L1::evict_unchanged.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B64*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_unchanged_is_not_supported_before_SM_70__();
-  std::uint64_t err_out_var = 0;
-  return *reinterpret_cast<B64*>(&err_out_var);
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_unchanged.b128 dest, [addr]; // PTX ISA 83, SM_70
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
+template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_evict_unchanged(
   const B128* addr);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_unchanged_is_not_supported_before_SM_70__();
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_global_nc_L1_evict_unchanged(const B128* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_unchanged_is_not_supported_before_SM_70__();
+template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
+_CCCL_DEVICE static inline _B128 ld_global_nc_L1_evict_unchanged(const _B128* __addr)
 {
-  static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
-  longlong2 dest;
+  static_assert(sizeof(_B128) == 16, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
+  longlong2 __dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.nc.L1::evict_unchanged.b128 B128_dest, [%2];\n\t"
     "mov.b128 {%0, %1}, B128_dest; \n"
     "}"
-    : "=l"(dest.x), "=l"(dest.y)
-    : "l"(__as_ptr_gmem(addr))
+    : "=l"(__dest.x), "=l"(__dest.y)
+    : "l"(__as_ptr_gmem(__addr))
     : "memory");
-  return *reinterpret_cast<B128*>(&dest);
+  return *reinterpret_cast<_B128*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_unchanged_is_not_supported_before_SM_70__();
-  longlong2 err_out_var{0, 0};
-  return *reinterpret_cast<B128*>(&err_out_var);
+  longlong2 __err_out_var{0, 0};
+  return *reinterpret_cast<_B128*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.nc.L1::evict_unchanged.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_nc_L1_evict_unchanged_L2_64B(
-  const B8* addr);
+template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
+__device__ static inline _B8 ld_global_nc_L1_evict_unchanged_L2_64B(
+  const _B8* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_nc_L1_evict_unchanged_L2_64B(const B8* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8 ld_global_nc_L1_evict_unchanged_L2_64B(const _B8* __addr)
 {
-  static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint32_t dest;
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint32_t __dest;
   asm volatile("ld.global.nc.L1::evict_unchanged.L2::64B.b8 %0, [%1];"
-               : "=r"(dest)
-               : "l"(__as_ptr_gmem(addr))
+               : "=r"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
                : "memory");
-  return __u32_as_b8<B8>(dest);
+  return __u32_as_b8<_B8>(__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B8*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_unchanged.L2::64B.b16 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_evict_unchanged_L2_64B(
   const B16* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_global_nc_L1_evict_unchanged_L2_64B(const B16* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16 ld_global_nc_L1_evict_unchanged_L2_64B(const _B16* __addr)
 {
-  static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint16_t dest;
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint16_t __dest;
   asm volatile("ld.global.nc.L1::evict_unchanged.L2::64B.b16 %0, [%1];"
-               : "=h"(dest)
-               : "l"(__as_ptr_gmem(addr))
+               : "=h"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
                : "memory");
-  return *reinterpret_cast<B16*>(&dest);
+  return *reinterpret_cast<_B16*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
-  std::uint16_t err_out_var = 0;
-  return *reinterpret_cast<B16*>(&err_out_var);
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_unchanged.L2::64B.b32 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_evict_unchanged_L2_64B(
   const B32* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_global_nc_L1_evict_unchanged_L2_64B(const B32* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32 ld_global_nc_L1_evict_unchanged_L2_64B(const _B32* __addr)
 {
-  static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint32_t dest;
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint32_t __dest;
   asm volatile("ld.global.nc.L1::evict_unchanged.L2::64B.b32 %0, [%1];"
-               : "=r"(dest)
-               : "l"(__as_ptr_gmem(addr))
+               : "=r"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
                : "memory");
-  return *reinterpret_cast<B32*>(&dest);
+  return *reinterpret_cast<_B32*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B32*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_unchanged.L2::64B.b64 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_evict_unchanged_L2_64B(
   const B64* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_global_nc_L1_evict_unchanged_L2_64B(const B64* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64 ld_global_nc_L1_evict_unchanged_L2_64B(const _B64* __addr)
 {
-  static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint64_t dest;
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint64_t __dest;
   asm volatile("ld.global.nc.L1::evict_unchanged.L2::64B.b64 %0, [%1];"
-               : "=l"(dest)
-               : "l"(__as_ptr_gmem(addr))
+               : "=l"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
                : "memory");
-  return *reinterpret_cast<B64*>(&dest);
+  return *reinterpret_cast<_B64*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
-  std::uint64_t err_out_var = 0;
-  return *reinterpret_cast<B64*>(&err_out_var);
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_unchanged.L2::64B.b128 dest, [addr]; // PTX ISA 83, SM_75
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
+template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_evict_unchanged_L2_64B(
   const B128* addr);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_global_nc_L1_evict_unchanged_L2_64B(const B128* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
+_CCCL_DEVICE static inline _B128 ld_global_nc_L1_evict_unchanged_L2_64B(const _B128* __addr)
 {
-  static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  longlong2 dest;
+  static_assert(sizeof(_B128) == 16, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  longlong2 __dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.nc.L1::evict_unchanged.L2::64B.b128 B128_dest, [%2];\n\t"
     "mov.b128 {%0, %1}, B128_dest; \n"
     "}"
-    : "=l"(dest.x), "=l"(dest.y)
-    : "l"(__as_ptr_gmem(addr))
+    : "=l"(__dest.x), "=l"(__dest.y)
+    : "l"(__as_ptr_gmem(__addr))
     : "memory");
-  return *reinterpret_cast<B128*>(&dest);
+  return *reinterpret_cast<_B128*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
-  longlong2 err_out_var{0, 0};
-  return *reinterpret_cast<B128*>(&err_out_var);
+  longlong2 __err_out_var{0, 0};
+  return *reinterpret_cast<_B128*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.nc.L1::evict_unchanged.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_nc_L1_evict_unchanged_L2_128B(
-  const B8* addr);
+template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
+__device__ static inline _B8 ld_global_nc_L1_evict_unchanged_L2_128B(
+  const _B8* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_nc_L1_evict_unchanged_L2_128B(const B8* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8 ld_global_nc_L1_evict_unchanged_L2_128B(const _B8* __addr)
 {
-  static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint32_t dest;
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint32_t __dest;
   asm volatile("ld.global.nc.L1::evict_unchanged.L2::128B.b8 %0, [%1];"
-               : "=r"(dest)
-               : "l"(__as_ptr_gmem(addr))
+               : "=r"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
                : "memory");
-  return __u32_as_b8<B8>(dest);
+  return __u32_as_b8<_B8>(__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B8*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_unchanged.L2::128B.b16 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_evict_unchanged_L2_128B(
   const B16* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_global_nc_L1_evict_unchanged_L2_128B(const B16* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16 ld_global_nc_L1_evict_unchanged_L2_128B(const _B16* __addr)
 {
-  static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint16_t dest;
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint16_t __dest;
   asm volatile("ld.global.nc.L1::evict_unchanged.L2::128B.b16 %0, [%1];"
-               : "=h"(dest)
-               : "l"(__as_ptr_gmem(addr))
+               : "=h"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
                : "memory");
-  return *reinterpret_cast<B16*>(&dest);
+  return *reinterpret_cast<_B16*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
-  std::uint16_t err_out_var = 0;
-  return *reinterpret_cast<B16*>(&err_out_var);
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_unchanged.L2::128B.b32 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_evict_unchanged_L2_128B(
   const B32* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_global_nc_L1_evict_unchanged_L2_128B(const B32* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32 ld_global_nc_L1_evict_unchanged_L2_128B(const _B32* __addr)
 {
-  static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint32_t dest;
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint32_t __dest;
   asm volatile("ld.global.nc.L1::evict_unchanged.L2::128B.b32 %0, [%1];"
-               : "=r"(dest)
-               : "l"(__as_ptr_gmem(addr))
+               : "=r"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
                : "memory");
-  return *reinterpret_cast<B32*>(&dest);
+  return *reinterpret_cast<_B32*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B32*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_unchanged.L2::128B.b64 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_evict_unchanged_L2_128B(
   const B64* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_global_nc_L1_evict_unchanged_L2_128B(const B64* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64 ld_global_nc_L1_evict_unchanged_L2_128B(const _B64* __addr)
 {
-  static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint64_t dest;
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint64_t __dest;
   asm volatile("ld.global.nc.L1::evict_unchanged.L2::128B.b64 %0, [%1];"
-               : "=l"(dest)
-               : "l"(__as_ptr_gmem(addr))
+               : "=l"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
                : "memory");
-  return *reinterpret_cast<B64*>(&dest);
+  return *reinterpret_cast<_B64*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
-  std::uint64_t err_out_var = 0;
-  return *reinterpret_cast<B64*>(&err_out_var);
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_unchanged.L2::128B.b128 dest, [addr]; // PTX ISA 83, SM_75
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
+template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_evict_unchanged_L2_128B(
   const B128* addr);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_global_nc_L1_evict_unchanged_L2_128B(const B128* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
+_CCCL_DEVICE static inline _B128 ld_global_nc_L1_evict_unchanged_L2_128B(const _B128* __addr)
 {
-  static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  longlong2 dest;
+  static_assert(sizeof(_B128) == 16, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  longlong2 __dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.nc.L1::evict_unchanged.L2::128B.b128 B128_dest, [%2];\n\t"
     "mov.b128 {%0, %1}, B128_dest; \n"
     "}"
-    : "=l"(dest.x), "=l"(dest.y)
-    : "l"(__as_ptr_gmem(addr))
+    : "=l"(__dest.x), "=l"(__dest.y)
+    : "l"(__as_ptr_gmem(__addr))
     : "memory");
-  return *reinterpret_cast<B128*>(&dest);
+  return *reinterpret_cast<_B128*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
-  longlong2 err_out_var{0, 0};
-  return *reinterpret_cast<B128*>(&err_out_var);
+  longlong2 __err_out_var{0, 0};
+  return *reinterpret_cast<_B128*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.nc.L1::evict_unchanged.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_nc_L1_evict_unchanged_L2_256B(
-  const B8* addr);
+template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
+__device__ static inline _B8 ld_global_nc_L1_evict_unchanged_L2_256B(
+  const _B8* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_nc_L1_evict_unchanged_L2_256B(const B8* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8 ld_global_nc_L1_evict_unchanged_L2_256B(const _B8* __addr)
 {
-  static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  std::uint32_t dest;
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint32_t __dest;
   asm volatile("ld.global.nc.L1::evict_unchanged.L2::256B.b8 %0, [%1];"
-               : "=r"(dest)
-               : "l"(__as_ptr_gmem(addr))
+               : "=r"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
                : "memory");
-  return __u32_as_b8<B8>(dest);
+  return __u32_as_b8<_B8>(__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B8*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_unchanged.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_evict_unchanged_L2_256B(
   const B16* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_global_nc_L1_evict_unchanged_L2_256B(const B16* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16 ld_global_nc_L1_evict_unchanged_L2_256B(const _B16* __addr)
 {
-  static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  std::uint16_t dest;
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint16_t __dest;
   asm volatile("ld.global.nc.L1::evict_unchanged.L2::256B.b16 %0, [%1];"
-               : "=h"(dest)
-               : "l"(__as_ptr_gmem(addr))
+               : "=h"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
                : "memory");
-  return *reinterpret_cast<B16*>(&dest);
+  return *reinterpret_cast<_B16*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
-  std::uint16_t err_out_var = 0;
-  return *reinterpret_cast<B16*>(&err_out_var);
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_unchanged.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_evict_unchanged_L2_256B(
   const B32* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_global_nc_L1_evict_unchanged_L2_256B(const B32* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32 ld_global_nc_L1_evict_unchanged_L2_256B(const _B32* __addr)
 {
-  static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  std::uint32_t dest;
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint32_t __dest;
   asm volatile("ld.global.nc.L1::evict_unchanged.L2::256B.b32 %0, [%1];"
-               : "=r"(dest)
-               : "l"(__as_ptr_gmem(addr))
+               : "=r"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
                : "memory");
-  return *reinterpret_cast<B32*>(&dest);
+  return *reinterpret_cast<_B32*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B32*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_unchanged.L2::256B.b64 dest, [addr]; // PTX ISA 74, SM_80
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_evict_unchanged_L2_256B(
   const B64* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_global_nc_L1_evict_unchanged_L2_256B(const B64* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64 ld_global_nc_L1_evict_unchanged_L2_256B(const _B64* __addr)
 {
-  static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  std::uint64_t dest;
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint64_t __dest;
   asm volatile("ld.global.nc.L1::evict_unchanged.L2::256B.b64 %0, [%1];"
-               : "=l"(dest)
-               : "l"(__as_ptr_gmem(addr))
+               : "=l"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
                : "memory");
-  return *reinterpret_cast<B64*>(&dest);
+  return *reinterpret_cast<_B64*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
-  std::uint64_t err_out_var = 0;
-  return *reinterpret_cast<B64*>(&err_out_var);
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_unchanged.L2::256B.b128 dest, [addr]; // PTX ISA 83, SM_80
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
+template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_evict_unchanged_L2_256B(
   const B128* addr);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_global_nc_L1_evict_unchanged_L2_256B(const B128* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
+_CCCL_DEVICE static inline _B128 ld_global_nc_L1_evict_unchanged_L2_256B(const _B128* __addr)
 {
-  static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  longlong2 dest;
+  static_assert(sizeof(_B128) == 16, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  longlong2 __dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.nc.L1::evict_unchanged.L2::256B.b128 B128_dest, [%2];\n\t"
     "mov.b128 {%0, %1}, B128_dest; \n"
     "}"
-    : "=l"(dest.x), "=l"(dest.y)
-    : "l"(__as_ptr_gmem(addr))
+    : "=l"(__dest.x), "=l"(__dest.y)
+    : "l"(__as_ptr_gmem(__addr))
     : "memory");
-  return *reinterpret_cast<B128*>(&dest);
+  return *reinterpret_cast<_B128*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
-  longlong2 err_out_var{0, 0};
-  return *reinterpret_cast<B128*>(&err_out_var);
+  longlong2 __err_out_var{0, 0};
+  return *reinterpret_cast<_B128*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.nc.L1::evict_first.b8 dest, [addr]; // PTX ISA 74, SM_70
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_nc_L1_evict_first(
-  const B8* addr);
+template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
+__device__ static inline _B8 ld_global_nc_L1_evict_first(
+  const _B8* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_first_is_not_supported_before_SM_70__();
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_nc_L1_evict_first(const B8* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_first_is_not_supported_before_SM_70__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8 ld_global_nc_L1_evict_first(const _B8* __addr)
 {
-  static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
-  std::uint32_t dest;
-  asm volatile("ld.global.nc.L1::evict_first.b8 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return __u32_as_b8<B8>(dest);
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.nc.L1::evict_first.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return __u32_as_b8<_B8>(__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_first_is_not_supported_before_SM_70__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B8*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_first.b16 dest, [addr]; // PTX ISA 74, SM_70
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_evict_first(
   const B16* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_first_is_not_supported_before_SM_70__();
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_global_nc_L1_evict_first(const B16* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_first_is_not_supported_before_SM_70__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16 ld_global_nc_L1_evict_first(const _B16* __addr)
 {
-  static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
-  std::uint16_t dest;
-  asm volatile("ld.global.nc.L1::evict_first.b16 %0, [%1];" : "=h"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B16*>(&dest);
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
+  _CUDA_VSTD::uint16_t __dest;
+  asm volatile("ld.global.nc.L1::evict_first.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B16*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_first_is_not_supported_before_SM_70__();
-  std::uint16_t err_out_var = 0;
-  return *reinterpret_cast<B16*>(&err_out_var);
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_first.b32 dest, [addr]; // PTX ISA 74, SM_70
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_evict_first(
   const B32* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_first_is_not_supported_before_SM_70__();
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_global_nc_L1_evict_first(const B32* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_first_is_not_supported_before_SM_70__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32 ld_global_nc_L1_evict_first(const _B32* __addr)
 {
-  static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
-  std::uint32_t dest;
-  asm volatile("ld.global.nc.L1::evict_first.b32 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B32*>(&dest);
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.nc.L1::evict_first.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B32*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_first_is_not_supported_before_SM_70__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B32*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_first.b64 dest, [addr]; // PTX ISA 74, SM_70
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_evict_first(
   const B64* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_first_is_not_supported_before_SM_70__();
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_global_nc_L1_evict_first(const B64* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_first_is_not_supported_before_SM_70__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64 ld_global_nc_L1_evict_first(const _B64* __addr)
 {
-  static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
-  std::uint64_t dest;
-  asm volatile("ld.global.nc.L1::evict_first.b64 %0, [%1];" : "=l"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B64*>(&dest);
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
+  _CUDA_VSTD::uint64_t __dest;
+  asm volatile("ld.global.nc.L1::evict_first.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B64*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_first_is_not_supported_before_SM_70__();
-  std::uint64_t err_out_var = 0;
-  return *reinterpret_cast<B64*>(&err_out_var);
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_first.b128 dest, [addr]; // PTX ISA 83, SM_70
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
+template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_evict_first(
   const B128* addr);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_first_is_not_supported_before_SM_70__();
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_global_nc_L1_evict_first(const B128* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_first_is_not_supported_before_SM_70__();
+template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
+_CCCL_DEVICE static inline _B128 ld_global_nc_L1_evict_first(const _B128* __addr)
 {
-  static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
-  longlong2 dest;
+  static_assert(sizeof(_B128) == 16, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
+  longlong2 __dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.nc.L1::evict_first.b128 B128_dest, [%2];\n\t"
     "mov.b128 {%0, %1}, B128_dest; \n"
     "}"
-    : "=l"(dest.x), "=l"(dest.y)
-    : "l"(__as_ptr_gmem(addr))
+    : "=l"(__dest.x), "=l"(__dest.y)
+    : "l"(__as_ptr_gmem(__addr))
     : "memory");
-  return *reinterpret_cast<B128*>(&dest);
+  return *reinterpret_cast<_B128*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_first_is_not_supported_before_SM_70__();
-  longlong2 err_out_var{0, 0};
-  return *reinterpret_cast<B128*>(&err_out_var);
+  longlong2 __err_out_var{0, 0};
+  return *reinterpret_cast<_B128*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.nc.L1::evict_first.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_nc_L1_evict_first_L2_64B(
-  const B8* addr);
+template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
+__device__ static inline _B8 ld_global_nc_L1_evict_first_L2_64B(
+  const _B8* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_nc_L1_evict_first_L2_64B(const B8* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8 ld_global_nc_L1_evict_first_L2_64B(const _B8* __addr)
 {
-  static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint32_t dest;
-  asm volatile("ld.global.nc.L1::evict_first.L2::64B.b8 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return __u32_as_b8<B8>(dest);
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.nc.L1::evict_first.L2::64B.b8 %0, [%1];"
+               : "=r"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return __u32_as_b8<_B8>(__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B8*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_first.L2::64B.b16 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_evict_first_L2_64B(
   const B16* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_global_nc_L1_evict_first_L2_64B(const B16* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16 ld_global_nc_L1_evict_first_L2_64B(const _B16* __addr)
 {
-  static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint16_t dest;
-  asm volatile("ld.global.nc.L1::evict_first.L2::64B.b16 %0, [%1];" : "=h"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B16*>(&dest);
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint16_t __dest;
+  asm volatile("ld.global.nc.L1::evict_first.L2::64B.b16 %0, [%1];"
+               : "=h"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return *reinterpret_cast<_B16*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
-  std::uint16_t err_out_var = 0;
-  return *reinterpret_cast<B16*>(&err_out_var);
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_first.L2::64B.b32 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_evict_first_L2_64B(
   const B32* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_global_nc_L1_evict_first_L2_64B(const B32* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32 ld_global_nc_L1_evict_first_L2_64B(const _B32* __addr)
 {
-  static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint32_t dest;
-  asm volatile("ld.global.nc.L1::evict_first.L2::64B.b32 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B32*>(&dest);
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.nc.L1::evict_first.L2::64B.b32 %0, [%1];"
+               : "=r"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return *reinterpret_cast<_B32*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B32*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_first.L2::64B.b64 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_evict_first_L2_64B(
   const B64* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_global_nc_L1_evict_first_L2_64B(const B64* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64 ld_global_nc_L1_evict_first_L2_64B(const _B64* __addr)
 {
-  static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint64_t dest;
-  asm volatile("ld.global.nc.L1::evict_first.L2::64B.b64 %0, [%1];" : "=l"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B64*>(&dest);
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint64_t __dest;
+  asm volatile("ld.global.nc.L1::evict_first.L2::64B.b64 %0, [%1];"
+               : "=l"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return *reinterpret_cast<_B64*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
-  std::uint64_t err_out_var = 0;
-  return *reinterpret_cast<B64*>(&err_out_var);
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_first.L2::64B.b128 dest, [addr]; // PTX ISA 83, SM_75
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
+template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_evict_first_L2_64B(
   const B128* addr);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_global_nc_L1_evict_first_L2_64B(const B128* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
+_CCCL_DEVICE static inline _B128 ld_global_nc_L1_evict_first_L2_64B(const _B128* __addr)
 {
-  static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  longlong2 dest;
+  static_assert(sizeof(_B128) == 16, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  longlong2 __dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.nc.L1::evict_first.L2::64B.b128 B128_dest, [%2];\n\t"
     "mov.b128 {%0, %1}, B128_dest; \n"
     "}"
-    : "=l"(dest.x), "=l"(dest.y)
-    : "l"(__as_ptr_gmem(addr))
+    : "=l"(__dest.x), "=l"(__dest.y)
+    : "l"(__as_ptr_gmem(__addr))
     : "memory");
-  return *reinterpret_cast<B128*>(&dest);
+  return *reinterpret_cast<_B128*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
-  longlong2 err_out_var{0, 0};
-  return *reinterpret_cast<B128*>(&err_out_var);
+  longlong2 __err_out_var{0, 0};
+  return *reinterpret_cast<_B128*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.nc.L1::evict_first.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_nc_L1_evict_first_L2_128B(
-  const B8* addr);
+template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
+__device__ static inline _B8 ld_global_nc_L1_evict_first_L2_128B(
+  const _B8* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_nc_L1_evict_first_L2_128B(const B8* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8 ld_global_nc_L1_evict_first_L2_128B(const _B8* __addr)
 {
-  static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint32_t dest;
-  asm volatile("ld.global.nc.L1::evict_first.L2::128B.b8 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return __u32_as_b8<B8>(dest);
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.nc.L1::evict_first.L2::128B.b8 %0, [%1];"
+               : "=r"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return __u32_as_b8<_B8>(__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B8*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_first.L2::128B.b16 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_evict_first_L2_128B(
   const B16* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_global_nc_L1_evict_first_L2_128B(const B16* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16 ld_global_nc_L1_evict_first_L2_128B(const _B16* __addr)
 {
-  static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint16_t dest;
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint16_t __dest;
   asm volatile("ld.global.nc.L1::evict_first.L2::128B.b16 %0, [%1];"
-               : "=h"(dest)
-               : "l"(__as_ptr_gmem(addr))
+               : "=h"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
                : "memory");
-  return *reinterpret_cast<B16*>(&dest);
+  return *reinterpret_cast<_B16*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
-  std::uint16_t err_out_var = 0;
-  return *reinterpret_cast<B16*>(&err_out_var);
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_first.L2::128B.b32 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_evict_first_L2_128B(
   const B32* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_global_nc_L1_evict_first_L2_128B(const B32* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32 ld_global_nc_L1_evict_first_L2_128B(const _B32* __addr)
 {
-  static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint32_t dest;
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint32_t __dest;
   asm volatile("ld.global.nc.L1::evict_first.L2::128B.b32 %0, [%1];"
-               : "=r"(dest)
-               : "l"(__as_ptr_gmem(addr))
+               : "=r"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
                : "memory");
-  return *reinterpret_cast<B32*>(&dest);
+  return *reinterpret_cast<_B32*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B32*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_first.L2::128B.b64 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_evict_first_L2_128B(
   const B64* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_global_nc_L1_evict_first_L2_128B(const B64* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64 ld_global_nc_L1_evict_first_L2_128B(const _B64* __addr)
 {
-  static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint64_t dest;
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint64_t __dest;
   asm volatile("ld.global.nc.L1::evict_first.L2::128B.b64 %0, [%1];"
-               : "=l"(dest)
-               : "l"(__as_ptr_gmem(addr))
+               : "=l"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
                : "memory");
-  return *reinterpret_cast<B64*>(&dest);
+  return *reinterpret_cast<_B64*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
-  std::uint64_t err_out_var = 0;
-  return *reinterpret_cast<B64*>(&err_out_var);
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_first.L2::128B.b128 dest, [addr]; // PTX ISA 83, SM_75
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
+template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_evict_first_L2_128B(
   const B128* addr);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_global_nc_L1_evict_first_L2_128B(const B128* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
+_CCCL_DEVICE static inline _B128 ld_global_nc_L1_evict_first_L2_128B(const _B128* __addr)
 {
-  static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  longlong2 dest;
+  static_assert(sizeof(_B128) == 16, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  longlong2 __dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.nc.L1::evict_first.L2::128B.b128 B128_dest, [%2];\n\t"
     "mov.b128 {%0, %1}, B128_dest; \n"
     "}"
-    : "=l"(dest.x), "=l"(dest.y)
-    : "l"(__as_ptr_gmem(addr))
+    : "=l"(__dest.x), "=l"(__dest.y)
+    : "l"(__as_ptr_gmem(__addr))
     : "memory");
-  return *reinterpret_cast<B128*>(&dest);
+  return *reinterpret_cast<_B128*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
-  longlong2 err_out_var{0, 0};
-  return *reinterpret_cast<B128*>(&err_out_var);
+  longlong2 __err_out_var{0, 0};
+  return *reinterpret_cast<_B128*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.nc.L1::evict_first.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_nc_L1_evict_first_L2_256B(
-  const B8* addr);
+template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
+__device__ static inline _B8 ld_global_nc_L1_evict_first_L2_256B(
+  const _B8* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_nc_L1_evict_first_L2_256B(const B8* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8 ld_global_nc_L1_evict_first_L2_256B(const _B8* __addr)
 {
-  static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  std::uint32_t dest;
-  asm volatile("ld.global.nc.L1::evict_first.L2::256B.b8 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return __u32_as_b8<B8>(dest);
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.nc.L1::evict_first.L2::256B.b8 %0, [%1];"
+               : "=r"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return __u32_as_b8<_B8>(__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B8*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_first.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_evict_first_L2_256B(
   const B16* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_global_nc_L1_evict_first_L2_256B(const B16* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16 ld_global_nc_L1_evict_first_L2_256B(const _B16* __addr)
 {
-  static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  std::uint16_t dest;
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint16_t __dest;
   asm volatile("ld.global.nc.L1::evict_first.L2::256B.b16 %0, [%1];"
-               : "=h"(dest)
-               : "l"(__as_ptr_gmem(addr))
+               : "=h"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
                : "memory");
-  return *reinterpret_cast<B16*>(&dest);
+  return *reinterpret_cast<_B16*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
-  std::uint16_t err_out_var = 0;
-  return *reinterpret_cast<B16*>(&err_out_var);
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_first.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_evict_first_L2_256B(
   const B32* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_global_nc_L1_evict_first_L2_256B(const B32* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32 ld_global_nc_L1_evict_first_L2_256B(const _B32* __addr)
 {
-  static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  std::uint32_t dest;
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint32_t __dest;
   asm volatile("ld.global.nc.L1::evict_first.L2::256B.b32 %0, [%1];"
-               : "=r"(dest)
-               : "l"(__as_ptr_gmem(addr))
+               : "=r"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
                : "memory");
-  return *reinterpret_cast<B32*>(&dest);
+  return *reinterpret_cast<_B32*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B32*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_first.L2::256B.b64 dest, [addr]; // PTX ISA 74, SM_80
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_evict_first_L2_256B(
   const B64* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_global_nc_L1_evict_first_L2_256B(const B64* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64 ld_global_nc_L1_evict_first_L2_256B(const _B64* __addr)
 {
-  static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  std::uint64_t dest;
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint64_t __dest;
   asm volatile("ld.global.nc.L1::evict_first.L2::256B.b64 %0, [%1];"
-               : "=l"(dest)
-               : "l"(__as_ptr_gmem(addr))
+               : "=l"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
                : "memory");
-  return *reinterpret_cast<B64*>(&dest);
+  return *reinterpret_cast<_B64*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
-  std::uint64_t err_out_var = 0;
-  return *reinterpret_cast<B64*>(&err_out_var);
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_first.L2::256B.b128 dest, [addr]; // PTX ISA 83, SM_80
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
+template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_evict_first_L2_256B(
   const B128* addr);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_global_nc_L1_evict_first_L2_256B(const B128* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
+_CCCL_DEVICE static inline _B128 ld_global_nc_L1_evict_first_L2_256B(const _B128* __addr)
 {
-  static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  longlong2 dest;
+  static_assert(sizeof(_B128) == 16, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  longlong2 __dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.nc.L1::evict_first.L2::256B.b128 B128_dest, [%2];\n\t"
     "mov.b128 {%0, %1}, B128_dest; \n"
     "}"
-    : "=l"(dest.x), "=l"(dest.y)
-    : "l"(__as_ptr_gmem(addr))
+    : "=l"(__dest.x), "=l"(__dest.y)
+    : "l"(__as_ptr_gmem(__addr))
     : "memory");
-  return *reinterpret_cast<B128*>(&dest);
+  return *reinterpret_cast<_B128*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
-  longlong2 err_out_var{0, 0};
-  return *reinterpret_cast<B128*>(&err_out_var);
+  longlong2 __err_out_var{0, 0};
+  return *reinterpret_cast<_B128*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.nc.L1::evict_last.b8 dest, [addr]; // PTX ISA 74, SM_70
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_nc_L1_evict_last(
-  const B8* addr);
+template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
+__device__ static inline _B8 ld_global_nc_L1_evict_last(
+  const _B8* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_last_is_not_supported_before_SM_70__();
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_nc_L1_evict_last(const B8* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_last_is_not_supported_before_SM_70__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8 ld_global_nc_L1_evict_last(const _B8* __addr)
 {
-  static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
-  std::uint32_t dest;
-  asm volatile("ld.global.nc.L1::evict_last.b8 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return __u32_as_b8<B8>(dest);
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.nc.L1::evict_last.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return __u32_as_b8<_B8>(__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_last_is_not_supported_before_SM_70__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B8*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_last.b16 dest, [addr]; // PTX ISA 74, SM_70
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_evict_last(
   const B16* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_last_is_not_supported_before_SM_70__();
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_global_nc_L1_evict_last(const B16* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_last_is_not_supported_before_SM_70__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16 ld_global_nc_L1_evict_last(const _B16* __addr)
 {
-  static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
-  std::uint16_t dest;
-  asm volatile("ld.global.nc.L1::evict_last.b16 %0, [%1];" : "=h"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B16*>(&dest);
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
+  _CUDA_VSTD::uint16_t __dest;
+  asm volatile("ld.global.nc.L1::evict_last.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B16*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_last_is_not_supported_before_SM_70__();
-  std::uint16_t err_out_var = 0;
-  return *reinterpret_cast<B16*>(&err_out_var);
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_last.b32 dest, [addr]; // PTX ISA 74, SM_70
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_evict_last(
   const B32* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_last_is_not_supported_before_SM_70__();
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_global_nc_L1_evict_last(const B32* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_last_is_not_supported_before_SM_70__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32 ld_global_nc_L1_evict_last(const _B32* __addr)
 {
-  static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
-  std::uint32_t dest;
-  asm volatile("ld.global.nc.L1::evict_last.b32 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B32*>(&dest);
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.nc.L1::evict_last.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B32*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_last_is_not_supported_before_SM_70__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B32*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_last.b64 dest, [addr]; // PTX ISA 74, SM_70
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_evict_last(
   const B64* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_last_is_not_supported_before_SM_70__();
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_global_nc_L1_evict_last(const B64* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_last_is_not_supported_before_SM_70__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64 ld_global_nc_L1_evict_last(const _B64* __addr)
 {
-  static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
-  std::uint64_t dest;
-  asm volatile("ld.global.nc.L1::evict_last.b64 %0, [%1];" : "=l"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B64*>(&dest);
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
+  _CUDA_VSTD::uint64_t __dest;
+  asm volatile("ld.global.nc.L1::evict_last.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B64*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_last_is_not_supported_before_SM_70__();
-  std::uint64_t err_out_var = 0;
-  return *reinterpret_cast<B64*>(&err_out_var);
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_last.b128 dest, [addr]; // PTX ISA 83, SM_70
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
+template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_evict_last(
   const B128* addr);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_last_is_not_supported_before_SM_70__();
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_global_nc_L1_evict_last(const B128* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_last_is_not_supported_before_SM_70__();
+template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
+_CCCL_DEVICE static inline _B128 ld_global_nc_L1_evict_last(const _B128* __addr)
 {
-  static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
-  longlong2 dest;
+  static_assert(sizeof(_B128) == 16, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
+  longlong2 __dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.nc.L1::evict_last.b128 B128_dest, [%2];\n\t"
     "mov.b128 {%0, %1}, B128_dest; \n"
     "}"
-    : "=l"(dest.x), "=l"(dest.y)
-    : "l"(__as_ptr_gmem(addr))
+    : "=l"(__dest.x), "=l"(__dest.y)
+    : "l"(__as_ptr_gmem(__addr))
     : "memory");
-  return *reinterpret_cast<B128*>(&dest);
+  return *reinterpret_cast<_B128*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_last_is_not_supported_before_SM_70__();
-  longlong2 err_out_var{0, 0};
-  return *reinterpret_cast<B128*>(&err_out_var);
+  longlong2 __err_out_var{0, 0};
+  return *reinterpret_cast<_B128*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.nc.L1::evict_last.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_nc_L1_evict_last_L2_64B(
-  const B8* addr);
+template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
+__device__ static inline _B8 ld_global_nc_L1_evict_last_L2_64B(
+  const _B8* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_nc_L1_evict_last_L2_64B(const B8* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8 ld_global_nc_L1_evict_last_L2_64B(const _B8* __addr)
 {
-  static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint32_t dest;
-  asm volatile("ld.global.nc.L1::evict_last.L2::64B.b8 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return __u32_as_b8<B8>(dest);
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.nc.L1::evict_last.L2::64B.b8 %0, [%1];"
+               : "=r"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return __u32_as_b8<_B8>(__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B8*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_last.L2::64B.b16 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_evict_last_L2_64B(
   const B16* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_global_nc_L1_evict_last_L2_64B(const B16* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16 ld_global_nc_L1_evict_last_L2_64B(const _B16* __addr)
 {
-  static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint16_t dest;
-  asm volatile("ld.global.nc.L1::evict_last.L2::64B.b16 %0, [%1];" : "=h"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B16*>(&dest);
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint16_t __dest;
+  asm volatile("ld.global.nc.L1::evict_last.L2::64B.b16 %0, [%1];"
+               : "=h"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return *reinterpret_cast<_B16*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
-  std::uint16_t err_out_var = 0;
-  return *reinterpret_cast<B16*>(&err_out_var);
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_last.L2::64B.b32 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_evict_last_L2_64B(
   const B32* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_global_nc_L1_evict_last_L2_64B(const B32* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32 ld_global_nc_L1_evict_last_L2_64B(const _B32* __addr)
 {
-  static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint32_t dest;
-  asm volatile("ld.global.nc.L1::evict_last.L2::64B.b32 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B32*>(&dest);
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.nc.L1::evict_last.L2::64B.b32 %0, [%1];"
+               : "=r"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return *reinterpret_cast<_B32*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B32*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_last.L2::64B.b64 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_evict_last_L2_64B(
   const B64* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_global_nc_L1_evict_last_L2_64B(const B64* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64 ld_global_nc_L1_evict_last_L2_64B(const _B64* __addr)
 {
-  static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint64_t dest;
-  asm volatile("ld.global.nc.L1::evict_last.L2::64B.b64 %0, [%1];" : "=l"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B64*>(&dest);
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint64_t __dest;
+  asm volatile("ld.global.nc.L1::evict_last.L2::64B.b64 %0, [%1];"
+               : "=l"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return *reinterpret_cast<_B64*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
-  std::uint64_t err_out_var = 0;
-  return *reinterpret_cast<B64*>(&err_out_var);
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_last.L2::64B.b128 dest, [addr]; // PTX ISA 83, SM_75
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
+template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_evict_last_L2_64B(
   const B128* addr);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_global_nc_L1_evict_last_L2_64B(const B128* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
+_CCCL_DEVICE static inline _B128 ld_global_nc_L1_evict_last_L2_64B(const _B128* __addr)
 {
-  static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  longlong2 dest;
+  static_assert(sizeof(_B128) == 16, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  longlong2 __dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.nc.L1::evict_last.L2::64B.b128 B128_dest, [%2];\n\t"
     "mov.b128 {%0, %1}, B128_dest; \n"
     "}"
-    : "=l"(dest.x), "=l"(dest.y)
-    : "l"(__as_ptr_gmem(addr))
+    : "=l"(__dest.x), "=l"(__dest.y)
+    : "l"(__as_ptr_gmem(__addr))
     : "memory");
-  return *reinterpret_cast<B128*>(&dest);
+  return *reinterpret_cast<_B128*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
-  longlong2 err_out_var{0, 0};
-  return *reinterpret_cast<B128*>(&err_out_var);
+  longlong2 __err_out_var{0, 0};
+  return *reinterpret_cast<_B128*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.nc.L1::evict_last.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_nc_L1_evict_last_L2_128B(
-  const B8* addr);
+template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
+__device__ static inline _B8 ld_global_nc_L1_evict_last_L2_128B(
+  const _B8* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_nc_L1_evict_last_L2_128B(const B8* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8 ld_global_nc_L1_evict_last_L2_128B(const _B8* __addr)
 {
-  static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint32_t dest;
-  asm volatile("ld.global.nc.L1::evict_last.L2::128B.b8 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return __u32_as_b8<B8>(dest);
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.nc.L1::evict_last.L2::128B.b8 %0, [%1];"
+               : "=r"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return __u32_as_b8<_B8>(__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B8*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_last.L2::128B.b16 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_evict_last_L2_128B(
   const B16* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_global_nc_L1_evict_last_L2_128B(const B16* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16 ld_global_nc_L1_evict_last_L2_128B(const _B16* __addr)
 {
-  static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint16_t dest;
-  asm volatile("ld.global.nc.L1::evict_last.L2::128B.b16 %0, [%1];" : "=h"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B16*>(&dest);
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint16_t __dest;
+  asm volatile("ld.global.nc.L1::evict_last.L2::128B.b16 %0, [%1];"
+               : "=h"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return *reinterpret_cast<_B16*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
-  std::uint16_t err_out_var = 0;
-  return *reinterpret_cast<B16*>(&err_out_var);
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_last.L2::128B.b32 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_evict_last_L2_128B(
   const B32* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_global_nc_L1_evict_last_L2_128B(const B32* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32 ld_global_nc_L1_evict_last_L2_128B(const _B32* __addr)
 {
-  static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint32_t dest;
-  asm volatile("ld.global.nc.L1::evict_last.L2::128B.b32 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B32*>(&dest);
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.nc.L1::evict_last.L2::128B.b32 %0, [%1];"
+               : "=r"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return *reinterpret_cast<_B32*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B32*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_last.L2::128B.b64 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_evict_last_L2_128B(
   const B64* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_global_nc_L1_evict_last_L2_128B(const B64* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64 ld_global_nc_L1_evict_last_L2_128B(const _B64* __addr)
 {
-  static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint64_t dest;
-  asm volatile("ld.global.nc.L1::evict_last.L2::128B.b64 %0, [%1];" : "=l"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B64*>(&dest);
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint64_t __dest;
+  asm volatile("ld.global.nc.L1::evict_last.L2::128B.b64 %0, [%1];"
+               : "=l"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return *reinterpret_cast<_B64*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
-  std::uint64_t err_out_var = 0;
-  return *reinterpret_cast<B64*>(&err_out_var);
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_last.L2::128B.b128 dest, [addr]; // PTX ISA 83, SM_75
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
+template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_evict_last_L2_128B(
   const B128* addr);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_global_nc_L1_evict_last_L2_128B(const B128* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
+_CCCL_DEVICE static inline _B128 ld_global_nc_L1_evict_last_L2_128B(const _B128* __addr)
 {
-  static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  longlong2 dest;
+  static_assert(sizeof(_B128) == 16, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  longlong2 __dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.nc.L1::evict_last.L2::128B.b128 B128_dest, [%2];\n\t"
     "mov.b128 {%0, %1}, B128_dest; \n"
     "}"
-    : "=l"(dest.x), "=l"(dest.y)
-    : "l"(__as_ptr_gmem(addr))
+    : "=l"(__dest.x), "=l"(__dest.y)
+    : "l"(__as_ptr_gmem(__addr))
     : "memory");
-  return *reinterpret_cast<B128*>(&dest);
+  return *reinterpret_cast<_B128*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
-  longlong2 err_out_var{0, 0};
-  return *reinterpret_cast<B128*>(&err_out_var);
+  longlong2 __err_out_var{0, 0};
+  return *reinterpret_cast<_B128*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.nc.L1::evict_last.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_nc_L1_evict_last_L2_256B(
-  const B8* addr);
+template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
+__device__ static inline _B8 ld_global_nc_L1_evict_last_L2_256B(
+  const _B8* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_nc_L1_evict_last_L2_256B(const B8* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8 ld_global_nc_L1_evict_last_L2_256B(const _B8* __addr)
 {
-  static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  std::uint32_t dest;
-  asm volatile("ld.global.nc.L1::evict_last.L2::256B.b8 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return __u32_as_b8<B8>(dest);
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.nc.L1::evict_last.L2::256B.b8 %0, [%1];"
+               : "=r"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return __u32_as_b8<_B8>(__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B8*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_last.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_evict_last_L2_256B(
   const B16* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_global_nc_L1_evict_last_L2_256B(const B16* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16 ld_global_nc_L1_evict_last_L2_256B(const _B16* __addr)
 {
-  static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  std::uint16_t dest;
-  asm volatile("ld.global.nc.L1::evict_last.L2::256B.b16 %0, [%1];" : "=h"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B16*>(&dest);
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint16_t __dest;
+  asm volatile("ld.global.nc.L1::evict_last.L2::256B.b16 %0, [%1];"
+               : "=h"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return *reinterpret_cast<_B16*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
-  std::uint16_t err_out_var = 0;
-  return *reinterpret_cast<B16*>(&err_out_var);
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_last.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_evict_last_L2_256B(
   const B32* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_global_nc_L1_evict_last_L2_256B(const B32* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32 ld_global_nc_L1_evict_last_L2_256B(const _B32* __addr)
 {
-  static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  std::uint32_t dest;
-  asm volatile("ld.global.nc.L1::evict_last.L2::256B.b32 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B32*>(&dest);
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.nc.L1::evict_last.L2::256B.b32 %0, [%1];"
+               : "=r"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return *reinterpret_cast<_B32*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B32*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_last.L2::256B.b64 dest, [addr]; // PTX ISA 74, SM_80
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_evict_last_L2_256B(
   const B64* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_global_nc_L1_evict_last_L2_256B(const B64* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64 ld_global_nc_L1_evict_last_L2_256B(const _B64* __addr)
 {
-  static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  std::uint64_t dest;
-  asm volatile("ld.global.nc.L1::evict_last.L2::256B.b64 %0, [%1];" : "=l"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B64*>(&dest);
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint64_t __dest;
+  asm volatile("ld.global.nc.L1::evict_last.L2::256B.b64 %0, [%1];"
+               : "=l"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return *reinterpret_cast<_B64*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
-  std::uint64_t err_out_var = 0;
-  return *reinterpret_cast<B64*>(&err_out_var);
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_last.L2::256B.b128 dest, [addr]; // PTX ISA 83, SM_80
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
+template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_evict_last_L2_256B(
   const B128* addr);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_global_nc_L1_evict_last_L2_256B(const B128* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
+_CCCL_DEVICE static inline _B128 ld_global_nc_L1_evict_last_L2_256B(const _B128* __addr)
 {
-  static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  longlong2 dest;
+  static_assert(sizeof(_B128) == 16, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  longlong2 __dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.nc.L1::evict_last.L2::256B.b128 B128_dest, [%2];\n\t"
     "mov.b128 {%0, %1}, B128_dest; \n"
     "}"
-    : "=l"(dest.x), "=l"(dest.y)
-    : "l"(__as_ptr_gmem(addr))
+    : "=l"(__dest.x), "=l"(__dest.y)
+    : "l"(__as_ptr_gmem(__addr))
     : "memory");
-  return *reinterpret_cast<B128*>(&dest);
+  return *reinterpret_cast<_B128*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
-  longlong2 err_out_var{0, 0};
-  return *reinterpret_cast<B128*>(&err_out_var);
+  longlong2 __err_out_var{0, 0};
+  return *reinterpret_cast<_B128*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.nc.L1::no_allocate.b8 dest, [addr]; // PTX ISA 74, SM_70
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_nc_L1_no_allocate(
-  const B8* addr);
+template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
+__device__ static inline _B8 ld_global_nc_L1_no_allocate(
+  const _B8* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_no_allocate_is_not_supported_before_SM_70__();
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_nc_L1_no_allocate(const B8* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_no_allocate_is_not_supported_before_SM_70__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8 ld_global_nc_L1_no_allocate(const _B8* __addr)
 {
-  static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
-  std::uint32_t dest;
-  asm volatile("ld.global.nc.L1::no_allocate.b8 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return __u32_as_b8<B8>(dest);
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.nc.L1::no_allocate.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return __u32_as_b8<_B8>(__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_no_allocate_is_not_supported_before_SM_70__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B8*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::no_allocate.b16 dest, [addr]; // PTX ISA 74, SM_70
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_no_allocate(
   const B16* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_no_allocate_is_not_supported_before_SM_70__();
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_global_nc_L1_no_allocate(const B16* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_no_allocate_is_not_supported_before_SM_70__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16 ld_global_nc_L1_no_allocate(const _B16* __addr)
 {
-  static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
-  std::uint16_t dest;
-  asm volatile("ld.global.nc.L1::no_allocate.b16 %0, [%1];" : "=h"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B16*>(&dest);
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
+  _CUDA_VSTD::uint16_t __dest;
+  asm volatile("ld.global.nc.L1::no_allocate.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B16*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_no_allocate_is_not_supported_before_SM_70__();
-  std::uint16_t err_out_var = 0;
-  return *reinterpret_cast<B16*>(&err_out_var);
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::no_allocate.b32 dest, [addr]; // PTX ISA 74, SM_70
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_no_allocate(
   const B32* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_no_allocate_is_not_supported_before_SM_70__();
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_global_nc_L1_no_allocate(const B32* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_no_allocate_is_not_supported_before_SM_70__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32 ld_global_nc_L1_no_allocate(const _B32* __addr)
 {
-  static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
-  std::uint32_t dest;
-  asm volatile("ld.global.nc.L1::no_allocate.b32 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B32*>(&dest);
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.nc.L1::no_allocate.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B32*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_no_allocate_is_not_supported_before_SM_70__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B32*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::no_allocate.b64 dest, [addr]; // PTX ISA 74, SM_70
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_no_allocate(
   const B64* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_no_allocate_is_not_supported_before_SM_70__();
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_global_nc_L1_no_allocate(const B64* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_no_allocate_is_not_supported_before_SM_70__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64 ld_global_nc_L1_no_allocate(const _B64* __addr)
 {
-  static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
-  std::uint64_t dest;
-  asm volatile("ld.global.nc.L1::no_allocate.b64 %0, [%1];" : "=l"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B64*>(&dest);
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
+  _CUDA_VSTD::uint64_t __dest;
+  asm volatile("ld.global.nc.L1::no_allocate.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B64*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_no_allocate_is_not_supported_before_SM_70__();
-  std::uint64_t err_out_var = 0;
-  return *reinterpret_cast<B64*>(&err_out_var);
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::no_allocate.b128 dest, [addr]; // PTX ISA 83, SM_70
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
+template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_no_allocate(
   const B128* addr);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_no_allocate_is_not_supported_before_SM_70__();
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_global_nc_L1_no_allocate(const B128* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_no_allocate_is_not_supported_before_SM_70__();
+template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
+_CCCL_DEVICE static inline _B128 ld_global_nc_L1_no_allocate(const _B128* __addr)
 {
-  static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
-  longlong2 dest;
+  static_assert(sizeof(_B128) == 16, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
+  longlong2 __dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.nc.L1::no_allocate.b128 B128_dest, [%2];\n\t"
     "mov.b128 {%0, %1}, B128_dest; \n"
     "}"
-    : "=l"(dest.x), "=l"(dest.y)
-    : "l"(__as_ptr_gmem(addr))
+    : "=l"(__dest.x), "=l"(__dest.y)
+    : "l"(__as_ptr_gmem(__addr))
     : "memory");
-  return *reinterpret_cast<B128*>(&dest);
+  return *reinterpret_cast<_B128*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_no_allocate_is_not_supported_before_SM_70__();
-  longlong2 err_out_var{0, 0};
-  return *reinterpret_cast<B128*>(&err_out_var);
+  longlong2 __err_out_var{0, 0};
+  return *reinterpret_cast<_B128*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.nc.L1::no_allocate.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_nc_L1_no_allocate_L2_64B(
-  const B8* addr);
+template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
+__device__ static inline _B8 ld_global_nc_L1_no_allocate_L2_64B(
+  const _B8* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_nc_L1_no_allocate_L2_64B(const B8* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8 ld_global_nc_L1_no_allocate_L2_64B(const _B8* __addr)
 {
-  static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint32_t dest;
-  asm volatile("ld.global.nc.L1::no_allocate.L2::64B.b8 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return __u32_as_b8<B8>(dest);
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.nc.L1::no_allocate.L2::64B.b8 %0, [%1];"
+               : "=r"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return __u32_as_b8<_B8>(__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B8*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::no_allocate.L2::64B.b16 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_no_allocate_L2_64B(
   const B16* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_global_nc_L1_no_allocate_L2_64B(const B16* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16 ld_global_nc_L1_no_allocate_L2_64B(const _B16* __addr)
 {
-  static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint16_t dest;
-  asm volatile("ld.global.nc.L1::no_allocate.L2::64B.b16 %0, [%1];" : "=h"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B16*>(&dest);
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint16_t __dest;
+  asm volatile("ld.global.nc.L1::no_allocate.L2::64B.b16 %0, [%1];"
+               : "=h"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return *reinterpret_cast<_B16*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
-  std::uint16_t err_out_var = 0;
-  return *reinterpret_cast<B16*>(&err_out_var);
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::no_allocate.L2::64B.b32 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_no_allocate_L2_64B(
   const B32* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_global_nc_L1_no_allocate_L2_64B(const B32* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32 ld_global_nc_L1_no_allocate_L2_64B(const _B32* __addr)
 {
-  static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint32_t dest;
-  asm volatile("ld.global.nc.L1::no_allocate.L2::64B.b32 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B32*>(&dest);
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.nc.L1::no_allocate.L2::64B.b32 %0, [%1];"
+               : "=r"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return *reinterpret_cast<_B32*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B32*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::no_allocate.L2::64B.b64 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_no_allocate_L2_64B(
   const B64* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_global_nc_L1_no_allocate_L2_64B(const B64* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64 ld_global_nc_L1_no_allocate_L2_64B(const _B64* __addr)
 {
-  static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint64_t dest;
-  asm volatile("ld.global.nc.L1::no_allocate.L2::64B.b64 %0, [%1];" : "=l"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return *reinterpret_cast<B64*>(&dest);
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint64_t __dest;
+  asm volatile("ld.global.nc.L1::no_allocate.L2::64B.b64 %0, [%1];"
+               : "=l"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return *reinterpret_cast<_B64*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
-  std::uint64_t err_out_var = 0;
-  return *reinterpret_cast<B64*>(&err_out_var);
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::no_allocate.L2::64B.b128 dest, [addr]; // PTX ISA 83, SM_75
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
+template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_no_allocate_L2_64B(
   const B128* addr);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_global_nc_L1_no_allocate_L2_64B(const B128* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
+template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
+_CCCL_DEVICE static inline _B128 ld_global_nc_L1_no_allocate_L2_64B(const _B128* __addr)
 {
-  static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  longlong2 dest;
+  static_assert(sizeof(_B128) == 16, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  longlong2 __dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.nc.L1::no_allocate.L2::64B.b128 B128_dest, [%2];\n\t"
     "mov.b128 {%0, %1}, B128_dest; \n"
     "}"
-    : "=l"(dest.x), "=l"(dest.y)
-    : "l"(__as_ptr_gmem(addr))
+    : "=l"(__dest.x), "=l"(__dest.y)
+    : "l"(__as_ptr_gmem(__addr))
     : "memory");
-  return *reinterpret_cast<B128*>(&dest);
+  return *reinterpret_cast<_B128*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
-  longlong2 err_out_var{0, 0};
-  return *reinterpret_cast<B128*>(&err_out_var);
+  longlong2 __err_out_var{0, 0};
+  return *reinterpret_cast<_B128*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.nc.L1::no_allocate.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_nc_L1_no_allocate_L2_128B(
-  const B8* addr);
+template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
+__device__ static inline _B8 ld_global_nc_L1_no_allocate_L2_128B(
+  const _B8* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_nc_L1_no_allocate_L2_128B(const B8* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8 ld_global_nc_L1_no_allocate_L2_128B(const _B8* __addr)
 {
-  static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint32_t dest;
-  asm volatile("ld.global.nc.L1::no_allocate.L2::128B.b8 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return __u32_as_b8<B8>(dest);
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.nc.L1::no_allocate.L2::128B.b8 %0, [%1];"
+               : "=r"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return __u32_as_b8<_B8>(__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B8*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::no_allocate.L2::128B.b16 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_no_allocate_L2_128B(
   const B16* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_global_nc_L1_no_allocate_L2_128B(const B16* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16 ld_global_nc_L1_no_allocate_L2_128B(const _B16* __addr)
 {
-  static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint16_t dest;
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint16_t __dest;
   asm volatile("ld.global.nc.L1::no_allocate.L2::128B.b16 %0, [%1];"
-               : "=h"(dest)
-               : "l"(__as_ptr_gmem(addr))
+               : "=h"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
                : "memory");
-  return *reinterpret_cast<B16*>(&dest);
+  return *reinterpret_cast<_B16*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
-  std::uint16_t err_out_var = 0;
-  return *reinterpret_cast<B16*>(&err_out_var);
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::no_allocate.L2::128B.b32 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_no_allocate_L2_128B(
   const B32* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_global_nc_L1_no_allocate_L2_128B(const B32* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32 ld_global_nc_L1_no_allocate_L2_128B(const _B32* __addr)
 {
-  static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint32_t dest;
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint32_t __dest;
   asm volatile("ld.global.nc.L1::no_allocate.L2::128B.b32 %0, [%1];"
-               : "=r"(dest)
-               : "l"(__as_ptr_gmem(addr))
+               : "=r"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
                : "memory");
-  return *reinterpret_cast<B32*>(&dest);
+  return *reinterpret_cast<_B32*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B32*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::no_allocate.L2::128B.b64 dest, [addr]; // PTX ISA 74, SM_75
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_no_allocate_L2_128B(
   const B64* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_global_nc_L1_no_allocate_L2_128B(const B64* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64 ld_global_nc_L1_no_allocate_L2_128B(const _B64* __addr)
 {
-  static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  std::uint64_t dest;
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  _CUDA_VSTD::uint64_t __dest;
   asm volatile("ld.global.nc.L1::no_allocate.L2::128B.b64 %0, [%1];"
-               : "=l"(dest)
-               : "l"(__as_ptr_gmem(addr))
+               : "=l"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
                : "memory");
-  return *reinterpret_cast<B64*>(&dest);
+  return *reinterpret_cast<_B64*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
-  std::uint64_t err_out_var = 0;
-  return *reinterpret_cast<B64*>(&err_out_var);
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::no_allocate.L2::128B.b128 dest, [addr]; // PTX ISA 83, SM_75
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
+template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_no_allocate_L2_128B(
   const B128* addr);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_global_nc_L1_no_allocate_L2_128B(const B128* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
+template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
+_CCCL_DEVICE static inline _B128 ld_global_nc_L1_no_allocate_L2_128B(const _B128* __addr)
 {
-  static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  longlong2 dest;
+  static_assert(sizeof(_B128) == 16, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
+  longlong2 __dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.nc.L1::no_allocate.L2::128B.b128 B128_dest, [%2];\n\t"
     "mov.b128 {%0, %1}, B128_dest; \n"
     "}"
-    : "=l"(dest.x), "=l"(dest.y)
-    : "l"(__as_ptr_gmem(addr))
+    : "=l"(__dest.x), "=l"(__dest.y)
+    : "l"(__as_ptr_gmem(__addr))
     : "memory");
-  return *reinterpret_cast<B128*>(&dest);
+  return *reinterpret_cast<_B128*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
-  longlong2 err_out_var{0, 0};
-  return *reinterpret_cast<B128*>(&err_out_var);
+  longlong2 __err_out_var{0, 0};
+  return *reinterpret_cast<_B128*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.nc.L1::no_allocate.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_nc_L1_no_allocate_L2_256B(
-  const B8* addr);
+template <typename _B8, enable_if_t<sizeof(_B8) == 1, bool> = true>
+__device__ static inline _B8 ld_global_nc_L1_no_allocate_L2_256B(
+  const _B8* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_global_nc_L1_no_allocate_L2_256B(const B8* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8 ld_global_nc_L1_no_allocate_L2_256B(const _B8* __addr)
 {
-  static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  std::uint32_t dest;
-  asm volatile("ld.global.nc.L1::no_allocate.L2::256B.b8 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
-  return __u32_as_b8<B8>(dest);
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint32_t __dest;
+  asm volatile("ld.global.nc.L1::no_allocate.L2::256B.b8 %0, [%1];"
+               : "=r"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
+               : "memory");
+  return __u32_as_b8<_B8>(__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B8*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::no_allocate.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_no_allocate_L2_256B(
   const B16* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_global_nc_L1_no_allocate_L2_256B(const B16* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16 ld_global_nc_L1_no_allocate_L2_256B(const _B16* __addr)
 {
-  static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  std::uint16_t dest;
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint16_t __dest;
   asm volatile("ld.global.nc.L1::no_allocate.L2::256B.b16 %0, [%1];"
-               : "=h"(dest)
-               : "l"(__as_ptr_gmem(addr))
+               : "=h"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
                : "memory");
-  return *reinterpret_cast<B16*>(&dest);
+  return *reinterpret_cast<_B16*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
-  std::uint16_t err_out_var = 0;
-  return *reinterpret_cast<B16*>(&err_out_var);
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::no_allocate.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_no_allocate_L2_256B(
   const B32* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_global_nc_L1_no_allocate_L2_256B(const B32* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32 ld_global_nc_L1_no_allocate_L2_256B(const _B32* __addr)
 {
-  static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  std::uint32_t dest;
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint32_t __dest;
   asm volatile("ld.global.nc.L1::no_allocate.L2::256B.b32 %0, [%1];"
-               : "=r"(dest)
-               : "l"(__as_ptr_gmem(addr))
+               : "=r"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
                : "memory");
-  return *reinterpret_cast<B32*>(&dest);
+  return *reinterpret_cast<_B32*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
-  std::uint32_t err_out_var = 0;
-  return *reinterpret_cast<B32*>(&err_out_var);
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::no_allocate.L2::256B.b64 dest, [addr]; // PTX ISA 74, SM_80
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_no_allocate_L2_256B(
   const B64* addr);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_global_nc_L1_no_allocate_L2_256B(const B64* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64 ld_global_nc_L1_no_allocate_L2_256B(const _B64* __addr)
 {
-  static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  std::uint64_t dest;
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint64_t __dest;
   asm volatile("ld.global.nc.L1::no_allocate.L2::256B.b64 %0, [%1];"
-               : "=l"(dest)
-               : "l"(__as_ptr_gmem(addr))
+               : "=l"(__dest)
+               : "l"(__as_ptr_gmem(__addr))
                : "memory");
-  return *reinterpret_cast<B64*>(&dest);
+  return *reinterpret_cast<_B64*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
-  std::uint64_t err_out_var = 0;
-  return *reinterpret_cast<B64*>(&err_out_var);
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::no_allocate.L2::256B.b128 dest, [addr]; // PTX ISA 83, SM_80
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
+template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_no_allocate_L2_256B(
   const B128* addr);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_global_nc_L1_no_allocate_L2_256B(const B128* addr)
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_global_nc_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
+_CCCL_DEVICE static inline _B128 ld_global_nc_L1_no_allocate_L2_256B(const _B128* __addr)
 {
-  static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  longlong2 dest;
+  static_assert(sizeof(_B128) == 16, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  longlong2 __dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.nc.L1::no_allocate.L2::256B.b128 B128_dest, [%2];\n\t"
     "mov.b128 {%0, %1}, B128_dest; \n"
     "}"
-    : "=l"(dest.x), "=l"(dest.y)
-    : "l"(__as_ptr_gmem(addr))
+    : "=l"(__dest.x), "=l"(__dest.y)
+    : "l"(__as_ptr_gmem(__addr))
     : "memory");
-  return *reinterpret_cast<B128*>(&dest);
+  return *reinterpret_cast<_B128*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
-  longlong2 err_out_var{0, 0};
-  return *reinterpret_cast<B128*>(&err_out_var);
+  longlong2 __err_out_var{0, 0};
+  return *reinterpret_cast<_B128*>(&__err_out_var);
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
-#endif // _CUDA_PTX_GENERATED_INSTRUCTIONS_LD_H
+#endif // _CUDA_PTX_GENERATED_LD_H_

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/ld.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/ld.h
@@ -1,7 +1,7 @@
 // This file was automatically generated. Do not edit.
 
-namespace cuda_ptx
-{
+#ifndef _CUDA_PTX_GENERATED_INSTRUCTIONS_LD_H
+#define _CUDA_PTX_GENERATED_INSTRUCTIONS_LD_H
 
 /*
 // ld.global.b8 dest, [addr]; // PTX ISA 10, SM_50
@@ -9,7 +9,7 @@ template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global(
   const B8* addr);
 */
-#if __libcuda_ptx_isa >= 100
+#if __cccl_ptx_isa >= 100
 extern "C" __device__ void __cuda_ptx_ld_global_is_not_supported_before_SM_50__();
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global(const B8* addr)
@@ -26,7 +26,7 @@ __device__ static inline B8 ld_global(const B8* addr)
   return *reinterpret_cast<B8*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 100
+#endif // __cccl_ptx_isa >= 100
 
 /*
 // ld.global.b16 dest, [addr]; // PTX ISA 10, SM_50
@@ -34,7 +34,7 @@ template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global(
   const B16* addr);
 */
-#if __libcuda_ptx_isa >= 100
+#if __cccl_ptx_isa >= 100
 extern "C" __device__ void __cuda_ptx_ld_global_is_not_supported_before_SM_50__();
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global(const B16* addr)
@@ -51,7 +51,7 @@ __device__ static inline B16 ld_global(const B16* addr)
   return *reinterpret_cast<B16*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 100
+#endif // __cccl_ptx_isa >= 100
 
 /*
 // ld.global.b32 dest, [addr]; // PTX ISA 10, SM_50
@@ -59,7 +59,7 @@ template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global(
   const B32* addr);
 */
-#if __libcuda_ptx_isa >= 100
+#if __cccl_ptx_isa >= 100
 extern "C" __device__ void __cuda_ptx_ld_global_is_not_supported_before_SM_50__();
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global(const B32* addr)
@@ -76,7 +76,7 @@ __device__ static inline B32 ld_global(const B32* addr)
   return *reinterpret_cast<B32*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 100
+#endif // __cccl_ptx_isa >= 100
 
 /*
 // ld.global.b64 dest, [addr]; // PTX ISA 10, SM_50
@@ -84,7 +84,7 @@ template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global(
   const B64* addr);
 */
-#if __libcuda_ptx_isa >= 100
+#if __cccl_ptx_isa >= 100
 extern "C" __device__ void __cuda_ptx_ld_global_is_not_supported_before_SM_50__();
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global(const B64* addr)
@@ -101,7 +101,7 @@ __device__ static inline B64 ld_global(const B64* addr)
   return *reinterpret_cast<B64*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 100
+#endif // __cccl_ptx_isa >= 100
 
 /*
 // ld.global.b128 dest, [addr]; // PTX ISA 83, SM_70
@@ -109,14 +109,14 @@ template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global(
   const B128* addr);
 */
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
 extern "C" __device__ void __cuda_ptx_ld_global_is_not_supported_before_SM_70__();
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global(const B128* addr)
 {
   static_assert(sizeof(B128) == 16, "");
 #  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
-  long2 dest;
+  longlong2 dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.b128 B128_dest, [%2];\n\t"
@@ -129,11 +129,11 @@ __device__ static inline B128 ld_global(const B128* addr)
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_is_not_supported_before_SM_70__();
-  long2 err_out_var{0, 0};
+  longlong2 err_out_var{0, 0};
   return *reinterpret_cast<B128*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 830
+#endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
@@ -141,7 +141,7 @@ template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_L2_64B(
   const B8* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L2_64B_is_not_supported_before_SM_75__();
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_L2_64B(const B8* addr)
@@ -158,7 +158,7 @@ __device__ static inline B8 ld_global_L2_64B(const B8* addr)
   return *reinterpret_cast<B8*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L2::64B.b16 dest, [addr]; // PTX ISA 74, SM_75
@@ -166,7 +166,7 @@ template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L2_64B(
   const B16* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L2_64B_is_not_supported_before_SM_75__();
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L2_64B(const B16* addr)
@@ -183,7 +183,7 @@ __device__ static inline B16 ld_global_L2_64B(const B16* addr)
   return *reinterpret_cast<B16*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L2::64B.b32 dest, [addr]; // PTX ISA 74, SM_75
@@ -191,7 +191,7 @@ template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L2_64B(
   const B32* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L2_64B_is_not_supported_before_SM_75__();
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L2_64B(const B32* addr)
@@ -208,7 +208,7 @@ __device__ static inline B32 ld_global_L2_64B(const B32* addr)
   return *reinterpret_cast<B32*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L2::64B.b64 dest, [addr]; // PTX ISA 74, SM_75
@@ -216,7 +216,7 @@ template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L2_64B(
   const B64* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L2_64B_is_not_supported_before_SM_75__();
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L2_64B(const B64* addr)
@@ -233,7 +233,7 @@ __device__ static inline B64 ld_global_L2_64B(const B64* addr)
   return *reinterpret_cast<B64*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L2::64B.b128 dest, [addr]; // PTX ISA 83, SM_75
@@ -241,14 +241,14 @@ template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L2_64B(
   const B128* addr);
 */
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
 extern "C" __device__ void __cuda_ptx_ld_global_L2_64B_is_not_supported_before_SM_75__();
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L2_64B(const B128* addr)
 {
   static_assert(sizeof(B128) == 16, "");
 #  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  long2 dest;
+  longlong2 dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.L2::64B.b128 B128_dest, [%2];\n\t"
@@ -261,11 +261,11 @@ __device__ static inline B128 ld_global_L2_64B(const B128* addr)
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L2_64B_is_not_supported_before_SM_75__();
-  long2 err_out_var{0, 0};
+  longlong2 err_out_var{0, 0};
   return *reinterpret_cast<B128*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 830
+#endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
@@ -273,7 +273,7 @@ template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_L2_128B(
   const B8* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L2_128B_is_not_supported_before_SM_75__();
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_L2_128B(const B8* addr)
@@ -290,7 +290,7 @@ __device__ static inline B8 ld_global_L2_128B(const B8* addr)
   return *reinterpret_cast<B8*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L2::128B.b16 dest, [addr]; // PTX ISA 74, SM_75
@@ -298,7 +298,7 @@ template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L2_128B(
   const B16* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L2_128B_is_not_supported_before_SM_75__();
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L2_128B(const B16* addr)
@@ -315,7 +315,7 @@ __device__ static inline B16 ld_global_L2_128B(const B16* addr)
   return *reinterpret_cast<B16*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L2::128B.b32 dest, [addr]; // PTX ISA 74, SM_75
@@ -323,7 +323,7 @@ template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L2_128B(
   const B32* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L2_128B_is_not_supported_before_SM_75__();
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L2_128B(const B32* addr)
@@ -340,7 +340,7 @@ __device__ static inline B32 ld_global_L2_128B(const B32* addr)
   return *reinterpret_cast<B32*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L2::128B.b64 dest, [addr]; // PTX ISA 74, SM_75
@@ -348,7 +348,7 @@ template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L2_128B(
   const B64* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L2_128B_is_not_supported_before_SM_75__();
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L2_128B(const B64* addr)
@@ -365,7 +365,7 @@ __device__ static inline B64 ld_global_L2_128B(const B64* addr)
   return *reinterpret_cast<B64*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L2::128B.b128 dest, [addr]; // PTX ISA 83, SM_75
@@ -373,14 +373,14 @@ template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L2_128B(
   const B128* addr);
 */
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
 extern "C" __device__ void __cuda_ptx_ld_global_L2_128B_is_not_supported_before_SM_75__();
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L2_128B(const B128* addr)
 {
   static_assert(sizeof(B128) == 16, "");
 #  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  long2 dest;
+  longlong2 dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.L2::128B.b128 B128_dest, [%2];\n\t"
@@ -393,11 +393,11 @@ __device__ static inline B128 ld_global_L2_128B(const B128* addr)
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L2_128B_is_not_supported_before_SM_75__();
-  long2 err_out_var{0, 0};
+  longlong2 err_out_var{0, 0};
   return *reinterpret_cast<B128*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 830
+#endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
@@ -405,7 +405,7 @@ template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_L2_256B(
   const B8* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L2_256B_is_not_supported_before_SM_80__();
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_L2_256B(const B8* addr)
@@ -422,7 +422,7 @@ __device__ static inline B8 ld_global_L2_256B(const B8* addr)
   return *reinterpret_cast<B8*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
@@ -430,7 +430,7 @@ template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L2_256B(
   const B16* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L2_256B_is_not_supported_before_SM_80__();
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L2_256B(const B16* addr)
@@ -447,7 +447,7 @@ __device__ static inline B16 ld_global_L2_256B(const B16* addr)
   return *reinterpret_cast<B16*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
@@ -455,7 +455,7 @@ template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L2_256B(
   const B32* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L2_256B_is_not_supported_before_SM_80__();
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L2_256B(const B32* addr)
@@ -472,7 +472,7 @@ __device__ static inline B32 ld_global_L2_256B(const B32* addr)
   return *reinterpret_cast<B32*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L2::256B.b64 dest, [addr]; // PTX ISA 74, SM_80
@@ -480,7 +480,7 @@ template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L2_256B(
   const B64* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L2_256B_is_not_supported_before_SM_80__();
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L2_256B(const B64* addr)
@@ -497,7 +497,7 @@ __device__ static inline B64 ld_global_L2_256B(const B64* addr)
   return *reinterpret_cast<B64*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L2::256B.b128 dest, [addr]; // PTX ISA 83, SM_80
@@ -505,14 +505,14 @@ template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L2_256B(
   const B128* addr);
 */
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
 extern "C" __device__ void __cuda_ptx_ld_global_L2_256B_is_not_supported_before_SM_80__();
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L2_256B(const B128* addr)
 {
   static_assert(sizeof(B128) == 16, "");
 #  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  long2 dest;
+  longlong2 dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.L2::256B.b128 B128_dest, [%2];\n\t"
@@ -525,126 +525,126 @@ __device__ static inline B128 ld_global_L2_256B(const B128* addr)
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L2_256B_is_not_supported_before_SM_80__();
-  long2 err_out_var{0, 0};
+  longlong2 err_out_var{0, 0};
   return *reinterpret_cast<B128*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 830
+#endif // __cccl_ptx_isa >= 830
 
 /*
-// ld.global.L1::evict_normal.b8 dest, [addr]; // PTX ISA 74, SM_75
+// ld.global.L1::evict_normal.b8 dest, [addr]; // PTX ISA 74, SM_70
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_L1_evict_normal(
   const B8* addr);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_normal_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_normal_is_not_supported_before_SM_70__();
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_L1_evict_normal(const B8* addr)
 {
   static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   std::uint32_t dest;
   asm volatile("ld.global.L1::evict_normal.b8 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
   return __u32_as_b8<B8>(dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_global_L1_evict_normal_is_not_supported_before_SM_75__();
+  __cuda_ptx_ld_global_L1_evict_normal_is_not_supported_before_SM_70__();
   std::uint32_t err_out_var = 0;
   return *reinterpret_cast<B8*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// ld.global.L1::evict_normal.b16 dest, [addr]; // PTX ISA 74, SM_75
+// ld.global.L1::evict_normal.b16 dest, [addr]; // PTX ISA 74, SM_70
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_evict_normal(
   const B16* addr);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_normal_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_normal_is_not_supported_before_SM_70__();
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_evict_normal(const B16* addr)
 {
   static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   std::uint16_t dest;
   asm volatile("ld.global.L1::evict_normal.b16 %0, [%1];" : "=h"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
   return *reinterpret_cast<B16*>(&dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_global_L1_evict_normal_is_not_supported_before_SM_75__();
+  __cuda_ptx_ld_global_L1_evict_normal_is_not_supported_before_SM_70__();
   std::uint16_t err_out_var = 0;
   return *reinterpret_cast<B16*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// ld.global.L1::evict_normal.b32 dest, [addr]; // PTX ISA 74, SM_75
+// ld.global.L1::evict_normal.b32 dest, [addr]; // PTX ISA 74, SM_70
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_evict_normal(
   const B32* addr);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_normal_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_normal_is_not_supported_before_SM_70__();
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_evict_normal(const B32* addr)
 {
   static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   std::uint32_t dest;
   asm volatile("ld.global.L1::evict_normal.b32 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
   return *reinterpret_cast<B32*>(&dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_global_L1_evict_normal_is_not_supported_before_SM_75__();
+  __cuda_ptx_ld_global_L1_evict_normal_is_not_supported_before_SM_70__();
   std::uint32_t err_out_var = 0;
   return *reinterpret_cast<B32*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// ld.global.L1::evict_normal.b64 dest, [addr]; // PTX ISA 74, SM_75
+// ld.global.L1::evict_normal.b64 dest, [addr]; // PTX ISA 74, SM_70
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_evict_normal(
   const B64* addr);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_normal_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_normal_is_not_supported_before_SM_70__();
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_evict_normal(const B64* addr)
 {
   static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   std::uint64_t dest;
   asm volatile("ld.global.L1::evict_normal.b64 %0, [%1];" : "=l"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
   return *reinterpret_cast<B64*>(&dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_global_L1_evict_normal_is_not_supported_before_SM_75__();
+  __cuda_ptx_ld_global_L1_evict_normal_is_not_supported_before_SM_70__();
   std::uint64_t err_out_var = 0;
   return *reinterpret_cast<B64*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// ld.global.L1::evict_normal.b128 dest, [addr]; // PTX ISA 83, SM_75
+// ld.global.L1::evict_normal.b128 dest, [addr]; // PTX ISA 83, SM_70
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_evict_normal(
   const B128* addr);
 */
-#if __libcuda_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_normal_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 830
+extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_normal_is_not_supported_before_SM_70__();
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_evict_normal(const B128* addr)
 {
   static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  long2 dest;
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
+  longlong2 dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.L1::evict_normal.b128 B128_dest, [%2];\n\t"
@@ -656,12 +656,12 @@ __device__ static inline B128 ld_global_L1_evict_normal(const B128* addr)
   return *reinterpret_cast<B128*>(&dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_global_L1_evict_normal_is_not_supported_before_SM_75__();
-  long2 err_out_var{0, 0};
+  __cuda_ptx_ld_global_L1_evict_normal_is_not_supported_before_SM_70__();
+  longlong2 err_out_var{0, 0};
   return *reinterpret_cast<B128*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 830
+#endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.L1::evict_normal.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
@@ -669,7 +669,7 @@ template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_L1_evict_normal_L2_64B(
   const B8* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_L1_evict_normal_L2_64B(const B8* addr)
@@ -686,7 +686,7 @@ __device__ static inline B8 ld_global_L1_evict_normal_L2_64B(const B8* addr)
   return *reinterpret_cast<B8*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_normal.L2::64B.b16 dest, [addr]; // PTX ISA 74, SM_75
@@ -694,7 +694,7 @@ template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_evict_normal_L2_64B(
   const B16* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_evict_normal_L2_64B(const B16* addr)
@@ -711,7 +711,7 @@ __device__ static inline B16 ld_global_L1_evict_normal_L2_64B(const B16* addr)
   return *reinterpret_cast<B16*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_normal.L2::64B.b32 dest, [addr]; // PTX ISA 74, SM_75
@@ -719,7 +719,7 @@ template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_evict_normal_L2_64B(
   const B32* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_evict_normal_L2_64B(const B32* addr)
@@ -736,7 +736,7 @@ __device__ static inline B32 ld_global_L1_evict_normal_L2_64B(const B32* addr)
   return *reinterpret_cast<B32*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_normal.L2::64B.b64 dest, [addr]; // PTX ISA 74, SM_75
@@ -744,7 +744,7 @@ template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_evict_normal_L2_64B(
   const B64* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_evict_normal_L2_64B(const B64* addr)
@@ -761,7 +761,7 @@ __device__ static inline B64 ld_global_L1_evict_normal_L2_64B(const B64* addr)
   return *reinterpret_cast<B64*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_normal.L2::64B.b128 dest, [addr]; // PTX ISA 83, SM_75
@@ -769,14 +769,14 @@ template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_evict_normal_L2_64B(
   const B128* addr);
 */
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_evict_normal_L2_64B(const B128* addr)
 {
   static_assert(sizeof(B128) == 16, "");
 #  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  long2 dest;
+  longlong2 dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.L1::evict_normal.L2::64B.b128 B128_dest, [%2];\n\t"
@@ -789,11 +789,11 @@ __device__ static inline B128 ld_global_L1_evict_normal_L2_64B(const B128* addr)
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
-  long2 err_out_var{0, 0};
+  longlong2 err_out_var{0, 0};
   return *reinterpret_cast<B128*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 830
+#endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.L1::evict_normal.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
@@ -801,7 +801,7 @@ template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_L1_evict_normal_L2_128B(
   const B8* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_L1_evict_normal_L2_128B(const B8* addr)
@@ -818,7 +818,7 @@ __device__ static inline B8 ld_global_L1_evict_normal_L2_128B(const B8* addr)
   return *reinterpret_cast<B8*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_normal.L2::128B.b16 dest, [addr]; // PTX ISA 74, SM_75
@@ -826,7 +826,7 @@ template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_evict_normal_L2_128B(
   const B16* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_evict_normal_L2_128B(const B16* addr)
@@ -843,7 +843,7 @@ __device__ static inline B16 ld_global_L1_evict_normal_L2_128B(const B16* addr)
   return *reinterpret_cast<B16*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_normal.L2::128B.b32 dest, [addr]; // PTX ISA 74, SM_75
@@ -851,7 +851,7 @@ template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_evict_normal_L2_128B(
   const B32* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_evict_normal_L2_128B(const B32* addr)
@@ -868,7 +868,7 @@ __device__ static inline B32 ld_global_L1_evict_normal_L2_128B(const B32* addr)
   return *reinterpret_cast<B32*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_normal.L2::128B.b64 dest, [addr]; // PTX ISA 74, SM_75
@@ -876,7 +876,7 @@ template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_evict_normal_L2_128B(
   const B64* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_evict_normal_L2_128B(const B64* addr)
@@ -893,7 +893,7 @@ __device__ static inline B64 ld_global_L1_evict_normal_L2_128B(const B64* addr)
   return *reinterpret_cast<B64*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_normal.L2::128B.b128 dest, [addr]; // PTX ISA 83, SM_75
@@ -901,14 +901,14 @@ template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_evict_normal_L2_128B(
   const B128* addr);
 */
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_evict_normal_L2_128B(const B128* addr)
 {
   static_assert(sizeof(B128) == 16, "");
 #  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  long2 dest;
+  longlong2 dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.L1::evict_normal.L2::128B.b128 B128_dest, [%2];\n\t"
@@ -921,11 +921,11 @@ __device__ static inline B128 ld_global_L1_evict_normal_L2_128B(const B128* addr
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
-  long2 err_out_var{0, 0};
+  longlong2 err_out_var{0, 0};
   return *reinterpret_cast<B128*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 830
+#endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.L1::evict_normal.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
@@ -933,7 +933,7 @@ template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_L1_evict_normal_L2_256B(
   const B8* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_L1_evict_normal_L2_256B(const B8* addr)
@@ -950,7 +950,7 @@ __device__ static inline B8 ld_global_L1_evict_normal_L2_256B(const B8* addr)
   return *reinterpret_cast<B8*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_normal.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
@@ -958,7 +958,7 @@ template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_evict_normal_L2_256B(
   const B16* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_evict_normal_L2_256B(const B16* addr)
@@ -975,7 +975,7 @@ __device__ static inline B16 ld_global_L1_evict_normal_L2_256B(const B16* addr)
   return *reinterpret_cast<B16*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_normal.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
@@ -983,7 +983,7 @@ template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_evict_normal_L2_256B(
   const B32* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_evict_normal_L2_256B(const B32* addr)
@@ -1000,7 +1000,7 @@ __device__ static inline B32 ld_global_L1_evict_normal_L2_256B(const B32* addr)
   return *reinterpret_cast<B32*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_normal.L2::256B.b64 dest, [addr]; // PTX ISA 74, SM_80
@@ -1008,7 +1008,7 @@ template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_evict_normal_L2_256B(
   const B64* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_evict_normal_L2_256B(const B64* addr)
@@ -1025,7 +1025,7 @@ __device__ static inline B64 ld_global_L1_evict_normal_L2_256B(const B64* addr)
   return *reinterpret_cast<B64*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_normal.L2::256B.b128 dest, [addr]; // PTX ISA 83, SM_80
@@ -1033,14 +1033,14 @@ template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_evict_normal_L2_256B(
   const B128* addr);
 */
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_evict_normal_L2_256B(const B128* addr)
 {
   static_assert(sizeof(B128) == 16, "");
 #  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  long2 dest;
+  longlong2 dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.L1::evict_normal.L2::256B.b128 B128_dest, [%2];\n\t"
@@ -1053,126 +1053,126 @@ __device__ static inline B128 ld_global_L1_evict_normal_L2_256B(const B128* addr
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
-  long2 err_out_var{0, 0};
+  longlong2 err_out_var{0, 0};
   return *reinterpret_cast<B128*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 830
+#endif // __cccl_ptx_isa >= 830
 
 /*
-// ld.global.L1::evict_unchanged.b8 dest, [addr]; // PTX ISA 74, SM_75
+// ld.global.L1::evict_unchanged.b8 dest, [addr]; // PTX ISA 74, SM_70
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_L1_evict_unchanged(
   const B8* addr);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_unchanged_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_unchanged_is_not_supported_before_SM_70__();
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_L1_evict_unchanged(const B8* addr)
 {
   static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   std::uint32_t dest;
   asm volatile("ld.global.L1::evict_unchanged.b8 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
   return __u32_as_b8<B8>(dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_global_L1_evict_unchanged_is_not_supported_before_SM_75__();
+  __cuda_ptx_ld_global_L1_evict_unchanged_is_not_supported_before_SM_70__();
   std::uint32_t err_out_var = 0;
   return *reinterpret_cast<B8*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// ld.global.L1::evict_unchanged.b16 dest, [addr]; // PTX ISA 74, SM_75
+// ld.global.L1::evict_unchanged.b16 dest, [addr]; // PTX ISA 74, SM_70
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_evict_unchanged(
   const B16* addr);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_unchanged_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_unchanged_is_not_supported_before_SM_70__();
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_evict_unchanged(const B16* addr)
 {
   static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   std::uint16_t dest;
   asm volatile("ld.global.L1::evict_unchanged.b16 %0, [%1];" : "=h"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
   return *reinterpret_cast<B16*>(&dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_global_L1_evict_unchanged_is_not_supported_before_SM_75__();
+  __cuda_ptx_ld_global_L1_evict_unchanged_is_not_supported_before_SM_70__();
   std::uint16_t err_out_var = 0;
   return *reinterpret_cast<B16*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// ld.global.L1::evict_unchanged.b32 dest, [addr]; // PTX ISA 74, SM_75
+// ld.global.L1::evict_unchanged.b32 dest, [addr]; // PTX ISA 74, SM_70
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_evict_unchanged(
   const B32* addr);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_unchanged_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_unchanged_is_not_supported_before_SM_70__();
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_evict_unchanged(const B32* addr)
 {
   static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   std::uint32_t dest;
   asm volatile("ld.global.L1::evict_unchanged.b32 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
   return *reinterpret_cast<B32*>(&dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_global_L1_evict_unchanged_is_not_supported_before_SM_75__();
+  __cuda_ptx_ld_global_L1_evict_unchanged_is_not_supported_before_SM_70__();
   std::uint32_t err_out_var = 0;
   return *reinterpret_cast<B32*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// ld.global.L1::evict_unchanged.b64 dest, [addr]; // PTX ISA 74, SM_75
+// ld.global.L1::evict_unchanged.b64 dest, [addr]; // PTX ISA 74, SM_70
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_evict_unchanged(
   const B64* addr);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_unchanged_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_unchanged_is_not_supported_before_SM_70__();
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_evict_unchanged(const B64* addr)
 {
   static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   std::uint64_t dest;
   asm volatile("ld.global.L1::evict_unchanged.b64 %0, [%1];" : "=l"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
   return *reinterpret_cast<B64*>(&dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_global_L1_evict_unchanged_is_not_supported_before_SM_75__();
+  __cuda_ptx_ld_global_L1_evict_unchanged_is_not_supported_before_SM_70__();
   std::uint64_t err_out_var = 0;
   return *reinterpret_cast<B64*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// ld.global.L1::evict_unchanged.b128 dest, [addr]; // PTX ISA 83, SM_75
+// ld.global.L1::evict_unchanged.b128 dest, [addr]; // PTX ISA 83, SM_70
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_evict_unchanged(
   const B128* addr);
 */
-#if __libcuda_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_unchanged_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 830
+extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_unchanged_is_not_supported_before_SM_70__();
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_evict_unchanged(const B128* addr)
 {
   static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  long2 dest;
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
+  longlong2 dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.L1::evict_unchanged.b128 B128_dest, [%2];\n\t"
@@ -1184,12 +1184,12 @@ __device__ static inline B128 ld_global_L1_evict_unchanged(const B128* addr)
   return *reinterpret_cast<B128*>(&dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_global_L1_evict_unchanged_is_not_supported_before_SM_75__();
-  long2 err_out_var{0, 0};
+  __cuda_ptx_ld_global_L1_evict_unchanged_is_not_supported_before_SM_70__();
+  longlong2 err_out_var{0, 0};
   return *reinterpret_cast<B128*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 830
+#endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.L1::evict_unchanged.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
@@ -1197,7 +1197,7 @@ template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_L1_evict_unchanged_L2_64B(
   const B8* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_L1_evict_unchanged_L2_64B(const B8* addr)
@@ -1214,7 +1214,7 @@ __device__ static inline B8 ld_global_L1_evict_unchanged_L2_64B(const B8* addr)
   return *reinterpret_cast<B8*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_unchanged.L2::64B.b16 dest, [addr]; // PTX ISA 74, SM_75
@@ -1222,7 +1222,7 @@ template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_evict_unchanged_L2_64B(
   const B16* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_evict_unchanged_L2_64B(const B16* addr)
@@ -1242,7 +1242,7 @@ __device__ static inline B16 ld_global_L1_evict_unchanged_L2_64B(const B16* addr
   return *reinterpret_cast<B16*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_unchanged.L2::64B.b32 dest, [addr]; // PTX ISA 74, SM_75
@@ -1250,7 +1250,7 @@ template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_evict_unchanged_L2_64B(
   const B32* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_evict_unchanged_L2_64B(const B32* addr)
@@ -1270,7 +1270,7 @@ __device__ static inline B32 ld_global_L1_evict_unchanged_L2_64B(const B32* addr
   return *reinterpret_cast<B32*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_unchanged.L2::64B.b64 dest, [addr]; // PTX ISA 74, SM_75
@@ -1278,7 +1278,7 @@ template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_evict_unchanged_L2_64B(
   const B64* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_evict_unchanged_L2_64B(const B64* addr)
@@ -1298,7 +1298,7 @@ __device__ static inline B64 ld_global_L1_evict_unchanged_L2_64B(const B64* addr
   return *reinterpret_cast<B64*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_unchanged.L2::64B.b128 dest, [addr]; // PTX ISA 83, SM_75
@@ -1306,14 +1306,14 @@ template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_evict_unchanged_L2_64B(
   const B128* addr);
 */
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_evict_unchanged_L2_64B(const B128* addr)
 {
   static_assert(sizeof(B128) == 16, "");
 #  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  long2 dest;
+  longlong2 dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.L1::evict_unchanged.L2::64B.b128 B128_dest, [%2];\n\t"
@@ -1326,11 +1326,11 @@ __device__ static inline B128 ld_global_L1_evict_unchanged_L2_64B(const B128* ad
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
-  long2 err_out_var{0, 0};
+  longlong2 err_out_var{0, 0};
   return *reinterpret_cast<B128*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 830
+#endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.L1::evict_unchanged.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
@@ -1338,7 +1338,7 @@ template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_L1_evict_unchanged_L2_128B(
   const B8* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_L1_evict_unchanged_L2_128B(const B8* addr)
@@ -1358,7 +1358,7 @@ __device__ static inline B8 ld_global_L1_evict_unchanged_L2_128B(const B8* addr)
   return *reinterpret_cast<B8*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_unchanged.L2::128B.b16 dest, [addr]; // PTX ISA 74, SM_75
@@ -1366,7 +1366,7 @@ template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_evict_unchanged_L2_128B(
   const B16* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_evict_unchanged_L2_128B(const B16* addr)
@@ -1386,7 +1386,7 @@ __device__ static inline B16 ld_global_L1_evict_unchanged_L2_128B(const B16* add
   return *reinterpret_cast<B16*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_unchanged.L2::128B.b32 dest, [addr]; // PTX ISA 74, SM_75
@@ -1394,7 +1394,7 @@ template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_evict_unchanged_L2_128B(
   const B32* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_evict_unchanged_L2_128B(const B32* addr)
@@ -1414,7 +1414,7 @@ __device__ static inline B32 ld_global_L1_evict_unchanged_L2_128B(const B32* add
   return *reinterpret_cast<B32*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_unchanged.L2::128B.b64 dest, [addr]; // PTX ISA 74, SM_75
@@ -1422,7 +1422,7 @@ template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_evict_unchanged_L2_128B(
   const B64* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_evict_unchanged_L2_128B(const B64* addr)
@@ -1442,7 +1442,7 @@ __device__ static inline B64 ld_global_L1_evict_unchanged_L2_128B(const B64* add
   return *reinterpret_cast<B64*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_unchanged.L2::128B.b128 dest, [addr]; // PTX ISA 83, SM_75
@@ -1450,14 +1450,14 @@ template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_evict_unchanged_L2_128B(
   const B128* addr);
 */
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_evict_unchanged_L2_128B(const B128* addr)
 {
   static_assert(sizeof(B128) == 16, "");
 #  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  long2 dest;
+  longlong2 dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.L1::evict_unchanged.L2::128B.b128 B128_dest, [%2];\n\t"
@@ -1470,11 +1470,11 @@ __device__ static inline B128 ld_global_L1_evict_unchanged_L2_128B(const B128* a
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
-  long2 err_out_var{0, 0};
+  longlong2 err_out_var{0, 0};
   return *reinterpret_cast<B128*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 830
+#endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.L1::evict_unchanged.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
@@ -1482,7 +1482,7 @@ template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_L1_evict_unchanged_L2_256B(
   const B8* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_L1_evict_unchanged_L2_256B(const B8* addr)
@@ -1502,7 +1502,7 @@ __device__ static inline B8 ld_global_L1_evict_unchanged_L2_256B(const B8* addr)
   return *reinterpret_cast<B8*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_unchanged.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
@@ -1510,7 +1510,7 @@ template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_evict_unchanged_L2_256B(
   const B16* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_evict_unchanged_L2_256B(const B16* addr)
@@ -1530,7 +1530,7 @@ __device__ static inline B16 ld_global_L1_evict_unchanged_L2_256B(const B16* add
   return *reinterpret_cast<B16*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_unchanged.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
@@ -1538,7 +1538,7 @@ template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_evict_unchanged_L2_256B(
   const B32* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_evict_unchanged_L2_256B(const B32* addr)
@@ -1558,7 +1558,7 @@ __device__ static inline B32 ld_global_L1_evict_unchanged_L2_256B(const B32* add
   return *reinterpret_cast<B32*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_unchanged.L2::256B.b64 dest, [addr]; // PTX ISA 74, SM_80
@@ -1566,7 +1566,7 @@ template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_evict_unchanged_L2_256B(
   const B64* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_evict_unchanged_L2_256B(const B64* addr)
@@ -1586,7 +1586,7 @@ __device__ static inline B64 ld_global_L1_evict_unchanged_L2_256B(const B64* add
   return *reinterpret_cast<B64*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_unchanged.L2::256B.b128 dest, [addr]; // PTX ISA 83, SM_80
@@ -1594,14 +1594,14 @@ template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_evict_unchanged_L2_256B(
   const B128* addr);
 */
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_evict_unchanged_L2_256B(const B128* addr)
 {
   static_assert(sizeof(B128) == 16, "");
 #  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  long2 dest;
+  longlong2 dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.L1::evict_unchanged.L2::256B.b128 B128_dest, [%2];\n\t"
@@ -1614,126 +1614,126 @@ __device__ static inline B128 ld_global_L1_evict_unchanged_L2_256B(const B128* a
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
-  long2 err_out_var{0, 0};
+  longlong2 err_out_var{0, 0};
   return *reinterpret_cast<B128*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 830
+#endif // __cccl_ptx_isa >= 830
 
 /*
-// ld.global.L1::evict_first.b8 dest, [addr]; // PTX ISA 74, SM_75
+// ld.global.L1::evict_first.b8 dest, [addr]; // PTX ISA 74, SM_70
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_L1_evict_first(
   const B8* addr);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_first_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_first_is_not_supported_before_SM_70__();
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_L1_evict_first(const B8* addr)
 {
   static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   std::uint32_t dest;
   asm volatile("ld.global.L1::evict_first.b8 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
   return __u32_as_b8<B8>(dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_global_L1_evict_first_is_not_supported_before_SM_75__();
+  __cuda_ptx_ld_global_L1_evict_first_is_not_supported_before_SM_70__();
   std::uint32_t err_out_var = 0;
   return *reinterpret_cast<B8*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// ld.global.L1::evict_first.b16 dest, [addr]; // PTX ISA 74, SM_75
+// ld.global.L1::evict_first.b16 dest, [addr]; // PTX ISA 74, SM_70
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_evict_first(
   const B16* addr);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_first_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_first_is_not_supported_before_SM_70__();
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_evict_first(const B16* addr)
 {
   static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   std::uint16_t dest;
   asm volatile("ld.global.L1::evict_first.b16 %0, [%1];" : "=h"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
   return *reinterpret_cast<B16*>(&dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_global_L1_evict_first_is_not_supported_before_SM_75__();
+  __cuda_ptx_ld_global_L1_evict_first_is_not_supported_before_SM_70__();
   std::uint16_t err_out_var = 0;
   return *reinterpret_cast<B16*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// ld.global.L1::evict_first.b32 dest, [addr]; // PTX ISA 74, SM_75
+// ld.global.L1::evict_first.b32 dest, [addr]; // PTX ISA 74, SM_70
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_evict_first(
   const B32* addr);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_first_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_first_is_not_supported_before_SM_70__();
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_evict_first(const B32* addr)
 {
   static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   std::uint32_t dest;
   asm volatile("ld.global.L1::evict_first.b32 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
   return *reinterpret_cast<B32*>(&dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_global_L1_evict_first_is_not_supported_before_SM_75__();
+  __cuda_ptx_ld_global_L1_evict_first_is_not_supported_before_SM_70__();
   std::uint32_t err_out_var = 0;
   return *reinterpret_cast<B32*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// ld.global.L1::evict_first.b64 dest, [addr]; // PTX ISA 74, SM_75
+// ld.global.L1::evict_first.b64 dest, [addr]; // PTX ISA 74, SM_70
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_evict_first(
   const B64* addr);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_first_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_first_is_not_supported_before_SM_70__();
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_evict_first(const B64* addr)
 {
   static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   std::uint64_t dest;
   asm volatile("ld.global.L1::evict_first.b64 %0, [%1];" : "=l"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
   return *reinterpret_cast<B64*>(&dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_global_L1_evict_first_is_not_supported_before_SM_75__();
+  __cuda_ptx_ld_global_L1_evict_first_is_not_supported_before_SM_70__();
   std::uint64_t err_out_var = 0;
   return *reinterpret_cast<B64*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// ld.global.L1::evict_first.b128 dest, [addr]; // PTX ISA 83, SM_75
+// ld.global.L1::evict_first.b128 dest, [addr]; // PTX ISA 83, SM_70
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_evict_first(
   const B128* addr);
 */
-#if __libcuda_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_first_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 830
+extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_first_is_not_supported_before_SM_70__();
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_evict_first(const B128* addr)
 {
   static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  long2 dest;
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
+  longlong2 dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.L1::evict_first.b128 B128_dest, [%2];\n\t"
@@ -1745,12 +1745,12 @@ __device__ static inline B128 ld_global_L1_evict_first(const B128* addr)
   return *reinterpret_cast<B128*>(&dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_global_L1_evict_first_is_not_supported_before_SM_75__();
-  long2 err_out_var{0, 0};
+  __cuda_ptx_ld_global_L1_evict_first_is_not_supported_before_SM_70__();
+  longlong2 err_out_var{0, 0};
   return *reinterpret_cast<B128*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 830
+#endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.L1::evict_first.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
@@ -1758,7 +1758,7 @@ template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_L1_evict_first_L2_64B(
   const B8* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_L1_evict_first_L2_64B(const B8* addr)
@@ -1775,7 +1775,7 @@ __device__ static inline B8 ld_global_L1_evict_first_L2_64B(const B8* addr)
   return *reinterpret_cast<B8*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_first.L2::64B.b16 dest, [addr]; // PTX ISA 74, SM_75
@@ -1783,7 +1783,7 @@ template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_evict_first_L2_64B(
   const B16* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_evict_first_L2_64B(const B16* addr)
@@ -1800,7 +1800,7 @@ __device__ static inline B16 ld_global_L1_evict_first_L2_64B(const B16* addr)
   return *reinterpret_cast<B16*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_first.L2::64B.b32 dest, [addr]; // PTX ISA 74, SM_75
@@ -1808,7 +1808,7 @@ template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_evict_first_L2_64B(
   const B32* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_evict_first_L2_64B(const B32* addr)
@@ -1825,7 +1825,7 @@ __device__ static inline B32 ld_global_L1_evict_first_L2_64B(const B32* addr)
   return *reinterpret_cast<B32*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_first.L2::64B.b64 dest, [addr]; // PTX ISA 74, SM_75
@@ -1833,7 +1833,7 @@ template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_evict_first_L2_64B(
   const B64* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_evict_first_L2_64B(const B64* addr)
@@ -1850,7 +1850,7 @@ __device__ static inline B64 ld_global_L1_evict_first_L2_64B(const B64* addr)
   return *reinterpret_cast<B64*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_first.L2::64B.b128 dest, [addr]; // PTX ISA 83, SM_75
@@ -1858,14 +1858,14 @@ template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_evict_first_L2_64B(
   const B128* addr);
 */
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_evict_first_L2_64B(const B128* addr)
 {
   static_assert(sizeof(B128) == 16, "");
 #  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  long2 dest;
+  longlong2 dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.L1::evict_first.L2::64B.b128 B128_dest, [%2];\n\t"
@@ -1878,11 +1878,11 @@ __device__ static inline B128 ld_global_L1_evict_first_L2_64B(const B128* addr)
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
-  long2 err_out_var{0, 0};
+  longlong2 err_out_var{0, 0};
   return *reinterpret_cast<B128*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 830
+#endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.L1::evict_first.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
@@ -1890,7 +1890,7 @@ template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_L1_evict_first_L2_128B(
   const B8* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_L1_evict_first_L2_128B(const B8* addr)
@@ -1907,7 +1907,7 @@ __device__ static inline B8 ld_global_L1_evict_first_L2_128B(const B8* addr)
   return *reinterpret_cast<B8*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_first.L2::128B.b16 dest, [addr]; // PTX ISA 74, SM_75
@@ -1915,7 +1915,7 @@ template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_evict_first_L2_128B(
   const B16* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_evict_first_L2_128B(const B16* addr)
@@ -1932,7 +1932,7 @@ __device__ static inline B16 ld_global_L1_evict_first_L2_128B(const B16* addr)
   return *reinterpret_cast<B16*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_first.L2::128B.b32 dest, [addr]; // PTX ISA 74, SM_75
@@ -1940,7 +1940,7 @@ template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_evict_first_L2_128B(
   const B32* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_evict_first_L2_128B(const B32* addr)
@@ -1957,7 +1957,7 @@ __device__ static inline B32 ld_global_L1_evict_first_L2_128B(const B32* addr)
   return *reinterpret_cast<B32*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_first.L2::128B.b64 dest, [addr]; // PTX ISA 74, SM_75
@@ -1965,7 +1965,7 @@ template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_evict_first_L2_128B(
   const B64* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_evict_first_L2_128B(const B64* addr)
@@ -1982,7 +1982,7 @@ __device__ static inline B64 ld_global_L1_evict_first_L2_128B(const B64* addr)
   return *reinterpret_cast<B64*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_first.L2::128B.b128 dest, [addr]; // PTX ISA 83, SM_75
@@ -1990,14 +1990,14 @@ template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_evict_first_L2_128B(
   const B128* addr);
 */
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_evict_first_L2_128B(const B128* addr)
 {
   static_assert(sizeof(B128) == 16, "");
 #  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  long2 dest;
+  longlong2 dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.L1::evict_first.L2::128B.b128 B128_dest, [%2];\n\t"
@@ -2010,11 +2010,11 @@ __device__ static inline B128 ld_global_L1_evict_first_L2_128B(const B128* addr)
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
-  long2 err_out_var{0, 0};
+  longlong2 err_out_var{0, 0};
   return *reinterpret_cast<B128*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 830
+#endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.L1::evict_first.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
@@ -2022,7 +2022,7 @@ template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_L1_evict_first_L2_256B(
   const B8* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_L1_evict_first_L2_256B(const B8* addr)
@@ -2039,7 +2039,7 @@ __device__ static inline B8 ld_global_L1_evict_first_L2_256B(const B8* addr)
   return *reinterpret_cast<B8*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_first.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
@@ -2047,7 +2047,7 @@ template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_evict_first_L2_256B(
   const B16* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_evict_first_L2_256B(const B16* addr)
@@ -2064,7 +2064,7 @@ __device__ static inline B16 ld_global_L1_evict_first_L2_256B(const B16* addr)
   return *reinterpret_cast<B16*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_first.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
@@ -2072,7 +2072,7 @@ template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_evict_first_L2_256B(
   const B32* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_evict_first_L2_256B(const B32* addr)
@@ -2089,7 +2089,7 @@ __device__ static inline B32 ld_global_L1_evict_first_L2_256B(const B32* addr)
   return *reinterpret_cast<B32*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_first.L2::256B.b64 dest, [addr]; // PTX ISA 74, SM_80
@@ -2097,7 +2097,7 @@ template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_evict_first_L2_256B(
   const B64* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_evict_first_L2_256B(const B64* addr)
@@ -2114,7 +2114,7 @@ __device__ static inline B64 ld_global_L1_evict_first_L2_256B(const B64* addr)
   return *reinterpret_cast<B64*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_first.L2::256B.b128 dest, [addr]; // PTX ISA 83, SM_80
@@ -2122,14 +2122,14 @@ template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_evict_first_L2_256B(
   const B128* addr);
 */
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_evict_first_L2_256B(const B128* addr)
 {
   static_assert(sizeof(B128) == 16, "");
 #  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  long2 dest;
+  longlong2 dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.L1::evict_first.L2::256B.b128 B128_dest, [%2];\n\t"
@@ -2142,126 +2142,126 @@ __device__ static inline B128 ld_global_L1_evict_first_L2_256B(const B128* addr)
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
-  long2 err_out_var{0, 0};
+  longlong2 err_out_var{0, 0};
   return *reinterpret_cast<B128*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 830
+#endif // __cccl_ptx_isa >= 830
 
 /*
-// ld.global.L1::evict_last.b8 dest, [addr]; // PTX ISA 74, SM_75
+// ld.global.L1::evict_last.b8 dest, [addr]; // PTX ISA 74, SM_70
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_L1_evict_last(
   const B8* addr);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_last_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_last_is_not_supported_before_SM_70__();
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_L1_evict_last(const B8* addr)
 {
   static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   std::uint32_t dest;
   asm volatile("ld.global.L1::evict_last.b8 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
   return __u32_as_b8<B8>(dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_global_L1_evict_last_is_not_supported_before_SM_75__();
+  __cuda_ptx_ld_global_L1_evict_last_is_not_supported_before_SM_70__();
   std::uint32_t err_out_var = 0;
   return *reinterpret_cast<B8*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// ld.global.L1::evict_last.b16 dest, [addr]; // PTX ISA 74, SM_75
+// ld.global.L1::evict_last.b16 dest, [addr]; // PTX ISA 74, SM_70
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_evict_last(
   const B16* addr);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_last_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_last_is_not_supported_before_SM_70__();
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_evict_last(const B16* addr)
 {
   static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   std::uint16_t dest;
   asm volatile("ld.global.L1::evict_last.b16 %0, [%1];" : "=h"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
   return *reinterpret_cast<B16*>(&dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_global_L1_evict_last_is_not_supported_before_SM_75__();
+  __cuda_ptx_ld_global_L1_evict_last_is_not_supported_before_SM_70__();
   std::uint16_t err_out_var = 0;
   return *reinterpret_cast<B16*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// ld.global.L1::evict_last.b32 dest, [addr]; // PTX ISA 74, SM_75
+// ld.global.L1::evict_last.b32 dest, [addr]; // PTX ISA 74, SM_70
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_evict_last(
   const B32* addr);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_last_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_last_is_not_supported_before_SM_70__();
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_evict_last(const B32* addr)
 {
   static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   std::uint32_t dest;
   asm volatile("ld.global.L1::evict_last.b32 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
   return *reinterpret_cast<B32*>(&dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_global_L1_evict_last_is_not_supported_before_SM_75__();
+  __cuda_ptx_ld_global_L1_evict_last_is_not_supported_before_SM_70__();
   std::uint32_t err_out_var = 0;
   return *reinterpret_cast<B32*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// ld.global.L1::evict_last.b64 dest, [addr]; // PTX ISA 74, SM_75
+// ld.global.L1::evict_last.b64 dest, [addr]; // PTX ISA 74, SM_70
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_evict_last(
   const B64* addr);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_last_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_last_is_not_supported_before_SM_70__();
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_evict_last(const B64* addr)
 {
   static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   std::uint64_t dest;
   asm volatile("ld.global.L1::evict_last.b64 %0, [%1];" : "=l"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
   return *reinterpret_cast<B64*>(&dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_global_L1_evict_last_is_not_supported_before_SM_75__();
+  __cuda_ptx_ld_global_L1_evict_last_is_not_supported_before_SM_70__();
   std::uint64_t err_out_var = 0;
   return *reinterpret_cast<B64*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// ld.global.L1::evict_last.b128 dest, [addr]; // PTX ISA 83, SM_75
+// ld.global.L1::evict_last.b128 dest, [addr]; // PTX ISA 83, SM_70
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_evict_last(
   const B128* addr);
 */
-#if __libcuda_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_last_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 830
+extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_last_is_not_supported_before_SM_70__();
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_evict_last(const B128* addr)
 {
   static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  long2 dest;
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
+  longlong2 dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.L1::evict_last.b128 B128_dest, [%2];\n\t"
@@ -2273,12 +2273,12 @@ __device__ static inline B128 ld_global_L1_evict_last(const B128* addr)
   return *reinterpret_cast<B128*>(&dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_global_L1_evict_last_is_not_supported_before_SM_75__();
-  long2 err_out_var{0, 0};
+  __cuda_ptx_ld_global_L1_evict_last_is_not_supported_before_SM_70__();
+  longlong2 err_out_var{0, 0};
   return *reinterpret_cast<B128*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 830
+#endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.L1::evict_last.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
@@ -2286,7 +2286,7 @@ template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_L1_evict_last_L2_64B(
   const B8* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_L1_evict_last_L2_64B(const B8* addr)
@@ -2303,7 +2303,7 @@ __device__ static inline B8 ld_global_L1_evict_last_L2_64B(const B8* addr)
   return *reinterpret_cast<B8*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_last.L2::64B.b16 dest, [addr]; // PTX ISA 74, SM_75
@@ -2311,7 +2311,7 @@ template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_evict_last_L2_64B(
   const B16* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_evict_last_L2_64B(const B16* addr)
@@ -2328,7 +2328,7 @@ __device__ static inline B16 ld_global_L1_evict_last_L2_64B(const B16* addr)
   return *reinterpret_cast<B16*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_last.L2::64B.b32 dest, [addr]; // PTX ISA 74, SM_75
@@ -2336,7 +2336,7 @@ template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_evict_last_L2_64B(
   const B32* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_evict_last_L2_64B(const B32* addr)
@@ -2353,7 +2353,7 @@ __device__ static inline B32 ld_global_L1_evict_last_L2_64B(const B32* addr)
   return *reinterpret_cast<B32*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_last.L2::64B.b64 dest, [addr]; // PTX ISA 74, SM_75
@@ -2361,7 +2361,7 @@ template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_evict_last_L2_64B(
   const B64* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_evict_last_L2_64B(const B64* addr)
@@ -2378,7 +2378,7 @@ __device__ static inline B64 ld_global_L1_evict_last_L2_64B(const B64* addr)
   return *reinterpret_cast<B64*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_last.L2::64B.b128 dest, [addr]; // PTX ISA 83, SM_75
@@ -2386,14 +2386,14 @@ template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_evict_last_L2_64B(
   const B128* addr);
 */
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_evict_last_L2_64B(const B128* addr)
 {
   static_assert(sizeof(B128) == 16, "");
 #  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  long2 dest;
+  longlong2 dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.L1::evict_last.L2::64B.b128 B128_dest, [%2];\n\t"
@@ -2406,11 +2406,11 @@ __device__ static inline B128 ld_global_L1_evict_last_L2_64B(const B128* addr)
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
-  long2 err_out_var{0, 0};
+  longlong2 err_out_var{0, 0};
   return *reinterpret_cast<B128*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 830
+#endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.L1::evict_last.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
@@ -2418,7 +2418,7 @@ template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_L1_evict_last_L2_128B(
   const B8* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_L1_evict_last_L2_128B(const B8* addr)
@@ -2435,7 +2435,7 @@ __device__ static inline B8 ld_global_L1_evict_last_L2_128B(const B8* addr)
   return *reinterpret_cast<B8*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_last.L2::128B.b16 dest, [addr]; // PTX ISA 74, SM_75
@@ -2443,7 +2443,7 @@ template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_evict_last_L2_128B(
   const B16* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_evict_last_L2_128B(const B16* addr)
@@ -2460,7 +2460,7 @@ __device__ static inline B16 ld_global_L1_evict_last_L2_128B(const B16* addr)
   return *reinterpret_cast<B16*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_last.L2::128B.b32 dest, [addr]; // PTX ISA 74, SM_75
@@ -2468,7 +2468,7 @@ template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_evict_last_L2_128B(
   const B32* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_evict_last_L2_128B(const B32* addr)
@@ -2485,7 +2485,7 @@ __device__ static inline B32 ld_global_L1_evict_last_L2_128B(const B32* addr)
   return *reinterpret_cast<B32*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_last.L2::128B.b64 dest, [addr]; // PTX ISA 74, SM_75
@@ -2493,7 +2493,7 @@ template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_evict_last_L2_128B(
   const B64* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_evict_last_L2_128B(const B64* addr)
@@ -2510,7 +2510,7 @@ __device__ static inline B64 ld_global_L1_evict_last_L2_128B(const B64* addr)
   return *reinterpret_cast<B64*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_last.L2::128B.b128 dest, [addr]; // PTX ISA 83, SM_75
@@ -2518,14 +2518,14 @@ template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_evict_last_L2_128B(
   const B128* addr);
 */
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_evict_last_L2_128B(const B128* addr)
 {
   static_assert(sizeof(B128) == 16, "");
 #  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  long2 dest;
+  longlong2 dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.L1::evict_last.L2::128B.b128 B128_dest, [%2];\n\t"
@@ -2538,11 +2538,11 @@ __device__ static inline B128 ld_global_L1_evict_last_L2_128B(const B128* addr)
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
-  long2 err_out_var{0, 0};
+  longlong2 err_out_var{0, 0};
   return *reinterpret_cast<B128*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 830
+#endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.L1::evict_last.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
@@ -2550,7 +2550,7 @@ template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_L1_evict_last_L2_256B(
   const B8* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_L1_evict_last_L2_256B(const B8* addr)
@@ -2567,7 +2567,7 @@ __device__ static inline B8 ld_global_L1_evict_last_L2_256B(const B8* addr)
   return *reinterpret_cast<B8*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_last.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
@@ -2575,7 +2575,7 @@ template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_evict_last_L2_256B(
   const B16* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_evict_last_L2_256B(const B16* addr)
@@ -2592,7 +2592,7 @@ __device__ static inline B16 ld_global_L1_evict_last_L2_256B(const B16* addr)
   return *reinterpret_cast<B16*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_last.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
@@ -2600,7 +2600,7 @@ template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_evict_last_L2_256B(
   const B32* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_evict_last_L2_256B(const B32* addr)
@@ -2617,7 +2617,7 @@ __device__ static inline B32 ld_global_L1_evict_last_L2_256B(const B32* addr)
   return *reinterpret_cast<B32*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_last.L2::256B.b64 dest, [addr]; // PTX ISA 74, SM_80
@@ -2625,7 +2625,7 @@ template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_evict_last_L2_256B(
   const B64* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_evict_last_L2_256B(const B64* addr)
@@ -2642,7 +2642,7 @@ __device__ static inline B64 ld_global_L1_evict_last_L2_256B(const B64* addr)
   return *reinterpret_cast<B64*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::evict_last.L2::256B.b128 dest, [addr]; // PTX ISA 83, SM_80
@@ -2650,14 +2650,14 @@ template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_evict_last_L2_256B(
   const B128* addr);
 */
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
 extern "C" __device__ void __cuda_ptx_ld_global_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_evict_last_L2_256B(const B128* addr)
 {
   static_assert(sizeof(B128) == 16, "");
 #  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  long2 dest;
+  longlong2 dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.L1::evict_last.L2::256B.b128 B128_dest, [%2];\n\t"
@@ -2670,126 +2670,126 @@ __device__ static inline B128 ld_global_L1_evict_last_L2_256B(const B128* addr)
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
-  long2 err_out_var{0, 0};
+  longlong2 err_out_var{0, 0};
   return *reinterpret_cast<B128*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 830
+#endif // __cccl_ptx_isa >= 830
 
 /*
-// ld.global.L1::no_allocate.b8 dest, [addr]; // PTX ISA 74, SM_75
+// ld.global.L1::no_allocate.b8 dest, [addr]; // PTX ISA 74, SM_70
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_L1_no_allocate(
   const B8* addr);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_no_allocate_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_ld_global_L1_no_allocate_is_not_supported_before_SM_70__();
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_L1_no_allocate(const B8* addr)
 {
   static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   std::uint32_t dest;
   asm volatile("ld.global.L1::no_allocate.b8 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
   return __u32_as_b8<B8>(dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_global_L1_no_allocate_is_not_supported_before_SM_75__();
+  __cuda_ptx_ld_global_L1_no_allocate_is_not_supported_before_SM_70__();
   std::uint32_t err_out_var = 0;
   return *reinterpret_cast<B8*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// ld.global.L1::no_allocate.b16 dest, [addr]; // PTX ISA 74, SM_75
+// ld.global.L1::no_allocate.b16 dest, [addr]; // PTX ISA 74, SM_70
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_no_allocate(
   const B16* addr);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_no_allocate_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_ld_global_L1_no_allocate_is_not_supported_before_SM_70__();
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_no_allocate(const B16* addr)
 {
   static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   std::uint16_t dest;
   asm volatile("ld.global.L1::no_allocate.b16 %0, [%1];" : "=h"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
   return *reinterpret_cast<B16*>(&dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_global_L1_no_allocate_is_not_supported_before_SM_75__();
+  __cuda_ptx_ld_global_L1_no_allocate_is_not_supported_before_SM_70__();
   std::uint16_t err_out_var = 0;
   return *reinterpret_cast<B16*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// ld.global.L1::no_allocate.b32 dest, [addr]; // PTX ISA 74, SM_75
+// ld.global.L1::no_allocate.b32 dest, [addr]; // PTX ISA 74, SM_70
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_no_allocate(
   const B32* addr);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_no_allocate_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_ld_global_L1_no_allocate_is_not_supported_before_SM_70__();
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_no_allocate(const B32* addr)
 {
   static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   std::uint32_t dest;
   asm volatile("ld.global.L1::no_allocate.b32 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
   return *reinterpret_cast<B32*>(&dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_global_L1_no_allocate_is_not_supported_before_SM_75__();
+  __cuda_ptx_ld_global_L1_no_allocate_is_not_supported_before_SM_70__();
   std::uint32_t err_out_var = 0;
   return *reinterpret_cast<B32*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// ld.global.L1::no_allocate.b64 dest, [addr]; // PTX ISA 74, SM_75
+// ld.global.L1::no_allocate.b64 dest, [addr]; // PTX ISA 74, SM_70
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_no_allocate(
   const B64* addr);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_L1_no_allocate_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_ld_global_L1_no_allocate_is_not_supported_before_SM_70__();
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_no_allocate(const B64* addr)
 {
   static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   std::uint64_t dest;
   asm volatile("ld.global.L1::no_allocate.b64 %0, [%1];" : "=l"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
   return *reinterpret_cast<B64*>(&dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_global_L1_no_allocate_is_not_supported_before_SM_75__();
+  __cuda_ptx_ld_global_L1_no_allocate_is_not_supported_before_SM_70__();
   std::uint64_t err_out_var = 0;
   return *reinterpret_cast<B64*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// ld.global.L1::no_allocate.b128 dest, [addr]; // PTX ISA 83, SM_75
+// ld.global.L1::no_allocate.b128 dest, [addr]; // PTX ISA 83, SM_70
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_no_allocate(
   const B128* addr);
 */
-#if __libcuda_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_ld_global_L1_no_allocate_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 830
+extern "C" __device__ void __cuda_ptx_ld_global_L1_no_allocate_is_not_supported_before_SM_70__();
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_no_allocate(const B128* addr)
 {
   static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  long2 dest;
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
+  longlong2 dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.L1::no_allocate.b128 B128_dest, [%2];\n\t"
@@ -2801,12 +2801,12 @@ __device__ static inline B128 ld_global_L1_no_allocate(const B128* addr)
   return *reinterpret_cast<B128*>(&dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_global_L1_no_allocate_is_not_supported_before_SM_75__();
-  long2 err_out_var{0, 0};
+  __cuda_ptx_ld_global_L1_no_allocate_is_not_supported_before_SM_70__();
+  longlong2 err_out_var{0, 0};
   return *reinterpret_cast<B128*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 830
+#endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.L1::no_allocate.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
@@ -2814,7 +2814,7 @@ template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_L1_no_allocate_L2_64B(
   const B8* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_L1_no_allocate_L2_64B(const B8* addr)
@@ -2831,7 +2831,7 @@ __device__ static inline B8 ld_global_L1_no_allocate_L2_64B(const B8* addr)
   return *reinterpret_cast<B8*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::no_allocate.L2::64B.b16 dest, [addr]; // PTX ISA 74, SM_75
@@ -2839,7 +2839,7 @@ template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_no_allocate_L2_64B(
   const B16* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_no_allocate_L2_64B(const B16* addr)
@@ -2856,7 +2856,7 @@ __device__ static inline B16 ld_global_L1_no_allocate_L2_64B(const B16* addr)
   return *reinterpret_cast<B16*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::no_allocate.L2::64B.b32 dest, [addr]; // PTX ISA 74, SM_75
@@ -2864,7 +2864,7 @@ template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_no_allocate_L2_64B(
   const B32* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_no_allocate_L2_64B(const B32* addr)
@@ -2881,7 +2881,7 @@ __device__ static inline B32 ld_global_L1_no_allocate_L2_64B(const B32* addr)
   return *reinterpret_cast<B32*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::no_allocate.L2::64B.b64 dest, [addr]; // PTX ISA 74, SM_75
@@ -2889,7 +2889,7 @@ template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_no_allocate_L2_64B(
   const B64* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_no_allocate_L2_64B(const B64* addr)
@@ -2906,7 +2906,7 @@ __device__ static inline B64 ld_global_L1_no_allocate_L2_64B(const B64* addr)
   return *reinterpret_cast<B64*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::no_allocate.L2::64B.b128 dest, [addr]; // PTX ISA 83, SM_75
@@ -2914,14 +2914,14 @@ template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_no_allocate_L2_64B(
   const B128* addr);
 */
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
 extern "C" __device__ void __cuda_ptx_ld_global_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_no_allocate_L2_64B(const B128* addr)
 {
   static_assert(sizeof(B128) == 16, "");
 #  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  long2 dest;
+  longlong2 dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.L1::no_allocate.L2::64B.b128 B128_dest, [%2];\n\t"
@@ -2934,11 +2934,11 @@ __device__ static inline B128 ld_global_L1_no_allocate_L2_64B(const B128* addr)
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
-  long2 err_out_var{0, 0};
+  longlong2 err_out_var{0, 0};
   return *reinterpret_cast<B128*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 830
+#endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.L1::no_allocate.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
@@ -2946,7 +2946,7 @@ template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_L1_no_allocate_L2_128B(
   const B8* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_L1_no_allocate_L2_128B(const B8* addr)
@@ -2963,7 +2963,7 @@ __device__ static inline B8 ld_global_L1_no_allocate_L2_128B(const B8* addr)
   return *reinterpret_cast<B8*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::no_allocate.L2::128B.b16 dest, [addr]; // PTX ISA 74, SM_75
@@ -2971,7 +2971,7 @@ template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_no_allocate_L2_128B(
   const B16* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_no_allocate_L2_128B(const B16* addr)
@@ -2988,7 +2988,7 @@ __device__ static inline B16 ld_global_L1_no_allocate_L2_128B(const B16* addr)
   return *reinterpret_cast<B16*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::no_allocate.L2::128B.b32 dest, [addr]; // PTX ISA 74, SM_75
@@ -2996,7 +2996,7 @@ template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_no_allocate_L2_128B(
   const B32* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_no_allocate_L2_128B(const B32* addr)
@@ -3013,7 +3013,7 @@ __device__ static inline B32 ld_global_L1_no_allocate_L2_128B(const B32* addr)
   return *reinterpret_cast<B32*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::no_allocate.L2::128B.b64 dest, [addr]; // PTX ISA 74, SM_75
@@ -3021,7 +3021,7 @@ template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_no_allocate_L2_128B(
   const B64* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_no_allocate_L2_128B(const B64* addr)
@@ -3038,7 +3038,7 @@ __device__ static inline B64 ld_global_L1_no_allocate_L2_128B(const B64* addr)
   return *reinterpret_cast<B64*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::no_allocate.L2::128B.b128 dest, [addr]; // PTX ISA 83, SM_75
@@ -3046,14 +3046,14 @@ template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_no_allocate_L2_128B(
   const B128* addr);
 */
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
 extern "C" __device__ void __cuda_ptx_ld_global_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_no_allocate_L2_128B(const B128* addr)
 {
   static_assert(sizeof(B128) == 16, "");
 #  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  long2 dest;
+  longlong2 dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.L1::no_allocate.L2::128B.b128 B128_dest, [%2];\n\t"
@@ -3066,11 +3066,11 @@ __device__ static inline B128 ld_global_L1_no_allocate_L2_128B(const B128* addr)
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
-  long2 err_out_var{0, 0};
+  longlong2 err_out_var{0, 0};
   return *reinterpret_cast<B128*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 830
+#endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.L1::no_allocate.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
@@ -3078,7 +3078,7 @@ template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_L1_no_allocate_L2_256B(
   const B8* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_L1_no_allocate_L2_256B(const B8* addr)
@@ -3095,7 +3095,7 @@ __device__ static inline B8 ld_global_L1_no_allocate_L2_256B(const B8* addr)
   return *reinterpret_cast<B8*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::no_allocate.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
@@ -3103,7 +3103,7 @@ template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_no_allocate_L2_256B(
   const B16* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_L1_no_allocate_L2_256B(const B16* addr)
@@ -3120,7 +3120,7 @@ __device__ static inline B16 ld_global_L1_no_allocate_L2_256B(const B16* addr)
   return *reinterpret_cast<B16*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::no_allocate.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
@@ -3128,7 +3128,7 @@ template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_no_allocate_L2_256B(
   const B32* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_L1_no_allocate_L2_256B(const B32* addr)
@@ -3145,7 +3145,7 @@ __device__ static inline B32 ld_global_L1_no_allocate_L2_256B(const B32* addr)
   return *reinterpret_cast<B32*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::no_allocate.L2::256B.b64 dest, [addr]; // PTX ISA 74, SM_80
@@ -3153,7 +3153,7 @@ template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_no_allocate_L2_256B(
   const B64* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_L1_no_allocate_L2_256B(const B64* addr)
@@ -3170,7 +3170,7 @@ __device__ static inline B64 ld_global_L1_no_allocate_L2_256B(const B64* addr)
   return *reinterpret_cast<B64*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.L1::no_allocate.L2::256B.b128 dest, [addr]; // PTX ISA 83, SM_80
@@ -3178,14 +3178,14 @@ template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_no_allocate_L2_256B(
   const B128* addr);
 */
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
 extern "C" __device__ void __cuda_ptx_ld_global_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_L1_no_allocate_L2_256B(const B128* addr)
 {
   static_assert(sizeof(B128) == 16, "");
 #  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  long2 dest;
+  longlong2 dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.L1::no_allocate.L2::256B.b128 B128_dest, [%2];\n\t"
@@ -3198,11 +3198,11 @@ __device__ static inline B128 ld_global_L1_no_allocate_L2_256B(const B128* addr)
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
-  long2 err_out_var{0, 0};
+  longlong2 err_out_var{0, 0};
   return *reinterpret_cast<B128*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 830
+#endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.nc.b8 dest, [addr]; // PTX ISA 10, SM_50
@@ -3210,7 +3210,7 @@ template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_nc(
   const B8* addr);
 */
-#if __libcuda_ptx_isa >= 100
+#if __cccl_ptx_isa >= 100
 extern "C" __device__ void __cuda_ptx_ld_global_nc_is_not_supported_before_SM_50__();
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_nc(const B8* addr)
@@ -3227,7 +3227,7 @@ __device__ static inline B8 ld_global_nc(const B8* addr)
   return *reinterpret_cast<B8*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 100
+#endif // __cccl_ptx_isa >= 100
 
 /*
 // ld.global.nc.b16 dest, [addr]; // PTX ISA 10, SM_50
@@ -3235,7 +3235,7 @@ template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc(
   const B16* addr);
 */
-#if __libcuda_ptx_isa >= 100
+#if __cccl_ptx_isa >= 100
 extern "C" __device__ void __cuda_ptx_ld_global_nc_is_not_supported_before_SM_50__();
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc(const B16* addr)
@@ -3252,7 +3252,7 @@ __device__ static inline B16 ld_global_nc(const B16* addr)
   return *reinterpret_cast<B16*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 100
+#endif // __cccl_ptx_isa >= 100
 
 /*
 // ld.global.nc.b32 dest, [addr]; // PTX ISA 10, SM_50
@@ -3260,7 +3260,7 @@ template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc(
   const B32* addr);
 */
-#if __libcuda_ptx_isa >= 100
+#if __cccl_ptx_isa >= 100
 extern "C" __device__ void __cuda_ptx_ld_global_nc_is_not_supported_before_SM_50__();
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc(const B32* addr)
@@ -3277,7 +3277,7 @@ __device__ static inline B32 ld_global_nc(const B32* addr)
   return *reinterpret_cast<B32*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 100
+#endif // __cccl_ptx_isa >= 100
 
 /*
 // ld.global.nc.b64 dest, [addr]; // PTX ISA 10, SM_50
@@ -3285,7 +3285,7 @@ template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc(
   const B64* addr);
 */
-#if __libcuda_ptx_isa >= 100
+#if __cccl_ptx_isa >= 100
 extern "C" __device__ void __cuda_ptx_ld_global_nc_is_not_supported_before_SM_50__();
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc(const B64* addr)
@@ -3302,7 +3302,7 @@ __device__ static inline B64 ld_global_nc(const B64* addr)
   return *reinterpret_cast<B64*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 100
+#endif // __cccl_ptx_isa >= 100
 
 /*
 // ld.global.nc.b128 dest, [addr]; // PTX ISA 83, SM_70
@@ -3310,14 +3310,14 @@ template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc(
   const B128* addr);
 */
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
 extern "C" __device__ void __cuda_ptx_ld_global_nc_is_not_supported_before_SM_70__();
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc(const B128* addr)
 {
   static_assert(sizeof(B128) == 16, "");
 #  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
-  long2 dest;
+  longlong2 dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.nc.b128 B128_dest, [%2];\n\t"
@@ -3330,11 +3330,11 @@ __device__ static inline B128 ld_global_nc(const B128* addr)
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_is_not_supported_before_SM_70__();
-  long2 err_out_var{0, 0};
+  longlong2 err_out_var{0, 0};
   return *reinterpret_cast<B128*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 830
+#endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.nc.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
@@ -3342,7 +3342,7 @@ template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_nc_L2_64B(
   const B8* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L2_64B_is_not_supported_before_SM_75__();
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_nc_L2_64B(const B8* addr)
@@ -3359,7 +3359,7 @@ __device__ static inline B8 ld_global_nc_L2_64B(const B8* addr)
   return *reinterpret_cast<B8*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L2::64B.b16 dest, [addr]; // PTX ISA 74, SM_75
@@ -3367,7 +3367,7 @@ template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L2_64B(
   const B16* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L2_64B_is_not_supported_before_SM_75__();
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L2_64B(const B16* addr)
@@ -3384,7 +3384,7 @@ __device__ static inline B16 ld_global_nc_L2_64B(const B16* addr)
   return *reinterpret_cast<B16*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L2::64B.b32 dest, [addr]; // PTX ISA 74, SM_75
@@ -3392,7 +3392,7 @@ template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L2_64B(
   const B32* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L2_64B_is_not_supported_before_SM_75__();
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L2_64B(const B32* addr)
@@ -3409,7 +3409,7 @@ __device__ static inline B32 ld_global_nc_L2_64B(const B32* addr)
   return *reinterpret_cast<B32*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L2::64B.b64 dest, [addr]; // PTX ISA 74, SM_75
@@ -3417,7 +3417,7 @@ template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L2_64B(
   const B64* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L2_64B_is_not_supported_before_SM_75__();
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L2_64B(const B64* addr)
@@ -3434,7 +3434,7 @@ __device__ static inline B64 ld_global_nc_L2_64B(const B64* addr)
   return *reinterpret_cast<B64*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L2::64B.b128 dest, [addr]; // PTX ISA 83, SM_75
@@ -3442,14 +3442,14 @@ template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L2_64B(
   const B128* addr);
 */
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L2_64B_is_not_supported_before_SM_75__();
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L2_64B(const B128* addr)
 {
   static_assert(sizeof(B128) == 16, "");
 #  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  long2 dest;
+  longlong2 dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.nc.L2::64B.b128 B128_dest, [%2];\n\t"
@@ -3462,11 +3462,11 @@ __device__ static inline B128 ld_global_nc_L2_64B(const B128* addr)
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L2_64B_is_not_supported_before_SM_75__();
-  long2 err_out_var{0, 0};
+  longlong2 err_out_var{0, 0};
   return *reinterpret_cast<B128*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 830
+#endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.nc.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
@@ -3474,7 +3474,7 @@ template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_nc_L2_128B(
   const B8* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L2_128B_is_not_supported_before_SM_75__();
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_nc_L2_128B(const B8* addr)
@@ -3491,7 +3491,7 @@ __device__ static inline B8 ld_global_nc_L2_128B(const B8* addr)
   return *reinterpret_cast<B8*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L2::128B.b16 dest, [addr]; // PTX ISA 74, SM_75
@@ -3499,7 +3499,7 @@ template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L2_128B(
   const B16* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L2_128B_is_not_supported_before_SM_75__();
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L2_128B(const B16* addr)
@@ -3516,7 +3516,7 @@ __device__ static inline B16 ld_global_nc_L2_128B(const B16* addr)
   return *reinterpret_cast<B16*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L2::128B.b32 dest, [addr]; // PTX ISA 74, SM_75
@@ -3524,7 +3524,7 @@ template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L2_128B(
   const B32* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L2_128B_is_not_supported_before_SM_75__();
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L2_128B(const B32* addr)
@@ -3541,7 +3541,7 @@ __device__ static inline B32 ld_global_nc_L2_128B(const B32* addr)
   return *reinterpret_cast<B32*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L2::128B.b64 dest, [addr]; // PTX ISA 74, SM_75
@@ -3549,7 +3549,7 @@ template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L2_128B(
   const B64* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L2_128B_is_not_supported_before_SM_75__();
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L2_128B(const B64* addr)
@@ -3566,7 +3566,7 @@ __device__ static inline B64 ld_global_nc_L2_128B(const B64* addr)
   return *reinterpret_cast<B64*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L2::128B.b128 dest, [addr]; // PTX ISA 83, SM_75
@@ -3574,14 +3574,14 @@ template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L2_128B(
   const B128* addr);
 */
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L2_128B_is_not_supported_before_SM_75__();
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L2_128B(const B128* addr)
 {
   static_assert(sizeof(B128) == 16, "");
 #  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  long2 dest;
+  longlong2 dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.nc.L2::128B.b128 B128_dest, [%2];\n\t"
@@ -3594,11 +3594,11 @@ __device__ static inline B128 ld_global_nc_L2_128B(const B128* addr)
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L2_128B_is_not_supported_before_SM_75__();
-  long2 err_out_var{0, 0};
+  longlong2 err_out_var{0, 0};
   return *reinterpret_cast<B128*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 830
+#endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.nc.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
@@ -3606,7 +3606,7 @@ template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_nc_L2_256B(
   const B8* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L2_256B_is_not_supported_before_SM_80__();
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_nc_L2_256B(const B8* addr)
@@ -3623,7 +3623,7 @@ __device__ static inline B8 ld_global_nc_L2_256B(const B8* addr)
   return *reinterpret_cast<B8*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
@@ -3631,7 +3631,7 @@ template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L2_256B(
   const B16* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L2_256B_is_not_supported_before_SM_80__();
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L2_256B(const B16* addr)
@@ -3648,7 +3648,7 @@ __device__ static inline B16 ld_global_nc_L2_256B(const B16* addr)
   return *reinterpret_cast<B16*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
@@ -3656,7 +3656,7 @@ template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L2_256B(
   const B32* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L2_256B_is_not_supported_before_SM_80__();
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L2_256B(const B32* addr)
@@ -3673,7 +3673,7 @@ __device__ static inline B32 ld_global_nc_L2_256B(const B32* addr)
   return *reinterpret_cast<B32*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L2::256B.b64 dest, [addr]; // PTX ISA 74, SM_80
@@ -3681,7 +3681,7 @@ template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L2_256B(
   const B64* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L2_256B_is_not_supported_before_SM_80__();
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L2_256B(const B64* addr)
@@ -3698,7 +3698,7 @@ __device__ static inline B64 ld_global_nc_L2_256B(const B64* addr)
   return *reinterpret_cast<B64*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L2::256B.b128 dest, [addr]; // PTX ISA 83, SM_80
@@ -3706,14 +3706,14 @@ template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L2_256B(
   const B128* addr);
 */
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L2_256B_is_not_supported_before_SM_80__();
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L2_256B(const B128* addr)
 {
   static_assert(sizeof(B128) == 16, "");
 #  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  long2 dest;
+  longlong2 dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.nc.L2::256B.b128 B128_dest, [%2];\n\t"
@@ -3726,126 +3726,126 @@ __device__ static inline B128 ld_global_nc_L2_256B(const B128* addr)
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L2_256B_is_not_supported_before_SM_80__();
-  long2 err_out_var{0, 0};
+  longlong2 err_out_var{0, 0};
   return *reinterpret_cast<B128*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 830
+#endif // __cccl_ptx_isa >= 830
 
 /*
-// ld.global.nc.L1::evict_normal.b8 dest, [addr]; // PTX ISA 74, SM_75
+// ld.global.nc.L1::evict_normal.b8 dest, [addr]; // PTX ISA 74, SM_70
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_nc_L1_evict_normal(
   const B8* addr);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_normal_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_normal_is_not_supported_before_SM_70__();
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_nc_L1_evict_normal(const B8* addr)
 {
   static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   std::uint32_t dest;
   asm volatile("ld.global.nc.L1::evict_normal.b8 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
   return __u32_as_b8<B8>(dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_global_nc_L1_evict_normal_is_not_supported_before_SM_75__();
+  __cuda_ptx_ld_global_nc_L1_evict_normal_is_not_supported_before_SM_70__();
   std::uint32_t err_out_var = 0;
   return *reinterpret_cast<B8*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// ld.global.nc.L1::evict_normal.b16 dest, [addr]; // PTX ISA 74, SM_75
+// ld.global.nc.L1::evict_normal.b16 dest, [addr]; // PTX ISA 74, SM_70
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_evict_normal(
   const B16* addr);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_normal_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_normal_is_not_supported_before_SM_70__();
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_evict_normal(const B16* addr)
 {
   static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   std::uint16_t dest;
   asm volatile("ld.global.nc.L1::evict_normal.b16 %0, [%1];" : "=h"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
   return *reinterpret_cast<B16*>(&dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_global_nc_L1_evict_normal_is_not_supported_before_SM_75__();
+  __cuda_ptx_ld_global_nc_L1_evict_normal_is_not_supported_before_SM_70__();
   std::uint16_t err_out_var = 0;
   return *reinterpret_cast<B16*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// ld.global.nc.L1::evict_normal.b32 dest, [addr]; // PTX ISA 74, SM_75
+// ld.global.nc.L1::evict_normal.b32 dest, [addr]; // PTX ISA 74, SM_70
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_evict_normal(
   const B32* addr);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_normal_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_normal_is_not_supported_before_SM_70__();
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_evict_normal(const B32* addr)
 {
   static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   std::uint32_t dest;
   asm volatile("ld.global.nc.L1::evict_normal.b32 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
   return *reinterpret_cast<B32*>(&dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_global_nc_L1_evict_normal_is_not_supported_before_SM_75__();
+  __cuda_ptx_ld_global_nc_L1_evict_normal_is_not_supported_before_SM_70__();
   std::uint32_t err_out_var = 0;
   return *reinterpret_cast<B32*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// ld.global.nc.L1::evict_normal.b64 dest, [addr]; // PTX ISA 74, SM_75
+// ld.global.nc.L1::evict_normal.b64 dest, [addr]; // PTX ISA 74, SM_70
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_evict_normal(
   const B64* addr);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_normal_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_normal_is_not_supported_before_SM_70__();
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_evict_normal(const B64* addr)
 {
   static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   std::uint64_t dest;
   asm volatile("ld.global.nc.L1::evict_normal.b64 %0, [%1];" : "=l"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
   return *reinterpret_cast<B64*>(&dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_global_nc_L1_evict_normal_is_not_supported_before_SM_75__();
+  __cuda_ptx_ld_global_nc_L1_evict_normal_is_not_supported_before_SM_70__();
   std::uint64_t err_out_var = 0;
   return *reinterpret_cast<B64*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// ld.global.nc.L1::evict_normal.b128 dest, [addr]; // PTX ISA 83, SM_75
+// ld.global.nc.L1::evict_normal.b128 dest, [addr]; // PTX ISA 83, SM_70
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_evict_normal(
   const B128* addr);
 */
-#if __libcuda_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_normal_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 830
+extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_normal_is_not_supported_before_SM_70__();
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_evict_normal(const B128* addr)
 {
   static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  long2 dest;
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
+  longlong2 dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.nc.L1::evict_normal.b128 B128_dest, [%2];\n\t"
@@ -3857,12 +3857,12 @@ __device__ static inline B128 ld_global_nc_L1_evict_normal(const B128* addr)
   return *reinterpret_cast<B128*>(&dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_global_nc_L1_evict_normal_is_not_supported_before_SM_75__();
-  long2 err_out_var{0, 0};
+  __cuda_ptx_ld_global_nc_L1_evict_normal_is_not_supported_before_SM_70__();
+  longlong2 err_out_var{0, 0};
   return *reinterpret_cast<B128*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 830
+#endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.nc.L1::evict_normal.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
@@ -3870,7 +3870,7 @@ template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_nc_L1_evict_normal_L2_64B(
   const B8* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_nc_L1_evict_normal_L2_64B(const B8* addr)
@@ -3887,7 +3887,7 @@ __device__ static inline B8 ld_global_nc_L1_evict_normal_L2_64B(const B8* addr)
   return *reinterpret_cast<B8*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_normal.L2::64B.b16 dest, [addr]; // PTX ISA 74, SM_75
@@ -3895,7 +3895,7 @@ template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_evict_normal_L2_64B(
   const B16* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_evict_normal_L2_64B(const B16* addr)
@@ -3915,7 +3915,7 @@ __device__ static inline B16 ld_global_nc_L1_evict_normal_L2_64B(const B16* addr
   return *reinterpret_cast<B16*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_normal.L2::64B.b32 dest, [addr]; // PTX ISA 74, SM_75
@@ -3923,7 +3923,7 @@ template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_evict_normal_L2_64B(
   const B32* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_evict_normal_L2_64B(const B32* addr)
@@ -3943,7 +3943,7 @@ __device__ static inline B32 ld_global_nc_L1_evict_normal_L2_64B(const B32* addr
   return *reinterpret_cast<B32*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_normal.L2::64B.b64 dest, [addr]; // PTX ISA 74, SM_75
@@ -3951,7 +3951,7 @@ template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_evict_normal_L2_64B(
   const B64* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_evict_normal_L2_64B(const B64* addr)
@@ -3971,7 +3971,7 @@ __device__ static inline B64 ld_global_nc_L1_evict_normal_L2_64B(const B64* addr
   return *reinterpret_cast<B64*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_normal.L2::64B.b128 dest, [addr]; // PTX ISA 83, SM_75
@@ -3979,14 +3979,14 @@ template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_evict_normal_L2_64B(
   const B128* addr);
 */
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_evict_normal_L2_64B(const B128* addr)
 {
   static_assert(sizeof(B128) == 16, "");
 #  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  long2 dest;
+  longlong2 dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.nc.L1::evict_normal.L2::64B.b128 B128_dest, [%2];\n\t"
@@ -3999,11 +3999,11 @@ __device__ static inline B128 ld_global_nc_L1_evict_normal_L2_64B(const B128* ad
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
-  long2 err_out_var{0, 0};
+  longlong2 err_out_var{0, 0};
   return *reinterpret_cast<B128*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 830
+#endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.nc.L1::evict_normal.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
@@ -4011,7 +4011,7 @@ template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_nc_L1_evict_normal_L2_128B(
   const B8* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_nc_L1_evict_normal_L2_128B(const B8* addr)
@@ -4031,7 +4031,7 @@ __device__ static inline B8 ld_global_nc_L1_evict_normal_L2_128B(const B8* addr)
   return *reinterpret_cast<B8*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_normal.L2::128B.b16 dest, [addr]; // PTX ISA 74, SM_75
@@ -4039,7 +4039,7 @@ template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_evict_normal_L2_128B(
   const B16* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_evict_normal_L2_128B(const B16* addr)
@@ -4059,7 +4059,7 @@ __device__ static inline B16 ld_global_nc_L1_evict_normal_L2_128B(const B16* add
   return *reinterpret_cast<B16*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_normal.L2::128B.b32 dest, [addr]; // PTX ISA 74, SM_75
@@ -4067,7 +4067,7 @@ template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_evict_normal_L2_128B(
   const B32* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_evict_normal_L2_128B(const B32* addr)
@@ -4087,7 +4087,7 @@ __device__ static inline B32 ld_global_nc_L1_evict_normal_L2_128B(const B32* add
   return *reinterpret_cast<B32*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_normal.L2::128B.b64 dest, [addr]; // PTX ISA 74, SM_75
@@ -4095,7 +4095,7 @@ template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_evict_normal_L2_128B(
   const B64* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_evict_normal_L2_128B(const B64* addr)
@@ -4115,7 +4115,7 @@ __device__ static inline B64 ld_global_nc_L1_evict_normal_L2_128B(const B64* add
   return *reinterpret_cast<B64*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_normal.L2::128B.b128 dest, [addr]; // PTX ISA 83, SM_75
@@ -4123,14 +4123,14 @@ template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_evict_normal_L2_128B(
   const B128* addr);
 */
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_evict_normal_L2_128B(const B128* addr)
 {
   static_assert(sizeof(B128) == 16, "");
 #  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  long2 dest;
+  longlong2 dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.nc.L1::evict_normal.L2::128B.b128 B128_dest, [%2];\n\t"
@@ -4143,11 +4143,11 @@ __device__ static inline B128 ld_global_nc_L1_evict_normal_L2_128B(const B128* a
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
-  long2 err_out_var{0, 0};
+  longlong2 err_out_var{0, 0};
   return *reinterpret_cast<B128*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 830
+#endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.nc.L1::evict_normal.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
@@ -4155,7 +4155,7 @@ template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_nc_L1_evict_normal_L2_256B(
   const B8* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_nc_L1_evict_normal_L2_256B(const B8* addr)
@@ -4175,7 +4175,7 @@ __device__ static inline B8 ld_global_nc_L1_evict_normal_L2_256B(const B8* addr)
   return *reinterpret_cast<B8*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_normal.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
@@ -4183,7 +4183,7 @@ template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_evict_normal_L2_256B(
   const B16* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_evict_normal_L2_256B(const B16* addr)
@@ -4203,7 +4203,7 @@ __device__ static inline B16 ld_global_nc_L1_evict_normal_L2_256B(const B16* add
   return *reinterpret_cast<B16*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_normal.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
@@ -4211,7 +4211,7 @@ template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_evict_normal_L2_256B(
   const B32* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_evict_normal_L2_256B(const B32* addr)
@@ -4231,7 +4231,7 @@ __device__ static inline B32 ld_global_nc_L1_evict_normal_L2_256B(const B32* add
   return *reinterpret_cast<B32*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_normal.L2::256B.b64 dest, [addr]; // PTX ISA 74, SM_80
@@ -4239,7 +4239,7 @@ template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_evict_normal_L2_256B(
   const B64* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_evict_normal_L2_256B(const B64* addr)
@@ -4259,7 +4259,7 @@ __device__ static inline B64 ld_global_nc_L1_evict_normal_L2_256B(const B64* add
   return *reinterpret_cast<B64*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_normal.L2::256B.b128 dest, [addr]; // PTX ISA 83, SM_80
@@ -4267,14 +4267,14 @@ template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_evict_normal_L2_256B(
   const B128* addr);
 */
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_evict_normal_L2_256B(const B128* addr)
 {
   static_assert(sizeof(B128) == 16, "");
 #  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  long2 dest;
+  longlong2 dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.nc.L1::evict_normal.L2::256B.b128 B128_dest, [%2];\n\t"
@@ -4287,126 +4287,126 @@ __device__ static inline B128 ld_global_nc_L1_evict_normal_L2_256B(const B128* a
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
-  long2 err_out_var{0, 0};
+  longlong2 err_out_var{0, 0};
   return *reinterpret_cast<B128*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 830
+#endif // __cccl_ptx_isa >= 830
 
 /*
-// ld.global.nc.L1::evict_unchanged.b8 dest, [addr]; // PTX ISA 74, SM_75
+// ld.global.nc.L1::evict_unchanged.b8 dest, [addr]; // PTX ISA 74, SM_70
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_nc_L1_evict_unchanged(
   const B8* addr);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_unchanged_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_unchanged_is_not_supported_before_SM_70__();
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_nc_L1_evict_unchanged(const B8* addr)
 {
   static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   std::uint32_t dest;
   asm volatile("ld.global.nc.L1::evict_unchanged.b8 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
   return __u32_as_b8<B8>(dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_global_nc_L1_evict_unchanged_is_not_supported_before_SM_75__();
+  __cuda_ptx_ld_global_nc_L1_evict_unchanged_is_not_supported_before_SM_70__();
   std::uint32_t err_out_var = 0;
   return *reinterpret_cast<B8*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// ld.global.nc.L1::evict_unchanged.b16 dest, [addr]; // PTX ISA 74, SM_75
+// ld.global.nc.L1::evict_unchanged.b16 dest, [addr]; // PTX ISA 74, SM_70
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_evict_unchanged(
   const B16* addr);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_unchanged_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_unchanged_is_not_supported_before_SM_70__();
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_evict_unchanged(const B16* addr)
 {
   static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   std::uint16_t dest;
   asm volatile("ld.global.nc.L1::evict_unchanged.b16 %0, [%1];" : "=h"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
   return *reinterpret_cast<B16*>(&dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_global_nc_L1_evict_unchanged_is_not_supported_before_SM_75__();
+  __cuda_ptx_ld_global_nc_L1_evict_unchanged_is_not_supported_before_SM_70__();
   std::uint16_t err_out_var = 0;
   return *reinterpret_cast<B16*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// ld.global.nc.L1::evict_unchanged.b32 dest, [addr]; // PTX ISA 74, SM_75
+// ld.global.nc.L1::evict_unchanged.b32 dest, [addr]; // PTX ISA 74, SM_70
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_evict_unchanged(
   const B32* addr);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_unchanged_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_unchanged_is_not_supported_before_SM_70__();
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_evict_unchanged(const B32* addr)
 {
   static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   std::uint32_t dest;
   asm volatile("ld.global.nc.L1::evict_unchanged.b32 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
   return *reinterpret_cast<B32*>(&dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_global_nc_L1_evict_unchanged_is_not_supported_before_SM_75__();
+  __cuda_ptx_ld_global_nc_L1_evict_unchanged_is_not_supported_before_SM_70__();
   std::uint32_t err_out_var = 0;
   return *reinterpret_cast<B32*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// ld.global.nc.L1::evict_unchanged.b64 dest, [addr]; // PTX ISA 74, SM_75
+// ld.global.nc.L1::evict_unchanged.b64 dest, [addr]; // PTX ISA 74, SM_70
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_evict_unchanged(
   const B64* addr);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_unchanged_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_unchanged_is_not_supported_before_SM_70__();
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_evict_unchanged(const B64* addr)
 {
   static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   std::uint64_t dest;
   asm volatile("ld.global.nc.L1::evict_unchanged.b64 %0, [%1];" : "=l"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
   return *reinterpret_cast<B64*>(&dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_global_nc_L1_evict_unchanged_is_not_supported_before_SM_75__();
+  __cuda_ptx_ld_global_nc_L1_evict_unchanged_is_not_supported_before_SM_70__();
   std::uint64_t err_out_var = 0;
   return *reinterpret_cast<B64*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// ld.global.nc.L1::evict_unchanged.b128 dest, [addr]; // PTX ISA 83, SM_75
+// ld.global.nc.L1::evict_unchanged.b128 dest, [addr]; // PTX ISA 83, SM_70
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_evict_unchanged(
   const B128* addr);
 */
-#if __libcuda_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_unchanged_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 830
+extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_unchanged_is_not_supported_before_SM_70__();
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_evict_unchanged(const B128* addr)
 {
   static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  long2 dest;
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
+  longlong2 dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.nc.L1::evict_unchanged.b128 B128_dest, [%2];\n\t"
@@ -4418,12 +4418,12 @@ __device__ static inline B128 ld_global_nc_L1_evict_unchanged(const B128* addr)
   return *reinterpret_cast<B128*>(&dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_global_nc_L1_evict_unchanged_is_not_supported_before_SM_75__();
-  long2 err_out_var{0, 0};
+  __cuda_ptx_ld_global_nc_L1_evict_unchanged_is_not_supported_before_SM_70__();
+  longlong2 err_out_var{0, 0};
   return *reinterpret_cast<B128*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 830
+#endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.nc.L1::evict_unchanged.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
@@ -4431,7 +4431,7 @@ template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_nc_L1_evict_unchanged_L2_64B(
   const B8* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_nc_L1_evict_unchanged_L2_64B(const B8* addr)
@@ -4451,7 +4451,7 @@ __device__ static inline B8 ld_global_nc_L1_evict_unchanged_L2_64B(const B8* add
   return *reinterpret_cast<B8*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_unchanged.L2::64B.b16 dest, [addr]; // PTX ISA 74, SM_75
@@ -4459,7 +4459,7 @@ template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_evict_unchanged_L2_64B(
   const B16* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_evict_unchanged_L2_64B(const B16* addr)
@@ -4479,7 +4479,7 @@ __device__ static inline B16 ld_global_nc_L1_evict_unchanged_L2_64B(const B16* a
   return *reinterpret_cast<B16*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_unchanged.L2::64B.b32 dest, [addr]; // PTX ISA 74, SM_75
@@ -4487,7 +4487,7 @@ template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_evict_unchanged_L2_64B(
   const B32* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_evict_unchanged_L2_64B(const B32* addr)
@@ -4507,7 +4507,7 @@ __device__ static inline B32 ld_global_nc_L1_evict_unchanged_L2_64B(const B32* a
   return *reinterpret_cast<B32*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_unchanged.L2::64B.b64 dest, [addr]; // PTX ISA 74, SM_75
@@ -4515,7 +4515,7 @@ template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_evict_unchanged_L2_64B(
   const B64* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_evict_unchanged_L2_64B(const B64* addr)
@@ -4535,7 +4535,7 @@ __device__ static inline B64 ld_global_nc_L1_evict_unchanged_L2_64B(const B64* a
   return *reinterpret_cast<B64*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_unchanged.L2::64B.b128 dest, [addr]; // PTX ISA 83, SM_75
@@ -4543,14 +4543,14 @@ template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_evict_unchanged_L2_64B(
   const B128* addr);
 */
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_evict_unchanged_L2_64B(const B128* addr)
 {
   static_assert(sizeof(B128) == 16, "");
 #  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  long2 dest;
+  longlong2 dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.nc.L1::evict_unchanged.L2::64B.b128 B128_dest, [%2];\n\t"
@@ -4563,11 +4563,11 @@ __device__ static inline B128 ld_global_nc_L1_evict_unchanged_L2_64B(const B128*
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
-  long2 err_out_var{0, 0};
+  longlong2 err_out_var{0, 0};
   return *reinterpret_cast<B128*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 830
+#endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.nc.L1::evict_unchanged.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
@@ -4575,7 +4575,7 @@ template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_nc_L1_evict_unchanged_L2_128B(
   const B8* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_nc_L1_evict_unchanged_L2_128B(const B8* addr)
@@ -4595,7 +4595,7 @@ __device__ static inline B8 ld_global_nc_L1_evict_unchanged_L2_128B(const B8* ad
   return *reinterpret_cast<B8*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_unchanged.L2::128B.b16 dest, [addr]; // PTX ISA 74, SM_75
@@ -4603,7 +4603,7 @@ template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_evict_unchanged_L2_128B(
   const B16* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_evict_unchanged_L2_128B(const B16* addr)
@@ -4623,7 +4623,7 @@ __device__ static inline B16 ld_global_nc_L1_evict_unchanged_L2_128B(const B16* 
   return *reinterpret_cast<B16*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_unchanged.L2::128B.b32 dest, [addr]; // PTX ISA 74, SM_75
@@ -4631,7 +4631,7 @@ template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_evict_unchanged_L2_128B(
   const B32* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_evict_unchanged_L2_128B(const B32* addr)
@@ -4651,7 +4651,7 @@ __device__ static inline B32 ld_global_nc_L1_evict_unchanged_L2_128B(const B32* 
   return *reinterpret_cast<B32*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_unchanged.L2::128B.b64 dest, [addr]; // PTX ISA 74, SM_75
@@ -4659,7 +4659,7 @@ template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_evict_unchanged_L2_128B(
   const B64* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_evict_unchanged_L2_128B(const B64* addr)
@@ -4679,7 +4679,7 @@ __device__ static inline B64 ld_global_nc_L1_evict_unchanged_L2_128B(const B64* 
   return *reinterpret_cast<B64*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_unchanged.L2::128B.b128 dest, [addr]; // PTX ISA 83, SM_75
@@ -4687,14 +4687,14 @@ template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_evict_unchanged_L2_128B(
   const B128* addr);
 */
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_evict_unchanged_L2_128B(const B128* addr)
 {
   static_assert(sizeof(B128) == 16, "");
 #  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  long2 dest;
+  longlong2 dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.nc.L1::evict_unchanged.L2::128B.b128 B128_dest, [%2];\n\t"
@@ -4707,11 +4707,11 @@ __device__ static inline B128 ld_global_nc_L1_evict_unchanged_L2_128B(const B128
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
-  long2 err_out_var{0, 0};
+  longlong2 err_out_var{0, 0};
   return *reinterpret_cast<B128*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 830
+#endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.nc.L1::evict_unchanged.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
@@ -4719,7 +4719,7 @@ template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_nc_L1_evict_unchanged_L2_256B(
   const B8* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_nc_L1_evict_unchanged_L2_256B(const B8* addr)
@@ -4739,7 +4739,7 @@ __device__ static inline B8 ld_global_nc_L1_evict_unchanged_L2_256B(const B8* ad
   return *reinterpret_cast<B8*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_unchanged.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
@@ -4747,7 +4747,7 @@ template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_evict_unchanged_L2_256B(
   const B16* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_evict_unchanged_L2_256B(const B16* addr)
@@ -4767,7 +4767,7 @@ __device__ static inline B16 ld_global_nc_L1_evict_unchanged_L2_256B(const B16* 
   return *reinterpret_cast<B16*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_unchanged.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
@@ -4775,7 +4775,7 @@ template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_evict_unchanged_L2_256B(
   const B32* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_evict_unchanged_L2_256B(const B32* addr)
@@ -4795,7 +4795,7 @@ __device__ static inline B32 ld_global_nc_L1_evict_unchanged_L2_256B(const B32* 
   return *reinterpret_cast<B32*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_unchanged.L2::256B.b64 dest, [addr]; // PTX ISA 74, SM_80
@@ -4803,7 +4803,7 @@ template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_evict_unchanged_L2_256B(
   const B64* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_evict_unchanged_L2_256B(const B64* addr)
@@ -4823,7 +4823,7 @@ __device__ static inline B64 ld_global_nc_L1_evict_unchanged_L2_256B(const B64* 
   return *reinterpret_cast<B64*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_unchanged.L2::256B.b128 dest, [addr]; // PTX ISA 83, SM_80
@@ -4831,14 +4831,14 @@ template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_evict_unchanged_L2_256B(
   const B128* addr);
 */
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_evict_unchanged_L2_256B(const B128* addr)
 {
   static_assert(sizeof(B128) == 16, "");
 #  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  long2 dest;
+  longlong2 dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.nc.L1::evict_unchanged.L2::256B.b128 B128_dest, [%2];\n\t"
@@ -4851,126 +4851,126 @@ __device__ static inline B128 ld_global_nc_L1_evict_unchanged_L2_256B(const B128
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
-  long2 err_out_var{0, 0};
+  longlong2 err_out_var{0, 0};
   return *reinterpret_cast<B128*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 830
+#endif // __cccl_ptx_isa >= 830
 
 /*
-// ld.global.nc.L1::evict_first.b8 dest, [addr]; // PTX ISA 74, SM_75
+// ld.global.nc.L1::evict_first.b8 dest, [addr]; // PTX ISA 74, SM_70
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_nc_L1_evict_first(
   const B8* addr);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_first_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_first_is_not_supported_before_SM_70__();
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_nc_L1_evict_first(const B8* addr)
 {
   static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   std::uint32_t dest;
   asm volatile("ld.global.nc.L1::evict_first.b8 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
   return __u32_as_b8<B8>(dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_global_nc_L1_evict_first_is_not_supported_before_SM_75__();
+  __cuda_ptx_ld_global_nc_L1_evict_first_is_not_supported_before_SM_70__();
   std::uint32_t err_out_var = 0;
   return *reinterpret_cast<B8*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// ld.global.nc.L1::evict_first.b16 dest, [addr]; // PTX ISA 74, SM_75
+// ld.global.nc.L1::evict_first.b16 dest, [addr]; // PTX ISA 74, SM_70
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_evict_first(
   const B16* addr);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_first_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_first_is_not_supported_before_SM_70__();
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_evict_first(const B16* addr)
 {
   static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   std::uint16_t dest;
   asm volatile("ld.global.nc.L1::evict_first.b16 %0, [%1];" : "=h"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
   return *reinterpret_cast<B16*>(&dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_global_nc_L1_evict_first_is_not_supported_before_SM_75__();
+  __cuda_ptx_ld_global_nc_L1_evict_first_is_not_supported_before_SM_70__();
   std::uint16_t err_out_var = 0;
   return *reinterpret_cast<B16*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// ld.global.nc.L1::evict_first.b32 dest, [addr]; // PTX ISA 74, SM_75
+// ld.global.nc.L1::evict_first.b32 dest, [addr]; // PTX ISA 74, SM_70
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_evict_first(
   const B32* addr);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_first_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_first_is_not_supported_before_SM_70__();
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_evict_first(const B32* addr)
 {
   static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   std::uint32_t dest;
   asm volatile("ld.global.nc.L1::evict_first.b32 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
   return *reinterpret_cast<B32*>(&dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_global_nc_L1_evict_first_is_not_supported_before_SM_75__();
+  __cuda_ptx_ld_global_nc_L1_evict_first_is_not_supported_before_SM_70__();
   std::uint32_t err_out_var = 0;
   return *reinterpret_cast<B32*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// ld.global.nc.L1::evict_first.b64 dest, [addr]; // PTX ISA 74, SM_75
+// ld.global.nc.L1::evict_first.b64 dest, [addr]; // PTX ISA 74, SM_70
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_evict_first(
   const B64* addr);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_first_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_first_is_not_supported_before_SM_70__();
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_evict_first(const B64* addr)
 {
   static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   std::uint64_t dest;
   asm volatile("ld.global.nc.L1::evict_first.b64 %0, [%1];" : "=l"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
   return *reinterpret_cast<B64*>(&dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_global_nc_L1_evict_first_is_not_supported_before_SM_75__();
+  __cuda_ptx_ld_global_nc_L1_evict_first_is_not_supported_before_SM_70__();
   std::uint64_t err_out_var = 0;
   return *reinterpret_cast<B64*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// ld.global.nc.L1::evict_first.b128 dest, [addr]; // PTX ISA 83, SM_75
+// ld.global.nc.L1::evict_first.b128 dest, [addr]; // PTX ISA 83, SM_70
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_evict_first(
   const B128* addr);
 */
-#if __libcuda_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_first_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 830
+extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_first_is_not_supported_before_SM_70__();
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_evict_first(const B128* addr)
 {
   static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  long2 dest;
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
+  longlong2 dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.nc.L1::evict_first.b128 B128_dest, [%2];\n\t"
@@ -4982,12 +4982,12 @@ __device__ static inline B128 ld_global_nc_L1_evict_first(const B128* addr)
   return *reinterpret_cast<B128*>(&dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_global_nc_L1_evict_first_is_not_supported_before_SM_75__();
-  long2 err_out_var{0, 0};
+  __cuda_ptx_ld_global_nc_L1_evict_first_is_not_supported_before_SM_70__();
+  longlong2 err_out_var{0, 0};
   return *reinterpret_cast<B128*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 830
+#endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.nc.L1::evict_first.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
@@ -4995,7 +4995,7 @@ template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_nc_L1_evict_first_L2_64B(
   const B8* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_nc_L1_evict_first_L2_64B(const B8* addr)
@@ -5012,7 +5012,7 @@ __device__ static inline B8 ld_global_nc_L1_evict_first_L2_64B(const B8* addr)
   return *reinterpret_cast<B8*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_first.L2::64B.b16 dest, [addr]; // PTX ISA 74, SM_75
@@ -5020,7 +5020,7 @@ template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_evict_first_L2_64B(
   const B16* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_evict_first_L2_64B(const B16* addr)
@@ -5037,7 +5037,7 @@ __device__ static inline B16 ld_global_nc_L1_evict_first_L2_64B(const B16* addr)
   return *reinterpret_cast<B16*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_first.L2::64B.b32 dest, [addr]; // PTX ISA 74, SM_75
@@ -5045,7 +5045,7 @@ template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_evict_first_L2_64B(
   const B32* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_evict_first_L2_64B(const B32* addr)
@@ -5062,7 +5062,7 @@ __device__ static inline B32 ld_global_nc_L1_evict_first_L2_64B(const B32* addr)
   return *reinterpret_cast<B32*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_first.L2::64B.b64 dest, [addr]; // PTX ISA 74, SM_75
@@ -5070,7 +5070,7 @@ template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_evict_first_L2_64B(
   const B64* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_evict_first_L2_64B(const B64* addr)
@@ -5087,7 +5087,7 @@ __device__ static inline B64 ld_global_nc_L1_evict_first_L2_64B(const B64* addr)
   return *reinterpret_cast<B64*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_first.L2::64B.b128 dest, [addr]; // PTX ISA 83, SM_75
@@ -5095,14 +5095,14 @@ template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_evict_first_L2_64B(
   const B128* addr);
 */
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_evict_first_L2_64B(const B128* addr)
 {
   static_assert(sizeof(B128) == 16, "");
 #  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  long2 dest;
+  longlong2 dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.nc.L1::evict_first.L2::64B.b128 B128_dest, [%2];\n\t"
@@ -5115,11 +5115,11 @@ __device__ static inline B128 ld_global_nc_L1_evict_first_L2_64B(const B128* add
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
-  long2 err_out_var{0, 0};
+  longlong2 err_out_var{0, 0};
   return *reinterpret_cast<B128*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 830
+#endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.nc.L1::evict_first.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
@@ -5127,7 +5127,7 @@ template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_nc_L1_evict_first_L2_128B(
   const B8* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_nc_L1_evict_first_L2_128B(const B8* addr)
@@ -5144,7 +5144,7 @@ __device__ static inline B8 ld_global_nc_L1_evict_first_L2_128B(const B8* addr)
   return *reinterpret_cast<B8*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_first.L2::128B.b16 dest, [addr]; // PTX ISA 74, SM_75
@@ -5152,7 +5152,7 @@ template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_evict_first_L2_128B(
   const B16* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_evict_first_L2_128B(const B16* addr)
@@ -5172,7 +5172,7 @@ __device__ static inline B16 ld_global_nc_L1_evict_first_L2_128B(const B16* addr
   return *reinterpret_cast<B16*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_first.L2::128B.b32 dest, [addr]; // PTX ISA 74, SM_75
@@ -5180,7 +5180,7 @@ template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_evict_first_L2_128B(
   const B32* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_evict_first_L2_128B(const B32* addr)
@@ -5200,7 +5200,7 @@ __device__ static inline B32 ld_global_nc_L1_evict_first_L2_128B(const B32* addr
   return *reinterpret_cast<B32*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_first.L2::128B.b64 dest, [addr]; // PTX ISA 74, SM_75
@@ -5208,7 +5208,7 @@ template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_evict_first_L2_128B(
   const B64* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_evict_first_L2_128B(const B64* addr)
@@ -5228,7 +5228,7 @@ __device__ static inline B64 ld_global_nc_L1_evict_first_L2_128B(const B64* addr
   return *reinterpret_cast<B64*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_first.L2::128B.b128 dest, [addr]; // PTX ISA 83, SM_75
@@ -5236,14 +5236,14 @@ template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_evict_first_L2_128B(
   const B128* addr);
 */
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_evict_first_L2_128B(const B128* addr)
 {
   static_assert(sizeof(B128) == 16, "");
 #  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  long2 dest;
+  longlong2 dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.nc.L1::evict_first.L2::128B.b128 B128_dest, [%2];\n\t"
@@ -5256,11 +5256,11 @@ __device__ static inline B128 ld_global_nc_L1_evict_first_L2_128B(const B128* ad
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
-  long2 err_out_var{0, 0};
+  longlong2 err_out_var{0, 0};
   return *reinterpret_cast<B128*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 830
+#endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.nc.L1::evict_first.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
@@ -5268,7 +5268,7 @@ template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_nc_L1_evict_first_L2_256B(
   const B8* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_nc_L1_evict_first_L2_256B(const B8* addr)
@@ -5285,7 +5285,7 @@ __device__ static inline B8 ld_global_nc_L1_evict_first_L2_256B(const B8* addr)
   return *reinterpret_cast<B8*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_first.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
@@ -5293,7 +5293,7 @@ template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_evict_first_L2_256B(
   const B16* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_evict_first_L2_256B(const B16* addr)
@@ -5313,7 +5313,7 @@ __device__ static inline B16 ld_global_nc_L1_evict_first_L2_256B(const B16* addr
   return *reinterpret_cast<B16*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_first.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
@@ -5321,7 +5321,7 @@ template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_evict_first_L2_256B(
   const B32* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_evict_first_L2_256B(const B32* addr)
@@ -5341,7 +5341,7 @@ __device__ static inline B32 ld_global_nc_L1_evict_first_L2_256B(const B32* addr
   return *reinterpret_cast<B32*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_first.L2::256B.b64 dest, [addr]; // PTX ISA 74, SM_80
@@ -5349,7 +5349,7 @@ template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_evict_first_L2_256B(
   const B64* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_evict_first_L2_256B(const B64* addr)
@@ -5369,7 +5369,7 @@ __device__ static inline B64 ld_global_nc_L1_evict_first_L2_256B(const B64* addr
   return *reinterpret_cast<B64*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_first.L2::256B.b128 dest, [addr]; // PTX ISA 83, SM_80
@@ -5377,14 +5377,14 @@ template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_evict_first_L2_256B(
   const B128* addr);
 */
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_evict_first_L2_256B(const B128* addr)
 {
   static_assert(sizeof(B128) == 16, "");
 #  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  long2 dest;
+  longlong2 dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.nc.L1::evict_first.L2::256B.b128 B128_dest, [%2];\n\t"
@@ -5397,126 +5397,126 @@ __device__ static inline B128 ld_global_nc_L1_evict_first_L2_256B(const B128* ad
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
-  long2 err_out_var{0, 0};
+  longlong2 err_out_var{0, 0};
   return *reinterpret_cast<B128*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 830
+#endif // __cccl_ptx_isa >= 830
 
 /*
-// ld.global.nc.L1::evict_last.b8 dest, [addr]; // PTX ISA 74, SM_75
+// ld.global.nc.L1::evict_last.b8 dest, [addr]; // PTX ISA 74, SM_70
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_nc_L1_evict_last(
   const B8* addr);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_last_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_last_is_not_supported_before_SM_70__();
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_nc_L1_evict_last(const B8* addr)
 {
   static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   std::uint32_t dest;
   asm volatile("ld.global.nc.L1::evict_last.b8 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
   return __u32_as_b8<B8>(dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_global_nc_L1_evict_last_is_not_supported_before_SM_75__();
+  __cuda_ptx_ld_global_nc_L1_evict_last_is_not_supported_before_SM_70__();
   std::uint32_t err_out_var = 0;
   return *reinterpret_cast<B8*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// ld.global.nc.L1::evict_last.b16 dest, [addr]; // PTX ISA 74, SM_75
+// ld.global.nc.L1::evict_last.b16 dest, [addr]; // PTX ISA 74, SM_70
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_evict_last(
   const B16* addr);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_last_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_last_is_not_supported_before_SM_70__();
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_evict_last(const B16* addr)
 {
   static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   std::uint16_t dest;
   asm volatile("ld.global.nc.L1::evict_last.b16 %0, [%1];" : "=h"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
   return *reinterpret_cast<B16*>(&dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_global_nc_L1_evict_last_is_not_supported_before_SM_75__();
+  __cuda_ptx_ld_global_nc_L1_evict_last_is_not_supported_before_SM_70__();
   std::uint16_t err_out_var = 0;
   return *reinterpret_cast<B16*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// ld.global.nc.L1::evict_last.b32 dest, [addr]; // PTX ISA 74, SM_75
+// ld.global.nc.L1::evict_last.b32 dest, [addr]; // PTX ISA 74, SM_70
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_evict_last(
   const B32* addr);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_last_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_last_is_not_supported_before_SM_70__();
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_evict_last(const B32* addr)
 {
   static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   std::uint32_t dest;
   asm volatile("ld.global.nc.L1::evict_last.b32 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
   return *reinterpret_cast<B32*>(&dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_global_nc_L1_evict_last_is_not_supported_before_SM_75__();
+  __cuda_ptx_ld_global_nc_L1_evict_last_is_not_supported_before_SM_70__();
   std::uint32_t err_out_var = 0;
   return *reinterpret_cast<B32*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// ld.global.nc.L1::evict_last.b64 dest, [addr]; // PTX ISA 74, SM_75
+// ld.global.nc.L1::evict_last.b64 dest, [addr]; // PTX ISA 74, SM_70
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_evict_last(
   const B64* addr);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_last_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_last_is_not_supported_before_SM_70__();
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_evict_last(const B64* addr)
 {
   static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   std::uint64_t dest;
   asm volatile("ld.global.nc.L1::evict_last.b64 %0, [%1];" : "=l"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
   return *reinterpret_cast<B64*>(&dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_global_nc_L1_evict_last_is_not_supported_before_SM_75__();
+  __cuda_ptx_ld_global_nc_L1_evict_last_is_not_supported_before_SM_70__();
   std::uint64_t err_out_var = 0;
   return *reinterpret_cast<B64*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// ld.global.nc.L1::evict_last.b128 dest, [addr]; // PTX ISA 83, SM_75
+// ld.global.nc.L1::evict_last.b128 dest, [addr]; // PTX ISA 83, SM_70
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_evict_last(
   const B128* addr);
 */
-#if __libcuda_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_last_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 830
+extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_last_is_not_supported_before_SM_70__();
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_evict_last(const B128* addr)
 {
   static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  long2 dest;
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
+  longlong2 dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.nc.L1::evict_last.b128 B128_dest, [%2];\n\t"
@@ -5528,12 +5528,12 @@ __device__ static inline B128 ld_global_nc_L1_evict_last(const B128* addr)
   return *reinterpret_cast<B128*>(&dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_global_nc_L1_evict_last_is_not_supported_before_SM_75__();
-  long2 err_out_var{0, 0};
+  __cuda_ptx_ld_global_nc_L1_evict_last_is_not_supported_before_SM_70__();
+  longlong2 err_out_var{0, 0};
   return *reinterpret_cast<B128*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 830
+#endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.nc.L1::evict_last.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
@@ -5541,7 +5541,7 @@ template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_nc_L1_evict_last_L2_64B(
   const B8* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_nc_L1_evict_last_L2_64B(const B8* addr)
@@ -5558,7 +5558,7 @@ __device__ static inline B8 ld_global_nc_L1_evict_last_L2_64B(const B8* addr)
   return *reinterpret_cast<B8*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_last.L2::64B.b16 dest, [addr]; // PTX ISA 74, SM_75
@@ -5566,7 +5566,7 @@ template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_evict_last_L2_64B(
   const B16* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_evict_last_L2_64B(const B16* addr)
@@ -5583,7 +5583,7 @@ __device__ static inline B16 ld_global_nc_L1_evict_last_L2_64B(const B16* addr)
   return *reinterpret_cast<B16*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_last.L2::64B.b32 dest, [addr]; // PTX ISA 74, SM_75
@@ -5591,7 +5591,7 @@ template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_evict_last_L2_64B(
   const B32* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_evict_last_L2_64B(const B32* addr)
@@ -5608,7 +5608,7 @@ __device__ static inline B32 ld_global_nc_L1_evict_last_L2_64B(const B32* addr)
   return *reinterpret_cast<B32*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_last.L2::64B.b64 dest, [addr]; // PTX ISA 74, SM_75
@@ -5616,7 +5616,7 @@ template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_evict_last_L2_64B(
   const B64* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_evict_last_L2_64B(const B64* addr)
@@ -5633,7 +5633,7 @@ __device__ static inline B64 ld_global_nc_L1_evict_last_L2_64B(const B64* addr)
   return *reinterpret_cast<B64*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_last.L2::64B.b128 dest, [addr]; // PTX ISA 83, SM_75
@@ -5641,14 +5641,14 @@ template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_evict_last_L2_64B(
   const B128* addr);
 */
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_evict_last_L2_64B(const B128* addr)
 {
   static_assert(sizeof(B128) == 16, "");
 #  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  long2 dest;
+  longlong2 dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.nc.L1::evict_last.L2::64B.b128 B128_dest, [%2];\n\t"
@@ -5661,11 +5661,11 @@ __device__ static inline B128 ld_global_nc_L1_evict_last_L2_64B(const B128* addr
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
-  long2 err_out_var{0, 0};
+  longlong2 err_out_var{0, 0};
   return *reinterpret_cast<B128*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 830
+#endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.nc.L1::evict_last.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
@@ -5673,7 +5673,7 @@ template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_nc_L1_evict_last_L2_128B(
   const B8* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_nc_L1_evict_last_L2_128B(const B8* addr)
@@ -5690,7 +5690,7 @@ __device__ static inline B8 ld_global_nc_L1_evict_last_L2_128B(const B8* addr)
   return *reinterpret_cast<B8*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_last.L2::128B.b16 dest, [addr]; // PTX ISA 74, SM_75
@@ -5698,7 +5698,7 @@ template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_evict_last_L2_128B(
   const B16* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_evict_last_L2_128B(const B16* addr)
@@ -5715,7 +5715,7 @@ __device__ static inline B16 ld_global_nc_L1_evict_last_L2_128B(const B16* addr)
   return *reinterpret_cast<B16*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_last.L2::128B.b32 dest, [addr]; // PTX ISA 74, SM_75
@@ -5723,7 +5723,7 @@ template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_evict_last_L2_128B(
   const B32* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_evict_last_L2_128B(const B32* addr)
@@ -5740,7 +5740,7 @@ __device__ static inline B32 ld_global_nc_L1_evict_last_L2_128B(const B32* addr)
   return *reinterpret_cast<B32*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_last.L2::128B.b64 dest, [addr]; // PTX ISA 74, SM_75
@@ -5748,7 +5748,7 @@ template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_evict_last_L2_128B(
   const B64* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_evict_last_L2_128B(const B64* addr)
@@ -5765,7 +5765,7 @@ __device__ static inline B64 ld_global_nc_L1_evict_last_L2_128B(const B64* addr)
   return *reinterpret_cast<B64*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_last.L2::128B.b128 dest, [addr]; // PTX ISA 83, SM_75
@@ -5773,14 +5773,14 @@ template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_evict_last_L2_128B(
   const B128* addr);
 */
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_evict_last_L2_128B(const B128* addr)
 {
   static_assert(sizeof(B128) == 16, "");
 #  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  long2 dest;
+  longlong2 dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.nc.L1::evict_last.L2::128B.b128 B128_dest, [%2];\n\t"
@@ -5793,11 +5793,11 @@ __device__ static inline B128 ld_global_nc_L1_evict_last_L2_128B(const B128* add
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
-  long2 err_out_var{0, 0};
+  longlong2 err_out_var{0, 0};
   return *reinterpret_cast<B128*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 830
+#endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.nc.L1::evict_last.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
@@ -5805,7 +5805,7 @@ template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_nc_L1_evict_last_L2_256B(
   const B8* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_nc_L1_evict_last_L2_256B(const B8* addr)
@@ -5822,7 +5822,7 @@ __device__ static inline B8 ld_global_nc_L1_evict_last_L2_256B(const B8* addr)
   return *reinterpret_cast<B8*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_last.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
@@ -5830,7 +5830,7 @@ template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_evict_last_L2_256B(
   const B16* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_evict_last_L2_256B(const B16* addr)
@@ -5847,7 +5847,7 @@ __device__ static inline B16 ld_global_nc_L1_evict_last_L2_256B(const B16* addr)
   return *reinterpret_cast<B16*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_last.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
@@ -5855,7 +5855,7 @@ template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_evict_last_L2_256B(
   const B32* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_evict_last_L2_256B(const B32* addr)
@@ -5872,7 +5872,7 @@ __device__ static inline B32 ld_global_nc_L1_evict_last_L2_256B(const B32* addr)
   return *reinterpret_cast<B32*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_last.L2::256B.b64 dest, [addr]; // PTX ISA 74, SM_80
@@ -5880,7 +5880,7 @@ template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_evict_last_L2_256B(
   const B64* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_evict_last_L2_256B(const B64* addr)
@@ -5897,7 +5897,7 @@ __device__ static inline B64 ld_global_nc_L1_evict_last_L2_256B(const B64* addr)
   return *reinterpret_cast<B64*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::evict_last.L2::256B.b128 dest, [addr]; // PTX ISA 83, SM_80
@@ -5905,14 +5905,14 @@ template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_evict_last_L2_256B(
   const B128* addr);
 */
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_evict_last_L2_256B(const B128* addr)
 {
   static_assert(sizeof(B128) == 16, "");
 #  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  long2 dest;
+  longlong2 dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.nc.L1::evict_last.L2::256B.b128 B128_dest, [%2];\n\t"
@@ -5925,126 +5925,126 @@ __device__ static inline B128 ld_global_nc_L1_evict_last_L2_256B(const B128* add
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
-  long2 err_out_var{0, 0};
+  longlong2 err_out_var{0, 0};
   return *reinterpret_cast<B128*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 830
+#endif // __cccl_ptx_isa >= 830
 
 /*
-// ld.global.nc.L1::no_allocate.b8 dest, [addr]; // PTX ISA 74, SM_75
+// ld.global.nc.L1::no_allocate.b8 dest, [addr]; // PTX ISA 74, SM_70
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_nc_L1_no_allocate(
   const B8* addr);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_no_allocate_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_no_allocate_is_not_supported_before_SM_70__();
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_nc_L1_no_allocate(const B8* addr)
 {
   static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   std::uint32_t dest;
   asm volatile("ld.global.nc.L1::no_allocate.b8 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
   return __u32_as_b8<B8>(dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_global_nc_L1_no_allocate_is_not_supported_before_SM_75__();
+  __cuda_ptx_ld_global_nc_L1_no_allocate_is_not_supported_before_SM_70__();
   std::uint32_t err_out_var = 0;
   return *reinterpret_cast<B8*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// ld.global.nc.L1::no_allocate.b16 dest, [addr]; // PTX ISA 74, SM_75
+// ld.global.nc.L1::no_allocate.b16 dest, [addr]; // PTX ISA 74, SM_70
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_no_allocate(
   const B16* addr);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_no_allocate_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_no_allocate_is_not_supported_before_SM_70__();
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_no_allocate(const B16* addr)
 {
   static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   std::uint16_t dest;
   asm volatile("ld.global.nc.L1::no_allocate.b16 %0, [%1];" : "=h"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
   return *reinterpret_cast<B16*>(&dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_global_nc_L1_no_allocate_is_not_supported_before_SM_75__();
+  __cuda_ptx_ld_global_nc_L1_no_allocate_is_not_supported_before_SM_70__();
   std::uint16_t err_out_var = 0;
   return *reinterpret_cast<B16*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// ld.global.nc.L1::no_allocate.b32 dest, [addr]; // PTX ISA 74, SM_75
+// ld.global.nc.L1::no_allocate.b32 dest, [addr]; // PTX ISA 74, SM_70
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_no_allocate(
   const B32* addr);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_no_allocate_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_no_allocate_is_not_supported_before_SM_70__();
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_no_allocate(const B32* addr)
 {
   static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   std::uint32_t dest;
   asm volatile("ld.global.nc.L1::no_allocate.b32 %0, [%1];" : "=r"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
   return *reinterpret_cast<B32*>(&dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_global_nc_L1_no_allocate_is_not_supported_before_SM_75__();
+  __cuda_ptx_ld_global_nc_L1_no_allocate_is_not_supported_before_SM_70__();
   std::uint32_t err_out_var = 0;
   return *reinterpret_cast<B32*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// ld.global.nc.L1::no_allocate.b64 dest, [addr]; // PTX ISA 74, SM_75
+// ld.global.nc.L1::no_allocate.b64 dest, [addr]; // PTX ISA 74, SM_70
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_no_allocate(
   const B64* addr);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_no_allocate_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_no_allocate_is_not_supported_before_SM_70__();
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_no_allocate(const B64* addr)
 {
   static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   std::uint64_t dest;
   asm volatile("ld.global.nc.L1::no_allocate.b64 %0, [%1];" : "=l"(dest) : "l"(__as_ptr_gmem(addr)) : "memory");
   return *reinterpret_cast<B64*>(&dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_global_nc_L1_no_allocate_is_not_supported_before_SM_75__();
+  __cuda_ptx_ld_global_nc_L1_no_allocate_is_not_supported_before_SM_70__();
   std::uint64_t err_out_var = 0;
   return *reinterpret_cast<B64*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// ld.global.nc.L1::no_allocate.b128 dest, [addr]; // PTX ISA 83, SM_75
+// ld.global.nc.L1::no_allocate.b128 dest, [addr]; // PTX ISA 83, SM_70
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_no_allocate(
   const B128* addr);
 */
-#if __libcuda_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_no_allocate_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 830
+extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_no_allocate_is_not_supported_before_SM_70__();
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_no_allocate(const B128* addr)
 {
   static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  long2 dest;
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
+  longlong2 dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.nc.L1::no_allocate.b128 B128_dest, [%2];\n\t"
@@ -6056,12 +6056,12 @@ __device__ static inline B128 ld_global_nc_L1_no_allocate(const B128* addr)
   return *reinterpret_cast<B128*>(&dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_global_nc_L1_no_allocate_is_not_supported_before_SM_75__();
-  long2 err_out_var{0, 0};
+  __cuda_ptx_ld_global_nc_L1_no_allocate_is_not_supported_before_SM_70__();
+  longlong2 err_out_var{0, 0};
   return *reinterpret_cast<B128*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 830
+#endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.nc.L1::no_allocate.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
@@ -6069,7 +6069,7 @@ template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_nc_L1_no_allocate_L2_64B(
   const B8* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_nc_L1_no_allocate_L2_64B(const B8* addr)
@@ -6086,7 +6086,7 @@ __device__ static inline B8 ld_global_nc_L1_no_allocate_L2_64B(const B8* addr)
   return *reinterpret_cast<B8*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::no_allocate.L2::64B.b16 dest, [addr]; // PTX ISA 74, SM_75
@@ -6094,7 +6094,7 @@ template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_no_allocate_L2_64B(
   const B16* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_no_allocate_L2_64B(const B16* addr)
@@ -6111,7 +6111,7 @@ __device__ static inline B16 ld_global_nc_L1_no_allocate_L2_64B(const B16* addr)
   return *reinterpret_cast<B16*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::no_allocate.L2::64B.b32 dest, [addr]; // PTX ISA 74, SM_75
@@ -6119,7 +6119,7 @@ template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_no_allocate_L2_64B(
   const B32* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_no_allocate_L2_64B(const B32* addr)
@@ -6136,7 +6136,7 @@ __device__ static inline B32 ld_global_nc_L1_no_allocate_L2_64B(const B32* addr)
   return *reinterpret_cast<B32*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::no_allocate.L2::64B.b64 dest, [addr]; // PTX ISA 74, SM_75
@@ -6144,7 +6144,7 @@ template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_no_allocate_L2_64B(
   const B64* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_no_allocate_L2_64B(const B64* addr)
@@ -6161,7 +6161,7 @@ __device__ static inline B64 ld_global_nc_L1_no_allocate_L2_64B(const B64* addr)
   return *reinterpret_cast<B64*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::no_allocate.L2::64B.b128 dest, [addr]; // PTX ISA 83, SM_75
@@ -6169,14 +6169,14 @@ template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_no_allocate_L2_64B(
   const B128* addr);
 */
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_no_allocate_L2_64B(const B128* addr)
 {
   static_assert(sizeof(B128) == 16, "");
 #  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  long2 dest;
+  longlong2 dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.nc.L1::no_allocate.L2::64B.b128 B128_dest, [%2];\n\t"
@@ -6189,11 +6189,11 @@ __device__ static inline B128 ld_global_nc_L1_no_allocate_L2_64B(const B128* add
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
-  long2 err_out_var{0, 0};
+  longlong2 err_out_var{0, 0};
   return *reinterpret_cast<B128*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 830
+#endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.nc.L1::no_allocate.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
@@ -6201,7 +6201,7 @@ template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_nc_L1_no_allocate_L2_128B(
   const B8* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_nc_L1_no_allocate_L2_128B(const B8* addr)
@@ -6218,7 +6218,7 @@ __device__ static inline B8 ld_global_nc_L1_no_allocate_L2_128B(const B8* addr)
   return *reinterpret_cast<B8*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::no_allocate.L2::128B.b16 dest, [addr]; // PTX ISA 74, SM_75
@@ -6226,7 +6226,7 @@ template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_no_allocate_L2_128B(
   const B16* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_no_allocate_L2_128B(const B16* addr)
@@ -6246,7 +6246,7 @@ __device__ static inline B16 ld_global_nc_L1_no_allocate_L2_128B(const B16* addr
   return *reinterpret_cast<B16*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::no_allocate.L2::128B.b32 dest, [addr]; // PTX ISA 74, SM_75
@@ -6254,7 +6254,7 @@ template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_no_allocate_L2_128B(
   const B32* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_no_allocate_L2_128B(const B32* addr)
@@ -6274,7 +6274,7 @@ __device__ static inline B32 ld_global_nc_L1_no_allocate_L2_128B(const B32* addr
   return *reinterpret_cast<B32*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::no_allocate.L2::128B.b64 dest, [addr]; // PTX ISA 74, SM_75
@@ -6282,7 +6282,7 @@ template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_no_allocate_L2_128B(
   const B64* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_no_allocate_L2_128B(const B64* addr)
@@ -6302,7 +6302,7 @@ __device__ static inline B64 ld_global_nc_L1_no_allocate_L2_128B(const B64* addr
   return *reinterpret_cast<B64*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::no_allocate.L2::128B.b128 dest, [addr]; // PTX ISA 83, SM_75
@@ -6310,14 +6310,14 @@ template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_no_allocate_L2_128B(
   const B128* addr);
 */
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_no_allocate_L2_128B(const B128* addr)
 {
   static_assert(sizeof(B128) == 16, "");
 #  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
-  long2 dest;
+  longlong2 dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.nc.L1::no_allocate.L2::128B.b128 B128_dest, [%2];\n\t"
@@ -6330,11 +6330,11 @@ __device__ static inline B128 ld_global_nc_L1_no_allocate_L2_128B(const B128* ad
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
-  long2 err_out_var{0, 0};
+  longlong2 err_out_var{0, 0};
   return *reinterpret_cast<B128*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 830
+#endif // __cccl_ptx_isa >= 830
 
 /*
 // ld.global.nc.L1::no_allocate.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
@@ -6342,7 +6342,7 @@ template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_nc_L1_no_allocate_L2_256B(
   const B8* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline B8 ld_global_nc_L1_no_allocate_L2_256B(const B8* addr)
@@ -6359,7 +6359,7 @@ __device__ static inline B8 ld_global_nc_L1_no_allocate_L2_256B(const B8* addr)
   return *reinterpret_cast<B8*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::no_allocate.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
@@ -6367,7 +6367,7 @@ template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_no_allocate_L2_256B(
   const B16* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline B16 ld_global_nc_L1_no_allocate_L2_256B(const B16* addr)
@@ -6387,7 +6387,7 @@ __device__ static inline B16 ld_global_nc_L1_no_allocate_L2_256B(const B16* addr
   return *reinterpret_cast<B16*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::no_allocate.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
@@ -6395,7 +6395,7 @@ template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_no_allocate_L2_256B(
   const B32* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline B32 ld_global_nc_L1_no_allocate_L2_256B(const B32* addr)
@@ -6415,7 +6415,7 @@ __device__ static inline B32 ld_global_nc_L1_no_allocate_L2_256B(const B32* addr
   return *reinterpret_cast<B32*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::no_allocate.L2::256B.b64 dest, [addr]; // PTX ISA 74, SM_80
@@ -6423,7 +6423,7 @@ template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_no_allocate_L2_256B(
   const B64* addr);
 */
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline B64 ld_global_nc_L1_no_allocate_L2_256B(const B64* addr)
@@ -6443,7 +6443,7 @@ __device__ static inline B64 ld_global_nc_L1_no_allocate_L2_256B(const B64* addr
   return *reinterpret_cast<B64*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.global.nc.L1::no_allocate.L2::256B.b128 dest, [addr]; // PTX ISA 83, SM_80
@@ -6451,14 +6451,14 @@ template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_no_allocate_L2_256B(
   const B128* addr);
 */
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
 extern "C" __device__ void __cuda_ptx_ld_global_nc_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline B128 ld_global_nc_L1_no_allocate_L2_256B(const B128* addr)
 {
   static_assert(sizeof(B128) == 16, "");
 #  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 800
-  long2 dest;
+  longlong2 dest;
   asm volatile(
     "{\n\t .reg .b128 B128_dest; \n\t"
     "ld.global.nc.L1::no_allocate.L2::256B.b128 B128_dest, [%2];\n\t"
@@ -6471,10 +6471,10 @@ __device__ static inline B128 ld_global_nc_L1_no_allocate_L2_256B(const B128* ad
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_global_nc_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
-  long2 err_out_var{0, 0};
+  longlong2 err_out_var{0, 0};
   return *reinterpret_cast<B128*>(&err_out_var);
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 830
+#endif // __cccl_ptx_isa >= 830
 
-} // namespace cuda_ptx
+#endif // _CUDA_PTX_GENERATED_INSTRUCTIONS_LD_H

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/st.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/st.h
@@ -1,7 +1,7 @@
 // This file was automatically generated. Do not edit.
 
-namespace cuda_ptx
-{
+#ifndef _CUDA_PTX_GENERATED_INSTRUCTIONS_ST_H
+#define _CUDA_PTX_GENERATED_INSTRUCTIONS_ST_H
 
 /*
 // st.global.b8 [addr], src; // PTX ISA 10, SM_50
@@ -10,7 +10,7 @@ __device__ static inline void st_global(
   B8* addr,
   B8 src);
 */
-#if __libcuda_ptx_isa >= 100
+#if __cccl_ptx_isa >= 100
 extern "C" __device__ void __cuda_ptx_st_global_is_not_supported_before_SM_50__();
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline void st_global(B8* addr, B8 src)
@@ -23,7 +23,7 @@ __device__ static inline void st_global(B8* addr, B8 src)
   __cuda_ptx_st_global_is_not_supported_before_SM_50__();
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 100
+#endif // __cccl_ptx_isa >= 100
 
 /*
 // st.global.b16 [addr], src; // PTX ISA 10, SM_50
@@ -32,7 +32,7 @@ __device__ static inline void st_global(
   B16* addr,
   B16 src);
 */
-#if __libcuda_ptx_isa >= 100
+#if __cccl_ptx_isa >= 100
 extern "C" __device__ void __cuda_ptx_st_global_is_not_supported_before_SM_50__();
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline void st_global(B16* addr, B16 src)
@@ -48,7 +48,7 @@ __device__ static inline void st_global(B16* addr, B16 src)
   __cuda_ptx_st_global_is_not_supported_before_SM_50__();
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 100
+#endif // __cccl_ptx_isa >= 100
 
 /*
 // st.global.b32 [addr], src; // PTX ISA 10, SM_50
@@ -57,7 +57,7 @@ __device__ static inline void st_global(
   B32* addr,
   B32 src);
 */
-#if __libcuda_ptx_isa >= 100
+#if __cccl_ptx_isa >= 100
 extern "C" __device__ void __cuda_ptx_st_global_is_not_supported_before_SM_50__();
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void st_global(B32* addr, B32 src)
@@ -73,7 +73,7 @@ __device__ static inline void st_global(B32* addr, B32 src)
   __cuda_ptx_st_global_is_not_supported_before_SM_50__();
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 100
+#endif // __cccl_ptx_isa >= 100
 
 /*
 // st.global.b64 [addr], src; // PTX ISA 10, SM_50
@@ -82,7 +82,7 @@ __device__ static inline void st_global(
   B64* addr,
   B64 src);
 */
-#if __libcuda_ptx_isa >= 100
+#if __cccl_ptx_isa >= 100
 extern "C" __device__ void __cuda_ptx_st_global_is_not_supported_before_SM_50__();
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline void st_global(B64* addr, B64 src)
@@ -98,7 +98,7 @@ __device__ static inline void st_global(B64* addr, B64 src)
   __cuda_ptx_st_global_is_not_supported_before_SM_50__();
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 100
+#endif // __cccl_ptx_isa >= 100
 
 /*
 // st.global.b128 [addr], src; // PTX ISA 83, SM_70
@@ -107,7 +107,7 @@ __device__ static inline void st_global(
   B128* addr,
   B128 src);
 */
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
 extern "C" __device__ void __cuda_ptx_st_global_is_not_supported_before_SM_70__();
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline void st_global(B128* addr, B128 src)
@@ -120,649 +120,661 @@ __device__ static inline void st_global(B128* addr, B128 src)
     "st.global.b128 [%0], B128_src;\n\t"
     "}"
     :
-    : "l"(__as_ptr_gmem(addr)), "l"((*reinterpret_cast<long2*>(&src)).x), "l"((*reinterpret_cast<long2*>(&src)).y)
+    : "l"(__as_ptr_gmem(addr)),
+      "l"((*reinterpret_cast<longlong2*>(&src)).x),
+      "l"((*reinterpret_cast<longlong2*>(&src)).y)
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_st_global_is_not_supported_before_SM_70__();
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 830
+#endif // __cccl_ptx_isa >= 830
 
 /*
-// st.global.L1::evict_normal.b8 [addr], src; // PTX ISA 74, SM_75
+// st.global.L1::evict_normal.b8 [addr], src; // PTX ISA 74, SM_70
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline void st_global_L1_evict_normal(
   B8* addr,
   B8 src);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_st_global_L1_evict_normal_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_st_global_L1_evict_normal_is_not_supported_before_SM_70__();
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline void st_global_L1_evict_normal(B8* addr, B8 src)
 {
   static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   asm volatile("st.global.L1::evict_normal.b8 [%0], %1;"
                :
                : "l"(__as_ptr_gmem(addr)), "r"(__b8_as_u32(src))
                : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_st_global_L1_evict_normal_is_not_supported_before_SM_75__();
+  __cuda_ptx_st_global_L1_evict_normal_is_not_supported_before_SM_70__();
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// st.global.L1::evict_normal.b16 [addr], src; // PTX ISA 74, SM_75
+// st.global.L1::evict_normal.b16 [addr], src; // PTX ISA 74, SM_70
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline void st_global_L1_evict_normal(
   B16* addr,
   B16 src);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_st_global_L1_evict_normal_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_st_global_L1_evict_normal_is_not_supported_before_SM_70__();
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline void st_global_L1_evict_normal(B16* addr, B16 src)
 {
   static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   asm volatile("st.global.L1::evict_normal.b16 [%0], %1;"
                :
                : "l"(__as_ptr_gmem(addr)), "h"(/*as_b16*/ *reinterpret_cast<const std::int16_t*>(&src))
                : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_st_global_L1_evict_normal_is_not_supported_before_SM_75__();
+  __cuda_ptx_st_global_L1_evict_normal_is_not_supported_before_SM_70__();
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// st.global.L1::evict_normal.b32 [addr], src; // PTX ISA 74, SM_75
+// st.global.L1::evict_normal.b32 [addr], src; // PTX ISA 74, SM_70
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void st_global_L1_evict_normal(
   B32* addr,
   B32 src);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_st_global_L1_evict_normal_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_st_global_L1_evict_normal_is_not_supported_before_SM_70__();
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void st_global_L1_evict_normal(B32* addr, B32 src)
 {
   static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   asm volatile("st.global.L1::evict_normal.b32 [%0], %1;"
                :
                : "l"(__as_ptr_gmem(addr)), "r"(/*as_b32*/ *reinterpret_cast<const std::int32_t*>(&src))
                : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_st_global_L1_evict_normal_is_not_supported_before_SM_75__();
+  __cuda_ptx_st_global_L1_evict_normal_is_not_supported_before_SM_70__();
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// st.global.L1::evict_normal.b64 [addr], src; // PTX ISA 74, SM_75
+// st.global.L1::evict_normal.b64 [addr], src; // PTX ISA 74, SM_70
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline void st_global_L1_evict_normal(
   B64* addr,
   B64 src);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_st_global_L1_evict_normal_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_st_global_L1_evict_normal_is_not_supported_before_SM_70__();
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline void st_global_L1_evict_normal(B64* addr, B64 src)
 {
   static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   asm volatile("st.global.L1::evict_normal.b64 [%0], %1;"
                :
                : "l"(__as_ptr_gmem(addr)), "l"(/*as_b64*/ *reinterpret_cast<const std::int64_t*>(&src))
                : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_st_global_L1_evict_normal_is_not_supported_before_SM_75__();
+  __cuda_ptx_st_global_L1_evict_normal_is_not_supported_before_SM_70__();
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// st.global.L1::evict_normal.b128 [addr], src; // PTX ISA 83, SM_75
+// st.global.L1::evict_normal.b128 [addr], src; // PTX ISA 83, SM_70
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline void st_global_L1_evict_normal(
   B128* addr,
   B128 src);
 */
-#if __libcuda_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_st_global_L1_evict_normal_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 830
+extern "C" __device__ void __cuda_ptx_st_global_L1_evict_normal_is_not_supported_before_SM_70__();
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline void st_global_L1_evict_normal(B128* addr, B128 src)
 {
   static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   asm volatile(
     "{\n\t .reg .b128 B128_src; \n\t"
     "mov.b128 B128_src, {%1, %2}; \n"
     "st.global.L1::evict_normal.b128 [%0], B128_src;\n\t"
     "}"
     :
-    : "l"(__as_ptr_gmem(addr)), "l"((*reinterpret_cast<long2*>(&src)).x), "l"((*reinterpret_cast<long2*>(&src)).y)
+    : "l"(__as_ptr_gmem(addr)),
+      "l"((*reinterpret_cast<longlong2*>(&src)).x),
+      "l"((*reinterpret_cast<longlong2*>(&src)).y)
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_st_global_L1_evict_normal_is_not_supported_before_SM_75__();
+  __cuda_ptx_st_global_L1_evict_normal_is_not_supported_before_SM_70__();
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 830
+#endif // __cccl_ptx_isa >= 830
 
 /*
-// st.global.L1::evict_unchanged.b8 [addr], src; // PTX ISA 74, SM_75
+// st.global.L1::evict_unchanged.b8 [addr], src; // PTX ISA 74, SM_70
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline void st_global_L1_evict_unchanged(
   B8* addr,
   B8 src);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_st_global_L1_evict_unchanged_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_st_global_L1_evict_unchanged_is_not_supported_before_SM_70__();
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline void st_global_L1_evict_unchanged(B8* addr, B8 src)
 {
   static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   asm volatile("st.global.L1::evict_unchanged.b8 [%0], %1;"
                :
                : "l"(__as_ptr_gmem(addr)), "r"(__b8_as_u32(src))
                : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_st_global_L1_evict_unchanged_is_not_supported_before_SM_75__();
+  __cuda_ptx_st_global_L1_evict_unchanged_is_not_supported_before_SM_70__();
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// st.global.L1::evict_unchanged.b16 [addr], src; // PTX ISA 74, SM_75
+// st.global.L1::evict_unchanged.b16 [addr], src; // PTX ISA 74, SM_70
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline void st_global_L1_evict_unchanged(
   B16* addr,
   B16 src);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_st_global_L1_evict_unchanged_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_st_global_L1_evict_unchanged_is_not_supported_before_SM_70__();
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline void st_global_L1_evict_unchanged(B16* addr, B16 src)
 {
   static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   asm volatile("st.global.L1::evict_unchanged.b16 [%0], %1;"
                :
                : "l"(__as_ptr_gmem(addr)), "h"(/*as_b16*/ *reinterpret_cast<const std::int16_t*>(&src))
                : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_st_global_L1_evict_unchanged_is_not_supported_before_SM_75__();
+  __cuda_ptx_st_global_L1_evict_unchanged_is_not_supported_before_SM_70__();
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// st.global.L1::evict_unchanged.b32 [addr], src; // PTX ISA 74, SM_75
+// st.global.L1::evict_unchanged.b32 [addr], src; // PTX ISA 74, SM_70
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void st_global_L1_evict_unchanged(
   B32* addr,
   B32 src);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_st_global_L1_evict_unchanged_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_st_global_L1_evict_unchanged_is_not_supported_before_SM_70__();
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void st_global_L1_evict_unchanged(B32* addr, B32 src)
 {
   static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   asm volatile("st.global.L1::evict_unchanged.b32 [%0], %1;"
                :
                : "l"(__as_ptr_gmem(addr)), "r"(/*as_b32*/ *reinterpret_cast<const std::int32_t*>(&src))
                : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_st_global_L1_evict_unchanged_is_not_supported_before_SM_75__();
+  __cuda_ptx_st_global_L1_evict_unchanged_is_not_supported_before_SM_70__();
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// st.global.L1::evict_unchanged.b64 [addr], src; // PTX ISA 74, SM_75
+// st.global.L1::evict_unchanged.b64 [addr], src; // PTX ISA 74, SM_70
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline void st_global_L1_evict_unchanged(
   B64* addr,
   B64 src);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_st_global_L1_evict_unchanged_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_st_global_L1_evict_unchanged_is_not_supported_before_SM_70__();
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline void st_global_L1_evict_unchanged(B64* addr, B64 src)
 {
   static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   asm volatile("st.global.L1::evict_unchanged.b64 [%0], %1;"
                :
                : "l"(__as_ptr_gmem(addr)), "l"(/*as_b64*/ *reinterpret_cast<const std::int64_t*>(&src))
                : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_st_global_L1_evict_unchanged_is_not_supported_before_SM_75__();
+  __cuda_ptx_st_global_L1_evict_unchanged_is_not_supported_before_SM_70__();
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// st.global.L1::evict_unchanged.b128 [addr], src; // PTX ISA 83, SM_75
+// st.global.L1::evict_unchanged.b128 [addr], src; // PTX ISA 83, SM_70
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline void st_global_L1_evict_unchanged(
   B128* addr,
   B128 src);
 */
-#if __libcuda_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_st_global_L1_evict_unchanged_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 830
+extern "C" __device__ void __cuda_ptx_st_global_L1_evict_unchanged_is_not_supported_before_SM_70__();
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline void st_global_L1_evict_unchanged(B128* addr, B128 src)
 {
   static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   asm volatile(
     "{\n\t .reg .b128 B128_src; \n\t"
     "mov.b128 B128_src, {%1, %2}; \n"
     "st.global.L1::evict_unchanged.b128 [%0], B128_src;\n\t"
     "}"
     :
-    : "l"(__as_ptr_gmem(addr)), "l"((*reinterpret_cast<long2*>(&src)).x), "l"((*reinterpret_cast<long2*>(&src)).y)
+    : "l"(__as_ptr_gmem(addr)),
+      "l"((*reinterpret_cast<longlong2*>(&src)).x),
+      "l"((*reinterpret_cast<longlong2*>(&src)).y)
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_st_global_L1_evict_unchanged_is_not_supported_before_SM_75__();
+  __cuda_ptx_st_global_L1_evict_unchanged_is_not_supported_before_SM_70__();
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 830
+#endif // __cccl_ptx_isa >= 830
 
 /*
-// st.global.L1::evict_first.b8 [addr], src; // PTX ISA 74, SM_75
+// st.global.L1::evict_first.b8 [addr], src; // PTX ISA 74, SM_70
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline void st_global_L1_evict_first(
   B8* addr,
   B8 src);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_st_global_L1_evict_first_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_st_global_L1_evict_first_is_not_supported_before_SM_70__();
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline void st_global_L1_evict_first(B8* addr, B8 src)
 {
   static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   asm volatile("st.global.L1::evict_first.b8 [%0], %1;" : : "l"(__as_ptr_gmem(addr)), "r"(__b8_as_u32(src)) : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_st_global_L1_evict_first_is_not_supported_before_SM_75__();
+  __cuda_ptx_st_global_L1_evict_first_is_not_supported_before_SM_70__();
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// st.global.L1::evict_first.b16 [addr], src; // PTX ISA 74, SM_75
+// st.global.L1::evict_first.b16 [addr], src; // PTX ISA 74, SM_70
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline void st_global_L1_evict_first(
   B16* addr,
   B16 src);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_st_global_L1_evict_first_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_st_global_L1_evict_first_is_not_supported_before_SM_70__();
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline void st_global_L1_evict_first(B16* addr, B16 src)
 {
   static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   asm volatile("st.global.L1::evict_first.b16 [%0], %1;"
                :
                : "l"(__as_ptr_gmem(addr)), "h"(/*as_b16*/ *reinterpret_cast<const std::int16_t*>(&src))
                : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_st_global_L1_evict_first_is_not_supported_before_SM_75__();
+  __cuda_ptx_st_global_L1_evict_first_is_not_supported_before_SM_70__();
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// st.global.L1::evict_first.b32 [addr], src; // PTX ISA 74, SM_75
+// st.global.L1::evict_first.b32 [addr], src; // PTX ISA 74, SM_70
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void st_global_L1_evict_first(
   B32* addr,
   B32 src);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_st_global_L1_evict_first_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_st_global_L1_evict_first_is_not_supported_before_SM_70__();
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void st_global_L1_evict_first(B32* addr, B32 src)
 {
   static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   asm volatile("st.global.L1::evict_first.b32 [%0], %1;"
                :
                : "l"(__as_ptr_gmem(addr)), "r"(/*as_b32*/ *reinterpret_cast<const std::int32_t*>(&src))
                : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_st_global_L1_evict_first_is_not_supported_before_SM_75__();
+  __cuda_ptx_st_global_L1_evict_first_is_not_supported_before_SM_70__();
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// st.global.L1::evict_first.b64 [addr], src; // PTX ISA 74, SM_75
+// st.global.L1::evict_first.b64 [addr], src; // PTX ISA 74, SM_70
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline void st_global_L1_evict_first(
   B64* addr,
   B64 src);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_st_global_L1_evict_first_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_st_global_L1_evict_first_is_not_supported_before_SM_70__();
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline void st_global_L1_evict_first(B64* addr, B64 src)
 {
   static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   asm volatile("st.global.L1::evict_first.b64 [%0], %1;"
                :
                : "l"(__as_ptr_gmem(addr)), "l"(/*as_b64*/ *reinterpret_cast<const std::int64_t*>(&src))
                : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_st_global_L1_evict_first_is_not_supported_before_SM_75__();
+  __cuda_ptx_st_global_L1_evict_first_is_not_supported_before_SM_70__();
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// st.global.L1::evict_first.b128 [addr], src; // PTX ISA 83, SM_75
+// st.global.L1::evict_first.b128 [addr], src; // PTX ISA 83, SM_70
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline void st_global_L1_evict_first(
   B128* addr,
   B128 src);
 */
-#if __libcuda_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_st_global_L1_evict_first_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 830
+extern "C" __device__ void __cuda_ptx_st_global_L1_evict_first_is_not_supported_before_SM_70__();
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline void st_global_L1_evict_first(B128* addr, B128 src)
 {
   static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   asm volatile(
     "{\n\t .reg .b128 B128_src; \n\t"
     "mov.b128 B128_src, {%1, %2}; \n"
     "st.global.L1::evict_first.b128 [%0], B128_src;\n\t"
     "}"
     :
-    : "l"(__as_ptr_gmem(addr)), "l"((*reinterpret_cast<long2*>(&src)).x), "l"((*reinterpret_cast<long2*>(&src)).y)
+    : "l"(__as_ptr_gmem(addr)),
+      "l"((*reinterpret_cast<longlong2*>(&src)).x),
+      "l"((*reinterpret_cast<longlong2*>(&src)).y)
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_st_global_L1_evict_first_is_not_supported_before_SM_75__();
+  __cuda_ptx_st_global_L1_evict_first_is_not_supported_before_SM_70__();
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 830
+#endif // __cccl_ptx_isa >= 830
 
 /*
-// st.global.L1::evict_last.b8 [addr], src; // PTX ISA 74, SM_75
+// st.global.L1::evict_last.b8 [addr], src; // PTX ISA 74, SM_70
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline void st_global_L1_evict_last(
   B8* addr,
   B8 src);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_st_global_L1_evict_last_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_st_global_L1_evict_last_is_not_supported_before_SM_70__();
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline void st_global_L1_evict_last(B8* addr, B8 src)
 {
   static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   asm volatile("st.global.L1::evict_last.b8 [%0], %1;" : : "l"(__as_ptr_gmem(addr)), "r"(__b8_as_u32(src)) : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_st_global_L1_evict_last_is_not_supported_before_SM_75__();
+  __cuda_ptx_st_global_L1_evict_last_is_not_supported_before_SM_70__();
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// st.global.L1::evict_last.b16 [addr], src; // PTX ISA 74, SM_75
+// st.global.L1::evict_last.b16 [addr], src; // PTX ISA 74, SM_70
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline void st_global_L1_evict_last(
   B16* addr,
   B16 src);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_st_global_L1_evict_last_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_st_global_L1_evict_last_is_not_supported_before_SM_70__();
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline void st_global_L1_evict_last(B16* addr, B16 src)
 {
   static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   asm volatile("st.global.L1::evict_last.b16 [%0], %1;"
                :
                : "l"(__as_ptr_gmem(addr)), "h"(/*as_b16*/ *reinterpret_cast<const std::int16_t*>(&src))
                : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_st_global_L1_evict_last_is_not_supported_before_SM_75__();
+  __cuda_ptx_st_global_L1_evict_last_is_not_supported_before_SM_70__();
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// st.global.L1::evict_last.b32 [addr], src; // PTX ISA 74, SM_75
+// st.global.L1::evict_last.b32 [addr], src; // PTX ISA 74, SM_70
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void st_global_L1_evict_last(
   B32* addr,
   B32 src);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_st_global_L1_evict_last_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_st_global_L1_evict_last_is_not_supported_before_SM_70__();
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void st_global_L1_evict_last(B32* addr, B32 src)
 {
   static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   asm volatile("st.global.L1::evict_last.b32 [%0], %1;"
                :
                : "l"(__as_ptr_gmem(addr)), "r"(/*as_b32*/ *reinterpret_cast<const std::int32_t*>(&src))
                : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_st_global_L1_evict_last_is_not_supported_before_SM_75__();
+  __cuda_ptx_st_global_L1_evict_last_is_not_supported_before_SM_70__();
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// st.global.L1::evict_last.b64 [addr], src; // PTX ISA 74, SM_75
+// st.global.L1::evict_last.b64 [addr], src; // PTX ISA 74, SM_70
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline void st_global_L1_evict_last(
   B64* addr,
   B64 src);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_st_global_L1_evict_last_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_st_global_L1_evict_last_is_not_supported_before_SM_70__();
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline void st_global_L1_evict_last(B64* addr, B64 src)
 {
   static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   asm volatile("st.global.L1::evict_last.b64 [%0], %1;"
                :
                : "l"(__as_ptr_gmem(addr)), "l"(/*as_b64*/ *reinterpret_cast<const std::int64_t*>(&src))
                : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_st_global_L1_evict_last_is_not_supported_before_SM_75__();
+  __cuda_ptx_st_global_L1_evict_last_is_not_supported_before_SM_70__();
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// st.global.L1::evict_last.b128 [addr], src; // PTX ISA 83, SM_75
+// st.global.L1::evict_last.b128 [addr], src; // PTX ISA 83, SM_70
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline void st_global_L1_evict_last(
   B128* addr,
   B128 src);
 */
-#if __libcuda_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_st_global_L1_evict_last_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 830
+extern "C" __device__ void __cuda_ptx_st_global_L1_evict_last_is_not_supported_before_SM_70__();
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline void st_global_L1_evict_last(B128* addr, B128 src)
 {
   static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   asm volatile(
     "{\n\t .reg .b128 B128_src; \n\t"
     "mov.b128 B128_src, {%1, %2}; \n"
     "st.global.L1::evict_last.b128 [%0], B128_src;\n\t"
     "}"
     :
-    : "l"(__as_ptr_gmem(addr)), "l"((*reinterpret_cast<long2*>(&src)).x), "l"((*reinterpret_cast<long2*>(&src)).y)
+    : "l"(__as_ptr_gmem(addr)),
+      "l"((*reinterpret_cast<longlong2*>(&src)).x),
+      "l"((*reinterpret_cast<longlong2*>(&src)).y)
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_st_global_L1_evict_last_is_not_supported_before_SM_75__();
+  __cuda_ptx_st_global_L1_evict_last_is_not_supported_before_SM_70__();
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 830
+#endif // __cccl_ptx_isa >= 830
 
 /*
-// st.global.L1::no_allocate.b8 [addr], src; // PTX ISA 74, SM_75
+// st.global.L1::no_allocate.b8 [addr], src; // PTX ISA 74, SM_70
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline void st_global_L1_no_allocate(
   B8* addr,
   B8 src);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_st_global_L1_no_allocate_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_st_global_L1_no_allocate_is_not_supported_before_SM_70__();
 template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline void st_global_L1_no_allocate(B8* addr, B8 src)
 {
   static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   asm volatile("st.global.L1::no_allocate.b8 [%0], %1;" : : "l"(__as_ptr_gmem(addr)), "r"(__b8_as_u32(src)) : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_st_global_L1_no_allocate_is_not_supported_before_SM_75__();
+  __cuda_ptx_st_global_L1_no_allocate_is_not_supported_before_SM_70__();
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// st.global.L1::no_allocate.b16 [addr], src; // PTX ISA 74, SM_75
+// st.global.L1::no_allocate.b16 [addr], src; // PTX ISA 74, SM_70
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline void st_global_L1_no_allocate(
   B16* addr,
   B16 src);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_st_global_L1_no_allocate_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_st_global_L1_no_allocate_is_not_supported_before_SM_70__();
 template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline void st_global_L1_no_allocate(B16* addr, B16 src)
 {
   static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   asm volatile("st.global.L1::no_allocate.b16 [%0], %1;"
                :
                : "l"(__as_ptr_gmem(addr)), "h"(/*as_b16*/ *reinterpret_cast<const std::int16_t*>(&src))
                : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_st_global_L1_no_allocate_is_not_supported_before_SM_75__();
+  __cuda_ptx_st_global_L1_no_allocate_is_not_supported_before_SM_70__();
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// st.global.L1::no_allocate.b32 [addr], src; // PTX ISA 74, SM_75
+// st.global.L1::no_allocate.b32 [addr], src; // PTX ISA 74, SM_70
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void st_global_L1_no_allocate(
   B32* addr,
   B32 src);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_st_global_L1_no_allocate_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_st_global_L1_no_allocate_is_not_supported_before_SM_70__();
 template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void st_global_L1_no_allocate(B32* addr, B32 src)
 {
   static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   asm volatile("st.global.L1::no_allocate.b32 [%0], %1;"
                :
                : "l"(__as_ptr_gmem(addr)), "r"(/*as_b32*/ *reinterpret_cast<const std::int32_t*>(&src))
                : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_st_global_L1_no_allocate_is_not_supported_before_SM_75__();
+  __cuda_ptx_st_global_L1_no_allocate_is_not_supported_before_SM_70__();
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// st.global.L1::no_allocate.b64 [addr], src; // PTX ISA 74, SM_75
+// st.global.L1::no_allocate.b64 [addr], src; // PTX ISA 74, SM_70
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline void st_global_L1_no_allocate(
   B64* addr,
   B64 src);
 */
-#if __libcuda_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_st_global_L1_no_allocate_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 740
+extern "C" __device__ void __cuda_ptx_st_global_L1_no_allocate_is_not_supported_before_SM_70__();
 template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline void st_global_L1_no_allocate(B64* addr, B64 src)
 {
   static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   asm volatile("st.global.L1::no_allocate.b64 [%0], %1;"
                :
                : "l"(__as_ptr_gmem(addr)), "l"(/*as_b64*/ *reinterpret_cast<const std::int64_t*>(&src))
                : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_st_global_L1_no_allocate_is_not_supported_before_SM_75__();
+  __cuda_ptx_st_global_L1_no_allocate_is_not_supported_before_SM_70__();
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 740
+#endif // __cccl_ptx_isa >= 740
 
 /*
-// st.global.L1::no_allocate.b128 [addr], src; // PTX ISA 83, SM_75
+// st.global.L1::no_allocate.b128 [addr], src; // PTX ISA 83, SM_70
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline void st_global_L1_no_allocate(
   B128* addr,
   B128 src);
 */
-#if __libcuda_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_st_global_L1_no_allocate_is_not_supported_before_SM_75__();
+#if __cccl_ptx_isa >= 830
+extern "C" __device__ void __cuda_ptx_st_global_L1_no_allocate_is_not_supported_before_SM_70__();
 template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline void st_global_L1_no_allocate(B128* addr, B128 src)
 {
   static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 750
+#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
   asm volatile(
     "{\n\t .reg .b128 B128_src; \n\t"
     "mov.b128 B128_src, {%1, %2}; \n"
     "st.global.L1::no_allocate.b128 [%0], B128_src;\n\t"
     "}"
     :
-    : "l"(__as_ptr_gmem(addr)), "l"((*reinterpret_cast<long2*>(&src)).x), "l"((*reinterpret_cast<long2*>(&src)).y)
+    : "l"(__as_ptr_gmem(addr)),
+      "l"((*reinterpret_cast<longlong2*>(&src)).x),
+      "l"((*reinterpret_cast<longlong2*>(&src)).y)
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_st_global_L1_no_allocate_is_not_supported_before_SM_75__();
+  __cuda_ptx_st_global_L1_no_allocate_is_not_supported_before_SM_70__();
 #  endif
 }
-#endif // __libcuda_ptx_isa >= 830
+#endif // __cccl_ptx_isa >= 830
 
-} // namespace cuda_ptx
+#endif // _CUDA_PTX_GENERATED_INSTRUCTIONS_ST_H

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/st.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/st.h
@@ -1,23 +1,23 @@
 // This file was automatically generated. Do not edit.
 
-#ifndef _CUDA_PTX_GENERATED_INSTRUCTIONS_ST_H
-#define _CUDA_PTX_GENERATED_INSTRUCTIONS_ST_H
+#ifndef _CUDA_PTX_GENERATED_ST_H_
+#define _CUDA_PTX_GENERATED_ST_H_
 
 /*
 // st.global.b8 [addr], src; // PTX ISA 10, SM_50
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline void st_global(
   B8* addr,
   B8 src);
 */
 #if __cccl_ptx_isa >= 100
-extern "C" __device__ void __cuda_ptx_st_global_is_not_supported_before_SM_50__();
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline void st_global(B8* addr, B8 src)
+extern "C" _CCCL_DEVICE void __cuda_ptx_st_global_is_not_supported_before_SM_50__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline void st_global(_B8* __addr, _B8 __src)
 {
-  static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 500
-  asm volatile("st.global.b8 [%0], %1;" : : "l"(__as_ptr_gmem(addr)), "r"(__b8_as_u32(src)) : "memory");
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 500
+  asm volatile("st.global.b8 [%0], %1;" : : "l"(__as_ptr_gmem(__addr)), "r"(__b8_as_u32(__src)) : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_st_global_is_not_supported_before_SM_50__();
@@ -27,21 +27,21 @@ __device__ static inline void st_global(B8* addr, B8 src)
 
 /*
 // st.global.b16 [addr], src; // PTX ISA 10, SM_50
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline void st_global(
   B16* addr,
   B16 src);
 */
 #if __cccl_ptx_isa >= 100
-extern "C" __device__ void __cuda_ptx_st_global_is_not_supported_before_SM_50__();
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline void st_global(B16* addr, B16 src)
+extern "C" _CCCL_DEVICE void __cuda_ptx_st_global_is_not_supported_before_SM_50__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline void st_global(_B16* __addr, _B16 __src)
 {
-  static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 500
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 500
   asm volatile("st.global.b16 [%0], %1;"
                :
-               : "l"(__as_ptr_gmem(addr)), "h"(/*as_b16*/ *reinterpret_cast<const std::int16_t*>(&src))
+               : "l"(__as_ptr_gmem(__addr)), "h"(/*as_b16*/ *reinterpret_cast<const _CUDA_VSTD::int16_t*>(&__src))
                : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
@@ -52,21 +52,21 @@ __device__ static inline void st_global(B16* addr, B16 src)
 
 /*
 // st.global.b32 [addr], src; // PTX ISA 10, SM_50
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void st_global(
   B32* addr,
   B32 src);
 */
 #if __cccl_ptx_isa >= 100
-extern "C" __device__ void __cuda_ptx_st_global_is_not_supported_before_SM_50__();
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline void st_global(B32* addr, B32 src)
+extern "C" _CCCL_DEVICE void __cuda_ptx_st_global_is_not_supported_before_SM_50__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline void st_global(_B32* __addr, _B32 __src)
 {
-  static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 500
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 500
   asm volatile("st.global.b32 [%0], %1;"
                :
-               : "l"(__as_ptr_gmem(addr)), "r"(/*as_b32*/ *reinterpret_cast<const std::int32_t*>(&src))
+               : "l"(__as_ptr_gmem(__addr)), "r"(/*as_b32*/ *reinterpret_cast<const _CUDA_VSTD::int32_t*>(&__src))
                : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
@@ -77,21 +77,21 @@ __device__ static inline void st_global(B32* addr, B32 src)
 
 /*
 // st.global.b64 [addr], src; // PTX ISA 10, SM_50
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline void st_global(
   B64* addr,
   B64 src);
 */
 #if __cccl_ptx_isa >= 100
-extern "C" __device__ void __cuda_ptx_st_global_is_not_supported_before_SM_50__();
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline void st_global(B64* addr, B64 src)
+extern "C" _CCCL_DEVICE void __cuda_ptx_st_global_is_not_supported_before_SM_50__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline void st_global(_B64* __addr, _B64 __src)
 {
-  static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 500
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 500
   asm volatile("st.global.b64 [%0], %1;"
                :
-               : "l"(__as_ptr_gmem(addr)), "l"(/*as_b64*/ *reinterpret_cast<const std::int64_t*>(&src))
+               : "l"(__as_ptr_gmem(__addr)), "l"(/*as_b64*/ *reinterpret_cast<const _CUDA_VSTD::int64_t*>(&__src))
                : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
@@ -102,27 +102,27 @@ __device__ static inline void st_global(B64* addr, B64 src)
 
 /*
 // st.global.b128 [addr], src; // PTX ISA 83, SM_70
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
+template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline void st_global(
   B128* addr,
   B128 src);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_st_global_is_not_supported_before_SM_70__();
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline void st_global(B128* addr, B128 src)
+extern "C" _CCCL_DEVICE void __cuda_ptx_st_global_is_not_supported_before_SM_70__();
+template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
+_CCCL_DEVICE static inline void st_global(_B128* __addr, _B128 __src)
 {
-  static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
+  static_assert(sizeof(_B128) == 16, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
   asm volatile(
     "{\n\t .reg .b128 B128_src; \n\t"
     "mov.b128 B128_src, {%1, %2}; \n"
     "st.global.b128 [%0], B128_src;\n\t"
     "}"
     :
-    : "l"(__as_ptr_gmem(addr)),
-      "l"((*reinterpret_cast<longlong2*>(&src)).x),
-      "l"((*reinterpret_cast<longlong2*>(&src)).y)
+    : "l"(__as_ptr_gmem(__addr)),
+      "l"((*reinterpret_cast<longlong2*>(&__src)).x),
+      "l"((*reinterpret_cast<longlong2*>(&__src)).y)
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
@@ -133,21 +133,21 @@ __device__ static inline void st_global(B128* addr, B128 src)
 
 /*
 // st.global.L1::evict_normal.b8 [addr], src; // PTX ISA 74, SM_70
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline void st_global_L1_evict_normal(
   B8* addr,
   B8 src);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_st_global_L1_evict_normal_is_not_supported_before_SM_70__();
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline void st_global_L1_evict_normal(B8* addr, B8 src)
+extern "C" _CCCL_DEVICE void __cuda_ptx_st_global_L1_evict_normal_is_not_supported_before_SM_70__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline void st_global_L1_evict_normal(_B8* __addr, _B8 __src)
 {
-  static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
   asm volatile("st.global.L1::evict_normal.b8 [%0], %1;"
                :
-               : "l"(__as_ptr_gmem(addr)), "r"(__b8_as_u32(src))
+               : "l"(__as_ptr_gmem(__addr)), "r"(__b8_as_u32(__src))
                : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
@@ -158,21 +158,21 @@ __device__ static inline void st_global_L1_evict_normal(B8* addr, B8 src)
 
 /*
 // st.global.L1::evict_normal.b16 [addr], src; // PTX ISA 74, SM_70
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline void st_global_L1_evict_normal(
   B16* addr,
   B16 src);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_st_global_L1_evict_normal_is_not_supported_before_SM_70__();
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline void st_global_L1_evict_normal(B16* addr, B16 src)
+extern "C" _CCCL_DEVICE void __cuda_ptx_st_global_L1_evict_normal_is_not_supported_before_SM_70__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline void st_global_L1_evict_normal(_B16* __addr, _B16 __src)
 {
-  static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
   asm volatile("st.global.L1::evict_normal.b16 [%0], %1;"
                :
-               : "l"(__as_ptr_gmem(addr)), "h"(/*as_b16*/ *reinterpret_cast<const std::int16_t*>(&src))
+               : "l"(__as_ptr_gmem(__addr)), "h"(/*as_b16*/ *reinterpret_cast<const _CUDA_VSTD::int16_t*>(&__src))
                : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
@@ -183,21 +183,21 @@ __device__ static inline void st_global_L1_evict_normal(B16* addr, B16 src)
 
 /*
 // st.global.L1::evict_normal.b32 [addr], src; // PTX ISA 74, SM_70
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void st_global_L1_evict_normal(
   B32* addr,
   B32 src);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_st_global_L1_evict_normal_is_not_supported_before_SM_70__();
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline void st_global_L1_evict_normal(B32* addr, B32 src)
+extern "C" _CCCL_DEVICE void __cuda_ptx_st_global_L1_evict_normal_is_not_supported_before_SM_70__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline void st_global_L1_evict_normal(_B32* __addr, _B32 __src)
 {
-  static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
   asm volatile("st.global.L1::evict_normal.b32 [%0], %1;"
                :
-               : "l"(__as_ptr_gmem(addr)), "r"(/*as_b32*/ *reinterpret_cast<const std::int32_t*>(&src))
+               : "l"(__as_ptr_gmem(__addr)), "r"(/*as_b32*/ *reinterpret_cast<const _CUDA_VSTD::int32_t*>(&__src))
                : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
@@ -208,21 +208,21 @@ __device__ static inline void st_global_L1_evict_normal(B32* addr, B32 src)
 
 /*
 // st.global.L1::evict_normal.b64 [addr], src; // PTX ISA 74, SM_70
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline void st_global_L1_evict_normal(
   B64* addr,
   B64 src);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_st_global_L1_evict_normal_is_not_supported_before_SM_70__();
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline void st_global_L1_evict_normal(B64* addr, B64 src)
+extern "C" _CCCL_DEVICE void __cuda_ptx_st_global_L1_evict_normal_is_not_supported_before_SM_70__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline void st_global_L1_evict_normal(_B64* __addr, _B64 __src)
 {
-  static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
   asm volatile("st.global.L1::evict_normal.b64 [%0], %1;"
                :
-               : "l"(__as_ptr_gmem(addr)), "l"(/*as_b64*/ *reinterpret_cast<const std::int64_t*>(&src))
+               : "l"(__as_ptr_gmem(__addr)), "l"(/*as_b64*/ *reinterpret_cast<const _CUDA_VSTD::int64_t*>(&__src))
                : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
@@ -233,27 +233,27 @@ __device__ static inline void st_global_L1_evict_normal(B64* addr, B64 src)
 
 /*
 // st.global.L1::evict_normal.b128 [addr], src; // PTX ISA 83, SM_70
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
+template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline void st_global_L1_evict_normal(
   B128* addr,
   B128 src);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_st_global_L1_evict_normal_is_not_supported_before_SM_70__();
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline void st_global_L1_evict_normal(B128* addr, B128 src)
+extern "C" _CCCL_DEVICE void __cuda_ptx_st_global_L1_evict_normal_is_not_supported_before_SM_70__();
+template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
+_CCCL_DEVICE static inline void st_global_L1_evict_normal(_B128* __addr, _B128 __src)
 {
-  static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
+  static_assert(sizeof(_B128) == 16, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
   asm volatile(
     "{\n\t .reg .b128 B128_src; \n\t"
     "mov.b128 B128_src, {%1, %2}; \n"
     "st.global.L1::evict_normal.b128 [%0], B128_src;\n\t"
     "}"
     :
-    : "l"(__as_ptr_gmem(addr)),
-      "l"((*reinterpret_cast<longlong2*>(&src)).x),
-      "l"((*reinterpret_cast<longlong2*>(&src)).y)
+    : "l"(__as_ptr_gmem(__addr)),
+      "l"((*reinterpret_cast<longlong2*>(&__src)).x),
+      "l"((*reinterpret_cast<longlong2*>(&__src)).y)
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
@@ -264,21 +264,21 @@ __device__ static inline void st_global_L1_evict_normal(B128* addr, B128 src)
 
 /*
 // st.global.L1::evict_unchanged.b8 [addr], src; // PTX ISA 74, SM_70
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline void st_global_L1_evict_unchanged(
   B8* addr,
   B8 src);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_st_global_L1_evict_unchanged_is_not_supported_before_SM_70__();
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline void st_global_L1_evict_unchanged(B8* addr, B8 src)
+extern "C" _CCCL_DEVICE void __cuda_ptx_st_global_L1_evict_unchanged_is_not_supported_before_SM_70__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline void st_global_L1_evict_unchanged(_B8* __addr, _B8 __src)
 {
-  static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
   asm volatile("st.global.L1::evict_unchanged.b8 [%0], %1;"
                :
-               : "l"(__as_ptr_gmem(addr)), "r"(__b8_as_u32(src))
+               : "l"(__as_ptr_gmem(__addr)), "r"(__b8_as_u32(__src))
                : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
@@ -289,21 +289,21 @@ __device__ static inline void st_global_L1_evict_unchanged(B8* addr, B8 src)
 
 /*
 // st.global.L1::evict_unchanged.b16 [addr], src; // PTX ISA 74, SM_70
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline void st_global_L1_evict_unchanged(
   B16* addr,
   B16 src);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_st_global_L1_evict_unchanged_is_not_supported_before_SM_70__();
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline void st_global_L1_evict_unchanged(B16* addr, B16 src)
+extern "C" _CCCL_DEVICE void __cuda_ptx_st_global_L1_evict_unchanged_is_not_supported_before_SM_70__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline void st_global_L1_evict_unchanged(_B16* __addr, _B16 __src)
 {
-  static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
   asm volatile("st.global.L1::evict_unchanged.b16 [%0], %1;"
                :
-               : "l"(__as_ptr_gmem(addr)), "h"(/*as_b16*/ *reinterpret_cast<const std::int16_t*>(&src))
+               : "l"(__as_ptr_gmem(__addr)), "h"(/*as_b16*/ *reinterpret_cast<const _CUDA_VSTD::int16_t*>(&__src))
                : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
@@ -314,21 +314,21 @@ __device__ static inline void st_global_L1_evict_unchanged(B16* addr, B16 src)
 
 /*
 // st.global.L1::evict_unchanged.b32 [addr], src; // PTX ISA 74, SM_70
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void st_global_L1_evict_unchanged(
   B32* addr,
   B32 src);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_st_global_L1_evict_unchanged_is_not_supported_before_SM_70__();
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline void st_global_L1_evict_unchanged(B32* addr, B32 src)
+extern "C" _CCCL_DEVICE void __cuda_ptx_st_global_L1_evict_unchanged_is_not_supported_before_SM_70__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline void st_global_L1_evict_unchanged(_B32* __addr, _B32 __src)
 {
-  static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
   asm volatile("st.global.L1::evict_unchanged.b32 [%0], %1;"
                :
-               : "l"(__as_ptr_gmem(addr)), "r"(/*as_b32*/ *reinterpret_cast<const std::int32_t*>(&src))
+               : "l"(__as_ptr_gmem(__addr)), "r"(/*as_b32*/ *reinterpret_cast<const _CUDA_VSTD::int32_t*>(&__src))
                : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
@@ -339,21 +339,21 @@ __device__ static inline void st_global_L1_evict_unchanged(B32* addr, B32 src)
 
 /*
 // st.global.L1::evict_unchanged.b64 [addr], src; // PTX ISA 74, SM_70
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline void st_global_L1_evict_unchanged(
   B64* addr,
   B64 src);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_st_global_L1_evict_unchanged_is_not_supported_before_SM_70__();
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline void st_global_L1_evict_unchanged(B64* addr, B64 src)
+extern "C" _CCCL_DEVICE void __cuda_ptx_st_global_L1_evict_unchanged_is_not_supported_before_SM_70__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline void st_global_L1_evict_unchanged(_B64* __addr, _B64 __src)
 {
-  static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
   asm volatile("st.global.L1::evict_unchanged.b64 [%0], %1;"
                :
-               : "l"(__as_ptr_gmem(addr)), "l"(/*as_b64*/ *reinterpret_cast<const std::int64_t*>(&src))
+               : "l"(__as_ptr_gmem(__addr)), "l"(/*as_b64*/ *reinterpret_cast<const _CUDA_VSTD::int64_t*>(&__src))
                : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
@@ -364,27 +364,27 @@ __device__ static inline void st_global_L1_evict_unchanged(B64* addr, B64 src)
 
 /*
 // st.global.L1::evict_unchanged.b128 [addr], src; // PTX ISA 83, SM_70
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
+template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline void st_global_L1_evict_unchanged(
   B128* addr,
   B128 src);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_st_global_L1_evict_unchanged_is_not_supported_before_SM_70__();
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline void st_global_L1_evict_unchanged(B128* addr, B128 src)
+extern "C" _CCCL_DEVICE void __cuda_ptx_st_global_L1_evict_unchanged_is_not_supported_before_SM_70__();
+template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
+_CCCL_DEVICE static inline void st_global_L1_evict_unchanged(_B128* __addr, _B128 __src)
 {
-  static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
+  static_assert(sizeof(_B128) == 16, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
   asm volatile(
     "{\n\t .reg .b128 B128_src; \n\t"
     "mov.b128 B128_src, {%1, %2}; \n"
     "st.global.L1::evict_unchanged.b128 [%0], B128_src;\n\t"
     "}"
     :
-    : "l"(__as_ptr_gmem(addr)),
-      "l"((*reinterpret_cast<longlong2*>(&src)).x),
-      "l"((*reinterpret_cast<longlong2*>(&src)).y)
+    : "l"(__as_ptr_gmem(__addr)),
+      "l"((*reinterpret_cast<longlong2*>(&__src)).x),
+      "l"((*reinterpret_cast<longlong2*>(&__src)).y)
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
@@ -395,19 +395,22 @@ __device__ static inline void st_global_L1_evict_unchanged(B128* addr, B128 src)
 
 /*
 // st.global.L1::evict_first.b8 [addr], src; // PTX ISA 74, SM_70
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline void st_global_L1_evict_first(
   B8* addr,
   B8 src);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_st_global_L1_evict_first_is_not_supported_before_SM_70__();
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline void st_global_L1_evict_first(B8* addr, B8 src)
+extern "C" _CCCL_DEVICE void __cuda_ptx_st_global_L1_evict_first_is_not_supported_before_SM_70__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline void st_global_L1_evict_first(_B8* __addr, _B8 __src)
 {
-  static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
-  asm volatile("st.global.L1::evict_first.b8 [%0], %1;" : : "l"(__as_ptr_gmem(addr)), "r"(__b8_as_u32(src)) : "memory");
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
+  asm volatile("st.global.L1::evict_first.b8 [%0], %1;"
+               :
+               : "l"(__as_ptr_gmem(__addr)), "r"(__b8_as_u32(__src))
+               : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_st_global_L1_evict_first_is_not_supported_before_SM_70__();
@@ -417,21 +420,21 @@ __device__ static inline void st_global_L1_evict_first(B8* addr, B8 src)
 
 /*
 // st.global.L1::evict_first.b16 [addr], src; // PTX ISA 74, SM_70
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline void st_global_L1_evict_first(
   B16* addr,
   B16 src);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_st_global_L1_evict_first_is_not_supported_before_SM_70__();
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline void st_global_L1_evict_first(B16* addr, B16 src)
+extern "C" _CCCL_DEVICE void __cuda_ptx_st_global_L1_evict_first_is_not_supported_before_SM_70__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline void st_global_L1_evict_first(_B16* __addr, _B16 __src)
 {
-  static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
   asm volatile("st.global.L1::evict_first.b16 [%0], %1;"
                :
-               : "l"(__as_ptr_gmem(addr)), "h"(/*as_b16*/ *reinterpret_cast<const std::int16_t*>(&src))
+               : "l"(__as_ptr_gmem(__addr)), "h"(/*as_b16*/ *reinterpret_cast<const _CUDA_VSTD::int16_t*>(&__src))
                : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
@@ -442,21 +445,21 @@ __device__ static inline void st_global_L1_evict_first(B16* addr, B16 src)
 
 /*
 // st.global.L1::evict_first.b32 [addr], src; // PTX ISA 74, SM_70
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void st_global_L1_evict_first(
   B32* addr,
   B32 src);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_st_global_L1_evict_first_is_not_supported_before_SM_70__();
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline void st_global_L1_evict_first(B32* addr, B32 src)
+extern "C" _CCCL_DEVICE void __cuda_ptx_st_global_L1_evict_first_is_not_supported_before_SM_70__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline void st_global_L1_evict_first(_B32* __addr, _B32 __src)
 {
-  static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
   asm volatile("st.global.L1::evict_first.b32 [%0], %1;"
                :
-               : "l"(__as_ptr_gmem(addr)), "r"(/*as_b32*/ *reinterpret_cast<const std::int32_t*>(&src))
+               : "l"(__as_ptr_gmem(__addr)), "r"(/*as_b32*/ *reinterpret_cast<const _CUDA_VSTD::int32_t*>(&__src))
                : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
@@ -467,21 +470,21 @@ __device__ static inline void st_global_L1_evict_first(B32* addr, B32 src)
 
 /*
 // st.global.L1::evict_first.b64 [addr], src; // PTX ISA 74, SM_70
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline void st_global_L1_evict_first(
   B64* addr,
   B64 src);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_st_global_L1_evict_first_is_not_supported_before_SM_70__();
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline void st_global_L1_evict_first(B64* addr, B64 src)
+extern "C" _CCCL_DEVICE void __cuda_ptx_st_global_L1_evict_first_is_not_supported_before_SM_70__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline void st_global_L1_evict_first(_B64* __addr, _B64 __src)
 {
-  static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
   asm volatile("st.global.L1::evict_first.b64 [%0], %1;"
                :
-               : "l"(__as_ptr_gmem(addr)), "l"(/*as_b64*/ *reinterpret_cast<const std::int64_t*>(&src))
+               : "l"(__as_ptr_gmem(__addr)), "l"(/*as_b64*/ *reinterpret_cast<const _CUDA_VSTD::int64_t*>(&__src))
                : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
@@ -492,27 +495,27 @@ __device__ static inline void st_global_L1_evict_first(B64* addr, B64 src)
 
 /*
 // st.global.L1::evict_first.b128 [addr], src; // PTX ISA 83, SM_70
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
+template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline void st_global_L1_evict_first(
   B128* addr,
   B128 src);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_st_global_L1_evict_first_is_not_supported_before_SM_70__();
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline void st_global_L1_evict_first(B128* addr, B128 src)
+extern "C" _CCCL_DEVICE void __cuda_ptx_st_global_L1_evict_first_is_not_supported_before_SM_70__();
+template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
+_CCCL_DEVICE static inline void st_global_L1_evict_first(_B128* __addr, _B128 __src)
 {
-  static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
+  static_assert(sizeof(_B128) == 16, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
   asm volatile(
     "{\n\t .reg .b128 B128_src; \n\t"
     "mov.b128 B128_src, {%1, %2}; \n"
     "st.global.L1::evict_first.b128 [%0], B128_src;\n\t"
     "}"
     :
-    : "l"(__as_ptr_gmem(addr)),
-      "l"((*reinterpret_cast<longlong2*>(&src)).x),
-      "l"((*reinterpret_cast<longlong2*>(&src)).y)
+    : "l"(__as_ptr_gmem(__addr)),
+      "l"((*reinterpret_cast<longlong2*>(&__src)).x),
+      "l"((*reinterpret_cast<longlong2*>(&__src)).y)
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
@@ -523,19 +526,22 @@ __device__ static inline void st_global_L1_evict_first(B128* addr, B128 src)
 
 /*
 // st.global.L1::evict_last.b8 [addr], src; // PTX ISA 74, SM_70
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline void st_global_L1_evict_last(
   B8* addr,
   B8 src);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_st_global_L1_evict_last_is_not_supported_before_SM_70__();
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline void st_global_L1_evict_last(B8* addr, B8 src)
+extern "C" _CCCL_DEVICE void __cuda_ptx_st_global_L1_evict_last_is_not_supported_before_SM_70__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline void st_global_L1_evict_last(_B8* __addr, _B8 __src)
 {
-  static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
-  asm volatile("st.global.L1::evict_last.b8 [%0], %1;" : : "l"(__as_ptr_gmem(addr)), "r"(__b8_as_u32(src)) : "memory");
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
+  asm volatile("st.global.L1::evict_last.b8 [%0], %1;"
+               :
+               : "l"(__as_ptr_gmem(__addr)), "r"(__b8_as_u32(__src))
+               : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_st_global_L1_evict_last_is_not_supported_before_SM_70__();
@@ -545,21 +551,21 @@ __device__ static inline void st_global_L1_evict_last(B8* addr, B8 src)
 
 /*
 // st.global.L1::evict_last.b16 [addr], src; // PTX ISA 74, SM_70
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline void st_global_L1_evict_last(
   B16* addr,
   B16 src);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_st_global_L1_evict_last_is_not_supported_before_SM_70__();
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline void st_global_L1_evict_last(B16* addr, B16 src)
+extern "C" _CCCL_DEVICE void __cuda_ptx_st_global_L1_evict_last_is_not_supported_before_SM_70__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline void st_global_L1_evict_last(_B16* __addr, _B16 __src)
 {
-  static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
   asm volatile("st.global.L1::evict_last.b16 [%0], %1;"
                :
-               : "l"(__as_ptr_gmem(addr)), "h"(/*as_b16*/ *reinterpret_cast<const std::int16_t*>(&src))
+               : "l"(__as_ptr_gmem(__addr)), "h"(/*as_b16*/ *reinterpret_cast<const _CUDA_VSTD::int16_t*>(&__src))
                : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
@@ -570,21 +576,21 @@ __device__ static inline void st_global_L1_evict_last(B16* addr, B16 src)
 
 /*
 // st.global.L1::evict_last.b32 [addr], src; // PTX ISA 74, SM_70
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void st_global_L1_evict_last(
   B32* addr,
   B32 src);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_st_global_L1_evict_last_is_not_supported_before_SM_70__();
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline void st_global_L1_evict_last(B32* addr, B32 src)
+extern "C" _CCCL_DEVICE void __cuda_ptx_st_global_L1_evict_last_is_not_supported_before_SM_70__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline void st_global_L1_evict_last(_B32* __addr, _B32 __src)
 {
-  static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
   asm volatile("st.global.L1::evict_last.b32 [%0], %1;"
                :
-               : "l"(__as_ptr_gmem(addr)), "r"(/*as_b32*/ *reinterpret_cast<const std::int32_t*>(&src))
+               : "l"(__as_ptr_gmem(__addr)), "r"(/*as_b32*/ *reinterpret_cast<const _CUDA_VSTD::int32_t*>(&__src))
                : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
@@ -595,21 +601,21 @@ __device__ static inline void st_global_L1_evict_last(B32* addr, B32 src)
 
 /*
 // st.global.L1::evict_last.b64 [addr], src; // PTX ISA 74, SM_70
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline void st_global_L1_evict_last(
   B64* addr,
   B64 src);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_st_global_L1_evict_last_is_not_supported_before_SM_70__();
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline void st_global_L1_evict_last(B64* addr, B64 src)
+extern "C" _CCCL_DEVICE void __cuda_ptx_st_global_L1_evict_last_is_not_supported_before_SM_70__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline void st_global_L1_evict_last(_B64* __addr, _B64 __src)
 {
-  static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
   asm volatile("st.global.L1::evict_last.b64 [%0], %1;"
                :
-               : "l"(__as_ptr_gmem(addr)), "l"(/*as_b64*/ *reinterpret_cast<const std::int64_t*>(&src))
+               : "l"(__as_ptr_gmem(__addr)), "l"(/*as_b64*/ *reinterpret_cast<const _CUDA_VSTD::int64_t*>(&__src))
                : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
@@ -620,27 +626,27 @@ __device__ static inline void st_global_L1_evict_last(B64* addr, B64 src)
 
 /*
 // st.global.L1::evict_last.b128 [addr], src; // PTX ISA 83, SM_70
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
+template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline void st_global_L1_evict_last(
   B128* addr,
   B128 src);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_st_global_L1_evict_last_is_not_supported_before_SM_70__();
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline void st_global_L1_evict_last(B128* addr, B128 src)
+extern "C" _CCCL_DEVICE void __cuda_ptx_st_global_L1_evict_last_is_not_supported_before_SM_70__();
+template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
+_CCCL_DEVICE static inline void st_global_L1_evict_last(_B128* __addr, _B128 __src)
 {
-  static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
+  static_assert(sizeof(_B128) == 16, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
   asm volatile(
     "{\n\t .reg .b128 B128_src; \n\t"
     "mov.b128 B128_src, {%1, %2}; \n"
     "st.global.L1::evict_last.b128 [%0], B128_src;\n\t"
     "}"
     :
-    : "l"(__as_ptr_gmem(addr)),
-      "l"((*reinterpret_cast<longlong2*>(&src)).x),
-      "l"((*reinterpret_cast<longlong2*>(&src)).y)
+    : "l"(__as_ptr_gmem(__addr)),
+      "l"((*reinterpret_cast<longlong2*>(&__src)).x),
+      "l"((*reinterpret_cast<longlong2*>(&__src)).y)
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
@@ -651,19 +657,22 @@ __device__ static inline void st_global_L1_evict_last(B128* addr, B128 src)
 
 /*
 // st.global.L1::no_allocate.b8 [addr], src; // PTX ISA 74, SM_70
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
 __device__ static inline void st_global_L1_no_allocate(
   B8* addr,
   B8 src);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_st_global_L1_no_allocate_is_not_supported_before_SM_70__();
-template <typename B8, std::enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline void st_global_L1_no_allocate(B8* addr, B8 src)
+extern "C" _CCCL_DEVICE void __cuda_ptx_st_global_L1_no_allocate_is_not_supported_before_SM_70__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline void st_global_L1_no_allocate(_B8* __addr, _B8 __src)
 {
-  static_assert(sizeof(B8) == 1, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
-  asm volatile("st.global.L1::no_allocate.b8 [%0], %1;" : : "l"(__as_ptr_gmem(addr)), "r"(__b8_as_u32(src)) : "memory");
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
+  asm volatile("st.global.L1::no_allocate.b8 [%0], %1;"
+               :
+               : "l"(__as_ptr_gmem(__addr)), "r"(__b8_as_u32(__src))
+               : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_st_global_L1_no_allocate_is_not_supported_before_SM_70__();
@@ -673,21 +682,21 @@ __device__ static inline void st_global_L1_no_allocate(B8* addr, B8 src)
 
 /*
 // st.global.L1::no_allocate.b16 [addr], src; // PTX ISA 74, SM_70
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
 __device__ static inline void st_global_L1_no_allocate(
   B16* addr,
   B16 src);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_st_global_L1_no_allocate_is_not_supported_before_SM_70__();
-template <typename B16, std::enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline void st_global_L1_no_allocate(B16* addr, B16 src)
+extern "C" _CCCL_DEVICE void __cuda_ptx_st_global_L1_no_allocate_is_not_supported_before_SM_70__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline void st_global_L1_no_allocate(_B16* __addr, _B16 __src)
 {
-  static_assert(sizeof(B16) == 2, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
   asm volatile("st.global.L1::no_allocate.b16 [%0], %1;"
                :
-               : "l"(__as_ptr_gmem(addr)), "h"(/*as_b16*/ *reinterpret_cast<const std::int16_t*>(&src))
+               : "l"(__as_ptr_gmem(__addr)), "h"(/*as_b16*/ *reinterpret_cast<const _CUDA_VSTD::int16_t*>(&__src))
                : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
@@ -698,21 +707,21 @@ __device__ static inline void st_global_L1_no_allocate(B16* addr, B16 src)
 
 /*
 // st.global.L1::no_allocate.b32 [addr], src; // PTX ISA 74, SM_70
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void st_global_L1_no_allocate(
   B32* addr,
   B32 src);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_st_global_L1_no_allocate_is_not_supported_before_SM_70__();
-template <typename B32, std::enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline void st_global_L1_no_allocate(B32* addr, B32 src)
+extern "C" _CCCL_DEVICE void __cuda_ptx_st_global_L1_no_allocate_is_not_supported_before_SM_70__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline void st_global_L1_no_allocate(_B32* __addr, _B32 __src)
 {
-  static_assert(sizeof(B32) == 4, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
   asm volatile("st.global.L1::no_allocate.b32 [%0], %1;"
                :
-               : "l"(__as_ptr_gmem(addr)), "r"(/*as_b32*/ *reinterpret_cast<const std::int32_t*>(&src))
+               : "l"(__as_ptr_gmem(__addr)), "r"(/*as_b32*/ *reinterpret_cast<const _CUDA_VSTD::int32_t*>(&__src))
                : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
@@ -723,21 +732,21 @@ __device__ static inline void st_global_L1_no_allocate(B32* addr, B32 src)
 
 /*
 // st.global.L1::no_allocate.b64 [addr], src; // PTX ISA 74, SM_70
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline void st_global_L1_no_allocate(
   B64* addr,
   B64 src);
 */
 #if __cccl_ptx_isa >= 740
-extern "C" __device__ void __cuda_ptx_st_global_L1_no_allocate_is_not_supported_before_SM_70__();
-template <typename B64, std::enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline void st_global_L1_no_allocate(B64* addr, B64 src)
+extern "C" _CCCL_DEVICE void __cuda_ptx_st_global_L1_no_allocate_is_not_supported_before_SM_70__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline void st_global_L1_no_allocate(_B64* __addr, _B64 __src)
 {
-  static_assert(sizeof(B64) == 8, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
   asm volatile("st.global.L1::no_allocate.b64 [%0], %1;"
                :
-               : "l"(__as_ptr_gmem(addr)), "l"(/*as_b64*/ *reinterpret_cast<const std::int64_t*>(&src))
+               : "l"(__as_ptr_gmem(__addr)), "l"(/*as_b64*/ *reinterpret_cast<const _CUDA_VSTD::int64_t*>(&__src))
                : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
@@ -748,27 +757,27 @@ __device__ static inline void st_global_L1_no_allocate(B64* addr, B64 src)
 
 /*
 // st.global.L1::no_allocate.b128 [addr], src; // PTX ISA 83, SM_70
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
+template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
 __device__ static inline void st_global_L1_no_allocate(
   B128* addr,
   B128 src);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" __device__ void __cuda_ptx_st_global_L1_no_allocate_is_not_supported_before_SM_70__();
-template <typename B128, std::enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline void st_global_L1_no_allocate(B128* addr, B128 src)
+extern "C" _CCCL_DEVICE void __cuda_ptx_st_global_L1_no_allocate_is_not_supported_before_SM_70__();
+template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
+_CCCL_DEVICE static inline void st_global_L1_no_allocate(_B128* __addr, _B128 __src)
 {
-  static_assert(sizeof(B128) == 16, "");
-#  if defined(_NVHPC_CUDA) || __CUDA_ARCH__ >= 700
+  static_assert(sizeof(_B128) == 16, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
   asm volatile(
     "{\n\t .reg .b128 B128_src; \n\t"
     "mov.b128 B128_src, {%1, %2}; \n"
     "st.global.L1::no_allocate.b128 [%0], B128_src;\n\t"
     "}"
     :
-    : "l"(__as_ptr_gmem(addr)),
-      "l"((*reinterpret_cast<longlong2*>(&src)).x),
-      "l"((*reinterpret_cast<longlong2*>(&src)).y)
+    : "l"(__as_ptr_gmem(__addr)),
+      "l"((*reinterpret_cast<longlong2*>(&__src)).x),
+      "l"((*reinterpret_cast<longlong2*>(&__src)).y)
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
@@ -777,4 +786,4 @@ __device__ static inline void st_global_L1_no_allocate(B128* addr, B128 src)
 }
 #endif // __cccl_ptx_isa >= 830
 
-#endif // _CUDA_PTX_GENERATED_INSTRUCTIONS_ST_H
+#endif // _CUDA_PTX_GENERATED_ST_H_

--- a/libcudacxx/include/cuda/__ptx/ptx_helper_functions.h
+++ b/libcudacxx/include/cuda/__ptx/ptx_helper_functions.h
@@ -116,6 +116,30 @@ inline _CCCL_DEVICE _CUDA_VSTD::uint64_t __as_b64(_Tp __val)
   return *reinterpret_cast<_CUDA_VSTD::uint64_t*>(&__val);
 }
 
+/*************************************************************
+ *
+ * Conversion to and from b8 type
+ *
+ **************************************************************/
+
+template <typename _B8>
+inline _CCCL_DEVICE uint32_t __b8_as_u32(_B8 __val)
+{
+  static_assert(sizeof(_B8) == 1);
+  _CUDA_VSTD::uint32_t __u32 = 0;
+  ::memcpy(&__u32, &__val, 1);
+  return __u32;
+}
+
+template <typename _B8>
+inline _CCCL_DEVICE _B8 __u32_as_b8(uint32_t __u32)
+{
+  static_assert(sizeof(_B8) == 1);
+  _B8 b8;
+  ::memcpy(&b8, &__u32, 1);
+  return b8;
+}
+
 _LIBCUDACXX_END_NAMESPACE_CUDA_PTX
 
 #endif // _CCCL_HAS_CUDA_COMPILER

--- a/libcudacxx/test/libcudacxx/cuda/ptx/generated/ld.h
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/generated/ld.h
@@ -179,7 +179,7 @@ __global__ void test_ld(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 830
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.L1::evict_normal.b8 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -187,7 +187,7 @@ __global__ void test_ld(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.L1::evict_normal.b16 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -195,7 +195,7 @@ __global__ void test_ld(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.L1::evict_normal.b32 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -203,7 +203,7 @@ __global__ void test_ld(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.L1::evict_normal.b64 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -211,7 +211,7 @@ __global__ void test_ld(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 830
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.L1::evict_normal.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -339,7 +339,7 @@ __global__ void test_ld(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 830
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.L1::evict_unchanged.b8 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -347,7 +347,7 @@ __global__ void test_ld(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.L1::evict_unchanged.b16 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -355,7 +355,7 @@ __global__ void test_ld(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.L1::evict_unchanged.b32 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -363,7 +363,7 @@ __global__ void test_ld(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.L1::evict_unchanged.b64 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -371,7 +371,7 @@ __global__ void test_ld(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 830
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.L1::evict_unchanged.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -499,7 +499,7 @@ __global__ void test_ld(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 830
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.L1::evict_first.b8 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -507,7 +507,7 @@ __global__ void test_ld(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.L1::evict_first.b16 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -515,7 +515,7 @@ __global__ void test_ld(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.L1::evict_first.b32 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -523,7 +523,7 @@ __global__ void test_ld(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.L1::evict_first.b64 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -531,7 +531,7 @@ __global__ void test_ld(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 830
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.L1::evict_first.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -659,7 +659,7 @@ __global__ void test_ld(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 830
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.L1::evict_last.b8 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -667,7 +667,7 @@ __global__ void test_ld(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.L1::evict_last.b16 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -675,7 +675,7 @@ __global__ void test_ld(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.L1::evict_last.b32 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -683,7 +683,7 @@ __global__ void test_ld(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.L1::evict_last.b64 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -691,7 +691,7 @@ __global__ void test_ld(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 830
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.L1::evict_last.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -819,7 +819,7 @@ __global__ void test_ld(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 830
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.L1::no_allocate.b8 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -827,7 +827,7 @@ __global__ void test_ld(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.L1::no_allocate.b16 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -835,7 +835,7 @@ __global__ void test_ld(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.L1::no_allocate.b32 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -843,7 +843,7 @@ __global__ void test_ld(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.L1::no_allocate.b64 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -851,7 +851,7 @@ __global__ void test_ld(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 830
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.L1::no_allocate.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -1139,7 +1139,7 @@ __global__ void test_ld(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 830
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.nc.L1::evict_normal.b8 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -1147,7 +1147,7 @@ __global__ void test_ld(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.nc.L1::evict_normal.b16 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -1155,7 +1155,7 @@ __global__ void test_ld(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.nc.L1::evict_normal.b32 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -1163,7 +1163,7 @@ __global__ void test_ld(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.nc.L1::evict_normal.b64 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -1171,7 +1171,7 @@ __global__ void test_ld(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 830
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.nc.L1::evict_normal.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -1299,7 +1299,7 @@ __global__ void test_ld(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 830
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.nc.L1::evict_unchanged.b8 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -1307,7 +1307,7 @@ __global__ void test_ld(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.nc.L1::evict_unchanged.b16 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -1315,7 +1315,7 @@ __global__ void test_ld(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.nc.L1::evict_unchanged.b32 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -1323,7 +1323,7 @@ __global__ void test_ld(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.nc.L1::evict_unchanged.b64 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -1331,7 +1331,7 @@ __global__ void test_ld(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 830
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.nc.L1::evict_unchanged.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -1459,7 +1459,7 @@ __global__ void test_ld(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 830
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.nc.L1::evict_first.b8 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -1467,7 +1467,7 @@ __global__ void test_ld(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.nc.L1::evict_first.b16 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -1475,7 +1475,7 @@ __global__ void test_ld(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.nc.L1::evict_first.b32 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -1483,7 +1483,7 @@ __global__ void test_ld(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.nc.L1::evict_first.b64 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -1491,7 +1491,7 @@ __global__ void test_ld(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 830
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.nc.L1::evict_first.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -1619,7 +1619,7 @@ __global__ void test_ld(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 830
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.nc.L1::evict_last.b8 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -1627,7 +1627,7 @@ __global__ void test_ld(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.nc.L1::evict_last.b16 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -1635,7 +1635,7 @@ __global__ void test_ld(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.nc.L1::evict_last.b32 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -1643,7 +1643,7 @@ __global__ void test_ld(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.nc.L1::evict_last.b64 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -1651,7 +1651,7 @@ __global__ void test_ld(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 830
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.nc.L1::evict_last.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -1779,7 +1779,7 @@ __global__ void test_ld(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 830
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.nc.L1::no_allocate.b8 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -1787,7 +1787,7 @@ __global__ void test_ld(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.nc.L1::no_allocate.b16 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -1795,7 +1795,7 @@ __global__ void test_ld(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.nc.L1::no_allocate.b32 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -1803,7 +1803,7 @@ __global__ void test_ld(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.nc.L1::no_allocate.b64 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -1811,7 +1811,7 @@ __global__ void test_ld(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 830
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.nc.L1::no_allocate.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(

--- a/libcudacxx/test/libcudacxx/cuda/ptx/generated/ld.h
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/generated/ld.h
@@ -1,1940 +1,1938 @@
 // This file was automatically generated. Do not edit.
 
-/*
- * We use a special strategy to force the generation of the PTX. This is mainly
- * a fight against dead-code-elimination in the NVVM layer.
- *
- * The reason we need this strategy is because certain older versions of ptxas
- * segfault when a non-sensical sequence of PTX is generated. So instead, we try
- * to force the instantiation and compilation to PTX of all the overloads of the
- * PTX wrapping functions.
- *
- * We do this by writing a function pointer of each overload to the kernel
- * parameter `fn_ptr`.
- *
- * Because `fn_ptr` is possibly visible outside this translation unit, the
- * compiler must compile all the functions which are stored.
- *
- */
+// We use a special strategy to force the generation of the PTX. This is mainly
+// a fight against dead-code-elimination in the NVVM layer.
+//
+// The reason we need this strategy is because certain older versions of ptxas
+// segfault when a non-sensical sequence of PTX is generated. So instead, we try
+// to force the instantiation and compilation to PTX of all the overloads of the
+// PTX wrapping functions.
+//
+// We do this by writing a function pointer of each overload to the kernel
+// parameter `fn_ptr`.
+//
+// Because `fn_ptr` is possibly visible outside this translation unit, the
+// compiler must compile all the functions which are stored.
 
 __global__ void test_ld(void** fn_ptr)
 {
-#if __libcuda_ptx_isa >= 100
-  NV_IF_TARGET(NV_PROVIDES_SM_50,
-               (
-                   // ld.global.b8 dest, [addr];
-                   * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(const int8_t*)>(cuda_ptx::ld_global));));
-#endif // __libcuda_ptx_isa >= 100
+#if __cccl_ptx_isa >= 100
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_50,
+    (
+        // ld.global.b8 dest, [addr];
+        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(const int8_t*)>(cuda::ptx::ld_global));));
+#endif // __cccl_ptx_isa >= 100
 
-#if __libcuda_ptx_isa >= 100
+#if __cccl_ptx_isa >= 100
   NV_IF_TARGET(
     NV_PROVIDES_SM_50,
     (
         // ld.global.b16 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int16_t (*)(const int16_t*)>(cuda_ptx::ld_global));));
-#endif // __libcuda_ptx_isa >= 100
+        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int16_t (*)(const int16_t*)>(cuda::ptx::ld_global));));
+#endif // __cccl_ptx_isa >= 100
 
-#if __libcuda_ptx_isa >= 100
+#if __cccl_ptx_isa >= 100
   NV_IF_TARGET(
     NV_PROVIDES_SM_50,
     (
         // ld.global.b32 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int32_t (*)(const int32_t*)>(cuda_ptx::ld_global));));
-#endif // __libcuda_ptx_isa >= 100
+        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int32_t (*)(const int32_t*)>(cuda::ptx::ld_global));));
+#endif // __cccl_ptx_isa >= 100
 
-#if __libcuda_ptx_isa >= 100
+#if __cccl_ptx_isa >= 100
   NV_IF_TARGET(
     NV_PROVIDES_SM_50,
     (
         // ld.global.b64 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int64_t (*)(const int64_t*)>(cuda_ptx::ld_global));));
-#endif // __libcuda_ptx_isa >= 100
+        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int64_t (*)(const int64_t*)>(cuda::ptx::ld_global));));
+#endif // __cccl_ptx_isa >= 100
 
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
   NV_IF_TARGET(
     NV_PROVIDES_SM_70,
     (
         // ld.global.b128 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<__int128 (*)(const __int128*)>(cuda_ptx::ld_global));));
-#endif // __libcuda_ptx_isa >= 830
+        * fn_ptr++ = reinterpret_cast<void*>(static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global));));
+#endif // __cccl_ptx_isa >= 830
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(
     NV_PROVIDES_SM_75,
     (
         // ld.global.L2::64B.b8 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(const int8_t*)>(cuda_ptx::ld_global_L2_64B));));
-#endif // __libcuda_ptx_isa >= 740
+        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(const int8_t*)>(cuda::ptx::ld_global_L2_64B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(
     NV_PROVIDES_SM_75,
     (
         // ld.global.L2::64B.b16 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int16_t (*)(const int16_t*)>(cuda_ptx::ld_global_L2_64B));));
-#endif // __libcuda_ptx_isa >= 740
+        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int16_t (*)(const int16_t*)>(cuda::ptx::ld_global_L2_64B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(
     NV_PROVIDES_SM_75,
     (
         // ld.global.L2::64B.b32 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int32_t (*)(const int32_t*)>(cuda_ptx::ld_global_L2_64B));));
-#endif // __libcuda_ptx_isa >= 740
+        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int32_t (*)(const int32_t*)>(cuda::ptx::ld_global_L2_64B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(
     NV_PROVIDES_SM_75,
     (
         // ld.global.L2::64B.b64 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int64_t (*)(const int64_t*)>(cuda_ptx::ld_global_L2_64B));));
-#endif // __libcuda_ptx_isa >= 740
+        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int64_t (*)(const int64_t*)>(cuda::ptx::ld_global_L2_64B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
   NV_IF_TARGET(
     NV_PROVIDES_SM_75,
     (
         // ld.global.L2::64B.b128 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<__int128 (*)(const __int128*)>(cuda_ptx::ld_global_L2_64B));));
-#endif // __libcuda_ptx_isa >= 830
+        * fn_ptr++ = reinterpret_cast<void*>(static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_L2_64B));));
+#endif // __cccl_ptx_isa >= 830
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(
     NV_PROVIDES_SM_75,
     (
         // ld.global.L2::128B.b8 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(const int8_t*)>(cuda_ptx::ld_global_L2_128B));));
-#endif // __libcuda_ptx_isa >= 740
+        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(const int8_t*)>(cuda::ptx::ld_global_L2_128B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(
     NV_PROVIDES_SM_75,
     (
         // ld.global.L2::128B.b16 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int16_t (*)(const int16_t*)>(cuda_ptx::ld_global_L2_128B));));
-#endif // __libcuda_ptx_isa >= 740
+        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int16_t (*)(const int16_t*)>(cuda::ptx::ld_global_L2_128B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(
     NV_PROVIDES_SM_75,
     (
         // ld.global.L2::128B.b32 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int32_t (*)(const int32_t*)>(cuda_ptx::ld_global_L2_128B));));
-#endif // __libcuda_ptx_isa >= 740
+        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int32_t (*)(const int32_t*)>(cuda::ptx::ld_global_L2_128B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(
     NV_PROVIDES_SM_75,
     (
         // ld.global.L2::128B.b64 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int64_t (*)(const int64_t*)>(cuda_ptx::ld_global_L2_128B));));
-#endif // __libcuda_ptx_isa >= 740
+        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int64_t (*)(const int64_t*)>(cuda::ptx::ld_global_L2_128B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.L2::128B.b128 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<__int128 (*)(const __int128*)>(cuda_ptx::ld_global_L2_128B));));
-#endif // __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
+  NV_IF_TARGET(NV_PROVIDES_SM_75,
+               (
+                   // ld.global.L2::128B.b128 dest, [addr];
+                   * fn_ptr++ = reinterpret_cast<void*>(
+                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_L2_128B));));
+#endif // __cccl_ptx_isa >= 830
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(
     NV_PROVIDES_SM_80,
     (
         // ld.global.L2::256B.b8 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(const int8_t*)>(cuda_ptx::ld_global_L2_256B));));
-#endif // __libcuda_ptx_isa >= 740
+        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(const int8_t*)>(cuda::ptx::ld_global_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(
     NV_PROVIDES_SM_80,
     (
         // ld.global.L2::256B.b16 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int16_t (*)(const int16_t*)>(cuda_ptx::ld_global_L2_256B));));
-#endif // __libcuda_ptx_isa >= 740
+        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int16_t (*)(const int16_t*)>(cuda::ptx::ld_global_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(
     NV_PROVIDES_SM_80,
     (
         // ld.global.L2::256B.b32 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int32_t (*)(const int32_t*)>(cuda_ptx::ld_global_L2_256B));));
-#endif // __libcuda_ptx_isa >= 740
+        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int32_t (*)(const int32_t*)>(cuda::ptx::ld_global_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(
     NV_PROVIDES_SM_80,
     (
         // ld.global.L2::256B.b64 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int64_t (*)(const int64_t*)>(cuda_ptx::ld_global_L2_256B));));
-#endif // __libcuda_ptx_isa >= 740
+        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int64_t (*)(const int64_t*)>(cuda::ptx::ld_global_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L2::256B.b128 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<__int128 (*)(const __int128*)>(cuda_ptx::ld_global_L2_256B));));
-#endif // __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
+  NV_IF_TARGET(NV_PROVIDES_SM_80,
+               (
+                   // ld.global.L2::256B.b128 dest, [addr];
+                   * fn_ptr++ = reinterpret_cast<void*>(
+                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_L2_256B));));
+#endif // __cccl_ptx_isa >= 830
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.L1::evict_normal.b8 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int8_t (*)(const int8_t*)>(cuda_ptx::ld_global_L1_evict_normal));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int8_t (*)(const int8_t*)>(cuda::ptx::ld_global_L1_evict_normal));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.L1::evict_normal.b16 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int16_t (*)(const int16_t*)>(cuda_ptx::ld_global_L1_evict_normal));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int16_t (*)(const int16_t*)>(cuda::ptx::ld_global_L1_evict_normal));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.L1::evict_normal.b32 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int32_t (*)(const int32_t*)>(cuda_ptx::ld_global_L1_evict_normal));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int32_t (*)(const int32_t*)>(cuda::ptx::ld_global_L1_evict_normal));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.L1::evict_normal.b64 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int64_t (*)(const int64_t*)>(cuda_ptx::ld_global_L1_evict_normal));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int64_t (*)(const int64_t*)>(cuda::ptx::ld_global_L1_evict_normal));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.L1::evict_normal.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda_ptx::ld_global_L1_evict_normal));));
-#endif // __libcuda_ptx_isa >= 830
+                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_L1_evict_normal));));
+#endif // __cccl_ptx_isa >= 830
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.L1::evict_normal.L2::64B.b8 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int8_t (*)(const int8_t*)>(cuda_ptx::ld_global_L1_evict_normal_L2_64B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int8_t (*)(const int8_t*)>(cuda::ptx::ld_global_L1_evict_normal_L2_64B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.L1::evict_normal.L2::64B.b16 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int16_t (*)(const int16_t*)>(cuda_ptx::ld_global_L1_evict_normal_L2_64B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int16_t (*)(const int16_t*)>(cuda::ptx::ld_global_L1_evict_normal_L2_64B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.L1::evict_normal.L2::64B.b32 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int32_t (*)(const int32_t*)>(cuda_ptx::ld_global_L1_evict_normal_L2_64B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int32_t (*)(const int32_t*)>(cuda::ptx::ld_global_L1_evict_normal_L2_64B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.L1::evict_normal.L2::64B.b64 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int64_t (*)(const int64_t*)>(cuda_ptx::ld_global_L1_evict_normal_L2_64B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int64_t (*)(const int64_t*)>(cuda::ptx::ld_global_L1_evict_normal_L2_64B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.L1::evict_normal.L2::64B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda_ptx::ld_global_L1_evict_normal_L2_64B));));
-#endif // __libcuda_ptx_isa >= 830
+                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_L1_evict_normal_L2_64B));));
+#endif // __cccl_ptx_isa >= 830
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.L1::evict_normal.L2::128B.b8 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int8_t (*)(const int8_t*)>(cuda_ptx::ld_global_L1_evict_normal_L2_128B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int8_t (*)(const int8_t*)>(cuda::ptx::ld_global_L1_evict_normal_L2_128B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.L1::evict_normal.L2::128B.b16 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int16_t (*)(const int16_t*)>(cuda_ptx::ld_global_L1_evict_normal_L2_128B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int16_t (*)(const int16_t*)>(cuda::ptx::ld_global_L1_evict_normal_L2_128B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.L1::evict_normal.L2::128B.b32 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int32_t (*)(const int32_t*)>(cuda_ptx::ld_global_L1_evict_normal_L2_128B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int32_t (*)(const int32_t*)>(cuda::ptx::ld_global_L1_evict_normal_L2_128B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.L1::evict_normal.L2::128B.b64 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int64_t (*)(const int64_t*)>(cuda_ptx::ld_global_L1_evict_normal_L2_128B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int64_t (*)(const int64_t*)>(cuda::ptx::ld_global_L1_evict_normal_L2_128B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.L1::evict_normal.L2::128B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda_ptx::ld_global_L1_evict_normal_L2_128B));));
-#endif // __libcuda_ptx_isa >= 830
+                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_L1_evict_normal_L2_128B));));
+#endif // __cccl_ptx_isa >= 830
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
                    // ld.global.L1::evict_normal.L2::256B.b8 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int8_t (*)(const int8_t*)>(cuda_ptx::ld_global_L1_evict_normal_L2_256B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int8_t (*)(const int8_t*)>(cuda::ptx::ld_global_L1_evict_normal_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
                    // ld.global.L1::evict_normal.L2::256B.b16 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int16_t (*)(const int16_t*)>(cuda_ptx::ld_global_L1_evict_normal_L2_256B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int16_t (*)(const int16_t*)>(cuda::ptx::ld_global_L1_evict_normal_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
                    // ld.global.L1::evict_normal.L2::256B.b32 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int32_t (*)(const int32_t*)>(cuda_ptx::ld_global_L1_evict_normal_L2_256B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int32_t (*)(const int32_t*)>(cuda::ptx::ld_global_L1_evict_normal_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
                    // ld.global.L1::evict_normal.L2::256B.b64 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int64_t (*)(const int64_t*)>(cuda_ptx::ld_global_L1_evict_normal_L2_256B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int64_t (*)(const int64_t*)>(cuda::ptx::ld_global_L1_evict_normal_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
                    // ld.global.L1::evict_normal.L2::256B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda_ptx::ld_global_L1_evict_normal_L2_256B));));
-#endif // __libcuda_ptx_isa >= 830
+                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_L1_evict_normal_L2_256B));));
+#endif // __cccl_ptx_isa >= 830
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.L1::evict_unchanged.b8 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int8_t (*)(const int8_t*)>(cuda_ptx::ld_global_L1_evict_unchanged));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int8_t (*)(const int8_t*)>(cuda::ptx::ld_global_L1_evict_unchanged));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.L1::evict_unchanged.b16 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int16_t (*)(const int16_t*)>(cuda_ptx::ld_global_L1_evict_unchanged));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int16_t (*)(const int16_t*)>(cuda::ptx::ld_global_L1_evict_unchanged));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.L1::evict_unchanged.b32 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int32_t (*)(const int32_t*)>(cuda_ptx::ld_global_L1_evict_unchanged));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int32_t (*)(const int32_t*)>(cuda::ptx::ld_global_L1_evict_unchanged));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.L1::evict_unchanged.b64 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int64_t (*)(const int64_t*)>(cuda_ptx::ld_global_L1_evict_unchanged));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int64_t (*)(const int64_t*)>(cuda::ptx::ld_global_L1_evict_unchanged));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.L1::evict_unchanged.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda_ptx::ld_global_L1_evict_unchanged));));
-#endif // __libcuda_ptx_isa >= 830
+                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_L1_evict_unchanged));));
+#endif // __cccl_ptx_isa >= 830
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.L1::evict_unchanged.L2::64B.b8 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int8_t (*)(const int8_t*)>(cuda_ptx::ld_global_L1_evict_unchanged_L2_64B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int8_t (*)(const int8_t*)>(cuda::ptx::ld_global_L1_evict_unchanged_L2_64B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.L1::evict_unchanged.L2::64B.b16 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int16_t (*)(const int16_t*)>(cuda_ptx::ld_global_L1_evict_unchanged_L2_64B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int16_t (*)(const int16_t*)>(cuda::ptx::ld_global_L1_evict_unchanged_L2_64B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.L1::evict_unchanged.L2::64B.b32 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int32_t (*)(const int32_t*)>(cuda_ptx::ld_global_L1_evict_unchanged_L2_64B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int32_t (*)(const int32_t*)>(cuda::ptx::ld_global_L1_evict_unchanged_L2_64B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.L1::evict_unchanged.L2::64B.b64 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int64_t (*)(const int64_t*)>(cuda_ptx::ld_global_L1_evict_unchanged_L2_64B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int64_t (*)(const int64_t*)>(cuda::ptx::ld_global_L1_evict_unchanged_L2_64B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.L1::evict_unchanged.L2::64B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda_ptx::ld_global_L1_evict_unchanged_L2_64B));));
-#endif // __libcuda_ptx_isa >= 830
+                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_L1_evict_unchanged_L2_64B));));
+#endif // __cccl_ptx_isa >= 830
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.L1::evict_unchanged.L2::128B.b8 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int8_t (*)(const int8_t*)>(cuda_ptx::ld_global_L1_evict_unchanged_L2_128B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int8_t (*)(const int8_t*)>(cuda::ptx::ld_global_L1_evict_unchanged_L2_128B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.L1::evict_unchanged.L2::128B.b16 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int16_t (*)(const int16_t*)>(cuda_ptx::ld_global_L1_evict_unchanged_L2_128B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int16_t (*)(const int16_t*)>(cuda::ptx::ld_global_L1_evict_unchanged_L2_128B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.L1::evict_unchanged.L2::128B.b32 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int32_t (*)(const int32_t*)>(cuda_ptx::ld_global_L1_evict_unchanged_L2_128B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int32_t (*)(const int32_t*)>(cuda::ptx::ld_global_L1_evict_unchanged_L2_128B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.L1::evict_unchanged.L2::128B.b64 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int64_t (*)(const int64_t*)>(cuda_ptx::ld_global_L1_evict_unchanged_L2_128B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int64_t (*)(const int64_t*)>(cuda::ptx::ld_global_L1_evict_unchanged_L2_128B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.L1::evict_unchanged.L2::128B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda_ptx::ld_global_L1_evict_unchanged_L2_128B));));
-#endif // __libcuda_ptx_isa >= 830
+                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_L1_evict_unchanged_L2_128B));));
+#endif // __cccl_ptx_isa >= 830
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
                    // ld.global.L1::evict_unchanged.L2::256B.b8 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int8_t (*)(const int8_t*)>(cuda_ptx::ld_global_L1_evict_unchanged_L2_256B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int8_t (*)(const int8_t*)>(cuda::ptx::ld_global_L1_evict_unchanged_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
                    // ld.global.L1::evict_unchanged.L2::256B.b16 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int16_t (*)(const int16_t*)>(cuda_ptx::ld_global_L1_evict_unchanged_L2_256B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int16_t (*)(const int16_t*)>(cuda::ptx::ld_global_L1_evict_unchanged_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
                    // ld.global.L1::evict_unchanged.L2::256B.b32 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int32_t (*)(const int32_t*)>(cuda_ptx::ld_global_L1_evict_unchanged_L2_256B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int32_t (*)(const int32_t*)>(cuda::ptx::ld_global_L1_evict_unchanged_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
                    // ld.global.L1::evict_unchanged.L2::256B.b64 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int64_t (*)(const int64_t*)>(cuda_ptx::ld_global_L1_evict_unchanged_L2_256B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int64_t (*)(const int64_t*)>(cuda::ptx::ld_global_L1_evict_unchanged_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
                    // ld.global.L1::evict_unchanged.L2::256B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda_ptx::ld_global_L1_evict_unchanged_L2_256B));));
-#endif // __libcuda_ptx_isa >= 830
+                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_L1_evict_unchanged_L2_256B));));
+#endif // __cccl_ptx_isa >= 830
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.L1::evict_first.b8 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int8_t (*)(const int8_t*)>(cuda_ptx::ld_global_L1_evict_first));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int8_t (*)(const int8_t*)>(cuda::ptx::ld_global_L1_evict_first));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.L1::evict_first.b16 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int16_t (*)(const int16_t*)>(cuda_ptx::ld_global_L1_evict_first));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int16_t (*)(const int16_t*)>(cuda::ptx::ld_global_L1_evict_first));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.L1::evict_first.b32 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int32_t (*)(const int32_t*)>(cuda_ptx::ld_global_L1_evict_first));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int32_t (*)(const int32_t*)>(cuda::ptx::ld_global_L1_evict_first));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.L1::evict_first.b64 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int64_t (*)(const int64_t*)>(cuda_ptx::ld_global_L1_evict_first));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int64_t (*)(const int64_t*)>(cuda::ptx::ld_global_L1_evict_first));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.L1::evict_first.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda_ptx::ld_global_L1_evict_first));));
-#endif // __libcuda_ptx_isa >= 830
+                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_L1_evict_first));));
+#endif // __cccl_ptx_isa >= 830
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.L1::evict_first.L2::64B.b8 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int8_t (*)(const int8_t*)>(cuda_ptx::ld_global_L1_evict_first_L2_64B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int8_t (*)(const int8_t*)>(cuda::ptx::ld_global_L1_evict_first_L2_64B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.L1::evict_first.L2::64B.b16 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int16_t (*)(const int16_t*)>(cuda_ptx::ld_global_L1_evict_first_L2_64B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int16_t (*)(const int16_t*)>(cuda::ptx::ld_global_L1_evict_first_L2_64B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.L1::evict_first.L2::64B.b32 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int32_t (*)(const int32_t*)>(cuda_ptx::ld_global_L1_evict_first_L2_64B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int32_t (*)(const int32_t*)>(cuda::ptx::ld_global_L1_evict_first_L2_64B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.L1::evict_first.L2::64B.b64 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int64_t (*)(const int64_t*)>(cuda_ptx::ld_global_L1_evict_first_L2_64B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int64_t (*)(const int64_t*)>(cuda::ptx::ld_global_L1_evict_first_L2_64B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.L1::evict_first.L2::64B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda_ptx::ld_global_L1_evict_first_L2_64B));));
-#endif // __libcuda_ptx_isa >= 830
+                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_L1_evict_first_L2_64B));));
+#endif // __cccl_ptx_isa >= 830
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.L1::evict_first.L2::128B.b8 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int8_t (*)(const int8_t*)>(cuda_ptx::ld_global_L1_evict_first_L2_128B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int8_t (*)(const int8_t*)>(cuda::ptx::ld_global_L1_evict_first_L2_128B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.L1::evict_first.L2::128B.b16 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int16_t (*)(const int16_t*)>(cuda_ptx::ld_global_L1_evict_first_L2_128B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int16_t (*)(const int16_t*)>(cuda::ptx::ld_global_L1_evict_first_L2_128B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.L1::evict_first.L2::128B.b32 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int32_t (*)(const int32_t*)>(cuda_ptx::ld_global_L1_evict_first_L2_128B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int32_t (*)(const int32_t*)>(cuda::ptx::ld_global_L1_evict_first_L2_128B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.L1::evict_first.L2::128B.b64 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int64_t (*)(const int64_t*)>(cuda_ptx::ld_global_L1_evict_first_L2_128B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int64_t (*)(const int64_t*)>(cuda::ptx::ld_global_L1_evict_first_L2_128B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.L1::evict_first.L2::128B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda_ptx::ld_global_L1_evict_first_L2_128B));));
-#endif // __libcuda_ptx_isa >= 830
+                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_L1_evict_first_L2_128B));));
+#endif // __cccl_ptx_isa >= 830
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
                    // ld.global.L1::evict_first.L2::256B.b8 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int8_t (*)(const int8_t*)>(cuda_ptx::ld_global_L1_evict_first_L2_256B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int8_t (*)(const int8_t*)>(cuda::ptx::ld_global_L1_evict_first_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
                    // ld.global.L1::evict_first.L2::256B.b16 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int16_t (*)(const int16_t*)>(cuda_ptx::ld_global_L1_evict_first_L2_256B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int16_t (*)(const int16_t*)>(cuda::ptx::ld_global_L1_evict_first_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
                    // ld.global.L1::evict_first.L2::256B.b32 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int32_t (*)(const int32_t*)>(cuda_ptx::ld_global_L1_evict_first_L2_256B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int32_t (*)(const int32_t*)>(cuda::ptx::ld_global_L1_evict_first_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
                    // ld.global.L1::evict_first.L2::256B.b64 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int64_t (*)(const int64_t*)>(cuda_ptx::ld_global_L1_evict_first_L2_256B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int64_t (*)(const int64_t*)>(cuda::ptx::ld_global_L1_evict_first_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
                    // ld.global.L1::evict_first.L2::256B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda_ptx::ld_global_L1_evict_first_L2_256B));));
-#endif // __libcuda_ptx_isa >= 830
+                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_L1_evict_first_L2_256B));));
+#endif // __cccl_ptx_isa >= 830
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.L1::evict_last.b8 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int8_t (*)(const int8_t*)>(cuda_ptx::ld_global_L1_evict_last));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int8_t (*)(const int8_t*)>(cuda::ptx::ld_global_L1_evict_last));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.L1::evict_last.b16 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int16_t (*)(const int16_t*)>(cuda_ptx::ld_global_L1_evict_last));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int16_t (*)(const int16_t*)>(cuda::ptx::ld_global_L1_evict_last));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.L1::evict_last.b32 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int32_t (*)(const int32_t*)>(cuda_ptx::ld_global_L1_evict_last));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int32_t (*)(const int32_t*)>(cuda::ptx::ld_global_L1_evict_last));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.L1::evict_last.b64 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int64_t (*)(const int64_t*)>(cuda_ptx::ld_global_L1_evict_last));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int64_t (*)(const int64_t*)>(cuda::ptx::ld_global_L1_evict_last));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.L1::evict_last.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda_ptx::ld_global_L1_evict_last));));
-#endif // __libcuda_ptx_isa >= 830
+                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_L1_evict_last));));
+#endif // __cccl_ptx_isa >= 830
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.L1::evict_last.L2::64B.b8 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int8_t (*)(const int8_t*)>(cuda_ptx::ld_global_L1_evict_last_L2_64B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int8_t (*)(const int8_t*)>(cuda::ptx::ld_global_L1_evict_last_L2_64B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.L1::evict_last.L2::64B.b16 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int16_t (*)(const int16_t*)>(cuda_ptx::ld_global_L1_evict_last_L2_64B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int16_t (*)(const int16_t*)>(cuda::ptx::ld_global_L1_evict_last_L2_64B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.L1::evict_last.L2::64B.b32 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int32_t (*)(const int32_t*)>(cuda_ptx::ld_global_L1_evict_last_L2_64B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int32_t (*)(const int32_t*)>(cuda::ptx::ld_global_L1_evict_last_L2_64B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.L1::evict_last.L2::64B.b64 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int64_t (*)(const int64_t*)>(cuda_ptx::ld_global_L1_evict_last_L2_64B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int64_t (*)(const int64_t*)>(cuda::ptx::ld_global_L1_evict_last_L2_64B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.L1::evict_last.L2::64B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda_ptx::ld_global_L1_evict_last_L2_64B));));
-#endif // __libcuda_ptx_isa >= 830
+                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_L1_evict_last_L2_64B));));
+#endif // __cccl_ptx_isa >= 830
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.L1::evict_last.L2::128B.b8 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int8_t (*)(const int8_t*)>(cuda_ptx::ld_global_L1_evict_last_L2_128B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int8_t (*)(const int8_t*)>(cuda::ptx::ld_global_L1_evict_last_L2_128B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.L1::evict_last.L2::128B.b16 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int16_t (*)(const int16_t*)>(cuda_ptx::ld_global_L1_evict_last_L2_128B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int16_t (*)(const int16_t*)>(cuda::ptx::ld_global_L1_evict_last_L2_128B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.L1::evict_last.L2::128B.b32 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int32_t (*)(const int32_t*)>(cuda_ptx::ld_global_L1_evict_last_L2_128B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int32_t (*)(const int32_t*)>(cuda::ptx::ld_global_L1_evict_last_L2_128B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.L1::evict_last.L2::128B.b64 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int64_t (*)(const int64_t*)>(cuda_ptx::ld_global_L1_evict_last_L2_128B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int64_t (*)(const int64_t*)>(cuda::ptx::ld_global_L1_evict_last_L2_128B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.L1::evict_last.L2::128B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda_ptx::ld_global_L1_evict_last_L2_128B));));
-#endif // __libcuda_ptx_isa >= 830
+                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_L1_evict_last_L2_128B));));
+#endif // __cccl_ptx_isa >= 830
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
                    // ld.global.L1::evict_last.L2::256B.b8 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int8_t (*)(const int8_t*)>(cuda_ptx::ld_global_L1_evict_last_L2_256B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int8_t (*)(const int8_t*)>(cuda::ptx::ld_global_L1_evict_last_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
                    // ld.global.L1::evict_last.L2::256B.b16 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int16_t (*)(const int16_t*)>(cuda_ptx::ld_global_L1_evict_last_L2_256B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int16_t (*)(const int16_t*)>(cuda::ptx::ld_global_L1_evict_last_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
                    // ld.global.L1::evict_last.L2::256B.b32 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int32_t (*)(const int32_t*)>(cuda_ptx::ld_global_L1_evict_last_L2_256B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int32_t (*)(const int32_t*)>(cuda::ptx::ld_global_L1_evict_last_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
                    // ld.global.L1::evict_last.L2::256B.b64 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int64_t (*)(const int64_t*)>(cuda_ptx::ld_global_L1_evict_last_L2_256B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int64_t (*)(const int64_t*)>(cuda::ptx::ld_global_L1_evict_last_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
                    // ld.global.L1::evict_last.L2::256B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda_ptx::ld_global_L1_evict_last_L2_256B));));
-#endif // __libcuda_ptx_isa >= 830
+                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_L1_evict_last_L2_256B));));
+#endif // __cccl_ptx_isa >= 830
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.L1::no_allocate.b8 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int8_t (*)(const int8_t*)>(cuda_ptx::ld_global_L1_no_allocate));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int8_t (*)(const int8_t*)>(cuda::ptx::ld_global_L1_no_allocate));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.L1::no_allocate.b16 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int16_t (*)(const int16_t*)>(cuda_ptx::ld_global_L1_no_allocate));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int16_t (*)(const int16_t*)>(cuda::ptx::ld_global_L1_no_allocate));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.L1::no_allocate.b32 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int32_t (*)(const int32_t*)>(cuda_ptx::ld_global_L1_no_allocate));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int32_t (*)(const int32_t*)>(cuda::ptx::ld_global_L1_no_allocate));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.L1::no_allocate.b64 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int64_t (*)(const int64_t*)>(cuda_ptx::ld_global_L1_no_allocate));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int64_t (*)(const int64_t*)>(cuda::ptx::ld_global_L1_no_allocate));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.L1::no_allocate.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda_ptx::ld_global_L1_no_allocate));));
-#endif // __libcuda_ptx_isa >= 830
+                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_L1_no_allocate));));
+#endif // __cccl_ptx_isa >= 830
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.L1::no_allocate.L2::64B.b8 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int8_t (*)(const int8_t*)>(cuda_ptx::ld_global_L1_no_allocate_L2_64B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int8_t (*)(const int8_t*)>(cuda::ptx::ld_global_L1_no_allocate_L2_64B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.L1::no_allocate.L2::64B.b16 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int16_t (*)(const int16_t*)>(cuda_ptx::ld_global_L1_no_allocate_L2_64B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int16_t (*)(const int16_t*)>(cuda::ptx::ld_global_L1_no_allocate_L2_64B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.L1::no_allocate.L2::64B.b32 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int32_t (*)(const int32_t*)>(cuda_ptx::ld_global_L1_no_allocate_L2_64B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int32_t (*)(const int32_t*)>(cuda::ptx::ld_global_L1_no_allocate_L2_64B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.L1::no_allocate.L2::64B.b64 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int64_t (*)(const int64_t*)>(cuda_ptx::ld_global_L1_no_allocate_L2_64B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int64_t (*)(const int64_t*)>(cuda::ptx::ld_global_L1_no_allocate_L2_64B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.L1::no_allocate.L2::64B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda_ptx::ld_global_L1_no_allocate_L2_64B));));
-#endif // __libcuda_ptx_isa >= 830
+                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_L1_no_allocate_L2_64B));));
+#endif // __cccl_ptx_isa >= 830
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.L1::no_allocate.L2::128B.b8 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int8_t (*)(const int8_t*)>(cuda_ptx::ld_global_L1_no_allocate_L2_128B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int8_t (*)(const int8_t*)>(cuda::ptx::ld_global_L1_no_allocate_L2_128B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.L1::no_allocate.L2::128B.b16 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int16_t (*)(const int16_t*)>(cuda_ptx::ld_global_L1_no_allocate_L2_128B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int16_t (*)(const int16_t*)>(cuda::ptx::ld_global_L1_no_allocate_L2_128B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.L1::no_allocate.L2::128B.b32 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int32_t (*)(const int32_t*)>(cuda_ptx::ld_global_L1_no_allocate_L2_128B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int32_t (*)(const int32_t*)>(cuda::ptx::ld_global_L1_no_allocate_L2_128B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.L1::no_allocate.L2::128B.b64 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int64_t (*)(const int64_t*)>(cuda_ptx::ld_global_L1_no_allocate_L2_128B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int64_t (*)(const int64_t*)>(cuda::ptx::ld_global_L1_no_allocate_L2_128B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.L1::no_allocate.L2::128B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda_ptx::ld_global_L1_no_allocate_L2_128B));));
-#endif // __libcuda_ptx_isa >= 830
+                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_L1_no_allocate_L2_128B));));
+#endif // __cccl_ptx_isa >= 830
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
                    // ld.global.L1::no_allocate.L2::256B.b8 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int8_t (*)(const int8_t*)>(cuda_ptx::ld_global_L1_no_allocate_L2_256B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int8_t (*)(const int8_t*)>(cuda::ptx::ld_global_L1_no_allocate_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
                    // ld.global.L1::no_allocate.L2::256B.b16 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int16_t (*)(const int16_t*)>(cuda_ptx::ld_global_L1_no_allocate_L2_256B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int16_t (*)(const int16_t*)>(cuda::ptx::ld_global_L1_no_allocate_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
                    // ld.global.L1::no_allocate.L2::256B.b32 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int32_t (*)(const int32_t*)>(cuda_ptx::ld_global_L1_no_allocate_L2_256B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int32_t (*)(const int32_t*)>(cuda::ptx::ld_global_L1_no_allocate_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
                    // ld.global.L1::no_allocate.L2::256B.b64 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int64_t (*)(const int64_t*)>(cuda_ptx::ld_global_L1_no_allocate_L2_256B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int64_t (*)(const int64_t*)>(cuda::ptx::ld_global_L1_no_allocate_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
                    // ld.global.L1::no_allocate.L2::256B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda_ptx::ld_global_L1_no_allocate_L2_256B));));
-#endif // __libcuda_ptx_isa >= 830
+                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_L1_no_allocate_L2_256B));));
+#endif // __cccl_ptx_isa >= 830
 
-#if __libcuda_ptx_isa >= 100
+#if __cccl_ptx_isa >= 100
   NV_IF_TARGET(
     NV_PROVIDES_SM_50,
     (
         // ld.global.nc.b8 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(const int8_t*)>(cuda_ptx::ld_global_nc));));
-#endif // __libcuda_ptx_isa >= 100
+        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(const int8_t*)>(cuda::ptx::ld_global_nc));));
+#endif // __cccl_ptx_isa >= 100
 
-#if __libcuda_ptx_isa >= 100
+#if __cccl_ptx_isa >= 100
   NV_IF_TARGET(
     NV_PROVIDES_SM_50,
     (
         // ld.global.nc.b16 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int16_t (*)(const int16_t*)>(cuda_ptx::ld_global_nc));));
-#endif // __libcuda_ptx_isa >= 100
+        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int16_t (*)(const int16_t*)>(cuda::ptx::ld_global_nc));));
+#endif // __cccl_ptx_isa >= 100
 
-#if __libcuda_ptx_isa >= 100
+#if __cccl_ptx_isa >= 100
   NV_IF_TARGET(
     NV_PROVIDES_SM_50,
     (
         // ld.global.nc.b32 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int32_t (*)(const int32_t*)>(cuda_ptx::ld_global_nc));));
-#endif // __libcuda_ptx_isa >= 100
+        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int32_t (*)(const int32_t*)>(cuda::ptx::ld_global_nc));));
+#endif // __cccl_ptx_isa >= 100
 
-#if __libcuda_ptx_isa >= 100
+#if __cccl_ptx_isa >= 100
   NV_IF_TARGET(
     NV_PROVIDES_SM_50,
     (
         // ld.global.nc.b64 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int64_t (*)(const int64_t*)>(cuda_ptx::ld_global_nc));));
-#endif // __libcuda_ptx_isa >= 100
+        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int64_t (*)(const int64_t*)>(cuda::ptx::ld_global_nc));));
+#endif // __cccl_ptx_isa >= 100
 
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
   NV_IF_TARGET(
     NV_PROVIDES_SM_70,
     (
         // ld.global.nc.b128 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<__int128 (*)(const __int128*)>(cuda_ptx::ld_global_nc));));
-#endif // __libcuda_ptx_isa >= 830
+        * fn_ptr++ = reinterpret_cast<void*>(static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_nc));));
+#endif // __cccl_ptx_isa >= 830
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(
     NV_PROVIDES_SM_75,
     (
         // ld.global.nc.L2::64B.b8 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(const int8_t*)>(cuda_ptx::ld_global_nc_L2_64B));));
-#endif // __libcuda_ptx_isa >= 740
+        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(const int8_t*)>(cuda::ptx::ld_global_nc_L2_64B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.nc.L2::64B.b16 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int16_t (*)(const int16_t*)>(cuda_ptx::ld_global_nc_L2_64B));));
-#endif // __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
+  NV_IF_TARGET(NV_PROVIDES_SM_75,
+               (
+                   // ld.global.nc.L2::64B.b16 dest, [addr];
+                   * fn_ptr++ = reinterpret_cast<void*>(
+                     static_cast<int16_t (*)(const int16_t*)>(cuda::ptx::ld_global_nc_L2_64B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.nc.L2::64B.b32 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int32_t (*)(const int32_t*)>(cuda_ptx::ld_global_nc_L2_64B));));
-#endif // __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
+  NV_IF_TARGET(NV_PROVIDES_SM_75,
+               (
+                   // ld.global.nc.L2::64B.b32 dest, [addr];
+                   * fn_ptr++ = reinterpret_cast<void*>(
+                     static_cast<int32_t (*)(const int32_t*)>(cuda::ptx::ld_global_nc_L2_64B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.nc.L2::64B.b64 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int64_t (*)(const int64_t*)>(cuda_ptx::ld_global_nc_L2_64B));));
-#endif // __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
+  NV_IF_TARGET(NV_PROVIDES_SM_75,
+               (
+                   // ld.global.nc.L2::64B.b64 dest, [addr];
+                   * fn_ptr++ = reinterpret_cast<void*>(
+                     static_cast<int64_t (*)(const int64_t*)>(cuda::ptx::ld_global_nc_L2_64B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.nc.L2::64B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda_ptx::ld_global_nc_L2_64B));));
-#endif // __libcuda_ptx_isa >= 830
+                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_nc_L2_64B));));
+#endif // __cccl_ptx_isa >= 830
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(
     NV_PROVIDES_SM_75,
     (
         // ld.global.nc.L2::128B.b8 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(const int8_t*)>(cuda_ptx::ld_global_nc_L2_128B));));
-#endif // __libcuda_ptx_isa >= 740
+        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(const int8_t*)>(cuda::ptx::ld_global_nc_L2_128B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.nc.L2::128B.b16 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int16_t (*)(const int16_t*)>(cuda_ptx::ld_global_nc_L2_128B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int16_t (*)(const int16_t*)>(cuda::ptx::ld_global_nc_L2_128B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.nc.L2::128B.b32 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int32_t (*)(const int32_t*)>(cuda_ptx::ld_global_nc_L2_128B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int32_t (*)(const int32_t*)>(cuda::ptx::ld_global_nc_L2_128B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.nc.L2::128B.b64 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int64_t (*)(const int64_t*)>(cuda_ptx::ld_global_nc_L2_128B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int64_t (*)(const int64_t*)>(cuda::ptx::ld_global_nc_L2_128B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.nc.L2::128B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda_ptx::ld_global_nc_L2_128B));));
-#endif // __libcuda_ptx_isa >= 830
+                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_nc_L2_128B));));
+#endif // __cccl_ptx_isa >= 830
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(
     NV_PROVIDES_SM_80,
     (
         // ld.global.nc.L2::256B.b8 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(const int8_t*)>(cuda_ptx::ld_global_nc_L2_256B));));
-#endif // __libcuda_ptx_isa >= 740
+        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(const int8_t*)>(cuda::ptx::ld_global_nc_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
                    // ld.global.nc.L2::256B.b16 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int16_t (*)(const int16_t*)>(cuda_ptx::ld_global_nc_L2_256B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int16_t (*)(const int16_t*)>(cuda::ptx::ld_global_nc_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
                    // ld.global.nc.L2::256B.b32 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int32_t (*)(const int32_t*)>(cuda_ptx::ld_global_nc_L2_256B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int32_t (*)(const int32_t*)>(cuda::ptx::ld_global_nc_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
                    // ld.global.nc.L2::256B.b64 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int64_t (*)(const int64_t*)>(cuda_ptx::ld_global_nc_L2_256B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int64_t (*)(const int64_t*)>(cuda::ptx::ld_global_nc_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
                    // ld.global.nc.L2::256B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda_ptx::ld_global_nc_L2_256B));));
-#endif // __libcuda_ptx_isa >= 830
+                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_nc_L2_256B));));
+#endif // __cccl_ptx_isa >= 830
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.nc.L1::evict_normal.b8 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int8_t (*)(const int8_t*)>(cuda_ptx::ld_global_nc_L1_evict_normal));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int8_t (*)(const int8_t*)>(cuda::ptx::ld_global_nc_L1_evict_normal));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.nc.L1::evict_normal.b16 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int16_t (*)(const int16_t*)>(cuda_ptx::ld_global_nc_L1_evict_normal));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int16_t (*)(const int16_t*)>(cuda::ptx::ld_global_nc_L1_evict_normal));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.nc.L1::evict_normal.b32 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int32_t (*)(const int32_t*)>(cuda_ptx::ld_global_nc_L1_evict_normal));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int32_t (*)(const int32_t*)>(cuda::ptx::ld_global_nc_L1_evict_normal));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.nc.L1::evict_normal.b64 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int64_t (*)(const int64_t*)>(cuda_ptx::ld_global_nc_L1_evict_normal));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int64_t (*)(const int64_t*)>(cuda::ptx::ld_global_nc_L1_evict_normal));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.nc.L1::evict_normal.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda_ptx::ld_global_nc_L1_evict_normal));));
-#endif // __libcuda_ptx_isa >= 830
+                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_nc_L1_evict_normal));));
+#endif // __cccl_ptx_isa >= 830
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.nc.L1::evict_normal.L2::64B.b8 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int8_t (*)(const int8_t*)>(cuda_ptx::ld_global_nc_L1_evict_normal_L2_64B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int8_t (*)(const int8_t*)>(cuda::ptx::ld_global_nc_L1_evict_normal_L2_64B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.nc.L1::evict_normal.L2::64B.b16 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int16_t (*)(const int16_t*)>(cuda_ptx::ld_global_nc_L1_evict_normal_L2_64B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int16_t (*)(const int16_t*)>(cuda::ptx::ld_global_nc_L1_evict_normal_L2_64B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.nc.L1::evict_normal.L2::64B.b32 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int32_t (*)(const int32_t*)>(cuda_ptx::ld_global_nc_L1_evict_normal_L2_64B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int32_t (*)(const int32_t*)>(cuda::ptx::ld_global_nc_L1_evict_normal_L2_64B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.nc.L1::evict_normal.L2::64B.b64 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int64_t (*)(const int64_t*)>(cuda_ptx::ld_global_nc_L1_evict_normal_L2_64B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int64_t (*)(const int64_t*)>(cuda::ptx::ld_global_nc_L1_evict_normal_L2_64B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.nc.L1::evict_normal.L2::64B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda_ptx::ld_global_nc_L1_evict_normal_L2_64B));));
-#endif // __libcuda_ptx_isa >= 830
+                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_nc_L1_evict_normal_L2_64B));));
+#endif // __cccl_ptx_isa >= 830
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.nc.L1::evict_normal.L2::128B.b8 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int8_t (*)(const int8_t*)>(cuda_ptx::ld_global_nc_L1_evict_normal_L2_128B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int8_t (*)(const int8_t*)>(cuda::ptx::ld_global_nc_L1_evict_normal_L2_128B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.nc.L1::evict_normal.L2::128B.b16 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int16_t (*)(const int16_t*)>(cuda_ptx::ld_global_nc_L1_evict_normal_L2_128B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int16_t (*)(const int16_t*)>(cuda::ptx::ld_global_nc_L1_evict_normal_L2_128B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.nc.L1::evict_normal.L2::128B.b32 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int32_t (*)(const int32_t*)>(cuda_ptx::ld_global_nc_L1_evict_normal_L2_128B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int32_t (*)(const int32_t*)>(cuda::ptx::ld_global_nc_L1_evict_normal_L2_128B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.nc.L1::evict_normal.L2::128B.b64 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int64_t (*)(const int64_t*)>(cuda_ptx::ld_global_nc_L1_evict_normal_L2_128B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int64_t (*)(const int64_t*)>(cuda::ptx::ld_global_nc_L1_evict_normal_L2_128B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.nc.L1::evict_normal.L2::128B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda_ptx::ld_global_nc_L1_evict_normal_L2_128B));));
-#endif // __libcuda_ptx_isa >= 830
+                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_nc_L1_evict_normal_L2_128B));));
+#endif // __cccl_ptx_isa >= 830
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
                    // ld.global.nc.L1::evict_normal.L2::256B.b8 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int8_t (*)(const int8_t*)>(cuda_ptx::ld_global_nc_L1_evict_normal_L2_256B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int8_t (*)(const int8_t*)>(cuda::ptx::ld_global_nc_L1_evict_normal_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
                    // ld.global.nc.L1::evict_normal.L2::256B.b16 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int16_t (*)(const int16_t*)>(cuda_ptx::ld_global_nc_L1_evict_normal_L2_256B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int16_t (*)(const int16_t*)>(cuda::ptx::ld_global_nc_L1_evict_normal_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
                    // ld.global.nc.L1::evict_normal.L2::256B.b32 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int32_t (*)(const int32_t*)>(cuda_ptx::ld_global_nc_L1_evict_normal_L2_256B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int32_t (*)(const int32_t*)>(cuda::ptx::ld_global_nc_L1_evict_normal_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
                    // ld.global.nc.L1::evict_normal.L2::256B.b64 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int64_t (*)(const int64_t*)>(cuda_ptx::ld_global_nc_L1_evict_normal_L2_256B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int64_t (*)(const int64_t*)>(cuda::ptx::ld_global_nc_L1_evict_normal_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
                    // ld.global.nc.L1::evict_normal.L2::256B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda_ptx::ld_global_nc_L1_evict_normal_L2_256B));));
-#endif // __libcuda_ptx_isa >= 830
+                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_nc_L1_evict_normal_L2_256B));));
+#endif // __cccl_ptx_isa >= 830
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.nc.L1::evict_unchanged.b8 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int8_t (*)(const int8_t*)>(cuda_ptx::ld_global_nc_L1_evict_unchanged));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int8_t (*)(const int8_t*)>(cuda::ptx::ld_global_nc_L1_evict_unchanged));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.nc.L1::evict_unchanged.b16 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int16_t (*)(const int16_t*)>(cuda_ptx::ld_global_nc_L1_evict_unchanged));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int16_t (*)(const int16_t*)>(cuda::ptx::ld_global_nc_L1_evict_unchanged));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.nc.L1::evict_unchanged.b32 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int32_t (*)(const int32_t*)>(cuda_ptx::ld_global_nc_L1_evict_unchanged));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int32_t (*)(const int32_t*)>(cuda::ptx::ld_global_nc_L1_evict_unchanged));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.nc.L1::evict_unchanged.b64 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int64_t (*)(const int64_t*)>(cuda_ptx::ld_global_nc_L1_evict_unchanged));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int64_t (*)(const int64_t*)>(cuda::ptx::ld_global_nc_L1_evict_unchanged));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.nc.L1::evict_unchanged.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda_ptx::ld_global_nc_L1_evict_unchanged));));
-#endif // __libcuda_ptx_isa >= 830
+                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_nc_L1_evict_unchanged));));
+#endif // __cccl_ptx_isa >= 830
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.nc.L1::evict_unchanged.L2::64B.b8 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int8_t (*)(const int8_t*)>(cuda_ptx::ld_global_nc_L1_evict_unchanged_L2_64B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int8_t (*)(const int8_t*)>(cuda::ptx::ld_global_nc_L1_evict_unchanged_L2_64B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.nc.L1::evict_unchanged.L2::64B.b16 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int16_t (*)(const int16_t*)>(cuda_ptx::ld_global_nc_L1_evict_unchanged_L2_64B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int16_t (*)(const int16_t*)>(cuda::ptx::ld_global_nc_L1_evict_unchanged_L2_64B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.nc.L1::evict_unchanged.L2::64B.b32 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int32_t (*)(const int32_t*)>(cuda_ptx::ld_global_nc_L1_evict_unchanged_L2_64B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int32_t (*)(const int32_t*)>(cuda::ptx::ld_global_nc_L1_evict_unchanged_L2_64B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.nc.L1::evict_unchanged.L2::64B.b64 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int64_t (*)(const int64_t*)>(cuda_ptx::ld_global_nc_L1_evict_unchanged_L2_64B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int64_t (*)(const int64_t*)>(cuda::ptx::ld_global_nc_L1_evict_unchanged_L2_64B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.nc.L1::evict_unchanged.L2::64B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda_ptx::ld_global_nc_L1_evict_unchanged_L2_64B));));
-#endif // __libcuda_ptx_isa >= 830
+                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_nc_L1_evict_unchanged_L2_64B));));
+#endif // __cccl_ptx_isa >= 830
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.nc.L1::evict_unchanged.L2::128B.b8 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int8_t (*)(const int8_t*)>(cuda_ptx::ld_global_nc_L1_evict_unchanged_L2_128B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int8_t (*)(const int8_t*)>(cuda::ptx::ld_global_nc_L1_evict_unchanged_L2_128B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.nc.L1::evict_unchanged.L2::128B.b16 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int16_t (*)(const int16_t*)>(cuda_ptx::ld_global_nc_L1_evict_unchanged_L2_128B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int16_t (*)(const int16_t*)>(cuda::ptx::ld_global_nc_L1_evict_unchanged_L2_128B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.nc.L1::evict_unchanged.L2::128B.b32 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int32_t (*)(const int32_t*)>(cuda_ptx::ld_global_nc_L1_evict_unchanged_L2_128B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int32_t (*)(const int32_t*)>(cuda::ptx::ld_global_nc_L1_evict_unchanged_L2_128B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.nc.L1::evict_unchanged.L2::128B.b64 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int64_t (*)(const int64_t*)>(cuda_ptx::ld_global_nc_L1_evict_unchanged_L2_128B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int64_t (*)(const int64_t*)>(cuda::ptx::ld_global_nc_L1_evict_unchanged_L2_128B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.nc.L1::evict_unchanged.L2::128B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda_ptx::ld_global_nc_L1_evict_unchanged_L2_128B));));
-#endif // __libcuda_ptx_isa >= 830
+                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_nc_L1_evict_unchanged_L2_128B));));
+#endif // __cccl_ptx_isa >= 830
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
                    // ld.global.nc.L1::evict_unchanged.L2::256B.b8 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int8_t (*)(const int8_t*)>(cuda_ptx::ld_global_nc_L1_evict_unchanged_L2_256B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int8_t (*)(const int8_t*)>(cuda::ptx::ld_global_nc_L1_evict_unchanged_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
                    // ld.global.nc.L1::evict_unchanged.L2::256B.b16 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int16_t (*)(const int16_t*)>(cuda_ptx::ld_global_nc_L1_evict_unchanged_L2_256B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int16_t (*)(const int16_t*)>(cuda::ptx::ld_global_nc_L1_evict_unchanged_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
                    // ld.global.nc.L1::evict_unchanged.L2::256B.b32 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int32_t (*)(const int32_t*)>(cuda_ptx::ld_global_nc_L1_evict_unchanged_L2_256B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int32_t (*)(const int32_t*)>(cuda::ptx::ld_global_nc_L1_evict_unchanged_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
                    // ld.global.nc.L1::evict_unchanged.L2::256B.b64 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int64_t (*)(const int64_t*)>(cuda_ptx::ld_global_nc_L1_evict_unchanged_L2_256B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int64_t (*)(const int64_t*)>(cuda::ptx::ld_global_nc_L1_evict_unchanged_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
                    // ld.global.nc.L1::evict_unchanged.L2::256B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda_ptx::ld_global_nc_L1_evict_unchanged_L2_256B));));
-#endif // __libcuda_ptx_isa >= 830
+                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_nc_L1_evict_unchanged_L2_256B));));
+#endif // __cccl_ptx_isa >= 830
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.nc.L1::evict_first.b8 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int8_t (*)(const int8_t*)>(cuda_ptx::ld_global_nc_L1_evict_first));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int8_t (*)(const int8_t*)>(cuda::ptx::ld_global_nc_L1_evict_first));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.nc.L1::evict_first.b16 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int16_t (*)(const int16_t*)>(cuda_ptx::ld_global_nc_L1_evict_first));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int16_t (*)(const int16_t*)>(cuda::ptx::ld_global_nc_L1_evict_first));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.nc.L1::evict_first.b32 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int32_t (*)(const int32_t*)>(cuda_ptx::ld_global_nc_L1_evict_first));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int32_t (*)(const int32_t*)>(cuda::ptx::ld_global_nc_L1_evict_first));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.nc.L1::evict_first.b64 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int64_t (*)(const int64_t*)>(cuda_ptx::ld_global_nc_L1_evict_first));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int64_t (*)(const int64_t*)>(cuda::ptx::ld_global_nc_L1_evict_first));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.nc.L1::evict_first.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda_ptx::ld_global_nc_L1_evict_first));));
-#endif // __libcuda_ptx_isa >= 830
+                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_nc_L1_evict_first));));
+#endif // __cccl_ptx_isa >= 830
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.nc.L1::evict_first.L2::64B.b8 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int8_t (*)(const int8_t*)>(cuda_ptx::ld_global_nc_L1_evict_first_L2_64B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int8_t (*)(const int8_t*)>(cuda::ptx::ld_global_nc_L1_evict_first_L2_64B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.nc.L1::evict_first.L2::64B.b16 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int16_t (*)(const int16_t*)>(cuda_ptx::ld_global_nc_L1_evict_first_L2_64B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int16_t (*)(const int16_t*)>(cuda::ptx::ld_global_nc_L1_evict_first_L2_64B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.nc.L1::evict_first.L2::64B.b32 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int32_t (*)(const int32_t*)>(cuda_ptx::ld_global_nc_L1_evict_first_L2_64B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int32_t (*)(const int32_t*)>(cuda::ptx::ld_global_nc_L1_evict_first_L2_64B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.nc.L1::evict_first.L2::64B.b64 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int64_t (*)(const int64_t*)>(cuda_ptx::ld_global_nc_L1_evict_first_L2_64B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int64_t (*)(const int64_t*)>(cuda::ptx::ld_global_nc_L1_evict_first_L2_64B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.nc.L1::evict_first.L2::64B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda_ptx::ld_global_nc_L1_evict_first_L2_64B));));
-#endif // __libcuda_ptx_isa >= 830
+                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_nc_L1_evict_first_L2_64B));));
+#endif // __cccl_ptx_isa >= 830
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.nc.L1::evict_first.L2::128B.b8 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int8_t (*)(const int8_t*)>(cuda_ptx::ld_global_nc_L1_evict_first_L2_128B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int8_t (*)(const int8_t*)>(cuda::ptx::ld_global_nc_L1_evict_first_L2_128B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.nc.L1::evict_first.L2::128B.b16 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int16_t (*)(const int16_t*)>(cuda_ptx::ld_global_nc_L1_evict_first_L2_128B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int16_t (*)(const int16_t*)>(cuda::ptx::ld_global_nc_L1_evict_first_L2_128B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.nc.L1::evict_first.L2::128B.b32 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int32_t (*)(const int32_t*)>(cuda_ptx::ld_global_nc_L1_evict_first_L2_128B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int32_t (*)(const int32_t*)>(cuda::ptx::ld_global_nc_L1_evict_first_L2_128B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.nc.L1::evict_first.L2::128B.b64 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int64_t (*)(const int64_t*)>(cuda_ptx::ld_global_nc_L1_evict_first_L2_128B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int64_t (*)(const int64_t*)>(cuda::ptx::ld_global_nc_L1_evict_first_L2_128B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.nc.L1::evict_first.L2::128B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda_ptx::ld_global_nc_L1_evict_first_L2_128B));));
-#endif // __libcuda_ptx_isa >= 830
+                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_nc_L1_evict_first_L2_128B));));
+#endif // __cccl_ptx_isa >= 830
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
                    // ld.global.nc.L1::evict_first.L2::256B.b8 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int8_t (*)(const int8_t*)>(cuda_ptx::ld_global_nc_L1_evict_first_L2_256B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int8_t (*)(const int8_t*)>(cuda::ptx::ld_global_nc_L1_evict_first_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
                    // ld.global.nc.L1::evict_first.L2::256B.b16 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int16_t (*)(const int16_t*)>(cuda_ptx::ld_global_nc_L1_evict_first_L2_256B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int16_t (*)(const int16_t*)>(cuda::ptx::ld_global_nc_L1_evict_first_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
                    // ld.global.nc.L1::evict_first.L2::256B.b32 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int32_t (*)(const int32_t*)>(cuda_ptx::ld_global_nc_L1_evict_first_L2_256B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int32_t (*)(const int32_t*)>(cuda::ptx::ld_global_nc_L1_evict_first_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
                    // ld.global.nc.L1::evict_first.L2::256B.b64 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int64_t (*)(const int64_t*)>(cuda_ptx::ld_global_nc_L1_evict_first_L2_256B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int64_t (*)(const int64_t*)>(cuda::ptx::ld_global_nc_L1_evict_first_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
                    // ld.global.nc.L1::evict_first.L2::256B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda_ptx::ld_global_nc_L1_evict_first_L2_256B));));
-#endif // __libcuda_ptx_isa >= 830
+                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_nc_L1_evict_first_L2_256B));));
+#endif // __cccl_ptx_isa >= 830
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.nc.L1::evict_last.b8 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int8_t (*)(const int8_t*)>(cuda_ptx::ld_global_nc_L1_evict_last));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int8_t (*)(const int8_t*)>(cuda::ptx::ld_global_nc_L1_evict_last));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.nc.L1::evict_last.b16 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int16_t (*)(const int16_t*)>(cuda_ptx::ld_global_nc_L1_evict_last));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int16_t (*)(const int16_t*)>(cuda::ptx::ld_global_nc_L1_evict_last));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.nc.L1::evict_last.b32 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int32_t (*)(const int32_t*)>(cuda_ptx::ld_global_nc_L1_evict_last));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int32_t (*)(const int32_t*)>(cuda::ptx::ld_global_nc_L1_evict_last));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.nc.L1::evict_last.b64 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int64_t (*)(const int64_t*)>(cuda_ptx::ld_global_nc_L1_evict_last));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int64_t (*)(const int64_t*)>(cuda::ptx::ld_global_nc_L1_evict_last));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.nc.L1::evict_last.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda_ptx::ld_global_nc_L1_evict_last));));
-#endif // __libcuda_ptx_isa >= 830
+                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_nc_L1_evict_last));));
+#endif // __cccl_ptx_isa >= 830
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.nc.L1::evict_last.L2::64B.b8 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int8_t (*)(const int8_t*)>(cuda_ptx::ld_global_nc_L1_evict_last_L2_64B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int8_t (*)(const int8_t*)>(cuda::ptx::ld_global_nc_L1_evict_last_L2_64B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.nc.L1::evict_last.L2::64B.b16 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int16_t (*)(const int16_t*)>(cuda_ptx::ld_global_nc_L1_evict_last_L2_64B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int16_t (*)(const int16_t*)>(cuda::ptx::ld_global_nc_L1_evict_last_L2_64B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.nc.L1::evict_last.L2::64B.b32 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int32_t (*)(const int32_t*)>(cuda_ptx::ld_global_nc_L1_evict_last_L2_64B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int32_t (*)(const int32_t*)>(cuda::ptx::ld_global_nc_L1_evict_last_L2_64B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.nc.L1::evict_last.L2::64B.b64 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int64_t (*)(const int64_t*)>(cuda_ptx::ld_global_nc_L1_evict_last_L2_64B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int64_t (*)(const int64_t*)>(cuda::ptx::ld_global_nc_L1_evict_last_L2_64B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.nc.L1::evict_last.L2::64B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda_ptx::ld_global_nc_L1_evict_last_L2_64B));));
-#endif // __libcuda_ptx_isa >= 830
+                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_nc_L1_evict_last_L2_64B));));
+#endif // __cccl_ptx_isa >= 830
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.nc.L1::evict_last.L2::128B.b8 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int8_t (*)(const int8_t*)>(cuda_ptx::ld_global_nc_L1_evict_last_L2_128B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int8_t (*)(const int8_t*)>(cuda::ptx::ld_global_nc_L1_evict_last_L2_128B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.nc.L1::evict_last.L2::128B.b16 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int16_t (*)(const int16_t*)>(cuda_ptx::ld_global_nc_L1_evict_last_L2_128B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int16_t (*)(const int16_t*)>(cuda::ptx::ld_global_nc_L1_evict_last_L2_128B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.nc.L1::evict_last.L2::128B.b32 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int32_t (*)(const int32_t*)>(cuda_ptx::ld_global_nc_L1_evict_last_L2_128B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int32_t (*)(const int32_t*)>(cuda::ptx::ld_global_nc_L1_evict_last_L2_128B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.nc.L1::evict_last.L2::128B.b64 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int64_t (*)(const int64_t*)>(cuda_ptx::ld_global_nc_L1_evict_last_L2_128B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int64_t (*)(const int64_t*)>(cuda::ptx::ld_global_nc_L1_evict_last_L2_128B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.nc.L1::evict_last.L2::128B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda_ptx::ld_global_nc_L1_evict_last_L2_128B));));
-#endif // __libcuda_ptx_isa >= 830
+                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_nc_L1_evict_last_L2_128B));));
+#endif // __cccl_ptx_isa >= 830
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
                    // ld.global.nc.L1::evict_last.L2::256B.b8 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int8_t (*)(const int8_t*)>(cuda_ptx::ld_global_nc_L1_evict_last_L2_256B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int8_t (*)(const int8_t*)>(cuda::ptx::ld_global_nc_L1_evict_last_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
                    // ld.global.nc.L1::evict_last.L2::256B.b16 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int16_t (*)(const int16_t*)>(cuda_ptx::ld_global_nc_L1_evict_last_L2_256B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int16_t (*)(const int16_t*)>(cuda::ptx::ld_global_nc_L1_evict_last_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
                    // ld.global.nc.L1::evict_last.L2::256B.b32 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int32_t (*)(const int32_t*)>(cuda_ptx::ld_global_nc_L1_evict_last_L2_256B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int32_t (*)(const int32_t*)>(cuda::ptx::ld_global_nc_L1_evict_last_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
                    // ld.global.nc.L1::evict_last.L2::256B.b64 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int64_t (*)(const int64_t*)>(cuda_ptx::ld_global_nc_L1_evict_last_L2_256B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int64_t (*)(const int64_t*)>(cuda::ptx::ld_global_nc_L1_evict_last_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
                    // ld.global.nc.L1::evict_last.L2::256B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda_ptx::ld_global_nc_L1_evict_last_L2_256B));));
-#endif // __libcuda_ptx_isa >= 830
+                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_nc_L1_evict_last_L2_256B));));
+#endif // __cccl_ptx_isa >= 830
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.nc.L1::no_allocate.b8 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int8_t (*)(const int8_t*)>(cuda_ptx::ld_global_nc_L1_no_allocate));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int8_t (*)(const int8_t*)>(cuda::ptx::ld_global_nc_L1_no_allocate));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.nc.L1::no_allocate.b16 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int16_t (*)(const int16_t*)>(cuda_ptx::ld_global_nc_L1_no_allocate));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int16_t (*)(const int16_t*)>(cuda::ptx::ld_global_nc_L1_no_allocate));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.nc.L1::no_allocate.b32 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int32_t (*)(const int32_t*)>(cuda_ptx::ld_global_nc_L1_no_allocate));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int32_t (*)(const int32_t*)>(cuda::ptx::ld_global_nc_L1_no_allocate));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.nc.L1::no_allocate.b64 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int64_t (*)(const int64_t*)>(cuda_ptx::ld_global_nc_L1_no_allocate));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int64_t (*)(const int64_t*)>(cuda::ptx::ld_global_nc_L1_no_allocate));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.nc.L1::no_allocate.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda_ptx::ld_global_nc_L1_no_allocate));));
-#endif // __libcuda_ptx_isa >= 830
+                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_nc_L1_no_allocate));));
+#endif // __cccl_ptx_isa >= 830
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.nc.L1::no_allocate.L2::64B.b8 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int8_t (*)(const int8_t*)>(cuda_ptx::ld_global_nc_L1_no_allocate_L2_64B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int8_t (*)(const int8_t*)>(cuda::ptx::ld_global_nc_L1_no_allocate_L2_64B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.nc.L1::no_allocate.L2::64B.b16 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int16_t (*)(const int16_t*)>(cuda_ptx::ld_global_nc_L1_no_allocate_L2_64B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int16_t (*)(const int16_t*)>(cuda::ptx::ld_global_nc_L1_no_allocate_L2_64B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.nc.L1::no_allocate.L2::64B.b32 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int32_t (*)(const int32_t*)>(cuda_ptx::ld_global_nc_L1_no_allocate_L2_64B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int32_t (*)(const int32_t*)>(cuda::ptx::ld_global_nc_L1_no_allocate_L2_64B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.nc.L1::no_allocate.L2::64B.b64 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int64_t (*)(const int64_t*)>(cuda_ptx::ld_global_nc_L1_no_allocate_L2_64B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int64_t (*)(const int64_t*)>(cuda::ptx::ld_global_nc_L1_no_allocate_L2_64B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.nc.L1::no_allocate.L2::64B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda_ptx::ld_global_nc_L1_no_allocate_L2_64B));));
-#endif // __libcuda_ptx_isa >= 830
+                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_nc_L1_no_allocate_L2_64B));));
+#endif // __cccl_ptx_isa >= 830
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.nc.L1::no_allocate.L2::128B.b8 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int8_t (*)(const int8_t*)>(cuda_ptx::ld_global_nc_L1_no_allocate_L2_128B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int8_t (*)(const int8_t*)>(cuda::ptx::ld_global_nc_L1_no_allocate_L2_128B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.nc.L1::no_allocate.L2::128B.b16 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int16_t (*)(const int16_t*)>(cuda_ptx::ld_global_nc_L1_no_allocate_L2_128B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int16_t (*)(const int16_t*)>(cuda::ptx::ld_global_nc_L1_no_allocate_L2_128B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.nc.L1::no_allocate.L2::128B.b32 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int32_t (*)(const int32_t*)>(cuda_ptx::ld_global_nc_L1_no_allocate_L2_128B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int32_t (*)(const int32_t*)>(cuda::ptx::ld_global_nc_L1_no_allocate_L2_128B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.nc.L1::no_allocate.L2::128B.b64 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int64_t (*)(const int64_t*)>(cuda_ptx::ld_global_nc_L1_no_allocate_L2_128B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int64_t (*)(const int64_t*)>(cuda::ptx::ld_global_nc_L1_no_allocate_L2_128B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.nc.L1::no_allocate.L2::128B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda_ptx::ld_global_nc_L1_no_allocate_L2_128B));));
-#endif // __libcuda_ptx_isa >= 830
+                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_nc_L1_no_allocate_L2_128B));));
+#endif // __cccl_ptx_isa >= 830
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
                    // ld.global.nc.L1::no_allocate.L2::256B.b8 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int8_t (*)(const int8_t*)>(cuda_ptx::ld_global_nc_L1_no_allocate_L2_256B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int8_t (*)(const int8_t*)>(cuda::ptx::ld_global_nc_L1_no_allocate_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
                    // ld.global.nc.L1::no_allocate.L2::256B.b16 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int16_t (*)(const int16_t*)>(cuda_ptx::ld_global_nc_L1_no_allocate_L2_256B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int16_t (*)(const int16_t*)>(cuda::ptx::ld_global_nc_L1_no_allocate_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
                    // ld.global.nc.L1::no_allocate.L2::256B.b32 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int32_t (*)(const int32_t*)>(cuda_ptx::ld_global_nc_L1_no_allocate_L2_256B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int32_t (*)(const int32_t*)>(cuda::ptx::ld_global_nc_L1_no_allocate_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
                    // ld.global.nc.L1::no_allocate.L2::256B.b64 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int64_t (*)(const int64_t*)>(cuda_ptx::ld_global_nc_L1_no_allocate_L2_256B));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<int64_t (*)(const int64_t*)>(cuda::ptx::ld_global_nc_L1_no_allocate_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
                    // ld.global.nc.L1::no_allocate.L2::256B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda_ptx::ld_global_nc_L1_no_allocate_L2_256B));));
-#endif // __libcuda_ptx_isa >= 830
+                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_nc_L1_no_allocate_L2_256B));));
+#endif // __cccl_ptx_isa >= 830
 }

--- a/libcudacxx/test/libcudacxx/cuda/ptx/generated/ld.h
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/generated/ld.h
@@ -53,7 +53,7 @@ __global__ void test_ld(void** fn_ptr)
     NV_PROVIDES_SM_70,
     (
         // ld.global.b128 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global));));
+        * fn_ptr++ = reinterpret_cast<void*>(static_cast<longlong2 (*)(const longlong2*)>(cuda::ptx::ld_global));));
 #endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 740
@@ -89,11 +89,11 @@ __global__ void test_ld(void** fn_ptr)
 #endif // __cccl_ptx_isa >= 740
 
 #if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.L2::64B.b128 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_L2_64B));));
+  NV_IF_TARGET(NV_PROVIDES_SM_75,
+               (
+                   // ld.global.L2::64B.b128 dest, [addr];
+                   * fn_ptr++ = reinterpret_cast<void*>(
+                     static_cast<longlong2 (*)(const longlong2*)>(cuda::ptx::ld_global_L2_64B));));
 #endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 740
@@ -133,7 +133,7 @@ __global__ void test_ld(void** fn_ptr)
                (
                    // ld.global.L2::128B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_L2_128B));));
+                     static_cast<longlong2 (*)(const longlong2*)>(cuda::ptx::ld_global_L2_128B));));
 #endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 740
@@ -173,7 +173,7 @@ __global__ void test_ld(void** fn_ptr)
                (
                    // ld.global.L2::256B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_L2_256B));));
+                     static_cast<longlong2 (*)(const longlong2*)>(cuda::ptx::ld_global_L2_256B));));
 #endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 740
@@ -213,7 +213,7 @@ __global__ void test_ld(void** fn_ptr)
                (
                    // ld.global.L1::evict_normal.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_L1_evict_normal));));
+                     static_cast<longlong2 (*)(const longlong2*)>(cuda::ptx::ld_global_L1_evict_normal));));
 #endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 740
@@ -253,7 +253,7 @@ __global__ void test_ld(void** fn_ptr)
                (
                    // ld.global.L1::evict_normal.L2::64B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_L1_evict_normal_L2_64B));));
+                     static_cast<longlong2 (*)(const longlong2*)>(cuda::ptx::ld_global_L1_evict_normal_L2_64B));));
 #endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 740
@@ -293,7 +293,7 @@ __global__ void test_ld(void** fn_ptr)
                (
                    // ld.global.L1::evict_normal.L2::128B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_L1_evict_normal_L2_128B));));
+                     static_cast<longlong2 (*)(const longlong2*)>(cuda::ptx::ld_global_L1_evict_normal_L2_128B));));
 #endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 740
@@ -333,7 +333,7 @@ __global__ void test_ld(void** fn_ptr)
                (
                    // ld.global.L1::evict_normal.L2::256B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_L1_evict_normal_L2_256B));));
+                     static_cast<longlong2 (*)(const longlong2*)>(cuda::ptx::ld_global_L1_evict_normal_L2_256B));));
 #endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 740
@@ -373,7 +373,7 @@ __global__ void test_ld(void** fn_ptr)
                (
                    // ld.global.L1::evict_unchanged.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_L1_evict_unchanged));));
+                     static_cast<longlong2 (*)(const longlong2*)>(cuda::ptx::ld_global_L1_evict_unchanged));));
 #endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 740
@@ -413,7 +413,7 @@ __global__ void test_ld(void** fn_ptr)
                (
                    // ld.global.L1::evict_unchanged.L2::64B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_L1_evict_unchanged_L2_64B));));
+                     static_cast<longlong2 (*)(const longlong2*)>(cuda::ptx::ld_global_L1_evict_unchanged_L2_64B));));
 #endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 740
@@ -453,7 +453,7 @@ __global__ void test_ld(void** fn_ptr)
                (
                    // ld.global.L1::evict_unchanged.L2::128B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_L1_evict_unchanged_L2_128B));));
+                     static_cast<longlong2 (*)(const longlong2*)>(cuda::ptx::ld_global_L1_evict_unchanged_L2_128B));));
 #endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 740
@@ -493,7 +493,7 @@ __global__ void test_ld(void** fn_ptr)
                (
                    // ld.global.L1::evict_unchanged.L2::256B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_L1_evict_unchanged_L2_256B));));
+                     static_cast<longlong2 (*)(const longlong2*)>(cuda::ptx::ld_global_L1_evict_unchanged_L2_256B));));
 #endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 740
@@ -533,7 +533,7 @@ __global__ void test_ld(void** fn_ptr)
                (
                    // ld.global.L1::evict_first.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_L1_evict_first));));
+                     static_cast<longlong2 (*)(const longlong2*)>(cuda::ptx::ld_global_L1_evict_first));));
 #endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 740
@@ -573,7 +573,7 @@ __global__ void test_ld(void** fn_ptr)
                (
                    // ld.global.L1::evict_first.L2::64B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_L1_evict_first_L2_64B));));
+                     static_cast<longlong2 (*)(const longlong2*)>(cuda::ptx::ld_global_L1_evict_first_L2_64B));));
 #endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 740
@@ -613,7 +613,7 @@ __global__ void test_ld(void** fn_ptr)
                (
                    // ld.global.L1::evict_first.L2::128B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_L1_evict_first_L2_128B));));
+                     static_cast<longlong2 (*)(const longlong2*)>(cuda::ptx::ld_global_L1_evict_first_L2_128B));));
 #endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 740
@@ -653,7 +653,7 @@ __global__ void test_ld(void** fn_ptr)
                (
                    // ld.global.L1::evict_first.L2::256B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_L1_evict_first_L2_256B));));
+                     static_cast<longlong2 (*)(const longlong2*)>(cuda::ptx::ld_global_L1_evict_first_L2_256B));));
 #endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 740
@@ -693,7 +693,7 @@ __global__ void test_ld(void** fn_ptr)
                (
                    // ld.global.L1::evict_last.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_L1_evict_last));));
+                     static_cast<longlong2 (*)(const longlong2*)>(cuda::ptx::ld_global_L1_evict_last));));
 #endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 740
@@ -733,7 +733,7 @@ __global__ void test_ld(void** fn_ptr)
                (
                    // ld.global.L1::evict_last.L2::64B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_L1_evict_last_L2_64B));));
+                     static_cast<longlong2 (*)(const longlong2*)>(cuda::ptx::ld_global_L1_evict_last_L2_64B));));
 #endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 740
@@ -773,7 +773,7 @@ __global__ void test_ld(void** fn_ptr)
                (
                    // ld.global.L1::evict_last.L2::128B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_L1_evict_last_L2_128B));));
+                     static_cast<longlong2 (*)(const longlong2*)>(cuda::ptx::ld_global_L1_evict_last_L2_128B));));
 #endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 740
@@ -813,7 +813,7 @@ __global__ void test_ld(void** fn_ptr)
                (
                    // ld.global.L1::evict_last.L2::256B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_L1_evict_last_L2_256B));));
+                     static_cast<longlong2 (*)(const longlong2*)>(cuda::ptx::ld_global_L1_evict_last_L2_256B));));
 #endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 740
@@ -853,7 +853,7 @@ __global__ void test_ld(void** fn_ptr)
                (
                    // ld.global.L1::no_allocate.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_L1_no_allocate));));
+                     static_cast<longlong2 (*)(const longlong2*)>(cuda::ptx::ld_global_L1_no_allocate));));
 #endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 740
@@ -893,7 +893,7 @@ __global__ void test_ld(void** fn_ptr)
                (
                    // ld.global.L1::no_allocate.L2::64B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_L1_no_allocate_L2_64B));));
+                     static_cast<longlong2 (*)(const longlong2*)>(cuda::ptx::ld_global_L1_no_allocate_L2_64B));));
 #endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 740
@@ -933,7 +933,7 @@ __global__ void test_ld(void** fn_ptr)
                (
                    // ld.global.L1::no_allocate.L2::128B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_L1_no_allocate_L2_128B));));
+                     static_cast<longlong2 (*)(const longlong2*)>(cuda::ptx::ld_global_L1_no_allocate_L2_128B));));
 #endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 740
@@ -973,7 +973,7 @@ __global__ void test_ld(void** fn_ptr)
                (
                    // ld.global.L1::no_allocate.L2::256B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_L1_no_allocate_L2_256B));));
+                     static_cast<longlong2 (*)(const longlong2*)>(cuda::ptx::ld_global_L1_no_allocate_L2_256B));));
 #endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 100
@@ -1013,7 +1013,7 @@ __global__ void test_ld(void** fn_ptr)
     NV_PROVIDES_SM_70,
     (
         // ld.global.nc.b128 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_nc));));
+        * fn_ptr++ = reinterpret_cast<void*>(static_cast<longlong2 (*)(const longlong2*)>(cuda::ptx::ld_global_nc));));
 #endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 740
@@ -1053,7 +1053,7 @@ __global__ void test_ld(void** fn_ptr)
                (
                    // ld.global.nc.L2::64B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_nc_L2_64B));));
+                     static_cast<longlong2 (*)(const longlong2*)>(cuda::ptx::ld_global_nc_L2_64B));));
 #endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 740
@@ -1093,7 +1093,7 @@ __global__ void test_ld(void** fn_ptr)
                (
                    // ld.global.nc.L2::128B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_nc_L2_128B));));
+                     static_cast<longlong2 (*)(const longlong2*)>(cuda::ptx::ld_global_nc_L2_128B));));
 #endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 740
@@ -1133,7 +1133,7 @@ __global__ void test_ld(void** fn_ptr)
                (
                    // ld.global.nc.L2::256B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_nc_L2_256B));));
+                     static_cast<longlong2 (*)(const longlong2*)>(cuda::ptx::ld_global_nc_L2_256B));));
 #endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 740
@@ -1173,7 +1173,7 @@ __global__ void test_ld(void** fn_ptr)
                (
                    // ld.global.nc.L1::evict_normal.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_nc_L1_evict_normal));));
+                     static_cast<longlong2 (*)(const longlong2*)>(cuda::ptx::ld_global_nc_L1_evict_normal));));
 #endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 740
@@ -1213,7 +1213,7 @@ __global__ void test_ld(void** fn_ptr)
                (
                    // ld.global.nc.L1::evict_normal.L2::64B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_nc_L1_evict_normal_L2_64B));));
+                     static_cast<longlong2 (*)(const longlong2*)>(cuda::ptx::ld_global_nc_L1_evict_normal_L2_64B));));
 #endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 740
@@ -1253,7 +1253,7 @@ __global__ void test_ld(void** fn_ptr)
                (
                    // ld.global.nc.L1::evict_normal.L2::128B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_nc_L1_evict_normal_L2_128B));));
+                     static_cast<longlong2 (*)(const longlong2*)>(cuda::ptx::ld_global_nc_L1_evict_normal_L2_128B));));
 #endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 740
@@ -1293,7 +1293,7 @@ __global__ void test_ld(void** fn_ptr)
                (
                    // ld.global.nc.L1::evict_normal.L2::256B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_nc_L1_evict_normal_L2_256B));));
+                     static_cast<longlong2 (*)(const longlong2*)>(cuda::ptx::ld_global_nc_L1_evict_normal_L2_256B));));
 #endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 740
@@ -1333,7 +1333,7 @@ __global__ void test_ld(void** fn_ptr)
                (
                    // ld.global.nc.L1::evict_unchanged.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_nc_L1_evict_unchanged));));
+                     static_cast<longlong2 (*)(const longlong2*)>(cuda::ptx::ld_global_nc_L1_evict_unchanged));));
 #endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 740
@@ -1372,8 +1372,8 @@ __global__ void test_ld(void** fn_ptr)
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.nc.L1::evict_unchanged.L2::64B.b128 dest, [addr];
-                   * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_nc_L1_evict_unchanged_L2_64B));));
+                   * fn_ptr++ = reinterpret_cast<void*>(static_cast<longlong2 (*)(const longlong2*)>(
+                     cuda::ptx::ld_global_nc_L1_evict_unchanged_L2_64B));));
 #endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 740
@@ -1412,8 +1412,8 @@ __global__ void test_ld(void** fn_ptr)
   NV_IF_TARGET(NV_PROVIDES_SM_75,
                (
                    // ld.global.nc.L1::evict_unchanged.L2::128B.b128 dest, [addr];
-                   * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_nc_L1_evict_unchanged_L2_128B));));
+                   * fn_ptr++ = reinterpret_cast<void*>(static_cast<longlong2 (*)(const longlong2*)>(
+                     cuda::ptx::ld_global_nc_L1_evict_unchanged_L2_128B));));
 #endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 740
@@ -1452,8 +1452,8 @@ __global__ void test_ld(void** fn_ptr)
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
                    // ld.global.nc.L1::evict_unchanged.L2::256B.b128 dest, [addr];
-                   * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_nc_L1_evict_unchanged_L2_256B));));
+                   * fn_ptr++ = reinterpret_cast<void*>(static_cast<longlong2 (*)(const longlong2*)>(
+                     cuda::ptx::ld_global_nc_L1_evict_unchanged_L2_256B));));
 #endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 740
@@ -1493,7 +1493,7 @@ __global__ void test_ld(void** fn_ptr)
                (
                    // ld.global.nc.L1::evict_first.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_nc_L1_evict_first));));
+                     static_cast<longlong2 (*)(const longlong2*)>(cuda::ptx::ld_global_nc_L1_evict_first));));
 #endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 740
@@ -1533,7 +1533,7 @@ __global__ void test_ld(void** fn_ptr)
                (
                    // ld.global.nc.L1::evict_first.L2::64B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_nc_L1_evict_first_L2_64B));));
+                     static_cast<longlong2 (*)(const longlong2*)>(cuda::ptx::ld_global_nc_L1_evict_first_L2_64B));));
 #endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 740
@@ -1573,7 +1573,7 @@ __global__ void test_ld(void** fn_ptr)
                (
                    // ld.global.nc.L1::evict_first.L2::128B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_nc_L1_evict_first_L2_128B));));
+                     static_cast<longlong2 (*)(const longlong2*)>(cuda::ptx::ld_global_nc_L1_evict_first_L2_128B));));
 #endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 740
@@ -1613,7 +1613,7 @@ __global__ void test_ld(void** fn_ptr)
                (
                    // ld.global.nc.L1::evict_first.L2::256B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_nc_L1_evict_first_L2_256B));));
+                     static_cast<longlong2 (*)(const longlong2*)>(cuda::ptx::ld_global_nc_L1_evict_first_L2_256B));));
 #endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 740
@@ -1653,7 +1653,7 @@ __global__ void test_ld(void** fn_ptr)
                (
                    // ld.global.nc.L1::evict_last.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_nc_L1_evict_last));));
+                     static_cast<longlong2 (*)(const longlong2*)>(cuda::ptx::ld_global_nc_L1_evict_last));));
 #endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 740
@@ -1693,7 +1693,7 @@ __global__ void test_ld(void** fn_ptr)
                (
                    // ld.global.nc.L1::evict_last.L2::64B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_nc_L1_evict_last_L2_64B));));
+                     static_cast<longlong2 (*)(const longlong2*)>(cuda::ptx::ld_global_nc_L1_evict_last_L2_64B));));
 #endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 740
@@ -1733,7 +1733,7 @@ __global__ void test_ld(void** fn_ptr)
                (
                    // ld.global.nc.L1::evict_last.L2::128B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_nc_L1_evict_last_L2_128B));));
+                     static_cast<longlong2 (*)(const longlong2*)>(cuda::ptx::ld_global_nc_L1_evict_last_L2_128B));));
 #endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 740
@@ -1773,7 +1773,7 @@ __global__ void test_ld(void** fn_ptr)
                (
                    // ld.global.nc.L1::evict_last.L2::256B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_nc_L1_evict_last_L2_256B));));
+                     static_cast<longlong2 (*)(const longlong2*)>(cuda::ptx::ld_global_nc_L1_evict_last_L2_256B));));
 #endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 740
@@ -1813,7 +1813,7 @@ __global__ void test_ld(void** fn_ptr)
                (
                    // ld.global.nc.L1::no_allocate.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_nc_L1_no_allocate));));
+                     static_cast<longlong2 (*)(const longlong2*)>(cuda::ptx::ld_global_nc_L1_no_allocate));));
 #endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 740
@@ -1853,7 +1853,7 @@ __global__ void test_ld(void** fn_ptr)
                (
                    // ld.global.nc.L1::no_allocate.L2::64B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_nc_L1_no_allocate_L2_64B));));
+                     static_cast<longlong2 (*)(const longlong2*)>(cuda::ptx::ld_global_nc_L1_no_allocate_L2_64B));));
 #endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 740
@@ -1893,7 +1893,7 @@ __global__ void test_ld(void** fn_ptr)
                (
                    // ld.global.nc.L1::no_allocate.L2::128B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_nc_L1_no_allocate_L2_128B));));
+                     static_cast<longlong2 (*)(const longlong2*)>(cuda::ptx::ld_global_nc_L1_no_allocate_L2_128B));));
 #endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 740
@@ -1933,6 +1933,6 @@ __global__ void test_ld(void** fn_ptr)
                (
                    // ld.global.nc.L1::no_allocate.L2::256B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<__int128 (*)(const __int128*)>(cuda::ptx::ld_global_nc_L1_no_allocate_L2_256B));));
+                     static_cast<longlong2 (*)(const longlong2*)>(cuda::ptx::ld_global_nc_L1_no_allocate_L2_256B));));
 #endif // __cccl_ptx_isa >= 830
 }

--- a/libcudacxx/test/libcudacxx/cuda/ptx/generated/st.h
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/generated/st.h
@@ -53,7 +53,7 @@ __global__ void test_st(void** fn_ptr)
     NV_PROVIDES_SM_70,
     (
         // st.global.b128 [addr], src;
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(__int128*, __int128)>(cuda::ptx::st_global));));
+        * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(longlong2*, longlong2)>(cuda::ptx::st_global));));
 #endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 740
@@ -93,7 +93,7 @@ __global__ void test_st(void** fn_ptr)
                (
                    // st.global.L1::evict_normal.b128 [addr], src;
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<void (*)(__int128*, __int128)>(cuda::ptx::st_global_L1_evict_normal));));
+                     static_cast<void (*)(longlong2*, longlong2)>(cuda::ptx::st_global_L1_evict_normal));));
 #endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 740
@@ -133,7 +133,7 @@ __global__ void test_st(void** fn_ptr)
                (
                    // st.global.L1::evict_unchanged.b128 [addr], src;
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<void (*)(__int128*, __int128)>(cuda::ptx::st_global_L1_evict_unchanged));));
+                     static_cast<void (*)(longlong2*, longlong2)>(cuda::ptx::st_global_L1_evict_unchanged));));
 #endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 740
@@ -173,7 +173,7 @@ __global__ void test_st(void** fn_ptr)
                (
                    // st.global.L1::evict_first.b128 [addr], src;
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<void (*)(__int128*, __int128)>(cuda::ptx::st_global_L1_evict_first));));
+                     static_cast<void (*)(longlong2*, longlong2)>(cuda::ptx::st_global_L1_evict_first));));
 #endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 740
@@ -213,7 +213,7 @@ __global__ void test_st(void** fn_ptr)
                (
                    // st.global.L1::evict_last.b128 [addr], src;
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<void (*)(__int128*, __int128)>(cuda::ptx::st_global_L1_evict_last));));
+                     static_cast<void (*)(longlong2*, longlong2)>(cuda::ptx::st_global_L1_evict_last));));
 #endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 740
@@ -253,6 +253,6 @@ __global__ void test_st(void** fn_ptr)
                (
                    // st.global.L1::no_allocate.b128 [addr], src;
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<void (*)(__int128*, __int128)>(cuda::ptx::st_global_L1_no_allocate));));
+                     static_cast<void (*)(longlong2*, longlong2)>(cuda::ptx::st_global_L1_no_allocate));));
 #endif // __cccl_ptx_isa >= 830
 }

--- a/libcudacxx/test/libcudacxx/cuda/ptx/generated/st.h
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/generated/st.h
@@ -1,260 +1,258 @@
 // This file was automatically generated. Do not edit.
 
-/*
- * We use a special strategy to force the generation of the PTX. This is mainly
- * a fight against dead-code-elimination in the NVVM layer.
- *
- * The reason we need this strategy is because certain older versions of ptxas
- * segfault when a non-sensical sequence of PTX is generated. So instead, we try
- * to force the instantiation and compilation to PTX of all the overloads of the
- * PTX wrapping functions.
- *
- * We do this by writing a function pointer of each overload to the kernel
- * parameter `fn_ptr`.
- *
- * Because `fn_ptr` is possibly visible outside this translation unit, the
- * compiler must compile all the functions which are stored.
- *
- */
+// We use a special strategy to force the generation of the PTX. This is mainly
+// a fight against dead-code-elimination in the NVVM layer.
+//
+// The reason we need this strategy is because certain older versions of ptxas
+// segfault when a non-sensical sequence of PTX is generated. So instead, we try
+// to force the instantiation and compilation to PTX of all the overloads of the
+// PTX wrapping functions.
+//
+// We do this by writing a function pointer of each overload to the kernel
+// parameter `fn_ptr`.
+//
+// Because `fn_ptr` is possibly visible outside this translation unit, the
+// compiler must compile all the functions which are stored.
 
 __global__ void test_st(void** fn_ptr)
 {
-#if __libcuda_ptx_isa >= 100
-  NV_IF_TARGET(NV_PROVIDES_SM_50,
-               (
-                   // st.global.b8 [addr], src;
-                   * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(int8_t*, int8_t)>(cuda_ptx::st_global));));
-#endif // __libcuda_ptx_isa >= 100
+#if __cccl_ptx_isa >= 100
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_50,
+    (
+        // st.global.b8 [addr], src;
+        * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(int8_t*, int8_t)>(cuda::ptx::st_global));));
+#endif // __cccl_ptx_isa >= 100
 
-#if __libcuda_ptx_isa >= 100
+#if __cccl_ptx_isa >= 100
   NV_IF_TARGET(
     NV_PROVIDES_SM_50,
     (
         // st.global.b16 [addr], src;
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(int16_t*, int16_t)>(cuda_ptx::st_global));));
-#endif // __libcuda_ptx_isa >= 100
+        * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(int16_t*, int16_t)>(cuda::ptx::st_global));));
+#endif // __cccl_ptx_isa >= 100
 
-#if __libcuda_ptx_isa >= 100
+#if __cccl_ptx_isa >= 100
   NV_IF_TARGET(
     NV_PROVIDES_SM_50,
     (
         // st.global.b32 [addr], src;
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(int32_t*, int32_t)>(cuda_ptx::st_global));));
-#endif // __libcuda_ptx_isa >= 100
+        * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(int32_t*, int32_t)>(cuda::ptx::st_global));));
+#endif // __cccl_ptx_isa >= 100
 
-#if __libcuda_ptx_isa >= 100
+#if __cccl_ptx_isa >= 100
   NV_IF_TARGET(
     NV_PROVIDES_SM_50,
     (
         // st.global.b64 [addr], src;
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(int64_t*, int64_t)>(cuda_ptx::st_global));));
-#endif // __libcuda_ptx_isa >= 100
+        * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(int64_t*, int64_t)>(cuda::ptx::st_global));));
+#endif // __cccl_ptx_isa >= 100
 
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
   NV_IF_TARGET(
     NV_PROVIDES_SM_70,
     (
         // st.global.b128 [addr], src;
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(__int128*, __int128)>(cuda_ptx::st_global));));
-#endif // __libcuda_ptx_isa >= 830
+        * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(__int128*, __int128)>(cuda::ptx::st_global));));
+#endif // __cccl_ptx_isa >= 830
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // st.global.L1::evict_normal.b8 [addr], src;
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<void (*)(int8_t*, int8_t)>(cuda_ptx::st_global_L1_evict_normal));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<void (*)(int8_t*, int8_t)>(cuda::ptx::st_global_L1_evict_normal));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // st.global.L1::evict_normal.b16 [addr], src;
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<void (*)(int16_t*, int16_t)>(cuda_ptx::st_global_L1_evict_normal));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<void (*)(int16_t*, int16_t)>(cuda::ptx::st_global_L1_evict_normal));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // st.global.L1::evict_normal.b32 [addr], src;
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<void (*)(int32_t*, int32_t)>(cuda_ptx::st_global_L1_evict_normal));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<void (*)(int32_t*, int32_t)>(cuda::ptx::st_global_L1_evict_normal));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // st.global.L1::evict_normal.b64 [addr], src;
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<void (*)(int64_t*, int64_t)>(cuda_ptx::st_global_L1_evict_normal));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<void (*)(int64_t*, int64_t)>(cuda::ptx::st_global_L1_evict_normal));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // st.global.L1::evict_normal.b128 [addr], src;
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<void (*)(__int128*, __int128)>(cuda_ptx::st_global_L1_evict_normal));));
-#endif // __libcuda_ptx_isa >= 830
+                     static_cast<void (*)(__int128*, __int128)>(cuda::ptx::st_global_L1_evict_normal));));
+#endif // __cccl_ptx_isa >= 830
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // st.global.L1::evict_unchanged.b8 [addr], src;
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<void (*)(int8_t*, int8_t)>(cuda_ptx::st_global_L1_evict_unchanged));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<void (*)(int8_t*, int8_t)>(cuda::ptx::st_global_L1_evict_unchanged));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // st.global.L1::evict_unchanged.b16 [addr], src;
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<void (*)(int16_t*, int16_t)>(cuda_ptx::st_global_L1_evict_unchanged));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<void (*)(int16_t*, int16_t)>(cuda::ptx::st_global_L1_evict_unchanged));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // st.global.L1::evict_unchanged.b32 [addr], src;
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<void (*)(int32_t*, int32_t)>(cuda_ptx::st_global_L1_evict_unchanged));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<void (*)(int32_t*, int32_t)>(cuda::ptx::st_global_L1_evict_unchanged));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // st.global.L1::evict_unchanged.b64 [addr], src;
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<void (*)(int64_t*, int64_t)>(cuda_ptx::st_global_L1_evict_unchanged));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<void (*)(int64_t*, int64_t)>(cuda::ptx::st_global_L1_evict_unchanged));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // st.global.L1::evict_unchanged.b128 [addr], src;
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<void (*)(__int128*, __int128)>(cuda_ptx::st_global_L1_evict_unchanged));));
-#endif // __libcuda_ptx_isa >= 830
+                     static_cast<void (*)(__int128*, __int128)>(cuda::ptx::st_global_L1_evict_unchanged));));
+#endif // __cccl_ptx_isa >= 830
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // st.global.L1::evict_first.b8 [addr], src;
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<void (*)(int8_t*, int8_t)>(cuda_ptx::st_global_L1_evict_first));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<void (*)(int8_t*, int8_t)>(cuda::ptx::st_global_L1_evict_first));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // st.global.L1::evict_first.b16 [addr], src;
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<void (*)(int16_t*, int16_t)>(cuda_ptx::st_global_L1_evict_first));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<void (*)(int16_t*, int16_t)>(cuda::ptx::st_global_L1_evict_first));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // st.global.L1::evict_first.b32 [addr], src;
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<void (*)(int32_t*, int32_t)>(cuda_ptx::st_global_L1_evict_first));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<void (*)(int32_t*, int32_t)>(cuda::ptx::st_global_L1_evict_first));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // st.global.L1::evict_first.b64 [addr], src;
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<void (*)(int64_t*, int64_t)>(cuda_ptx::st_global_L1_evict_first));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<void (*)(int64_t*, int64_t)>(cuda::ptx::st_global_L1_evict_first));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // st.global.L1::evict_first.b128 [addr], src;
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<void (*)(__int128*, __int128)>(cuda_ptx::st_global_L1_evict_first));));
-#endif // __libcuda_ptx_isa >= 830
+                     static_cast<void (*)(__int128*, __int128)>(cuda::ptx::st_global_L1_evict_first));));
+#endif // __cccl_ptx_isa >= 830
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // st.global.L1::evict_last.b8 [addr], src;
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<void (*)(int8_t*, int8_t)>(cuda_ptx::st_global_L1_evict_last));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<void (*)(int8_t*, int8_t)>(cuda::ptx::st_global_L1_evict_last));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // st.global.L1::evict_last.b16 [addr], src;
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<void (*)(int16_t*, int16_t)>(cuda_ptx::st_global_L1_evict_last));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<void (*)(int16_t*, int16_t)>(cuda::ptx::st_global_L1_evict_last));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // st.global.L1::evict_last.b32 [addr], src;
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<void (*)(int32_t*, int32_t)>(cuda_ptx::st_global_L1_evict_last));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<void (*)(int32_t*, int32_t)>(cuda::ptx::st_global_L1_evict_last));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // st.global.L1::evict_last.b64 [addr], src;
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<void (*)(int64_t*, int64_t)>(cuda_ptx::st_global_L1_evict_last));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<void (*)(int64_t*, int64_t)>(cuda::ptx::st_global_L1_evict_last));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // st.global.L1::evict_last.b128 [addr], src;
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<void (*)(__int128*, __int128)>(cuda_ptx::st_global_L1_evict_last));));
-#endif // __libcuda_ptx_isa >= 830
+                     static_cast<void (*)(__int128*, __int128)>(cuda::ptx::st_global_L1_evict_last));));
+#endif // __cccl_ptx_isa >= 830
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // st.global.L1::no_allocate.b8 [addr], src;
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<void (*)(int8_t*, int8_t)>(cuda_ptx::st_global_L1_no_allocate));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<void (*)(int8_t*, int8_t)>(cuda::ptx::st_global_L1_no_allocate));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // st.global.L1::no_allocate.b16 [addr], src;
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<void (*)(int16_t*, int16_t)>(cuda_ptx::st_global_L1_no_allocate));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<void (*)(int16_t*, int16_t)>(cuda::ptx::st_global_L1_no_allocate));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // st.global.L1::no_allocate.b32 [addr], src;
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<void (*)(int32_t*, int32_t)>(cuda_ptx::st_global_L1_no_allocate));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<void (*)(int32_t*, int32_t)>(cuda::ptx::st_global_L1_no_allocate));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 740
+#if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // st.global.L1::no_allocate.b64 [addr], src;
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<void (*)(int64_t*, int64_t)>(cuda_ptx::st_global_L1_no_allocate));));
-#endif // __libcuda_ptx_isa >= 740
+                     static_cast<void (*)(int64_t*, int64_t)>(cuda::ptx::st_global_L1_no_allocate));));
+#endif // __cccl_ptx_isa >= 740
 
-#if __libcuda_ptx_isa >= 830
+#if __cccl_ptx_isa >= 830
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // st.global.L1::no_allocate.b128 [addr], src;
                    * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<void (*)(__int128*, __int128)>(cuda_ptx::st_global_L1_no_allocate));));
-#endif // __libcuda_ptx_isa >= 830
+                     static_cast<void (*)(__int128*, __int128)>(cuda::ptx::st_global_L1_no_allocate));));
+#endif // __cccl_ptx_isa >= 830
 }

--- a/libcudacxx/test/libcudacxx/cuda/ptx/generated/st.h
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/generated/st.h
@@ -59,7 +59,7 @@ __global__ void test_st(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 830
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // st.global.L1::evict_normal.b8 [addr], src;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -67,7 +67,7 @@ __global__ void test_st(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // st.global.L1::evict_normal.b16 [addr], src;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -75,7 +75,7 @@ __global__ void test_st(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // st.global.L1::evict_normal.b32 [addr], src;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -83,7 +83,7 @@ __global__ void test_st(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // st.global.L1::evict_normal.b64 [addr], src;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -91,7 +91,7 @@ __global__ void test_st(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 830
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // st.global.L1::evict_normal.b128 [addr], src;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -99,7 +99,7 @@ __global__ void test_st(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 830
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // st.global.L1::evict_unchanged.b8 [addr], src;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -107,7 +107,7 @@ __global__ void test_st(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // st.global.L1::evict_unchanged.b16 [addr], src;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -115,7 +115,7 @@ __global__ void test_st(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // st.global.L1::evict_unchanged.b32 [addr], src;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -123,7 +123,7 @@ __global__ void test_st(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // st.global.L1::evict_unchanged.b64 [addr], src;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -131,7 +131,7 @@ __global__ void test_st(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 830
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // st.global.L1::evict_unchanged.b128 [addr], src;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -139,7 +139,7 @@ __global__ void test_st(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 830
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // st.global.L1::evict_first.b8 [addr], src;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -147,7 +147,7 @@ __global__ void test_st(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // st.global.L1::evict_first.b16 [addr], src;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -155,7 +155,7 @@ __global__ void test_st(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // st.global.L1::evict_first.b32 [addr], src;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -163,7 +163,7 @@ __global__ void test_st(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // st.global.L1::evict_first.b64 [addr], src;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -171,7 +171,7 @@ __global__ void test_st(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 830
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // st.global.L1::evict_first.b128 [addr], src;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -179,7 +179,7 @@ __global__ void test_st(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 830
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // st.global.L1::evict_last.b8 [addr], src;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -187,7 +187,7 @@ __global__ void test_st(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // st.global.L1::evict_last.b16 [addr], src;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -195,7 +195,7 @@ __global__ void test_st(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // st.global.L1::evict_last.b32 [addr], src;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -203,7 +203,7 @@ __global__ void test_st(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // st.global.L1::evict_last.b64 [addr], src;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -211,7 +211,7 @@ __global__ void test_st(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 830
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // st.global.L1::evict_last.b128 [addr], src;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -219,7 +219,7 @@ __global__ void test_st(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 830
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // st.global.L1::no_allocate.b8 [addr], src;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -227,7 +227,7 @@ __global__ void test_st(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // st.global.L1::no_allocate.b16 [addr], src;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -235,7 +235,7 @@ __global__ void test_st(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // st.global.L1::no_allocate.b32 [addr], src;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -243,7 +243,7 @@ __global__ void test_st(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // st.global.L1::no_allocate.b64 [addr], src;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -251,7 +251,7 @@ __global__ void test_st(void** fn_ptr)
 #endif // __libcuda_ptx_isa >= 740
 
 #if __libcuda_ptx_isa >= 830
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // st.global.L1::no_allocate.b128 [addr], src;
                    * fn_ptr++ = reinterpret_cast<void*>(


### PR DESCRIPTION
## Description

PTX generated `ld`/`st` have the following problems:

- Use `long2` instead of `longlong2` which generates error on windows platforms
- Wrong namespace in generated `.h` files
- Wrong target arch for eviction policy