### PR TITLE
Allow default-initializing and skipping initialization of Thrust vectors

### DIFF
--- a/thrust/testing/vector.cu
+++ b/thrust/testing/vector.cu
@@ -834,3 +834,65 @@ void TestVectorMove()
   ASSERT_EQUAL(ptr3, ptr4);
 }
 DECLARE_VECTOR_UNITTEST(TestVectorMove);
+
+struct IntWithInit
+{
+  int value = 42;
+};
+
+void TestVectorDefaultInitCtor()
+{
+  // trivially-constructible type: just compilation test, since we cannot check that initialization was skipped
+  {
+    thrust::host_vector<int> hv(10, thrust::default_init);
+    thrust::device_vector<int> dv(10, thrust::default_init);
+  }
+
+  // non-trivially-constructible type: check that initialization was performed
+  {
+    thrust::host_vector<IntWithInit> hv(10, thrust::default_init);
+    for (auto e : hv)
+    {
+      ASSERT_EQUAL(e.value, 42);
+    }
+
+    thrust::device_vector<IntWithInit> dv(10, thrust::default_init);
+    for (auto e : dv)
+    {
+      ASSERT_EQUAL(static_cast<IntWithInit>(e).value, 42);
+    }
+  }
+}
+DECLARE_UNITTEST(TestVectorDefaultInitCtor);
+
+void TestVectorDefaultInitResize()
+{
+  // trivially-constructible type: just compilation test, since we cannot check that initialization was skipped
+  {
+    thrust::host_vector<int> hv(10);
+    hv.resize(10, thrust::default_init);
+  }
+  {
+    thrust::device_vector<int> dv(10);
+    dv.resize(10, thrust::default_init);
+  }
+
+  // non-trivially-constructible type: check that initialization was performed
+  {
+    thrust::host_vector<IntWithInit> hv(5);
+    hv.resize(10, thrust::default_init);
+    for (auto e : hv)
+    {
+      ASSERT_EQUAL(e.value, 42);
+    }
+  }
+  {
+    thrust::device_vector<IntWithInit> dv(5, thrust::default_init);
+    dv.resize(10, thrust::default_init);
+    for (auto e : dv)
+    {
+      ASSERT_EQUAL(static_cast<IntWithInit>(e).value, 42);
+    }
+  }
+}
+DECLARE_UNITTEST(TestVectorDefaultInitResize);

--- a/thrust/testing/vector.cu
+++ b/thrust/testing/vector.cu
@@ -924,7 +924,7 @@ void TestVectorNoInitResize()
   }
 
   // non-trivially-constructible type: those should fail to compile
-  thrust::host_vector<IntWithInit>(5).resize(10, thrust::no_init);
-  thrust::device_vector<IntWithInit>(5).resize(10, thrust::no_init);
+  // thrust::host_vector<IntWithInit>(5).resize(10, thrust::no_init);
+  // thrust::device_vector<IntWithInit>(5).resize(10, thrust::no_init);
 }
 DECLARE_UNITTEST(TestVectorNoInitResize);

--- a/thrust/testing/vector.cu
+++ b/thrust/testing/vector.cu
@@ -865,15 +865,29 @@ void TestVectorDefaultInitCtor()
 }
 DECLARE_UNITTEST(TestVectorDefaultInitCtor);
 
+void TestVectorNoInitCtor()
+{
+  // trivially-constructible type: just compilation test, since we cannot check that initialization was skipped
+  {
+    thrust::host_vector<int> hv(10, thrust::no_init);
+    thrust::device_vector<int> dv(10, thrust::no_init);
+  }
+
+  // non-trivially-constructible type: those should fail to compile
+  // thrust::host_vector<IntWithInit> hv(10, thrust::no_init);
+  // thrust::device_vector<IntWithInit> dv(10, thrust::no_init);
+}
+DECLARE_UNITTEST(TestVectorNoInitCtor);
+
 void TestVectorDefaultInitResize()
 {
   // trivially-constructible type: just compilation test, since we cannot check that initialization was skipped
   {
-    thrust::host_vector<int> hv(10);
+    thrust::host_vector<int> hv(5);
     hv.resize(10, thrust::default_init);
   }
   {
-    thrust::device_vector<int> dv(10);
+    thrust::device_vector<int> dv(5);
     dv.resize(10, thrust::default_init);
   }
 
@@ -896,3 +910,21 @@ void TestVectorDefaultInitResize()
   }
 }
 DECLARE_UNITTEST(TestVectorDefaultInitResize);
