### PR TITLE
Allow zero size bitmask

### DIFF
--- a/docs/libcudacxx/extended_api/bit/bitfield_extract.rst
+++ b/docs/libcudacxx/extended_api/bit/bitfield_extract.rst
@@ -29,7 +29,7 @@ The function extracts a bitfield from a value and returns it in the lower bits.
 **Preconditions**
 
     - ``start >= 0 && start < num_bits(T)``
-    - ``width >  0 && width <= num_bits(T)``
+    - ``width >= 0 && width <= num_bits(T)``
     - ``start + width <= num_bits(T)``
 
 **Performance considerations**

--- a/docs/libcudacxx/extended_api/bit/bitfield_insert.rst
+++ b/docs/libcudacxx/extended_api/bit/bitfield_insert.rst
@@ -29,7 +29,7 @@ The function extracts the lower bitfield of size ``width`` from ``source`` and i
 **Preconditions**
 
     - ``start >= 0 && start < num_bits(T)``
-    - ``width >  0 && width <= num_bits(T)``
+    - ``width >= 0 && width <= num_bits(T)``
     - ``start + width <= num_bits(T)``
 
 **Performance considerations**

--- a/docs/libcudacxx/extended_api/bit/bitmask.rst
+++ b/docs/libcudacxx/extended_api/bit/bitmask.rst
@@ -27,7 +27,7 @@ The function generates a bitmask of size ``width`` starting at position ``start`
 **Preconditions**
 
     - ``start >= 0 && start < num_bits(T)``
-    - ``width >  0 && width <= num_bits(T)``
+    - ``width >= 0 && width <= num_bits(T)``
     - ``start + width <= num_bits(T)``
 
 **Performance considerations**

--- a/libcudacxx/include/cuda/__bit/bitfield.h
+++ b/libcudacxx/include/cuda/__bit/bitfield.h
@@ -69,7 +69,7 @@ bitfield_insert(const _Tp __dest, const _Tp __source, int __start, int __width) 
 {
   static_assert(_CUDA_VSTD::__cccl_is_unsigned_integer_v<_Tp>, "bitfield_insert() requires unsigned integer types");
   constexpr auto __digits = _CUDA_VSTD::numeric_limits<_Tp>::digits;
-  _CCCL_ASSERT(__width > 0 && __width <= __digits, "width out of range");
+  _CCCL_ASSERT(__width >= 0 && __width <= __digits, "width out of range");
   _CCCL_ASSERT(__start >= 0 && __start < __digits, "start position out of range");
   _CCCL_ASSERT(__start + __width <= __digits, "start position + width out of range");
   if constexpr (sizeof(_Tp) <= sizeof(uint64_t))
@@ -95,7 +95,7 @@ bitfield_extract(const _Tp __value, int __start, int __width) noexcept
 {
   static_assert(_CUDA_VSTD::__cccl_is_unsigned_integer_v<_Tp>, "bitfield_extract() requires unsigned integer types");
   constexpr auto __digits = _CUDA_VSTD::numeric_limits<_Tp>::digits;
-  _CCCL_ASSERT(__width > 0 && __width <= __digits, "width out of range");
+  _CCCL_ASSERT(__width >= 0 && __width <= __digits, "width out of range");
   _CCCL_ASSERT(__start >= 0 && __start < __digits, "start position out of range");
   _CCCL_ASSERT(__start + __width <= __digits, "start position + width out of range");
   if constexpr (sizeof(_Tp) <= sizeof(uint32_t))

--- a/libcudacxx/include/cuda/__bit/bitmask.h
+++ b/libcudacxx/include/cuda/__bit/bitmask.h
@@ -61,7 +61,7 @@ _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp bitmask(int __start, int
 {
   static_assert(_CUDA_VSTD::__cccl_is_unsigned_integer_v<_Tp>, "bitmask() requires unsigned integer types");
   constexpr auto __digits = _CUDA_VSTD::numeric_limits<_Tp>::digits;
-  _CCCL_ASSERT(__width > 0 && __width <= __digits, "width out of range");
+  _CCCL_ASSERT(__width >= 0 && __width <= __digits, "width out of range");
   _CCCL_ASSERT(__start >= 0 && __start < __digits, "start position out of range");
   _CCCL_ASSERT(__start + __width <= __digits, "start position + width out of range");
   if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())

--- a/libcudacxx/test/libcudacxx/cuda/bit/bitfield.fail.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/bit/bitfield.fail.cpp
@@ -17,17 +17,16 @@
 int main(int, char**)
 {
   using T = uint32_t;
-  static_assert(cuda::bitfield_insert(int{0}, int{0}, 0, 0));
-  static_assert(cuda::bitfield_insert(T{0}, T{0}, -1, 0));
+  static_assert(cuda::bitfield_insert(T{0}, T{0}, -1, 1));
   static_assert(cuda::bitfield_insert(T{0}, T{0}, 0, -1));
   static_assert(cuda::bitfield_insert(T{0}, T{0}, 0, 33));
-  static_assert(cuda::bitfield_insert(T{0}, T{0}, 32, 0));
+  static_assert(cuda::bitfield_insert(T{0}, T{0}, 32, 1));
   static_assert(cuda::bitfield_insert(T{0}, T{0}, 20, 20));
 
-  static_assert(cuda::bitfield_extract(T{0}, -1, 0));
+  static_assert(cuda::bitfield_extract(T{0}, -1, 1));
   static_assert(cuda::bitfield_extract(T{0}, 0, -1));
   static_assert(cuda::bitfield_extract(T{0}, 0, 33));
-  static_assert(cuda::bitfield_extract(T{0}, 32, 0));
+  static_assert(cuda::bitfield_extract(T{0}, 31, 1));
   static_assert(cuda::bitfield_extract(T{0}, 20, 20));
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/cuda/bit/bitfield.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/bit/bitfield.pass.cpp
@@ -23,6 +23,7 @@ __host__ __device__ constexpr bool test()
   assert(cuda::bitfield_insert(T{0}, all_ones, 0, 1) == 1);
   assert(cuda::bitfield_insert(T{0}, all_ones, 1, 1) == 0b10);
   assert(cuda::bitfield_insert(T{0b10}, all_ones, 0, 1) == 0b11);
+  static_assert(cuda::bitfield_insert(all_ones, all_ones, 0, 0) == all_ones);
   assert(cuda::bitfield_insert(all_ones, all_ones, 0, 1) == all_ones);
   assert(cuda::bitfield_insert(all_ones, all_ones, 2, 1) == all_ones);
   assert(cuda::bitfield_insert(all_ones, T{0b1000}, 1, 2) == (all_ones & static_cast<T>(~T{0b110})));
@@ -38,6 +39,7 @@ __host__ __device__ constexpr bool test()
   assert(cuda::bitfield_extract(T{0b1011}, 0, 1) == 1);
   assert(cuda::bitfield_extract(T{0b1011}, 1, 1) == 1);
   assert(cuda::bitfield_extract(T{0b1011}, 2, 2) == 0b10);
+  assert(cuda::bitfield_extract(all_ones, 0, 0) == 0);
   assert(cuda::bitfield_extract(all_ones, 0, 4) == 0b1111);
   assert(cuda::bitfield_extract(all_ones, 2, 4) == 0b1111);
 

--- a/libcudacxx/test/libcudacxx/cuda/bit/bitmask.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/bit/bitmask.pass.cpp
@@ -20,7 +20,9 @@ __host__ __device__ constexpr bool test()
   using nl             = cuda::std::numeric_limits<T>;
   constexpr T all_ones = static_cast<T>(~T{0});
   unused(all_ones);
+  assert(cuda::bitmask<T>(0, 0) == 0);
   assert(cuda::bitmask<T>(0, 1) == 1);
+  assert(cuda::bitmask<T>(1, 0) == 0);
   assert(cuda::bitmask<T>(1, 1) == 0b10);
   assert(cuda::bitmask<T>(0, 2) == 0b11);
   assert(cuda::bitmask<T>(2, 2) == 0b1100);


### PR DESCRIPTION
## Description

Discussed with @elstehle. 
`cuda::bitmask`, `cuda::bitfield_extract` , and `cuda::bitfield_insert` currently prevent zero-size bitwidth. This slightly limit their flexibility. The PR allows this behavior