### PR TITLE
[CUDAX] Add universal comparison across memory resources

### DIFF
--- a/cudax/include/cuda/experimental/__memory_resource/managed_memory_resource.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/managed_memory_resource.cuh
@@ -160,69 +160,6 @@ public:
 #endif // _CCCL_STD_VER <= 2017
 
 #ifndef _CCCL_DOXYGEN_INVOKED // Do not document
-
-private:
-  template <class _Resource>
-  _CCCL_NODISCARD bool __equal_to(_Resource const& __rhs) const noexcept
-  {
-    if constexpr (has_property<_Resource, device_accessible>)
-    {
-      return resource_ref<device_accessible>{*const_cast<managed_memory_resource*>(this)}
-          == __cudax::__as_resource_ref<device_accessible>(const_cast<_Resource&>(__rhs));
-    }
-    else if constexpr (has_property<_Resource, host_accessible>)
-    {
-      return resource_ref<host_accessible>{*const_cast<managed_memory_resource*>(this)}
-          == __cudax::__as_resource_ref<host_accessible>(const_cast<_Resource&>(__rhs));
-    }
-    else
-    {
-      return false;
-    }
-  }
-
-public:
-#  if _CCCL_STD_VER >= 2020
-  //! @brief Equality comparison between a \c managed_memory_resource and another resource
-  //! @param __rhs The resource to compare to
-  //! @return If the underlying types are equality comparable, returns the result of equality comparison of both
-  //! resources. Otherwise, returns false.
-  template <class _Resource>
-    requires _CUDA_VMR::__different_resource<managed_memory_resource, _Resource>
-  _CCCL_NODISCARD bool operator==(_Resource const& __rhs) const noexcept
-  {
-    return this->__equal_to(__rhs);
-  }
-#  else // ^^^ C++20 ^^^ / vvv C++17
-  template <class _Resource>
-  _CCCL_NODISCARD_FRIEND auto operator==(managed_memory_resource const& __lhs, _Resource const& __rhs) noexcept
-    _CCCL_TRAILING_REQUIRES(bool)(_CUDA_VMR::__different_resource<managed_memory_resource, _Resource>)
-  {
-    return __lhs.__equal_to(__rhs);
-  }
-
-  template <class _Resource>
-  _CCCL_NODISCARD_FRIEND auto operator==(_Resource const& __lhs, managed_memory_resource const& __rhs) noexcept
-    _CCCL_TRAILING_REQUIRES(bool)(_CUDA_VMR::__different_resource<managed_memory_resource, _Resource>)
-  {
-    return __rhs.__equal_to(__lhs);
-  }
-
-  template <class _Resource>
-  _CCCL_NODISCARD_FRIEND auto operator!=(managed_memory_resource const& __lhs, _Resource const& __rhs) noexcept
-    _CCCL_TRAILING_REQUIRES(bool)(_CUDA_VMR::__different_resource<managed_memory_resource, _Resource>)
-  {
-    return !__lhs.__equal_to(__rhs);
-  }
-
-  template <class _Resource>
-  _CCCL_NODISCARD_FRIEND auto operator!=(_Resource const& __lhs, managed_memory_resource const& __rhs) noexcept
-    _CCCL_TRAILING_REQUIRES(bool)(_CUDA_VMR::__different_resource<managed_memory_resource, _Resource>)
-  {
-    return !__rhs.__equal_to(__lhs);
-  }
-#  endif // _CCCL_STD_VER <= 2017
-
   //! @brief Enables the \c device_accessible property
   friend constexpr void get_property(managed_memory_resource const&, device_accessible) noexcept {}
   //! @brief Enables the \c host_accessible property

--- a/cudax/include/cuda/experimental/__memory_resource/memory_resource_base.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/memory_resource_base.cuh
@@ -246,56 +246,6 @@ public:
   }
 #endif // _CCCL_STD_VER <= 2017
 