+
+void TestVectorNoInitResize()
+{
+  // trivially-constructible type: just compilation test, since we cannot check that initialization was skipped
+  {
+    thrust::host_vector<int> hv(5);
+    hv.resize(10, thrust::no_init);
+  }
+  {
+    thrust::device_vector<int> dv(5);
+    dv.resize(10, thrust::no_init);
+  }
+
+  // non-trivially-constructible type: those should fail to compile
+  thrust::host_vector<IntWithInit>(5).resize(10, thrust::no_init);
+  thrust::device_vector<IntWithInit>(5).resize(10, thrust::no_init);
+}
+DECLARE_UNITTEST(TestVectorNoInitResize);

--- a/thrust/thrust/detail/vector_base.h
+++ b/thrust/thrust/detail/vector_base.h
@@ -103,6 +103,7 @@ public:
   //! This constructor creates a vector_base without initializing elements. It mandates that the element type is
   //! trivially default-constructible.
   //! \param n The number of elements to create.
+  template <typename T2 = T>
   explicit vector_base(size_type n, no_init_t);
 
   /*! This constructor creates a vector_base with value-initialized elements.
@@ -247,6 +248,7 @@ public:
   //! that the element type is trivially default-constructible.
   //! \param new_size Number of elements this vector_base should contain.
   //! \throw std::length_error If n exceeds max_size().
+  template <typename T2 = T>
   void resize(size_type new_size, no_init_t);
 
   /*! \brief Resizes this vector_base to the specified number of elements.

--- a/thrust/thrust/detail/vector_base.h
+++ b/thrust/thrust/detail/vector_base.h
@@ -48,7 +48,7 @@ THRUST_NAMESPACE_BEGIN
 struct default_init_t
 {};
 
-constexpr default_init_t default_init;
+inline constexpr default_init_t default_init;
 
 namespace detail
 {

--- a/thrust/thrust/detail/vector_base.h
+++ b/thrust/thrust/detail/vector_base.h
@@ -45,6 +45,11 @@
 
 THRUST_NAMESPACE_BEGIN
 
+struct default_init_t
+{};
+
+constexpr default_init_t default_init;
+
 namespace detail
 {
 
@@ -84,6 +89,11 @@ public:
    *  \param n The number of elements to create.
    */
   explicit vector_base(size_type n);
+
+  /*! This constructor creates a vector_base with default-initialized elements.
+   *  \param n The number of elements to create.
+   */
+  explicit vector_base(size_type n, default_init_t);
 
   /*! This constructor creates a vector_base with value-initialized elements.
    *  \param n The number of elements to create.
@@ -208,7 +218,7 @@ public:
 
   /*! \brief Resizes this vector_base to the specified number of elements.
    *  \param new_size Number of elements this vector_base should contain.
-   *  \throw std::length_error If n exceeds max_size9).
+   *  \throw std::length_error If n exceeds max_size().
    *
    *  This method will resize this vector_base to the specified number of
    *  elements. If the number is smaller than this vector_base's current
@@ -216,6 +226,17 @@ public:
    *  extended and new elements are value initialized.
    */
   void resize(size_type new_size);
