### PR TITLE
Fix typos in cuda mdspan documentation

### DIFF
--- a/docs/libcudacxx/extended_api/mdspan/host_device_accessor.rst
+++ b/docs/libcudacxx/extended_api/mdspan/host_device_accessor.rst
@@ -71,7 +71,7 @@ Features
 
 **Memory spaces**
 
-*Host*, *device*, and *managed* ``mdspan`` can be created and "sliced" (``cuda::std::submdspan``) on any memory spaces. However, accessing to a specific memory space is restricted to the respective *accessor* type.
+*Host*, *device*, and *managed* ``mdspan`` can be created and "sliced" (``cuda::std::submdspan``) on any memory space. However, access to a specific memory space is restricted to the respective *accessor* type.
 
 +----------------------------------+------------------+-------------------+
 | ``mdspan`` / memory space access | Host memory      | Device memory     |


### PR DESCRIPTION
## Description

Fix documentation typos pointed out by @bernhardmgruber in https://github.com/NVIDIA/cccl/pull/4220#discussion_r2006707566