### PR TITLE
Fix definition of `<cuda/std/numbers>`

### DIFF
--- a/docs/libcudacxx/standard_api/numerics_library/numbers.rst
+++ b/docs/libcudacxx/standard_api/numerics_library/numbers.rst
@@ -7,4 +7,6 @@ Extensions
 ----------
 
 -  All features of ``<numbers>`` are made available in C++14 onwards
+-  Specializations for CUDA extended floating point types `__half` and `__nvbfloat16` are provided only on Linux systems
+```suggestion
 -  Specializations for CUDA extended floating point types `__half` and `__nvbfloat16` are provided on Linux systems

--- a/docs/libcudacxx/standard_api/numerics_library/numbers.rst
+++ b/docs/libcudacxx/standard_api/numerics_library/numbers.rst
@@ -8,5 +8,3 @@ Extensions
 
 -  All features of ``<numbers>`` are made available in C++14 onwards
 -  Specializations for CUDA extended floating point types `__half` and `__nvbfloat16` are provided only on Linux systems
-```suggestion
--  Specializations for CUDA extended floating point types `__half` and `__nvbfloat16` are provided on Linux systems

--- a/docs/libcudacxx/standard_api/numerics_library/numbers.rst
+++ b/docs/libcudacxx/standard_api/numerics_library/numbers.rst
@@ -7,3 +7,4 @@ Extensions
 ----------
 
 -  All features of ``<numbers>`` are made available in C++14 onwards
+-  Specializations for CUDA extended floating point types `__half` and `__nvbfloat16` are provided on Linux systems

--- a/libcudacxx/include/cuda/std/__cccl/dialect.h
+++ b/libcudacxx/include/cuda/std/__cccl/dialect.h
@@ -147,11 +147,9 @@
 #  define _CCCL_TRAIT(__TRAIT, ...) __TRAIT##_v<__VA_ARGS__>
 #endif // !_CCCL_NO_VARIABLE_TEMPLATES
 
-#define _CCCL_CONSTEXPR_GLOBAL constexpr
-
 // We need to treat host and device separately
 #if defined(__CUDA_ARCH__)
-#  define _CCCL_GLOBAL_CONSTANT _CCCL_DEVICE _CCCL_CONSTEXPR_GLOBAL
+#  define _CCCL_GLOBAL_CONSTANT _CCCL_DEVICE constexpr
 #else // ^^^ __CUDA_ARCH__ ^^^ / vvv !__CUDA_ARCH__ vvv
 #  define _CCCL_GLOBAL_CONSTANT _CCCL_INLINE_VAR constexpr
 #endif // __CUDA_ARCH__

--- a/libcudacxx/include/cuda/std/__cccl/execution_space.h
+++ b/libcudacxx/include/cuda/std/__cccl/execution_space.h
@@ -38,8 +38,8 @@
 #if defined(__CUDA_ARCH__)
 #  define _CCCL_DEVICE_VARIABLE __device__
 #else
-#  define _CCCL_DEVICE_VARIABLE
-#endif //
+#  define _CCCL_DEVICE_VARIABLE inline
+#endif
 
 /// In device code, _CCCL_PTX_ARCH expands to the PTX version for which we are compiling.
 /// In host code, _CCCL_PTX_ARCH's value is implementation defined.

--- a/libcudacxx/include/cuda/std/__cccl/execution_space.h
+++ b/libcudacxx/include/cuda/std/__cccl/execution_space.h
@@ -33,14 +33,6 @@
 #  define _CCCL_HOST_DEVICE
 #endif // !_CCCL_CUDA_COMPILATION
 
-// NVCC complains bitterly that inline variable of non literal types are not defined in device code
-// This is a hack around this and one of the few cases we use `__CUDA_ARCH__` open coded
-#if defined(__CUDA_ARCH__)
-#  define _CCCL_DEVICE_VARIABLE __device__
-#else
-#  define _CCCL_DEVICE_VARIABLE inline
-#endif
-
 /// In device code, _CCCL_PTX_ARCH expands to the PTX version for which we are compiling.
 /// In host code, _CCCL_PTX_ARCH's value is implementation defined.
 #if !defined(__CUDA_ARCH__)

--- a/libcudacxx/include/cuda/std/numbers
+++ b/libcudacxx/include/cuda/std/numbers
@@ -46,19 +46,58 @@ _CCCL_DIAG_SUPPRESS_MSVC(4305) // truncation from 'double' to 'const _Tp'
 template <class _Tp>
 struct __numbers<_Tp, enable_if_t<_CCCL_TRAIT(is_floating_point, _Tp)>>
 {
-  static constexpr _Tp __e          = 2.718281828459045235360287471352662;
-  static constexpr _Tp __log2e      = 1.442695040888963407359924681001892;
-  static constexpr _Tp __log10e     = 0.434294481903251827651128918916605;
-  static constexpr _Tp __pi         = 3.141592653589793238462643383279502;
-  static constexpr _Tp __inv_pi     = 0.318309886183790671537767526745028;
-  static constexpr _Tp __inv_sqrtpi = 0.564189583547756286948079451560772;
-  static constexpr _Tp __ln2        = 0.693147180559945309417232121458176;
-  static constexpr _Tp __ln10       = 2.302585092994045684017991454684364;
-  static constexpr _Tp __sqrt2      = 1.414213562373095048801688724209698;
-  static constexpr _Tp __sqrt3      = 1.732050807568877293527446341505872;
-  static constexpr _Tp __inv_sqrt3  = 0.577350269189625764509148780501957;
-  static constexpr _Tp __egamma     = 0.577215664901532860606512090082402;
-  static constexpr _Tp __phi        = 1.618033988749894848204586834365638;
+  static _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp __e() noexcept
+  {
+    return 2.718281828459045235360287471352662;
+  }
+  static _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp __log2e() noexcept
+  {
+    return 1.442695040888963407359924681001892;
+  }
+  static _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp __log10e() noexcept
+  {
+    return 0.434294481903251827651128918916605;
+  }
+  static _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp __pi() noexcept
+  {
+    return 3.141592653589793238462643383279502;
+  }
+  static _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp __inv_pi() noexcept
+  {
+    return 0.318309886183790671537767526745028;
+  }
+  static _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp __inv_sqrtpi() noexcept
+  {
+    return 0.564189583547756286948079451560772;
+  }
+  static _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp __ln2() noexcept
+  {
+    return 0.693147180559945309417232121458176;
+  }
+  static _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp __ln10() noexcept
+  {
+    return 2.302585092994045684017991454684364;
+  }
+  static _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp __sqrt2() noexcept
+  {
+    return 1.414213562373095048801688724209698;
+  }
+  static _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp __sqrt3() noexcept
+  {
+    return 1.732050807568877293527446341505872;
+  }
+  static _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp __inv_sqrt3() noexcept
+  {
+    return 0.577350269189625764509148780501957;
+  }
+  static _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp __egamma() noexcept
+  {
+    return 0.577215664901532860606512090082402;
+  }
+  static _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp __phi() noexcept
+  {
+    return 1.618033988749894848204586834365638;
+  }
 };
 
 _CCCL_DIAG_POP
