### PR TITLE
[CUDAX] Don't use memcpy direction hints in async_buffer

### DIFF
--- a/cudax/include/cuda/experimental/__algorithm/copy.cuh
+++ b/cudax/include/cuda/experimental/__algorithm/copy.cuh
@@ -40,7 +40,6 @@ void __copy_bytes_impl(stream_ref __stream, _CUDA_VSTD::span<_SrcTy> __src, _CUD
     _CUDA_VSTD::__throw_invalid_argument("Copy destination is too small to fit the source data");
   }
 
-  // TODO pass copy direction hint once we have span with properties
   _CCCL_TRY_CUDA_API(
     ::cudaMemcpyAsync,
     "Failed to perform a copy",

--- a/cudax/include/cuda/experimental/__memory_resource/properties.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/properties.cuh
@@ -40,13 +40,6 @@ namespace cuda::experimental
 using ::cuda::mr::device_accessible;
 using ::cuda::mr::host_accessible;
 
-//! @brief determines the cudaMemcpyKind needed to transfer memory pointed to by an iterator to a cudax::async_buffer
-template <bool _IsHostOnly, class _Iter>
-_CCCL_INLINE_VAR constexpr cudaMemcpyKind __detect_transfer_kind =
-  has_property<_Iter, _CUDA_VMR::device_accessible>
-    ? (_IsHostOnly ? cudaMemcpyKind::cudaMemcpyDeviceToHost : cudaMemcpyKind::cudaMemcpyDeviceToDevice)
-    : (_IsHostOnly ? cudaMemcpyKind::cudaMemcpyHostToHost : cudaMemcpyKind::cudaMemcpyHostToDevice);
-
 } // namespace cuda::experimental
 
 #endif //_CUDAX__MEMORY_RESOURCE_PROPERTIES_CUH

--- a/cudax/test/containers/async_buffer/helper.h
+++ b/cudax/test/containers/async_buffer/helper.h
@@ -64,7 +64,7 @@ constexpr bool compare_value(const T& value, const T& expected)
       cuda::std::addressof(host_value),
       cuda::std::addressof(value),
       sizeof(T),
-      ::cudaMemcpyDeviceToHost);
+      ::cudaMemcpyDefault);
     return host_value == expected;
   }
 }
@@ -85,7 +85,7 @@ void assign_value(T& value, const T& input)
       cuda::std::addressof(value),
       cuda::std::addressof(input),
       sizeof(T),
-      ::cudaMemcpyHostToDevice);
+      ::cudaMemcpyDefault);
   }
 }
 


### PR DESCRIPTION
The direction hints were wrong for pinned memory (stated as Device), which caused issues in #3975 when pinned resource was changed to use a mempool.

In general with Universal Virtual Addressing the hints are not useful except with managed memory. Since our usage of hints was based on static properties, we would give a good hints for managed memory anyway.

This PR changes removes usage of hints other than cudaMemcpyDefault.