### PR TITLE
Fix compilation error in c.parallel unique_by_key caused by wrong datatype

### DIFF
--- a/c/parallel/src/unique_by_key.cu
+++ b/c/parallel/src/unique_by_key.cu
@@ -171,7 +171,7 @@ struct dynamic_unique_by_key_policy_t
     return op.template Invoke<unique_by_key_runtime_tuning_policy>(GetPolicy(device_ptx_version, key_size));
   }
 
-  int key_size;
+  uint64_t key_size;
 };
 
 struct unique_by_key_kernel_source


### PR DESCRIPTION
## Description

c.parallel `unique_by_key` is not compiling due to the wrong datatype being used in the policy

## Checklist
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
