### PR TITLE
Implement `__fp_is_subset` trait

### DIFF
--- a/libcudacxx/include/cuda/std/__cmath/signbit.h
+++ b/libcudacxx/include/cuda/std/__cmath/signbit.h
@@ -25,6 +25,7 @@
 #include <cuda/std/__floating_point/fp.h>
 #include <cuda/std/__type_traits/is_integral.h>
 #include <cuda/std/__type_traits/is_signed.h>
+#include <cuda/std/limits>
 
 // MSVC and clang cuda need the host side functions included
 #if _CCCL_COMPILER(MSVC) || _CCCL_CUDA_COMPILER(CLANG)

--- a/libcudacxx/include/cuda/std/__floating_point/conversion_rank_order.h
+++ b/libcudacxx/include/cuda/std/__floating_point/conversion_rank_order.h
@@ -21,9 +21,9 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/std/__floating_point/traits.h>
 #include <cuda/std/__type_traits/conditional.h>
 #include <cuda/std/__type_traits/is_same.h>
-#include <cuda/std/limits>
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
@@ -38,18 +38,11 @@ enum class __fp_conv_rank_order
 template <class _Lhs, class _Rhs>
 _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr __fp_conv_rank_order __fp_conv_rank_order_v_impl() noexcept
 {
-  static_assert(numeric_limits<_Lhs>::is_specialized, "numeric_limits<_Lhs> is not specialized");
-  static_assert(numeric_limits<_Rhs>::is_specialized, "numeric_limits<_Rhs> is not specialized");
-
-  if constexpr (numeric_limits<_Lhs>::min_exponent == numeric_limits<_Rhs>::min_exponent
-                && numeric_limits<_Lhs>::max_exponent == numeric_limits<_Rhs>::max_exponent
-                && numeric_limits<_Lhs>::digits == numeric_limits<_Rhs>::digits)
+  if constexpr (__fp_is_subset_of_v<_Lhs, _Rhs> && __fp_is_subset_of_v<_Rhs, _Lhs>)
   {
 #if _CCCL_HAS_LONG_DOUBLE()
     // If double and long double have the same properties, long double has the higher subrank
-    if constexpr (numeric_limits<double>::min_exponent == numeric_limits<long double>::min_exponent
-                  && numeric_limits<double>::max_exponent == numeric_limits<long double>::max_exponent
-                  && numeric_limits<double>::digits == numeric_limits<long double>::digits)
+    if constexpr (__fp_is_subset_of_v<long double, double>)
     {
       if constexpr (_CCCL_TRAIT(is_same, _Lhs, long double) && !_CCCL_TRAIT(is_same, _Rhs, long double))
       {
@@ -70,17 +63,11 @@ _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr __fp_conv_rank_order __fp_co
       return __fp_conv_rank_order::__equal;
     }
   }
-  else if constexpr (numeric_limits<_Lhs>::min_exponent <= numeric_limits<_Rhs>::min_exponent
-                     && numeric_limits<_Lhs>::max_exponent >= numeric_limits<_Rhs>::max_exponent
-                     && numeric_limits<_Lhs>::digits >= numeric_limits<_Rhs>::digits
-                     && (numeric_limits<_Lhs>::is_signed || !numeric_limits<_Rhs>::is_signed))
+  else if constexpr (__fp_is_subset_of_v<_Rhs, _Lhs>)
   {
     return __fp_conv_rank_order::__greater;
   }
-  else if constexpr (numeric_limits<_Lhs>::min_exponent >= numeric_limits<_Rhs>::min_exponent
-                     && numeric_limits<_Lhs>::max_exponent <= numeric_limits<_Rhs>::max_exponent
-                     && numeric_limits<_Lhs>::digits <= numeric_limits<_Rhs>::digits
-                     && (!numeric_limits<_Lhs>::is_signed || numeric_limits<_Rhs>::is_signed))
+  else if constexpr (__fp_is_subset_of_v<_Lhs, _Rhs>)
   {
     return __fp_conv_rank_order::__less;
   }

--- a/libcudacxx/include/cuda/std/__floating_point/conversion_rank_order.h
+++ b/libcudacxx/include/cuda/std/__floating_point/conversion_rank_order.h
@@ -23,6 +23,7 @@
 
 #include <cuda/std/__floating_point/traits.h>
 #include <cuda/std/__type_traits/conditional.h>
+#include <cuda/std/__type_traits/is_integral.h>
 #include <cuda/std/__type_traits/is_same.h>
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD

--- a/libcudacxx/include/cuda/std/__floating_point/traits.h
+++ b/libcudacxx/include/cuda/std/__floating_point/traits.h
@@ -134,16 +134,16 @@ inline constexpr bool __is_fp_v = __is_std_fp_v<_Tp> || __is_ext_fp_v<_Tp>;
 
 // __fp_is_subset_v
 
-template <__fp_format _Lhs, __fp_format _Rhs>
+template <__fp_format _LhsFmt, __fp_format _RhsFmt>
 inline constexpr bool __fp_is_subset_v =
-  (!__fp_is_signed_v<_Lhs> || __fp_is_signed_v<_Rhs>)
-  && __fp_exp_min_v<_Lhs> >= __fp_exp_min_v<_Rhs> && __fp_exp_max_v<_Lhs> <= __fp_exp_max_v<_Rhs>
-  && __fp_digits_v<_Lhs> <= __fp_digits_v<_Rhs> && (!__fp_has_denorm_v<_Lhs> || __fp_has_denorm_v<_Rhs>);
+  (!__fp_is_signed_v<_LhsFmt> || __fp_is_signed_v<_RhsFmt>)
+  && __fp_exp_min_v<_LhsFmt> >= __fp_exp_min_v<_RhsFmt> && __fp_exp_max_v<_LhsFmt> <= __fp_exp_max_v<_RhsFmt>
+  && __fp_digits_v<_LhsFmt> <= __fp_digits_v<_RhsFmt> && (!__fp_has_denorm_v<_LhsFmt> || __fp_has_denorm_v<_RhsFmt>);
 
 // __fp_is_subset_of_v
 
-template <class _Tp, class _Up>
-inline constexpr bool __fp_is_subset_of_v = __fp_is_subset_v<__fp_format_of_v<_Tp>, __fp_format_of_v<_Up>>;
+template <class _Lhs, class _Rhs>
+inline constexpr bool __fp_is_subset_of_v = __fp_is_subset_v<__fp_format_of_v<_Lhs>, __fp_format_of_v<_Rhs>>;
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__floating_point/traits.h
+++ b/libcudacxx/include/cuda/std/__floating_point/traits.h
@@ -22,6 +22,7 @@
 #endif // no system header
 
 #include <cuda/std/__floating_point/nvfp_types.h>
+#include <cuda/std/__floating_point/properties.h>
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
@@ -130,6 +131,19 @@ inline constexpr bool __is_ext_fp_v = __is_ext_nv_fp_v<_Tp> || __is_ext_compiler
 
 template <class _Tp>
 inline constexpr bool __is_fp_v = __is_std_fp_v<_Tp> || __is_ext_fp_v<_Tp>;
+
+// __fp_is_subset_v
+
+template <__fp_format _Lhs, __fp_format _Rhs>
+inline constexpr bool __fp_is_subset_v =
+  (!__fp_is_signed_v<_Lhs> || __fp_is_signed_v<_Rhs>)
+  && __fp_exp_min_v<_Lhs> >= __fp_exp_min_v<_Rhs> && __fp_exp_max_v<_Lhs> <= __fp_exp_max_v<_Rhs>
+  && __fp_digits_v<_Lhs> <= __fp_digits_v<_Rhs> && (!__fp_has_denorm_v<_Lhs> || __fp_has_denorm_v<_Rhs>);
+
+// __fp_is_subset_of_v
+
+template <class _Tp, class _Up>
+inline constexpr bool __fp_is_subset_of_v = __fp_is_subset_v<__fp_format_of_v<_Tp>, __fp_format_of_v<_Up>>;
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/conversion_rank_order.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/conversion_rank_order.pass.cpp
@@ -20,7 +20,8 @@
 constexpr bool long_double_is_double =
   cuda::std::numeric_limits<double>::min_exponent == cuda::std::numeric_limits<long double>::min_exponent
   && cuda::std::numeric_limits<double>::max_exponent == cuda::std::numeric_limits<long double>::max_exponent
-  && cuda::std::numeric_limits<double>::digits == cuda::std::numeric_limits<long double>::digits;
+  && cuda::std::numeric_limits<double>::digits == cuda::std::numeric_limits<long double>::digits
+  && cuda::std::numeric_limits<double>::has_denorm == cuda::std::numeric_limits<long double>::has_denorm;
 #endif // _CCCL_HAS_LONG_DOUBLE()
 
 using fp_conv_rank_order = cuda::std::__fp_conv_rank_order;
@@ -137,7 +138,7 @@ static_assert(fp_conv_rank_order_v<__half, __nv_bfloat16> == fp_conv_rank_order:
 static_assert(fp_conv_rank_order_v<__half, __nv_fp8_e4m3> == fp_conv_rank_order::__greater);
 #  endif // _CCCL_HAS_NVFP8_E4M3()
 #  if _CCCL_HAS_NVFP8_E5M2()
-static_assert(fp_conv_rank_order_v<__half, __nv_fp8_e5m2> == fp_conv_rank_order::__unordered);
+static_assert(fp_conv_rank_order_v<__half, __nv_fp8_e5m2> == fp_conv_rank_order::__greater);
 #  endif // _CCCL_HAS_NVFP8_E5M2()
 #  if _CCCL_HAS_NVFP8_E8M0()
 static_assert(fp_conv_rank_order_v<__half, __nv_fp8_e8m0> == fp_conv_rank_order::__unordered);
@@ -224,7 +225,7 @@ static_assert(fp_conv_rank_order_v<__nv_fp8_e5m2, double> == fp_conv_rank_order:
 static_assert(fp_conv_rank_order_v<__nv_fp8_e5m2, long double> == fp_conv_rank_order::__less);
 #  endif // _CCCL_HAS_LONG_DOUBLE()
 #  if _CCCL_HAS_NVFP16()
-static_assert(fp_conv_rank_order_v<__nv_fp8_e5m2, __half> == fp_conv_rank_order::__unordered);
+static_assert(fp_conv_rank_order_v<__nv_fp8_e5m2, __half> == fp_conv_rank_order::__less);
 #  endif // _CCCL_HAS_NVFP16()
 #  if _CCCL_HAS_NVBF16()
 static_assert(fp_conv_rank_order_v<__nv_fp8_e5m2, __nv_bfloat16> == fp_conv_rank_order::__less);

--- a/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/traits/classification.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/traits/classification.pass.cpp
@@ -15,7 +15,7 @@
 #include <cuda/std/__floating_point/fp.h>
 
 template <class T>
-__host__ __device__ void test_is_std_fp()
+__host__ __device__ void test_std_fp()
 {
   static_assert(cuda::std::__is_std_fp_v<T>);
   static_assert(!cuda::std::__is_ext_nv_fp_v<T>);
@@ -100,10 +100,10 @@ __host__ __device__ void test_ext_compiler_fp()
 
 int main(int, char**)
 {
-  test_is_std_fp<float>();
-  test_is_std_fp<double>();
+  test_std_fp<float>();
+  test_std_fp<double>();
 #if _CCCL_HAS_LONG_DOUBLE()
-  test_is_std_fp<long double>();
+  test_std_fp<long double>();
 #endif // _CCCL_HAS_LONG_DOUBLE()
 
 #if _CCCL_HAS_NVFP16()

--- a/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/traits/is_subset.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/traits/is_subset.pass.cpp
@@ -1,0 +1,179 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+#include <disable_nvfp_conversions_and_operators.h>
+// clang-format on
+
+#include <cuda/std/__floating_point/fp.h>
+
+using cuda::std::__fp_format;
+using cuda::std::__fp_is_subset_v;
+
+static_assert(__fp_is_subset_v<__fp_format::__binary16, __fp_format::__binary16>);
+static_assert(__fp_is_subset_v<__fp_format::__binary16, __fp_format::__binary32>);
+static_assert(__fp_is_subset_v<__fp_format::__binary16, __fp_format::__binary64>);
+static_assert(__fp_is_subset_v<__fp_format::__binary16, __fp_format::__binary128>);
+static_assert(!__fp_is_subset_v<__fp_format::__binary16, __fp_format::__bfloat16>);
+static_assert(__fp_is_subset_v<__fp_format::__binary16, __fp_format::__fp80_x86>);
+static_assert(!__fp_is_subset_v<__fp_format::__binary16, __fp_format::__fp8_nv_e4m3>);
+static_assert(!__fp_is_subset_v<__fp_format::__binary16, __fp_format::__fp8_nv_e5m2>);
+static_assert(!__fp_is_subset_v<__fp_format::__binary16, __fp_format::__fp8_nv_e8m0>);
+static_assert(!__fp_is_subset_v<__fp_format::__binary16, __fp_format::__fp6_nv_e2m3>);
+static_assert(!__fp_is_subset_v<__fp_format::__binary16, __fp_format::__fp6_nv_e3m2>);
+static_assert(!__fp_is_subset_v<__fp_format::__binary16, __fp_format::__fp4_nv_e2m1>);
+
+static_assert(!__fp_is_subset_v<__fp_format::__binary32, __fp_format::__binary16>);
+static_assert(__fp_is_subset_v<__fp_format::__binary32, __fp_format::__binary32>);
+static_assert(__fp_is_subset_v<__fp_format::__binary32, __fp_format::__binary64>);
+static_assert(__fp_is_subset_v<__fp_format::__binary32, __fp_format::__binary128>);
+static_assert(!__fp_is_subset_v<__fp_format::__binary32, __fp_format::__bfloat16>);
+static_assert(__fp_is_subset_v<__fp_format::__binary32, __fp_format::__fp80_x86>);
+static_assert(!__fp_is_subset_v<__fp_format::__binary32, __fp_format::__fp8_nv_e4m3>);
+static_assert(!__fp_is_subset_v<__fp_format::__binary32, __fp_format::__fp8_nv_e5m2>);
+static_assert(!__fp_is_subset_v<__fp_format::__binary32, __fp_format::__fp8_nv_e8m0>);
+static_assert(!__fp_is_subset_v<__fp_format::__binary32, __fp_format::__fp6_nv_e2m3>);
+static_assert(!__fp_is_subset_v<__fp_format::__binary32, __fp_format::__fp6_nv_e3m2>);
+static_assert(!__fp_is_subset_v<__fp_format::__binary32, __fp_format::__fp4_nv_e2m1>);
+
+static_assert(!__fp_is_subset_v<__fp_format::__binary64, __fp_format::__binary16>);
+static_assert(!__fp_is_subset_v<__fp_format::__binary64, __fp_format::__binary32>);
+static_assert(__fp_is_subset_v<__fp_format::__binary64, __fp_format::__binary64>);
+static_assert(__fp_is_subset_v<__fp_format::__binary64, __fp_format::__binary128>);
+static_assert(!__fp_is_subset_v<__fp_format::__binary64, __fp_format::__bfloat16>);
+static_assert(__fp_is_subset_v<__fp_format::__binary64, __fp_format::__fp80_x86>);
+static_assert(!__fp_is_subset_v<__fp_format::__binary64, __fp_format::__fp8_nv_e4m3>);
+static_assert(!__fp_is_subset_v<__fp_format::__binary64, __fp_format::__fp8_nv_e5m2>);
+static_assert(!__fp_is_subset_v<__fp_format::__binary64, __fp_format::__fp8_nv_e8m0>);
+static_assert(!__fp_is_subset_v<__fp_format::__binary64, __fp_format::__fp6_nv_e2m3>);
+static_assert(!__fp_is_subset_v<__fp_format::__binary64, __fp_format::__fp6_nv_e3m2>);
+static_assert(!__fp_is_subset_v<__fp_format::__binary64, __fp_format::__fp4_nv_e2m1>);
+
+static_assert(!__fp_is_subset_v<__fp_format::__binary128, __fp_format::__binary16>);
+static_assert(!__fp_is_subset_v<__fp_format::__binary128, __fp_format::__binary32>);
+static_assert(!__fp_is_subset_v<__fp_format::__binary128, __fp_format::__binary64>);
+static_assert(__fp_is_subset_v<__fp_format::__binary128, __fp_format::__binary128>);
+static_assert(!__fp_is_subset_v<__fp_format::__binary128, __fp_format::__bfloat16>);
+static_assert(!__fp_is_subset_v<__fp_format::__binary128, __fp_format::__fp80_x86>);
+static_assert(!__fp_is_subset_v<__fp_format::__binary128, __fp_format::__fp8_nv_e4m3>);
+static_assert(!__fp_is_subset_v<__fp_format::__binary128, __fp_format::__fp8_nv_e5m2>);
+static_assert(!__fp_is_subset_v<__fp_format::__binary128, __fp_format::__fp8_nv_e8m0>);
+static_assert(!__fp_is_subset_v<__fp_format::__binary128, __fp_format::__fp6_nv_e2m3>);
+static_assert(!__fp_is_subset_v<__fp_format::__binary128, __fp_format::__fp6_nv_e3m2>);
+static_assert(!__fp_is_subset_v<__fp_format::__binary128, __fp_format::__fp4_nv_e2m1>);
+
+static_assert(!__fp_is_subset_v<__fp_format::__bfloat16, __fp_format::__binary16>);
+static_assert(__fp_is_subset_v<__fp_format::__bfloat16, __fp_format::__binary32>);
+static_assert(__fp_is_subset_v<__fp_format::__bfloat16, __fp_format::__binary64>);
+static_assert(__fp_is_subset_v<__fp_format::__bfloat16, __fp_format::__binary128>);
+static_assert(__fp_is_subset_v<__fp_format::__bfloat16, __fp_format::__bfloat16>);
+static_assert(__fp_is_subset_v<__fp_format::__bfloat16, __fp_format::__fp80_x86>);
+static_assert(!__fp_is_subset_v<__fp_format::__bfloat16, __fp_format::__fp8_nv_e4m3>);
+static_assert(!__fp_is_subset_v<__fp_format::__bfloat16, __fp_format::__fp8_nv_e5m2>);
+static_assert(!__fp_is_subset_v<__fp_format::__bfloat16, __fp_format::__fp8_nv_e8m0>);
+static_assert(!__fp_is_subset_v<__fp_format::__bfloat16, __fp_format::__fp6_nv_e2m3>);
+static_assert(!__fp_is_subset_v<__fp_format::__bfloat16, __fp_format::__fp6_nv_e3m2>);
+static_assert(!__fp_is_subset_v<__fp_format::__bfloat16, __fp_format::__fp4_nv_e2m1>);
+
+static_assert(!__fp_is_subset_v<__fp_format::__fp80_x86, __fp_format::__binary16>);
+static_assert(!__fp_is_subset_v<__fp_format::__fp80_x86, __fp_format::__binary32>);
+static_assert(!__fp_is_subset_v<__fp_format::__fp80_x86, __fp_format::__binary64>);
+static_assert(__fp_is_subset_v<__fp_format::__fp80_x86, __fp_format::__binary128>);
+static_assert(!__fp_is_subset_v<__fp_format::__fp80_x86, __fp_format::__bfloat16>);
+static_assert(__fp_is_subset_v<__fp_format::__fp80_x86, __fp_format::__fp80_x86>);
+static_assert(!__fp_is_subset_v<__fp_format::__fp80_x86, __fp_format::__fp8_nv_e4m3>);
+static_assert(!__fp_is_subset_v<__fp_format::__fp80_x86, __fp_format::__fp8_nv_e5m2>);
+static_assert(!__fp_is_subset_v<__fp_format::__fp80_x86, __fp_format::__fp8_nv_e8m0>);
+static_assert(!__fp_is_subset_v<__fp_format::__fp80_x86, __fp_format::__fp6_nv_e2m3>);
+static_assert(!__fp_is_subset_v<__fp_format::__fp80_x86, __fp_format::__fp6_nv_e3m2>);
+static_assert(!__fp_is_subset_v<__fp_format::__fp80_x86, __fp_format::__fp4_nv_e2m1>);
+
+static_assert(__fp_is_subset_v<__fp_format::__fp8_nv_e4m3, __fp_format::__binary16>);
+static_assert(__fp_is_subset_v<__fp_format::__fp8_nv_e4m3, __fp_format::__binary32>);
+static_assert(__fp_is_subset_v<__fp_format::__fp8_nv_e4m3, __fp_format::__binary64>);
+static_assert(__fp_is_subset_v<__fp_format::__fp8_nv_e4m3, __fp_format::__binary128>);
+static_assert(__fp_is_subset_v<__fp_format::__fp8_nv_e4m3, __fp_format::__bfloat16>);
+static_assert(__fp_is_subset_v<__fp_format::__fp8_nv_e4m3, __fp_format::__fp80_x86>);
+static_assert(__fp_is_subset_v<__fp_format::__fp8_nv_e4m3, __fp_format::__fp8_nv_e4m3>);
+static_assert(!__fp_is_subset_v<__fp_format::__fp8_nv_e4m3, __fp_format::__fp8_nv_e5m2>);
+static_assert(!__fp_is_subset_v<__fp_format::__fp8_nv_e4m3, __fp_format::__fp8_nv_e8m0>);
+static_assert(!__fp_is_subset_v<__fp_format::__fp8_nv_e4m3, __fp_format::__fp6_nv_e2m3>);
+static_assert(!__fp_is_subset_v<__fp_format::__fp8_nv_e4m3, __fp_format::__fp6_nv_e3m2>);
+static_assert(!__fp_is_subset_v<__fp_format::__fp8_nv_e4m3, __fp_format::__fp4_nv_e2m1>);
+
+static_assert(__fp_is_subset_v<__fp_format::__fp8_nv_e5m2, __fp_format::__binary16>);
+static_assert(__fp_is_subset_v<__fp_format::__fp8_nv_e5m2, __fp_format::__binary32>);
+static_assert(__fp_is_subset_v<__fp_format::__fp8_nv_e5m2, __fp_format::__binary64>);
+static_assert(__fp_is_subset_v<__fp_format::__fp8_nv_e5m2, __fp_format::__binary128>);
+static_assert(__fp_is_subset_v<__fp_format::__fp8_nv_e5m2, __fp_format::__bfloat16>);
+static_assert(__fp_is_subset_v<__fp_format::__fp8_nv_e5m2, __fp_format::__fp80_x86>);
+static_assert(!__fp_is_subset_v<__fp_format::__fp8_nv_e5m2, __fp_format::__fp8_nv_e4m3>);
+static_assert(__fp_is_subset_v<__fp_format::__fp8_nv_e5m2, __fp_format::__fp8_nv_e5m2>);
+static_assert(!__fp_is_subset_v<__fp_format::__fp8_nv_e5m2, __fp_format::__fp8_nv_e8m0>);
+static_assert(!__fp_is_subset_v<__fp_format::__fp8_nv_e5m2, __fp_format::__fp6_nv_e2m3>);
+static_assert(!__fp_is_subset_v<__fp_format::__fp8_nv_e5m2, __fp_format::__fp6_nv_e3m2>);
+static_assert(!__fp_is_subset_v<__fp_format::__fp8_nv_e5m2, __fp_format::__fp4_nv_e2m1>);
+
+static_assert(!__fp_is_subset_v<__fp_format::__fp8_nv_e8m0, __fp_format::__binary16>);
+static_assert(!__fp_is_subset_v<__fp_format::__fp8_nv_e8m0, __fp_format::__binary32>);
+static_assert(__fp_is_subset_v<__fp_format::__fp8_nv_e8m0, __fp_format::__binary64>);
+static_assert(__fp_is_subset_v<__fp_format::__fp8_nv_e8m0, __fp_format::__binary128>);
+static_assert(!__fp_is_subset_v<__fp_format::__fp8_nv_e8m0, __fp_format::__bfloat16>);
+static_assert(__fp_is_subset_v<__fp_format::__fp8_nv_e8m0, __fp_format::__fp80_x86>);
+static_assert(!__fp_is_subset_v<__fp_format::__fp8_nv_e8m0, __fp_format::__fp8_nv_e4m3>);
+static_assert(!__fp_is_subset_v<__fp_format::__fp8_nv_e8m0, __fp_format::__fp8_nv_e5m2>);
+static_assert(__fp_is_subset_v<__fp_format::__fp8_nv_e8m0, __fp_format::__fp8_nv_e8m0>);
+static_assert(!__fp_is_subset_v<__fp_format::__fp8_nv_e8m0, __fp_format::__fp6_nv_e2m3>);
+static_assert(!__fp_is_subset_v<__fp_format::__fp8_nv_e8m0, __fp_format::__fp6_nv_e3m2>);
+static_assert(!__fp_is_subset_v<__fp_format::__fp8_nv_e8m0, __fp_format::__fp4_nv_e2m1>);
+
+static_assert(__fp_is_subset_v<__fp_format::__fp6_nv_e2m3, __fp_format::__binary16>);
+static_assert(__fp_is_subset_v<__fp_format::__fp6_nv_e2m3, __fp_format::__binary32>);
+static_assert(__fp_is_subset_v<__fp_format::__fp6_nv_e2m3, __fp_format::__binary64>);
+static_assert(__fp_is_subset_v<__fp_format::__fp6_nv_e2m3, __fp_format::__binary128>);
+static_assert(__fp_is_subset_v<__fp_format::__fp6_nv_e2m3, __fp_format::__bfloat16>);
+static_assert(__fp_is_subset_v<__fp_format::__fp6_nv_e2m3, __fp_format::__fp80_x86>);
+static_assert(__fp_is_subset_v<__fp_format::__fp6_nv_e2m3, __fp_format::__fp8_nv_e4m3>);
+static_assert(!__fp_is_subset_v<__fp_format::__fp6_nv_e2m3, __fp_format::__fp8_nv_e5m2>);
+static_assert(!__fp_is_subset_v<__fp_format::__fp6_nv_e2m3, __fp_format::__fp8_nv_e8m0>);
+static_assert(__fp_is_subset_v<__fp_format::__fp6_nv_e2m3, __fp_format::__fp6_nv_e2m3>);
+static_assert(!__fp_is_subset_v<__fp_format::__fp6_nv_e2m3, __fp_format::__fp6_nv_e3m2>);
+static_assert(!__fp_is_subset_v<__fp_format::__fp6_nv_e2m3, __fp_format::__fp4_nv_e2m1>);
+
+static_assert(__fp_is_subset_v<__fp_format::__fp6_nv_e3m2, __fp_format::__binary16>);
+static_assert(__fp_is_subset_v<__fp_format::__fp6_nv_e3m2, __fp_format::__binary32>);
+static_assert(__fp_is_subset_v<__fp_format::__fp6_nv_e3m2, __fp_format::__binary64>);
+static_assert(__fp_is_subset_v<__fp_format::__fp6_nv_e3m2, __fp_format::__binary128>);
+static_assert(__fp_is_subset_v<__fp_format::__fp6_nv_e3m2, __fp_format::__bfloat16>);
+static_assert(__fp_is_subset_v<__fp_format::__fp6_nv_e3m2, __fp_format::__fp80_x86>);
+static_assert(__fp_is_subset_v<__fp_format::__fp6_nv_e3m2, __fp_format::__fp8_nv_e4m3>);
+static_assert(__fp_is_subset_v<__fp_format::__fp6_nv_e3m2, __fp_format::__fp8_nv_e5m2>);
+static_assert(!__fp_is_subset_v<__fp_format::__fp6_nv_e3m2, __fp_format::__fp8_nv_e8m0>);
+static_assert(!__fp_is_subset_v<__fp_format::__fp6_nv_e3m2, __fp_format::__fp6_nv_e2m3>);
+static_assert(__fp_is_subset_v<__fp_format::__fp6_nv_e3m2, __fp_format::__fp6_nv_e3m2>);
+static_assert(!__fp_is_subset_v<__fp_format::__fp6_nv_e3m2, __fp_format::__fp4_nv_e2m1>);
+
+static_assert(__fp_is_subset_v<__fp_format::__fp4_nv_e2m1, __fp_format::__binary16>);
+static_assert(__fp_is_subset_v<__fp_format::__fp4_nv_e2m1, __fp_format::__binary32>);
+static_assert(__fp_is_subset_v<__fp_format::__fp4_nv_e2m1, __fp_format::__binary64>);
+static_assert(__fp_is_subset_v<__fp_format::__fp4_nv_e2m1, __fp_format::__binary128>);
+static_assert(__fp_is_subset_v<__fp_format::__fp4_nv_e2m1, __fp_format::__bfloat16>);
+static_assert(__fp_is_subset_v<__fp_format::__fp4_nv_e2m1, __fp_format::__fp80_x86>);
+static_assert(__fp_is_subset_v<__fp_format::__fp4_nv_e2m1, __fp_format::__fp8_nv_e4m3>);
+static_assert(__fp_is_subset_v<__fp_format::__fp4_nv_e2m1, __fp_format::__fp8_nv_e5m2>);
+static_assert(!__fp_is_subset_v<__fp_format::__fp4_nv_e2m1, __fp_format::__fp8_nv_e8m0>);
+static_assert(__fp_is_subset_v<__fp_format::__fp4_nv_e2m1, __fp_format::__fp6_nv_e2m3>);
+static_assert(__fp_is_subset_v<__fp_format::__fp4_nv_e2m1, __fp_format::__fp6_nv_e3m2>);
+static_assert(__fp_is_subset_v<__fp_format::__fp4_nv_e2m1, __fp_format::__fp4_nv_e2m1>);
+
+int main(int, char**)
+{
+  return 0;
+}


### PR DESCRIPTION
This PR implements `__fp_is_subset` trait for extended floating point types. It also fixes and simplifies `__fp_conv_rank_order` implementation.