### PR TITLE
Add `thrust::offset_iterator`

### DIFF
--- a/thrust/testing/cuda/offset_iterator.cu
+++ b/thrust/testing/cuda/offset_iterator.cu
@@ -129,7 +129,5 @@ void TestOffsetIteratorIndirectValue()
   offset = 2;
 
   ASSERT_EQUAL(*iter, 2);
-  // iter++;
-  // ASSERT_EQUAL(*iter, 3);
 }
 DECLARE_VECTOR_UNITTEST(TestOffsetIteratorIndirectValue);

--- a/thrust/testing/cuda/offset_iterator.cu
+++ b/thrust/testing/cuda/offset_iterator.cu
@@ -1,0 +1,118 @@
+#include <thrust/distance.h>
+#include <thrust/iterator/offset_iterator.h>
+
+#include <cuda/std/iterator>
+
+#include <unittest/unittest.h>
+
+struct device_only_iterator
+{
+  using iterator_category = cuda::std::random_access_iterator_tag;
+  using difference_type   = cuda::std::ptrdiff_t;
+  using value_type        = int;
+  using pointer           = int*;
+  using reference         = int&;
+
+  _CCCL_HOST_DEVICE device_only_iterator(pointer ptr)
+      : m_ptr(ptr)
+  {}
+
+  _CCCL_DEVICE reference operator*() const
+  {
+    return *m_ptr;
+  }
+
+  _CCCL_DEVICE device_only_iterator& operator++()
+  {
+    ++m_ptr;
+    return *this;
+  }
+
+  _CCCL_DEVICE device_only_iterator operator++(int)
+  {
+    device_only_iterator tmp = *this;
+    ++*this;
+    return tmp;
+  }
+
+  _CCCL_DEVICE device_only_iterator& operator--()
+  {
+    --m_ptr;
+    return *this;
+  }
+
+  _CCCL_DEVICE device_only_iterator operator--(int)
+  {
+    device_only_iterator tmp = *this;
+    --*this;
+    return tmp;
+  }
+
+  _CCCL_DEVICE device_only_iterator& operator+=(difference_type n)
+  {
+    m_ptr += n;
+    return *this;
+  }
+
+  _CCCL_DEVICE friend bool operator-(const device_only_iterator& a, const device_only_iterator& b)
+  {
+    return a.m_ptr - b.m_ptr;
+  }
+
+  _CCCL_DEVICE friend bool operator==(const device_only_iterator& a, const device_only_iterator& b)
+  {
+    return a.m_ptr == b.m_ptr;
+  }
+
+  _CCCL_DEVICE friend bool operator!=(const device_only_iterator& a, const device_only_iterator& b)
+  {
+    return a.m_ptr != b.m_ptr;
+  }
+
+private:
+  pointer m_ptr;
+};
+
+_CCCL_HOST_DEVICE void TestOffsetIteratorBoth(thrust::offset_iterator<device_only_iterator> iter)
+{
+  assert(iter.offset() == 0);
+  ++iter;
+  assert(iter.offset() == 1);
+  iter++;
+  assert(iter.offset() == 2);
+  --iter;
+  assert(iter.offset() == 1);
+  iter--;
+  assert(iter.offset() == 0);
+  iter += 100;
+  assert(iter.offset() == 100);
+}
+
+__global__ void TestOffsetIteratorDevice(thrust::offset_iterator<device_only_iterator> iter)
+{
+  TestOffsetIteratorBoth(iter);
+
+  // access
+  assert(*iter == 1);
+
+  auto iter2 = iter;
+  iter2 += 3;
+  assert(*iter2 == 1);
+
+  // difference
+  assert(iter2 - iter == 3);
+
+  // comparison
+  assert(!(iter2 == iter));
+  assert(iter2 != iter);
+}
+
+void TestOffsetIterator()
+{
+  thrust::device_vector<int> v{1, 2, 3, 4, 5};
+  device_only_iterator base(thrust::raw_pointer_cast(v.data()));
+  thrust::offset_iterator iter(base);
+  TestOffsetIteratorBoth(iter);
+  TestOffsetIteratorDevice<<<1, 1>>>(iter);
+}
+DECLARE_UNITTEST(TestOffsetIterator);

--- a/thrust/testing/cuda/offset_iterator.cu
+++ b/thrust/testing/cuda/offset_iterator.cu
@@ -1,3 +1,5 @@
+#include <cub/util_type.cuh>
+
 #include <thrust/distance.h>
 #include <thrust/iterator/offset_iterator.h>
 