-// TODO Should this be declared in general for two things that satisfy resource concept?
-#if _CCCL_STD_VER >= 2020
-  //! @brief Equality comparison between a \c __memory_resource_base and another resource.
-  //! @param __rhs The resource to compare to.
-  //! @returns If the underlying types are equality comparable, returns the result of equality comparison of both
-  //! resources. Otherwise, returns false.
-  template <class _Resource>
-    requires _CUDA_VMR::__different_resource<__memory_resource_base, _Resource> && __non_polymorphic<_Resource>
-  _CCCL_NODISCARD bool operator==([[maybe_unused]] _Resource const& __rhs) const noexcept
-  {
-    return false;
-  }
-#else // ^^^ C++20 ^^^ / vvv C++17
-  template <class _Resource>
-  _CCCL_NODISCARD_FRIEND auto
-  operator==([[maybe_unused]] __memory_resource_base const& __lhs, [[maybe_unused]] _Resource const& __rhs) noexcept
-    _CCCL_TRAILING_REQUIRES(bool)(
-      _CUDA_VMR::__different_resource<__memory_resource_base, _Resource>&& __non_polymorphic<_Resource>)
-  {
-    return false;
-  }
-
-  template <class _Resource>
-  _CCCL_NODISCARD_FRIEND auto
-  operator==([[maybe_unused]] _Resource const& __lhs, [[maybe_unused]] __memory_resource_base const& __rhs) noexcept
-    _CCCL_TRAILING_REQUIRES(bool)(
-      _CUDA_VMR::__different_resource<__memory_resource_base, _Resource>&& __non_polymorphic<_Resource>)
-  {
-    return false;
-  }
-
-  template <class _Resource>
-  _CCCL_NODISCARD_FRIEND auto
-  operator!=([[maybe_unused]] __memory_resource_base const& __lhs, [[maybe_unused]] _Resource const& __rhs) noexcept
-    _CCCL_TRAILING_REQUIRES(bool)(
-      _CUDA_VMR::__different_resource<__memory_resource_base, _Resource>&& __non_polymorphic<_Resource>)
-  {
-    return true;
-  }
-
-  template <class _Resource>
-  _CCCL_NODISCARD_FRIEND auto
-  operator!=([[maybe_unused]] _Resource const& __lhs, [[maybe_unused]] __memory_resource_base const& __rhs) noexcept
-    _CCCL_TRAILING_REQUIRES(bool)(
-      _CUDA_VMR::__different_resource<__memory_resource_base, _Resource>&& __non_polymorphic<_Resource>)
-  {
-    return true;
-  }
-#endif // _CCCL_STD_VER <= 2017
-
   _CCCL_NODISCARD constexpr cudaMemPool_t get() const noexcept
   {
     return __pool_;

--- a/cudax/include/cuda/experimental/__memory_resource/pinned_memory_resource.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/pinned_memory_resource.cuh
@@ -209,65 +209,6 @@ public:
 #  endif // _CCCL_STD_VER <= 2017
 
 #  ifndef _CCCL_DOXYGEN_INVOKED // Do not document
-  template <class _Resource>
-  _CCCL_NODISCARD bool __equal_to(_Resource const& __rhs) const noexcept
-  {
-    if constexpr (has_property<_Resource, device_accessible>)
-    {
-      return resource_ref<device_accessible>{*const_cast<pinned_memory_resource*>(this)}
-          == __cudax::__as_resource_ref<device_accessible>(const_cast<_Resource&>(__rhs));
-    }
-    else if constexpr (has_property<_Resource, host_accessible>)
-    {
-      return resource_ref<host_accessible>{*const_cast<pinned_memory_resource*>(this)}
-          == __cudax::__as_resource_ref<host_accessible>(const_cast<_Resource&>(__rhs));
-    }
-    else
-    {
-      return false;
-    }
-  }
-#    if _CCCL_STD_VER >= 2020
-  //! @brief Equality comparison between a \c pinned_memory_resource and another resource
-  //! @param __rhs The resource to compare to
-  //! @return If the underlying types are equality comparable, returns the result of equality comparison of both
-  //! resources. Otherwise, returns false.
-  template <class _Resource>
-    requires _CUDA_VMR::__different_resource<pinned_memory_resource, _Resource>
-  _CCCL_NODISCARD bool operator==(_Resource const& __rhs) const noexcept
-  {
-    return this->__equal_to(__rhs);
-  }
-#    else // ^^^ C++20 ^^^ / vvv C++17
-  template <class _Resource>
-  _CCCL_NODISCARD_FRIEND auto operator==(pinned_memory_resource const& __lhs, _Resource const& __rhs) noexcept
-    _CCCL_TRAILING_REQUIRES(bool)(_CUDA_VMR::__different_resource<pinned_memory_resource, _Resource>)
-  {
-    return __lhs.__equal_to(__rhs);
-  }
-
-  template <class _Resource>
-  _CCCL_NODISCARD_FRIEND auto operator==(_Resource const& __lhs, pinned_memory_resource const& __rhs) noexcept
-    _CCCL_TRAILING_REQUIRES(bool)(_CUDA_VMR::__different_resource<pinned_memory_resource, _Resource>)
-  {
-    return __rhs.__equal_to(__lhs);
-  }
-
-  template <class _Resource>
-  _CCCL_NODISCARD_FRIEND auto operator!=(pinned_memory_resource const& __lhs, _Resource const& __rhs) noexcept
-    _CCCL_TRAILING_REQUIRES(bool)(_CUDA_VMR::__different_resource<pinned_memory_resource, _Resource>)
-  {
-    return !__lhs.__equal_to(__rhs);
-  }
-
-  template <class _Resource>
-  _CCCL_NODISCARD_FRIEND auto operator!=(_Resource const& __lhs, pinned_memory_resource const& __rhs) noexcept
-    _CCCL_TRAILING_REQUIRES(bool)(_CUDA_VMR::__different_resource<pinned_memory_resource, _Resource>)
-  {
-    return !__rhs.__equal_to(__lhs);
-  }
-#    endif // _CCCL_STD_VER <= 2017
-
   //! @brief Enables the \c device_accessible property
   friend constexpr void get_property(pinned_memory_resource const&, device_accessible) noexcept {}
   //! @brief Enables the \c host_accessible property

--- a/cudax/include/cuda/experimental/__memory_resource/resource.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/resource.cuh
@@ -37,8 +37,7 @@ template <class _Resource, class _OtherResource>
   requires _CUDA_VMR::resource<_Resource> && _CUDA_VMR::resource<_OtherResource>
         && _CUDA_VMR::__different_resource<_Resource, _OtherResource> && __non_polymorphic<_Resource>
         && __non_polymorphic<_OtherResource>
-_CCCL_NODISCARD bool
-operator==([[maybe_unused]] _Resource const& __lhs, [[maybe_unused]] _OtherResource const& __rhs) noexcept
+_CCCL_NODISCARD bool operator==(_Resource const&, _OtherResource const&) noexcept
 {
   return false;
 }
@@ -49,11 +48,10 @@ operator==([[maybe_unused]] _Resource const& __lhs, [[maybe_unused]] _OtherResou
 //! @param __rhs The right-hand side resource.
 //! @returns Always returns false.
 template <class _Resource, class _OtherResource>
-_CCCL_NODISCARD auto
-operator==([[maybe_unused]] _Resource const& __lhs, [[maybe_unused]] _OtherResource const& __rhs) noexcept
-  _CCCL_TRAILING_REQUIRES(bool)(_CUDA_VMR::resource<_Resource>&& _CUDA_VMR::resource<_OtherResource>&&
-                                  _CUDA_VMR::__different_resource<_Resource, _OtherResource>&&
-                                    __non_polymorphic<_Resource>&& __non_polymorphic<_OtherResource>)
+_CCCL_NODISCARD auto operator==(_Resource const&, _OtherResource const&) noexcept _CCCL_TRAILING_REQUIRES(bool)(
+  _CUDA_VMR::resource<_Resource>&& _CUDA_VMR::resource<_OtherResource>&&
+    _CUDA_VMR::__different_resource<_Resource, _OtherResource>&& __non_polymorphic<_Resource>&&
+      __non_polymorphic<_OtherResource>)
 {
   return false;
 }
@@ -63,11 +61,10 @@ operator==([[maybe_unused]] _Resource const& __lhs, [[maybe_unused]] _OtherResou
 //! @param __rhs The right-hand side resource.
 //! @returns Always returns true.
 template <class _Resource, class _OtherResource>
-_CCCL_NODISCARD auto
-operator!=([[maybe_unused]] _Resource const& __lhs, [[maybe_unused]] _OtherResource const& __rhs) noexcept
-  _CCCL_TRAILING_REQUIRES(bool)(_CUDA_VMR::resource<_Resource>&& _CUDA_VMR::resource<_OtherResource>&&
-                                  _CUDA_VMR::__different_resource<_Resource, _OtherResource>&&
-                                    __non_polymorphic<_Resource>&& __non_polymorphic<_OtherResource>)
+_CCCL_NODISCARD auto operator!=(_Resource const&, _OtherResource const&) noexcept _CCCL_TRAILING_REQUIRES(bool)(
+  _CUDA_VMR::resource<_Resource>&& _CUDA_VMR::resource<_OtherResource>&&
+    _CUDA_VMR::__different_resource<_Resource, _OtherResource>&& __non_polymorphic<_Resource>&&
+      __non_polymorphic<_OtherResource>)
 {
   return true;
 }

--- a/cudax/include/cuda/experimental/__memory_resource/resource.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/resource.cuh
@@ -28,47 +28,36 @@
 namespace cuda::experimental
 {
 
-#if _CCCL_STD_VER >= 2020
+template <class _Resource, class _OtherResource>
+_CCCL_CONCEPT __comparable_resources = _CCCL_REQUIRES_EXPR((_Resource, _OtherResource))(
+  requires(_CUDA_VMR::__different_resource<_Resource, _OtherResource>),
+  requires(_CUDA_VMR::resource<_Resource>),
+  requires(_CUDA_VMR::resource<_OtherResource>),
+  requires(__non_polymorphic<_Resource>),
+  requires(__non_polymorphic<_OtherResource>));
+
 //! @brief Equality comparison between two resources of different types.
 //! @param __lhs The left-hand side resource.
 //! @param __rhs The right-hand side resource.
 //! @returns Always returns false.
 template <class _Resource, class _OtherResource>
-  requires _CUDA_VMR::resource<_Resource> && _CUDA_VMR::resource<_OtherResource>
-        && _CUDA_VMR::__different_resource<_Resource, _OtherResource> && __non_polymorphic<_Resource>
-        && __non_polymorphic<_OtherResource>
-_CCCL_NODISCARD bool operator==(_Resource const&, _OtherResource const&) noexcept
+_CCCL_NODISCARD auto operator==(_Resource const&, _OtherResource const&) noexcept
+  _CCCL_TRAILING_REQUIRES(bool)(__comparable_resources<_Resource, _OtherResource>)
 {
   return false;
 }
 
-#else // ^^^ C++20 ^^^ / vvv C++17
-//! @brief Equality comparison between two resources of different types.
-//! @param __lhs The left-hand side resource.
-//! @param __rhs The right-hand side resource.
-//! @returns Always returns false.
-template <class _Resource, class _OtherResource>
-_CCCL_NODISCARD auto operator==(_Resource const&, _OtherResource const&) noexcept _CCCL_TRAILING_REQUIRES(bool)(
-  _CUDA_VMR::resource<_Resource>&& _CUDA_VMR::resource<_OtherResource>&&
-    _CUDA_VMR::__different_resource<_Resource, _OtherResource>&& __non_polymorphic<_Resource>&&
-      __non_polymorphic<_OtherResource>)
-{
-  return false;
-}
-
+#if _CCCL_STD_VER <= 2017
 //! @brief Inequality comparison between two resources of different types.
 //! @param __lhs The left-hand side resource.
 //! @param __rhs The right-hand side resource.
 //! @returns Always returns true.
 template <class _Resource, class _OtherResource>
-_CCCL_NODISCARD auto operator!=(_Resource const&, _OtherResource const&) noexcept _CCCL_TRAILING_REQUIRES(bool)(
-  _CUDA_VMR::resource<_Resource>&& _CUDA_VMR::resource<_OtherResource>&&
-    _CUDA_VMR::__different_resource<_Resource, _OtherResource>&& __non_polymorphic<_Resource>&&
-      __non_polymorphic<_OtherResource>)
+_CCCL_NODISCARD auto operator!=(_Resource const&, _OtherResource const&) noexcept
+  _CCCL_TRAILING_REQUIRES(bool)(__comparable_resources<_Resource, _OtherResource>)
 {
   return true;
 }
-
 #endif // _CCCL_STD_VER <= 2017
 
 } // namespace cuda::experimental

--- a/cudax/include/cuda/experimental/__memory_resource/resource.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/resource.cuh
@@ -40,9 +40,9 @@ _CCCL_CONCEPT __comparable_resources = _CCCL_REQUIRES_EXPR((_Resource, _OtherRes
 //! @param __lhs The left-hand side resource.
 //! @param __rhs The right-hand side resource.
 //! @returns Always returns false.
-template <class _Resource, class _OtherResource>
-_CCCL_NODISCARD auto operator==(_Resource const&, _OtherResource const&) noexcept
-  _CCCL_TRAILING_REQUIRES(bool)(__comparable_resources<_Resource, _OtherResource>)
+_CCCL_TEMPLATE(class _Resource, class _OtherResource)
+_CCCL_REQUIRES(__comparable_resources<_Resource, _OtherResource>)
+_CCCL_NODISCARD bool operator==(_Resource const&, _OtherResource const&) noexcept
 {
   return false;
 }
@@ -52,9 +52,9 @@ _CCCL_NODISCARD auto operator==(_Resource const&, _OtherResource const&) noexcep
 //! @param __lhs The left-hand side resource.
 //! @param __rhs The right-hand side resource.
 //! @returns Always returns true.
-template <class _Resource, class _OtherResource>
-_CCCL_NODISCARD auto operator!=(_Resource const&, _OtherResource const&) noexcept
-  _CCCL_TRAILING_REQUIRES(bool)(__comparable_resources<_Resource, _OtherResource>)
+_CCCL_TEMPLATE(class _Resource, class _OtherResource)
+_CCCL_REQUIRES(__comparable_resources<_Resource, _OtherResource>)
+_CCCL_NODISCARD bool operator!=(_Resource const&, _OtherResource const&) noexcept
 {
   return true;
 }

--- a/cudax/include/cuda/experimental/__memory_resource/resource.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/resource.cuh
@@ -29,11 +29,10 @@ namespace cuda::experimental
 {
 
 #if _CCCL_STD_VER >= 2020
-//! @brief Equality comparison between two resources.
+//! @brief Equality comparison between two resources of different types.
 //! @param __lhs The left-hand side resource.
 //! @param __rhs The right-hand side resource.
-//! @returns If the underlying types are equality comparable, returns the result of equality comparison of both
-//! resources. Otherwise, returns false.
+//! @returns Always returns false.
 template <class _Resource, class _OtherResource>
   requires _CUDA_VMR::resource<_Resource> && _CUDA_VMR::resource<_OtherResource>
         && _CUDA_VMR::__different_resource<_Resource, _OtherResource> && __non_polymorphic<_Resource>
@@ -45,6 +44,10 @@ operator==([[maybe_unused]] _Resource const& __lhs, [[maybe_unused]] _OtherResou
 }
 
 #else // ^^^ C++20 ^^^ / vvv C++17
+//! @brief Equality comparison between two resources of different types.
+//! @param __lhs The left-hand side resource.
+//! @param __rhs The right-hand side resource.
+//! @returns Always returns false.
 template <class _Resource, class _OtherResource>
 _CCCL_NODISCARD auto
 operator==([[maybe_unused]] _Resource const& __lhs, [[maybe_unused]] _OtherResource const& __rhs) noexcept
@@ -55,6 +58,10 @@ operator==([[maybe_unused]] _Resource const& __lhs, [[maybe_unused]] _OtherResou
   return false;
 }
 
+//! @brief Inequality comparison between two resources of different types.
+//! @param __lhs The left-hand side resource.
+//! @param __rhs The right-hand side resource.
+//! @returns Always returns true.
 template <class _Resource, class _OtherResource>
 _CCCL_NODISCARD auto
 operator!=([[maybe_unused]] _Resource const& __lhs, [[maybe_unused]] _OtherResource const& __rhs) noexcept

--- a/cudax/include/cuda/experimental/__memory_resource/resource.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/resource.cuh
@@ -1,0 +1,72 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDAX__MEMORY_RESOURCE_RESOURCE_CUH
+#define _CUDAX__MEMORY_RESOURCE_RESOURCE_CUH
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/__memory_resource/resource.h>
+
+#include <cuda/experimental/__utility/basic_any/semiregular.cuh>
+
+namespace cuda::experimental
+{
+
+#if _CCCL_STD_VER >= 2020
+//! @brief Equality comparison between two resources.
+//! @param __lhs The left-hand side resource.
+//! @param __rhs The right-hand side resource.
+//! @returns If the underlying types are equality comparable, returns the result of equality comparison of both
+//! resources. Otherwise, returns false.
+template <class _Resource, class _OtherResource>
+  requires _CUDA_VMR::resource<_Resource> && _CUDA_VMR::resource<_OtherResource>
+        && _CUDA_VMR::__different_resource<_Resource, _OtherResource> && __non_polymorphic<_Resource>
+        && __non_polymorphic<_OtherResource>
+_CCCL_NODISCARD bool
+operator==([[maybe_unused]] _Resource const& __lhs, [[maybe_unused]] _OtherResource const& __rhs) noexcept
+{
+  return false;
+}
+
+#else // ^^^ C++20 ^^^ / vvv C++17
+template <class _Resource, class _OtherResource>
+_CCCL_NODISCARD auto
+operator==([[maybe_unused]] _Resource const& __lhs, [[maybe_unused]] _OtherResource const& __rhs) noexcept
+  _CCCL_TRAILING_REQUIRES(bool)(_CUDA_VMR::resource<_Resource>&& _CUDA_VMR::resource<_OtherResource>&&
+                                  _CUDA_VMR::__different_resource<_Resource, _OtherResource>&&
+                                    __non_polymorphic<_Resource>&& __non_polymorphic<_OtherResource>)
+{
+  return false;
+}
+
+template <class _Resource, class _OtherResource>
+_CCCL_NODISCARD auto
+operator!=([[maybe_unused]] _Resource const& __lhs, [[maybe_unused]] _OtherResource const& __rhs) noexcept
+  _CCCL_TRAILING_REQUIRES(bool)(_CUDA_VMR::resource<_Resource>&& _CUDA_VMR::resource<_OtherResource>&&
+                                  _CUDA_VMR::__different_resource<_Resource, _OtherResource>&&
+                                    __non_polymorphic<_Resource>&& __non_polymorphic<_OtherResource>)
+{
+  return true;
+}
+
+#endif // _CCCL_STD_VER <= 2017
+
+} // namespace cuda::experimental
+
+#endif //_CUDAX__MEMORY_RESOURCE_RESOURCE_CUH

--- a/cudax/include/cuda/experimental/memory_resource.cuh
+++ b/cudax/include/cuda/experimental/memory_resource.cuh
@@ -30,6 +30,7 @@
 #include <cuda/experimental/__memory_resource/pinned_memory_pool.cuh>
 #include <cuda/experimental/__memory_resource/pinned_memory_resource.cuh>
 #include <cuda/experimental/__memory_resource/properties.cuh>
+#include <cuda/experimental/__memory_resource/resource.cuh>
 #include <cuda/experimental/__memory_resource/shared_resource.cuh>
 
 #endif // __CUDAX_MEMORY_RESOURCE___

--- a/cudax/test/containers/async_buffer/test_resources.h
+++ b/cudax/test/containers/async_buffer/test_resources.h
@@ -140,23 +140,25 @@ public:
 template <class... Properties>
 struct memory_resource_wrapper
 {
-  cuda::mr::async_resource_ref<Properties...> ref_;
+  // Not a resource_ref, because it can't be used to create any_async_resource (yet)
+  // https://github.com/NVIDIA/cccl/issues/4166
+  cudax::any_async_resource<Properties...> resource_;
 
   void* allocate(std::size_t size, std::size_t alignment)
   {
-    return ref_.allocate(size, alignment);
+    return resource_.allocate(size, alignment);
   }
   void deallocate(void* ptr, std::size_t size, std::size_t alignment)
   {
-    ref_.deallocate(ptr, size, alignment);
+    resource_.deallocate(ptr, size, alignment);
   }
   void* allocate_async(std::size_t size, std::size_t alignment, cuda::stream_ref stream)
   {
-    return ref_.allocate_async(size, alignment, stream);
+    return resource_.allocate_async(size, alignment, stream);
   }
   void deallocate_async(void* ptr, std::size_t size, std::size_t alignment, cuda::stream_ref stream)
   {
-    ref_.deallocate_async(ptr, size, alignment, stream);
+    resource_.deallocate_async(ptr, size, alignment, stream);
   }
 
   bool operator==(const memory_resource_wrapper&) const

--- a/cudax/test/memory_resource/managed_memory_resource.cu
+++ b/cudax/test/memory_resource/managed_memory_resource.cu
@@ -226,7 +226,7 @@ TEST_CASE("managed_memory_resource comparison", "[memory_resource]")
 
   { // comparison against a managed_memory_resource wrapped inside a resource_ref<device_accessible>
     managed_resource second{};
-    cuda::mr::resource_ref<cudax::device_accessible> second_ref{second};
+    cudax::resource_ref<cudax::device_accessible> second_ref{second};
     CHECK((first == second_ref));
     CHECK(!(first != second_ref));
     CHECK((second_ref == first));
@@ -235,7 +235,7 @@ TEST_CASE("managed_memory_resource comparison", "[memory_resource]")
 
   { // comparison against a managed_memory_resource wrapped inside a async_resource_ref
     managed_resource second{};
-    cuda::mr::async_resource_ref<cudax::device_accessible> second_ref{second};
+    cudax::async_resource_ref<cudax::device_accessible> second_ref{second};
 
     CHECK((first == second_ref));
     CHECK(!(first != second_ref));


### PR DESCRIPTION
Currently base class for memory resources exposes `operator==` with any non-polymorphic resource. If a similar thing is provided in other resource implementations that would lead to multiple candidates in overload resolution.

Instead this PR implements a universal `operator==` for two types that satisfy resource concept, are different resource types and non-polymorphic. That comparison obviously just always returns false.

This way we can now discourage providing such comparisons in resource implementations, they should only provide comparisons for their own resource type.

Comparison with polymorphic resource types is handled by `basic_any` and it lowers down to comparisons of the underlying resource types. This is why polymorphic resources are excluded from the universal comparison.