@@ -67,19 +106,58 @@ _CCCL_DIAG_POP
 template <>
 struct __numbers<__half>
 {
-  static constexpr __half __e          = __half_raw{0x4170u};
-  static constexpr __half __log2e      = __half_raw{0x3dc5u};
-  static constexpr __half __log10e     = __half_raw{0x36f3u};
-  static constexpr __half __pi         = __half_raw{0x4248u};
-  static constexpr __half __inv_pi     = __half_raw{0x3518u};
-  static constexpr __half __inv_sqrtpi = __half_raw{0x3883u};
-  static constexpr __half __ln2        = __half_raw{0x398cu};
-  static constexpr __half __ln10       = __half_raw{0x409bu};
-  static constexpr __half __sqrt2      = __half_raw{0x3da8u};
-  static constexpr __half __sqrt3      = __half_raw{0x3eeeu};
-  static constexpr __half __inv_sqrt3  = __half_raw{0x389eu};
-  static constexpr __half __egamma     = __half_raw{0x389eu};
-  static constexpr __half __phi        = __half_raw{0x3e79u};
+  static _LIBCUDACXX_HIDE_FROM_ABI constexpr __half __e() noexcept
+  {
+    return __half_raw{0x4170u};
+  }
+  static _LIBCUDACXX_HIDE_FROM_ABI constexpr __half __log2e() noexcept
+  {
+    return __half_raw{0x3dc5u};
+  }
+  static _LIBCUDACXX_HIDE_FROM_ABI constexpr __half __log10e() noexcept
+  {
+    return __half_raw{0x36f3u};
+  }
+  static _LIBCUDACXX_HIDE_FROM_ABI constexpr __half __pi() noexcept
+  {
+    return __half_raw{0x4248u};
+  }
+  static _LIBCUDACXX_HIDE_FROM_ABI constexpr __half __inv_pi() noexcept
+  {
+    return __half_raw{0x3518u};
+  }
+  static _LIBCUDACXX_HIDE_FROM_ABI constexpr __half __inv_sqrtpi() noexcept
+  {
+    return __half_raw{0x3883u};
+  }
+  static _LIBCUDACXX_HIDE_FROM_ABI constexpr __half __ln2() noexcept
+  {
+    return __half_raw{0x398cu};
+  }
+  static _LIBCUDACXX_HIDE_FROM_ABI constexpr __half __ln10() noexcept
+  {
+    return __half_raw{0x409bu};
+  }
+  static _LIBCUDACXX_HIDE_FROM_ABI constexpr __half __sqrt2() noexcept
+  {
+    return __half_raw{0x3da8u};
+  }
+  static _LIBCUDACXX_HIDE_FROM_ABI constexpr __half __sqrt3() noexcept
+  {
+    return __half_raw{0x3eeeu};
+  }
+  static _LIBCUDACXX_HIDE_FROM_ABI constexpr __half __inv_sqrt3() noexcept
+  {
+    return __half_raw{0x389eu};
+  }
+  static _LIBCUDACXX_HIDE_FROM_ABI constexpr __half __egamma() noexcept
+  {
+    return __half_raw{0x389eu};
+  }
+  static _LIBCUDACXX_HIDE_FROM_ABI constexpr __half __phi() noexcept
+  {
+    return __half_raw{0x3e79u};
+  }
 };
 #endif // _LIBCUDACXX_HAS_NVFP16()
 
@@ -87,19 +165,58 @@ struct __numbers<__half>
 template <>
 struct __numbers<__nv_bfloat16>
 {
-  static constexpr __nv_bfloat16 __e          = __nv_bfloat16_raw{0x402eu};
-  static constexpr __nv_bfloat16 __log2e      = __nv_bfloat16_raw{0x3fb9u};
-  static constexpr __nv_bfloat16 __log10e     = __nv_bfloat16_raw{0x3edeu};
-  static constexpr __nv_bfloat16 __pi         = __nv_bfloat16_raw{0x4049u};
-  static constexpr __nv_bfloat16 __inv_pi     = __nv_bfloat16_raw{0x3ea3u};
-  static constexpr __nv_bfloat16 __inv_sqrtpi = __nv_bfloat16_raw{0x3f10u};
-  static constexpr __nv_bfloat16 __ln2        = __nv_bfloat16_raw{0x3f31u};
-  static constexpr __nv_bfloat16 __ln10       = __nv_bfloat16_raw{0x4013u};
-  static constexpr __nv_bfloat16 __sqrt2      = __nv_bfloat16_raw{0x3fb5u};
-  static constexpr __nv_bfloat16 __sqrt3      = __nv_bfloat16_raw{0x3fdeu};
-  static constexpr __nv_bfloat16 __inv_sqrt3  = __nv_bfloat16_raw{0x3f14u};
-  static constexpr __nv_bfloat16 __egamma     = __nv_bfloat16_raw{0x3f14u};
-  static constexpr __nv_bfloat16 __phi        = __nv_bfloat16_raw{0x3fcfu};
+  static _LIBCUDACXX_HIDE_FROM_ABI constexpr __nv_bfloat16 __e() noexcept
+  {
+    return __nv_bfloat16_raw{0x402eu};
+  }
+  static _LIBCUDACXX_HIDE_FROM_ABI constexpr __nv_bfloat16 __log2e() noexcept
+  {
+    return __nv_bfloat16_raw{0x3fb9u};
+  }
+  static _LIBCUDACXX_HIDE_FROM_ABI constexpr __nv_bfloat16 __log10e() noexcept
+  {
+    return __nv_bfloat16_raw{0x3edeu};
+  }
+  static _LIBCUDACXX_HIDE_FROM_ABI constexpr __nv_bfloat16 __pi() noexcept
+  {
+    return __nv_bfloat16_raw{0x4049u};
+  }
+  static _LIBCUDACXX_HIDE_FROM_ABI constexpr __nv_bfloat16 __inv_pi() noexcept
+  {
+    return __nv_bfloat16_raw{0x3ea3u};
+  }
+  static _LIBCUDACXX_HIDE_FROM_ABI constexpr __nv_bfloat16 __inv_sqrtpi() noexcept
+  {
+    return __nv_bfloat16_raw{0x3f10u};
+  }
+  static _LIBCUDACXX_HIDE_FROM_ABI constexpr __nv_bfloat16 __ln2() noexcept
+  {
+    return __nv_bfloat16_raw{0x3f31u};
+  }
+  static _LIBCUDACXX_HIDE_FROM_ABI constexpr __nv_bfloat16 __ln10() noexcept
+  {
+    return __nv_bfloat16_raw{0x4013u};
+  }
+  static _LIBCUDACXX_HIDE_FROM_ABI constexpr __nv_bfloat16 __sqrt2() noexcept
+  {
+    return __nv_bfloat16_raw{0x3fb5u};
+  }
+  static _LIBCUDACXX_HIDE_FROM_ABI constexpr __nv_bfloat16 __sqrt3() noexcept
+  {
+    return __nv_bfloat16_raw{0x3fdeu};
+  }
+  static _LIBCUDACXX_HIDE_FROM_ABI constexpr __nv_bfloat16 __inv_sqrt3() noexcept
+  {
+    return __nv_bfloat16_raw{0x3f14u};
+  }
+  static _LIBCUDACXX_HIDE_FROM_ABI constexpr __nv_bfloat16 __egamma() noexcept
+  {
+    return __nv_bfloat16_raw{0x3f14u};
+  }
+  static _LIBCUDACXX_HIDE_FROM_ABI constexpr __nv_bfloat16 __phi() noexcept
+  {
+    return __nv_bfloat16_raw{0x3fcfu};
+  }
 };
 #endif // _LIBCUDACXX_HAS_NVBF16()
 
