### PR TITLE
Avoid instantiating discard_iterator while parsing

### DIFF
--- a/cub/cub/util_type.cuh
+++ b/cub/cub/util_type.cuh
@@ -46,12 +46,12 @@
 #include <cub/detail/type_traits.cuh>
 #include <cub/detail/uninitialized_copy.cuh>
 
-#include <thrust/iterator/discard_iterator.h>
+#include <thrust/iterator/detail/any_assign.h>
 
 #include <cuda/std/cstdint>
 #include <cuda/std/iterator>
 #include <cuda/std/limits>
-#include <cuda/std/type_traits>
+#include <cuda/type_traits>
 
 #if _CCCL_HAS_NVFP16()
 #  include <cuda_fp16.h>
@@ -113,13 +113,12 @@ struct non_void_value_impl
 template <typename It, typename FallbackT>
 struct non_void_value_impl<It, FallbackT, false>
 {
-  // we consider thrust::discard_iterator's value_type as `void` as well, so users can switch from
+  // we consider thrust::discard_iterator's value_type (`any_assign`) as `void` as well, so users can switch from
   // cub::DiscardInputIterator to thrust::discard_iterator.
-  using type =
-    ::cuda::std::_If<::cuda::std::is_void_v<it_value_t<It>>
-                       || ::cuda::std::is_same_v<it_value_t<It>, THRUST_NS_QUALIFIER::discard_iterator<>::value_type>,
-                     FallbackT,
-                     it_value_t<It>>;
+  using type = ::cuda::std::_If<::cuda::std::is_void_v<it_value_t<It>>
+                                  || ::cuda::std::is_same_v<it_value_t<It>, THRUST_NS_QUALIFIER::detail::any_assign>,
+                                FallbackT,
+                                it_value_t<It>>;
 };
 
 /**

--- a/thrust/thrust/iterator/discard_iterator.h
+++ b/thrust/thrust/iterator/discard_iterator.h
@@ -164,10 +164,11 @@ private: // Core iterator interface
 //! parameter is \c 0.
 //! \return A new \p discard_iterator with index as given by \p i.
 //! \see constant_iterator
+template <typename System = use_default>
 inline _CCCL_HOST_DEVICE discard_iterator<>
-make_discard_iterator(discard_iterator<>::difference_type i = discard_iterator<>::difference_type(0))
+make_discard_iterator(typename discard_iterator<System>::difference_type i = {})
 {
-  return discard_iterator<>(i);
+  return discard_iterator<System>(i);
 }
 
 //! \} // end fancyiterators

--- a/thrust/thrust/system/cuda/detail/core/load_iterator.h
+++ b/thrust/thrust/system/cuda/detail/core/load_iterator.h
@@ -30,6 +30,7 @@
 
 #include <cub/iterator/cache_modified_input_iterator.cuh>
 
+#include <thrust/iterator/iterator_traits.h>
 #include <thrust/type_traits/is_contiguous_iterator.h>
 
 THRUST_NAMESPACE_BEGIN

--- a/thrust/thrust/system/cuda/detail/execution_policy.h
+++ b/thrust/thrust/system/cuda/detail/execution_policy.h
@@ -62,7 +62,7 @@ struct execution_policy<tag> : thrust::execution_policy<tag>
 
 struct tag
     : execution_policy<tag>
-    , detail::allocator_aware_execution_policy<cuda_cub::execution_policy>
+    , thrust::detail::allocator_aware_execution_policy<cuda_cub::execution_policy>
 {};
 
 template <class Derived>


### PR DESCRIPTION
This avoids 32ms of compile-time by pruning this instantiation stack:
![image](https://github.com/user-attachments/assets/64d3fde1-46c9-46f4-aded-f3f48b47f0e7)



