### PR TITLE
Support CMAKE_CUDA_ARCHITECTURES=native/all/all-major

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # 3.15 is the minimum for including the project with add_subdirectory.
-# 3.21 is the minimum for the developer build.
+# 3.24 is the minimum for the developer build.
 cmake_minimum_required(VERSION 3.15)
 
 # sccache cannot handle the -Fd option generating pdb files:
@@ -27,7 +27,7 @@ endif()
 
 # We require a higher cmake version for dev builds
 if (CCCL_TOPLEVEL_PROJECT)
-  cmake_minimum_required(VERSION 3.21)
+  cmake_minimum_required(VERSION 3.24)
 endif()
 
 option(CCCL_ENABLE_LIBCUDACXX "Enable the libcu++ developer build." ${CCCL_TOPLEVEL_PROJECT})

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -289,6 +289,7 @@
       "generator": "Ninja",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_CUDA_ARCHITECTURES": "native",
         "CCCL_ENABLE_BENCHMARKS": true,
         "CCCL_ENABLE_CUB": true,
         "CCCL_ENABLE_THRUST": false,

--- a/cub/cmake/CubCudaConfig.cmake
+++ b/cub/cmake/CubCudaConfig.cmake
@@ -4,19 +4,16 @@ enable_language(CUDA)
 # Architecture options:
 #
 
-# Since we have to filter the arch list based on target features, we don't
-# currently support the convenience arch flags:
-if ("all" IN_LIST CMAKE_CUDA_ARCHITECTURES OR
-    "all-major" IN_LIST CMAKE_CUDA_ARCHITECTURES OR
-    "native" IN_LIST CMAKE_CUDA_ARCHITECTURES)
-  message(FATAL_ERROR
-    "The CUB dev build requires an explicit list of architectures in CMAKE_CUDA_ARCHITECTURES. "
-    "The convenience flags of 'all', 'all-major', and 'native' are not supported.\n"
-    "CMAKE_CUDA_ARCHITECTURES=${CMAKE_CUDA_ARCHITECTURES}")
-endif()
-
 # Create a new arch list that only contains arches that support CDP:
-set(CUB_CUDA_ARCHITECTURES ${CMAKE_CUDA_ARCHITECTURES})
+if ("native" IN_LIST CMAKE_CUDA_ARCHITECTURES)
+  set(CUB_CUDA_ARCHITECTURES ${CMAKE_CUDA_ARCHITECTURES_NATIVE})
+elseif ("all" IN_LIST CMAKE_CUDA_ARCHITECTURES)
+  set(CUB_CUDA_ARCHITECTURES ${CMAKE_CUDA_ARCHITECTURES_ALL})
+elseif ("all-major" IN_LIST CMAKE_CUDA_ARCHITECTURES)
+  set(CUB_CUDA_ARCHITECTURES ${CMAKE_CUDA_ARCHITECTURES_ALL_MAJOR})
+else()
+  set(CUB_CUDA_ARCHITECTURES ${CMAKE_CUDA_ARCHITECTURES})
+endif()
 set(CUB_CUDA_ARCHITECTURES_RDC ${CUB_CUDA_ARCHITECTURES})
 list(FILTER CUB_CUDA_ARCHITECTURES_RDC EXCLUDE REGEX "53|62|72")
 

--- a/docs/cub/benchmarking.rst
+++ b/docs/cub/benchmarking.rst
@@ -21,10 +21,10 @@ Starting from scratch:
     cd cccl
     mkdir build
     cd build
-    cmake .. --preset=cub-benchmark -DCMAKE_CUDA_ARCHITECTURES=native
+    cmake .. --preset=cub-benchmark
 
 You clone the repository, create a build directory and configure the build with CMake.
-It's important that you enable benchmarks (`CCCL_ENABLE_BENCHMARKS=ON`),
+The preset will automatically enable benchmarks (`CCCL_ENABLE_BENCHMARKS=ON`),
 build in Release mode (`CMAKE_BUILD_TYPE=Release`),
 and set the GPU architecture to match your system (`CMAKE_CUDA_ARCHITECTURES=native`).
 This `website <https://arnon.dk/matching-sm-architectures-arch-and-gencode-for-various-nvidia-cards/>`_

--- a/docs/cub/benchmarking.rst
+++ b/docs/cub/benchmarking.rst
@@ -21,12 +21,12 @@ Starting from scratch:
     cd cccl
     mkdir build
     cd build
-    cmake .. --preset=cub-benchmark -DCMAKE_CUDA_ARCHITECTURES=90 # TODO: Set your GPU architecture
+    cmake .. --preset=cub-benchmark -DCMAKE_CUDA_ARCHITECTURES=native
 
 You clone the repository, create a build directory and configure the build with CMake.
 It's important that you enable benchmarks (`CCCL_ENABLE_BENCHMARKS=ON`),
 build in Release mode (`CMAKE_BUILD_TYPE=Release`),
