### PR TITLE
Implement `__fp_native_type_t`

### DIFF
--- a/libcudacxx/include/cuda/std/__floating_point/fp.h
+++ b/libcudacxx/include/cuda/std/__floating_point/fp.h
@@ -1,11 +1,12 @@
-//===---------------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
-//===---------------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #ifndef _LIBCUDACXX___FLOATING_POINT_FP_H
 #define _LIBCUDACXX___FLOATING_POINT_FP_H
@@ -25,6 +26,7 @@
 #include <cuda/std/__floating_point/conversion_rank_order.h>
 #include <cuda/std/__floating_point/format.h>
 #include <cuda/std/__floating_point/mask.h>
+#include <cuda/std/__floating_point/native_type.h>
 #include <cuda/std/__floating_point/nvfp_types.h>
 #include <cuda/std/__floating_point/storage.h>
 

--- a/libcudacxx/include/cuda/std/__floating_point/native_type.h
+++ b/libcudacxx/include/cuda/std/__floating_point/native_type.h
@@ -1,0 +1,72 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___FLOATING_POINT_NATIVE_TYPE_H
+#define _LIBCUDACXX___FLOATING_POINT_NATIVE_TYPE_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__floating_point/format.h>
+#include <cuda/std/__type_traits/is_void.h>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_STD
+
+template <__fp_format _Fmt>
+_LIBCUDACXX_HIDE_FROM_ABI constexpr auto __fp_native_type_impl()
+{
+  if constexpr (_Fmt == __fp_format::__binary32)
+  {
+    return float{};
+  }
+  else if constexpr (_Fmt == __fp_format::__binary64)
+  {
+    return double{};
+  }
+  else if constexpr (_Fmt == __fp_format::__binary128)
+  {
+#if _CCCL_HAS_FLOAT128()
+    return __float128{};
+#elif _CCCL_HAS_LONG_DOUBLE() && LDBL_MIN_EXP == -16381 && LDBL_MAX_EXP == 16384 && LDBL_MANT_DIG == 113
+    return long double{};
+#else // ^^^ has native binary128 ^^^ / vvv no native binary128 vvv
+    return;
+#endif // ^^^ no native binary128 ^^^
+  }
+  else if constexpr (_Fmt == __fp_format::__fp80_x86)
+  {
+#if _CCCL_HAS_LONG_DOUBLE() && LDBL_MIN_EXP == -16381 && LDBL_MAX_EXP == 16384 && LDBL_MANT_DIG == 64
+    return long double{};
+#else // ^^^ has native x86 fp80 ^^^ / vvv no native x86 fp80 vvv
+    return;
+#endif // ^^^ no native x86 fp80 ^^^
+  }
+  else
+  {
+    return;
+  }
+}
+
+template <__fp_format _Fmt>
+using __fp_native_type_t = decltype(__fp_native_type_impl<_Fmt>());
+
+template <__fp_format _Fmt>
+_CCCL_INLINE_VAR constexpr bool __fp_has_native_type_v = !_CCCL_TRAIT(is_void, __fp_native_type_t<_Fmt>);
+
+_LIBCUDACXX_END_NAMESPACE_STD
+
+#endif // _LIBCUDACXX___FLOATING_POINT_NATIVE_TYPE_H

--- a/libcudacxx/include/cuda/std/__floating_point/native_type.h
+++ b/libcudacxx/include/cuda/std/__floating_point/native_type.h
@@ -42,7 +42,7 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr auto __fp_native_type_impl()
 #if _CCCL_HAS_FLOAT128()
     return __float128{};
 #elif _CCCL_HAS_LONG_DOUBLE() && LDBL_MIN_EXP == -16381 && LDBL_MAX_EXP == 16384 && LDBL_MANT_DIG == 113
-    return long double{};
+    return long double();
 #else // ^^^ has native binary128 ^^^ / vvv no native binary128 vvv
     return;
 #endif // ^^^ no native binary128 ^^^
