### PR TITLE
Use CUDA 12.8 for RAPIDS builds, update devcontainers

### DIFF
--- a/.devcontainer/cuda12.0-gcc10/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc10/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.02-cpp-gcc10-cuda12.0",
+  "image": "rapidsai/devcontainers:25.04-cpp-gcc10-cuda12.0",
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.0-gcc11/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc11/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.02-cpp-gcc11-cuda12.0",
+  "image": "rapidsai/devcontainers:25.04-cpp-gcc11-cuda12.0",
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.0-gcc12/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc12/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.02-cpp-gcc12-cuda12.0",
+  "image": "rapidsai/devcontainers:25.04-cpp-gcc12-cuda12.0",
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.0-gcc7/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc7/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.02-cpp-gcc7-cuda12.0",
+  "image": "rapidsai/devcontainers:25.04-cpp-gcc7-cuda12.0",
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.0-gcc8/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc8/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.02-cpp-gcc8-cuda12.0",
+  "image": "rapidsai/devcontainers:25.04-cpp-gcc8-cuda12.0",
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.0-gcc9/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc9/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.02-cpp-gcc9-cuda12.0",
+  "image": "rapidsai/devcontainers:25.04-cpp-gcc9-cuda12.0",
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.0-llvm14/devcontainer.json
+++ b/.devcontainer/cuda12.0-llvm14/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.02-cpp-llvm14-cuda12.0",
+  "image": "rapidsai/devcontainers:25.04-cpp-llvm14-cuda12.0",
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.5-nvhpc24.7/devcontainer.json
+++ b/.devcontainer/cuda12.5-nvhpc24.7/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.02-cpp-nvhpc24.7",
+  "image": "rapidsai/devcontainers:25.04-cpp-nvhpc24.7",
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.5-rapids-conda
+++ b/.devcontainer/cuda12.5-rapids-conda
@@ -1,1 +1,0 @@
-../ci/rapids/cuda12.5-conda

--- a/.devcontainer/cuda12.8-gcc10/devcontainer.json
+++ b/.devcontainer/cuda12.8-gcc10/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.02-cpp-gcc10-cuda12.8",
+  "image": "rapidsai/devcontainers:25.04-cpp-gcc10-cuda12.8",
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.8-gcc11/devcontainer.json
+++ b/.devcontainer/cuda12.8-gcc11/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.02-cpp-gcc11-cuda12.8",
+  "image": "rapidsai/devcontainers:25.04-cpp-gcc11-cuda12.8",
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.8-gcc12/devcontainer.json
+++ b/.devcontainer/cuda12.8-gcc12/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.02-cpp-gcc12-cuda12.8",
+  "image": "rapidsai/devcontainers:25.04-cpp-gcc12-cuda12.8",
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.8-gcc13/devcontainer.json
+++ b/.devcontainer/cuda12.8-gcc13/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.02-cpp-gcc13-cuda12.8",
+  "image": "rapidsai/devcontainers:25.04-cpp-gcc13-cuda12.8",
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.8-gcc7/devcontainer.json
+++ b/.devcontainer/cuda12.8-gcc7/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.02-cpp-gcc7-cuda12.8",
+  "image": "rapidsai/devcontainers:25.04-cpp-gcc7-cuda12.8",
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.8-gcc8/devcontainer.json
+++ b/.devcontainer/cuda12.8-gcc8/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.02-cpp-gcc8-cuda12.8",
+  "image": "rapidsai/devcontainers:25.04-cpp-gcc8-cuda12.8",
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.8-gcc9/devcontainer.json
+++ b/.devcontainer/cuda12.8-gcc9/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.02-cpp-gcc9-cuda12.8",
+  "image": "rapidsai/devcontainers:25.04-cpp-gcc9-cuda12.8",
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.8-llvm14/devcontainer.json
+++ b/.devcontainer/cuda12.8-llvm14/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.02-cpp-llvm14-cuda12.8",
+  "image": "rapidsai/devcontainers:25.04-cpp-llvm14-cuda12.8",
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.8-llvm15/devcontainer.json
+++ b/.devcontainer/cuda12.8-llvm15/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.02-cpp-llvm15-cuda12.8",
+  "image": "rapidsai/devcontainers:25.04-cpp-llvm15-cuda12.8",
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.8-llvm16/devcontainer.json
+++ b/.devcontainer/cuda12.8-llvm16/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.02-cpp-llvm16-cuda12.8",
+  "image": "rapidsai/devcontainers:25.04-cpp-llvm16-cuda12.8",
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.8-llvm17/devcontainer.json
+++ b/.devcontainer/cuda12.8-llvm17/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.02-cpp-llvm17-cuda12.8",
+  "image": "rapidsai/devcontainers:25.04-cpp-llvm17-cuda12.8",
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.8-llvm18/devcontainer.json
+++ b/.devcontainer/cuda12.8-llvm18/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.02-cpp-llvm18-cuda12.8",
+  "image": "rapidsai/devcontainers:25.04-cpp-llvm18-cuda12.8",
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.8-rapids-conda
+++ b/.devcontainer/cuda12.8-rapids-conda
@@ -1,0 +1,1 @@
+../ci/rapids/cuda12.8-conda

