### PR TITLE
Enable cmath traits for `__half` and `__nv_bfloat16` before CUDA 12.2

### DIFF
--- a/libcudacxx/include/cuda/std/__cmath/abs.h
+++ b/libcudacxx/include/cuda/std/__cmath/abs.h
@@ -76,23 +76,23 @@ _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double fabs(long double __x) noex
 }
 #endif // _CCCL_HAS_LONG_DOUBLE()
 
-#if _LIBCUDACXX_HAS_NVFP16()
+#if _CCCL_HAS_NVFP16()
 _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr __half fabs(__half __x) noexcept
 {
   // We cannot use `abs.f16` because it is not IEEE 754 compliant, see docs
   const auto __val = _CUDA_VSTD::__cccl_fp_get_storage(__x) & __cccl_nvfp16_exp_mant_mask;
   return _CUDA_VSTD::__cccl_make_nvfp16_from_storage(static_cast<uint16_t>(__val));
 }
-#endif // _LIBCUDACXX_HAS_NVFP16()
+#endif // _CCCL_HAS_NVFP16()
 
-#if _LIBCUDACXX_HAS_NVBF16()
+#if _CCCL_HAS_NVBF16()
 _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr __nv_bfloat16 fabs(__nv_bfloat16 __x) noexcept
 {
   // We cannot use `abs.bf16` because it is not IEEE 754 compliant, see docs
   const auto __val = _CUDA_VSTD::__cccl_fp_get_storage(__x) & __cccl_nvbf16_exp_mant_mask;
   return _CUDA_VSTD::__cccl_make_nvbf16_from_storage(static_cast<uint16_t>(__val));
 }
-#endif // _LIBCUDACXX_HAS_NVBF16()
+#endif // _CCCL_HAS_NVBF16()
 
 #if _CCCL_HAS_NVFP8_E4M3()
 _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr __nv_fp8_e4m3 fabs(__nv_fp8_e4m3 __x) noexcept

--- a/libcudacxx/include/cuda/std/__cmath/copysign.h
+++ b/libcudacxx/include/cuda/std/__cmath/copysign.h
@@ -66,23 +66,23 @@ _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double copysign(long double __x, 
 }
 #endif // _CCCL_HAS_LONG_DOUBLE()
 
-#if _LIBCUDACXX_HAS_NVFP16()
+#if _CCCL_HAS_NVFP16()
 _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr __half copysign(__half __x, __half __y) noexcept
 {
   const auto __val = (_CUDA_VSTD::__cccl_fp_get_storage(__x) & __cccl_nvfp16_exp_mant_mask)
                    | (_CUDA_VSTD::__cccl_fp_get_storage(__y) & __cccl_nvfp16_sign_mask);
   return _CUDA_VSTD::__cccl_make_nvfp16_from_storage(static_cast<uint16_t>(__val));
 }
-#endif // _LIBCUDACXX_HAS_NVFP16()
+#endif // _CCCL_HAS_NVFP16()
 
-#if _LIBCUDACXX_HAS_NVBF16()
+#if _CCCL_HAS_NVBF16()
 _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr __nv_bfloat16 copysign(__nv_bfloat16 __x, __nv_bfloat16 __y) noexcept
 {
   const auto __val = (_CUDA_VSTD::__cccl_fp_get_storage(__x) & __cccl_nvbf16_exp_mant_mask)
                    | (_CUDA_VSTD::__cccl_fp_get_storage(__y) & __cccl_nvbf16_sign_mask);
   return _CUDA_VSTD::__cccl_make_nvbf16_from_storage(static_cast<uint16_t>(__val));
 }
-#endif // _LIBCUDACXX_HAS_NVBF16()
+#endif // _CCCL_HAS_NVBF16()
 
 #if _CCCL_HAS_NVFP8_E4M3()
 _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr __nv_fp8_e4m3 copysign(__nv_fp8_e4m3 __x, __nv_fp8_e4m3 __y) noexcept