@@ -107,103 +224,103 @@ namespace numbers
 {
 
 template <class _Tp>
-_CCCL_DEVICE_VARIABLE constexpr _Tp e_v = __numbers<_Tp>::__e;
+inline constexpr _Tp e_v = __numbers<_Tp>::__e();
 template <class _Tp>
-_CCCL_DEVICE_VARIABLE constexpr _Tp log2e_v = __numbers<_Tp>::__log2e;
+inline constexpr _Tp log2e_v = __numbers<_Tp>::__log2e();
 template <class _Tp>
-_CCCL_DEVICE_VARIABLE constexpr _Tp log10e_v = __numbers<_Tp>::__log10e;
+inline constexpr _Tp log10e_v = __numbers<_Tp>::__log10e();
 template <class _Tp>
-_CCCL_DEVICE_VARIABLE constexpr _Tp pi_v = __numbers<_Tp>::__pi;
+inline constexpr _Tp pi_v = __numbers<_Tp>::__pi();
 template <class _Tp>
-_CCCL_DEVICE_VARIABLE constexpr _Tp inv_pi_v = __numbers<_Tp>::__inv_pi;
+inline constexpr _Tp inv_pi_v = __numbers<_Tp>::__inv_pi();
 template <class _Tp>
-_CCCL_DEVICE_VARIABLE constexpr _Tp inv_sqrtpi_v = __numbers<_Tp>::__inv_sqrtpi;
+inline constexpr _Tp inv_sqrtpi_v = __numbers<_Tp>::__inv_sqrtpi();
 template <class _Tp>
-_CCCL_DEVICE_VARIABLE constexpr _Tp ln2_v = __numbers<_Tp>::__ln2;
+inline constexpr _Tp ln2_v = __numbers<_Tp>::__ln2();
 template <class _Tp>
-_CCCL_DEVICE_VARIABLE constexpr _Tp ln10_v = __numbers<_Tp>::__ln10;
+inline constexpr _Tp ln10_v = __numbers<_Tp>::__ln10();
 template <class _Tp>
-_CCCL_DEVICE_VARIABLE constexpr _Tp sqrt2_v = __numbers<_Tp>::__sqrt2;
+inline constexpr _Tp sqrt2_v = __numbers<_Tp>::__sqrt2();
 template <class _Tp>
-_CCCL_DEVICE_VARIABLE constexpr _Tp sqrt3_v = __numbers<_Tp>::__sqrt3;
+inline constexpr _Tp sqrt3_v = __numbers<_Tp>::__sqrt3();
 template <class _Tp>
-_CCCL_DEVICE_VARIABLE constexpr _Tp inv_sqrt3_v = __numbers<_Tp>::__inv_sqrt3;
+inline constexpr _Tp inv_sqrt3_v = __numbers<_Tp>::__inv_sqrt3();
 template <class _Tp>
-_CCCL_DEVICE_VARIABLE constexpr _Tp egamma_v = __numbers<_Tp>::__egamma;
+inline constexpr _Tp egamma_v = __numbers<_Tp>::__egamma();
 template <class _Tp>
-_CCCL_DEVICE_VARIABLE constexpr _Tp phi_v = __numbers<_Tp>::__phi;
+inline constexpr _Tp phi_v = __numbers<_Tp>::__phi();
 
 #if _LIBCUDACXX_HAS_NVFP16()
 template <>
-_CCCL_DEVICE_VARIABLE constexpr __half e_v<__half> = __numbers<__half>::__e;
+_CCCL_GLOBAL_CONSTANT __half e_v<__half> = __numbers<__half>::__e();
 template <>
-_CCCL_DEVICE_VARIABLE constexpr __half log2e_v<__half> = __numbers<__half>::__log2e;
+_CCCL_GLOBAL_CONSTANT __half log2e_v<__half> = __numbers<__half>::__log2e();
 template <>
-_CCCL_DEVICE_VARIABLE constexpr __half log10e_v<__half> = __numbers<__half>::__log10e;
+_CCCL_GLOBAL_CONSTANT __half log10e_v<__half> = __numbers<__half>::__log10e();
 template <>
-_CCCL_DEVICE_VARIABLE constexpr __half pi_v<__half> = __numbers<__half>::__pi;
+_CCCL_GLOBAL_CONSTANT __half pi_v<__half> = __numbers<__half>::__pi();
 template <>
-_CCCL_DEVICE_VARIABLE constexpr __half inv_pi_v<__half> = __numbers<__half>::__inv_pi;
+_CCCL_GLOBAL_CONSTANT __half inv_pi_v<__half> = __numbers<__half>::__inv_pi();
 template <>
-_CCCL_DEVICE_VARIABLE constexpr __half inv_sqrtpi_v<__half> = __numbers<__half>::__inv_sqrtpi;
+_CCCL_GLOBAL_CONSTANT __half inv_sqrtpi_v<__half> = __numbers<__half>::__inv_sqrtpi();
 template <>
-_CCCL_DEVICE_VARIABLE constexpr __half ln2_v<__half> = __numbers<__half>::__ln2;
+_CCCL_GLOBAL_CONSTANT __half ln2_v<__half> = __numbers<__half>::__ln2();
 template <>
-_CCCL_DEVICE_VARIABLE constexpr __half ln10_v<__half> = __numbers<__half>::__ln10;
+_CCCL_GLOBAL_CONSTANT __half ln10_v<__half> = __numbers<__half>::__ln10();
 template <>
-_CCCL_DEVICE_VARIABLE constexpr __half sqrt2_v<__half> = __numbers<__half>::__sqrt2;
+_CCCL_GLOBAL_CONSTANT __half sqrt2_v<__half> = __numbers<__half>::__sqrt2();
 template <>
-_CCCL_DEVICE_VARIABLE constexpr __half sqrt3_v<__half> = __numbers<__half>::__sqrt3;
+_CCCL_GLOBAL_CONSTANT __half sqrt3_v<__half> = __numbers<__half>::__sqrt3();
 template <>
-_CCCL_DEVICE_VARIABLE constexpr __half inv_sqrt3_v<__half> = __numbers<__half>::__inv_sqrt3;
+_CCCL_GLOBAL_CONSTANT __half inv_sqrt3_v<__half> = __numbers<__half>::__inv_sqrt3();
 template <>
-_CCCL_DEVICE_VARIABLE constexpr __half egamma_v<__half> = __numbers<__half>::__egamma;
+_CCCL_GLOBAL_CONSTANT __half egamma_v<__half> = __numbers<__half>::__egamma();
 template <>
-_CCCL_DEVICE_VARIABLE constexpr __half phi_v<__half> = __numbers<__half>::__phi;
+_CCCL_GLOBAL_CONSTANT __half phi_v<__half> = __numbers<__half>::__phi();
 #endif // _LIBCUDACXX_HAS_NVFP16()
 
 #if _LIBCUDACXX_HAS_NVBF16()
 template <>
-_CCCL_DEVICE_VARIABLE constexpr __nv_bfloat16 e_v<__nv_bfloat16> = __numbers<__nv_bfloat16>::__e;
+_CCCL_GLOBAL_CONSTANT __nv_bfloat16 e_v<__nv_bfloat16> = __numbers<__nv_bfloat16>::__e();
 template <>
-_CCCL_DEVICE_VARIABLE constexpr __nv_bfloat16 log2e_v<__nv_bfloat16> = __numbers<__nv_bfloat16>::__log2e;
+_CCCL_GLOBAL_CONSTANT __nv_bfloat16 log2e_v<__nv_bfloat16> = __numbers<__nv_bfloat16>::__log2e();
 template <>
-_CCCL_DEVICE_VARIABLE constexpr __nv_bfloat16 log10e_v<__nv_bfloat16> = __numbers<__nv_bfloat16>::__log10e;
+_CCCL_GLOBAL_CONSTANT __nv_bfloat16 log10e_v<__nv_bfloat16> = __numbers<__nv_bfloat16>::__log10e();
 template <>
-_CCCL_DEVICE_VARIABLE constexpr __nv_bfloat16 pi_v<__nv_bfloat16> = __numbers<__nv_bfloat16>::__pi;
+_CCCL_GLOBAL_CONSTANT __nv_bfloat16 pi_v<__nv_bfloat16> = __numbers<__nv_bfloat16>::__pi();
 template <>
-_CCCL_DEVICE_VARIABLE constexpr __nv_bfloat16 inv_pi_v<__nv_bfloat16> = __numbers<__nv_bfloat16>::__inv_pi;
+_CCCL_GLOBAL_CONSTANT __nv_bfloat16 inv_pi_v<__nv_bfloat16> = __numbers<__nv_bfloat16>::__inv_pi();
 template <>
-_CCCL_DEVICE_VARIABLE constexpr __nv_bfloat16 inv_sqrtpi_v<__nv_bfloat16> = __numbers<__nv_bfloat16>::__inv_sqrtpi;
+_CCCL_GLOBAL_CONSTANT __nv_bfloat16 inv_sqrtpi_v<__nv_bfloat16> = __numbers<__nv_bfloat16>::__inv_sqrtpi();
 template <>
-_CCCL_DEVICE_VARIABLE constexpr __nv_bfloat16 ln2_v<__nv_bfloat16> = __numbers<__nv_bfloat16>::__ln2;
+_CCCL_GLOBAL_CONSTANT __nv_bfloat16 ln2_v<__nv_bfloat16> = __numbers<__nv_bfloat16>::__ln2();
 template <>
-_CCCL_DEVICE_VARIABLE constexpr __nv_bfloat16 ln10_v<__nv_bfloat16> = __numbers<__nv_bfloat16>::__ln10;
+_CCCL_GLOBAL_CONSTANT __nv_bfloat16 ln10_v<__nv_bfloat16> = __numbers<__nv_bfloat16>::__ln10();
 template <>
-_CCCL_DEVICE_VARIABLE constexpr __nv_bfloat16 sqrt2_v<__nv_bfloat16> = __numbers<__nv_bfloat16>::__sqrt2;
+_CCCL_GLOBAL_CONSTANT __nv_bfloat16 sqrt2_v<__nv_bfloat16> = __numbers<__nv_bfloat16>::__sqrt2();
 template <>
-_CCCL_DEVICE_VARIABLE constexpr __nv_bfloat16 sqrt3_v<__nv_bfloat16> = __numbers<__nv_bfloat16>::__sqrt3;
+_CCCL_GLOBAL_CONSTANT __nv_bfloat16 sqrt3_v<__nv_bfloat16> = __numbers<__nv_bfloat16>::__sqrt3();
 template <>
-_CCCL_DEVICE_VARIABLE constexpr __nv_bfloat16 inv_sqrt3_v<__nv_bfloat16> = __numbers<__nv_bfloat16>::__inv_sqrt3;
+_CCCL_GLOBAL_CONSTANT __nv_bfloat16 inv_sqrt3_v<__nv_bfloat16> = __numbers<__nv_bfloat16>::__inv_sqrt3();
 template <>
-_CCCL_DEVICE_VARIABLE constexpr __nv_bfloat16 egamma_v<__nv_bfloat16> = __numbers<__nv_bfloat16>::__egamma;
+_CCCL_GLOBAL_CONSTANT __nv_bfloat16 egamma_v<__nv_bfloat16> = __numbers<__nv_bfloat16>::__egamma();
 template <>
-_CCCL_DEVICE_VARIABLE constexpr __nv_bfloat16 phi_v<__nv_bfloat16> = __numbers<__nv_bfloat16>::__phi;
+_CCCL_GLOBAL_CONSTANT __nv_bfloat16 phi_v<__nv_bfloat16> = __numbers<__nv_bfloat16>::__phi();
 #endif // _LIBCUDACXX_HAS_NVBF16()
 
-_CCCL_DEVICE_VARIABLE constexpr double e          = e_v<double>;
-_CCCL_DEVICE_VARIABLE constexpr double log2e      = log2e_v<double>;
-_CCCL_DEVICE_VARIABLE constexpr double log10e     = log10e_v<double>;
-_CCCL_DEVICE_VARIABLE constexpr double pi         = pi_v<double>;
-_CCCL_DEVICE_VARIABLE constexpr double inv_pi     = inv_pi_v<double>;
-_CCCL_DEVICE_VARIABLE constexpr double inv_sqrtpi = inv_sqrtpi_v<double>;
-_CCCL_DEVICE_VARIABLE constexpr double ln2        = ln2_v<double>;
-_CCCL_DEVICE_VARIABLE constexpr double ln10       = ln10_v<double>;
-_CCCL_DEVICE_VARIABLE constexpr double sqrt2      = sqrt2_v<double>;
-_CCCL_DEVICE_VARIABLE constexpr double sqrt3      = sqrt3_v<double>;
-_CCCL_DEVICE_VARIABLE constexpr double inv_sqrt3  = inv_sqrt3_v<double>;
-_CCCL_DEVICE_VARIABLE constexpr double egamma     = egamma_v<double>;
-_CCCL_DEVICE_VARIABLE constexpr double phi        = phi_v<double>;
+inline constexpr double e          = __numbers<double>::__e();
+inline constexpr double log2e      = __numbers<double>::__log2e();
+inline constexpr double log10e     = __numbers<double>::__log10e();
+inline constexpr double pi         = __numbers<double>::__pi();
+inline constexpr double inv_pi     = __numbers<double>::__inv_pi();
+inline constexpr double inv_sqrtpi = __numbers<double>::__inv_sqrtpi();
+inline constexpr double ln2        = __numbers<double>::__ln2();
+inline constexpr double ln10       = __numbers<double>::__ln10();
+inline constexpr double sqrt2      = __numbers<double>::__sqrt2();
+inline constexpr double sqrt3      = __numbers<double>::__sqrt3();
+inline constexpr double inv_sqrt3  = __numbers<double>::__inv_sqrt3();
+inline constexpr double egamma     = __numbers<double>::__egamma();
+inline constexpr double phi        = __numbers<double>::__phi();
 
 } // namespace numbers
 