@@ -50,7 +50,7 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr auto __fp_native_type_impl()
   else if constexpr (_Fmt == __fp_format::__fp80_x86)
   {
 #if _CCCL_HAS_LONG_DOUBLE() && LDBL_MIN_EXP == -16381 && LDBL_MAX_EXP == 16384 && LDBL_MANT_DIG == 64
-    return long double{};
+    return long double();
 #else // ^^^ has native x86 fp80 ^^^ / vvv no native x86 fp80 vvv
     return;
 #endif // ^^^ no native x86 fp80 ^^^

--- a/libcudacxx/include/cuda/std/__floating_point/native_type.h
+++ b/libcudacxx/include/cuda/std/__floating_point/native_type.h
@@ -42,7 +42,7 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr auto __fp_native_type_impl()
 #if _CCCL_HAS_FLOAT128()
     return __float128{};
 #elif _CCCL_HAS_LONG_DOUBLE() && LDBL_MIN_EXP == -16381 && LDBL_MAX_EXP == 16384 && LDBL_MANT_DIG == 113
-    return long double();
+    return (long double) {};
 #else // ^^^ has native binary128 ^^^ / vvv no native binary128 vvv
     return;
 #endif // ^^^ no native binary128 ^^^
@@ -50,7 +50,7 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr auto __fp_native_type_impl()
   else if constexpr (_Fmt == __fp_format::__fp80_x86)
   {
 #if _CCCL_HAS_LONG_DOUBLE() && LDBL_MIN_EXP == -16381 && LDBL_MAX_EXP == 16384 && LDBL_MANT_DIG == 64
-    return long double();
+    return (long double) {};
 #else // ^^^ has native x86 fp80 ^^^ / vvv no native x86 fp80 vvv
     return;
 #endif // ^^^ no native x86 fp80 ^^^

--- a/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/format.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/format.pass.cpp
@@ -14,7 +14,6 @@
 
 #include <cuda/std/__floating_point/fp.h>
 #include <cuda/std/cassert>
-#include <cuda/std/cstring>
 
 #include "test_macros.h"
 

--- a/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/native_type.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/native_type.pass.cpp
@@ -1,0 +1,54 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===
+
+//// clang-format off
+#include <disable_nvfp_conversions_and_operators.h>
+// clang-format on
+
+#include <cuda/std/__floating_point/fp.h>
+#include <cuda/std/cassert>
+#include <cuda/std/type_traits>
+
+#include "test_macros.h"
+
+template <cuda::std::__fp_format format, class T>
+__host__ __device__ void test_fp_native_type()
+{
+  static_assert(cuda::std::is_same_v<T, cuda::std::__fp_native_type_t<format>>);
+  static_assert(cuda::std::is_void_v<T> == !cuda::std::__fp_has_native_type_v<format>);
+}
+
+int main(int, char**)
+{
+  test_fp_native_type<cuda::std::__fp_format::__binary16, void>();
+  test_fp_native_type<cuda::std::__fp_format::__binary32, float>();
+  test_fp_native_type<cuda::std::__fp_format::__binary64, double>();
+#if _CCCL_HAS_FLOAT128()
+  test_fp_native_type<cuda::std::__fp_format::__binary128, __float128>();
+#elif _CCCL_HAS_LONG_DOUBLE() && LDBL_MIN_EXP == -16381 && LDBL_MAX_EXP == 16384 && LDBL_MANT_DIG == 113
+  test_fp_native_type<cuda::std::__fp_format::__binary128, long double>();
+#else // ^^^ has native binary128 ^^^ / vvv no native binary128 vvv
+  test_fp_native_type<cuda::std::__fp_format::__binary128, void>();
+#endif // ^^^ no native binary128 ^^^
+  test_fp_native_type<cuda::std::__fp_format::__bfloat16, void>();
+#if _CCCL_HAS_LONG_DOUBLE() && LDBL_MIN_EXP == -16381 && LDBL_MAX_EXP == 16384 && LDBL_MANT_DIG == 64
+  test_fp_native_type<cuda::std::__fp_format::__fp80_x86, void>();
+#else // ^^^ has native __fp80_x86 ^^^ / vvv no native __fp80_x86 vvv
+  test_fp_native_type<cuda::std::__fp_format::__fp80_x86, void>();
+#endif // ^^^ no native __fp80_x86 ^^^
+  test_fp_native_type<cuda::std::__fp_format::__fp8_nv_e4m3, void>();
+  test_fp_native_type<cuda::std::__fp_format::__fp8_nv_e5m2, void>();
+  test_fp_native_type<cuda::std::__fp_format::__fp8_nv_e8m0, void>();
+  test_fp_native_type<cuda::std::__fp_format::__fp6_nv_e2m3, void>();
+  test_fp_native_type<cuda::std::__fp_format::__fp6_nv_e3m2, void>();
+  test_fp_native_type<cuda::std::__fp_format::__fp4_nv_e2m1, void>();
+
+  return 0;
+}


### PR DESCRIPTION
This PR implements compiler's native type selection for extended floating point types operations. This PR does not add any new external extended floating point types.
