### PR TITLE
Remove python/cuda_cooperative/setup.py

### DIFF
--- a/python/cuda_cooperative/setup.py
+++ b/python/cuda_cooperative/setup.py
@@ -1,9 +1,0 @@
-# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
-#
-# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-
-from setuptools import setup
-
-setup(
-    license_files=["LICENSE"],
-)


### PR DESCRIPTION
## Description
PR #4212 made cuda_cooperative/setup.py obsolete.

The main purpose of this PR is to remove cuda_cooperative/setup.py

Secondary question:

Do we want to specify `LICENSE` explicitly in pyproject.toml?

setuptools automatically looks for the `LICENSE` file. According to ChatGPT, we could specify

```
[tool.setuptools]
license_files = ["LICENSE"] 
```

in pyproject.toml explicitly, but it's really not necessary, and we're not specifying the `LICENSE` file explicitly in cuda_parallel, too.

Therefore this PR does not change cuda_cooperative/pyproject.toml.