--- a/libcudacxx/include/cuda/std/numbers
+++ b/libcudacxx/include/cuda/std/numbers
@@ -107,104 +107,103 @@ namespace numbers
 {
 
 template <class _Tp>
-inline constexpr _Tp e_v = __numbers<_Tp>::__e;
+_CCCL_DEVICE_VARIABLE constexpr _Tp e_v = __numbers<_Tp>::__e;
 template <class _Tp>
-inline constexpr _Tp log2e_v = __numbers<_Tp>::__log2e;
+_CCCL_DEVICE_VARIABLE constexpr _Tp log2e_v = __numbers<_Tp>::__log2e;
 template <class _Tp>
-inline constexpr _Tp log10e_v = __numbers<_Tp>::__log10e;
+_CCCL_DEVICE_VARIABLE constexpr _Tp log10e_v = __numbers<_Tp>::__log10e;
 template <class _Tp>
-inline constexpr _Tp pi_v = __numbers<_Tp>::__pi;
+_CCCL_DEVICE_VARIABLE constexpr _Tp pi_v = __numbers<_Tp>::__pi;
 template <class _Tp>
-inline constexpr _Tp inv_pi_v = __numbers<_Tp>::__inv_pi;
+_CCCL_DEVICE_VARIABLE constexpr _Tp inv_pi_v = __numbers<_Tp>::__inv_pi;
 template <class _Tp>
-inline constexpr _Tp inv_sqrtpi_v = __numbers<_Tp>::__inv_sqrtpi;
+_CCCL_DEVICE_VARIABLE constexpr _Tp inv_sqrtpi_v = __numbers<_Tp>::__inv_sqrtpi;
 template <class _Tp>
-inline constexpr _Tp ln2_v = __numbers<_Tp>::__ln2;
+_CCCL_DEVICE_VARIABLE constexpr _Tp ln2_v = __numbers<_Tp>::__ln2;
 template <class _Tp>
-inline constexpr _Tp ln10_v = __numbers<_Tp>::__ln10;
+_CCCL_DEVICE_VARIABLE constexpr _Tp ln10_v = __numbers<_Tp>::__ln10;
 template <class _Tp>
-inline constexpr _Tp sqrt2_v = __numbers<_Tp>::__sqrt2;
+_CCCL_DEVICE_VARIABLE constexpr _Tp sqrt2_v = __numbers<_Tp>::__sqrt2;
 template <class _Tp>
-inline constexpr _Tp sqrt3_v = __numbers<_Tp>::__sqrt3;
+_CCCL_DEVICE_VARIABLE constexpr _Tp sqrt3_v = __numbers<_Tp>::__sqrt3;
 template <class _Tp>
-inline constexpr _Tp inv_sqrt3_v = __numbers<_Tp>::__inv_sqrt3;
+_CCCL_DEVICE_VARIABLE constexpr _Tp inv_sqrt3_v = __numbers<_Tp>::__inv_sqrt3;
 template <class _Tp>
-inline constexpr _Tp egamma_v = __numbers<_Tp>::__egamma;
+_CCCL_DEVICE_VARIABLE constexpr _Tp egamma_v = __numbers<_Tp>::__egamma;
 template <class _Tp>
-inline constexpr _Tp phi_v = __numbers<_Tp>::__phi;
+_CCCL_DEVICE_VARIABLE constexpr _Tp phi_v = __numbers<_Tp>::__phi;
 
 #if _LIBCUDACXX_HAS_NVFP16()
 template <>
-_CCCL_DEVICE_VARIABLE inline constexpr __half e_v<__half> = __numbers<__half>::__e;
+_CCCL_DEVICE_VARIABLE constexpr __half e_v<__half> = __numbers<__half>::__e;
 template <>
-_CCCL_DEVICE_VARIABLE inline constexpr __half log2e_v<__half> = __numbers<__half>::__log2e;
+_CCCL_DEVICE_VARIABLE constexpr __half log2e_v<__half> = __numbers<__half>::__log2e;
 template <>
-_CCCL_DEVICE_VARIABLE inline constexpr __half log10e_v<__half> = __numbers<__half>::__log10e;
+_CCCL_DEVICE_VARIABLE constexpr __half log10e_v<__half> = __numbers<__half>::__log10e;
 template <>
-_CCCL_DEVICE_VARIABLE inline constexpr __half pi_v<__half> = __numbers<__half>::__pi;
+_CCCL_DEVICE_VARIABLE constexpr __half pi_v<__half> = __numbers<__half>::__pi;
 template <>
-_CCCL_DEVICE_VARIABLE inline constexpr __half inv_pi_v<__half> = __numbers<__half>::__inv_pi;
+_CCCL_DEVICE_VARIABLE constexpr __half inv_pi_v<__half> = __numbers<__half>::__inv_pi;
 template <>
-_CCCL_DEVICE_VARIABLE inline constexpr __half inv_sqrtpi_v<__half> = __numbers<__half>::__inv_sqrtpi;
+_CCCL_DEVICE_VARIABLE constexpr __half inv_sqrtpi_v<__half> = __numbers<__half>::__inv_sqrtpi;
 template <>
-_CCCL_DEVICE_VARIABLE inline constexpr __half ln2_v<__half> = __numbers<__half>::__ln2;
+_CCCL_DEVICE_VARIABLE constexpr __half ln2_v<__half> = __numbers<__half>::__ln2;
 template <>
-_CCCL_DEVICE_VARIABLE inline constexpr __half ln10_v<__half> = __numbers<__half>::__ln10;
+_CCCL_DEVICE_VARIABLE constexpr __half ln10_v<__half> = __numbers<__half>::__ln10;
 template <>
-_CCCL_DEVICE_VARIABLE inline constexpr __half sqrt2_v<__half> = __numbers<__half>::__sqrt2;
+_CCCL_DEVICE_VARIABLE constexpr __half sqrt2_v<__half> = __numbers<__half>::__sqrt2;
 template <>
-_CCCL_DEVICE_VARIABLE inline constexpr __half sqrt3_v<__half> = __numbers<__half>::__sqrt3;
+_CCCL_DEVICE_VARIABLE constexpr __half sqrt3_v<__half> = __numbers<__half>::__sqrt3;
 template <>
-_CCCL_DEVICE_VARIABLE inline constexpr __half inv_sqrt3_v<__half> = __numbers<__half>::__inv_sqrt3;
+_CCCL_DEVICE_VARIABLE constexpr __half inv_sqrt3_v<__half> = __numbers<__half>::__inv_sqrt3;
 template <>
-_CCCL_DEVICE_VARIABLE inline constexpr __half egamma_v<__half> = __numbers<__half>::__egamma;
+_CCCL_DEVICE_VARIABLE constexpr __half egamma_v<__half> = __numbers<__half>::__egamma;
 template <>
-_CCCL_DEVICE_VARIABLE inline constexpr __half phi_v<__half> = __numbers<__half>::__phi;
+_CCCL_DEVICE_VARIABLE constexpr __half phi_v<__half> = __numbers<__half>::__phi;
 #endif // _LIBCUDACXX_HAS_NVFP16()
 
 #if _LIBCUDACXX_HAS_NVBF16()
 template <>
-_CCCL_DEVICE_VARIABLE inline constexpr __nv_bfloat16 e_v<__nv_bfloat16> = __numbers<__nv_bfloat16>::__e;
+_CCCL_DEVICE_VARIABLE constexpr __nv_bfloat16 e_v<__nv_bfloat16> = __numbers<__nv_bfloat16>::__e;
 template <>
-_CCCL_DEVICE_VARIABLE inline constexpr __nv_bfloat16 log2e_v<__nv_bfloat16> = __numbers<__nv_bfloat16>::__log2e;
+_CCCL_DEVICE_VARIABLE constexpr __nv_bfloat16 log2e_v<__nv_bfloat16> = __numbers<__nv_bfloat16>::__log2e;
 template <>
-_CCCL_DEVICE_VARIABLE inline constexpr __nv_bfloat16 log10e_v<__nv_bfloat16> = __numbers<__nv_bfloat16>::__log10e;
+_CCCL_DEVICE_VARIABLE constexpr __nv_bfloat16 log10e_v<__nv_bfloat16> = __numbers<__nv_bfloat16>::__log10e;
 template <>
-_CCCL_DEVICE_VARIABLE inline constexpr __nv_bfloat16 pi_v<__nv_bfloat16> = __numbers<__nv_bfloat16>::__pi;
+_CCCL_DEVICE_VARIABLE constexpr __nv_bfloat16 pi_v<__nv_bfloat16> = __numbers<__nv_bfloat16>::__pi;
 template <>
-_CCCL_DEVICE_VARIABLE inline constexpr __nv_bfloat16 inv_pi_v<__nv_bfloat16> = __numbers<__nv_bfloat16>::__inv_pi;
+_CCCL_DEVICE_VARIABLE constexpr __nv_bfloat16 inv_pi_v<__nv_bfloat16> = __numbers<__nv_bfloat16>::__inv_pi;
 template <>
-_CCCL_DEVICE_VARIABLE inline constexpr __nv_bfloat16 inv_sqrtpi_v<__nv_bfloat16> =
-  __numbers<__nv_bfloat16>::__inv_sqrtpi;
+_CCCL_DEVICE_VARIABLE constexpr __nv_bfloat16 inv_sqrtpi_v<__nv_bfloat16> = __numbers<__nv_bfloat16>::__inv_sqrtpi;
 template <>
-_CCCL_DEVICE_VARIABLE inline constexpr __nv_bfloat16 ln2_v<__nv_bfloat16> = __numbers<__nv_bfloat16>::__ln2;
+_CCCL_DEVICE_VARIABLE constexpr __nv_bfloat16 ln2_v<__nv_bfloat16> = __numbers<__nv_bfloat16>::__ln2;
 template <>
-_CCCL_DEVICE_VARIABLE inline constexpr __nv_bfloat16 ln10_v<__nv_bfloat16> = __numbers<__nv_bfloat16>::__ln10;
+_CCCL_DEVICE_VARIABLE constexpr __nv_bfloat16 ln10_v<__nv_bfloat16> = __numbers<__nv_bfloat16>::__ln10;
 template <>
-_CCCL_DEVICE_VARIABLE inline constexpr __nv_bfloat16 sqrt2_v<__nv_bfloat16> = __numbers<__nv_bfloat16>::__sqrt2;
+_CCCL_DEVICE_VARIABLE constexpr __nv_bfloat16 sqrt2_v<__nv_bfloat16> = __numbers<__nv_bfloat16>::__sqrt2;
 template <>
-_CCCL_DEVICE_VARIABLE inline constexpr __nv_bfloat16 sqrt3_v<__nv_bfloat16> = __numbers<__nv_bfloat16>::__sqrt3;
+_CCCL_DEVICE_VARIABLE constexpr __nv_bfloat16 sqrt3_v<__nv_bfloat16> = __numbers<__nv_bfloat16>::__sqrt3;
 template <>
-_CCCL_DEVICE_VARIABLE inline constexpr __nv_bfloat16 inv_sqrt3_v<__nv_bfloat16> = __numbers<__nv_bfloat16>::__inv_sqrt3;
+_CCCL_DEVICE_VARIABLE constexpr __nv_bfloat16 inv_sqrt3_v<__nv_bfloat16> = __numbers<__nv_bfloat16>::__inv_sqrt3;
 template <>
-_CCCL_DEVICE_VARIABLE inline constexpr __nv_bfloat16 egamma_v<__nv_bfloat16> = __numbers<__nv_bfloat16>::__egamma;
+_CCCL_DEVICE_VARIABLE constexpr __nv_bfloat16 egamma_v<__nv_bfloat16> = __numbers<__nv_bfloat16>::__egamma;
 template <>
-_CCCL_DEVICE_VARIABLE inline constexpr __nv_bfloat16 phi_v<__nv_bfloat16> = __numbers<__nv_bfloat16>::__phi;
+_CCCL_DEVICE_VARIABLE constexpr __nv_bfloat16 phi_v<__nv_bfloat16> = __numbers<__nv_bfloat16>::__phi;
 #endif // _LIBCUDACXX_HAS_NVBF16()
 
-inline constexpr double e          = e_v<double>;
-inline constexpr double log2e      = log2e_v<double>;
-inline constexpr double log10e     = log10e_v<double>;
-inline constexpr double pi         = pi_v<double>;
-inline constexpr double inv_pi     = inv_pi_v<double>;
-inline constexpr double inv_sqrtpi = inv_sqrtpi_v<double>;
-inline constexpr double ln2        = ln2_v<double>;
-inline constexpr double ln10       = ln10_v<double>;
-inline constexpr double sqrt2      = sqrt2_v<double>;
-inline constexpr double sqrt3      = sqrt3_v<double>;
-inline constexpr double inv_sqrt3  = inv_sqrt3_v<double>;
-inline constexpr double egamma     = egamma_v<double>;
-inline constexpr double phi        = phi_v<double>;
+_CCCL_DEVICE_VARIABLE constexpr double e          = e_v<double>;
+_CCCL_DEVICE_VARIABLE constexpr double log2e      = log2e_v<double>;
+_CCCL_DEVICE_VARIABLE constexpr double log10e     = log10e_v<double>;
+_CCCL_DEVICE_VARIABLE constexpr double pi         = pi_v<double>;
+_CCCL_DEVICE_VARIABLE constexpr double inv_pi     = inv_pi_v<double>;
+_CCCL_DEVICE_VARIABLE constexpr double inv_sqrtpi = inv_sqrtpi_v<double>;
+_CCCL_DEVICE_VARIABLE constexpr double ln2        = ln2_v<double>;
+_CCCL_DEVICE_VARIABLE constexpr double ln10       = ln10_v<double>;
+_CCCL_DEVICE_VARIABLE constexpr double sqrt2      = sqrt2_v<double>;
+_CCCL_DEVICE_VARIABLE constexpr double sqrt3      = sqrt3_v<double>;
+_CCCL_DEVICE_VARIABLE constexpr double inv_sqrt3  = inv_sqrt3_v<double>;
+_CCCL_DEVICE_VARIABLE constexpr double egamma     = egamma_v<double>;
+_CCCL_DEVICE_VARIABLE constexpr double phi        = phi_v<double>;
 
 } // namespace numbers
 

