### PR TITLE
Add multi-dimensional support to block_reduce routines.

### DIFF
--- a/python/cuda_cooperative/cuda/cooperative/experimental/_common.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/_common.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
@@ -23,6 +23,13 @@ CUB_BLOCK_SCAN_ALGOS = {
     "raking": "::cub::BlockScanAlgorithm::BLOCK_SCAN_RAKING",
     "raking_memoize": "::cub::BlockScanAlgorithm::BLOCK_SCAN_RAKING_MEMOIZE",
     "warp_scans": "::cub::BlockScanAlgorithm::BLOCK_SCAN_WARP_SCANS",
+}
+
+
+CUB_BLOCK_REDUCE_ALGOS = {
+    "raking_commutative_only": "::cub::BlockReduceAlgorithm::BLOCK_REDUCE_RAKING_COMMUTATIVE_ONLY",
+    "raking": "::cub::BlockReduceAlgorithm::BLOCK_REDUCE_RAKING",
+    "warp_reductions": "::cub::BlockReduceAlgorithm::BLOCK_REDUCE_WARP_REDUCTIONS",
 }
 
 

--- a/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_reduce.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_reduce.py
@@ -1,10 +1,13 @@
-# Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from typing import TYPE_CHECKING, Callable, Literal, Union
 
 import numba
 
 from cuda.cooperative.experimental._common import (
+    CUB_BLOCK_REDUCE_ALGOS,
     make_binary_tempfile,
     normalize_dtype_param,
 )
@@ -21,9 +24,154 @@ from cuda.cooperative.experimental._types import (
     numba_type_to_wrapper,
 )
 
+if TYPE_CHECKING:
+    import numpy as np
 
-def reduce(dtype, threads_per_block, binary_op, items_per_thread=1, methods=None):
-    """Creates an operation that computes a block-wide reduction for thread\ :sub:`0` using the
+
+def _reduce(
+    dtype: Union[str, type, "np.dtype", "numba.types.Type"],
+    threads_per_block: int,
+    items_per_thread: int,
+    binary_op: Callable,
+    algorithm: Literal["raking", "raking_commutative_only", "warp_reductions"],
+    methods: dict = None,
+) -> Callable:
+    if algorithm not in CUB_BLOCK_REDUCE_ALGOS:
+        raise ValueError(f"Unsupported algorithm: {algorithm}")
+
+    if items_per_thread < 1:
+        raise ValueError("items_per_thread must be greater than or equal to 1")
+
+    dtype = normalize_dtype_param(dtype)
+
+    specialization_kwds = {
+        "T": dtype,
+        "BLOCK_DIM_X": threads_per_block,
+        "ALGORITHM": CUB_BLOCK_REDUCE_ALGOS[algorithm],
+    }
+
+    template_parameters = [
+        TemplateParameter("T"),
+        TemplateParameter("BLOCK_DIM_X"),
+        TemplateParameter("ALGORITHM"),
+    ]
+
+    if binary_op is None:
+        cpp_method_name = "Sum"
+
+        if items_per_thread == 1:
+            parameters = [
+                # Signatures:
+                # T Sum(T);
+                [
+                    Pointer(numba.uint8),
+                    DependentReference(Dependency("T")),
+                    DependentReference(Dependency("T"), is_output=True),
+                ],
+                # T Sum(T, int num_valid);
+                [
+                    Pointer(numba.uint8),
+                    DependentReference(Dependency("T")),
+                    Value(numba.int32),
+                    DependentReference(Dependency("T"), is_output=True),
+                ],
+            ]
+
+        else:
+            assert items_per_thread > 1, items_per_thread
+            specialization_kwds["ITEMS_PER_THREAD"] = items_per_thread
+
+            parameters = [
+                # Signatures:
+                # T Sum(T(&)[ITEMS_PER_THREAD]);
+                [
+                    Pointer(numba.uint8),
+                    DependentArray(Dependency("T"), Dependency("ITEMS_PER_THREAD")),
+                    DependentReference(Dependency("T"), is_output=True),
+                ],
+            ]
+
+    else:
+        cpp_method_name = "Reduce"
+        specialization_kwds["Op"] = binary_op
+
+        if items_per_thread == 1:
+            parameters = [
+                # Signatures:
+                # T Reduce(T, Op);
+                [
+                    Pointer(numba.uint8),
+                    DependentReference(Dependency("T")),
+                    DependentOperator(
+                        Dependency("T"),
+                        [Dependency("T"), Dependency("T")],
+                        Dependency("Op"),
+                    ),
+                    DependentReference(Dependency("T"), is_output=True),
+                ],
+                # T Reduce(T, Op, int num_valid);
+                [
+                    Pointer(numba.uint8),
+                    DependentReference(Dependency("T")),
+                    DependentOperator(
+                        Dependency("T"),
+                        [Dependency("T"), Dependency("T")],
+                        Dependency("Op"),
+                    ),
+                    Value(numba.int32),
+                    DependentReference(Dependency("T"), is_output=True),
+                ],
+            ]
+
+        else:
+            assert items_per_thread > 1, items_per_thread
+            specialization_kwds["ITEMS_PER_THREAD"] = items_per_thread
+
+            parameters = [
+                # Signatures:
+                # T Reduce(T(&)[ITEMS_PER_THREAD], Op);
+                [
+                    Pointer(numba.uint8),
+                    DependentArray(Dependency("T"), Dependency("ITEMS_PER_THREAD")),
+                    DependentOperator(
+                        Dependency("T"),
+                        [Dependency("T"), Dependency("T")],
+                        Dependency("Op"),
+                    ),
+                    DependentReference(Dependency("T"), is_output=True),
+                ],
+            ]
+
+    template = Algorithm(
+        "BlockReduce",
+        cpp_method_name,
+        "block_reduce",
+        ["cub/block/block_reduce.cuh"],
+        template_parameters,
+        parameters,
+        type_definitions=[numba_type_to_wrapper(dtype, methods=methods)],
+    )
+
+    specialization = template.specialize(specialization_kwds)
+    return Invocable(
+        temp_files=[
+            make_binary_tempfile(ltoir, ".ltoir")
+            for ltoir in specialization.get_lto_ir()
+        ],
+        temp_storage_bytes=specialization.get_temp_storage_bytes(),
+        algorithm=specialization,
+    )
+
+
+def reduce(
+    dtype,
+    threads_per_block,
+    binary_op,
+    items_per_thread=1,
+    algorithm="warp_reductions",
+    methods=None,
+):
+    """Creates an operation that computes a block-wide reduction for thread :sub:`0` using the
     specified binary reduction functor.
 
     Returns a callable object that can be linked to and invoked from device code. It can be
