### PR TITLE
[backport/3.0] Replace CUB util_arch.cuh macros with inline constexpr variables #4165

### DIFF
--- a/cub/cub/agent/agent_batch_memcpy.cuh
+++ b/cub/cub/agent/agent_batch_memcpy.cuh
@@ -863,13 +863,13 @@ private:
     BufferSizeIteratorT tile_buffer_sizes,
     BlockBufferOffsetT num_wlev_buffers)
   {
-    const int32_t warp_id              = threadIdx.x / CUB_PTX_WARP_THREADS;
-    constexpr uint32_t warps_per_block = BLOCK_THREADS / CUB_PTX_WARP_THREADS;
+    const int32_t warp_id              = threadIdx.x / warp_threads;
+    constexpr uint32_t warps_per_block = BLOCK_THREADS / warp_threads;
 
     for (BlockBufferOffsetT buffer_offset = warp_id; buffer_offset < num_wlev_buffers; buffer_offset += warps_per_block)
     {
       const auto buffer_id = buffers_by_size_class[buffer_offset].buffer_id;
-      copy_items<IsMemcpy, CUB_PTX_WARP_THREADS, InputBufferT, OutputBufferT, BufferSizeT>(
+      copy_items<IsMemcpy, warp_threads, InputBufferT, OutputBufferT, BufferSizeT>(
         tile_buffer_srcs[buffer_id], tile_buffer_dsts[buffer_id], tile_buffer_sizes[buffer_id]);
     }
   }
@@ -1068,7 +1068,7 @@ public:
         blev_buffer_scan_state, temp_storage.buffer_scan_callback, ::cuda::std::plus<>{}, tile_id);
 
       // Signal our partial prefix and wait for the inclusive prefix of previous tiles
-      if (threadIdx.x < CUB_PTX_WARP_THREADS)
+      if (threadIdx.x < warp_threads)
       {
         buffer_exclusive_prefix = blev_buffer_prefix_op(size_class_agg.get(BLEV_SIZE_CLASS));
       }

