### PR TITLE
Fix `numeric_limits` digits for NVFP8/6/4

### DIFF
--- a/libcudacxx/include/cuda/std/__limits/numeric_limits_ext.h
+++ b/libcudacxx/include/cuda/std/__limits/numeric_limits_ext.h
@@ -194,9 +194,9 @@ public:
   static constexpr bool is_specialized = true;
 
   static constexpr bool is_signed   = true;
-  static constexpr int digits       = 3;
+  static constexpr int digits       = 4;
   static constexpr int digits10     = 0;
-  static constexpr int max_digits10 = 2;
+  static constexpr int max_digits10 = 3;
   _LIBCUDACXX_HIDE_FROM_ABI static constexpr type min() noexcept
   {
     return _CUDA_VSTD::__cccl_make_nvfp8_e4m3_from_storage(0x08u);
@@ -271,7 +271,7 @@ public:
   static constexpr bool is_specialized = true;
 
   static constexpr bool is_signed   = true;
-  static constexpr int digits       = 2;
+  static constexpr int digits       = 3;
   static constexpr int digits10     = 0;
   static constexpr int max_digits10 = 2;
   _LIBCUDACXX_HIDE_FROM_ABI static constexpr type min() noexcept
@@ -348,9 +348,9 @@ public:
   static constexpr bool is_specialized = true;
 
   static constexpr bool is_signed   = false;
-  static constexpr int digits       = 0;
+  static constexpr int digits       = 1;
   static constexpr int digits10     = 0;
-  static constexpr int max_digits10 = 1;
+  static constexpr int max_digits10 = 2;
   _LIBCUDACXX_HIDE_FROM_ABI static constexpr type min() noexcept
   {
     return _CUDA_VSTD::__cccl_make_nvfp8_e8m0_from_storage(0x00u);
@@ -425,9 +425,9 @@ public:
   static constexpr bool is_specialized = true;
 
   static constexpr bool is_signed   = true;
-  static constexpr int digits       = 3;
+  static constexpr int digits       = 4;
   static constexpr int digits10     = 0;
-  static constexpr int max_digits10 = 2;
+  static constexpr int max_digits10 = 3;
   _LIBCUDACXX_HIDE_FROM_ABI static constexpr type min() noexcept
   {
     return _CUDA_VSTD::__cccl_make_nvfp6_e2m3_from_storage(0x08u);
@@ -502,7 +502,7 @@ public:
   static constexpr bool is_specialized = true;
 
   static constexpr bool is_signed   = true;
-  static constexpr int digits       = 2;
+  static constexpr int digits       = 3;
   static constexpr int digits10     = 0;
   static constexpr int max_digits10 = 2;
   _LIBCUDACXX_HIDE_FROM_ABI static constexpr type min() noexcept
@@ -579,7 +579,7 @@ public:
   static constexpr bool is_specialized = true;
 
   static constexpr bool is_signed   = true;
-  static constexpr int digits       = 1;
+  static constexpr int digits       = 2;
   static constexpr int digits10     = 0;
   static constexpr int max_digits10 = 2;
   _LIBCUDACXX_HIDE_FROM_ABI static constexpr type min() noexcept

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/digits.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/digits.pass.cpp
@@ -62,22 +62,22 @@ int main(int, char**)
   test<__nv_bfloat16, 8>();
 #endif // _CCCL_HAS_NVBF16
 #if _CCCL_HAS_NVFP8_E4M3()
-  test<__nv_fp8_e4m3, 3>();
+  test<__nv_fp8_e4m3, 4>();
 #endif // _CCCL_HAS_NVFP8_E4M3()
 #if _CCCL_HAS_NVFP8_E5M2()
-  test<__nv_fp8_e5m2, 2>();
+  test<__nv_fp8_e5m2, 3>();
 #endif // _CCCL_HAS_NVFP8_E5M2()
 #if _CCCL_HAS_NVFP8_E8M0()
-  test<__nv_fp8_e8m0, 0>();
+  test<__nv_fp8_e8m0, 1>();
 #endif // _CCCL_HAS_NVFP8_E8M0()
 #if _CCCL_HAS_NVFP6_E2M3()
-  test<__nv_fp6_e2m3, 3>();
+  test<__nv_fp6_e2m3, 4>();
 #endif // _CCCL_HAS_NVFP6_E2M3()
 #if _CCCL_HAS_NVFP6_E3M2()
-  test<__nv_fp6_e3m2, 2>();
+  test<__nv_fp6_e3m2, 3>();
 #endif // _CCCL_HAS_NVFP6_E3M2()
 #if _CCCL_HAS_NVFP4_E2M1()
-  test<__nv_fp4_e2m1, 1>();
+  test<__nv_fp4_e2m1, 2>();
 #endif // _CCCL_HAS_NVFP4_E2M1()
 
   return 0;


### PR DESCRIPTION
This PR fixes `numeric_limits::digits` for NVFP8/6/4 types.

The `digits` static member should have the value of `mant_nbits + 1`.