@@ -116,3 +118,18 @@ void TestOffsetIterator()
   TestOffsetIteratorDevice<<<1, 1>>>(iter);
 }
 DECLARE_UNITTEST(TestOffsetIterator);
+
+// this is not strictly a CUDA test, but it uses CUB
+template <typename Vector>
+void TestOffsetIteratorIndirectValue()
+{
+  typename Vector::difference_type offset;
+  Vector v{0, 1, 2, 3, 4, 5, 6, 7, 8};
+  thrust::offset_iterator iter(v.begin(), cub::FutureValue{&offset});
+  offset = 2;
+
+  ASSERT_EQUAL(*iter, 2);
+  // iter++;
+  // ASSERT_EQUAL(*iter, 3);
+}
+DECLARE_VECTOR_UNITTEST(TestOffsetIteratorIndirectValue);

--- a/thrust/testing/cuda/offset_iterator.cu
+++ b/thrust/testing/cuda/offset_iterator.cu
@@ -1,7 +1,9 @@
 #include <cub/util_type.cuh>
 
 #include <thrust/distance.h>
+#include <thrust/functional.h>
 #include <thrust/iterator/offset_iterator.h>
+#include <thrust/iterator/transform_iterator.h>
 
 #include <cuda/std/iterator>
 
@@ -131,3 +133,18 @@ void TestOffsetIteratorIndirectValue()
   ASSERT_EQUAL(*iter, 2);
 }
 DECLARE_VECTOR_UNITTEST(TestOffsetIteratorIndirectValue);
+
+// this is not strictly a CUDA test, but it uses CUB
+template <typename Vector>
+void TestOffsetIteratorIndirectValueFancyIterator()
+{
+  using thrust::placeholders::_1;
+
+  Vector v{0, 1, 2, 3, 4, 5, 6, 7, 8};
+  thrust::device_vector<typename Vector::difference_type> offsets{2};
+  auto it = thrust::make_transform_iterator(offsets.begin(), _1 * 3);
+  thrust::offset_iterator iter(v.begin(), cub::FutureValue{it});
+
+  ASSERT_EQUAL(*iter, 6);
+}
+DECLARE_VECTOR_UNITTEST(TestOffsetIteratorIndirectValueFancyIterator);

--- a/thrust/testing/cuda/offset_iterator.cu
+++ b/thrust/testing/cuda/offset_iterator.cu
@@ -1,5 +1,3 @@
-#include <cub/util_type.cuh>
-
 #include <thrust/distance.h>
 #include <thrust/functional.h>
 #include <thrust/iterator/offset_iterator.h>
@@ -111,7 +109,7 @@ __global__ void TestOffsetIteratorDevice(thrust::offset_iterator<device_only_ite
   assert(iter2 != iter);
 }
 
-void TestOffsetIterator()
+void TestOffsetIteratorWithDeviceOnlyIterator()
 {
   thrust::device_vector<int> v{1, 2, 3, 4, 5};
   device_only_iterator base(thrust::raw_pointer_cast(v.data()));
@@ -119,32 +117,4 @@ void TestOffsetIterator()
   TestOffsetIteratorBoth(iter);
   TestOffsetIteratorDevice<<<1, 1>>>(iter);
 }
-DECLARE_UNITTEST(TestOffsetIterator);
-
-// this is not strictly a CUDA test, but it uses CUB
-template <typename Vector>
-void TestOffsetIteratorIndirectValue()
-{
-  typename Vector::difference_type offset;
-  Vector v{0, 1, 2, 3, 4, 5, 6, 7, 8};
-  thrust::offset_iterator iter(v.begin(), cub::FutureValue{&offset});
-  offset = 2;
-
-  ASSERT_EQUAL(*iter, 2);
-}
-DECLARE_VECTOR_UNITTEST(TestOffsetIteratorIndirectValue);
-
-// this is not strictly a CUDA test, but it uses CUB
-template <typename Vector>
-void TestOffsetIteratorIndirectValueFancyIterator()
-{
-  using thrust::placeholders::_1;
-
-  Vector v{0, 1, 2, 3, 4, 5, 6, 7, 8};
-  thrust::device_vector<typename Vector::difference_type> offsets{2};
-  auto it = thrust::make_transform_iterator(offsets.begin(), _1 * 3);
-  thrust::offset_iterator iter(v.begin(), cub::FutureValue{it});
-
-  ASSERT_EQUAL(*iter, 6);
-}
-DECLARE_VECTOR_UNITTEST(TestOffsetIteratorIndirectValueFancyIterator);
+DECLARE_UNITTEST(TestOffsetIteratorWithDeviceOnlyIterator);