+
+  /*! \brief Resizes this vector_base to the specified number of elements, performing default-initialization instead of
+   *         value-initialization.
+   * \param new_size Number of elements this vector_base should contain.
+   * \throw std::length_error If n exceeds max_size().
+   *
+   * This method will resize this vector_base to the specified number of elements. If the number is smaller than this
+   * vector_base's current size this vector_base is truncated, otherwise this vector_base is extended and new elements
+   * are default-initialized instead of value-initialized.
+   */
+  void resize(size_type new_size, default_init_t);
 
   /*! \brief Resizes this vector_base to the specified number of elements.
    *  \param new_size Number of elements this vector_base should contain.
@@ -515,6 +536,7 @@ private:
   void insert_dispatch(iterator position, InputIteratorOrIntegralType n, InputIteratorOrIntegralType x, true_type);
 
   // this method appends n value-initialized elements at the end
+  template <bool OnlyDefaultInit = false>
   void append(size_type n);
 
   // this method performs insertion from a fill value

--- a/thrust/thrust/detail/vector_base.h
+++ b/thrust/thrust/detail/vector_base.h
@@ -47,8 +47,14 @@ THRUST_NAMESPACE_BEGIN
 
 struct default_init_t
 {};
+struct no_init_t
+{};
 
+//! Tag to indicate that a vector's elements should be default initialized
 inline constexpr default_init_t default_init;
+
+//! Tag to indicate that a vector's elements should not be initialized
+inline constexpr no_init_t no_init;
 
 namespace detail
 {
@@ -90,10 +96,14 @@ public:
    */
   explicit vector_base(size_type n);
 
-  /*! This constructor creates a vector_base with default-initialized elements.
-   *  \param n The number of elements to create.
-   */
+  //! This constructor creates a vector_base with default-initialized elements.
+  //! \param n The number of elements to create.
   explicit vector_base(size_type n, default_init_t);
+
+  //! This constructor creates a vector_base without initializing elements. It mandates that the element type is
+  //! trivially default-constructible.
+  //! \param n The number of elements to create.
+  explicit vector_base(size_type n, no_init_t);
 
   /*! This constructor creates a vector_base with value-initialized elements.
    *  \param n The number of elements to create.
@@ -227,16 +237,17 @@ public:
    */
   void resize(size_type new_size);
 
-  /*! \brief Resizes this vector_base to the specified number of elements, performing default-initialization instead of
-   *         value-initialization.
-   * \param new_size Number of elements this vector_base should contain.
-   * \throw std::length_error If n exceeds max_size().
-   *
-   * This method will resize this vector_base to the specified number of elements. If the number is smaller than this
-   * vector_base's current size this vector_base is truncated, otherwise this vector_base is extended and new elements
-   * are default-initialized instead of value-initialized.
-   */
+  //! \brief Resizes this vector_base to the specified number of elements, performing default-initialization instead of
+  //!         value-initialization.
+  //! \param new_size Number of elements this vector_base should contain.
+  //! \throw std::length_error If n exceeds max_size().
   void resize(size_type new_size, default_init_t);