--- a/libcudacxx/include/cuda/std/__cmath/fpclassify.h
+++ b/libcudacxx/include/cuda/std/__cmath/fpclassify.h
@@ -139,7 +139,7 @@ _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr int fpclassify(long double _
 }
 #endif // _CCCL_HAS_LONG_DOUBLE()
 
-#if _LIBCUDACXX_HAS_NVFP16()
+#if _CCCL_HAS_NVFP16()
 _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr int fpclassify(__half __x) noexcept
 {
   const auto __storage = _CUDA_VSTD::__cccl_fp_get_storage(__x);
@@ -153,9 +153,9 @@ _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr int fpclassify(__half __x) n
   }
   return FP_NORMAL;
 }
-#endif // _LIBCUDACXX_HAS_NVFP16()
+#endif // _CCCL_HAS_NVFP16()
 
-#if _LIBCUDACXX_HAS_NVBF16()
+#if _CCCL_HAS_NVBF16()
 _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr int fpclassify(__nv_bfloat16 __x) noexcept
 {
   const auto __storage = _CUDA_VSTD::__cccl_fp_get_storage(__x);
@@ -169,7 +169,7 @@ _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr int fpclassify(__nv_bfloat16
   }
   return FP_NORMAL;
 }
-#endif // _LIBCUDACXX_HAS_NVBF16()
+#endif // _CCCL_HAS_NVBF16()
 
 #if _CCCL_HAS_NVFP8_E4M3()
 _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr int fpclassify(__nv_fp8_e4m3 __x) noexcept

--- a/libcudacxx/include/cuda/std/__cmath/isfinite.h
+++ b/libcudacxx/include/cuda/std/__cmath/isfinite.h
@@ -91,19 +91,19 @@ _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr bool isfinite(long double __
 }
 #endif // _CCCL_HAS_LONG_DOUBLE()
 
-#if _LIBCUDACXX_HAS_NVFP16()
+#if _CCCL_HAS_NVFP16()
 _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr bool isfinite(__half __x) noexcept
 {
   return (_CUDA_VSTD::__cccl_fp_get_storage(__x) & __cccl_nvfp16_exp_mask) != __cccl_nvfp16_exp_mask;
 }
-#endif // _LIBCUDACXX_HAS_NVFP16()
+#endif // _CCCL_HAS_NVFP16()
 
-#if _LIBCUDACXX_HAS_NVBF16()
+#if _CCCL_HAS_NVBF16()
 _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr bool isfinite(__nv_bfloat16 __x) noexcept
 {
   return (_CUDA_VSTD::__cccl_fp_get_storage(__x) & __cccl_nvbf16_exp_mask) != __cccl_nvbf16_exp_mask;
 }
-#endif // _LIBCUDACXX_HAS_NVBF16()
+#endif // _CCCL_HAS_NVBF16()
 
 #if _CCCL_HAS_NVFP8_E4M3()
 _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr bool isfinite(__nv_fp8_e4m3 __x) noexcept

--- a/libcudacxx/include/cuda/std/__cmath/isinf.h
+++ b/libcudacxx/include/cuda/std/__cmath/isinf.h
@@ -106,37 +106,41 @@ _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr bool isinf(long double __x) 
 }
 #endif // _CCCL_HAS_LONG_DOUBLE()
 