--- a/thrust/testing/offset_iterator.cu
+++ b/thrust/testing/offset_iterator.cu
@@ -1,0 +1,126 @@
+#include <thrust/distance.h>
+#include <thrust/iterator/offset_iterator.h>
+
+#include <cuda/std/iterator>
+
+#include <unittest/unittest.h>
+
+// ensure that we properly support thrust::counting_iterator from cuda::std
+void TestOffsetIteratorTraits()
+{
+  using base_it    = thrust::host_vector<int>::iterator;
+  using it         = thrust::offset_iterator<base_it>;
+  using traits     = cuda::std::iterator_traits<it>;
+  using vec_traits = cuda::std::iterator_traits<base_it>;
+
+  static_assert(cuda::std::is_same_v<traits::difference_type, vec_traits::difference_type>);
+  static_assert(cuda::std::is_same_v<traits::value_type, vec_traits::value_type>);
+  static_assert(cuda::std::is_same_v<traits::pointer, vec_traits::pointer>);
+  static_assert(cuda::std::is_same_v<traits::reference, vec_traits::reference>);
+  static_assert(cuda::std::is_same_v<traits::iterator_category, vec_traits::iterator_category>);
+
+  static_assert(cuda::std::is_same_v<thrust::iterator_traversal_t<it>, thrust::random_access_traversal_tag>);
+
+  static_assert(cuda::std::__is_cpp17_random_access_iterator<it>::value);
+
+  static_assert(cuda::std::output_iterator<it, int>);
+  static_assert(cuda::std::input_iterator<it>);
+  static_assert(cuda::std::forward_iterator<it>);
+  static_assert(cuda::std::bidirectional_iterator<it>);
+  static_assert(cuda::std::random_access_iterator<it>);
+  static_assert(!cuda::std::contiguous_iterator<it>);
+}
+DECLARE_UNITTEST(TestOffsetIteratorTraits);
+
+template <typename Vector>
+void TestOffsetConstructor()
+{
+  thrust::offset_iterator<int*> iter0;
+  ASSERT_EQUAL(iter0.base(), nullptr);
+  ASSERT_EQUAL(iter0.offset(), 0);
+
+  Vector v{42, 43};
+  thrust::offset_iterator iter1(v.begin());
+  ASSERT_EQUAL_QUIET(iter1.base(), v.begin());
+  ASSERT_EQUAL(iter1.offset(), 0);
+  ASSERT_EQUAL(*iter1, 42);
+
+  thrust::offset_iterator iter2(v.begin(), 1);
+  ASSERT_EQUAL_QUIET(iter2.base(), v.begin());
+  ASSERT_EQUAL(iter2.offset(), 1);
+  ASSERT_EQUAL(*iter2, 43);
+}
+DECLARE_VECTOR_UNITTEST(TestOffsetConstructor);
+
+template <typename Vector>
+void TestOffsetIteratorCopyConstructorAndAssignment()
+{
+  Vector v{42, 43};
+  thrust::offset_iterator iter0(v.begin());
+  thrust::offset_iterator iter1(iter0);
+
+  ASSERT_EQUAL(iter0 == iter1, true);
+  ASSERT_EQUAL(*iter0 == *iter1, true);
+
+  thrust::offset_iterator iter2(v.begin() + 1);
+  ASSERT_EQUAL(iter0 != iter2, true);
+  ASSERT_EQUAL(*iter0 != *iter2, true);
+
+  iter2 = iter0;
+  ASSERT_EQUAL(iter0 == iter2, true);
+  ASSERT_EQUAL(*iter0 == *iter2, true);
+}
+DECLARE_VECTOR_UNITTEST(TestOffsetIteratorCopyConstructorAndAssignment);
+
+template <typename Vector>
+void TestOffsetIteratorIncrement()
+{
+  Vector v{-2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8};
+  thrust::offset_iterator iter(v.begin() + 2); // start at 0
+
+  ASSERT_EQUAL(*iter, 0);
+  iter++;
+  ASSERT_EQUAL(*iter, 1);
+  iter++;
+  iter++;
+  ASSERT_EQUAL(*iter, 3);
+  iter += 5;
+  ASSERT_EQUAL(*iter, 8);
+  iter -= 10;
+  ASSERT_EQUAL(*iter, -2);
+}
+DECLARE_VECTOR_UNITTEST(TestOffsetIteratorIncrement);
+
+template <typename Vector>
+void TestOffsetIteratorComparisonAndDistance()
+{
+  Vector v(101);
+  thrust::offset_iterator iter1(v.begin());
+  thrust::offset_iterator iter2(v.begin());
+
+  ASSERT_EQUAL(iter1 == iter2, true);
+  ASSERT_EQUAL(iter1 - iter2, 0);
+  ASSERT_EQUAL(thrust::distance(iter1, iter2), 0);
+
+  iter1++;
+  ASSERT_EQUAL(iter1 == iter2, false);
+  ASSERT_EQUAL(iter1 - iter2, 1);
+  ASSERT_EQUAL(thrust::distance(iter1, iter2), -1);
+
+  iter2++;
+  ASSERT_EQUAL(iter1 == iter2, true);
+  ASSERT_EQUAL(iter1 - iter2, 0);
+  ASSERT_EQUAL(thrust::distance(iter1, iter2), 0);
+
+  iter1 += 100;
+  iter2 += 100;
+  ASSERT_EQUAL(iter1 == iter2, true);
+  ASSERT_EQUAL(iter1 - iter2, 0);
+  ASSERT_EQUAL(thrust::distance(iter1, iter2), 0);
+
+  iter1 -= 5;
+  ASSERT_EQUAL(iter1 == iter2, false);
+  ASSERT_EQUAL(iter1 - iter2, -5);
+  ASSERT_EQUAL(thrust::distance(iter1, iter2), 5);
+}
+DECLARE_VECTOR_UNITTEST(TestOffsetIteratorComparisonAndDistance);