--- a/.devcontainer/cuda12.8ext-gcc13/devcontainer.json
+++ b/.devcontainer/cuda12.8ext-gcc13/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.02-cpp-gcc13-cuda12.8ext",
+  "image": "rapidsai/devcontainers:25.04-cpp-gcc13-cuda12.8ext",
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.02-cpp-gcc13-cuda12.8",
+  "image": "rapidsai/devcontainers:25.04-cpp-gcc13-cuda12.8",
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.github/workflows/build-rapids.yml
+++ b/.github/workflows/build-rapids.yml
@@ -63,9 +63,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { cuda: '12.5', libs: 'rmm kvikio cudf cudf_kafka cuspatial' }
-          - { cuda: '12.5', libs: 'rmm ucxx raft cuvs cumlprims_mg cuml' }
-          - { cuda: '12.5', libs: 'rmm ucxx raft cugraph'                }
+          - { cuda: '12.8', libs: 'rmm kvikio cudf cudf_kafka cuspatial' }
+          - { cuda: '12.8', libs: 'rmm ucxx raft cuvs cumlprims_mg cuml' }
+          - { cuda: '12.8', libs: 'rmm ucxx raft cugraph'                }
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/build-rapids.yml
+++ b/.github/workflows/build-rapids.yml
@@ -101,7 +101,7 @@ jobs:
           # RAPIDS_kvikio_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-25.04"}'
           # RAPIDS_raft_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-25.04"}'
           # RAPIDS_rmm_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-25.04"}'
-          # RAPIDS_ucxx_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-0.42"}'
+          # RAPIDS_ucxx_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-0.43"}'
         run: |
           cat <<"EOF" > "$RUNNER_TEMP/ci-entrypoint.sh"
           #! /usr/bin/env bash

--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -110,7 +110,7 @@ workflows:
 
 
 # The version of the devcontainer images to use from https://hub.docker.com/r/rapidsai/devcontainers
-devcontainer_version: '25.02'
+devcontainer_version: '25.04'
 
 # All supported C++ standards:
 all_stds: [17, 20]

--- a/ci/rapids/cuda12.8-conda/devcontainer.json
+++ b/ci/rapids/cuda12.8-conda/devcontainer.json
@@ -3,7 +3,7 @@
   "runArgs": [
     "--rm",
     "--name",
-    "${localEnv:USER:anon}-${localWorkspaceFolderBasename}-rapids-25.04-cuda12.5-conda"
+    "${localEnv:USER:anon}-${localWorkspaceFolderBasename}-rapids-25.04-cuda12.8-conda"
   ],
   "hostRequirements": {"gpu": "optional"},
   "features": {
@@ -15,7 +15,7 @@
   "containerEnv": {
     "CI": "${localEnv:CI}",
     "CUDAARCHS": "70-real",
-    "CUDA_VERSION": "12.5",
+    "CUDA_VERSION": "12.8",
     "DEFAULT_CONDA_ENV": "rapids",
     "PYTHONSAFEPATH": "1",
     "PYTHONUNBUFFERED": "1",

--- a/ci/update_rapids_version.sh
+++ b/ci/update_rapids_version.sh
@@ -18,7 +18,7 @@ NEXT_SHORT_TAG=${NEXT_MAJOR}.${NEXT_MINOR}
 NEXT_UCXX_SHORT_TAG="$(curl -sL https://version.gpuci.io/rapids/${NEXT_SHORT_TAG})"
 
 # Need to distutils-normalize the versions for some use cases
-NEXT_SHORT_TAG_PEP440=$(python -c "from setuptools.extern import packaging; print(packaging.version.Version('${NEXT_SHORT_TAG}'))")
+NEXT_SHORT_TAG_PEP440=$(python -c "from packaging.version import Version; print(Version('${NEXT_SHORT_TAG}'))")
 
 echo "Updating RAPIDS and devcontainers to $NEXT_FULL_TAG"
 


### PR DESCRIPTION
## Description

This PR uses CUDA 12.8 in RAPIDS containers, and updates devcontainers to use 25.04.

Generated by running `./ci/update_rapids_version.sh 25.04.00` and updating other files by hand.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
