### PR TITLE
[CUDAX] Rename enable/disable_peer_access_from to enable/disable_access_from in memory pools/resources

### DIFF
--- a/cudax/examples/simple_p2p.cu
+++ b/cudax/examples/simple_p2p.cu
@@ -219,9 +219,9 @@ try
 
   printf("Enabling peer access between GPU%d and GPU%d...\n", peers[0].get(), peers[1].get());
   cudax::device_memory_resource dev0_resource(peers[0]);
-  dev0_resource.enable_peer_access_from(peers[1]);
+  dev0_resource.enable_access_from(peers[1]);
   cudax::device_memory_resource dev1_resource(peers[1]);
-  dev1_resource.enable_peer_access_from(peers[0]);
+  dev1_resource.enable_access_from(peers[0]);
 
   // Allocate buffers
   constexpr size_t buf_cnt = 1024 * 1024 * 16;
@@ -239,8 +239,8 @@ try
 
   // Disable peer access
   printf("Disabling peer access...\n");
-  dev0_resource.disable_peer_access_from(peers[1]);
-  dev1_resource.disable_peer_access_from(peers[0]);
+  dev0_resource.disable_access_from(peers[1]);
+  dev1_resource.disable_access_from(peers[0]);
 
   // No cleanup needed
   printf("Test passed\n");

--- a/cudax/include/cuda/experimental/__memory_resource/memory_pool_base.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/memory_pool_base.cuh
@@ -63,7 +63,7 @@ inline void __verify_device_supports_stream_ordered_allocations(const int __devi
   }
 }
 
-//! @brief Enable peer access to this memory pool from the supplied devices
+//! @brief Enable access to this memory pool from the supplied devices
 //!
 //! Device on which this pool resides can be included in the vector.
 //!
@@ -317,47 +317,47 @@ public:
       static_cast<void*>(&__value));
   }
 
-  //! @brief Enable peer access to this memory pool from the supplied devices
+  //! @brief Enable access to this memory pool from the supplied devices
   //!
   //! Device on which this pool resides can be included in the vector.
   //!
   //! @param __devices A vector of `device_ref`s listing devices to enable access for
-  void enable_peer_access_from(const ::std::vector<device_ref>& __devices)
+  void enable_access_from(const ::std::vector<device_ref>& __devices)
   {
     ::cuda::experimental::__mempool_set_access(
       __pool_handle_, {__devices.data(), __devices.size()}, cudaMemAccessFlagsProtReadWrite);
   }
 
-  //! @brief Enable peer access to this memory pool from the supplied device
+  //! @brief Enable access to this memory pool from the supplied device
   //!
   //! @param __device device_ref indicating for which device the access should be enabled
-  void enable_peer_access_from(device_ref __device)
+  void enable_access_from(device_ref __device)
   {
     ::cuda::experimental::__mempool_set_access(__pool_handle_, {&__device, 1}, cudaMemAccessFlagsProtReadWrite);
   }
 
-  //! @brief Disable peer access to this memory pool from the supplied devices
+  //! @brief Disable access to this memory pool from the supplied devices
   //!
   //! Device on which this pool resides can be included in the vector.
   //!
   //! @param __devices A vector of `device_ref`s listing devices to disable access for
-  void disable_peer_access_from(const ::std::vector<device_ref>& __devices)
+  void disable_access_from(const ::std::vector<device_ref>& __devices)
   {
     ::cuda::experimental::__mempool_set_access(
       __pool_handle_, {__devices.data(), __devices.size()}, cudaMemAccessFlagsProtNone);
   }
 
-  //! @brief Disable peer access to this memory pool from the supplied device
+  //! @brief Disable access to this memory pool from the supplied device
   //!
   //! @param __device device_ref indicating for which device the access should be disable
-  void disable_peer_access_from(device_ref __device)
+  void disable_access_from(device_ref __device)
   {
     ::cuda::experimental::__mempool_set_access(__pool_handle_, {&__device, 1}, cudaMemAccessFlagsProtNone);
   }
 
   //! @brief Query if memory allocated through this memory resource is accessible by the supplied device
   //!
-  //! @param __device device for which the peer access is queried
+  //! @param __device device for which the access is queried
   _CCCL_NODISCARD bool is_accessible_from(device_ref __device)
   {
     return ::cuda::experimental::__mempool_get_access(__pool_handle_, __device);

--- a/cudax/include/cuda/experimental/__memory_resource/memory_resource_base.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/memory_resource_base.cuh
@@ -174,57 +174,57 @@ public:
     _CCCL_ASSERT_CUDA_API(::cudaFreeAsync, "__memory_resource_base::deallocate_async failed", __ptr, __stream.get());
   }
 
