### PR TITLE
Drop tuning params for benchmarks with custom ops

### DIFF
--- a/cub/benchmarks/bench/reduce/custom.cu
+++ b/cub/benchmarks/bench/reduce/custom.cu
@@ -33,10 +33,6 @@
 
 #include <nvbench_helper.cuh>
 
-// %RANGE% TUNE_ITEMS_PER_THREAD ipt 7:24:1
-// %RANGE% TUNE_THREADS_PER_BLOCK tpb 128:1024:32
-// %RANGE% TUNE_ITEMS_PER_VEC_LOAD_POW2 ipv 1:2:1
-
 using value_types = all_types;
 using op_t        = max_t;
 #include "base.cuh"

--- a/cub/benchmarks/bench/scan/exclusive/custom.cu
+++ b/cub/benchmarks/bench/scan/exclusive/custom.cu
@@ -31,14 +31,6 @@
 // Because CUB cannot detect this operator, we cannot add any tunings based on the results of this benchmark. Its main
 // use is to detect regressions.
 
-// %RANGE% TUNE_ITEMS ipt 7:24:1
-// %RANGE% TUNE_THREADS tpb 128:1024:32
-// %RANGE% TUNE_MAGIC_NS ns 0:2048:4
-// %RANGE% TUNE_DELAY_CONSTRUCTOR_ID dcid 0:7:1
-// %RANGE% TUNE_L2_WRITE_LATENCY_NS l2w 0:1200:5
-// %RANGE% TUNE_TRANSPOSE trp 0:1:1
-// %RANGE% TUNE_LOAD ld 0:1:1
-
 #include <nvbench_helper.cuh>
 
 using op_t = max_t;


### PR DESCRIPTION
Benchmarks with custom operators unbeknownst to CUB cannot be tuned, since CUB cannot detect the operator or make assumptions about its impact on a kernel.