### PR TITLE
Link to universal_[host_pinned_][allocator|vector] in the docs

### DIFF
--- a/docs/thrust/api_docs/containers.rst
+++ b/docs/thrust/api_docs/containers.rst
@@ -9,3 +9,5 @@ Containers
 
    ${repo_docs_api_path}/*host__vector*
    ${repo_docs_api_path}/*device__vector*
+   ${repo_docs_api_path}/*universal_vector*
+   ${repo_docs_api_path}/*universal_host_pinned_vector*

--- a/docs/thrust/api_docs/containers.rst
+++ b/docs/thrust/api_docs/containers.rst
@@ -9,5 +9,4 @@ Containers
 
    ${repo_docs_api_path}/*host__vector*
    ${repo_docs_api_path}/*device__vector*
-   ${repo_docs_api_path}/*universal_vector*
-   ${repo_docs_api_path}/*universal_host_pinned_vector*
+   ${repo_docs_api_path}/typedef_group__containers*

--- a/docs/thrust/api_docs/memory_management/allocators.rst
+++ b/docs/thrust/api_docs/memory_management/allocators.rst
@@ -6,8 +6,9 @@ Allocators
   - :cpp:class:`thrust::device_allocator <thrust::device_allocator>`
   - :cpp:class:`thrust::device_malloc_allocator <thrust::device_malloc_allocator>`
   - :cpp:class:`thrust::device_new_allocator <thrust::device_new_allocator>`
+  - :cpp:class:`thrust::universal_allocator <thrust::universal_allocator>`
+  - :cpp:class:`thrust::universal_host_pinned_allocator <thrust::universal_host_pinned_allocator>`
   - :cpp:class:`thrust::mr::allocator <thrust::mr::allocator>`
-  - :cpp:class:`thrust::mr::stateless_resource_allocator <thrust::mr::stateless_resource_allocator>`
   - :cpp:class:`thrust::mr::stateless_resource_allocator <thrust::mr::stateless_resource_allocator>`
 
 .. toctree::

--- a/thrust/thrust/system/cpp/vector.h
+++ b/thrust/thrust/system/cpp/vector.h
@@ -77,11 +77,14 @@ using vector = thrust::detail::vector_base<T, Allocator>;
  *  \see host_vector For the documentation of the complete interface which is
  *                   shared by \p cpp::universal_vector
  *  \see device_vector
- *  \see universal_vector
+ *  \see universal_host_pinned_vector
  */
 template <typename T, typename Allocator = thrust::system::cpp::universal_allocator<T>>
 using universal_vector = thrust::detail::vector_base<T, Allocator>;
 
+//! Like \ref universal_vector but uses pinned memory when the system supports it.
+//! \see device_vector
+//! \see universal_vector
 template <typename T>
 using universal_host_pinned_vector = thrust::detail::vector_base<T, universal_host_pinned_allocator<T>>;
 } // namespace cpp

--- a/thrust/thrust/system/omp/vector.h
+++ b/thrust/thrust/system/omp/vector.h
@@ -77,11 +77,14 @@ using vector = thrust::detail::vector_base<T, Allocator>;
  *  \see host_vector For the documentation of the complete interface which is
  *                   shared by \p omp::universal_vector
  *  \see device_vector
- *  \see universal_vector
+ *  \see universal_host_pinned_vector
  */
 template <typename T, typename Allocator = thrust::system::omp::universal_allocator<T>>
 using universal_vector = thrust::detail::vector_base<T, Allocator>;
 
+//! Like \ref universal_vector but uses pinned memory when the system supports it.
+//! \see device_vector
+//! \see universal_vector
 template <typename T>
 using universal_host_pinned_vector = thrust::detail::vector_base<T, universal_host_pinned_allocator<T>>;
 } // namespace omp

--- a/thrust/thrust/system/tbb/vector.h
+++ b/thrust/thrust/system/tbb/vector.h
@@ -77,11 +77,14 @@ using vector = thrust::detail::vector_base<T, Allocator>;
  *  \see host_vector For the documentation of the complete interface which is
  *                   shared by \p tbb::universal_vector
  *  \see device_vector
- *  \see universal_vector
+ *  \see universal_host_pinned_vector
  */
 template <typename T, typename Allocator = thrust::system::tbb::universal_allocator<T>>
 using universal_vector = thrust::detail::vector_base<T, Allocator>;
 
+//! Like \ref universal_vector but uses pinned memory when the system supports it.
+//! \see device_vector
+//! \see universal_vector
 template <typename T>
 using universal_host_pinned_vector = thrust::detail::vector_base<T, universal_host_pinned_allocator<T>>;
 } // namespace tbb

--- a/thrust/thrust/universal_allocator.h
+++ b/thrust/thrust/universal_allocator.h
@@ -50,6 +50,13 @@ THRUST_NAMESPACE_BEGIN
  */
 using thrust::system::__THRUST_DEVICE_SYSTEM_NAMESPACE::universal_allocator;
 
+/*! \brief An allocator which creates new elements in memory accessible by both hosts and devices. Uses pinned memory
+ *         when the system supports it.
+ *
+ *  \see https://en.cppreference.com/w/cpp/named_req/Allocator
+ */
+using thrust::system::__THRUST_DEVICE_SYSTEM_NAMESPACE::universal_host_pinned_allocator;
+
 /*! \p universal_ptr stores a pointer to an object allocated in memory accessible
  *  to both hosts and devices.
  *

--- a/thrust/thrust/universal_vector.h
+++ b/thrust/thrust/universal_vector.h
@@ -56,12 +56,14 @@ THRUST_NAMESPACE_BEGIN
  *  \see device_vector
  *  \see universal_host_pinned_vector
  */
-using thrust::system::__THRUST_DEVICE_SYSTEM_NAMESPACE::universal_vector;
+template <typename T, typename Allocator = universal_allocator<T>>
+using universal_vector = thrust::system::__THRUST_DEVICE_SYSTEM_NAMESPACE::universal_vector<T, Allocator>;
 
 //! Like \ref universal_vector but uses pinned memory when the system supports it.
 //! \see device_vector
 //! \see universal_vector
-using thrust::system::__THRUST_DEVICE_SYSTEM_NAMESPACE::universal_host_pinned_vector;
+template <typename T>
+using universal_host_pinned_vector = thrust::system::__THRUST_DEVICE_SYSTEM_NAMESPACE::universal_host_pinned_vector<T>;
 
 /*! \} // containers
  */


### PR DESCRIPTION
Also expose `thrust::universal_host_pinned_allocator`

Fixes: #4106