### PR TITLE
Always define `LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE` when using cudax memory resources

### DIFF
--- a/cudax/include/cuda/experimental/__memory_resource/any_resource.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/any_resource.cuh
@@ -21,16 +21,6 @@
 #  pragma system_header
 #endif // no system header
 
-// If the memory resource header was included without the experimental flag,
-// tell the user to define the experimental flag.
-#if defined(_CUDA_MEMORY_RESOURCE) && !defined(LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE)
-#  error "To use the experimental memory resource, define LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE"
-#endif
-
-#if !defined(LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE)
-#  define LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE
-#endif
-
 #include <cuda/__memory_resource/get_property.h>
 #include <cuda/__memory_resource/properties.h>
 #include <cuda/__memory_resource/resource.h>

--- a/cudax/include/cuda/experimental/__memory_resource/get_memory_resource.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/get_memory_resource.cuh
@@ -21,16 +21,6 @@
 #  pragma system_header
 #endif // no system header
 
-// If the memory resource header was included without the experimental flag,
-// tell the user to define the experimental flag.
-#if defined(_CUDA_MEMORY_RESOURCE) && !defined(LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE)
-#  error "To use the experimental memory resource, define LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE"
-#endif
-
-#if !defined(LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE)
-#  define LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE
-#endif
-
 #include <cuda/__memory_resource/properties.h>
 #include <cuda/std/__type_traits/is_same.h>
 

--- a/cudax/include/cuda/experimental/__memory_resource/properties.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/properties.cuh
@@ -21,16 +21,6 @@
 #  pragma system_header
 #endif // no system header
 
-// If the memory resource header was included without the experimental flag,
-// tell the user to define the experimental flag.
-#if defined(_CUDA_MEMORY_RESOURCE) && !defined(LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE)
-#  error "To use the experimental memory resource, define LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE"
-#endif
-
-#if !defined(LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE)
-#  define LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE
-#endif
-
 #include <cuda/__memory_resource/get_property.h>
 #include <cuda/__memory_resource/properties.h>
 

--- a/cudax/include/cuda/experimental/__memory_resource/shared_resource.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/shared_resource.cuh
@@ -21,16 +21,6 @@
 #  pragma system_header
 #endif // no system header
 
-// If the memory resource header was included without the experimental flag,
-// tell the user to define the experimental flag.
-#if defined(_CUDA_MEMORY_RESOURCE) && !defined(LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE)
-#  error "To use the experimental memory resource, define LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE"
-#endif
-
-#if !defined(LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE)
-#  define LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE
-#endif
-
 #include <cuda/__memory_resource/resource.h>
 #include <cuda/std/__new_>
 #include <cuda/std/__type_traits/is_swappable.h>

--- a/cudax/include/cuda/experimental/memory_resource.cuh
+++ b/cudax/include/cuda/experimental/memory_resource.cuh
@@ -11,6 +11,17 @@
 #ifndef __CUDAX_MEMORY_RESOURCE___
 #define __CUDAX_MEMORY_RESOURCE___
 
+// If the memory resource header was included without the experimental flag,
+// tell the user to define the experimental flag.
+#ifndef LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE
+#  ifdef _CUDA_MEMORY_RESOURCE
+#    error "To use the experimental memory resource, define LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE"
+#  else // ^^^ _CUDA_MEMORY_RESOURCE ^^^ / vvv !_CUDA_MEMORY_RESOURCE vvv
+#    warning "To use the experimental memory resource, define LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE"
+#    define LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE
+#  endif // _CUDA_MEMORY_RESOURCE
+#endif // !LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE
+
 #include <cuda/experimental/__memory_resource/any_resource.cuh>
 #include <cuda/experimental/__memory_resource/device_memory_pool.cuh>
 #include <cuda/experimental/__memory_resource/device_memory_resource.cuh>


### PR DESCRIPTION
We also add a warning so that users are aware they should define `LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE`
