### PR TITLE
Testing CI times on different hardware.

### DIFF
--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -8,6 +8,9 @@ workflows:
   #   - {jobs: ['test'], project: 'thrust', std: 17, ctk: 'curr', cxx: ['gcc12', 'clang16']}
   #
   override:
+    - {jobs: ['test_nolid', 'test_lid0'], project: 'cub',                   std: 'max', gpu: ['t4'], sm: '70;75;86;89;90;100'}
+    - {jobs: ['test_gpu'],                project: 'thrust',                std: 'max', gpu: ['t4'], sm: '70;75;86;89;90;100'}
+    - {jobs: ['test'],                    project: ['libcudacxx', 'cudax'], std: 'max', gpu: ['t4'], sm: '70;75;86;89;90;100'}
 
   pull_request:
     # Old CTK/compiler


### PR DESCRIPTION
| GPU          | CUB TestGPU | CUB HostLaunch | Thrust | libcudacxx | cudax |
|-------------|----------------|--------------------|--------|-------------|-------|
| V100         | 19m                | 41m                    | 15m     | 2h02m      | 16m |
| T4 (3 core) | 54m                | 59m                    | 48m     | 3h06m*     | 29m |
| T4 (6 core) | 44m                | 40m                    | 32m     | 2h35m       | 24m |
| RTX2080   | 25m                | 24m                    | 19m     | 1h59m      | 21m |
| RTXA6000 | 27m                | 29m                    | 18m    | 1h34m       | 14m |
| L4             | 30m                 | 29m                   | 16m     | 1h29m      | 14m |
| RTX4090   | 27m                | 24m                    | 14m     | 1h20m      | 13m |
| H100        | 29m                | 29m                    | 16m     | 1h36m      | 16m |

* Test runner timed out.