--- a/thrust/testing/offset_iterator.cu
+++ b/thrust/testing/offset_iterator.cu
@@ -37,7 +37,7 @@ template <typename Vector>
 void TestOffsetConstructor()
 {
   thrust::offset_iterator<int*> iter0;
-  ASSERT_EQUAL(iter0.base(), nullptr);
+  ASSERT_EQUAL(iter0.base(), static_cast<int*>(nullptr));
   ASSERT_EQUAL(iter0.offset(), 0);
 
   Vector v{42, 43};

--- a/thrust/testing/offset_iterator.cu
+++ b/thrust/testing/offset_iterator.cu
@@ -58,8 +58,11 @@ void TestOffsetIteratorCopyConstructorAndAssignment()
 {
   Vector v{42, 43};
   thrust::offset_iterator iter0(v.begin());
+#if _CCCL_COMPILER(MSVC) // MSVC cannot deduce the template arguments from the copy ctor
+  decltype(iter0) iter1(iter0);
+#else // _CCCL_COMPILER(MSVC)
   thrust::offset_iterator iter1(iter0);
-
+#endif // _CCCL_COMPILER(MSVC)
   ASSERT_EQUAL(iter0 == iter1, true);
   ASSERT_EQUAL(*iter0 == *iter1, true);
 

--- a/thrust/testing/offset_iterator.cu
+++ b/thrust/testing/offset_iterator.cu
@@ -1,3 +1,5 @@
+#include <cub/util_type.cuh>
+
 #include <thrust/distance.h>
 #include <thrust/iterator/offset_iterator.h>
 
@@ -124,3 +126,17 @@ void TestOffsetIteratorComparisonAndDistance()
   ASSERT_EQUAL(thrust::distance(iter1, iter2), 5);
 }
 DECLARE_VECTOR_UNITTEST(TestOffsetIteratorComparisonAndDistance);
+
+template <typename Vector>
+void TestOffsetIteratorIndirectValue()
+{
+  typename Vector::difference_type offset;
+  Vector v{0, 1, 2, 3, 4, 5, 6, 7, 8};
+  thrust::offset_iterator iter(v.begin(), cub::FutureValue{&offset});
+  offset = 2;
+
+  ASSERT_EQUAL(*iter, 2);
+  iter++;
+  ASSERT_EQUAL(*iter, 3);
+}
+DECLARE_VECTOR_UNITTEST(TestOffsetIteratorIndirectValue);

--- a/thrust/testing/offset_iterator.cu
+++ b/thrust/testing/offset_iterator.cu
@@ -50,6 +50,13 @@ void TestOffsetConstructor()
   ASSERT_EQUAL_QUIET(iter2.base(), v.begin());
   ASSERT_EQUAL(iter2.offset(), 1);
   ASSERT_EQUAL(*iter2, 43);
+
+  ptrdiff_t offset = 1;
+  thrust::offset_iterator iter3(v.begin(), &offset);
+  ASSERT_EQUAL_QUIET(iter3.base(), v.begin());
+  ASSERT_EQUAL(iter3.offset(), &offset);
+  ASSERT_EQUAL(*iter3.offset(), 1);
+  ASSERT_EQUAL(*iter3, 43);
 }
 DECLARE_VECTOR_UNITTEST(TestOffsetConstructor);
 