+
+  //! \brief Resizes this vector_base to the specified number of elements, without initializing elements. It mandates
+  //! that the element type is trivially default-constructible.
+  //! \param new_size Number of elements this vector_base should contain.
+  //! \throw std::length_error If n exceeds max_size().
+  void resize(size_type new_size, no_init_t);
 
   /*! \brief Resizes this vector_base to the specified number of elements.
    *  \param new_size Number of elements this vector_base should contain.
@@ -536,7 +547,7 @@ private:
   void insert_dispatch(iterator position, InputIteratorOrIntegralType n, InputIteratorOrIntegralType x, true_type);
 
   // this method appends n value-initialized elements at the end
-  template <bool OnlyDefaultInit = false>
+  template <bool SkipInit = false>
   void append(size_type n);
 
   // this method performs insertion from a fill value

--- a/thrust/thrust/detail/vector_base.inl
+++ b/thrust/thrust/detail/vector_base.inl
@@ -818,7 +818,7 @@ void vector_base<T, Alloc>::append(size_type n)
     {
       // we've got room for all of them
 
-      if constexpr (OnlyDefaultInit && !::cuda::std::is_trivially_constructible_v<T>)
+      if constexpr (!OnlyDefaultInit || !::cuda::std::is_trivially_constructible_v<T>)
       {
         // default construct new elements at the end of the vector
         m_storage.value_initialize_n(end(), n);
@@ -851,7 +851,7 @@ void vector_base<T, Alloc>::append(size_type n)
         // construct copy all elements into the newly allocated storage
         new_end = m_storage.uninitialized_copy(begin(), end(), new_storage.begin());
 
-        if constexpr (OnlyDefaultInit && !::cuda::std::is_trivially_constructible_v<T>)
+        if constexpr (!OnlyDefaultInit || !::cuda::std::is_trivially_constructible_v<T>)
         {
           // construct new elements to insert
           new_storage.value_initialize_n(new_end, n);

--- a/thrust/thrust/detail/vector_base.inl
+++ b/thrust/thrust/detail/vector_base.inl
@@ -89,11 +89,12 @@ vector_base<T, Alloc>::vector_base(size_type n, default_init_t)
 }
 
 template <typename T, typename Alloc>
+template <typename T2>
 vector_base<T, Alloc>::vector_base(size_type n, no_init_t)
     : m_storage()
     , m_size(0)
 {
-  static_assert(::cuda::std::is_trivially_constructible_v<T>,
+  static_assert(::cuda::std::is_trivially_constructible_v<T2>,
                 "The vector's element type must be trivially constructible to skip initialization.");
   if (n > 0)
   {
@@ -355,9 +356,10 @@ void vector_base<T, Alloc>::resize(size_type new_size, default_init_t)
 }
 
 template <typename T, typename Alloc>
+template <typename T2>
 void vector_base<T, Alloc>::resize(size_type new_size, no_init_t)
 {
-  static_assert(::cuda::std::is_trivially_constructible_v<T>,
+  static_assert(::cuda::std::is_trivially_constructible_v<T2>,
                 "The vector's element type must be trivially constructible to skip initialization.");
   if (new_size < size())
   {

--- a/thrust/thrust/detail/vector_base.inl
+++ b/thrust/thrust/detail/vector_base.inl
@@ -83,7 +83,7 @@ vector_base<T, Alloc>::vector_base(size_type n, default_init_t)
 
     if constexpr (!::cuda::std::is_trivially_constructible_v<T>)
     {
-      value_init(n);
+      m_storage.value_initialize_n(begin(), size());
     }
   }
 }

--- a/thrust/thrust/device_vector.h
+++ b/thrust/thrust/device_vector.h
@@ -314,13 +314,13 @@ public:
     //!         value-initialization.
     //! \param new_size Number of elements this vector should contain.
     //! \throw std::length_error If n exceeds max_size().
-  void resize(size_type new_size, default_init_t);
+    void resize(size_type new_size, default_init_t);
 
-  //! \brief Resizes this vector_base to the specified number of elements, without initializing elements. It mandates
-  //! that the element type is trivially default-constructible.
-  //! \param new_size Number of elements this vector_base should contain.
-  //! \throw std::length_error If n exceeds max_size().
-  void resize(size_type new_size, no_init_t);
+    //! \brief Resizes this vector_base to the specified number of elements, without initializing elements. It mandates
+    //! that the element type is trivially default-constructible.
+    //! \param new_size Number of elements this vector_base should contain.
+    //! \throw std::length_error If n exceeds max_size().
+    void resize(size_type new_size, no_init_t);
 
     /*! Returns the number of elements in this vector.
      */

--- a/thrust/thrust/device_vector.h
+++ b/thrust/thrust/device_vector.h
@@ -97,12 +97,18 @@ public:
       : Parent(n)
   {}
 
-  /*! This constructor creates a \p device_vector with the given size, performing only default-initialization instead of
-   * value-initialization.
-   * \param n The number of elements to initially create.
-   */
+  //! This constructor creates a \p device_vector with the given size, performing only default-initialization instead of
+  //! value-initialization.
+  //! \param n The number of elements to initially create.
   device_vector(size_type n, default_init_t)
       : Parent(n, default_init_t{})
