### PR TITLE
Add transform c parallel implementation

### DIFF
--- a/c/parallel/CMakeLists.txt
+++ b/c/parallel/CMakeLists.txt
@@ -40,8 +40,9 @@ target_link_libraries(cccl.c.parallel PRIVATE
   CUB::CUB
   Thrust::Thrust
 )
-target_compile_definitions(cccl.c.parallel PUBLIC CCCL_C_EXPERIMENTAL=1)
+target_compile_definitions(cccl.c.parallel PUBLIC CCCL_C_EXPERIMENTAL=1 _CUB_HAS_TRANSFORM_UBLKCP=0)
 target_compile_definitions(cccl.c.parallel PRIVATE NVRTC_GET_TYPE_NAME=1)
+target_compile_options(cccl.c.parallel PRIVATE $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:--extended-lambda>)
 
 target_include_directories(cccl.c.parallel PUBLIC "include")
 target_include_directories(cccl.c.parallel PRIVATE "src")

--- a/c/parallel/include/cccl/c/transform.h
+++ b/c/parallel/include/cccl/c/transform.h
@@ -1,0 +1,78 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA Core Compute Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#ifndef CCCL_C_EXPERIMENTAL
+#  error "C exposure is experimental and subject to change. Define CCCL_C_EXPERIMENTAL to acknowledge this notice."
+#endif // !CCCL_C_EXPERIMENTAL
+
+#include <cuda.h>
+
+#include <cccl/c/extern_c.h>
+#include <cccl/c/types.h>
+
+CCCL_C_EXTERN_C_BEGIN
+
+typedef struct cccl_device_transform_build_result_t
+{
+  int cc;
+  void* cubin;
+  size_t cubin_size;
+  CUlibrary library;
+  CUkernel transform_kernel;
+  int loaded_bytes_per_iteration;
+} cccl_device_transform_build_result_t;
+
+CCCL_C_API CUresult cccl_device_unary_transform_build(
+  cccl_device_transform_build_result_t* build_ptr,
+  cccl_iterator_t d_in,
+  cccl_iterator_t d_out,
+  cccl_op_t op,
+  int cc_major,
+  int cc_minor,
+  const char* cub_path,
+  const char* thrust_path,
+  const char* libcudacxx_path,
+  const char* ctk_path);
+
+CCCL_C_API CUresult cccl_device_unary_transform(
+  cccl_device_transform_build_result_t build,
+  cccl_iterator_t d_in,
+  cccl_iterator_t d_out,
+  unsigned long long num_items,
+  cccl_op_t op,
+  CUstream stream);
+
+CCCL_C_API CUresult cccl_device_binary_transform_build(
+  cccl_device_transform_build_result_t* build_ptr,
+  cccl_iterator_t d_in1,
+  cccl_iterator_t d_in2,
+  cccl_iterator_t d_out,
+  cccl_op_t op,
+  int cc_major,
+  int cc_minor,
+  const char* cub_path,
+  const char* thrust_path,
+  const char* libcudacxx_path,
+  const char* ctk_path);
+
+CCCL_C_API CUresult cccl_device_binary_transform(
+  cccl_device_transform_build_result_t build,
+  cccl_iterator_t d_in1,
+  cccl_iterator_t d_in2,
+  cccl_iterator_t d_out,
+  unsigned long long num_items,
+  cccl_op_t op,
+  CUstream stream);
+
+CCCL_C_API CUresult cccl_device_transform_cleanup(cccl_device_transform_build_result_t* bld_ptr);
+
+CCCL_C_EXTERN_C_END

--- a/c/parallel/src/kernels/operators.cpp
+++ b/c/parallel/src/kernels/operators.cpp
@@ -16,25 +16,27 @@
 #include <util/errors.h>
 #include <util/types.h>
 
-constexpr std::string_view op_template = R"XXX(
-#define VALUE_T {0}
-#define OP_NAME {1}
-#define OP_ALIGNMENT {2}
-#define OP_SIZE {3}
+constexpr std::string_view binary_op_template = R"XXX(
+#define LHS_T {0}
+#define RHS_T {1}
+#define OP_NAME {2}
+#define OP_ALIGNMENT {3}
+#define OP_SIZE {4}
 
 // Source
-{4}
+{5}
 
-#undef VALUE_T
+#undef LHS_T
+#undef RHS_T
 #undef OP_NAME
 #undef OP_ALIGNMENT
 #undef OP_SIZE
 )XXX";
 
 constexpr std::string_view stateless_binary_op_template = R"XXX(
