### PR TITLE
Use self.bindings instead of making call to get_bindings function

### DIFF
--- a/python/cuda_parallel/cuda/parallel/experimental/algorithms/merge_sort.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/algorithms/merge_sort.py
@@ -69,7 +69,7 @@ class _MergeSort:
         self.d_out_keys_cccl = cccl.to_cccl_iter(d_out_keys)
         self.d_out_items_cccl = cccl.to_cccl_iter(d_out_items)
 
-        bindings = get_bindings()
+        self.bindings = get_bindings()
 
         if isinstance(d_in_keys, IteratorBase):
             value_type = d_in_keys.value_type
@@ -81,7 +81,7 @@ class _MergeSort:
 
         self.build_result = cccl.DeviceMergeSortBuildResult()
         error = call_build(
-            bindings.cccl_device_merge_sort_build,
+            self.bindings.cccl_device_merge_sort_build,
             ctypes.byref(self.build_result),
             self.d_in_keys_cccl,
             self.d_in_items_cccl,
@@ -113,7 +113,6 @@ class _MergeSort:
             set_state_fn(self.d_out_items_cccl, d_out_items)
 
         stream_handle = protocols.validate_and_get_stream(stream)
-        bindings = get_bindings()
         if temp_storage is None:
             temp_storage_bytes = ctypes.c_size_t()
             d_temp_storage = None
@@ -123,7 +122,7 @@ class _MergeSort:
             # TODO: switch to use gpumemoryview once it's ready
             d_temp_storage = temp_storage.__cuda_array_interface__["data"][0]
 
-        error = bindings.cccl_device_merge_sort(
+        error = self.bindings.cccl_device_merge_sort(
             self.build_result,
             ctypes.c_void_p(d_temp_storage),
             ctypes.byref(temp_storage_bytes),
@@ -144,8 +143,7 @@ class _MergeSort:
     def __del__(self):
         if self.build_result is None:
             return
-        bindings = get_bindings()
-        bindings.cccl_device_merge_sort_cleanup(ctypes.byref(self.build_result))
+        self.bindings.cccl_device_merge_sort_cleanup(ctypes.byref(self.build_result))
 
 
 @cache_with_key(make_cache_key)

--- a/python/cuda_parallel/cuda/parallel/experimental/algorithms/reduce.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/algorithms/reduce.py
@@ -103,8 +103,7 @@ class _Reduce:
     def __del__(self):
         if self.build_result is None:
             return
-        bindings = get_bindings()
-        bindings.cccl_device_reduce_cleanup(ctypes.byref(self.build_result))
+        self.bindings.cccl_device_reduce_cleanup(ctypes.byref(self.build_result))
 
 
 def make_cache_key(

--- a/python/cuda_parallel/cuda/parallel/experimental/algorithms/scan.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/algorithms/scan.py
@@ -98,8 +98,7 @@ class _Scan:
     def __del__(self):
         if self.build_result is None:
             return
-        bindings = get_bindings()
-        bindings.cccl_device_scan_cleanup(ctypes.byref(self.build_result))
+        self.bindings.cccl_device_scan_cleanup(ctypes.byref(self.build_result))
 
 
 def make_cache_key(

--- a/python/cuda_parallel/cuda/parallel/experimental/algorithms/segmented_reduce.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/algorithms/segmented_reduce.py
@@ -17,8 +17,9 @@ class _SegmentedReduce:
     def __del__(self):
         if self.build_result is None:
             return
-        bindings = get_bindings()
-        bindings.cccl_device_segmented_reduce_cleanup(ctypes.byref(self.build_result))
+        self.bindings.cccl_device_segmented_reduce_cleanup(
+            ctypes.byref(self.build_result)
+        )
 
     def __init__(
         self,


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes gh-4143

<!-- Provide a standalone description of changes in this PR. -->

This change applies to every algorithm in `cuda.parallel.experimental.algorithms` to save the result of `get_bindings()` call to `self.bindings` in `__init__` method, and reuse the class instance property in `__call__`, `__del__` special methods instead of making repeated calls to `get_bindings`. 

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