+  {}
+
+  //! This constructor creates a \p device_vector with the given size, without initializing elements. It mandates that
+  //! the element type is trivially default-constructible.
+  //! \param n The number of elements to initially create.
+  device_vector(size_type n, no_init_t)
+      : Parent(n, no_init_t{})
   {}
 
   /*! This constructor creates a \p device_vector with the given
@@ -304,16 +310,17 @@ public:
      */
     void resize(size_type new_size, const value_type &x = value_type());
 
-    /*! \brief Resizes this vector to the specified number of elements, performing default-initialization instead of
-     *         value-initialization.
-     * \param new_size Number of elements this vector should contain.
-     * \throw std::length_error If n exceeds max_size().
-     *
-     * This method will resize this vector to the specified number of elements. If the number is smaller than this
-     * vector's current size this vector is truncated, otherwise this vector is extended and new elements are
-     * default-initialized instead of value-initialized.
-     */
-    void resize(size_type new_size, default_init_t);
+    //! \brief Resizes this vector to the specified number of elements, performing default-initialization instead of
+    //!         value-initialization.
+    //! \param new_size Number of elements this vector should contain.
+    //! \throw std::length_error If n exceeds max_size().
+  void resize(size_type new_size, default_init_t);
+
+  //! \brief Resizes this vector_base to the specified number of elements, without initializing elements. It mandates
+  //! that the element type is trivially default-constructible.
+  //! \param new_size Number of elements this vector_base should contain.
+  //! \throw std::length_error If n exceeds max_size().
+  void resize(size_type new_size, no_init_t);
 
     /*! Returns the number of elements in this vector.
      */

--- a/thrust/thrust/device_vector.h
+++ b/thrust/thrust/device_vector.h
@@ -97,6 +97,14 @@ public:
       : Parent(n)
   {}
 
+  /*! This constructor creates a \p device_vector with the given size, performing only default-initialization instead of
+   * value-initialization.
+   * \param n The number of elements to initially create.
+   */
+  device_vector(size_type n, default_init_t)
+      : Parent(n, default_init_t{})
+  {}
+
   /*! This constructor creates a \p device_vector with the given
    *  size.
    *  \param n The number of elements to initially create.
@@ -295,6 +303,17 @@ public:
      *  extended and new elements are populated with given data.
      */
     void resize(size_type new_size, const value_type &x = value_type());
+
+    /*! \brief Resizes this vector to the specified number of elements, performing default-initialization instead of
+     *         value-initialization.
+     * \param new_size Number of elements this vector should contain.
+     * \throw std::length_error If n exceeds max_size().
+     *
+     * This method will resize this vector to the specified number of elements. If the number is smaller than this
+     * vector's current size this vector is truncated, otherwise this vector is extended and new elements are
+     * default-initialized instead of value-initialized.
+     */
+    void resize(size_type new_size, default_init_t);
 
     /*! Returns the number of elements in this vector.
      */

--- a/thrust/thrust/host_vector.h
+++ b/thrust/thrust/host_vector.h
@@ -307,13 +307,13 @@ public:
     //!         value-initialization.
     //! \param new_size Number of elements this vector should contain.
     //! \throw std::length_error If n exceeds max_size().
-  void resize(size_type new_size, default_init_t);
+    void resize(size_type new_size, default_init_t);
 
-  //! \brief Resizes this vector to the specified number of elements, without initializing elements. It mandates
-  //! that the element type is trivially default-constructible.
-  //! \param new_size Number of elements this vector should contain.
-  //! \throw std::length_error If n exceeds max_size().
-  void resize(size_type new_size, no_init_t);
+    //! \brief Resizes this vector to the specified number of elements, without initializing elements. It mandates
+    //! that the element type is trivially default-constructible.
+    //! \param new_size Number of elements this vector should contain.
+    //! \throw std::length_error If n exceeds max_size().
+    void resize(size_type new_size, no_init_t);
 
     /*! Returns the number of elements in this vector.
      */

--- a/thrust/thrust/host_vector.h
+++ b/thrust/thrust/host_vector.h
@@ -98,12 +98,18 @@ public:
       : Parent(n)
   {}
 
