### PR TITLE
Backport PR #4221 to branch/3.0.x — Remove python/cuda_cooperative/setup.py

### DIFF
--- a/python/cuda_cooperative/setup.py
+++ b/python/cuda_cooperative/setup.py
@@ -1,9 +1,0 @@
-# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
-#
-# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-
-from setuptools import setup
-
-setup(
-    license_files=["LICENSE"],
-)


### PR DESCRIPTION
## Description
Backport of the boring PR #4221, mainly to minimize the delta between main and branch/3.0.x

(I verified that cuda_cooperative/pyproject.toml on branch/3.0.x is identical to that on the main branch.)