-extern "C" __device__ {0} OP_NAME(VALUE_T lhs, VALUE_T rhs);
+extern "C" __device__ {0} OP_NAME(LHS_T lhs, RHS_T rhs);
 struct op_wrapper {{
-  __device__ {0} operator()(VALUE_T lhs, VALUE_T rhs) const {{
+  __device__ {0} operator()(LHS_T lhs, RHS_T rhs) const {{
     return OP_NAME(lhs, rhs);
   }}
 }};
@@ -44,25 +46,26 @@ constexpr std::string_view stateful_binary_op_template = R"XXX(
 struct __align__(OP_ALIGNMENT) op_state {{
   char data[OP_SIZE];
 }};
-extern "C" __device__ {0} OP_NAME(op_state *state, VALUE_T lhs, VALUE_T rhs);
+extern "C" __device__ {0} OP_NAME(op_state *state, LHS_T lhs, RHS_T rhs);
 struct op_wrapper {{
   op_state state;
-  __device__ {0} operator()(VALUE_T lhs, VALUE_T rhs) {{
+  __device__ {0} operator()(LHS_T lhs, RHS_T rhs) {{
     return OP_NAME(&state, lhs, rhs);
   }}
 }};
 )XXX";
 
-std::string
-make_kernel_binary_operator_full_source(std::string_view input_t, cccl_op_t operation, std::string_view return_type)
+std::string make_kernel_binary_operator_full_source(
+  std::string_view lhs_t, std::string_view rhs_t, cccl_op_t operation, std::string_view return_type)
 {
   const std::string op_alignment =
     operation.type == cccl_op_kind_t::CCCL_STATELESS ? "" : std::format("{}", operation.alignment);
   const std::string op_size = operation.type == cccl_op_kind_t::CCCL_STATELESS ? "" : std::format("{}", operation.size);
 
   return std::format(
-    op_template,
-    input_t,
+    binary_op_template,
+    lhs_t,
+    rhs_t,
     operation.name,
     op_alignment,
     op_size,
@@ -71,22 +74,40 @@ make_kernel_binary_operator_full_source(std::string_view input_t, cccl_op_t oper
       : std::format(stateful_binary_op_template, return_type));
 }
 
-std::string make_kernel_user_binary_operator(std::string_view input_t, cccl_op_t operation)
+std::string make_kernel_user_binary_operator(
+  std::string_view lhs_t, std::string_view rhs_t, std::string_view output_t, cccl_op_t operation)
 {
-  return make_kernel_binary_operator_full_source(input_t, operation, "VALUE_T");
+  return make_kernel_binary_operator_full_source(lhs_t, rhs_t, operation, output_t);
 }
 
 std::string make_kernel_user_comparison_operator(std::string_view input_t, cccl_op_t operation)
 {
-  return make_kernel_binary_operator_full_source(input_t, operation, "bool");
+  return make_kernel_binary_operator_full_source(input_t, input_t, operation, "bool");
 }
 
-std::string make_kernel_user_unary_operator(std::string_view input_t, cccl_op_t operation)
+std::string make_kernel_user_unary_operator(std::string_view input_t, std::string_view output_t, cccl_op_t operation)
 {
+  constexpr std::string_view unary_op_template = R"XXX(
+#define INPUT_T {0}
+#define OUTPUT_T {1}
+#define OP_NAME {2}
+#define OP_ALIGNMENT {3}
+#define OP_SIZE {4}
+
+// Source
+{5}
+
+#undef INPUT_T
+#undef OUTPUT_T
+#undef OP_NAME
+#undef OP_ALIGNMENT
+#undef OP_SIZE
+)XXX";
+
   constexpr std::string_view stateless_op = R"XXX(
-extern "C" __device__ VALUE_T OP_NAME(VALUE_T val);
+extern "C" __device__ OUTPUT_T OP_NAME(INPUT_T val);
 struct op_wrapper {
-  __device__ VALUE_T operator()(VALUE_T val) const {
+  __device__ OUTPUT_T operator()(INPUT_T val) const {
     return OP_NAME(val);
   }
 };
@@ -96,16 +117,19 @@ struct op_wrapper {
 struct __align__(OP_ALIGNMENT) op_state {
   char data[OP_SIZE];
 };
-extern "C" __device__ VALUE_T OP_NAME(op_state *state, VALUE_T val);
+extern "C" __device__ OUPUT_T OP_NAME(op_state *state, INPUT_T val);
 struct op_wrapper {
   op_state state;
-  __device__ VALUE_T operator()(VALUE_T val) {
+  __device__ OUTPUT_T operator()(INPUT_T val) {
     return OP_NAME(&state, val);
   }
 };
+
+
 )XXX";
 
   return (operation.type == cccl_op_kind_t::CCCL_STATELESS)
-         ? std::format(op_template, input_t, operation.name, "", "", stateless_op)
-         : std::format(op_template, input_t, operation.name, operation.alignment, operation.size, stateful_op);
+         ? std::format(unary_op_template, input_t, output_t, operation.name, "", "", stateless_op)
+         : std::format(
+             unary_op_template, input_t, output_t, operation.name, operation.alignment, operation.size, stateful_op);
 }

--- a/c/parallel/src/kernels/operators.h
+++ b/c/parallel/src/kernels/operators.h
@@ -14,6 +14,10 @@
 
 #include <cccl/c/types.h>
 
-std::string make_kernel_user_binary_operator(std::string_view input_value_t, cccl_op_t operation);
+std::string make_kernel_user_binary_operator(
+  std::string_view lhs_value_t, std::string_view rhs_value_t, std::string_view output_value_t, cccl_op_t operation);
+
+std::string
+make_kernel_user_unary_operator(std::string_view input_value_t, std::string_view output_value_t, cccl_op_t operation);
 
 std::string make_kernel_user_comparison_operator(std::string_view input_value_t, cccl_op_t operation);

--- a/c/parallel/src/reduce.cu
+++ b/c/parallel/src/reduce.cu
@@ -281,7 +281,7 @@ CUresult cccl_device_reduce_build(
     const std::string output_iterator_src =
       make_kernel_output_iterator(offset_t, output_iterator_typename, accum_cpp, output_it);
 
-    const std::string op_src = make_kernel_user_binary_operator(accum_cpp, op);
+    const std::string op_src = make_kernel_user_binary_operator(accum_cpp, accum_cpp, accum_cpp, op);
 
     const std::string src = std::format(
       R"XXX(

--- a/c/parallel/src/scan.cu
+++ b/c/parallel/src/scan.cu
@@ -239,7 +239,7 @@ CUresult cccl_device_scan_build(
     const std::string output_iterator_src =
       make_kernel_output_iterator(offset_t, "output_iterator_t", accum_cpp, output_it);
 
-    const std::string op_src = make_kernel_user_binary_operator(accum_cpp, op);
+    const std::string op_src = make_kernel_user_binary_operator(accum_cpp, accum_cpp, accum_cpp, op);
 
     constexpr std::string_view src_template = R"XXX(
 #include <cub/block/block_scan.cuh>

--- a/c/parallel/src/segmented_reduce.cu
+++ b/c/parallel/src/segmented_reduce.cu
@@ -283,7 +283,7 @@ CUresult cccl_device_segmented_reduce_build(
     const std::string end_offset_iterator_src =
       make_kernel_input_iterator(offset_t, "end_offset_iterator_t", end_offset_it_value_t, end_offset_it);
 
-    const std::string op_src = make_kernel_user_binary_operator(accum_cpp, op);
+    const std::string op_src = make_kernel_user_binary_operator(accum_cpp, accum_cpp, accum_cpp, op);
 
     // agent_policy_t is to specify parameters like policy_hub does in dispatch_reduce.cuh
     constexpr std::string_view program_preamble_template = R"XXX(

--- a/c/parallel/src/transform.cu
+++ b/c/parallel/src/transform.cu
@@ -1,0 +1,617 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA Core Compute Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+#include <cub/detail/choose_offset.cuh>
+#include <cub/detail/launcher/cuda_driver.cuh>
+#include <cub/device/dispatch/dispatch_transform.cuh>
+#include <cub/device/dispatch/tuning/tuning_transform.cuh> // cub::detail::transform::Algorithm
+#include <cub/util_arch.cuh>
+#include <cub/util_temporary_storage.cuh>
+#include <cub/util_type.cuh>
+
+#include <format>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <type_traits>
+
+#include "kernels/iterators.h"
+#include "kernels/operators.h"
+#include "util/context.h"
+#include "util/errors.h"
+#include "util/indirect_arg.h"
+#include "util/types.h"
+#include <cccl/c/transform.h>
+#include <cccl/c/types.h> // cccl_type_info
+#include <nvrtc/command_list.h>
+#include <nvrtc/ltoir_list_appender.h>
+#include <stdio.h> // printf
+
+struct op_wrapper;
+struct device_transform_policy;
+
+using OffsetT = long;
+static_assert(std::is_same_v<cub::detail::choose_signed_offset_t<OffsetT>, OffsetT>,
+              "OffsetT must be signed int32 or int64");
+
+struct input_iterator_t;
+struct input1_iterator_t;
+struct input2_iterator_t;
+struct output_iterator_t;
+
+struct input_storage_t;
+struct input1_storage_t;
+struct input2_storage_t;
+struct output_storage_t;
+
+namespace transform
+{
+
+struct transform_runtime_tuning_policy
+{
+  int block_threads;
+  int items_per_thread_no_input;
+  int min_items_per_thread;
+  int max_items_per_thread;
+
+  // Note: when we extend transform to support UBLKCP, we may no longer
+  // be able to keep this constexpr:
+  static constexpr cub::detail::transform::Algorithm GetAlgorithm()
+  {
+    return cub::detail::transform::Algorithm::prefetch;
+  }
+
+  int BlockThreads()
+  {
+    return block_threads;
+  }
+
+  int ItemsPerThreadNoInput()
+  {
+    return items_per_thread_no_input;
+  }
+
+  int MinItemsPerThread()
+  {
+    return min_items_per_thread;
+  }
+
+  int MaxItemsPerThread()
+  {
+    return max_items_per_thread;
+  }
+  static constexpr int min_bif = 1024 * 12;
+};
+
+transform_runtime_tuning_policy get_policy()
+{
+  // return prefetch policy defaults:
+  return {256, 2, 1, 32};
+}
+
+std::string get_input_iterator_name()
+{
+  std::string iterator_t;
+  check(nvrtcGetTypeName<input_iterator_t>(&iterator_t));
+  return iterator_t;
+}
+
+std::string get_input1_iterator_name()
+{
+  std::string iterator_t;
+  check(nvrtcGetTypeName<input1_iterator_t>(&iterator_t));
+  return iterator_t;
+}
+
+std::string get_input2_iterator_name()
+{
+  std::string iterator_t;
+  check(nvrtcGetTypeName<input2_iterator_t>(&iterator_t));
+  return iterator_t;
+}
+
+std::string get_output_iterator_name()
+{
+  std::string iterator_t;
+  check(nvrtcGetTypeName<output_iterator_t>(&iterator_t));
+  return iterator_t;
+}
+
+std::string get_kernel_name(cccl_iterator_t input_it, cccl_iterator_t output_it, cccl_op_t /*op*/)
+{
+  std::string chained_policy_t;
+  check(nvrtcGetTypeName<device_transform_policy>(&chained_policy_t));
+
+  const std::string input_iterator_t =
+    input_it.type == cccl_iterator_kind_t::CCCL_POINTER //
+      ? cccl_type_enum_to_name<input_storage_t>(input_it.value_type.type, true) //
+      : transform::get_input_iterator_name();
+
+  const std::string output_iterator_t =
+    (output_it.type == cccl_iterator_kind_t::CCCL_POINTER //
+       ? cccl_type_enum_to_name<output_storage_t>(output_it.value_type.type, true) //
+       : transform::get_output_iterator_name());
+
+  std::string offset_t;
+  check(nvrtcGetTypeName<OffsetT>(&offset_t));
+
+  std::string transform_op_t;
+  check(nvrtcGetTypeName<op_wrapper>(&transform_op_t));
+
+  return std::format(
+    "cub::detail::transform::transform_kernel<{0}, {1}, {2}, {3}, {4}>",
+    chained_policy_t, // 0
+    offset_t, // 1
+    transform_op_t, // 2
+    output_iterator_t, // 3
+    input_iterator_t); // 4
+}
+
+std::string
+get_kernel_name(cccl_iterator_t input1_it, cccl_iterator_t input2_it, cccl_iterator_t output_it, cccl_op_t /*op*/)
+{
+  std::string chained_policy_t;
+  check(nvrtcGetTypeName<device_transform_policy>(&chained_policy_t));
+
+  const std::string input1_iterator_t =
+    input1_it.type == cccl_iterator_kind_t::CCCL_POINTER //
+      ? cccl_type_enum_to_name<input1_storage_t>(input1_it.value_type.type, true) //
+      : transform::get_input1_iterator_name();
+
+  const std::string input2_iterator_t =
+    input2_it.type == cccl_iterator_kind_t::CCCL_POINTER //
+      ? cccl_type_enum_to_name<input2_storage_t>(input2_it.value_type.type, true) //
+      : transform::get_input2_iterator_name();
+
+  const std::string output_iterator_t =
+    (output_it.type == cccl_iterator_kind_t::CCCL_POINTER //
+       ? cccl_type_enum_to_name<output_storage_t>(output_it.value_type.type, true) //
+       : transform::get_output_iterator_name());
+
+  std::string offset_t;
+  check(nvrtcGetTypeName<OffsetT>(&offset_t));
+
+  std::string transform_op_t;
+  check(nvrtcGetTypeName<op_wrapper>(&transform_op_t));
+
+  return std::format(
+    "cub::detail::transform::transform_kernel<{0}, {1}, {2}, {3}, {4}, {5}>",
+    chained_policy_t, // 0
+    offset_t, // 1
+    transform_op_t, // 2
+    output_iterator_t, // 3
+    input1_iterator_t, // 4
+    input2_iterator_t); // 5
+}
+
+template <auto* GetPolicy>
+struct dynamic_transform_policy_t
+{
+  using max_policy = dynamic_transform_policy_t;
+
+  template <typename F>
+  cudaError_t Invoke(int /*device_ptx_version*/, F& op)
+  {
+    return op.template Invoke<transform_runtime_tuning_policy>(GetPolicy());
+  }
+};
+
+struct transform_kernel_source
+{
+  cccl_device_transform_build_result_t& build;
+
+  CUkernel TransformKernel() const
+  {
+    return build.transform_kernel;
+  }
+
+  int LoadedBytesPerIteration()
+  {
+    return build.loaded_bytes_per_iteration;
+  }
+
+  template <typename It>
+  constexpr It MakeIteratorKernelArg(It it)
+  {
+    return it;
+  }
+};
+
+} // namespace transform
+
+CUresult cccl_device_unary_transform_build(
+  cccl_device_transform_build_result_t* build_ptr,
+  cccl_iterator_t input_it,
+  cccl_iterator_t output_it,
+  cccl_op_t op,
+  int cc_major,
+  int cc_minor,
+  const char* cub_path,
+  const char* thrust_path,
+  const char* libcudacxx_path,
+  const char* ctk_path)
+{
+  CUresult error = CUDA_SUCCESS;
+
+  try
+  {
+    const char* name = "test";
+
+    const int cc                 = cc_major * 10 + cc_minor;
+    const auto policy            = transform::get_policy();
+    const auto input_it_value_t  = cccl_type_enum_to_name<input_storage_t>(input_it.value_type.type);
+    const auto output_it_value_t = cccl_type_enum_to_name<output_storage_t>(output_it.value_type.type);
+    const auto offset_t          = cccl_type_enum_to_name(cccl_type_enum::CCCL_INT64);
+    const std::string input_iterator_src =
+      make_kernel_input_iterator(offset_t, "input_iterator_t", input_it_value_t, input_it);
+    const std::string output_iterator_src =
+      make_kernel_output_iterator(offset_t, "output_iterator_t", output_it_value_t, output_it);
+    const std::string op_src = make_kernel_user_unary_operator(input_it_value_t, output_it_value_t, op);
+
+    constexpr std::string_view src_template = R"XXX(
+#define _CUB_HAS_TRANSFORM_UBLKCP 0
+#include <cub/device/dispatch/kernels/transform.cuh>
+struct __align__({1}) input_storage_t {{
+  char data[{0}];
+}};
+struct __align__({2}) output_storage_t {{
+  char data[{3}];
+}};
+{8}
+{9}
+struct prefetch_policy_t {{
+  static constexpr int block_threads = {4};
+  static constexpr int items_per_thread_no_input = {5};
+  static constexpr int min_items_per_thread      = {6};
+  static constexpr int max_items_per_thread      = {7};
+}};
+struct device_transform_policy {{
+  struct ActivePolicy {{
+    static constexpr auto algorithm = cub::detail::transform::Algorithm::prefetch;
+    using algo_policy = prefetch_policy_t;
+  }};
+}};
+{10}
+)XXX";
+
+    const std::string& src = std::format(
+      src_template,
+      input_it.value_type.size, // 0
+      input_it.value_type.alignment, // 1
+      output_it.value_type.size, // 2
+      output_it.value_type.alignment, // 3
+      policy.block_threads, // 4
+      policy.items_per_thread_no_input, // 5
+      policy.min_items_per_thread, // 6
+      policy.max_items_per_thread, // 7
+      input_iterator_src, // 8
+      output_iterator_src, // 9
+      op_src); // 10
+
+#if false // CCCL_DEBUGGING_SWITCH
+    fflush(stderr);
+    printf("\nCODE4NVRTC BEGIN\n%sCODE4NVRTC END\n", src.c_str());
+    fflush(stdout);
+#endif
+
+    std::string kernel_name = transform::get_kernel_name(input_it, output_it, op);
+    std::string kernel_lowered_name;
+
+    const std::string arch = std::format("-arch=sm_{0}{1}", cc_major, cc_minor);
+
+    constexpr size_t num_args  = 8;
+    const char* args[num_args] = {
+      arch.c_str(), cub_path, thrust_path, libcudacxx_path, ctk_path, "-rdc=true", "-dlto", "-default-device"};
+
+    constexpr size_t num_lto_args   = 2;
+    const char* lopts[num_lto_args] = {"-lto", arch.c_str()};
+
+    // Collect all LTO-IRs to be linked.
+    nvrtc_ltoir_list ltoir_list;
+    nvrtc_ltoir_list_appender appender{ltoir_list};
+
+    appender.append({op.ltoir, op.ltoir_size});
+    appender.add_iterator_definition(input_it);
+    appender.add_iterator_definition(output_it);
+
+    nvrtc_link_result result =
+      make_nvrtc_command_list()
+        .add_program(nvrtc_translation_unit{src.c_str(), name})
+        .add_expression({kernel_name})
+        .compile_program({args, num_args})
+        .get_name({kernel_name, kernel_lowered_name})
+        .cleanup_program()
+        .add_link_list(ltoir_list)
+        .finalize_program(num_lto_args, lopts);
+
+    cuLibraryLoadData(&build_ptr->library, result.data.get(), nullptr, nullptr, 0, nullptr, nullptr, 0);
+    check(cuLibraryGetKernel(&build_ptr->transform_kernel, build_ptr->library, kernel_lowered_name.c_str()));
+
+    build_ptr->loaded_bytes_per_iteration = input_it.value_type.size;
+    build_ptr->cc                         = cc;
+    build_ptr->cubin                      = (void*) result.data.release();
+    build_ptr->cubin_size                 = result.size;
+  }
+  catch (const std::exception& exc)
+  {
+    fflush(stderr);
+    printf("\nEXCEPTION in cccl_device_transform_build(): %s\n", exc.what());
+    fflush(stdout);
+    error = CUDA_ERROR_UNKNOWN;
+  }
+
+  return error;
+}
+
+CUresult cccl_device_unary_transform(
+  cccl_device_transform_build_result_t build,
+  cccl_iterator_t d_in,
+  cccl_iterator_t d_out,
+  unsigned long long num_items,
+  cccl_op_t op,
+  CUstream stream)
+{
+  bool pushed    = false;
+  CUresult error = CUDA_SUCCESS;
+  try
+  {
+    pushed = try_push_context();
+
+    CUdevice cu_device;
+    check(cuCtxGetDevice(&cu_device));
+    auto cuda_error = cub::detail::transform::dispatch_t<
+      cub::detail::transform::requires_stable_address::no, // TODO implement yes
+      ::cuda::std::int64_t,
+      ::cuda::std::tuple<indirect_arg_t>,
+      indirect_arg_t,
+      indirect_arg_t,
+      transform::dynamic_transform_policy_t<&transform::get_policy>,
+      transform::transform_kernel_source,
+      cub::detail::CudaDriverLauncherFactory>::
+      dispatch(d_in, d_out, num_items, op, stream, {build}, cub::detail::CudaDriverLauncherFactory{cu_device, build.cc});
+    if (cuda_error != cudaSuccess)
+    {
+      const char* errorString = cudaGetErrorString(cuda_error); // Get the error string
+      std::cerr << "CUDA error: " << errorString << std::endl;
+    }
+  }
+  catch (const std::exception& exc)
+  {
+    fflush(stderr);
+    printf("\nEXCEPTION in cccl_device_transform(): %s\n", exc.what());
+    fflush(stdout);
+    error = CUDA_ERROR_UNKNOWN;
+  }
+  if (pushed)
+  {
+    CUcontext cu_context;
+    cuCtxPopCurrent(&cu_context);
+  }
+  return error;
+}
+
+CUresult cccl_device_binary_transform_build(
+  cccl_device_transform_build_result_t* build_ptr,
+  cccl_iterator_t input1_it,
+  cccl_iterator_t input2_it,
+  cccl_iterator_t output_it,
+  cccl_op_t op,
+  int cc_major,
+  int cc_minor,
+  const char* cub_path,
+  const char* thrust_path,
+  const char* libcudacxx_path,
+  const char* ctk_path)
+{
+  CUresult error = CUDA_SUCCESS;
+
+  try
+  {
+    const char* name = "test";
+
+    const int cc                 = cc_major * 10 + cc_minor;
+    const auto policy            = transform::get_policy();
+    const auto input1_it_value_t = cccl_type_enum_to_name<input1_storage_t>(input1_it.value_type.type);
+    const auto input2_it_value_t = cccl_type_enum_to_name<input2_storage_t>(input2_it.value_type.type);
+
+    const auto output_it_value_t = cccl_type_enum_to_name<output_storage_t>(output_it.value_type.type);
+    const auto offset_t          = cccl_type_enum_to_name(cccl_type_enum::CCCL_INT64);
+
+    const std::string input1_iterator_src =
+      make_kernel_input_iterator(offset_t, "input1_iterator_t", input1_it_value_t, input1_it);
+    const std::string input2_iterator_src =
+      make_kernel_input_iterator(offset_t, "input2_iterator_t", input2_it_value_t, input2_it);
+
+    const std::string output_iterator_src =
+      make_kernel_output_iterator(offset_t, "output_iterator_t", output_it_value_t, output_it);
+    const std::string op_src =
+      make_kernel_user_binary_operator(input1_it_value_t, input2_it_value_t, output_it_value_t, op);
+
+    constexpr std::string_view src_template = R"XXX(
+#define _CUB_HAS_TRANSFORM_UBLKCP 0
+#include <cub/device/dispatch/kernels/transform.cuh>
+struct __align__({1}) input1_storage_t {{
+  char data[{0}];
+}};
+struct __align__({3}) input2_storage_t {{
+  char data[{2}];
+}};
+
+struct __align__({5}) output_storage_t {{
+  char data[{4}];
+}};
+
+{10}
+{11}
+{12}
+
+struct prefetch_policy_t {{
+  static constexpr int block_threads = {6};
+  static constexpr int items_per_thread_no_input = {7};
+  static constexpr int min_items_per_thread      = {8};
+  static constexpr int max_items_per_thread      = {9};
+}};
+
+struct device_transform_policy {{
+  struct ActivePolicy {{
+    static constexpr auto algorithm = cub::detail::transform::Algorithm::prefetch;
+    using algo_policy = prefetch_policy_t;
+  }};
+}};
+
+{13}
+)XXX";
+    const std::string& src                  = std::format(
+      src_template,
+      input1_it.value_type.size, // 0
+      input1_it.value_type.alignment, // 1
+      input2_it.value_type.size, // 2
+      input2_it.value_type.alignment, // 3
+      output_it.value_type.size, // 4
+      output_it.value_type.alignment, // 5
+      policy.block_threads, // 6
+      policy.items_per_thread_no_input, // 7
+      policy.min_items_per_thread, // 8
+      policy.max_items_per_thread, // 9
+      input1_iterator_src, // 10
+      input2_iterator_src, // 11
+      output_iterator_src, // 12
+      op_src); // 13
+
+#if false // CCCL_DEBUGGING_SWITCH
+    fflush(stderr);
+    printf("\nCODE4NVRTC BEGIN\n%sCODE4NVRTC END\n", src.c_str());
+    fflush(stdout);
+#endif
+
+    std::string kernel_name = transform::get_kernel_name(input1_it, input2_it, output_it, op);
+    std::string kernel_lowered_name;
+
+    const std::string arch = std::format("-arch=sm_{0}{1}", cc_major, cc_minor);
+
+    constexpr size_t num_args  = 8;
+    const char* args[num_args] = {
+      arch.c_str(), cub_path, thrust_path, libcudacxx_path, ctk_path, "-rdc=true", "-dlto", "-default-device"};
+
+    constexpr size_t num_lto_args   = 2;
+    const char* lopts[num_lto_args] = {"-lto", arch.c_str()};
+
+    // Collect all LTO-IRs to be linked.
+    nvrtc_ltoir_list ltoir_list;
+    nvrtc_ltoir_list_appender appender{ltoir_list};
+
+    appender.append({op.ltoir, op.ltoir_size});
+    appender.add_iterator_definition(input1_it);
+    appender.add_iterator_definition(input2_it);
+    appender.add_iterator_definition(output_it);
+
+    nvrtc_link_result result =
+      make_nvrtc_command_list()
+        .add_program(nvrtc_translation_unit{src.c_str(), name})
+        .add_expression({kernel_name})
+        .compile_program({args, num_args})
+        .get_name({kernel_name, kernel_lowered_name})
+        .cleanup_program()
+        .add_link_list(ltoir_list)
+        .finalize_program(num_lto_args, lopts);
+
+    cuLibraryLoadData(&build_ptr->library, result.data.get(), nullptr, nullptr, 0, nullptr, nullptr, 0);
+    check(cuLibraryGetKernel(&build_ptr->transform_kernel, build_ptr->library, kernel_lowered_name.c_str()));
+
+    build_ptr->loaded_bytes_per_iteration = (input1_it.value_type.size + input2_it.value_type.size);
+    build_ptr->cc                         = cc;
+    build_ptr->cubin                      = (void*) result.data.release();
+    build_ptr->cubin_size                 = result.size;
+  }
+  catch (const std::exception& exc)
+  {
+    fflush(stderr);
+    printf("\nEXCEPTION in cccl_device_transform_build(): %s\n", exc.what());
+    fflush(stdout);
+    error = CUDA_ERROR_UNKNOWN;
+  }
+
+  return error;
+}
+
+CUresult cccl_device_binary_transform(
+  cccl_device_transform_build_result_t build,
+  cccl_iterator_t d_in1,
+  cccl_iterator_t d_in2,
+  cccl_iterator_t d_out,
+  unsigned long long num_items,
+  cccl_op_t op,
+  CUstream stream)
+{
+  bool pushed    = false;
+  CUresult error = CUDA_SUCCESS;
+  try
+  {
+    pushed = try_push_context();
+
+    CUdevice cu_device;
+    check(cuCtxGetDevice(&cu_device));
+    auto cuda_error = cub::detail::transform::dispatch_t<
+      cub::detail::transform::requires_stable_address::no, // TODO implement yes
+      ::cuda::std::int64_t,
+      ::cuda::std::tuple<indirect_arg_t, indirect_arg_t>,
+      indirect_arg_t,
+      indirect_arg_t,
+      transform::dynamic_transform_policy_t<&transform::get_policy>,
+      transform::transform_kernel_source,
+      cub::detail::CudaDriverLauncherFactory>::
+      dispatch(::cuda::std::make_tuple<indirect_arg_t, indirect_arg_t>(d_in1, d_in2),
+               d_out,
+               num_items,
+               op,
+               stream,
+               {build},
+               cub::detail::CudaDriverLauncherFactory{cu_device, build.cc});
+    if (cuda_error != cudaSuccess)
+    {
+      const char* errorString = cudaGetErrorString(cuda_error); // Get the error string
+      std::cerr << "CUDA error: " << errorString << std::endl;
+    }
+  }
+  catch (const std::exception& exc)
+  {
+    fflush(stderr);
+    printf("\nEXCEPTION in cccl_device_transform(): %s\n", exc.what());
+    fflush(stdout);
+    error = CUDA_ERROR_UNKNOWN;
+  }
+  if (pushed)
+  {
+    CUcontext cu_context;
+    cuCtxPopCurrent(&cu_context);
+  }
+  return error;
+}
+
+CUresult cccl_device_transform_cleanup(cccl_device_transform_build_result_t* build_ptr)
+{
+  try
+  {
+    if (build_ptr == nullptr)
+    {
+      return CUDA_ERROR_INVALID_VALUE;
+    }
+    std::unique_ptr<char[]> cubin(reinterpret_cast<char*>(build_ptr->cubin));
+    check(cuLibraryUnload(build_ptr->library));
+  }
+  catch (const std::exception& exc)
+  {
+    fflush(stderr);
+    printf("\nEXCEPTION in cccl_device_transform_cleanup(): %s\n", exc.what());
+    fflush(stdout);
+    return CUDA_ERROR_UNKNOWN;
+  }
+
+  return CUDA_SUCCESS;
+}

--- a/c/parallel/src/transform.cu
+++ b/c/parallel/src/transform.cu
@@ -269,6 +269,9 @@ struct device_transform_policy {{
 
     const std::string arch = std::format("-arch=sm_{0}{1}", cc_major, cc_minor);
 
+    // Note: `-default-device` is needed because of the use of lambdas
+    // in the transform kernel code. Qualifying those explicitly with
+    // `__device__` seems not to be supported by NVRTC.
     constexpr size_t num_args  = 8;
     const char* args[num_args] = {
       arch.c_str(), cub_path, thrust_path, libcudacxx_path, ctk_path, "-rdc=true", "-dlto", "-default-device"};

--- a/c/parallel/src/transform.cu
+++ b/c/parallel/src/transform.cu
@@ -16,8 +16,6 @@
 #include <cub/util_type.cuh>
 
 #include <format>
-#include <iostream>
-#include <optional>
 #include <string>
 #include <type_traits>
 
@@ -308,7 +306,7 @@ struct device_transform_policy {{
   catch (const std::exception& exc)
   {
     fflush(stderr);
-    printf("\nEXCEPTION in cccl_device_transform_build(): %s\n", exc.what());
+    printf("\nEXCEPTION in cccl_device_unary_transform_build(): %s\n", exc.what());
     fflush(stdout);
     error = CUDA_ERROR_UNKNOWN;
   }
@@ -334,7 +332,7 @@ CUresult cccl_device_unary_transform(
     check(cuCtxGetDevice(&cu_device));
     auto cuda_error = cub::detail::transform::dispatch_t<
       cub::detail::transform::requires_stable_address::no, // TODO implement yes
-      ::cuda::std::int64_t,
+      OffsetT,
       ::cuda::std::tuple<indirect_arg_t>,
       indirect_arg_t,
       indirect_arg_t,
@@ -351,7 +349,7 @@ CUresult cccl_device_unary_transform(
   catch (const std::exception& exc)
   {
     fflush(stderr);
-    printf("\nEXCEPTION in cccl_device_transform(): %s\n", exc.what());
+    printf("\nEXCEPTION in cccl_device_unary_transform(): %s\n", exc.what());
     fflush(stdout);
     error = CUDA_ERROR_UNKNOWN;
   }
@@ -498,7 +496,7 @@ struct device_transform_policy {{
   catch (const std::exception& exc)
   {
     fflush(stderr);
-    printf("\nEXCEPTION in cccl_device_transform_build(): %s\n", exc.what());
+    printf("\nEXCEPTION in cccl_device_binary_transform_build(): %s\n", exc.what());
     fflush(stdout);
     error = CUDA_ERROR_UNKNOWN;
   }
@@ -525,7 +523,7 @@ CUresult cccl_device_binary_transform(
     check(cuCtxGetDevice(&cu_device));
     auto cuda_error = cub::detail::transform::dispatch_t<
       cub::detail::transform::requires_stable_address::no, // TODO implement yes
-      ::cuda::std::int64_t,
+      OffsetT,
       ::cuda::std::tuple<indirect_arg_t, indirect_arg_t>,
       indirect_arg_t,
       indirect_arg_t,
@@ -548,7 +546,7 @@ CUresult cccl_device_binary_transform(
   catch (const std::exception& exc)
   {
     fflush(stderr);
-    printf("\nEXCEPTION in cccl_device_transform(): %s\n", exc.what());
+    printf("\nEXCEPTION in cccl_device_binary_transform(): %s\n", exc.what());
     fflush(stdout);
     error = CUDA_ERROR_UNKNOWN;
   }

--- a/c/parallel/src/util/types.h
+++ b/c/parallel/src/util/types.h
@@ -18,6 +18,8 @@
 #include <cccl/c/types.h>
 
 struct storage_t;
+struct input_storage_t;
+struct output_storage_t;
 struct items_storage_t; // Used in merge_sort
 
 template <typename StorageT = storage_t>

--- a/c/parallel/test/test_transform.cpp
+++ b/c/parallel/test/test_transform.cpp
@@ -1,0 +1,268 @@
+
+#include <cuda_runtime.h>
+
+#include <cstdint>
+#include <cstdlib>
+#include <numeric>
+
+#include "cccl/c/types.h"
+#include "test_util.h"
+#include <cccl/c/transform.h>
+
+void unary_transform(cccl_iterator_t input, cccl_iterator_t output, long num_items, cccl_op_t op)
+{
+  cudaDeviceProp deviceProp;
+  cudaGetDeviceProperties(&deviceProp, 0);
+
+  const int cc_major = deviceProp.major;
+  const int cc_minor = deviceProp.minor;
+
+  const char* cub_path        = TEST_CUB_PATH;
+  const char* thrust_path     = TEST_THRUST_PATH;
+  const char* libcudacxx_path = TEST_LIBCUDACXX_PATH;
+  const char* ctk_path        = TEST_CTK_PATH;
+
+  cccl_device_transform_build_result_t build;
+  REQUIRE(CUDA_SUCCESS
+          == cccl_device_unary_transform_build(
+            &build, input, output, op, cc_major, cc_minor, cub_path, thrust_path, libcudacxx_path, ctk_path));
+
+  const std::string sass = inspect_sass(build.cubin, build.cubin_size);
+
+  REQUIRE(sass.find("LDL") == std::string::npos);
+  REQUIRE(sass.find("STL") == std::string::npos);
+
+  REQUIRE(CUDA_SUCCESS == cccl_device_unary_transform(build, input, output, num_items, op, 0));
+  REQUIRE(CUDA_SUCCESS == cccl_device_transform_cleanup(&build));
+}
+
+void binary_transform(
+  cccl_iterator_t input1, cccl_iterator_t input2, cccl_iterator_t output, long num_items, cccl_op_t op)
+{
+  cudaDeviceProp deviceProp;
+  cudaGetDeviceProperties(&deviceProp, 0);
+
+  const int cc_major = deviceProp.major;
+  const int cc_minor = deviceProp.minor;
+
+  const char* cub_path        = TEST_CUB_PATH;
+  const char* thrust_path     = TEST_THRUST_PATH;
+  const char* libcudacxx_path = TEST_LIBCUDACXX_PATH;
+  const char* ctk_path        = TEST_CTK_PATH;
+
+  cccl_device_transform_build_result_t build;
+  REQUIRE(CUDA_SUCCESS
+          == cccl_device_binary_transform_build(
+            &build, input1, input2, output, op, cc_major, cc_minor, cub_path, thrust_path, libcudacxx_path, ctk_path));
+
+  const std::string sass = inspect_sass(build.cubin, build.cubin_size);
+
+  REQUIRE(sass.find("LDL") == std::string::npos);
+  REQUIRE(sass.find("STL") == std::string::npos);
+
+  REQUIRE(CUDA_SUCCESS == cccl_device_binary_transform(build, input1, input2, output, num_items, op, 0));
+  REQUIRE(CUDA_SUCCESS == cccl_device_transform_cleanup(&build));
+}
+
+using integral_types = std::tuple<int32_t, uint32_t, int64_t, uint64_t>;
+TEMPLATE_LIST_TEST_CASE("Transform works with integral types", "[transform]", integral_types)
+{
+  const std::size_t num_items       = GENERATE(0, 42, take(4, random(1 << 12, 1 << 16)));
+  operation_t op                    = make_operation("op", get_unary_op(get_type_info<TestType>().type));
+  const std::vector<TestType> input = generate<TestType>(num_items);
+  const std::vector<TestType> output(num_items, 0);
+  pointer_t<TestType> input_ptr(input);
+  pointer_t<TestType> output_ptr(output);
+
+  unary_transform(input_ptr, output_ptr, num_items, op);
+
+  std::vector<TestType> expected(num_items, 0);
+  std::transform(input.begin(), input.end(), expected.begin(), [](const TestType& x) {
+    return 2 * x;
+  });
+
+  if (num_items > 0)
+  {
+    REQUIRE(expected == std::vector<TestType>(output_ptr));
+  }
+}
+
+struct pair
+{
+  short a;
+  size_t b;
+
+  bool operator==(const pair& other) const
+  {
+    return a == other.a && b == other.b;
+  }
+};
+
+TEST_CASE("Transform works with output of different type", "[transform]")
+{
+  const std::size_t num_items = GENERATE(0, 42, take(4, random(1 << 12, 1 << 24)));
+
+  operation_t op = make_operation(
+    "op",
+    "struct pair { short a; size_t b; };\n"
+    "extern \"C\" __device__ pair op(int x) {\n"
+    "  return pair{ short(x), size_t(x) };\n"
+    "}");
+  const std::vector<int> input = generate<int>(num_items);
+  std::vector<pair> expected(num_items);
+  std::vector<pair> output(num_items);
+  for (std::size_t i = 0; i < num_items; ++i)
+  {
+    expected[i] = {short(input[i]), size_t(input[i])};
+  }
+  pointer_t<int> input_ptr(input);
+  pointer_t<pair> output_ptr(output);
+
+  unary_transform(input_ptr, output_ptr, num_items, op);
+  if (num_items > 0)
+  {
+    REQUIRE(expected == std::vector<pair>(output_ptr));
+  }
+}
+
+TEST_CASE("Transform works with custom types", "[transform]")
+{
+  const std::size_t num_items = GENERATE(0, 42, take(4, random(1 << 12, 1 << 24)));
+
+  operation_t op = make_operation(
+    "op",
+    "struct pair { short a; size_t b; };\n"
+    "extern \"C\" __device__ pair op(pair x) {\n"
+    "  return pair{ x.a * 2, x.b * 2  };\n"
+    "}");
+  const std::vector<short> a  = generate<short>(num_items);
+  const std::vector<size_t> b = generate<size_t>(num_items);
+  std::vector<pair> input(num_items);
+  std::vector<pair> output(num_items);
+  for (std::size_t i = 0; i < num_items; ++i)
+  {
+    input[i] = pair{a[i], b[i]};
+  }
+  pointer_t<pair> input_ptr(input);
+  pointer_t<pair> output_ptr(output);
+
+  unary_transform(input_ptr, output_ptr, num_items, op);
+
+  std::vector<pair> expected(num_items, {0, 0});
+  std::transform(input.begin(), input.end(), expected.begin(), [](const pair& x) {
+    return pair{short(x.a * 2), x.b * 2};
+  });
+  if (num_items > 0)
+  {
+    REQUIRE(expected == std::vector<pair>(output_ptr));
+  }
+}
+
+TEST_CASE("Transform works with input iterators", "[transform]")
+{
+  const std::size_t num_items = GENERATE(1, 42, take(1, random(1 << 12, 1 << 16)));
+  operation_t op              = make_operation("op", get_unary_op(get_type_info<int>().type));
+  iterator_t<int, counting_iterator_state_t<int>> input_it = make_counting_iterator<int>("int");
+  input_it.state.value                                     = 0;
+  pointer_t<int> output_it(num_items);
+
+  unary_transform(input_it, output_it, num_items, op);
+
+  // vector storing a sequence of values 0, 1, 2, ..., num_items - 1
+  std::vector<int> input(num_items);
+  std::iota(input.begin(), input.end(), 0);
+
+  std::vector<int> expected(num_items);
+  std::transform(input.begin(), input.end(), expected.begin(), [](const int& x) {
+    return x * 2;
+  });
+  if (num_items > 0)
+  {
+    REQUIRE(expected == std::vector<int>(output_it));
+  }
+}
+
+TEST_CASE("Transform works with output iterators", "[transform]")
+{
+  const int num_items = GENERATE(1, 42, take(1, random(1 << 12, 1 << 16)));
+  operation_t op      = make_operation("op", get_unary_op(get_type_info<int>().type));
+  iterator_t<int, random_access_iterator_state_t<int>> output_it =
+    make_random_access_iterator<int>(iterator_kind::OUTPUT, "int", "out", " * 2");
+  const std::vector<int> input = generate<int>(num_items);
+  pointer_t<int> input_it(input);
+  pointer_t<int> inner_output_it(num_items);
+  output_it.state.data = inner_output_it.ptr;
+
+  unary_transform(input_it, output_it, num_items, op);
+
+  std::vector<int> expected(num_items);
+  std::transform(input.begin(), input.end(), expected.begin(), [](int x) {
+    return x * 4;
+  });
+  if (num_items > 0)
+  {
+    REQUIRE(expected == std::vector<int>(inner_output_it));
+  }
+}
+
+TEST_CASE("Transform with binary operator", "[transform]")
+{
+  const std::size_t num_items   = GENERATE(0, 42, take(4, random(1 << 12, 1 << 16)));
+  const std::vector<int> input1 = generate<int>(num_items);
+  const std::vector<int> input2 = generate<int>(num_items);
+  const std::vector<int> output(num_items, 0);
+  pointer_t<int> input1_ptr(input1);
+  pointer_t<int> input2_ptr(input2);
+  pointer_t<int> output_ptr(output);
+
+  operation_t op = make_operation(
+    "op",
+    "extern \"C\" __device__ int op(int x, int y) {\n"
+    "  return (x > y) ? x : y;\n"
+    "}");
+
+  binary_transform(input1_ptr, input2_ptr, output_ptr, num_items, op);
+
+  std::vector<int> expected(num_items, 0);
+  std::transform(input1.begin(), input1.end(), input2.begin(), expected.begin(), [](const int& x, const int& y) {
+    return (x > y) ? x : y;
+  });
+
+  if (num_items > 0)
+  {
+    REQUIRE(expected == std::vector<int>(output_ptr));
+  }
+}
+
+TEST_CASE("Binary transform with one iterator", "[transform]")
+{
+  const std::size_t num_items   = GENERATE(0, 42, take(4, random(1 << 12, 1 << 16)));
+  const std::vector<int> input1 = generate<int>(num_items);
+
+  iterator_t<int, counting_iterator_state_t<int>> input2_it = make_counting_iterator<int>("int");
+  input2_it.state.value                                     = 0;
+
+  const std::vector<int> output(num_items, 0);
+  pointer_t<int> input1_ptr(input1);
+  pointer_t<int> output_ptr(output);
+
+  operation_t op = make_operation(
+    "op",
+    "extern \"C\" __device__ int op(int x, int y) {\n"
+    "  return (x > y) ? x : y;\n"
+    "}");
+
+  binary_transform(input1_ptr, input2_it, output_ptr, num_items, op);
+
+  std::vector<int> input2(num_items);
+  std::iota(input2.begin(), input2.end(), 0);
+  std::vector<int> expected(num_items, 0);
+  std::transform(input1.begin(), input1.end(), input2.begin(), expected.begin(), [](const int& x, const int& y) {
+    return (x > y) ? x : y;
+  });
+
+  if (num_items > 0)
+  {
+    REQUIRE(expected == std::vector<int>(output_ptr));
+  }
+}

--- a/c/parallel/test/test_util.h
+++ b/c/parallel/test/test_util.h
@@ -303,7 +303,32 @@ static std::string get_unique_by_key_op(cccl_type_enum t)
       return "extern \"C\" __device__ bool op(float lhs, float rhs) { return lhs == rhs; }";
     case cccl_type_enum::CCCL_FLOAT64:
       return "extern \"C\" __device__ bool op(double lhs, double rhs) { return lhs == rhs; }";
+    default:
+      throw std::runtime_error("Unsupported type");
+  }
+  return "";
+}
 
+static std::string get_unary_op(cccl_type_enum t)
+{
+  switch (t)
+  {
+    case cccl_type_enum::CCCL_INT8:
+      return "extern \"C\" __device__ char op(char a) { return 2 * a; }";
+    case cccl_type_enum::CCCL_INT32:
+      return "extern \"C\" __device__ int op(int a) { return 2 * a; }";
+    case cccl_type_enum::CCCL_UINT32:
+      return "extern \"C\" __device__ unsigned int op(unsigned int a) { return 2 * a; }";
+    case cccl_type_enum::CCCL_INT64:
+      return "extern \"C\" __device__ long long op(long long a) { return 2 * a; }";
+    case cccl_type_enum::CCCL_UINT64:
+      return "extern \"C\" __device__ unsigned long long op(unsigned long long a) { "
+             " return 2 * a; "
+             "}";
+    case cccl_type_enum::CCCL_FLOAT32:
+      return "extern \"C\" __device__ float op(float a) { return 2 * a; }";
+    case cccl_type_enum::CCCL_FLOAT64:
+      return "extern \"C\" __device__ double op(double a) { return 2 * a; }";
     default:
       throw std::runtime_error("Unsupported type");
   }

--- a/cub/cub/device/dispatch/dispatch_transform.cuh
+++ b/cub/cub/device/dispatch/dispatch_transform.cuh
@@ -372,7 +372,7 @@ struct dispatch_t<StableAddress,
     }
 
     int ptx_version = 0;
-    auto error      = CubDebug(PtxVersion(ptx_version));
+    auto error      = CubDebug(launcher_factory.PtxVersion(ptx_version));
     if (cudaSuccess != error)
     {
       return error;

--- a/cub/cub/device/dispatch/kernels/transform.cuh
+++ b/cub/cub/device/dispatch/kernels/transform.cuh
@@ -386,7 +386,7 @@ template <typename It>
 _CCCL_HOST_DEVICE auto make_iterator_kernel_arg(It it) -> kernel_arg<It>
 {
   kernel_arg<It> arg;
-  arg.iterator = it;
+  ::cuda::std::__construct_at(&arg.iterator, it);
   return arg;
 }
 

--- a/cub/cub/device/dispatch/kernels/transform.cuh
+++ b/cub/cub/device/dispatch/kernels/transform.cuh
@@ -361,10 +361,11 @@ _CCCL_DEVICE void transform_kernel_impl(
 template <typename It>
 union kernel_arg
 {
+#if _CUB_HAS_TRANSFORM_UBLKCP
   aligned_base_ptr<it_value_t<It>> aligned_ptr; // first member is trivial
-  It iterator; // may not be trivially [default|copy]-constructible
-
   static_assert(::cuda::std::is_trivial_v<decltype(aligned_ptr)>, "");
+#endif
+  It iterator; // may not be trivially [default|copy]-constructible
 
   // Sometimes It is not trivially [default|copy]-constructible (e.g.
   // thrust::normal_iterator<thrust::device_pointer<T>>), so because of
@@ -388,7 +389,7 @@ _CCCL_HOST_DEVICE auto make_iterator_kernel_arg(It it) -> kernel_arg<It>
   // since we switch the active member of the union, we must use placement new or construct_at. This also uses the copy
   // constructor of It, which works in more cases than assignment (e.g. thrust::transform_iterator with
   // non-copy-assignable functor, e.g. in merge sort tests)
-  ::cuda::std::__construct_at(&arg.iterator, it);
+  arg.iterator = it;
   return arg;
 }
 

--- a/cub/cub/device/dispatch/kernels/transform.cuh
+++ b/cub/cub/device/dispatch/kernels/transform.cuh
@@ -386,6 +386,8 @@ template <typename It>
 _CCCL_HOST_DEVICE auto make_iterator_kernel_arg(It it) -> kernel_arg<It>
 {
   kernel_arg<It> arg;
+  // constructor of It, which works in more cases than assignment (e.g. thrust::transform_iterator with
+  // non-copy-assignable functor, e.g. in merge sort tests)
   ::cuda::std::__construct_at(&arg.iterator, it);
   return arg;
 }

--- a/cub/cub/device/dispatch/kernels/transform.cuh
+++ b/cub/cub/device/dispatch/kernels/transform.cuh
@@ -386,6 +386,7 @@ template <typename It>
 _CCCL_HOST_DEVICE auto make_iterator_kernel_arg(It it) -> kernel_arg<It>
 {
   kernel_arg<It> arg;
+  // since we switch the active member of the union, we must use placement new or construct_at. This also uses the copy
   // constructor of It, which works in more cases than assignment (e.g. thrust::transform_iterator with
   // non-copy-assignable functor, e.g. in merge sort tests)
   ::cuda::std::__construct_at(&arg.iterator, it);

--- a/cub/cub/device/dispatch/kernels/transform.cuh
+++ b/cub/cub/device/dispatch/kernels/transform.cuh
@@ -386,9 +386,6 @@ template <typename It>
 _CCCL_HOST_DEVICE auto make_iterator_kernel_arg(It it) -> kernel_arg<It>
 {
   kernel_arg<It> arg;
-  // since we switch the active member of the union, we must use placement new or construct_at. This also uses the copy
-  // constructor of It, which works in more cases than assignment (e.g. thrust::transform_iterator with
-  // non-copy-assignable functor, e.g. in merge sort tests)
   arg.iterator = it;
   return arg;
 }

--- a/cub/cub/device/dispatch/tuning/tuning_transform.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_transform.cuh
@@ -49,7 +49,9 @@
 // The ublkcp kernel needs PTX features that are only available and understood by nvcc >=12.
 // Also, cooperative groups do not support NVHPC yet.
 #if !_CCCL_CUDA_COMPILER(NVHPC)
-#  define _CUB_HAS_TRANSFORM_UBLKCP
+#  ifndef _CUB_HAS_TRANSFORM_UBLKCP
+#    define _CUB_HAS_TRANSFORM_UBLKCP 1
+#  endif // !_CUB_HAS_TRANSFORM_UBLKCP
 #endif // !_CCCL_CUDA_COMPILER(NVHPC)
 
 CUB_NAMESPACE_BEGIN


### PR DESCRIPTION
## Description

Closes https://github.com/NVIDIA/cccl/issues/3877

This PR introduces `transform` to the c.parallel API, using only the `prefetch` algorithm (not `ublkcp`).

- `unary_transform` applies a unary operation on a single input iterator
- `binary_transform` applies a binary operation on two input iterators

Note that this is more limited than the C++ CUB API, which allows passing an arbitrary number of input iterators.

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