-  //! @brief Enable peer access to memory allocated through this memory resource by the supplied devices
+  //! @brief Enable access to memory allocated through this memory resource by the supplied devices
   //!
   //! Access is controlled through the underlying memory pool, so this
   //! setting is shared between all memory resources created from the same pool.
   //! Device on which this resource allocates memory can be included in the vector.
   //!
   //! @param __devices A vector of `device_ref`s listing devices to enable access for
-  void enable_peer_access_from(const ::std::vector<device_ref>& __devices)
+  void enable_access_from(const ::std::vector<device_ref>& __devices)
   {
     ::cuda::experimental::__mempool_set_access(
       __pool_, {__devices.data(), __devices.size()}, cudaMemAccessFlagsProtReadWrite);
   }
 
-  //! @brief Enable peer access to memory allocated through this memory resource by the supplied device
+  //! @brief Enable access to memory allocated through this memory resource by the supplied device
   //!
   //! Access is controlled through the underlying memory pool, so this
   //! setting is shared between all memory resources created from the same pool.
   //!
   //! @param __device device_ref indicating for which device the access should be enabled
-  void enable_peer_access_from(device_ref __device)
+  void enable_access_from(device_ref __device)
   {
     ::cuda::experimental::__mempool_set_access(__pool_, {&__device, 1}, cudaMemAccessFlagsProtReadWrite);
   }
 
-  //! @brief Enable peer access to memory allocated through this memory resource by the supplied devices
+  //! @brief Disable access to memory allocated through this memory resource by the supplied devices
   //!
   //! Access is controlled through the underlying memory pool, so this
   //! setting is shared between all memory resources created from the same pool.
   //! Device on which this resource allocates memory can be included in the vector.
   //!
   //! @param __devices A vector of `device_ref`s listing devices to disable access for
-  void disable_peer_access_from(const ::std::vector<device_ref>& __devices)
+  void disable_access_from(const ::std::vector<device_ref>& __devices)
   {
     ::cuda::experimental::__mempool_set_access(
       __pool_, {__devices.data(), __devices.size()}, cudaMemAccessFlagsProtNone);
   }
 
-  //! @brief Enable peer access to memory allocated through this memory resource by the supplied device
+  //! @brief Disable access to memory allocated through this memory resource by the supplied device
   //!
   //! Access is controlled through the underlying memory pool, so this
   //! setting is shared between all memory resources created from the same pool.
   //!
-  //! @param __device device_ref indicating for which device the access should be enabled
-  void disable_peer_access_from(device_ref __device)
+  //! @param __device device_ref indicating for which device the access should be disabled
+  void disable_access_from(device_ref __device)
   {
     ::cuda::experimental::__mempool_set_access(__pool_, {&__device, 1}, cudaMemAccessFlagsProtNone);
   }
 
   //! @brief Query if memory allocated through this memory resource is accessible by the supplied device
   //!
-  //! @param __device device for which the peer access is queried
+  //! @param __device device for which the access is queried
   _CCCL_NODISCARD bool is_accessible_from(device_ref __device)
   {
     return ::cuda::experimental::__mempool_get_access(__pool_, __device);

--- a/cudax/include/cuda/experimental/__memory_resource/pinned_memory_pool.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/pinned_memory_pool.cuh
@@ -62,7 +62,7 @@ public:
   explicit pinned_memory_pool(int __numa_id, memory_pool_properties __properties)
       : __memory_pool_base(__memory_location_type::__host, __properties, __numa_id)
   {
-    enable_peer_access_from(devices);
+    enable_access_from(devices);
   }
 
   //! @brief Constructs a \c pinned_memory_pool on the host with the specified NUMA node id.

--- a/cudax/test/memory_resource/device_memory_resource.cu
+++ b/cudax/test/memory_resource/device_memory_resource.cu
@@ -465,7 +465,7 @@ TEST_CASE("device_memory_resource comparison", "[memory_resource]")
   }
 }
 