@@ -41,10 +189,12 @@ def reduce(dtype, threads_per_block, binary_op, items_per_thread=1, methods=None
         threads_per_block: The number of threads in a block
         binary_op: Binary reduction function
         items_per_thread: The number of items each thread contributes to the reduction
+        algorithm: Algorithm to use for the reduction (one of "raking",
+            "raking_commutative_only", "warp_reductions")
         methods: A dict of methods for user-defined types
 
     Warning:
-        The return value is undefined in threads other than thread\ :sub:`0`.
+        The return value is undefined in threads other than thread :sub:`0`.
 
     Example:
         The code snippet below illustrates a max reduction of 128 integer items that are
@@ -63,77 +213,26 @@ def reduce(dtype, threads_per_block, binary_op, items_per_thread=1, methods=None
             :end-before: example-end reduce
 
         Suppose the set of inputs across the block of threads is ``{ 0, 1, 2, 3, ..., 127 }``.
-        The corresponding output in the threads thread\ :sub:`0` will be ``{ 127 }``.
+        The corresponding output in the threads thread :sub:`0` will be ``{ 127 }``.
     """
-    # Normalize the dtype parameter.
-    dtype = normalize_dtype_param(dtype)
-
-    template = Algorithm(
-        "BlockReduce",
-        "Reduce",
-        "block_reduce",
-        ["cub/block/block_reduce.cuh"],
-        [TemplateParameter("T"), TemplateParameter("BLOCK_DIM_X")],
-        [
-            # Signatures:
-            # T Reduce(T(&)[ITEMS_PER_THREAD], Op);
-            [
-                Pointer(numba.uint8),
-                DependentArray(Dependency("T"), Dependency("ITEMS_PER_THREAD")),
-                DependentOperator(
-                    Dependency("T"),
-                    [Dependency("T"), Dependency("T")],
-                    Dependency("Op"),
-                ),
-                DependentReference(Dependency("T"), True),
-            ],
-            # T Reduce(T&, Op);
-            [
-                Pointer(numba.uint8),
-                DependentReference(Dependency("T")),
-                DependentOperator(
-                    Dependency("T"),
-                    [Dependency("T"), Dependency("T")],
-                    Dependency("Op"),
-                ),
-                DependentReference(Dependency("T"), True),
-            ],
-            # T Reduce(T&, Op, int num_valid);
-            [
-                Pointer(numba.uint8),
-                DependentReference(Dependency("T")),
-                DependentOperator(
-                    Dependency("T"),
-                    [Dependency("T"), Dependency("T")],
-                    Dependency("Op"),
-                ),
-                Value(numba.int32),
-                DependentReference(Dependency("T"), True),
-            ],
-        ],
-        type_definitions=[numba_type_to_wrapper(dtype, methods=methods)],
-    )
-    specialization = template.specialize(
-        {
-            "T": dtype,
-            "BLOCK_DIM_X": threads_per_block,
-            "ITEMS_PER_THREAD": items_per_thread,
-            "Op": binary_op,
-        }
-    )
-
-    return Invocable(
-        temp_files=[
-            make_binary_tempfile(ltoir, ".ltoir")
-            for ltoir in specialization.get_lto_ir()
-        ],
-        temp_storage_bytes=specialization.get_temp_storage_bytes(),
-        algorithm=specialization,
+    return _reduce(
+        dtype=dtype,
+        threads_per_block=threads_per_block,
+        items_per_thread=items_per_thread,
+        binary_op=binary_op,
+        algorithm=algorithm,
+        methods=methods,
     )
 
 
-def sum(dtype, threads_per_block, items_per_thread=1, methods=None):
-    """Creates an operation that computes a block-wide reduction for thread\ :sub:`0` using
+def sum(
+    dtype,
+    threads_per_block,
+    items_per_thread=1,
+    algorithm="warp_reductions",
+    methods=None,
+):
+    """Creates an operation that computes a block-wide reduction for thread :sub:`0` using
     addition (+) as the reduction operator.
 
     Returns a callable object that can be linked to and invoked from device code. It can be
@@ -150,10 +249,12 @@ def sum(dtype, threads_per_block, items_per_thread=1, methods=None):
         dtype: Data type being reduced
         threads_per_block: The number of threads in a block
         items_per_thread: The number of items each thread owns
+        algorithm: Algorithm to use for the reduction (one of "raking",
+            "raking_commutative_only", "warp_reductions")
         methods: A dict of methods for user-defined types
 
     Warning:
-        The return value is undefined in threads other than thread\ :sub:`0`.
+        The return value is undefined in threads other than thread :sub:`0`.
 
     Example:
         The code snippet below illustrates a sum of 128 integer items that are partitioned
@@ -172,53 +273,13 @@ def sum(dtype, threads_per_block, items_per_thread=1, methods=None):
             :end-before: example-end sum
 
         Suppose the set of inputs across the block of threads is ``{ 1, 1, 1, 1, ..., 1 }``.
-        The corresponding output in the threads thread\ :sub:`0` will be ``{ 128 }``.
+        The corresponding output in the threads thread :sub:`0` will be ``{ 128 }``.
     """
-    # Normalize the dtype parameter.
-    dtype = normalize_dtype_param(dtype)
-
-    template = Algorithm(
-        "BlockReduce",
-        "Sum",
-        "block_reduce",
-        ["cub/block/block_reduce.cuh"],
-        [TemplateParameter("T"), TemplateParameter("BLOCK_DIM_X")],
-        [
-            # Signatures:
-            # T Sum(T(&)[ITEMS_PER_THREAD]);
-            [
-                Pointer(numba.uint8),
-                DependentArray(Dependency("T"), Dependency("ITEMS_PER_THREAD")),
-                DependentReference(Dependency("T"), True),
-            ],
-            # T Sum(T&);
-            [
-                Pointer(numba.uint8),
-                DependentReference(Dependency("T")),
-                DependentReference(Dependency("T"), True),
-            ],
-            # T Sum(T&, int num_valid);
-            [
-                Pointer(numba.uint8),
-                DependentReference(Dependency("T")),
-                Value(numba.int32),
-                DependentReference(Dependency("T"), True),
-            ],
-        ],
-        type_definitions=[numba_type_to_wrapper(dtype, methods=methods)],
-    )
-    specialization = template.specialize(
-        {
-            "T": dtype,
-            "BLOCK_DIM_X": threads_per_block,
-            "ITEMS_PER_THREAD": items_per_thread,
-        }
-    )
-    return Invocable(
-        temp_files=[
-            make_binary_tempfile(ltoir, ".ltoir")
-            for ltoir in specialization.get_lto_ir()
-        ],
-        temp_storage_bytes=specialization.get_temp_storage_bytes(),
-        algorithm=specialization,
+    return _reduce(
+        dtype=dtype,
+        threads_per_block=threads_per_block,
+        items_per_thread=items_per_thread,
+        binary_op=None,
+        algorithm=algorithm,
+        methods=methods,
     )


### PR DESCRIPTION
# Refactor cuda.cooperative.block_reduce module.
    
    This commit takes care of some refactoring needed in preparation for an upcoming
    commit that adds multi-dimensional support.
    
     - Introduce a new `_reduce()` worker routine, and refactor `reduce()` and
       `sum()` to call into it, reducing duplicate code.
    
     - Add support for `items_per_thread` == 1 (similar to PR #3829).  Specifically,
       this is explicitly handled such that the single-item C++ CUB specializations
       are used when `items_per_thread` is 1, e.g.:
    
            `T Reduce(T input)` instead of `T Reduce(T (&input)[ITEMS_PER_THREAD])`
            `T Sum(T input)` instead of `T Sum(T (&input)[ITEMS_PER_THREAD])`
    
     - Add support for `algorithm` and update tests accordingly.
    
     - Add tests for invalid `algorithm` and invalid `items_per_thread`.
     
# Add multi-dimensional support to block_reduce module.

Update tests accordingly.
 