### PR TITLE
[CUDAX] Make fill_bytes and copy_bytes require input mdspans to be exhaustive

### DIFF
--- a/cudax/include/cuda/experimental/__algorithm/copy.cuh
+++ b/cudax/include/cuda/experimental/__algorithm/copy.cuh
@@ -106,6 +106,12 @@ void __nd_copy_bytes_impl(stream_ref __stream,
   static_assert(_CUDA_VSTD::is_same_v<_SrcLayout, _DstLayout>,
                 "Multidimensional copy requires both source and destination layouts to match");
 
+  // Check only source, because the layout of destination is the same as source
+  if (!__src.is_exhaustive())
+  {
+    _CUDA_VSTD::__throw_invalid_argument("copy_bytes supports only exhaustive mdspans");
+  }
+
   if (!__copy_bytes_runtime_extents_match(__src.extents(), __dst.extents()))
   {
     _CUDA_VSTD::__throw_invalid_argument("Copy destination size differs from the source");
@@ -120,8 +126,9 @@ void __nd_copy_bytes_impl(stream_ref __stream,
 //!
 //! Both source and destination needs to either be an instance of `cuda::std::mdspan` or launch transform to
 //! one. They can also implicitly convert to `cuda::std::mdspan`, but the type needs to contain `mdspan` template
-//! arguments as member aliases named `value_type`, `extents_type`, `layout_type` and `accessor_type`. Both source and
-//! destination type is required to be trivially copyable.
+//! arguments as member aliases named `value_type`, `extents_type`, `layout_type` and `accessor_type`.
+//! Resulting mdspan is required to be exhaustive.
+//! Both source and destination type is required to be trivially copyable.
 //!
 //! This call might be synchronous if either source or destination is pagable host memory.
 //! It will be synchronous if both destination and copy is located in host memory.

--- a/cudax/include/cuda/experimental/__algorithm/copy.cuh
+++ b/cudax/include/cuda/experimental/__algorithm/copy.cuh
@@ -106,8 +106,8 @@ void __nd_copy_bytes_impl(stream_ref __stream,
   static_assert(_CUDA_VSTD::is_same_v<_SrcLayout, _DstLayout>,
                 "Multidimensional copy requires both source and destination layouts to match");
 
-  // Check only source, because the layout of destination is the same as source
-  if (!__src.is_exhaustive())
+  // Check only destination, because the layout of destination is the same as source
+  if (!__dst.is_exhaustive())
   {
     _CUDA_VSTD::__throw_invalid_argument("copy_bytes supports only exhaustive mdspans");
   }

--- a/cudax/test/algorithm/common.cuh
+++ b/cudax/test/algorithm/common.cuh
@@ -56,6 +56,14 @@ auto make_buffer_for_mdspan(Extents extents, char value = 0)
   return buffer;
 }
 
+inline auto create_fake_strided_mdspan()
+{
+  cuda::std::dextents<size_t, 3> dynamic_extents{1, 2, 3};
+  cuda::std::array<size_t, 3> strides{12, 4, 1};
+  cuda::std::layout_stride::mapping map{dynamic_extents, strides};
+  return cuda::std::mdspan<int, decltype(dynamic_extents), cuda::std::layout_stride>(nullptr, map);
+};
+
 namespace cuda::experimental
 {
 

--- a/cudax/test/algorithm/copy.cu
+++ b/cudax/test/algorithm/copy.cu
@@ -167,3 +167,20 @@ TEST_CASE("Mdspan copy", "[data_manipulation]")
     CUDAX_REQUIRE(!memcmp(mdspan_buffer.data(), buffer.data, mdspan_buffer.size()));
   }
 }
+
+TEST_CASE("Non exhaustive mdspan copy_bytes", "[data_manipulation]")
+{
+  cudax::stream stream;
+  {
+    auto fake_strided_mdspan = create_fake_strided_mdspan();
+
+    try
+    {
+      cudax::copy_bytes(stream, fake_strided_mdspan, fake_strided_mdspan);
+    }
+    catch (const ::std::invalid_argument& e)
+    {
+      CHECK(e.what() == ::std::string("copy_bytes supports only exhaustive mdspans"));
+    }
+  }
+}

--- a/cudax/test/algorithm/fill.cu
+++ b/cudax/test/algorithm/fill.cu
@@ -73,3 +73,20 @@ TEST_CASE("Mdspan Fill", "[data_manipulation]")
     check_result_and_erase(stream, cuda::std::span(buffer.data, buffer.size));
   }
 }
+
+TEST_CASE("Non exhaustive mdspan fill_bytes", "[data_manipulation]")
+{
+  cudax::stream stream;
+  {
+    auto fake_strided_mdspan = create_fake_strided_mdspan();
+
+    try
+    {
+      cudax::fill_bytes(stream, fake_strided_mdspan, fill_byte);
+    }
+    catch (const ::std::invalid_argument& e)
+    {
+      CHECK(e.what() == ::std::string("fill_bytes supports only exhaustive mdspans"));
+    }
+  }
+}


### PR DESCRIPTION
We currently have limited support for mdspan in `copy_bytes` and `fill_bytes`, where the copy/fill is treated as a 1d copy of the entire underlying buffer.
Because we are not yet sure how we want to extend it to more complex mdspans, especially copy of non-matching layouts, for now we require the input mdspans to be exhaustive. This way we don't need to decide what happens with the non-reachable parts of the underlying memory.