### PR TITLE
Extend `cub::FutureValue`

### DIFF
--- a/cub/cub/util_type.cuh
+++ b/cub/cub/util_type.cuh
@@ -262,10 +262,17 @@ struct FutureValue
 {
   using value_type    = T;
   using iterator_type = IterT;
+
   explicit _CCCL_HOST_DEVICE _CCCL_FORCEINLINE FutureValue(IterT iter)
       : m_iter(iter)
   {}
-  _CCCL_HOST_DEVICE _CCCL_FORCEINLINE operator T()
+
+  _CCCL_HOST_DEVICE _CCCL_FORCEINLINE operator const T&() const
+  {
+    return *m_iter;
+  }
+
+  _CCCL_HOST_DEVICE _CCCL_FORCEINLINE operator T&()
   {
     return *m_iter;
   }
@@ -273,6 +280,9 @@ struct FutureValue
 private:
   IterT m_iter;
 };
+
+template <typename IterT>
+FutureValue(IterT) -> FutureValue<detail::it_value_t<IterT>, IterT>;
 
 namespace detail
 {

--- a/cub/cub/util_type.cuh
+++ b/cub/cub/util_type.cuh
@@ -267,7 +267,7 @@ struct FutureValue
       : m_iter(iter)
   {}
 
-  _CCCL_HOST_DEVICE _CCCL_FORCEINLINE operator const T&() const noexcept
+  _CCCL_HOST_DEVICE _CCCL_FORCEINLINE operator T() const noexcept
   {
     return *m_iter;
   }

--- a/cub/cub/util_type.cuh
+++ b/cub/cub/util_type.cuh
@@ -272,11 +272,6 @@ struct FutureValue
     return *m_iter;
   }
 
-  _CCCL_HOST_DEVICE _CCCL_FORCEINLINE operator T&() noexcept
-  {
-    return *m_iter;
-  }
-
 private:
   IterT m_iter;
 };

--- a/cub/cub/util_type.cuh
+++ b/cub/cub/util_type.cuh
@@ -267,12 +267,12 @@ struct FutureValue
       : m_iter(iter)
   {}
 
-  _CCCL_HOST_DEVICE _CCCL_FORCEINLINE operator const T&() const
+  _CCCL_HOST_DEVICE _CCCL_FORCEINLINE operator const T&() const noexcept
   {
     return *m_iter;
   }
 
-  _CCCL_HOST_DEVICE _CCCL_FORCEINLINE operator T&()
+  _CCCL_HOST_DEVICE _CCCL_FORCEINLINE operator T&() noexcept
   {
     return *m_iter;
   }

--- a/cub/test/catch2_test_util_type.cu
+++ b/cub/test/catch2_test_util_type.cu
@@ -107,3 +107,27 @@ C2H_TEST("Test CustomHalf", "[util][type]")
   CHECK(cuda::std::numeric_limits<half_t>::max() == half_t::max());
   CHECK(cuda::std::numeric_limits<half_t>::lowest() == half_t::lowest());
 }
+
+C2H_TEST("Test FutureValue", "[util][type]")
+{
+  // read
+  int value;
+  cub::FutureValue<int> fv{&value};
+  value = 42;
+  CHECK(fv == 42);
+  value = 43;
+  CHECK(fv == 43);
+
+  // write
+  ++fv;
+  CHECK(value == 44);
+
+  // CTAD
+  cub::FutureValue fv2{&value};
+  STATIC_REQUIRE(::cuda::std::is_same_v<decltype(fv2), cub::FutureValue<int, int*>>);
+
+  c2h::device_vector<int> v(0);
+  cub::FutureValue fv3{v.begin()};
+  STATIC_REQUIRE(
+    ::cuda::std::is_same_v<decltype(fv3), cub::FutureValue<int, typename c2h::device_vector<int>::iterator>>);
+}

--- a/cub/test/catch2_test_util_type.cu
+++ b/cub/test/catch2_test_util_type.cu
@@ -118,10 +118,6 @@ C2H_TEST("Test FutureValue", "[util][type]")
   value = 43;
   CHECK(fv == 43);
 
-  // write
-  ++fv;
-  CHECK(value == 44);
-
   // CTAD
   cub::FutureValue fv2{&value};
   STATIC_REQUIRE(::cuda::std::is_same_v<decltype(fv2), cub::FutureValue<int, int*>>);


### PR DESCRIPTION
This PR:
* ~~Allows write access to the future value (up for debate, I don't necessarily need it, but it would allow an indirect `offset_iterator` (with a `FutureValue` as offset) to be moved. See also: #4073~~
* Make getting the value out a `const` operation
* Adds a deduction guide
* Adds tests