@@ -57,74 +64,158 @@ template <typename Vector>
 void TestOffsetIteratorCopyConstructorAndAssignment()
 {
   Vector v{42, 43};
-  thrust::offset_iterator iter0(v.begin());
+
+  // value offset
+  {
+    thrust::offset_iterator iter0(v.begin());
 #if _CCCL_COMPILER(MSVC) // MSVC cannot deduce the template arguments from the copy ctor
-  decltype(iter0) iter1(iter0);
+    decltype(iter0) iter1(iter0);
 #else // _CCCL_COMPILER(MSVC)
-  thrust::offset_iterator iter1(iter0);
+    thrust::offset_iterator iter1(iter0);
 #endif // _CCCL_COMPILER(MSVC)
-  ASSERT_EQUAL(iter0 == iter1, true);
-  ASSERT_EQUAL(*iter0 == *iter1, true);
+    ASSERT_EQUAL(iter0 == iter1, true);
+    ASSERT_EQUAL(*iter0 == *iter1, true);
 
-  thrust::offset_iterator iter2(v.begin() + 1);
-  ASSERT_EQUAL(iter0 != iter2, true);
-  ASSERT_EQUAL(*iter0 != *iter2, true);
+    thrust::offset_iterator iter2(v.begin() + 1);
+    ASSERT_EQUAL(iter0 != iter2, true);
+    ASSERT_EQUAL(*iter0 != *iter2, true);
 
-  iter2 = iter0;
-  ASSERT_EQUAL(iter0 == iter2, true);
-  ASSERT_EQUAL(*iter0 == *iter2, true);
+    iter2 = iter0;
+    ASSERT_EQUAL(iter0 == iter2, true);
+    ASSERT_EQUAL(*iter0 == *iter2, true);
+  }
+
+  // indirect offset
+  {
+    const typename Vector::iterator::difference_type offset = 0;
+    thrust::offset_iterator iter0(v.begin(), &offset);
+
+#if _CCCL_COMPILER(MSVC) // MSVC cannot deduce the template arguments from the copy ctor
+    decltype(iter0) iter1(iter0);
+#else // _CCCL_COMPILER(MSVC)
+    thrust::offset_iterator iter1(iter0);
+#endif // _CCCL_COMPILER(MSVC)
+    ASSERT_EQUAL(iter0 == iter1, true);
+    ASSERT_EQUAL(*iter0 == *iter1, true);
+
+    thrust::offset_iterator iter2(v.begin() + 1, &offset);
+    ASSERT_EQUAL(iter0 != iter2, true);
+    ASSERT_EQUAL(*iter0 != *iter2, true);
+
+    iter2 = iter0;
+    ASSERT_EQUAL(iter0 == iter2, true);
+    ASSERT_EQUAL(*iter0 == *iter2, true);
+  }
 }
 DECLARE_VECTOR_UNITTEST(TestOffsetIteratorCopyConstructorAndAssignment);
 
 template <typename Vector>
 void TestOffsetIteratorIncrement()
 {
-  Vector v{-2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8};
-  thrust::offset_iterator iter(v.begin() + 2); // start at 0
+  auto test = [](auto iter) {
+    ASSERT_EQUAL(*iter, 0);
+    iter++;
+    ASSERT_EQUAL(*iter, 1);
+    iter++;
+    iter++;
+    ASSERT_EQUAL(*iter, 3);
+    iter += 5;
+    ASSERT_EQUAL(*iter, 8);
+    iter -= 10;
+    ASSERT_EQUAL(*iter, -2);
+  };
 
-  ASSERT_EQUAL(*iter, 0);
-  iter++;
-  ASSERT_EQUAL(*iter, 1);
-  iter++;
-  iter++;
-  ASSERT_EQUAL(*iter, 3);
-  iter += 5;
-  ASSERT_EQUAL(*iter, 8);
-  iter -= 10;
-  ASSERT_EQUAL(*iter, -2);
+  const Vector v{-2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8};
+  test(thrust::offset_iterator(v.begin() + 1, 1));
+  const typename Vector::iterator::difference_type offset = 1;
+  test(thrust::offset_iterator(v.begin() + 1, &offset));
 }
 DECLARE_VECTOR_UNITTEST(TestOffsetIteratorIncrement);
 
 template <typename Vector>
+void TestOffsetIteratorMutation()
+{
+  {
+    Vector v{-2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8};
+    thrust::offset_iterator it(v.begin() + 1, 1);
+    *it = 42;
+    ++it;
+    *it = 43;
+    ++it.offset();
+    *it = 44;
+    ASSERT_EQUAL(v, (Vector{-2, -1, 42, 43, 44, 3, 4, 5, 6, 7, 8}));
+  }
+  {
+    Vector v{-2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8};
+    typename Vector::iterator::difference_type offset = 1;
+    thrust::offset_iterator it(v.begin() + 1, &offset);
+    *it = 42;
+    ++it;
+    *it    = 43;
+    offset = 2;
+    *it    = 44;
+    ASSERT_EQUAL(v, (Vector{-2, -1, 42, 43, 44, 3, 4, 5, 6, 7, 8}));
+  }
+}
+DECLARE_VECTOR_UNITTEST(TestOffsetIteratorMutation);
+
+template <typename Vector>
 void TestOffsetIteratorComparisonAndDistance()
 {
+  auto test = [](auto iter1, auto iter2) {
+    ASSERT_EQUAL(iter1 == iter2, true);
+    ASSERT_EQUAL(iter1 - iter2, 0);
+    ASSERT_EQUAL(thrust::distance(iter1, iter2), 0);
+
+    iter1++;
+    ASSERT_EQUAL(iter1 == iter2, false);
+    ASSERT_EQUAL(iter1 - iter2, 1);
+    ASSERT_EQUAL(thrust::distance(iter1, iter2), -1);
+
+    iter2++;
+    ASSERT_EQUAL(iter1 == iter2, true);
+    ASSERT_EQUAL(iter1 - iter2, 0);
+    ASSERT_EQUAL(thrust::distance(iter1, iter2), 0);
+
+    iter1 += 100;
+    iter2 += 100;
+    ASSERT_EQUAL(iter1 == iter2, true);
+    ASSERT_EQUAL(iter1 - iter2, 0);
+    ASSERT_EQUAL(thrust::distance(iter1, iter2), 0);
+
+    iter1 -= 5;
+    ASSERT_EQUAL(iter1 == iter2, false);
+    ASSERT_EQUAL(iter1 - iter2, -5);
+    ASSERT_EQUAL(thrust::distance(iter1, iter2), 5);
+  };
+
   Vector v(101);
-  thrust::offset_iterator iter1(v.begin());
-  thrust::offset_iterator iter2(v.begin());
-
-  ASSERT_EQUAL(iter1 == iter2, true);
-  ASSERT_EQUAL(iter1 - iter2, 0);
-  ASSERT_EQUAL(thrust::distance(iter1, iter2), 0);
-
-  iter1++;
-  ASSERT_EQUAL(iter1 == iter2, false);
-  ASSERT_EQUAL(iter1 - iter2, 1);
-  ASSERT_EQUAL(thrust::distance(iter1, iter2), -1);
-
-  iter2++;
-  ASSERT_EQUAL(iter1 == iter2, true);
-  ASSERT_EQUAL(iter1 - iter2, 0);
-  ASSERT_EQUAL(thrust::distance(iter1, iter2), 0);
-
-  iter1 += 100;
-  iter2 += 100;
-  ASSERT_EQUAL(iter1 == iter2, true);
-  ASSERT_EQUAL(iter1 - iter2, 0);
-  ASSERT_EQUAL(thrust::distance(iter1, iter2), 0);
-
-  iter1 -= 5;
-  ASSERT_EQUAL(iter1 == iter2, false);
-  ASSERT_EQUAL(iter1 - iter2, -5);
-  ASSERT_EQUAL(thrust::distance(iter1, iter2), 5);
+  test(thrust::offset_iterator(v.begin()), thrust::offset_iterator(v.begin()));
+  const typename Vector::iterator::difference_type offset = 0;
+  test(thrust::offset_iterator(v.begin(), &offset), thrust::offset_iterator(v.begin(), &offset));
 }
 DECLARE_VECTOR_UNITTEST(TestOffsetIteratorComparisonAndDistance);
+
+template <typename Vector>
+void TestOffsetIteratorLateValue()
+{
+  typename Vector::difference_type offset;
+  Vector v{0, 1, 2, 3, 4, 5, 6, 7, 8};
+  thrust::offset_iterator iter(v.begin(), &offset);
+  offset = 2; // we provide the offset value **after** constructing the iterator
+  ASSERT_EQUAL(*iter, 2);
+}
+DECLARE_VECTOR_UNITTEST(TestOffsetIteratorLateValue);
+
+template <typename Vector>
+void TestOffsetIteratorIndirectValueFancyIterator()
+{
+  using thrust::placeholders::_1;
+
+  Vector v{0, 1, 2, 3, 4, 5, 6, 7, 8};
+  thrust::device_vector<typename Vector::difference_type> offsets{2};
+  auto it = thrust::make_transform_iterator(offsets.begin(), _1 * 3);
+  thrust::offset_iterator iter(v.begin(), it);
+  ASSERT_EQUAL(*iter, 6);
+}
+DECLARE_VECTOR_UNITTEST(TestOffsetIteratorIndirectValueFancyIterator);

--- a/thrust/testing/offset_iterator.cu
+++ b/thrust/testing/offset_iterator.cu
@@ -1,4 +1,3 @@
-#include <cub/util_type.cuh>
 
 #include <thrust/distance.h>
 #include <thrust/iterator/offset_iterator.h>
@@ -126,17 +125,3 @@ void TestOffsetIteratorComparisonAndDistance()
   ASSERT_EQUAL(thrust::distance(iter1, iter2), 5);
 }
 DECLARE_VECTOR_UNITTEST(TestOffsetIteratorComparisonAndDistance);
-
-template <typename Vector>
-void TestOffsetIteratorIndirectValue()
-{
-  typename Vector::difference_type offset;
-  Vector v{0, 1, 2, 3, 4, 5, 6, 7, 8};
-  thrust::offset_iterator iter(v.begin(), cub::FutureValue{&offset});
-  offset = 2;
-
-  ASSERT_EQUAL(*iter, 2);
-  iter++;
-  ASSERT_EQUAL(*iter, 3);
-}
-DECLARE_VECTOR_UNITTEST(TestOffsetIteratorIndirectValue);

--- a/thrust/thrust/iterator/offset_iterator.h
+++ b/thrust/thrust/iterator/offset_iterator.h
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#pragma once
+
+#include <thrust/detail/config.h>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/iterator/iterator_adaptor.h>
+#include <thrust/iterator/iterator_facade.h>
+
+#include <cuda/std/cstdint>
+
+THRUST_NAMESPACE_BEGIN
+
+//! \addtogroup iterators
+//! \{
+
+//! \addtogroup fancyiterator Fancy Iterators
+//! \ingroup iterators
+//! \{
+
+//! \p offset_iterator wraps another iterator and an integral offset, apply the offset to the iterator when
+//! dereferencing, comparing, or computing the distance between two offset_iterators. This is useful, when the
+//! underlying iterator cannot be incremented, decremented, or advanced (e.g., because those operations are only
+//! supported in device code).
+//!
+//! The following code snippet demonstrates how to create a \p offset_iterator:
+//!
+//! \code
+//! #include <thrust/iterator/offset_iterator.h>
+//! #include <thrust/fill.h>
+//! #include <thrust/device_vector.h>
+//!
+//! int main()
+//! {
+//!   thrust::device_vector<int> data{1, 2, 3, 4};
+//!   auto b = offset_iterator{data.begin(), 1};
+//!   auto e = offset_iterator{data.end(), -1};
+//!   thrust::fill(b, e, 42);
+//!   // data is now [1, 42, 42, 4]
+//!   ++b; // does not call ++ on the underlying iterator
+//!   assert(b == e - 1);
+//!
+//!   return 0;
+//! }
+//! \endcode
+template <typename Iterator>
+class offset_iterator : public iterator_adaptor<offset_iterator<Iterator>, Iterator>
+{
+  //! \cond
+  friend class iterator_core_access;
+  using super_t = iterator_adaptor<offset_iterator<Iterator>, Iterator>;
+
+public:
+  using reference       = typename super_t::reference;
+  using difference_type = typename super_t::difference_type;
+  //! \endcond
+
+  _CCCL_HOST_DEVICE offset_iterator(Iterator it = {}, difference_type offset = {})
+      : super_t(::cuda::std::move(it))
+      , m_offset(offset)
+  {}
+
+  _CCCL_HOST_DEVICE const difference_type& offset() const
+  {
+    return m_offset;
+  }
+
+  _CCCL_HOST_DEVICE difference_type& offset()
+  {
+    return m_offset;
+  }
+
+  //! \cond
+
+private:
+  _CCCL_HOST_DEVICE reference dereference() const
+  {
+    return *(this->base() + m_offset);
+  }
+
+  _CCCL_EXEC_CHECK_DISABLE
+  _CCCL_HOST_DEVICE bool equal(const offset_iterator& other) const
+  {
+    return (this->base() + m_offset) == (other.base() + other.m_offset);
+  }
+
+  _CCCL_HOST_DEVICE void advance(difference_type n)
+  {
+    m_offset += n;
+  }
+
+  _CCCL_HOST_DEVICE void increment()
+  {
+    ++m_offset;
+  }
+
+  _CCCL_HOST_DEVICE void decrement()
+  {
+    --m_offset;
+  }
+
+  _CCCL_EXEC_CHECK_DISABLE
+  _CCCL_HOST_DEVICE difference_type distance_to(const offset_iterator& other) const
+  {
+    return (other.base() + other.m_offset) - (this->base() + m_offset);
+  }
+
+  difference_type m_offset;
+  //! \endcond
+};
+
+template <typename Iterator>
+_CCCL_HOST_DEVICE offset_iterator(Iterator) -> offset_iterator<Iterator>;
+
+//! \} // end fancyiterators
+//! \} // end iterators
+
+THRUST_NAMESPACE_END

--- a/thrust/thrust/iterator/offset_iterator.h
+++ b/thrust/thrust/iterator/offset_iterator.h
@@ -53,6 +53,33 @@ THRUST_NAMESPACE_BEGIN
 //!   return 0;
 //! }
 //! \endcode
+//!
+//! Combining a \p offset_iterator with \p cub::FutureValue can also be used to retrieve the offset from an iterator.
+//! However, such an \p offset_iterator cannot be moved anymore, since changes to the offset can not be written back.
+//!
+//! \code
+//! #include <thrust/iterator/offset_iterator.h>
+//! #include <thrust/fill.h>
+//! #include <thrust/functional.h>
+//! #include <thrust/device_vector.h>
+//! #include <cub/util_type.h>
+//!
+//! int main()
+//! {
+//!   using thrust::placeholders::_1;
+//!   thrust::device_vector<int> data{1, 2, 3, 4};
+//!
+//!   thrust::device_vector<ptrdiff> offsets{1}; // offset is only available on device
+//!   auto offset = cub::FutureValue{thrust::make_transform_iterator(offsets.begin(), _1 * 2)};
+//!   thrust::offset_iterator iter(v.begin(), offset); // load and transform offset upon access
+//!   // iter is at position 2 (= 1 * 2) in data, and would return 3 in device code
+//!
+//!   return 0;
+//! }
+//! \endcode
+//!
+//! In the above example, the offset is loaded from a device vector, transformed by a \p transform_iterator, and then
+//! applied to the underlying iterator, when the \p offset_iterator is accessed.
 template <typename Iterator, typename Offset = typename ::cuda::std::iterator_traits<Iterator>::difference_type>
 class offset_iterator : public iterator_adaptor<offset_iterator<Iterator, Offset>, Iterator>
 {

--- a/thrust/thrust/iterator/offset_iterator.h
+++ b/thrust/thrust/iterator/offset_iterator.h
@@ -28,13 +28,13 @@ THRUST_NAMESPACE_BEGIN
 //! \ingroup iterators
 //! \{
 
-//! \p offset_iterator wraps another iterator and an integral offset, apply the offset to the iterator when
+//! \p offset_iterator wraps another iterator and an integral offset, applies the offset to the iterator when
 //! dereferencing, comparing, or computing the distance between two offset_iterators. This is useful, when the
 //! underlying iterator cannot be incremented, decremented, or advanced (e.g., because those operations are only
 //! supported in device code).
 //!
 //!
-//! The following code snippet demonstrates how to create a \p offset_iterator:
+//! The following code snippet demonstrates how to create an \p offset_iterator:
 //!
 //! \code
 //! #include <thrust/iterator/offset_iterator.h>
@@ -71,7 +71,7 @@ THRUST_NAMESPACE_BEGIN
 //!
 //!   thrust::device_vector<ptrdiff> offsets{1}; // offset is only available on device
 //!   auto offset = thrust::make_transform_iterator(offsets.begin(), _1 * 2);
-//!   thrust::offset_iterator iter(v.begin(), offset); // load and transform offset upon access
+//!   thrust::offset_iterator iter(data.begin(), offset); // load and transform offset upon access
 //!   // iter is at position 2 (= 1 * 2) in data, and would return 3 in device code
 //!
 //!   return 0;


### PR DESCRIPTION
Adds a new `offset_iterator` to Thrust that bundles a base iterator and a offset. The offset is either a value or an `indirectly_readable`. Dereferencing and comparing iterators will apply the offset to the base iterator. if the offset is `indirectly_readable`, the offset value will be loaded as required.

This iterator has two use cases with different mechanics:
1. A user can wrap an iterator that cannot be advanced (e.g. `+=`) in host code inside an `offset_iterator`. Advancing the offset iterator will advance the offset and not the base iterator. This enables to use such iterators in host code as well.
2. We can build an iterator on the host applying an offset that lives in device memory at a later point in time. This is useful when we launch algorithms with iterator positions depending on a previous algorithm's outcome (see select_if example). Advancing such an iterator will advance the base iterator instead, to avoid concurrent access to the indirectly accessed offset in case the iterator is copied and advanced on multiple threads.

Related: #3767
