### PR TITLE
Simplify thrust::cuda_cub::swap_ranges

### DIFF
--- a/thrust/thrust/detail/reference.h
+++ b/thrust/thrust/detail/reference.h
@@ -161,7 +161,7 @@ public:
    *
    *  \param other The \p tagged_reference to swap with.
    */
-  _CCCL_HOST_DEVICE void swap(derived_type& other)
+  _CCCL_HOST_DEVICE void swap(derived_type other)
   {
     // Avoid default-constructing a system; instead, just use a null pointer
     // for dispatch. This assumes that `get_value` will not access any system
@@ -494,7 +494,7 @@ class tagged_reference<void const, Tag>
 // note: this is not a hidden friend, because we have template specializations of tagged_reference
 template <typename Element, typename Tag>
 _CCCL_HOST_DEVICE void
-swap(tagged_reference<Element, Tag>& x, tagged_reference<Element, Tag>& y) noexcept(noexcept(x.swap(y)))
+swap(tagged_reference<Element, Tag> x, tagged_reference<Element, Tag> y) noexcept(noexcept(x.swap(y)))
 {
   x.swap(y);
 }

--- a/thrust/thrust/detail/reference.h
+++ b/thrust/thrust/detail/reference.h
@@ -367,7 +367,7 @@ private:
   }
 
   template <typename System>
-  _CCCL_HOST_DEVICE void swap(System* system, derived_type& other)
+  _CCCL_HOST_DEVICE void swap(System* system, derived_type other)
   {
     using thrust::system::detail::generic::iter_swap;
     using thrust::system::detail::generic::select_system;

--- a/thrust/thrust/device_reference.h
+++ b/thrust/thrust/device_reference.h
@@ -323,7 +323,7 @@ public:
      *  \p other The other \p device_reference with which to swap.
      */
     _CCCL_HOST_DEVICE
-    void swap(device_reference &other);
+    void swap(device_reference other);
 
     /*! Prefix increment operator increments the object referenced by this
      *  \p device_reference.
@@ -948,7 +948,6 @@ public:
     device_reference &operator^=(const T &rhs);
 #endif // end doxygen-only members
 }; // end device_reference
-
 
 /*! swaps the value of one \p device_reference with another.
  *  \p x The first \p device_reference of interest.

--- a/thrust/thrust/device_reference.h
+++ b/thrust/thrust/device_reference.h
@@ -952,7 +952,7 @@ public:
    *  \p x The first \p device_reference of interest.
    *  \p y The second \p device_reference of interest.
    */
-  _CCCL_HOST_DEVICE friend void swap(device_reference& x, device_reference& y) noexcept(noexcept(x.swap(y)))
+  _CCCL_HOST_DEVICE friend void swap(device_reference x, device_reference y) noexcept(noexcept(x.swap(y)))
   {
     x.swap(y);
   }

--- a/thrust/thrust/device_reference.h
+++ b/thrust/thrust/device_reference.h
@@ -947,16 +947,19 @@ public:
      */
     device_reference &operator^=(const T &rhs);
 #endif // end doxygen-only members
-
-  /*! swaps the value of one \p device_reference with another.
-   *  \p x The first \p device_reference of interest.
-   *  \p y The second \p device_reference of interest.
-   */
-  _CCCL_HOST_DEVICE friend void swap(device_reference x, device_reference y) noexcept(noexcept(x.swap(y)))
-  {
-    x.swap(y);
-  }
 }; // end device_reference
+
+
+/*! swaps the value of one \p device_reference with another.
+ *  \p x The first \p device_reference of interest.
+ *  \p y The second \p device_reference of interest.
+ */
+// note: this is not a hidden friend, because nvcc 12.0 will miscompile with: error: incomplete type is not allowed
+template <typename T>
+_CCCL_HOST_DEVICE void swap(device_reference<T> x, device_reference<T> y) noexcept(noexcept(x.swap(y)))
+{
+  x.swap(y);
+}
 
 // declare these methods for the purpose of Doxygenating them
 // they actually are defined for a base class