--- a/libcudacxx/include/cuda/std/numbers
+++ b/libcudacxx/include/cuda/std/numbers
@@ -250,7 +250,9 @@ inline constexpr _Tp egamma_v = __numbers<_Tp>::__egamma();
 template <class _Tp>
 inline constexpr _Tp phi_v = __numbers<_Tp>::__phi();
 
-#if _LIBCUDACXX_HAS_NVFP16()
+#if !_CCCL_COMPILER(MSVC)
+// MSVC errors here because of "error: A __device__ variable template cannot have a const qualified type on Windows"
+#  if _LIBCUDACXX_HAS_NVFP16()
 template <>
 _CCCL_GLOBAL_CONSTANT __half e_v<__half> = __numbers<__half>::__e();
 template <>
@@ -277,9 +279,9 @@ template <>
 _CCCL_GLOBAL_CONSTANT __half egamma_v<__half> = __numbers<__half>::__egamma();
 template <>
 _CCCL_GLOBAL_CONSTANT __half phi_v<__half> = __numbers<__half>::__phi();
-#endif // _LIBCUDACXX_HAS_NVFP16()
+#  endif // _LIBCUDACXX_HAS_NVFP16()
 
-#if _LIBCUDACXX_HAS_NVBF16()
+#  if _LIBCUDACXX_HAS_NVBF16()
 template <>
 _CCCL_GLOBAL_CONSTANT __nv_bfloat16 e_v<__nv_bfloat16> = __numbers<__nv_bfloat16>::__e();
 template <>