-#if _LIBCUDACXX_HAS_NVFP16()
+#if _CCCL_HAS_NVFP16()
 _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr bool isinf(__half __x) noexcept
 {
+#  if _LIBCUDACXX_HAS_NVFP16()
   if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
   {
-#  if _CCCL_STD_VER >= 2020 && _CCCL_CUDACC_BELOW(12, 3)
+#    if _CCCL_STD_VER >= 2020 && _CCCL_CUDACC_BELOW(12, 3)
     // this is a workaround for nvbug 4362808
     return !::__hisnan(__x) && ::__hisnan(__x - __x);
-#  else // ^^^ C++20 && below 12.3 ^^^ / vvv C++17 or 12.3+ vvv
+#    else // ^^^ C++20 && below 12.3 ^^^ / vvv C++17 or 12.3+ vvv
     return ::__hisinf(__x) != 0;
-#  endif // _CCCL_STD_VER <= 2017 || _CCCL_CUDACC_BELOW(12, 3)
+#    endif // _CCCL_STD_VER <= 2017 || _CCCL_CUDACC_BELOW(12, 3)
   }
+#  endif // _LIBCUDACXX_HAS_NVFP16()
   return (_CUDA_VSTD::__cccl_fp_get_storage(__x) & __cccl_nvfp16_exp_mant_mask) == __cccl_nvfp16_exp_mask;
 }
-#endif // _LIBCUDACXX_HAS_NVFP16()
+#endif // _CCCL_HAS_NVFP16()
 
-#if _LIBCUDACXX_HAS_NVBF16()
+#if _CCCL_HAS_NVBF16()
 _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr bool isinf(__nv_bfloat16 __x) noexcept
 {
+#  if _LIBCUDACXX_HAS_NVBF16()
   if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
   {
-#  if _CCCL_STD_VER >= 2020 && _CCCL_CUDACC_BELOW(12, 3)
+#    if _CCCL_STD_VER >= 2020 && _CCCL_CUDACC_BELOW(12, 3)
     // this is a workaround for nvbug 4362808
     return !::__hisnan(__x) && ::__hisnan(__x - __x);
-#  else // ^^^ C++20 && below 12.3 ^^^ / vvv C++17 or 12.3+ vvv
+#    else // ^^^ C++20 && below 12.3 ^^^ / vvv C++17 or 12.3+ vvv
     return ::__hisinf(__x) != 0;
-#  endif // _CCCL_STD_VER <= 2017 || _CCCL_CUDACC_BELOW(12, 3)
+#    endif // _CCCL_STD_VER <= 2017 || _CCCL_CUDACC_BELOW(12, 3)
   }
+#  endif // _LIBCUDACXX_HAS_NVBF16()
   return (_CUDA_VSTD::__cccl_fp_get_storage(__x) & __cccl_nvbf16_exp_mant_mask) == __cccl_nvbf16_exp_mask;
 }
-#endif // _LIBCUDACXX_HAS_NVBF16()
+#endif // _CCCL_HAS_NVBF16()
 
 #if _CCCL_HAS_NVFP8_E4M3()
 _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr bool isinf(__nv_fp8_e4m3) noexcept

--- a/libcudacxx/include/cuda/std/__cmath/isnan.h
+++ b/libcudacxx/include/cuda/std/__cmath/isnan.h
@@ -74,31 +74,35 @@ _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr bool isnan(long double __x) 
 }
 #endif // _CCCL_HAS_LONG_DOUBLE()
 
-#if _LIBCUDACXX_HAS_NVFP16()
+#if _CCCL_HAS_NVFP16()
 _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr bool isnan(__half __x) noexcept
 {
+#  if _LIBCUDACXX_HAS_NVFP16()
   if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
   {
     return ::__hisnan(__x);
   }
+#  endif // _LIBCUDACXX_HAS_NVFP16()
 
   const auto __storage = _CUDA_VSTD::__cccl_fp_get_storage(__x);
   return ((__storage & __cccl_nvfp16_exp_mask) == __cccl_nvfp16_exp_mask) && (__storage & __cccl_nvfp16_mant_mask);
 }
-#endif // _LIBCUDACXX_HAS_NVFP16()
+#endif // _CCCL_HAS_NVFP16()
 
-#if _LIBCUDACXX_HAS_NVBF16()
+#if _CCCL_HAS_NVBF16()
 _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr bool isnan(__nv_bfloat16 __x) noexcept
 {
+#  if _LIBCUDACXX_HAS_NVFP16()
   if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
   {
     return ::__hisnan(__x);
   }
+#  endif // _LIBCUDACXX_HAS_NVFP16()
 
   const auto __storage = _CUDA_VSTD::__cccl_fp_get_storage(__x);
   return ((__storage & __cccl_nvbf16_exp_mask) == __cccl_nvbf16_exp_mask) && (__storage & __cccl_nvbf16_mant_mask);
 }
-#endif // _LIBCUDACXX_HAS_NVBF16()
+#endif // _CCCL_HAS_NVBF16()
 
 #if _CCCL_HAS_NVFP8_E4M3()
 _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr bool isnan(__nv_fp8_e4m3 __x) noexcept

--- a/libcudacxx/include/cuda/std/__cmath/isnormal.h
+++ b/libcudacxx/include/cuda/std/__cmath/isnormal.h
@@ -57,19 +57,19 @@ _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr bool isnormal(long double __
 }
 #endif // _CCCL_HAS_LONG_DOUBLE()
 
-#if _LIBCUDACXX_HAS_NVFP16()
+#if _CCCL_HAS_NVFP16()
 _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr bool isnormal(__half __x) noexcept
 {
   return _CUDA_VSTD::fpclassify(__x) == FP_NORMAL;
 }
-#endif // _LIBCUDACXX_HAS_NVFP16()
+#endif // _CCCL_HAS_NVFP16()
 
-#if _LIBCUDACXX_HAS_NVBF16()
+#if _CCCL_HAS_NVBF16()
 _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr bool isnormal(__nv_bfloat16 __x) noexcept
 {
   return _CUDA_VSTD::fpclassify(__x) == FP_NORMAL;
 }
-#endif // _LIBCUDACXX_HAS_NVBF16()
+#endif // _CCCL_HAS_NVBF16()
 
 #if _CCCL_HAS_NVFP8_E4M3()
 _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr bool isnormal(__nv_fp8_e4m3 __x) noexcept

--- a/libcudacxx/include/cuda/std/__cmath/signbit.h
+++ b/libcudacxx/include/cuda/std/__cmath/signbit.h
@@ -63,19 +63,19 @@ _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI bool signbit(long double __x) noexcept
 }
 #endif // _CCCL_HAS_LONG_DOUBLE()
 
-#if _LIBCUDACXX_HAS_NVFP16()
+#if _CCCL_HAS_NVFP16()
 _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr bool signbit(__half __x) noexcept
 {
   return _CUDA_VSTD::__cccl_fp_get_storage(__x) & __cccl_nvfp16_sign_mask;
 }
-#endif // _LIBCUDACXX_HAS_NVFP16()
+#endif // _CCCL_HAS_NVFP16()
 
-#if _LIBCUDACXX_HAS_NVBF16()
+#if _CCCL_HAS_NVBF16()
 _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr bool signbit(__nv_bfloat16 __x) noexcept
 {
   return _CUDA_VSTD::__cccl_fp_get_storage(__x) & __cccl_nvbf16_sign_mask;
 }
-#endif // _LIBCUDACXX_HAS_NVBF16()
+#endif // _CCCL_HAS_NVBF16()
 
 #if _CCCL_HAS_NVFP8_E4M3()
 _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr bool signbit(__nv_fp8_e4m3 __x) noexcept

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/fp_manip/copysign.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/fp_manip/copysign.pass.cpp
@@ -116,12 +116,12 @@ __host__ __device__ constexpr bool test()
 #if _CCCL_HAS_LONG_DOUBLE()
   test_type<long double>();
 #endif // _CCCL_HAS_LONG_DOUBLE()
-#if _LIBCUDACXX_HAS_NVFP16()
+#if _CCCL_HAS_NVFP16()
   test_type<__half>();
-#endif // _LIBCUDACXX_HAS_NVFP16()
-#if _LIBCUDACXX_HAS_NVBF16()
+#endif // _CCCL_HAS_NVFP16()
+#if _CCCL_HAS_NVBF16()
   test_type<__nv_bfloat16>();