-TEST_CASE("Async memory resource peer access")
+TEST_CASE("Async memory resource access")
 {
   if (cudax::devices.size() > 1)
   {
@@ -488,7 +488,7 @@ TEST_CASE("Async memory resource peer access")
         resource.deallocate(ptr2, sizeof(int));
       };
 
-      resource.enable_peer_access_from(peers);
+      resource.enable_access_from(peers);
 
       CUDAX_CHECK(pool.is_accessible_from(peers.front()));
       CUDAX_CHECK(resource.is_accessible_from(peers.front()));
@@ -498,7 +498,7 @@ TEST_CASE("Async memory resource peer access")
       CUDAX_CHECK(another_resource.is_accessible_from(peers.front()));
       allocate_and_check_access(another_resource);
 
-      resource.disable_peer_access_from(peers.front());
+      resource.disable_access_from(peers.front());
       CUDAX_CHECK(!resource.is_accessible_from(peers.front()));
       CUDAX_CHECK(!another_resource.is_accessible_from(peers.front()));
 
@@ -507,21 +507,21 @@ TEST_CASE("Async memory resource peer access")
         CUDAX_CHECK(resource.is_accessible_from(peers[1]));
       }
 
-      resource.disable_peer_access_from(peers);
+      resource.disable_access_from(peers);
 
-      resource.enable_peer_access_from(peers.front());
+      resource.enable_access_from(peers.front());
       CUDAX_CHECK(resource.is_accessible_from(peers.front()));
       CUDAX_CHECK(another_resource.is_accessible_from(peers.front()));
 
       // Check if enable can include the device on which the pool resides
       peers.push_back(cudax::devices[0]);
-      resource.enable_peer_access_from(peers);
+      resource.enable_access_from(peers);
 
       // Check the resource using the default pool
       cudax::device_memory_resource default_pool_resource{};
       cudax::device_memory_resource another_default_pool_resource{};
 
-      default_pool_resource.enable_peer_access_from(peers.front());
+      default_pool_resource.enable_access_from(peers.front());
 
       CUDAX_CHECK(default_pool_resource.is_accessible_from(peers.front()));
       allocate_and_check_access(default_pool_resource);

--- a/cudax/test/memory_resource/memory_pools.cu
+++ b/cudax/test/memory_resource/memory_pools.cu
@@ -509,7 +509,7 @@ TEMPLATE_TEST_CASE("device_memory_pool accessors", "[memory_resource]", TEST_TYP
   }
 }
 
-TEST_CASE("device_memory_pool::enable_peer_access", "[memory_resource]")
+TEST_CASE("device_memory_pool::enable_access", "[memory_resource]")
 {
   if (cudax::devices.size() > 1)
   {
@@ -519,10 +519,10 @@ TEST_CASE("device_memory_pool::enable_peer_access", "[memory_resource]")
       cudax::device_memory_pool pool{cudax::devices[0]};
       CUDAX_CHECK(pool.is_accessible_from(cudax::devices[0]));
 
-      pool.enable_peer_access_from(peers);
+      pool.enable_access_from(peers);
       CUDAX_CHECK(pool.is_accessible_from(peers.front()));
 
-      pool.disable_peer_access_from(peers.front());
+      pool.disable_access_from(peers.front());
       CUDAX_CHECK(!pool.is_accessible_from(peers.front()));
 
       if (peers.size() > 1)
@@ -534,16 +534,16 @@ TEST_CASE("device_memory_pool::enable_peer_access", "[memory_resource]")
 }
 
 #if _CCCL_CUDACC_AT_LEAST(12, 6)
-TEST_CASE("pinned_memory_pool::enable_peer_access", "[memory_resource]")
+TEST_CASE("pinned_memory_pool::enable_access", "[memory_resource]")
 {
   cudax::pinned_memory_pool pool{};
   CUDAX_CHECK(pool.is_accessible_from(cudax::devices[0]));
 
   // Currently bugged, need to wait for driver fix
-  // pool.disable_peer_access_from(cudax::devices[0]);
+  // pool.disable_access_from(cudax::devices[0]);
   // CUDAX_CHECK(!pool.is_accessible_from(cudax::devices[0]));
 
-  // pool.enable_peer_access_from(cudax::devices[0]);
+  // pool.enable_access_from(cudax::devices[0]);
   // CUDAX_CHECK(pool.is_accessible_from(cudax::devices[0]));
 }
 #endif


### PR DESCRIPTION
With the `pinned_memory_pool` that can enable/disable access to that memory from specific devices, we should call that API more generically without the peer part. It now fits the pinned memory case better and its still specific enough for the device memory case.