### PR TITLE
Provide `restrict` accessor

### DIFF
--- a/docs/libcudacxx/extended_api.rst
+++ b/docs/libcudacxx/extended_api.rst
@@ -18,5 +18,6 @@ Extended API
    extended_api/streams
    extended_api/memory_resource
    extended_api/math
+   extended_api/mdspan
    extended_api/warp
    extended_api/work_stealing

--- a/docs/libcudacxx/extended_api/mdspan.rst
+++ b/docs/libcudacxx/extended_api/mdspan.rst
@@ -18,7 +18,7 @@ Mdspan
      - **CCCL Availability**
      - **CUDA Toolkit Availability**
 
-   * - :ref:`restrict_accessor <libcudacxx-extended-api-mdspan-restrict-accessor>`
-     - Accessor with the *restrict* aliasing policy
+   * - :ref:`restrict mdspan and accessor <libcudacxx-extended-api-mdspan-restrict-accessor>`
+     - ``mdspan`` and accessor with the *restrict* aliasing policy
      - CCCL 3.0.0
      - CUDA 13.0

--- a/docs/libcudacxx/extended_api/mdspan.rst
+++ b/docs/libcudacxx/extended_api/mdspan.rst
@@ -1,0 +1,24 @@
+.. _libcudacxx-extended-api-mdspan:
+
+Mdspan
+======
+
+.. toctree::
+   :hidden:
+   :maxdepth: 1
+
+   mdspan/restrict_accessor
+
+.. list-table::
+   :widths: 25 45 30 30
+   :header-rows: 1
+
+   * - **Header**
+     - **Content**
+     - **CCCL Availability**
+     - **CUDA Toolkit Availability**
+
+   * - :ref:`restrict_accessor <libcudacxx-extended-api-mdspan-restrict-accessor>`
+     - Accessor with the *restrict* aliasing policy
+     - CCCL 3.0.0
+     - CUDA 13.0

--- a/docs/libcudacxx/extended_api/mdspan/restrict_accessor.rst
+++ b/docs/libcudacxx/extended_api/mdspan/restrict_accessor.rst
@@ -1,7 +1,7 @@
 .. _libcudacxx-extended-api-mdspan-restrict-accessor:
 
-``restrict_accessor``
-=====================
+``restrict`` ``mdspan`` and ``accessor``
+========================================
 
 .. code:: cpp
 
@@ -10,7 +10,7 @@
 
 An alias type to create an accessor with the *restrict aliasing policy* starting from an existing accessor.
 
-More information related to the *restrict aliasing policy* can be found in the CUDA programming guide `__restrict__ keyword <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#restrict>`_.
+More information related to the *restrict aliasing policy* can be found in the CUDA programming guide: `__restrict__ keyword <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#restrict>`_.
 
 ----
 
@@ -24,13 +24,28 @@ More information related to the *restrict aliasing policy* can be found in the C
 
 An alias type to create an ``mdspan`` with a *restrict aliasing policy* accessor.
 
+----
+
+Traits:
+
+.. code:: cpp
+
+    template <typename T>
+    inline constexpr bool is_restrict_accessor_v = /*true if T is a restrict accessor, false otherwise*/;
+
+    template <typename T>
+    inline constexpr bool is_restrict_mdspan_v = /*true if T is a restrict mdspan, false otherwise*/;
+
+----
+
 **Constraints**:
 
 - Accessor ``data_handle_type`` must be a pointer type.
 
-**Example**:
+Example
+-------
 
-.. code:: cpp
+.. code:: cuda
 
     #include <cuda/mdspan>
 