-  /*! This constructor creates a \p host_vector with the given size, performing only default-initialization instead of
-   * value-initialization.
-   * \param n The number of elements to initially create.
-   */
+  //! This constructor creates a \p host_vector with the given size, performing only default-initialization instead of
+  //! value-initialization.
+  //! \param n The number of elements to initially create.
   _CCCL_HOST host_vector(size_type n, default_init_t)
       : Parent(n, default_init_t{})
+  {}
+
+  //! This constructor creates a \p host_vector with the given size, without initializing elements. It mandates that
+  //! the element type is trivially default-constructible.
+  //! \param n The number of elements to initially create.
+  _CCCL_HOST host_vector(size_type n, no_init_t)
+      : Parent(n, no_init_t{})
   {}
 
   /*! This constructor creates a \p host_vector with the given
@@ -297,16 +303,17 @@ public:
      */
     void resize(size_type new_size, const value_type &x = value_type());
 
-    /*! \brief Resizes this vector to the specified number of elements, performing default-initialization instead of
-     *         value-initialization.
-     * \param new_size Number of elements this vector should contain.
-     * \throw std::length_error If n exceeds max_size().
-     *
-     * This method will resize this vector to the specified number of elements. If the number is smaller than this
-     * vector's current size this vector is truncated, otherwise this vector is extended and new elements are
-     * default-initialized instead of value-initialized.
-     */
-    void resize(size_type new_size, default_init_t);
+    //! \brief Resizes this vector to the specified number of elements, performing default-initialization instead of
+    //!         value-initialization.
+    //! \param new_size Number of elements this vector should contain.
+    //! \throw std::length_error If n exceeds max_size().
+  void resize(size_type new_size, default_init_t);
+
+  //! \brief Resizes this vector to the specified number of elements, without initializing elements. It mandates
+  //! that the element type is trivially default-constructible.
+  //! \param new_size Number of elements this vector should contain.
+  //! \throw std::length_error If n exceeds max_size().
+  void resize(size_type new_size, no_init_t);
 
     /*! Returns the number of elements in this vector.
      */

--- a/thrust/thrust/host_vector.h
+++ b/thrust/thrust/host_vector.h
@@ -98,6 +98,14 @@ public:
       : Parent(n)
   {}
 
+  /*! This constructor creates a \p host_vector with the given size, performing only default-initialization instead of
+   * value-initialization.
+   * \param n The number of elements to initially create.
+   */
+  _CCCL_HOST host_vector(size_type n, default_init_t)
+      : Parent(n, default_init_t{})
+  {}
+
   /*! This constructor creates a \p host_vector with the given
    *  size.
    *  \param n The number of elements to initially create.
@@ -288,6 +296,17 @@ public:
      *  extended and new elements are populated with given data.
      */
     void resize(size_type new_size, const value_type &x = value_type());
+
+    /*! \brief Resizes this vector to the specified number of elements, performing default-initialization instead of
+     *         value-initialization.
+     * \param new_size Number of elements this vector should contain.
+     * \throw std::length_error If n exceeds max_size().
+     *
+     * This method will resize this vector to the specified number of elements. If the number is smaller than this
+     * vector's current size this vector is truncated, otherwise this vector is extended and new elements are
+     * default-initialized instead of value-initialized.
+     */
+    void resize(size_type new_size, default_init_t);
 
     /*! Returns the number of elements in this vector.
      */


### PR DESCRIPTION
I was having this changeset for a while now, but didn't push it, since the discussion in #1992 and among the team was somewhat controversial. However, I keep getting asked about this every now and then, so here is it: an overload for a Thrust vector's constructor and `resize` member function to turn value initialization into default initialization. I refer to #1992 for rational and discussion.

Fixes: #1992


Compiling `dv.cu`:
```c++
#include <thrust/device_vector.h>
int main() {
  thrust::device_vector<int> v(10, thrust::default_init);
  v.resize(100, thrust::default_init);
}
```
(or `no_init`)
with
```
nvcc -Ithrust -Icub -Ilibcudacxx/include dv.cu
```
and dumping the SASS shows that only code for `cub::detail::EmptyKernel` is generated.