### PR TITLE
Add missing `explicit` conversion constructor to `cuda::std::aligned_accessor`

### DIFF
--- a/libcudacxx/include/cuda/std/__mdspan/aligned_accessor.h
+++ b/libcudacxx/include/cuda/std/__mdspan/aligned_accessor.h
@@ -70,7 +70,7 @@ public:
 
   _CCCL_TEMPLATE(class _OtherElementType)
   _CCCL_REQUIRES(_CCCL_TRAIT(is_convertible, _OtherElementType (*)[], element_type (*)[]))
-  _LIBCUDACXX_HIDE_FROM_ABI constexpr aligned_accessor(default_accessor<_OtherElementType>) noexcept {}
+  _LIBCUDACXX_HIDE_FROM_ABI constexpr explicit aligned_accessor(default_accessor<_OtherElementType>) noexcept {}
 
   _CCCL_TEMPLATE(class _OtherElementType)
   _CCCL_REQUIRES(_CCCL_TRAIT(is_convertible, _OtherElementType (*)[], element_type (*)[]))

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan.aligned_accessor/aligned_accessor.alignment.fail.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan.aligned_accessor/aligned_accessor.alignment.fail.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: msvc && c++17
-
 #include <cuda/std/mdspan>
 
 #include <test_macros.h>

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan.aligned_accessor/aligned_accessor.explicit.fail.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan.aligned_accessor/aligned_accessor.explicit.fail.cpp
@@ -1,0 +1,18 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+#include <cuda/std/mdspan>
+
+#include <test_macros.h>
+
+int main(int, char**)
+{
+  cuda::std::default_accessor<int> acc{};
+  cuda::std::aligned_accessor<int, sizeof(int)> acc_aligned = acc;
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan.aligned_accessor/aligned_accessor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan.aligned_accessor/aligned_accessor.pass.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: msvc && c++17
-
 #include <cuda/std/cassert>
 #include <cuda/std/mdspan>
 #include <cuda/std/type_traits>


### PR DESCRIPTION
## Description

Original implementation of missed the  `explicit` keyword in the conversion constructor from  `cuda::std::default_accessor` to `cuda::std::aligned_accessor`.
see also https://eel.is/c++draft/mdspan.accessor.aligned#members