--- a/docs/libcudacxx/extended_api/mdspan/restrict_accessor.rst
+++ b/docs/libcudacxx/extended_api/mdspan/restrict_accessor.rst
@@ -1,0 +1,65 @@
+.. _libcudacxx-extended-api-mdspan-restrict-accessor:
+
+``restrict_accessor``
+=====================
+
+.. code:: cpp
+
+  template <typename Accessor>
+  using restrict_accessor;
+
+An alias type to create an accessor with the *restrict aliasing policy* starting from an existing accessor.
+
+More information related to the *restrict aliasing policy* can be found in the CUDA programming guide `__restrict__ keyword <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#restrict>`_.
+
+----
+
+.. code:: cpp
+
+  template <typename ElementType,
+            typename Extents,
+            typename LayoutPolicy   = cuda::std::layout_right,
+            typename AccessorPolicy = cuda::std::default_accessor<_ElementType>>
+  using restrict_mdspan = cuda::std::mdspan<ElementType, Extents, LayoutPolicy, restrict_accessor<AccessorPolicy>>;
+
+An alias type to create an ``mdspan`` with a *restrict aliasing policy* accessor.
+
+**Constraints**:
+
+- Accessor ``data_handle_type`` must be a pointer type.
+
+**Example**:
+
+.. code:: cpp
+
+    #include <cuda/mdspan>
+
+    using restrict_mdspan = cuda::restrict_mdspan<int, cuda::std::dims<1>>;
+
+    __host__ __device__ void
+    compute(restrict_mdspan a, restrict_mdspan b, restrict_mdspan c) {
+        c[0] = a[0] * b[0];
+        c[1] = a[0] * b[0];
+        c[2] = a[0] * b[0] * a[1];
+        c[3] = a[0] * a[1];
+        c[4] = a[0] * b[0];
+        c[5] = b[0];
+    }
+
+    int main() {
+        using  dim      = cuda::std::dims<1>;
+        using  mdspan   = cuda::std::mdspan<int, dim>;
+        int    arrayA[] = {1, 2};
+        int    arrayB[] = {5};
+        int    arrayC[] = {9, 10, 11, 12, 13, 14};
+        mdspan mdA{arrayA, dim{1}};
+        mdspan mdB{arrayB, dim{5}};
+        mdspan mdC{arrayC, dim{6}};
+        compute(mdA, mdB, mdC);
+
+        using restrict_aligned_accesor = cuda::std::restrict_accessor<cuda::std::aligned_accessor<int, 8>>;
+        using restrict_aligned_mdspan  = cuda::std::mdspan<int, dim, layout_right, restrict_aligned_accesor>;
+        restrict_aligned_mdspan mdD{mdC};
+    }
+
+`See it on Godbolt 🔗 <https://godbolt.org/z/Wjco996z8>`_

--- a/libcudacxx/include/cuda/__mdspan/restrict_accessor.h
+++ b/libcudacxx/include/cuda/__mdspan/restrict_accessor.h
@@ -59,7 +59,7 @@ struct __restrict_accessor : public _Accessor
   static_assert(_CUDA_VSTD::is_pointer_v<typename _Accessor::data_handle_type>, "Accessor must be pointer based");
 
   using offset_policy = __restrict_accessor<typename _Accessor::offset_policy>;
-#if _CCCL_COMPILER(GCC, <, 12)
+#if _CCCL_COMPILER(GCC, <, 12) || _CCCL_COMPILER(MSVC)
   using data_handle_type = typename _Accessor::data_handle_type;
 #else
   using data_handle_type = _CCCL_RESTRICT typename _Accessor::data_handle_type;

--- a/libcudacxx/include/cuda/__mdspan/restrict_accessor.h
+++ b/libcudacxx/include/cuda/__mdspan/restrict_accessor.h
@@ -34,7 +34,7 @@
 _LIBCUDACXX_BEGIN_NAMESPACE_CUDA
 
 template <typename _Accessor>
-struct __restrict_accessor;
+class __restrict_accessor;
 
 template <typename _Accessor>
 using restrict_accessor = __restrict_accessor<_Accessor>;

--- a/libcudacxx/include/cuda/__mdspan/restrict_accessor.h
+++ b/libcudacxx/include/cuda/__mdspan/restrict_accessor.h
@@ -58,10 +58,14 @@ struct __restrict_accessor : public _Accessor
 {
   static_assert(_CUDA_VSTD::is_pointer_v<typename _Accessor::data_handle_type>, "Accessor must be pointer based");
 
-  using offset_policy    = __restrict_accessor<typename _Accessor::offset_policy>;
+  using offset_policy = __restrict_accessor<typename _Accessor::offset_policy>;
+#if _CCCL_COMPILER(GCC, <, 12)
+  using data_handle_type = typename _Accessor::data_handle_type;
+#else
   using data_handle_type = _CCCL_RESTRICT typename _Accessor::data_handle_type;
-  using reference        = typename _Accessor::reference;
-  using element_type     = typename _Accessor::element_type;
+#endif
+  using reference    = typename _Accessor::reference;
+  using element_type = typename _Accessor::element_type;
 
 private:
   static constexpr bool __is_access_noexcept = noexcept(_Accessor{}.access(data_handle_type{}, 0));

--- a/libcudacxx/include/cuda/__mdspan/restrict_accessor.h
+++ b/libcudacxx/include/cuda/__mdspan/restrict_accessor.h
@@ -1,0 +1,114 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA___MDSPAN_RESTRICT_ACCESSOR
+#define _CUDA___MDSPAN_RESTRICT_ACCESSOR
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__concepts/concept_macros.h>
+#include <cuda/std/__iterator/concepts.h>
+#include <cuda/std/__type_traits/is_convertible.h>
+#include <cuda/std/__type_traits/is_default_constructible.h>
+#include <cuda/std/__type_traits/is_nothrow_copy_constructible.h>
+#include <cuda/std/__type_traits/is_nothrow_default_constructible.h>
+#include <cuda/std/__type_traits/is_pointer.h>
+#include <cuda/std/__utility/declval.h>
+#include <cuda/std/cstddef>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_CUDA
+
+template <typename _Accessor>
+struct __restrict_accessor;
+
+template <typename _Accessor>
+using restrict_accessor = __restrict_accessor<_Accessor>;
+
+/***********************************************************************************************************************
+ * Accessor Traits
+ **********************************************************************************************************************/
+
+template <typename>
+inline constexpr bool is_restrict_accessor_v = false;
+
+template <typename _Accessor>
+inline constexpr bool is_restrict_accessor_v<__restrict_accessor<_Accessor>> = true;
+
+/***********************************************************************************************************************
+ * Restrict Accessor
+ **********************************************************************************************************************/
+
+template <typename _Accessor>
+struct __restrict_accessor : public _Accessor
+{
+  static_assert(_CUDA_VSTD::is_pointer_v<typename _Accessor::data_handle_type>, "Accessor must be pointer based");
+
+  using offset_policy    = __restrict_accessor<typename _Accessor::offset_policy>;
+  using data_handle_type = _CCCL_RESTRICT typename _Accessor::data_handle_type;
+  using reference        = typename _Accessor::reference;
+  using element_type     = typename _Accessor::element_type;
+
+private:
+  static constexpr bool __is_access_noexcept = noexcept(_Accessor{}.access(data_handle_type{}, 0));
+  static constexpr bool __is_offset_noexcept = noexcept(_Accessor{}.offset(data_handle_type{}, 0));
+
+public:
+  _CCCL_TEMPLATE(class _Accessor2 = _Accessor)
+  _CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::is_default_constructible, _Accessor2))
+  _LIBCUDACXX_HIDE_FROM_ABI __restrict_accessor() noexcept(_CUDA_VSTD::is_nothrow_default_constructible_v<_Accessor2>)
+      : _Accessor{}
+  {}
+
+  _LIBCUDACXX_HIDE_FROM_ABI constexpr __restrict_accessor(const _Accessor& __acc) noexcept(
+    _CUDA_VSTD::is_nothrow_copy_constructible_v<_Accessor>)
+      : _Accessor{__acc}
+  {}
+
+  _CCCL_TEMPLATE(typename _OtherAccessor)
+  _CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::is_constructible, _OtherAccessor)
+                   _CCCL_AND(_CUDA_VSTD::is_convertible_v<_OtherAccessor, _Accessor>))
+  _LIBCUDACXX_HIDE_FROM_ABI constexpr __restrict_accessor(const __restrict_accessor<_OtherAccessor>& __acc) noexcept(
+    noexcept(_Accessor{_CUDA_VSTD::declval<_OtherAccessor>()}))
+      : _Accessor{__acc}
+  {}
+
+  _CCCL_TEMPLATE(typename _OtherAccessor)
+  _CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::is_constructible, _OtherAccessor)
+                   _CCCL_AND(!_CUDA_VSTD::is_convertible_v<_OtherAccessor, _Accessor>))
+  _LIBCUDACXX_HIDE_FROM_ABI constexpr explicit __restrict_accessor(
+    const __restrict_accessor<_OtherAccessor>& __acc) noexcept(noexcept(_Accessor{
+    _CUDA_VSTD::declval<_OtherAccessor>()}))
+      : _Accessor{__acc}
+  {}
+
+  _LIBCUDACXX_HIDE_FROM_ABI constexpr reference access(_CCCL_RESTRICT data_handle_type __p, size_t __i) const
+    noexcept(__is_access_noexcept)
+  {
+    return _Accessor::access(__p, __i);
+  }
+
+  _LIBCUDACXX_HIDE_FROM_ABI constexpr data_handle_type offset(_CCCL_RESTRICT data_handle_type __p, size_t __i) const
+    noexcept(__is_offset_noexcept)
+  {
+    return _Accessor::offset(__p, __i);
+  }
+};
+
+_LIBCUDACXX_END_NAMESPACE_CUDA
+
+#endif // _CUDA___MDSPAN_RESTRICT_ACCESSOR

--- a/libcudacxx/include/cuda/__mdspan/restrict_mdspan.h
+++ b/libcudacxx/include/cuda/__mdspan/restrict_mdspan.h
@@ -1,0 +1,47 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA___MDSPAN_RESTRICT_MDSPAN
+#define _CUDA___MDSPAN_RESTRICT_MDSPAN
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/__mdspan/restrict_accessor.h>
+#include <cuda/std/mdspan>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_CUDA
+
+template <typename _ElementType,
+          typename _Extents,
+          typename _LayoutPolicy   = _CUDA_VSTD::layout_right,
+          typename _AccessorPolicy = _CUDA_VSTD::default_accessor<_ElementType>>
+using restrict_mdspan = _CUDA_VSTD::mdspan<_ElementType, _Extents, _LayoutPolicy, restrict_accessor<_AccessorPolicy>>;
+
+/***********************************************************************************************************************
+ * Accessibility Traits
+ **********************************************************************************************************************/
+
+template <typename>
+inline constexpr bool is_restrict_mdspan_v = false;
+
+template <typename _Tp, typename _Ep, typename _Lp, typename _Ap>
+inline constexpr bool is_restrict_mdspan_v<_CUDA_VSTD::mdspan<_Tp, _Ep, _Lp, _Ap>> = is_restrict_accessor_v<_Ap>;
+
+_LIBCUDACXX_END_NAMESPACE_CUDA
+
+#endif // _CUDA___MDSPAN_RESTRICT_MDSPAN

--- a/libcudacxx/include/cuda/mdspan
+++ b/libcudacxx/include/cuda/mdspan
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_MDSPAN
+#define _CUDA_MDSPAN
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/__mdspan/restrict_mdspan.h>
+#include <cuda/std/mdspan>
+
+#endif // _CUDA_MDSPAN

--- a/libcudacxx/test/libcudacxx/cuda/mdspan/accessor.restrict.conversion.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/mdspan/accessor.restrict.conversion.pass.cpp
@@ -1,0 +1,306 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the libcu++ Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/mdspan>
+#include <cuda/std/type_traits>
+
+#include "test_macros.h"
+
+//----------------------------------------------------------------------------------------------------------------------
+// USER 1 CODE
+
+namespace user1
+{
+
+template <class ElementType>
+class AccessorB;
+
+// AccessorA is more type-erased than AccessorB.
+template <class ElementType>
+class AccessorA
+{
+public:
+  using offset_policy    = AccessorA<ElementType>;
+  using element_type     = ElementType;
+  using reference        = ElementType&;
+  using data_handle_type = ElementType*;
+
+  constexpr AccessorA() noexcept = default;
+
+  template <class OtherElementType,
+            cuda::std::enable_if_t<cuda::std::is_convertible_v<OtherElementType (*)[], element_type (*)[]>, int> = 0>
+  __host__ __device__ constexpr AccessorA(const AccessorA<OtherElementType>&) noexcept
+  {}
+
+  // Conversion from AccessorB to AccessorA type-erases; it has no preconditions, and can therefore be safely implicit.
+  template <class OtherElementType,
+            cuda::std::enable_if_t<cuda::std::is_convertible_v<OtherElementType (*)[], element_type (*)[]>, int> = 0>
+  __host__ __device__ constexpr AccessorA(const AccessorB<OtherElementType>&) noexcept
+  {}
+
+  __host__ __device__ constexpr reference access(data_handle_type p, size_t i) const noexcept
+  {
+    return p[i];
+  }
+
+  __host__ __device__ constexpr typename offset_policy::data_handle_type
+  offset(data_handle_type p, size_t i) const noexcept
+  {
+    return p + i;
+  }
+};
+
+template <class ElementType>
+class AccessorB
+{
+public:
+  using offset_policy    = AccessorA<ElementType>;
+  using element_type     = ElementType;
+  using reference        = ElementType&;
+  using data_handle_type = ElementType*;
+
+  constexpr AccessorB() noexcept = default;
+
+  template <class OtherElementType,
+            cuda::std::enable_if_t<cuda::std::is_convertible_v<OtherElementType (*)[], element_type (*)[]>, int> = 0>
+  __host__ __device__ constexpr AccessorB(const AccessorB<OtherElementType>&) noexcept
+  {}
+
+  // Conversion from AccessorA to AccessorB asserts a precondition;
+  // it un-type-erases from less specific AccessorA to more specific AccessorB. Thus, it is explicit.
+  template <class OtherElementType,
+            cuda::std::enable_if_t<cuda::std::is_convertible_v<OtherElementType (*)[], element_type (*)[]>, int> = 0>
+  __host__ __device__ constexpr explicit AccessorB(const AccessorA<OtherElementType>&) noexcept
+  {}
+
+  __host__ __device__ constexpr reference access(data_handle_type p, size_t i) const noexcept
+  {
+    return p[i];
+  }
+
+  __host__ __device__ constexpr typename offset_policy::data_handle_type
+  offset(data_handle_type p, size_t i) const noexcept
+  {
+    return p + i;
+  }
+};
+
+} // namespace user1
+
+//----------------------------------------------------------------------------------------------------------------------
+// USER 2 CODE
+
+namespace user2
+{
+
+// Imagine that a different user1 writes AccessorC.
+// They can't change the public interface of AccessorA, but they want to permit a conversion from AccessorC to
+// AccessorA. AccessorA happens to be more type-erased than AccessorC, so this is a conversion without preconditions;
+// therefore, it's not explicit.
+template <class ElementType>
+class AccessorC
+{
+public:
+  using offset_policy    = AccessorC<ElementType>;
+  using element_type     = ElementType;
+  using reference        = ElementType&;
+  using data_handle_type = ElementType*;
+
+  constexpr AccessorC() noexcept = default;
+
+  template <class OtherElementType,
+            cuda::std::enable_if_t<cuda::std::is_convertible_v<OtherElementType (*)[], element_type (*)[]>, int> = 0>
+  __host__ __device__ constexpr AccessorC(const AccessorC<OtherElementType>&) noexcept
+  {}
+
+  __host__ __device__ constexpr operator user1::AccessorA<element_type>() const noexcept
+  {
+    return {};
+  }
+
+  __host__ __device__ constexpr reference access(data_handle_type p, size_t i) const noexcept
+  {
+    return p[i];
+  }
+
+  __host__ __device__ constexpr typename offset_policy::data_handle_type
+  offset(data_handle_type p, size_t i) const noexcept
+  {
+    return p + i;
+  }
+};
+
+// Imagine that a different user1 writes AccessorD.
+// They can't change the public interface of AccessorB, but they want to permit a conversion from AccessorD to
+// AccessorB. This is a conversion with preconditions, so it's explicit.
+template <class ElementType>
+class AccessorD
+{
+public:
+  using offset_policy    = AccessorD<ElementType>;
+  using element_type     = ElementType;
+  using reference        = ElementType&;
+  using data_handle_type = ElementType*;
+
+  constexpr AccessorD() noexcept = default;
+
+  template <class OtherElementType,
+            cuda::std::enable_if_t<cuda::std::is_convertible_v<OtherElementType (*)[], element_type (*)[]>, int> = 0>
+  __host__ __device__ constexpr AccessorD(const AccessorD<OtherElementType>&) noexcept
+  {}
+
+  __host__ __device__ constexpr explicit operator user1::AccessorB<element_type>() const noexcept
+  {
+    return {};
+  }
+
+  __host__ __device__ constexpr reference access(data_handle_type p, size_t i) const noexcept
+  {
+    return p[i];
+  }
+
+  __host__ __device__ constexpr typename offset_policy::data_handle_type
+  offset(data_handle_type p, size_t i) const noexcept
+  {
+    return p + i;
+  }
+};
+
+} // namespace user2
+
+//----------------------------------------------------------------------------------------------------------------------
+// TEST CODE
+
+__host__ __device__ void test_host_device_accessor_conversions()
+{
+  using user1::AccessorA;
+  using user1::AccessorB;
+  using WrapperA      = cuda::__restrict_accessor<AccessorA<float>>;
+  using WrapperAconst = cuda::__restrict_accessor<AccessorA<const float>>;
+  using WrapperB      = cuda::__restrict_accessor<AccessorB<float>>;
+  {
+    // Test CTAD with wrapping constructor
+    WrapperA wrapper_acc1(AccessorA<float>{});
+    static_assert(cuda::std::is_same_v<decltype(wrapper_acc1), WrapperA>);
+    WrapperAconst wrapper_acc_const1(AccessorA<const float>{});
+    static_assert(cuda::std::is_same_v<decltype(wrapper_acc_const1), WrapperAconst>);
+
+    // Test CTAD with copy constructor
+    WrapperA wrapper_acc2{wrapper_acc1};
+    static_assert(cuda::std::is_same_v<decltype(wrapper_acc2), decltype(wrapper_acc1)>);
+    WrapperAconst wrapper_acc_const2{wrapper_acc_const1};
+    static_assert(cuda::std::is_same_v<decltype(wrapper_acc_const2), decltype(wrapper_acc_const1)>);
+    unused(wrapper_acc2);
+    unused(wrapper_acc_const2);
+
+    // Test converting constructor: cuda::__restrict_accessor<AccessorA<const T>>(AccessorA<T>)
+    WrapperAconst wrapper_acc_const3{wrapper_acc1};
+    unused(wrapper_acc_const3);
+    // Test implicit conversion: cuda::__restrict_accessor<AccessorA<T>> -> cuda::__restrict_accessor<AccessorA<const
+    // T>>
+    auto f = [](const WrapperA& wrapper_acc1) -> WrapperAconst {
+      return wrapper_acc1;
+    };
+    unused(f(WrapperA{}));
+  }
+  {
+    // Test (explicit) converting constructor: cuda::__restrict_accessor<AccessorB<T>>(AccessorA<T>)
+    WrapperB wrapper_acc3{WrapperA{}};
+    // Test implicit conversion from AccessorB<T> to AccessorA<T> (type erasure)
+    auto f1 = [](const WrapperB& wrapper_acc1) -> WrapperA {
+      return wrapper_acc1;
+    };
+    unused(f1(wrapper_acc3));
+
+    // Test implicit conversion from AccessorB<T> to AccessorA<const T> (type erasure)
+    auto f2 = [](const WrapperB& wrapper_acc1) -> WrapperAconst {
+      return wrapper_acc1;
+    };
+    unused(f2(wrapper_acc3));
+
+    // Test that implicit conversion from AccessorA<T> to AccessorB<T> is forbidden
+    auto f3 = [](const WrapperA& wrapper_acc1) -> WrapperB {
+      return WrapperB{wrapper_acc1};
+      // return wrapper_acc1; // rightfully does not compile
+    };
+    unused(f3(WrapperA{}));
+  }
+}
+
+__host__ __device__ void test_conversion()
+{
+  using user1::AccessorA;
+  using user1::AccessorB;
+  using user2::AccessorC;
+  using user2::AccessorD;
+  using WrapperA = cuda::__restrict_accessor<AccessorA<float>>;
+  using WrapperB = cuda::__restrict_accessor<AccessorB<float>>;
+  using WrapperC = cuda::__restrict_accessor<AccessorC<float>>;
+  using WrapperD = cuda::__restrict_accessor<AccessorD<float>>;
+  {
+    // Test explicit and implicit conversion from cuda::__restrict_accessor<AccessorC<T>> to
+    // cuda::__restrict_accessor<AccessorA<T>>. This works because cuda::__restrict_accessor<AccessorC<T>> publicly
+    // inherits from AccessorC<T>, so it inherits AccessorC<T>'s conversion operators.
+    WrapperA wrapper_acc1{WrapperC{}};
+    auto f1 = [](const WrapperA& wrapper_acc1) -> WrapperA {
+      return wrapper_acc1;
+    };
+    unused(f1(WrapperC{}));
+  }
+  {
+    // Test explicit conversion from cuda::__restrict_accessor<AccessorD<T>> to cuda::__restrict_accessor<AccessorB<T>>.
+    // This works because cuda::__restrict_accessor<AccessorD<T>> publicly inherits from AccessorD<T>,
+    // so it inherits AccessorD<T>'s conversion operators.
+    WrapperB wrapper_acc1{WrapperD{}};
+    auto f1 = [](const WrapperD& w) -> WrapperB {
+      return WrapperB{};
+      // return w; // rightfully does not compile
+    };
+    unused(f1(WrapperD{}));
+  }
+}
+
+// Application: conversion of cuda::__restrict_accessor<aligned_accessor<T, N>>
+// to cuda::__restrict_accessor<default_accessor<T>>.
+__host__ __device__ void test_aligned_to_default()
+{
+  using WrapperDefault = cuda::__restrict_accessor<cuda::std::default_accessor<float>>;
+  using WrapperAligned = cuda::__restrict_accessor<cuda::std::aligned_accessor<float, 16>>;
+  WrapperAligned wrapper_align_acc{cuda::std::aligned_accessor<float, 16>{}};
+  WrapperDefault wrapper_default_acc{wrapper_align_acc};
+  auto f = [](const WrapperAligned& w) -> WrapperDefault {
+    return w;
+  };
+  unused(f(wrapper_default_acc));
+}
+
+// Application: Explicit conversion of cuda::__restrict_accessor<default_accessor<T>>
+// to cuda::__restrict_accessor<aligned_accessor<T, N>>.
+__host__ __device__ void test_default_to_aligned()
+{
+  using WrapperDefault = cuda::__restrict_accessor<cuda::std::default_accessor<float>>;
+  using WrapperAligned = cuda::__restrict_accessor<cuda::std::aligned_accessor<float, 16>>;
+  WrapperDefault wrapper_default_acc{cuda::std::default_accessor<float>{}};
+  WrapperAligned wrapper_aligned_acc{wrapper_default_acc};
+  auto f = [](const WrapperDefault& w) -> WrapperAligned {
+    return WrapperAligned{w};
+    // return w; // rightfully does not compile
+  };
+  unused(wrapper_aligned_acc);
+  unused(f(wrapper_default_acc));
+}
+
+int main(int, char**)
+{
+  test_host_device_accessor_conversions();
+  test_conversion();
+  test_aligned_to_default();
+  test_default_to_aligned();
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/mdspan/accessor.restrict.functional.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/mdspan/accessor.restrict.functional.pass.cpp
@@ -1,0 +1,48 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the libcu++ Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/mdspan>
+
+#include "test_macros.h"
+
+using dim = cuda::std::dims<1>;
+
+__host__ __device__ void
+compute(cuda::restrict_mdspan<int, dim> a, cuda::restrict_mdspan<int, dim> b, cuda::restrict_mdspan<int, dim> c)
+{
+  c[0] = a[0] * b[0];
+  c[1] = a[0] * b[0];
+  c[2] = a[0] * b[0] * a[1];
+  c[3] = a[0] * a[1];
+  c[4] = a[0] * b[0];
+  c[5] = b[0];
+}
+
+__host__ __device__ void test()
+{
+  int arrayA[] = {1, 2};
+  int arrayB[] = {5};
+  int arrayC[] = {9, 10, 11, 12, 13, 14};
+  cuda::std::mdspan<int, dim> mdA{arrayA, dim{2}};
+  cuda::std::mdspan<int, dim> mdB{arrayB, dim{1}};
+  cuda::std::mdspan<int, dim> mdC{arrayC, dim{6}};
+  compute(mdA, mdB, mdC);
+  assert(mdC[0] == 5);
+  assert(mdC[1] == 5);
+  assert(mdC[2] == 10);
+  assert(mdC[3] == 2);
+  assert(mdC[4] == 5);
+  assert(mdC[5] == 5);
+}
+
+int main(int, char**)
+{
+  test();
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/mdspan/accessor.restrict.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/mdspan/accessor.restrict.pass.cpp
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the libcu++ Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/mdspan>
+
+#include "test_macros.h"
+
+__host__ __device__ void restrict_mdspan_test()
+{
+  int array[] = {1, 2, 3, 4};
+  using ext_t = cuda::std::extents<int, 4>;
+  cuda::restrict_mdspan<int, ext_t> md{array, ext_t{}};
+  unused(md[0] == 1);
+  unused(md[1] == 2);
+  unused(md.accessor().offset(array, 1) == array + 1);
+}
+
+int main(int, char**)
+{
+  restrict_mdspan_test();
+  return 0;
+}


### PR DESCRIPTION
## Description

Provides `restrict_accessor` and `restrict_mdspan` based on https://github.com/kokkos/mdspan/blob/stable/examples/restrict_accessor/restrict_accessor.cpp