-#endif // _LIBCUDACXX_HAS_NVBF16()
+#endif // _CCCL_HAS_NVBF16()
 #if _CCCL_HAS_NVFP8_E4M3()
   test_type<__nv_fp8_e4m3>();
 #endif // _CCCL_HAS_NVFP8_E4M3

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/fp_traits/fpclassify.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/fp_traits/fpclassify.pass.cpp
@@ -104,12 +104,12 @@ __host__ __device__ constexpr bool test()
 #if _CCCL_HAS_LONG_DOUBLE()
   test_type<long double>();
 #endif // _CCCL_HAS_LONG_DOUBLE()
-#if _LIBCUDACXX_HAS_NVFP16()
+#if _CCCL_HAS_NVFP16()
   test_type<__half>();
-#endif // _LIBCUDACXX_HAS_NVFP16()
-#if _LIBCUDACXX_HAS_NVBF16()
+#endif // _CCCL_HAS_NVFP16()
+#if _CCCL_HAS_NVBF16()
   test_type<__nv_bfloat16>();
-#endif // _LIBCUDACXX_HAS_NVBF16()
+#endif // _CCCL_HAS_NVBF16()
 #if _CCCL_HAS_NVFP8_E4M3()
   test_type<__nv_fp8_e4m3>();
 #endif // _CCCL_HAS_NVFP8_E4M3

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/fp_traits/isfinite.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/fp_traits/isfinite.pass.cpp
@@ -91,12 +91,12 @@ __host__ __device__ constexpr bool test()
 #if _CCCL_HAS_LONG_DOUBLE()
   test_type<long double>();
 #endif // _CCCL_HAS_LONG_DOUBLE()
-#if _LIBCUDACXX_HAS_NVFP16()
+#if _CCCL_HAS_NVFP16()
   test_type<__half>();
-#endif // _LIBCUDACXX_HAS_NVFP16()
-#if _LIBCUDACXX_HAS_NVBF16()
+#endif // _CCCL_HAS_NVFP16()
+#if _CCCL_HAS_NVBF16()
   test_type<__nv_bfloat16>();
-#endif // _LIBCUDACXX_HAS_NVBF16()
+#endif // _CCCL_HAS_NVBF16()
 #if _CCCL_HAS_NVFP8_E4M3()
   test_type<__nv_fp8_e4m3>();
 #endif // _CCCL_HAS_NVFP8_E4M3

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/fp_traits/isinf.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/fp_traits/isinf.pass.cpp
@@ -91,12 +91,12 @@ __host__ __device__ constexpr bool test()
 #if _CCCL_HAS_LONG_DOUBLE()
   test_type<long double>();
 #endif // _CCCL_HAS_LONG_DOUBLE()
-#if _LIBCUDACXX_HAS_NVFP16()
+#if _CCCL_HAS_NVFP16()
   test_type<__half>();
-#endif // _LIBCUDACXX_HAS_NVFP16()
-#if _LIBCUDACXX_HAS_NVBF16()
+#endif // _CCCL_HAS_NVFP16()
+#if _CCCL_HAS_NVBF16()
   test_type<__nv_bfloat16>();
-#endif // _LIBCUDACXX_HAS_NVBF16()
+#endif // _CCCL_HAS_NVBF16()
 #if _CCCL_HAS_NVFP8_E4M3()
   test_type<__nv_fp8_e4m3>();
 #endif // _CCCL_HAS_NVFP8_E4M3

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/fp_traits/isnan.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/fp_traits/isnan.pass.cpp
@@ -91,12 +91,12 @@ __host__ __device__ constexpr bool test()
 #if _CCCL_HAS_LONG_DOUBLE()
   test_type<long double>();
 #endif // _CCCL_HAS_LONG_DOUBLE()
-#if _LIBCUDACXX_HAS_NVFP16()
+#if _CCCL_HAS_NVFP16()
   test_type<__half>();
-#endif // _LIBCUDACXX_HAS_NVFP16()
-#if _LIBCUDACXX_HAS_NVBF16()
+#endif // _CCCL_HAS_NVFP16()
+#if _CCCL_HAS_NVBF16()
   test_type<__nv_bfloat16>();
-#endif // _LIBCUDACXX_HAS_NVBF16()
+#endif // _CCCL_HAS_NVBF16()
 #if _CCCL_HAS_NVFP8_E4M3()
   test_type<__nv_fp8_e4m3>();
 #endif // _CCCL_HAS_NVFP8_E4M3

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/fp_traits/isnormal.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/fp_traits/isnormal.pass.cpp
@@ -93,12 +93,12 @@ __host__ __device__ constexpr bool test()
 #if _CCCL_HAS_LONG_DOUBLE()
   test_type<long double>();
 #endif // _CCCL_HAS_LONG_DOUBLE()
-#if _LIBCUDACXX_HAS_NVFP16()
+#if _CCCL_HAS_NVFP16()
   test_type<__half>();
-#endif // _LIBCUDACXX_HAS_NVFP16()
-#if _LIBCUDACXX_HAS_NVBF16()
+#endif // _CCCL_HAS_NVFP16()
+#if _CCCL_HAS_NVBF16()
   test_type<__nv_bfloat16>();
-#endif // _LIBCUDACXX_HAS_NVBF16()
+#endif // _CCCL_HAS_NVBF16()
 #if _CCCL_HAS_NVFP8_E4M3()
   test_type<__nv_fp8_e4m3>();
 #endif // _CCCL_HAS_NVFP8_E4M3

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/fp_traits/signbit.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/fp_traits/signbit.pass.cpp
@@ -93,12 +93,12 @@ __host__ __device__ constexpr bool test()
 #if _CCCL_HAS_LONG_DOUBLE()
   test_type<long double>();
 #endif // _CCCL_HAS_LONG_DOUBLE()
-#if _LIBCUDACXX_HAS_NVFP16()
+#if _CCCL_HAS_NVFP16()
   test_type<__half>();
-#endif // _LIBCUDACXX_HAS_NVFP16()
-#if _LIBCUDACXX_HAS_NVBF16()
+#endif // _CCCL_HAS_NVFP16()
+#if _CCCL_HAS_NVBF16()
   test_type<__nv_bfloat16>();
-#endif // _LIBCUDACXX_HAS_NVBF16()
+#endif // _CCCL_HAS_NVBF16()
 #if _CCCL_HAS_NVFP8_E4M3()
   test_type<__nv_fp8_e4m3>();
 #endif // _CCCL_HAS_NVFP8_E4M3
@@ -138,12 +138,12 @@ __host__ __device__ constexpr bool test()
 
 __host__ __device__ constexpr bool test_constexpr()
 {
-#if _LIBCUDACXX_HAS_NVFP16()
+#if _CCCL_HAS_NVFP16()
   test_type<__half>();
-#endif // _LIBCUDACXX_HAS_NVFP16()
-#if _LIBCUDACXX_HAS_NVBF16()
+#endif // _CCCL_HAS_NVFP16()
+#if _CCCL_HAS_NVBF16()
   test_type<__nv_bfloat16>();
-#endif // _LIBCUDACXX_HAS_NVBF16()
+#endif // _CCCL_HAS_NVBF16()
 #if _CCCL_HAS_NVFP8_E4M3()
   test_type<__nv_fp8_e4m3>();
 #endif // _CCCL_HAS_NVFP8_E4M3


### PR DESCRIPTION
`numeric_limits` `NaN` tests use `cuda::std::isnan` to check the value, however, `cuda::std::isnan` for `__half` and `__nv_bfloat16` is unavailable before CUDA 12.2, but the `numeric_limits` are available back in CUDA 12.0.

This PR makes the `cuda::std::isnan` function available before CUDA 12.2.