--- a/thrust/thrust/system/cuda/detail/swap_ranges.h
+++ b/thrust/thrust/system/cuda/detail/swap_ranges.h
@@ -57,13 +57,7 @@ struct __swap_f
   template <class Size>
   _CCCL_HOST_DEVICE void operator()(Size idx) const
   {
-    // TODO(bgruber): this should probably use ::cuda::std::iter_swap(items1 + idx, items2 + idx);
-    thrust::detail::it_value_t<ItemsIt1> item1 = items1[idx];
-    thrust::detail::it_value_t<ItemsIt2> item2 = items2[idx];
-    using ::cuda::std::swap;
-    swap(item1, item2);
-    items1[idx] = item1;
-    items2[idx] = item2;
+    ::cuda::std::iter_swap(items1 + idx, items2 + idx);
   }
 };
 

--- a/thrust/thrust/system/cuda/detail/swap_ranges.h
+++ b/thrust/thrust/system/cuda/detail/swap_ranges.h
@@ -37,64 +37,44 @@
 #endif // no system header
 
 #if _CCCL_HAS_CUDA_COMPILER()
-#  include <thrust/distance.h>
-#  include <thrust/swap.h>
-#  include <thrust/system/cuda/detail/par_to_seq.h>
-#  include <thrust/system/cuda/detail/parallel_for.h>
-#  include <thrust/system/cuda/detail/transform.h>
 
-#  include <cuda/std/utility>
+#  include <thrust/iterator/iterator_traits.h>
+#  include <thrust/system/cuda/detail/parallel_for.h>
+
+#  include <cuda/std/__algorithm_>
+#  include <cuda/std/iterator>
 
 THRUST_NAMESPACE_BEGIN
 
 namespace cuda_cub
 {
-
-namespace __swap_ranges
-{
-
 template <class ItemsIt1, class ItemsIt2>
-struct swap_f
+struct __swap_f
 {
   ItemsIt1 items1;
   ItemsIt2 items2;
 
-  using value1_type = thrust::detail::it_value_t<ItemsIt1>;
-  using value2_type = thrust::detail::it_value_t<ItemsIt2>;
-
-  THRUST_FUNCTION
-  swap_f(ItemsIt1 items1_, ItemsIt2 items2_)
-      : items1(items1_)
-      , items2(items2_)
-  {}
-
   template <class Size>
-  void THRUST_DEVICE_FUNCTION operator()(Size idx)
+  _CCCL_HOST_DEVICE void operator()(Size idx) const
   {
     // TODO(bgruber): this should probably use ::cuda::std::iter_swap(items1 + idx, items2 + idx);
-    value1_type item1 = items1[idx];
-    value2_type item2 = items2[idx];
+    thrust::detail::it_value_t<ItemsIt1> item1 = items1[idx];
+    thrust::detail::it_value_t<ItemsIt2> item2 = items2[idx];
     using ::cuda::std::swap;
     swap(item1, item2);
     items1[idx] = item1;
     items2[idx] = item2;
   }
 };
-} // namespace __swap_ranges
 
 template <class Derived, class ItemsIt1, class ItemsIt2>
 ItemsIt2 _CCCL_HOST_DEVICE
 swap_ranges(execution_policy<Derived>& policy, ItemsIt1 first1, ItemsIt1 last1, ItemsIt2 first2)
 {
-  using size_type = thrust::detail::it_difference_t<ItemsIt1>;
-
-  size_type num_items = static_cast<size_type>(::cuda::std::distance(first1, last1));
-
-  cuda_cub::parallel_for(policy, __swap_ranges::swap_f<ItemsIt1, ItemsIt2>(first1, first2), num_items);
-
+  const auto num_items = ::cuda::std::distance(first1, last1);
+  cuda_cub::parallel_for(policy, __swap_f<ItemsIt1, ItemsIt2>{first1, first2}, num_items);
   return first2 + num_items;
 }
-
 } // namespace cuda_cub
 
 THRUST_NAMESPACE_END


### PR DESCRIPTION
Which requires changing `device_reference::swap` to take it's argument by value.