@@ -306,7 +308,8 @@ template <>
 _CCCL_GLOBAL_CONSTANT __nv_bfloat16 egamma_v<__nv_bfloat16> = __numbers<__nv_bfloat16>::__egamma();
 template <>
 _CCCL_GLOBAL_CONSTANT __nv_bfloat16 phi_v<__nv_bfloat16> = __numbers<__nv_bfloat16>::__phi();
-#endif // _LIBCUDACXX_HAS_NVBF16()
+#  endif // _LIBCUDACXX_HAS_NVBF16()
+#endif // !_CCCL_COMPILER(MSVC)
 
 inline constexpr double e          = __numbers<double>::__e();
 inline constexpr double log2e      = __numbers<double>::__log2e();

--- a/libcudacxx/test/libcudacxx/std/language.support/support.srcloc/general.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.srcloc/general.pass.cpp
@@ -47,7 +47,7 @@ static_assert(cuda::std::is_same<cuda::std::uint_least32_t, decltype(empty.colum
 static_assert(cuda::std::is_same<const char*, decltype(empty.file_name())>::value, "");
 static_assert(cuda::std::is_same<const char*, decltype(empty.function_name())>::value, "");
 
-__device__ _CCCL_CONSTEXPR_GLOBAL cuda::std::source_location device_empty{};
+__device__ constexpr cuda::std::source_location device_empty{};
 static_assert(device_empty.line() == 0, "");
 static_assert(device_empty.column() == 0, "");
 static_assert(device_empty.file_name()[0] == '\0', "");

--- a/libcudacxx/test/libcudacxx/std/numerics/numbers/defined.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/numbers/defined.pass.cpp
@@ -75,6 +75,11 @@ __host__ __device__ constexpr bool test()
   return true;
 }
 
+__global__ void test_kernel()
+{
+  test();
+}
+
 int main(int, char**)
 {
   test();

--- a/libcudacxx/test/libcudacxx/std/numerics/numbers/value.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/numbers/value.pass.cpp
@@ -120,6 +120,12 @@ __host__ __device__ void test_ext_fp()
 #endif // _LIBCUDACXX_HAS_NVBF16()
 }
 
+__global__ void test_kernel()
+{
+  test();
+  test_ext_fp();
+}
+
 int main(int, char**)
 {
   test();

--- a/libcudacxx/test/libcudacxx/std/numerics/numbers/value.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/numbers/value.pass.cpp
@@ -86,7 +86,9 @@ __host__ __device__ constexpr bool test()
 // Extended floating point types are not comparable in constexpr context
 __host__ __device__ void test_ext_fp()
 {
-#if _LIBCUDACXX_HAS_NVFP16()
+#ifndef TEST_COMPILER_MSVC
+  // MSVC errors here because of "error: A __device__ variable template cannot have a const qualified type on Windows"
+#  if _LIBCUDACXX_HAS_NVFP16()
   // __half constants
   assert(cuda::std::numbers::e_v<__half> == __half{2.71875});
   assert(cuda::std::numbers::log2e_v<__half> == __half{1.4423828125});
@@ -101,9 +103,9 @@ __host__ __device__ void test_ext_fp()
   assert(cuda::std::numbers::inv_sqrt3_v<__half> == __half{0.5771484375});
   assert(cuda::std::numbers::egamma_v<__half> == __half{0.5771484375});
   assert(cuda::std::numbers::phi_v<__half> == __half{1.6181640625});
-#endif // _LIBCUDACXX_HAS_NVFP16()
+#  endif // _LIBCUDACXX_HAS_NVFP16()
 
-#if _LIBCUDACXX_HAS_NVBF16()
+#  if _LIBCUDACXX_HAS_NVBF16()
   assert(cuda::std::numbers::e_v<__nv_bfloat16> == __nv_bfloat16{2.71875f});
   assert(cuda::std::numbers::log2e_v<__nv_bfloat16> == __nv_bfloat16{1.4453125f});
   assert(cuda::std::numbers::log10e_v<__nv_bfloat16> == __nv_bfloat16{0.43359375f});
@@ -117,7 +119,8 @@ __host__ __device__ void test_ext_fp()
   assert(cuda::std::numbers::inv_sqrt3_v<__nv_bfloat16> == __nv_bfloat16{0.578125f});
   assert(cuda::std::numbers::egamma_v<__nv_bfloat16> == __nv_bfloat16{0.578125f});
   assert(cuda::std::numbers::phi_v<__nv_bfloat16> == __nv_bfloat16{1.6171875f});
-#endif // _LIBCUDACXX_HAS_NVBF16()
+#  endif // _LIBCUDACXX_HAS_NVBF16()
+#endif // !TEST_COMPILER_MSVC
 }
 
 __global__ void test_kernel()

--- a/libcudacxx/test/support/test_macros.h
+++ b/libcudacxx/test/support/test_macros.h
@@ -425,7 +425,7 @@ __host__ __device__ constexpr bool unused(T&&...)
 #  define TEST_NV_DIAG_SUPPRESS(WARNING) _CCCL_PRAGMA(diag_suppress WARNING)
 #endif
 
-#define TEST_CONSTEXPR_GLOBAL _CCCL_CONSTEXPR_GLOBAL
+#define TEST_CONSTEXPR_GLOBAL constexpr
 
 // Some convenience macros for checking nvcc versions
 #if _CCCL_CUDACC_BELOW(12, 3)

--- a/thrust/thrust/optional.h
+++ b/thrust/thrust/optional.h
@@ -686,7 +686,7 @@ struct CCCL_DEPRECATED nullopt_t
 /// foo(thrust::nullopt); //pass an empty optional
 /// ```
 #ifdef __CUDA_ARCH__
-__device__ static _CCCL_CONSTEXPR_GLOBAL
+__device__ static constexpr
 #else
 static constexpr
 #endif // __CUDA_ARCH__


### PR DESCRIPTION
For whatever reason our tests did not pick up that the variablee tempaltes are not usable on device.

Fix this by dropping the inline keyword on device :shrug:
