### PR TITLE
work-around an nvcc-12.0 compiler bug in CTAD exposed by cudax

### DIFF
--- a/cudax/test/algorithm/common.cuh
+++ b/cudax/test/algorithm/common.cuh
@@ -12,6 +12,7 @@
 #define __ALGORITHM_COMMON__
 
 #include <cuda/memory_resource>
+#include <cuda/std/mdspan>
 
 #include <cuda/experimental/algorithm.cuh>
 #include <cuda/experimental/container.cuh>
@@ -60,7 +61,11 @@ inline auto create_fake_strided_mdspan()
 {
   cuda::std::dextents<size_t, 3> dynamic_extents{1, 2, 3};
   cuda::std::array<size_t, 3> strides{12, 4, 1};
+#if _CCCL_CUDACC_BELOW(12, 6)
+  auto map = cuda::std::layout_stride::mapping{dynamic_extents, strides};
+#else
   cuda::std::layout_stride::mapping map{dynamic_extents, strides};
+#endif
   return cuda::std::mdspan<int, decltype(dynamic_extents), cuda::std::layout_stride>(nullptr, map);
 };
 

--- a/libcudacxx/include/cuda/std/__mdspan/layout_stride.h
+++ b/libcudacxx/include/cuda/std/__mdspan/layout_stride.h
@@ -322,7 +322,7 @@ public:
             enable_if_t<_CCCL_TRAIT(is_constructible, index_type, const _OtherIndexType&), int> = 0,
             enable_if_t<_CCCL_TRAIT(is_convertible, const _OtherIndexType&, index_type), int>   = 0>
   _LIBCUDACXX_HIDE_FROM_ABI constexpr mapping(const extents_type& __ext,
-                                              const array<_OtherIndexType, extents_type::rank()> __strides) noexcept
+                                              const array<_OtherIndexType, extents_type::rank()>& __strides) noexcept
       : mapping(__ext, span<const _OtherIndexType, extents_type::rank()>(__strides))
   {}
 


### PR DESCRIPTION
drive-by: add missing `&` to ctor arg of `layout_stride::mapping`

## Description

address the build failure here: https://github.com/NVIDIA/cccl/actions/runs/13890771454/job/38862329397#step:5:1627

```
  /home/coder/cccl/cudax/test/algorithm/common.cuh: In function ‘auto create_fake_strided_mdspan()’:
  /home/coder/cccl/cudax/test/algorithm/common.cuh:63:41: error: invalid use of template-name ‘cuda::std::__4::layout_stride::mapping’ without an argument list
     63 |   cuda::std::layout_stride::mapping map{dynamic_extents, strides};
        |                                         ^~~~~~~
  /home/coder/cccl/lib/cmake/libcudacxx/../../../libcudacxx/include/cuda/std/__fwd/mdspan.h:52:32: note: ‘template<class Extents> class cuda::std::__4::layout_stride::mapping’ declared here
     52 |   template <class Extents>
        |                                ^      
  /home/coder/cccl/cudax/test/algorithm/common.cuh:63:49: error: scalar object ‘map’ requires one element in initializer
     63 |   cuda::std::layout_stride::mapping map{dynamic_extents, strides};
        |                                                 ^~~
```

the problem is that nvcc is erroneously turning the following line of code:

```c++
cuda::std::layout_stride::mapping map{dynamic_extents, strides};
```

into

```c++
typename cuda::std::layout_stride::mapping map{dynamic_extents, strides};
```

which naturally causes gcc to choke. the fix is to re-express the code as follows:

```c++
auto map = cuda::std::layout_stride::mapping{dynamic_extents, strides};
```

which does not trigger the nvcc bug.



## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