--- a/cub/cub/agent/agent_radix_sort_downsweep.cuh
+++ b/cub/cub/agent/agent_radix_sort_downsweep.cuh
@@ -361,7 +361,7 @@ struct AgentRadixSortDownsweep
   {
     // Register pressure work-around: moving valid_items through shfl prevents compiler
     // from reusing guards/addressing from prior guarded loads
-    valid_items = ShuffleIndex<CUB_PTX_WARP_THREADS>(valid_items, 0, 0xffffffff);
+    valid_items = ShuffleIndex<warp_threads>(valid_items, 0, 0xffffffff);
 
     BlockLoadKeysT(temp_storage.load_keys).Load(d_keys_in + block_offset, keys, valid_items, oob_item);
 
@@ -395,7 +395,7 @@ struct AgentRadixSortDownsweep
   {
     // Register pressure work-around: moving valid_items through shfl prevents compiler
     // from reusing guards/addressing from prior guarded loads
-    valid_items = ShuffleIndex<CUB_PTX_WARP_THREADS>(valid_items, 0, 0xffffffff);
+    valid_items = ShuffleIndex<warp_threads>(valid_items, 0, 0xffffffff);
 
     LoadDirectWarpStriped(threadIdx.x, d_keys_in + block_offset, keys, valid_items, oob_item);
   }
@@ -427,7 +427,7 @@ struct AgentRadixSortDownsweep
   {
     // Register pressure work-around: moving valid_items through shfl prevents compiler
     // from reusing guards/addressing from prior guarded loads
-    valid_items = ShuffleIndex<CUB_PTX_WARP_THREADS>(valid_items, 0, 0xffffffff);
+    valid_items = ShuffleIndex<warp_threads>(valid_items, 0, 0xffffffff);
 
     BlockLoadValuesT(temp_storage.load_values).Load(d_values_in + block_offset, values, valid_items);
 
@@ -459,7 +459,7 @@ struct AgentRadixSortDownsweep
   {
     // Register pressure work-around: moving valid_items through shfl prevents compiler
     // from reusing guards/addressing from prior guarded loads
-    valid_items = ShuffleIndex<CUB_PTX_WARP_THREADS>(valid_items, 0, 0xffffffff);
+    valid_items = ShuffleIndex<warp_threads>(valid_items, 0, 0xffffffff);
 
     LoadDirectWarpStriped(threadIdx.x, d_values_in + block_offset, values, valid_items);
   }

--- a/cub/cub/agent/agent_radix_sort_onesweep.cuh
+++ b/cub/cub/agent/agent_radix_sort_onesweep.cuh
@@ -124,7 +124,7 @@ struct AgentRadixSortOnesweep
     RADIX_DIGITS          = 1 << RADIX_BITS,
     BINS_PER_THREAD       = (RADIX_DIGITS + BLOCK_THREADS - 1) / BLOCK_THREADS,
     FULL_BINS             = BINS_PER_THREAD * BLOCK_THREADS == RADIX_DIGITS,
-    WARP_THREADS          = CUB_PTX_WARP_THREADS,
+    WARP_THREADS          = warp_threads,
     BLOCK_WARPS           = BLOCK_THREADS / WARP_THREADS,
     WARP_MASK             = ~0,
     LOOKBACK_PARTIAL_MASK = 1 << (PortionOffsetT(sizeof(PortionOffsetT)) * 8 - 2),

--- a/cub/cub/agent/agent_radix_sort_upsweep.cuh
+++ b/cub/cub/agent/agent_radix_sort_upsweep.cuh
@@ -149,7 +149,7 @@ struct AgentRadixSortUpsweep
 
     RADIX_DIGITS = 1 << RADIX_BITS,
 
-    LOG_WARP_THREADS = CUB_PTX_LOG_WARP_THREADS,
+    LOG_WARP_THREADS = log2_warp_threads,
     WARP_THREADS     = 1 << LOG_WARP_THREADS,
     WARPS            = (BLOCK_THREADS + WARP_THREADS - 1) / WARP_THREADS,
 

--- a/cub/cub/agent/agent_rle.cuh
+++ b/cub/cub/agent/agent_rle.cuh
@@ -185,7 +185,7 @@ struct AgentRle
   // Constants
   enum
   {
-    WARP_THREADS     = CUB_WARP_THREADS(0),
+    WARP_THREADS     = warp_threads,
     BLOCK_THREADS    = AgentRlePolicyT::BLOCK_THREADS,
     ITEMS_PER_THREAD = AgentRlePolicyT::ITEMS_PER_THREAD,
     WARP_ITEMS       = WARP_THREADS * ITEMS_PER_THREAD,

--- a/cub/cub/agent/single_pass_scan_operators.cuh
+++ b/cub/cub/agent/single_pass_scan_operators.cuh
@@ -543,7 +543,7 @@ struct tile_state_with_memory_order
 
 _CCCL_HOST_DEVICE _CCCL_FORCEINLINE constexpr int num_tiles_to_num_tile_states(int num_tiles)
 {
-  return CUB_PTX_WARP_THREADS + num_tiles;
+  return warp_threads + num_tiles;
 }
 
 _CCCL_HOST_DEVICE _CCCL_FORCEINLINE size_t
@@ -623,7 +623,7 @@ struct ScanTileState<T, true>
   // Constants
   enum
   {
-    TILE_STATUS_PADDING = CUB_PTX_WARP_THREADS,
+    TILE_STATUS_PADDING = detail::warp_threads,
   };
 
   // Device storage
@@ -824,7 +824,7 @@ struct ScanTileState<T, false>
   // Constants
   enum
   {
-    TILE_STATUS_PADDING = CUB_PTX_WARP_THREADS,
+    TILE_STATUS_PADDING = detail::warp_threads,
   };
 
   // Device storage
@@ -1012,7 +1012,7 @@ struct ReduceByKeyScanTileState<ValueT, KeyT, true>
     TXN_WORD_SIZE    = 1 << Log2<PAIR_SIZE + 1>::VALUE,
     STATUS_WORD_SIZE = TXN_WORD_SIZE - PAIR_SIZE,
 
-    TILE_STATUS_PADDING = CUB_PTX_WARP_THREADS,
+    TILE_STATUS_PADDING = detail::warp_threads,
   };
 
   // Status word type
@@ -1297,7 +1297,7 @@ struct TilePrefixCallbackOp
     // Keep sliding the window back until we come across a tile whose inclusive prefix is known
     while (__all_sync(0xffffffff, (predecessor_status != StatusWord(SCAN_TILE_INCLUSIVE))))
     {
-      predecessor_idx -= CUB_PTX_WARP_THREADS;
+      predecessor_idx -= detail::warp_threads;
 
       // Update exclusive tile prefix with the window prefix
       ProcessWindow(predecessor_idx, predecessor_status, window_aggregate, construct_delay());

--- a/cub/cub/block/block_exchange.cuh
+++ b/cub/cub/block/block_exchange.cuh
@@ -146,10 +146,10 @@ template <typename T,
 class BlockExchange
 {
   static constexpr int BLOCK_THREADS = BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z; ///< The thread block size in threads
-  static constexpr int WARP_THREADS  = CUB_WARP_THREADS(0);
+  static constexpr int WARP_THREADS  = detail::warp_threads;
   static constexpr int WARPS = (BLOCK_THREADS + WARP_THREADS - 1) / WARP_THREADS; // TODO(bgruber): use ceil_div in
                                                                                   // C++14
-  static constexpr int LOG_SMEM_BANKS = CUB_LOG_SMEM_BANKS(0);
+  static constexpr int LOG_SMEM_BANKS = detail::log2_smem_banks;
 
   static constexpr int TILE_ITEMS  = BLOCK_THREADS * ITEMS_PER_THREAD;
   static constexpr int TIME_SLICES = WARP_TIME_SLICING ? WARPS : 1;

--- a/cub/cub/block/block_load.cuh
+++ b/cub/cub/block/block_load.cuh
@@ -468,15 +468,15 @@ template <typename T, int ITEMS_PER_THREAD, typename RandomAccessIterator>
 _CCCL_DEVICE _CCCL_FORCEINLINE void
 LoadDirectWarpStriped(int linear_tid, RandomAccessIterator block_src_it, T (&dst_items)[ITEMS_PER_THREAD])
 {
-  const int tid         = linear_tid & (CUB_PTX_WARP_THREADS - 1);
-  const int wid         = linear_tid >> CUB_PTX_LOG_WARP_THREADS;
-  const int warp_offset = wid * CUB_PTX_WARP_THREADS * ITEMS_PER_THREAD;
+  const int tid         = linear_tid & (detail::warp_threads - 1);
+  const int wid         = linear_tid >> detail::log2_warp_threads;
+  const int warp_offset = wid * detail::warp_threads * ITEMS_PER_THREAD;
 
   // Load directly in warp-striped order
   _CCCL_PRAGMA_UNROLL_FULL()
   for (int i = 0; i < ITEMS_PER_THREAD; i++)
   {
-    new (&dst_items[i]) T(block_src_it[warp_offset + tid + (i * CUB_PTX_WARP_THREADS)]);
+    new (&dst_items[i]) T(block_src_it[warp_offset + tid + (i * detail::warp_threads)]);
   }
 }
 
@@ -517,15 +517,15 @@ template <typename T, int ITEMS_PER_THREAD, typename RandomAccessIterator>
 _CCCL_DEVICE _CCCL_FORCEINLINE void LoadDirectWarpStriped(
   int linear_tid, RandomAccessIterator block_src_it, T (&dst_items)[ITEMS_PER_THREAD], int block_items_end)
 {
-  const int tid         = linear_tid & (CUB_PTX_WARP_THREADS - 1);
-  const int wid         = linear_tid >> CUB_PTX_LOG_WARP_THREADS;
-  const int warp_offset = wid * CUB_PTX_WARP_THREADS * ITEMS_PER_THREAD;
+  const int tid         = linear_tid & (detail::warp_threads - 1);
+  const int wid         = linear_tid >> detail::log2_warp_threads;
+  const int warp_offset = wid * detail::warp_threads * ITEMS_PER_THREAD;
 
   // Load directly in warp-striped order
   _CCCL_PRAGMA_UNROLL_FULL()
   for (int i = 0; i < ITEMS_PER_THREAD; i++)
   {
-    const auto src_pos = warp_offset + tid + (i * CUB_PTX_WARP_THREADS);
+    const auto src_pos = warp_offset + tid + (i * detail::warp_threads);
     if (src_pos < block_items_end)
     {
       new (&dst_items[i]) T(block_src_it[src_pos]);
@@ -975,7 +975,7 @@ class BlockLoad
   template <int DUMMY>
   struct LoadInternal<BLOCK_LOAD_WARP_TRANSPOSE, DUMMY>
   {
-    static constexpr int WARP_THREADS = CUB_WARP_THREADS(0);
+    static constexpr int WARP_THREADS = detail::warp_threads;
     static_assert(BLOCK_THREADS % WARP_THREADS == 0, "BLOCK_THREADS must be a multiple of WARP_THREADS");
 
     using BlockExchange = BlockExchange<T, BLOCK_DIM_X, ITEMS_PER_THREAD, false, BLOCK_DIM_Y, BLOCK_DIM_Z>;
@@ -1017,7 +1017,7 @@ class BlockLoad
   template <int DUMMY>
   struct LoadInternal<BLOCK_LOAD_WARP_TRANSPOSE_TIMESLICED, DUMMY>
   {
-    static constexpr int WARP_THREADS = CUB_WARP_THREADS(0);
+    static constexpr int WARP_THREADS = detail::warp_threads;
     static_assert(BLOCK_THREADS % WARP_THREADS == 0, "BLOCK_THREADS must be a multiple of WARP_THREADS");
 
     using BlockExchange = BlockExchange<T, BLOCK_DIM_X, ITEMS_PER_THREAD, true, BLOCK_DIM_Y, BLOCK_DIM_Z>;

--- a/cub/cub/block/block_radix_rank.cuh
+++ b/cub/cub/block/block_radix_rank.cuh
@@ -232,7 +232,7 @@ private:
 
     RADIX_DIGITS = 1 << RADIX_BITS,
 
-    LOG_WARP_THREADS = CUB_LOG_WARP_THREADS(0),
+    LOG_WARP_THREADS = detail::log2_warp_threads,
     WARP_THREADS     = 1 << LOG_WARP_THREADS,
     WARPS            = (BLOCK_THREADS + WARP_THREADS - 1) / WARP_THREADS,
 
@@ -572,7 +572,7 @@ private:
 
     RADIX_DIGITS = 1 << RADIX_BITS,
 
-    LOG_WARP_THREADS     = CUB_LOG_WARP_THREADS(0),
+    LOG_WARP_THREADS     = detail::log2_warp_threads,
     WARP_THREADS         = 1 << LOG_WARP_THREADS,
     PARTIAL_WARP_THREADS = BLOCK_THREADS % WARP_THREADS,
     WARPS                = (BLOCK_THREADS + WARP_THREADS - 1) / WARP_THREADS,
@@ -903,7 +903,7 @@ struct BlockRadixRankMatchEarlyCounts
     BINS_PER_THREAD         = (RADIX_DIGITS + BLOCK_THREADS - 1) / BLOCK_THREADS,
     BINS_TRACKED_PER_THREAD = BINS_PER_THREAD,
     FULL_BINS               = BINS_PER_THREAD * BLOCK_THREADS == RADIX_DIGITS,
-    WARP_THREADS            = CUB_PTX_WARP_THREADS,
+    WARP_THREADS            = detail::warp_threads,
     PARTIAL_WARP_THREADS    = BLOCK_THREADS % WARP_THREADS,
     BLOCK_WARPS             = BLOCK_THREADS / WARP_THREADS,
     PARTIAL_WARP_ID         = BLOCK_WARPS - 1,

--- a/cub/cub/block/block_raking_layout.cuh
+++ b/cub/cub/block/block_raking_layout.cuh
@@ -81,7 +81,7 @@ struct BlockRakingLayout
     SHARED_ELEMENTS = BLOCK_THREADS,
 
     /// Maximum number of warp-synchronous raking threads
-    MAX_RAKING_THREADS = _CUDA_VSTD::min(BLOCK_THREADS, CUB_WARP_THREADS(0)),
+    MAX_RAKING_THREADS = _CUDA_VSTD::min(BLOCK_THREADS, detail::warp_threads),
 
     /// Number of raking elements per warp-synchronous raking thread (rounded up)
     SEGMENT_LENGTH = (SHARED_ELEMENTS + MAX_RAKING_THREADS - 1) / MAX_RAKING_THREADS,
@@ -91,10 +91,10 @@ struct BlockRakingLayout
     RAKING_THREADS = (SHARED_ELEMENTS + SEGMENT_LENGTH - 1) / SEGMENT_LENGTH,
 
     /// Whether we will have bank conflicts (technically we should find out if the GCD is > 1)
-    HAS_CONFLICTS = (CUB_SMEM_BANKS(0) % SEGMENT_LENGTH == 0),
+    HAS_CONFLICTS = (detail::smem_banks % SEGMENT_LENGTH == 0),
 
     /// Degree of bank conflicts (e.g., 4-way)
-    CONFLICT_DEGREE = (HAS_CONFLICTS) ? (MAX_RAKING_THREADS * SEGMENT_LENGTH) / CUB_SMEM_BANKS(0) : 1,
+    CONFLICT_DEGREE = (HAS_CONFLICTS) ? (MAX_RAKING_THREADS * SEGMENT_LENGTH) / detail::smem_banks : 1,
 
     /// Pad each segment length with one element if segment length is not relatively prime to warp size and can't be
     /// optimized as a vector load

--- a/cub/cub/block/block_scan.cuh
+++ b/cub/cub/block/block_scan.cuh
@@ -243,7 +243,7 @@ private:
    * architectural warp size.
    */
   static constexpr BlockScanAlgorithm SAFE_ALGORITHM =
-    ((ALGORITHM == BLOCK_SCAN_WARP_SCANS) && (BLOCK_THREADS % CUB_WARP_THREADS(0) != 0))
+    ((ALGORITHM == BLOCK_SCAN_WARP_SCANS) && (BLOCK_THREADS % detail::warp_threads != 0))
       ? BLOCK_SCAN_RAKING
       : ALGORITHM;
 

--- a/cub/cub/block/block_shuffle.cuh
+++ b/cub/cub/block/block_shuffle.cuh
@@ -81,7 +81,7 @@ private:
   {
     BLOCK_THREADS = BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z,
 
-    LOG_WARP_THREADS = CUB_LOG_WARP_THREADS(0),
+    LOG_WARP_THREADS = detail::log2_warp_threads,
     WARP_THREADS     = 1 << LOG_WARP_THREADS,
     WARPS            = (BLOCK_THREADS + WARP_THREADS - 1) / WARP_THREADS,
   };

--- a/cub/cub/block/block_store.cuh
+++ b/cub/cub/block/block_store.cuh
@@ -340,9 +340,9 @@ template <typename T, int ITEMS_PER_THREAD, typename OutputIteratorT>
 _CCCL_DEVICE _CCCL_FORCEINLINE void
 StoreDirectWarpStriped(int linear_tid, OutputIteratorT block_itr, T (&items)[ITEMS_PER_THREAD])
 {
-  int tid         = linear_tid & (CUB_PTX_WARP_THREADS - 1);
-  int wid         = linear_tid >> CUB_PTX_LOG_WARP_THREADS;
-  int warp_offset = wid * CUB_PTX_WARP_THREADS * ITEMS_PER_THREAD;
+  int tid         = linear_tid & (detail::warp_threads - 1);
+  int wid         = linear_tid >> detail::log2_warp_threads;
+  int warp_offset = wid * detail::warp_threads * ITEMS_PER_THREAD;
 
   OutputIteratorT thread_itr = block_itr + warp_offset + tid;
 
@@ -350,7 +350,7 @@ StoreDirectWarpStriped(int linear_tid, OutputIteratorT block_itr, T (&items)[ITE
   _CCCL_PRAGMA_UNROLL_FULL()
   for (int ITEM = 0; ITEM < ITEMS_PER_THREAD; ITEM++)
   {
-    thread_itr[(ITEM * CUB_PTX_WARP_THREADS)] = items[ITEM];
+    thread_itr[(ITEM * detail::warp_threads)] = items[ITEM];
   }
 }
 
@@ -392,9 +392,9 @@ template <typename T, int ITEMS_PER_THREAD, typename OutputIteratorT>
 _CCCL_DEVICE _CCCL_FORCEINLINE void
 StoreDirectWarpStriped(int linear_tid, OutputIteratorT block_itr, T (&items)[ITEMS_PER_THREAD], int valid_items)
 {
-  int tid         = linear_tid & (CUB_PTX_WARP_THREADS - 1);
-  int wid         = linear_tid >> CUB_PTX_LOG_WARP_THREADS;
-  int warp_offset = wid * CUB_PTX_WARP_THREADS * ITEMS_PER_THREAD;
+  int tid         = linear_tid & (detail::warp_threads - 1);
+  int wid         = linear_tid >> detail::log2_warp_threads;
+  int warp_offset = wid * detail::warp_threads * ITEMS_PER_THREAD;
 
   OutputIteratorT thread_itr = block_itr + warp_offset + tid;
 
@@ -402,9 +402,9 @@ StoreDirectWarpStriped(int linear_tid, OutputIteratorT block_itr, T (&items)[ITE
   _CCCL_PRAGMA_UNROLL_FULL()
   for (int ITEM = 0; ITEM < ITEMS_PER_THREAD; ITEM++)
   {
-    if (warp_offset + tid + (ITEM * CUB_PTX_WARP_THREADS) < valid_items)
+    if (warp_offset + tid + (ITEM * detail::warp_threads) < valid_items)
     {
-      thread_itr[(ITEM * CUB_PTX_WARP_THREADS)] = items[ITEM];
+      thread_itr[(ITEM * detail::warp_threads)] = items[ITEM];
     }
   }
 }
@@ -907,7 +907,7 @@ private:
   {
     enum
     {
-      WARP_THREADS = CUB_WARP_THREADS(0)
+      WARP_THREADS = detail::warp_threads
     };
 
     // Assert BLOCK_THREADS must be a multiple of WARP_THREADS
@@ -990,7 +990,7 @@ private:
   {
     enum
     {
-      WARP_THREADS = CUB_WARP_THREADS(0)
+      WARP_THREADS = detail::warp_threads
     };
 
     // Assert BLOCK_THREADS must be a multiple of WARP_THREADS

--- a/cub/cub/block/specializations/block_reduce_raking.cuh
+++ b/cub/cub/block/specializations/block_reduce_raking.cuh
@@ -216,7 +216,7 @@ struct BlockReduceRaking
         int valid_raking_threads = (IS_FULL_TILE) ? RAKING_THREADS : (num_valid + SEGMENT_LENGTH - 1) / SEGMENT_LENGTH;
 
         // sync before re-using shmem (warp_storage/raking_grid are aliased)
-        static_assert(RAKING_THREADS <= CUB_PTX_WARP_THREADS, "RAKING_THREADS must be <= warp size.");
+        static_assert(RAKING_THREADS <= warp_threads, "RAKING_THREADS must be <= warp size.");
         unsigned int mask = static_cast<unsigned int>((1ull << RAKING_THREADS) - 1);
         __syncwarp(mask);
 

--- a/cub/cub/block/specializations/block_reduce_raking_commutative_only.cuh
+++ b/cub/cub/block/specializations/block_reduce_raking_commutative_only.cuh
@@ -87,7 +87,7 @@ struct BlockReduceRakingCommutativeOnly
   enum
   {
     /// Number of warp threads
-    WARP_THREADS = CUB_WARP_THREADS(0),
+    WARP_THREADS = warp_threads,
 
     /// Whether or not to use fall-back
     USE_FALLBACK = ((BLOCK_THREADS % WARP_THREADS != 0) || (BLOCK_THREADS <= WARP_THREADS)),

--- a/cub/cub/block/specializations/block_reduce_warp_reductions.cuh
+++ b/cub/cub/block/specializations/block_reduce_warp_reductions.cuh
@@ -78,7 +78,7 @@ struct BlockReduceWarpReductions
     BLOCK_THREADS = BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z,
 
     /// Number of warp threads
-    WARP_THREADS = CUB_WARP_THREADS(0),
+    WARP_THREADS = warp_threads,
 
     /// Number of active warps
     WARPS = (BLOCK_THREADS + WARP_THREADS - 1) / WARP_THREADS,

--- a/cub/cub/block/specializations/block_scan_warp_scans.cuh
+++ b/cub/cub/block/specializations/block_scan_warp_scans.cuh
@@ -75,7 +75,7 @@ struct BlockScanWarpScans
 
   /// Constants
   /// Number of warp threads
-  static constexpr int WARP_THREADS = CUB_WARP_THREADS(0);
+  static constexpr int WARP_THREADS = warp_threads;
 
   /// The thread block size in threads
   static constexpr int BLOCK_THREADS = BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z;

--- a/cub/cub/device/dispatch/dispatch_batch_memcpy.cuh
+++ b/cub/cub/device/dispatch/dispatch_batch_memcpy.cuh
@@ -540,7 +540,7 @@ struct DispatchBatchMemcpy
     }
 
     const int batch_memcpy_blev_grid_size =
-      static_cast<int>(sm_count * batch_memcpy_blev_occupancy * CUB_SUBSCRIPTION_FACTOR(0));
+      static_cast<int>(sm_count * batch_memcpy_blev_occupancy * subscription_factor);
 
     const ::cuda::std::int64_t num_invocations = ::cuda::ceil_div(num_buffers, max_num_buffers_per_invocation);
 

--- a/cub/cub/device/dispatch/dispatch_radix_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_radix_sort.cuh
@@ -445,7 +445,7 @@ struct DispatchRadixSort
           break;
         }
 
-        max_downsweep_grid_size = (downsweep_config.sm_occupancy * sm_count) * CUB_SUBSCRIPTION_FACTOR(0);
+        max_downsweep_grid_size = (downsweep_config.sm_occupancy * sm_count) * detail::subscription_factor;
 
         even_share.DispatchInit(
           num_items, max_downsweep_grid_size, _CUDA_VSTD::max(downsweep_config.tile_size, upsweep_config.tile_size));

--- a/cub/cub/device/dispatch/dispatch_reduce.cuh
+++ b/cub/cub/device/dispatch/dispatch_reduce.cuh
@@ -334,7 +334,7 @@ struct DispatchReduce
       int reduce_device_occupancy = reduce_config.sm_occupancy * sm_count;
 
       // Even-share work distribution
-      int max_blocks = reduce_device_occupancy * CUB_SUBSCRIPTION_FACTOR(0);
+      int max_blocks = reduce_device_occupancy * detail::subscription_factor;
       GridEvenShare<OffsetT> even_share;
       even_share.DispatchInit(num_items, max_blocks, reduce_config.tile_size);
 

--- a/cub/cub/device/dispatch/kernels/radix_sort.cuh
+++ b/cub/cub/device/dispatch/kernels/radix_sort.cuh
@@ -396,7 +396,7 @@ __launch_bounds__(int(ChainedPolicyT::ActivePolicy::SingleTilePolicy::BLOCK_THRE
   {
     // Register pressure work-around: moving num_items through shfl prevents compiler
     // from reusing guards/addressing from prior guarded loads
-    num_items = ShuffleIndex<CUB_PTX_WARP_THREADS>(num_items, 0, 0xffffffff);
+    num_items = ShuffleIndex<warp_threads>(num_items, 0, 0xffffffff);
 
     BlockLoadValues(temp_storage.load_values).Load(d_values_in, values, num_items);
 

--- a/cub/cub/util_arch.cuh
+++ b/cub/cub/util_arch.cuh
@@ -75,43 +75,65 @@ CUB_NAMESPACE_BEGIN
 
 /// Maximum number of devices supported.
 #  ifndef CUB_MAX_DEVICES
+//! Deprecated [Since 3.0]
 #    define CUB_MAX_DEVICES (128)
 #  endif
-
 static_assert(CUB_MAX_DEVICES > 0, "CUB_MAX_DEVICES must be greater than 0.");
 
 /// Number of threads per warp
 #  ifndef CUB_LOG_WARP_THREADS
+//! Deprecated [Since 3.0]
 #    define CUB_LOG_WARP_THREADS(unused) (5)
-#    define CUB_WARP_THREADS(unused)     (1 << CUB_LOG_WARP_THREADS(0))
+//! Deprecated [Since 3.0]
+#    define CUB_WARP_THREADS(unused) (1 << CUB_LOG_WARP_THREADS(0))
 
-#    define CUB_PTX_WARP_THREADS     CUB_WARP_THREADS(0)
+//! Deprecated [Since 3.0]
+#    define CUB_PTX_WARP_THREADS CUB_WARP_THREADS(0)
+//! Deprecated [Since 3.0]
 #    define CUB_PTX_LOG_WARP_THREADS CUB_LOG_WARP_THREADS(0)
 #  endif
 
 /// Number of smem banks
 #  ifndef CUB_LOG_SMEM_BANKS
+//! Deprecated [Since 3.0]
 #    define CUB_LOG_SMEM_BANKS(unused) (5)
-#    define CUB_SMEM_BANKS(unused)     (1 << CUB_LOG_SMEM_BANKS(0))
+//! Deprecated [Since 3.0]
+#    define CUB_SMEM_BANKS(unused) (1 << CUB_LOG_SMEM_BANKS(0))
 
+//! Deprecated [Since 3.0]
 #    define CUB_PTX_LOG_SMEM_BANKS CUB_LOG_SMEM_BANKS(0)
-#    define CUB_PTX_SMEM_BANKS     CUB_SMEM_BANKS
+//! Deprecated [Since 3.0]
+#    define CUB_PTX_SMEM_BANKS CUB_SMEM_BANKS
 #  endif
 
 /// Oversubscription factor
 #  ifndef CUB_SUBSCRIPTION_FACTOR
+//! Deprecated [Since 3.0]
 #    define CUB_SUBSCRIPTION_FACTOR(unused) (5)
-#    define CUB_PTX_SUBSCRIPTION_FACTOR     CUB_SUBSCRIPTION_FACTOR(0)
+//! Deprecated [Since 3.0]
+#    define CUB_PTX_SUBSCRIPTION_FACTOR CUB_SUBSCRIPTION_FACTOR(0)
 #  endif
 
 /// Prefer padding overhead vs X-way conflicts greater than this threshold
 #  ifndef CUB_PREFER_CONFLICT_OVER_PADDING
+//! Deprecated [Since 3.0]
 #    define CUB_PREFER_CONFLICT_OVER_PADDING(unused) (1)
-#    define CUB_PTX_PREFER_CONFLICT_OVER_PADDING     CUB_PREFER_CONFLICT_OVER_PADDING(0)
+//! Deprecated [Since 3.0]
+#    define CUB_PTX_PREFER_CONFLICT_OVER_PADDING CUB_PREFER_CONFLICT_OVER_PADDING(0)
 #  endif
 
 namespace detail
 {
+
+inline constexpr int max_devices       = CUB_MAX_DEVICES;
+inline constexpr int warp_threads      = CUB_PTX_WARP_THREADS;
+inline constexpr int log2_warp_threads = CUB_PTX_LOG_WARP_THREADS;
+inline constexpr int smem_banks        = CUB_SMEM_BANKS(0);
+inline constexpr int log2_smem_banks   = CUB_PTX_LOG_SMEM_BANKS;
+
+inline constexpr int subscription_factor           = CUB_PTX_SUBSCRIPTION_FACTOR;
+inline constexpr bool prefer_conflict_over_padding = CUB_PTX_PREFER_CONFLICT_OVER_PADDING;
+
 // The maximum amount of static shared memory available per thread block
 // Note that in contrast to dynamic shared memory, static shared memory is still limited to 48 KB
 static constexpr ::cuda::std::size_t max_smem_per_block = 48 * 1024;

--- a/cub/cub/util_device.cuh
+++ b/cub/cub/util_device.cuh
@@ -170,7 +170,7 @@ struct PerDeviceAttributeCache
   };
 
 private:
-  std::array<DeviceEntry, CUB_MAX_DEVICES> entries_;
+  std::array<DeviceEntry, detail::max_devices> entries_;
 
 public:
   /**
@@ -179,7 +179,7 @@ public:
   _CCCL_HOST inline PerDeviceAttributeCache()
       : entries_()
   {
-    assert(DeviceCount() <= CUB_MAX_DEVICES);
+    assert(DeviceCount() <= detail::max_devices);
   }
 
   /**

--- a/cub/cub/util_ptx.cuh
+++ b/cub/cub/util_ptx.cuh
@@ -168,9 +168,9 @@ template <int LOGICAL_WARP_THREADS>
 _CCCL_HOST_DEVICE _CCCL_FORCEINLINE unsigned int WarpMask(unsigned int warp_id)
 {
   constexpr bool is_pow_of_two = PowerOfTwo<LOGICAL_WARP_THREADS>::VALUE;
-  constexpr bool is_arch_warp  = LOGICAL_WARP_THREADS == CUB_WARP_THREADS(0);
+  constexpr bool is_arch_warp  = LOGICAL_WARP_THREADS == detail::warp_threads;
 
-  unsigned int member_mask = 0xFFFFFFFFu >> (CUB_WARP_THREADS(0) - LOGICAL_WARP_THREADS);
+  unsigned int member_mask = 0xFFFFFFFFu >> (detail::warp_threads - LOGICAL_WARP_THREADS);
 
   if constexpr (is_pow_of_two && !is_arch_warp)
   {
@@ -444,7 +444,7 @@ struct warp_matcher_t
 };
 
 template <int LABEL_BITS>
-struct warp_matcher_t<LABEL_BITS, CUB_PTX_WARP_THREADS>
+struct warp_matcher_t<LABEL_BITS, warp_threads>
 {
   // match.any.sync.b32 is slower when matching a few bits
   // using a ballot loop instead
@@ -505,7 +505,7 @@ _CCCL_DEVICE _CCCL_FORCEINLINE uint32_t LogicShiftRight(uint32_t val, uint32_t n
  * Compute a 32b mask of threads having the same least-significant
  * LABEL_BITS of \p label as the calling thread.
  */
-template <int LABEL_BITS, int WARP_ACTIVE_THREADS = CUB_PTX_WARP_THREADS>
+template <int LABEL_BITS, int WARP_ACTIVE_THREADS = detail::warp_threads>
 inline _CCCL_DEVICE unsigned int MatchAny(unsigned int label)
 {
   return detail::warp_matcher_t<LABEL_BITS, WARP_ACTIVE_THREADS>::match_any(label);

--- a/cub/cub/warp/specializations/warp_exchange_shfl.cuh
+++ b/cub/cub/warp/specializations/warp_exchange_shfl.cuh
@@ -47,7 +47,7 @@ CUB_NAMESPACE_BEGIN
 namespace detail
 {
 
-template <typename InputT, int ITEMS_PER_THREAD, int LOGICAL_WARP_THREADS = CUB_PTX_WARP_THREADS>
+template <typename InputT, int ITEMS_PER_THREAD, int LOGICAL_WARP_THREADS = warp_threads>
 class WarpExchangeShfl
 {
   static_assert(PowerOfTwo<LOGICAL_WARP_THREADS>::VALUE, "LOGICAL_WARP_THREADS must be a power of two");
@@ -56,7 +56,7 @@ class WarpExchangeShfl
                 "WARP_EXCHANGE_SHUFFLE currently only works when ITEMS_PER_THREAD == "
                 "LOGICAL_WARP_THREADS");
 
-  static constexpr bool IS_ARCH_WARP = LOGICAL_WARP_THREADS == CUB_WARP_THREADS(0);
+  static constexpr bool IS_ARCH_WARP = LOGICAL_WARP_THREADS == warp_threads;
 
   // concrete recursion class
   template <typename OutputT, int IDX, int SIZE>

--- a/cub/cub/warp/specializations/warp_exchange_smem.cuh
+++ b/cub/cub/warp/specializations/warp_exchange_smem.cuh
@@ -53,16 +53,16 @@ CUB_NAMESPACE_BEGIN
 namespace detail
 {
 
-template <typename InputT, int ITEMS_PER_THREAD, int LOGICAL_WARP_THREADS = CUB_PTX_WARP_THREADS>
+template <typename InputT, int ITEMS_PER_THREAD, int LOGICAL_WARP_THREADS = warp_threads>
 class WarpExchangeSmem
 {
   static_assert(PowerOfTwo<LOGICAL_WARP_THREADS>::VALUE, "LOGICAL_WARP_THREADS must be a power of two");
 
   static constexpr int ITEMS_PER_TILE = ITEMS_PER_THREAD * LOGICAL_WARP_THREADS + 1;
 
-  static constexpr bool IS_ARCH_WARP = LOGICAL_WARP_THREADS == CUB_WARP_THREADS(0);
+  static constexpr bool IS_ARCH_WARP = LOGICAL_WARP_THREADS == warp_threads;
 
-  static constexpr int LOG_SMEM_BANKS = CUB_LOG_SMEM_BANKS(0);
+  static constexpr int LOG_SMEM_BANKS = log2_smem_banks;
 
   // Insert padding if the number of items per thread is a power of two
   // and > 4 (otherwise we can typically use 128b loads)

--- a/cub/cub/warp/specializations/warp_reduce_shfl.cuh
+++ b/cub/cub/warp/specializations/warp_reduce_shfl.cuh
@@ -103,16 +103,16 @@ struct WarpReduceShfl
   //---------------------------------------------------------------------
 
   /// Whether the logical warp size and the PTX warp size coincide
-  static constexpr bool IS_ARCH_WARP = (LOGICAL_WARP_THREADS == CUB_WARP_THREADS(0));
+  static constexpr bool IS_ARCH_WARP = (LOGICAL_WARP_THREADS == warp_threads);
 
   /// The number of warp reduction steps
   static constexpr int STEPS = Log2<LOGICAL_WARP_THREADS>::VALUE;
 
   /// Number of logical warps in a PTX warp
-  static constexpr int LOGICAL_WARPS = CUB_WARP_THREADS(0) / LOGICAL_WARP_THREADS;
+  static constexpr int LOGICAL_WARPS = warp_threads / LOGICAL_WARP_THREADS;
 
   /// The 5-bit SHFL mask for logically splitting warps into sub-segments starts 8-bits up
-  static constexpr unsigned SHFL_C = (CUB_WARP_THREADS(0) - LOGICAL_WARP_THREADS) << 8;
+  static constexpr unsigned SHFL_C = (warp_threads - LOGICAL_WARP_THREADS) << 8;
 
   template <typename S>
   struct IsInteger

--- a/cub/cub/warp/specializations/warp_reduce_smem.cuh
+++ b/cub/cub/warp/specializations/warp_reduce_smem.cuh
@@ -72,7 +72,7 @@ struct WarpReduceSmem
    ******************************************************************************/
 
   /// Whether the logical warp size and the PTX warp size coincide
-  static constexpr bool IS_ARCH_WARP = (LOGICAL_WARP_THREADS == CUB_WARP_THREADS(0));
+  static constexpr bool IS_ARCH_WARP = (LOGICAL_WARP_THREADS == warp_threads);
 
   /// Whether the logical warp size is a power-of-two
   static constexpr bool IS_POW_OF_TWO = PowerOfTwo<LOGICAL_WARP_THREADS>::VALUE;

--- a/cub/cub/warp/specializations/warp_scan_shfl.cuh
+++ b/cub/cub/warp/specializations/warp_scan_shfl.cuh
@@ -74,13 +74,13 @@ struct WarpScanShfl
   enum
   {
     /// Whether the logical warp size and the PTX warp size coincide
-    IS_ARCH_WARP = (LOGICAL_WARP_THREADS == CUB_WARP_THREADS(0)),
+    IS_ARCH_WARP = (LOGICAL_WARP_THREADS == warp_threads),
 
     /// The number of warp scan steps
     STEPS = Log2<LOGICAL_WARP_THREADS>::VALUE,
 
     /// The 5-bit SHFL mask for logically splitting warps into sub-segments starts 8-bits up
-    SHFL_C = (CUB_WARP_THREADS(0) - LOGICAL_WARP_THREADS) << 8
+    SHFL_C = (warp_threads - LOGICAL_WARP_THREADS) << 8
   };
 
   template <typename S>

--- a/cub/cub/warp/specializations/warp_scan_smem.cuh
+++ b/cub/cub/warp/specializations/warp_scan_smem.cuh
@@ -72,7 +72,7 @@ struct WarpScanSmem
    ******************************************************************************/
 
   /// Whether the logical warp size and the PTX warp size coincide
-  static constexpr bool IS_ARCH_WARP = (LOGICAL_WARP_THREADS == CUB_WARP_THREADS(0));
+  static constexpr bool IS_ARCH_WARP = (LOGICAL_WARP_THREADS == warp_threads);
 
   /// The number of warp scan steps
   static constexpr int STEPS = Log2<LOGICAL_WARP_THREADS>::VALUE;

--- a/cub/cub/warp/warp_exchange.cuh
+++ b/cub/cub/warp/warp_exchange.cuh
@@ -135,7 +135,7 @@ using InternalWarpExchangeImpl =
  */
 template <typename InputT,
           int ITEMS_PER_THREAD,
-          int LOGICAL_WARP_THREADS                      = CUB_PTX_WARP_THREADS,
+          int LOGICAL_WARP_THREADS                      = detail::warp_threads,
           WarpExchangeAlgorithm WARP_EXCHANGE_ALGORITHM = WARP_EXCHANGE_SMEM>
 class WarpExchange
     : private detail::InternalWarpExchangeImpl<InputT, ITEMS_PER_THREAD, LOGICAL_WARP_THREADS, WARP_EXCHANGE_ALGORITHM>

--- a/cub/cub/warp/warp_load.cuh
+++ b/cub/cub/warp/warp_load.cuh
@@ -219,10 +219,10 @@ enum WarpLoadAlgorithm
 template <typename InputT,
           int ITEMS_PER_THREAD,
           WarpLoadAlgorithm ALGORITHM = WARP_LOAD_DIRECT,
-          int LOGICAL_WARP_THREADS    = CUB_PTX_WARP_THREADS>
+          int LOGICAL_WARP_THREADS    = detail::warp_threads>
 class WarpLoad
 {
-  static constexpr bool IS_ARCH_WARP = LOGICAL_WARP_THREADS == CUB_WARP_THREADS(0);
+  static constexpr bool IS_ARCH_WARP = LOGICAL_WARP_THREADS == detail::warp_threads;
 
   static_assert(PowerOfTwo<LOGICAL_WARP_THREADS>::VALUE, "LOGICAL_WARP_THREADS must be a power of two");
 

--- a/cub/cub/warp/warp_merge_sort.cuh
+++ b/cub/cub/warp/warp_merge_sort.cuh
@@ -122,7 +122,7 @@ CUB_NAMESPACE_BEGIN
 //!   <b>[optional]</b> Value type (default: cub::NullType, which indicates a
 //!   keys-only sort)
 //!
-template <typename KeyT, int ITEMS_PER_THREAD, int LOGICAL_WARP_THREADS = CUB_WARP_THREADS(0), typename ValueT = NullType>
+template <typename KeyT, int ITEMS_PER_THREAD, int LOGICAL_WARP_THREADS = detail::warp_threads, typename ValueT = NullType>
 class WarpMergeSort
     : public BlockMergeSortStrategy<KeyT,
                                     ValueT,
@@ -131,7 +131,7 @@ class WarpMergeSort
                                     WarpMergeSort<KeyT, ITEMS_PER_THREAD, LOGICAL_WARP_THREADS, ValueT>>
 {
 private:
-  static constexpr bool IS_ARCH_WARP = LOGICAL_WARP_THREADS == CUB_WARP_THREADS(0);
+  static constexpr bool IS_ARCH_WARP = LOGICAL_WARP_THREADS == detail::warp_threads;
   static constexpr bool KEYS_ONLY    = ::cuda::std::is_same_v<ValueT, NullType>;
   static constexpr int TILE_SIZE     = ITEMS_PER_THREAD * LOGICAL_WARP_THREADS;
 

--- a/cub/cub/warp/warp_reduce.cuh
+++ b/cub/cub/warp/warp_reduce.cuh
@@ -150,7 +150,7 @@ CUB_NAMESPACE_BEGIN
 //!   hardware warp threads).  Default is the warp size of the targeted CUDA compute-capability
 //!   (e.g., 32 threads for SM20).
 //!
-template <typename T, int LOGICAL_WARP_THREADS = CUB_PTX_WARP_THREADS>
+template <typename T, int LOGICAL_WARP_THREADS = detail::warp_threads>
 class WarpReduce
 {
 private:
@@ -161,7 +161,7 @@ private:
   enum
   {
     /// Whether the logical warp size and the PTX warp size coincide
-    IS_ARCH_WARP = (LOGICAL_WARP_THREADS == CUB_WARP_THREADS(0)),
+    IS_ARCH_WARP = (LOGICAL_WARP_THREADS == cub::detail::warp_threads),
 
     /// Whether the logical warp size is a power-of-two
     IS_POW_OF_TWO = PowerOfTwo<LOGICAL_WARP_THREADS>::VALUE,

--- a/cub/cub/warp/warp_scan.cuh
+++ b/cub/cub/warp/warp_scan.cuh
@@ -156,7 +156,7 @@ CUB_NAMESPACE_BEGIN
 //!   hardware warp threads). Default is the warp size associated with the CUDA Compute Capability
 //!   targeted by the compiler (e.g., 32 threads for SM20).
 //!
-template <typename T, int LOGICAL_WARP_THREADS = CUB_PTX_WARP_THREADS>
+template <typename T, int LOGICAL_WARP_THREADS = detail::warp_threads>
 class WarpScan
 {
 private:
@@ -167,7 +167,7 @@ private:
   enum
   {
     /// Whether the logical warp size and the PTX warp size coincide
-    IS_ARCH_WARP = (LOGICAL_WARP_THREADS == CUB_WARP_THREADS(0)),
+    IS_ARCH_WARP = (LOGICAL_WARP_THREADS == detail::warp_threads),
 
     /// Whether the logical warp size is a power-of-two
     IS_POW_OF_TWO = ((LOGICAL_WARP_THREADS & (LOGICAL_WARP_THREADS - 1)) == 0),

--- a/cub/cub/warp/warp_store.cuh
+++ b/cub/cub/warp/warp_store.cuh
@@ -226,12 +226,12 @@ enum WarpStoreAlgorithm
 template <typename T,
           int ITEMS_PER_THREAD,
           WarpStoreAlgorithm ALGORITHM = WARP_STORE_DIRECT,
-          int LOGICAL_WARP_THREADS     = CUB_PTX_WARP_THREADS>
+          int LOGICAL_WARP_THREADS     = detail::warp_threads>
 class WarpStore
 {
   static_assert(PowerOfTwo<LOGICAL_WARP_THREADS>::VALUE, "LOGICAL_WARP_THREADS must be a power of two");
 
-  static constexpr bool IS_ARCH_WARP = LOGICAL_WARP_THREADS == CUB_WARP_THREADS(0);
+  static constexpr bool IS_ARCH_WARP = LOGICAL_WARP_THREADS == detail::warp_threads;
 
 private:
   /// Store helper

--- a/cub/test/catch2_test_warp_exchange.cuh
+++ b/cub/test/catch2_test_warp_exchange.cuh
@@ -241,7 +241,7 @@ struct total_warps_t
 {
 private:
   static constexpr int max_warps      = 2;
-  static constexpr bool is_arch_warp  = (logical_warp_threads == CUB_WARP_THREADS(0));
+  static constexpr bool is_arch_warp  = (logical_warp_threads == cub::detail::warp_threads);
   static constexpr bool is_pow_of_two = ((logical_warp_threads & (logical_warp_threads - 1)) == 0);
   static constexpr int total_warps    = (is_arch_warp || is_pow_of_two) ? max_warps : 1;
 

--- a/cub/test/catch2_test_warp_load.cu
+++ b/cub/test/catch2_test_warp_load.cu
@@ -213,7 +213,7 @@ struct total_warps_t
 {
 private:
   static constexpr int max_warps      = 2;
-  static constexpr bool is_arch_warp  = (logical_warp_threads == CUB_WARP_THREADS(0));
+  static constexpr bool is_arch_warp  = (logical_warp_threads == cub::detail::warp_threads);
   static constexpr bool is_pow_of_two = ((logical_warp_threads & (logical_warp_threads - 1)) == 0);
   static constexpr int total_warps    = (is_arch_warp || is_pow_of_two) ? max_warps : 1;
 

--- a/cub/test/catch2_test_warp_mask.cu
+++ b/cub/test/catch2_test_warp_mask.cu
@@ -34,7 +34,7 @@ struct total_warps_t
 {
 private:
   static constexpr unsigned int total_warps =
-    (cub::PowerOfTwo<logical_warp_threads>::VALUE) ? CUB_WARP_THREADS(0) / logical_warp_threads : 1;
+    (cub::PowerOfTwo<logical_warp_threads>::VALUE) ? cub::detail::warp_threads / logical_warp_threads : 1;
 
 public:
   static constexpr unsigned int value()
@@ -97,7 +97,7 @@ C2H_TEST("Warp mask ignores lanes after current logical warp", "[mask][warp]", l
     const unsigned int warp_begin = logical_warp_thread * warp_id;
     const unsigned int warp_end   = warp_begin + logical_warp_thread;
 
-    for (unsigned int post_warp_lane = warp_end; post_warp_lane < CUB_WARP_THREADS(0); post_warp_lane++)
+    for (unsigned int post_warp_lane = warp_end; post_warp_lane < cub::detail::warp_threads; post_warp_lane++)
     {
       REQUIRE_FALSE(is_lane_involved(warp_mask, post_warp_lane));
     }

--- a/cub/test/catch2_test_warp_reduce.cu
+++ b/cub/test/catch2_test_warp_reduce.cu
@@ -316,7 +316,7 @@ struct total_warps_t
 {
 private:
   static constexpr int max_warps      = 2;
-  static constexpr bool is_arch_warp  = (logical_warp_threads == CUB_WARP_THREADS(0));
+  static constexpr bool is_arch_warp  = (logical_warp_threads == cub::detail::warp_threads);
   static constexpr bool is_pow_of_two = ((logical_warp_threads & (logical_warp_threads - 1)) == 0);
   static constexpr int total_warps    = (is_arch_warp || is_pow_of_two) ? max_warps : 1;
 

--- a/cub/test/catch2_test_warp_scan.cu
+++ b/cub/test/catch2_test_warp_scan.cu
@@ -335,7 +335,7 @@ struct total_warps_t
 {
 private:
   static constexpr int max_warps      = 2;
-  static constexpr bool is_arch_warp  = (logical_warp_threads == CUB_WARP_THREADS(0));
+  static constexpr bool is_arch_warp  = (logical_warp_threads == cub::detail::warp_threads);
   static constexpr bool is_pow_of_two = ((logical_warp_threads & (logical_warp_threads - 1)) == 0);
   static constexpr int total_warps    = (is_arch_warp || is_pow_of_two) ? max_warps : 1;
 

--- a/cub/test/catch2_test_warp_store.cu
+++ b/cub/test/catch2_test_warp_store.cu
@@ -168,7 +168,7 @@ struct total_warps_t
 {
 private:
   static constexpr int max_warps      = 2;
-  static constexpr bool is_arch_warp  = (logical_warp_threads == CUB_WARP_THREADS(0));
+  static constexpr bool is_arch_warp  = (logical_warp_threads == cub::detail::warp_threads);
   static constexpr bool is_pow_of_two = ((logical_warp_threads & (logical_warp_threads - 1)) == 0);
   static constexpr int total_warps    = (is_arch_warp || is_pow_of_two) ? max_warps : 1;
 


### PR DESCRIPTION
## Description

backport of https://github.com/NVIDIA/cccl/pull/4165