-and set the GPU architecture to match your system (`CMAKE_CUDA_ARCHITECTURES=XX`).
+and set the GPU architecture to match your system (`CMAKE_CUDA_ARCHITECTURES=native`).
 This `website <https://arnon.dk/matching-sm-architectures-arch-and-gencode-for-various-nvidia-cards/>`_
 contains a great table listing the architectures for different brands of GPUs.
 

--- a/docs/cub/tuning.rst
+++ b/docs/cub/tuning.rst
@@ -258,7 +258,7 @@ You can use the following command:
 
   $ mkdir build
   $ cd build
-  $ cmake .. --preset=cub-tune -DCMAKE_CUDA_ARCHITECTURES=90 # TODO: Set your GPU architecture
+  $ cmake .. --preset=cub-tune -DCMAKE_CUDA_ARCHITECTURES=native
 
 You can then run the tuning search for a specific algorithm and compile-time workload:
 

--- a/docs/cub/tuning.rst
+++ b/docs/cub/tuning.rst
@@ -252,13 +252,14 @@ Search Process
 --------------------------------------------------------------------------------
 
 To get started with tuning, you need to configure CMake.
-You can use the following command:
+You can use the following command, which will preconfigure CUB accordingly,
+including setting  :code:`CMAKE_BUILD_TYPE=Release` and :code:`CMAKE_CUDA_ARCHITECTURES=native`:
 
 .. code:: bash
 
   $ mkdir build
   $ cd build
-  $ cmake .. --preset=cub-tune -DCMAKE_CUDA_ARCHITECTURES=native
+  $ cmake .. --preset=cub-tune
 
 You can then run the tuning search for a specific algorithm and compile-time workload:
 

--- a/examples/cudax/CMakeLists.txt
+++ b/examples/cudax/CMakeLists.txt
@@ -38,7 +38,7 @@ CPMAddPackage(
 
 # Default to building for the GPU on the current system
 if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
-  set(CMAKE_CUDA_ARCHITECTURES 86)
+  set(CMAKE_CUDA_ARCHITECTURES native)
 endif()
 
 add_library(cudax_samples_interface INTERFACE)

--- a/thrust/cmake/ThrustCudaConfig.cmake
+++ b/thrust/cmake/ThrustCudaConfig.cmake
@@ -4,19 +4,16 @@ enable_language(CUDA)
 # Architecture options:
 #
 
-# Since we have to filter the arch list based on target features, we don't
-# currently support the convenience arch flags:
-if ("all" IN_LIST CMAKE_CUDA_ARCHITECTURES OR
-    "all-major" IN_LIST CMAKE_CUDA_ARCHITECTURES OR
-    "native" IN_LIST CMAKE_CUDA_ARCHITECTURES)
-  message(FATAL_ERROR
-    "The Thrust dev build requires an explicit list of architectures in CMAKE_CUDA_ARCHITECTURES. "
-    "The convenience flags of 'all', 'all-major', and 'native' are not supported.\n"
-    "CMAKE_CUDA_ARCHITECTURES=${CMAKE_CUDA_ARCHITECTURES}")
-endif()
-
 # Create a new arch list that only contains arches that support CDP:
-set(THRUST_CUDA_ARCHITECTURES ${CMAKE_CUDA_ARCHITECTURES})
+if ("native" IN_LIST CMAKE_CUDA_ARCHITECTURES)
+  set(THRUST_CUDA_ARCHITECTURES ${CMAKE_CUDA_ARCHITECTURES_NATIVE})
+elseif ("all" IN_LIST CMAKE_CUDA_ARCHITECTURES)
+  set(THRUST_CUDA_ARCHITECTURES ${CMAKE_CUDA_ARCHITECTURES_ALL})
+elseif ("all-major" IN_LIST CMAKE_CUDA_ARCHITECTURES)
+  set(THRUST_CUDA_ARCHITECTURES ${CMAKE_CUDA_ARCHITECTURES_ALL_MAJOR})
+else()
+  set(THRUST_CUDA_ARCHITECTURES ${CMAKE_CUDA_ARCHITECTURES})
+endif()
 set(THRUST_CUDA_ARCHITECTURES_RDC ${THRUST_CUDA_ARCHITECTURES})
 list(FILTER THRUST_CUDA_ARCHITECTURES_RDC EXCLUDE REGEX "53|62|72")
 


### PR DESCRIPTION
I (again) wasted enough hours running benchmarks where the configured GPU architecture didn't match the underlying GPU in the system. This problem is solved in CMake by configuring with `-DCMAKE_CUDA_ARCHITECTURES=native`, but we didn't allow this value since we needed an explicit list of architectures to filter those which don't support RDC. However, CMake since 3.24 provides us with enough information.

This PR allows to configure with `CMAKE_CUDA_ARCHITECTURES=native/all/all-major`.