### PR TITLE
Make `cuda::stream_ref` constructible on device

### DIFF
--- a/cub/benchmarks/nvbench_helper/nvbench_helper/nvbench_helper.cuh
+++ b/cub/benchmarks/nvbench_helper/nvbench_helper/nvbench_helper.cuh
@@ -595,7 +595,7 @@ auto policy(caching_allocator_t&)
 #if THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
 auto policy(caching_allocator_t& alloc, nvbench::launch& launch)
 {
-  return thrust::cuda::par(alloc).on(launch.get_stream());
+  return thrust::cuda::par(alloc).on(static_cast<::cudaStream_t>(launch.get_stream()));
 }
 #else
 auto policy(caching_allocator_t&, nvbench::launch&)

--- a/libcudacxx/include/cuda/stream_ref
+++ b/libcudacxx/include/cuda/stream_ref
@@ -86,7 +86,7 @@ public:
    * outlive the stream identified by the `cudaStream_t` handle.
    *
    */
-  constexpr stream_ref(value_type __stream_) noexcept
+  _LIBCUDACXX_HIDE_FROM_ABI constexpr stream_ref(value_type __stream_) noexcept
       : __stream{__stream_}
   {}
 
@@ -106,7 +106,8 @@ public:
    * \param rhs The second `stream_ref` to compare
    * \return true if equal, false if unequal
    */
-  _CCCL_NODISCARD_FRIEND constexpr bool operator==(const stream_ref& __lhs, const stream_ref& __rhs) noexcept
+  _CCCL_NODISCARD_FRIEND _LIBCUDACXX_HIDE_FROM_ABI constexpr bool
+  operator==(const stream_ref& __lhs, const stream_ref& __rhs) noexcept
   {
     return __lhs.__stream == __rhs.__stream;
   }
@@ -121,13 +122,14 @@ public:
    * \param rhs The second `stream_ref` to compare
    * \return true if unequal, false if equal
    */
-  _CCCL_NODISCARD_FRIEND constexpr bool operator!=(const stream_ref& __lhs, const stream_ref& __rhs) noexcept
+  _CCCL_NODISCARD_FRIEND _LIBCUDACXX_HIDE_FROM_ABI constexpr bool
+  operator!=(const stream_ref& __lhs, const stream_ref& __rhs) noexcept
   {
     return __lhs.__stream != __rhs.__stream;
   }
 
   /// Returns the wrapped `cudaStream_t` handle.
-  _CCCL_NODISCARD constexpr value_type get() const noexcept
+  _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr value_type get() const noexcept
   {
     return __stream;
   }

--- a/libcudacxx/test/libcudacxx/cuda/stream_ref/stream_ref.constructor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/stream_ref/stream_ref.constructor.pass.cpp
@@ -24,23 +24,25 @@ template <class T>
 constexpr bool has_value_type<T, cuda::std::void_t<typename T::value_type>> = true;
 static_assert(has_value_type<cuda::stream_ref>, "");
 
+__host__ __device__ void test()
+{
+  { // default construction
+    cuda::stream_ref ref;
+    static_assert(noexcept(cuda::stream_ref{}), "");
+    assert(ref.get() == reinterpret_cast<cudaStream_t>(0));
+  }
+
+  { // from stream
+    cudaStream_t stream = reinterpret_cast<cudaStream_t>(42);
+    cuda::stream_ref ref{stream};
+    static_assert(noexcept(cuda::stream_ref{stream}), "");
+    assert(ref.get() == reinterpret_cast<cudaStream_t>(42));
+  }
+}
+
 int main(int argc, char** argv)
 {
-  NV_IF_TARGET(
-    NV_IS_HOST,
-    (
-      { // default construction
-        cuda::stream_ref ref;
-        static_assert(noexcept(cuda::stream_ref{}), "");
-        assert(ref.get() == reinterpret_cast<cudaStream_t>(0));
-      }
-
-      { // from stream
-        cudaStream_t stream = reinterpret_cast<cudaStream_t>(42);
-        cuda::stream_ref ref{stream};
-        static_assert(noexcept(cuda::stream_ref{stream}), "");
-        assert(ref.get() == reinterpret_cast<cudaStream_t>(42));
-      }))
+  test();
 
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/cuda/stream_ref/stream_ref.equality.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/stream_ref/stream_ref.equality.pass.cpp
@@ -13,17 +13,20 @@
 #include <cuda/std/cassert>
 #include <cuda/stream_ref>
 
+__host__ __device__ void test()
+{
+  cuda::stream_ref left{reinterpret_cast<cudaStream_t>(42)};
+  cuda::stream_ref right{reinterpret_cast<cudaStream_t>(1337)};
+  static_assert(noexcept(left == right), "");
+  static_assert(noexcept(left != right), "");
+
+  assert(left == left);
+  assert(left != right);
+}
+
 int main(int argc, char** argv)
 {
-  NV_IF_TARGET(
-    NV_IS_HOST,
-    (cuda::stream_ref left{reinterpret_cast<cudaStream_t>(42)};
-     cuda::stream_ref right{reinterpret_cast<cudaStream_t>(1337)};
-     static_assert(noexcept(left == right), "");
-     static_assert(noexcept(left != right), "");
-
-     assert(left == left);
-     assert(left != right);))
+  test();
 
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/cuda/stream_ref/stream_ref.get.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/stream_ref/stream_ref.get.pass.cpp
@@ -13,11 +13,16 @@
 #include <cuda/std/cassert>
 #include <cuda/stream_ref>
 
+__host__ __device__ void test()
+{
+  cudaStream_t stream = reinterpret_cast<cudaStream_t>(42);
+  cuda::stream_ref ref{stream};
+  assert(ref.get() == stream);
+}
+
 int main(int argc, char** argv)
 {
-  NV_IF_TARGET(NV_IS_HOST,
-               (cudaStream_t stream = reinterpret_cast<cudaStream_t>(42); cuda::stream_ref ref{stream};
-                assert(ref.get() == stream);))
+  test();
 
   return 0;
 }

--- a/thrust/thrust/system/cuda/detail/par.h
+++ b/thrust/thrust/system/cuda/detail/par.h
@@ -52,21 +52,15 @@ private:
   cudaStream_t stream;
 
 public:
-  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_HOST_DEVICE execute_on_stream_base(cudaStream_t stream_ = default_stream())
       : stream(stream_)
   {}
 
-  THRUST_RUNTIME_FUNCTION Derived on(cudaStream_t const& s) const
+  _CCCL_HOST_DEVICE Derived on(::cuda::stream_ref const& s) const
   {
     Derived result = derived_cast(*this);
-    result.stream  = s;
+    result.stream  = s.get();
     return result;
-  }
-
-  Derived on(::cuda::stream_ref const& s) const
-  {
-    return on(s.get());
   }
 
 private:
@@ -87,16 +81,11 @@ public:
       : stream(stream_)
   {}
 
-  THRUST_RUNTIME_FUNCTION Derived on(cudaStream_t const& s) const
+  _CCCL_HOST_DEVICE Derived on(::cuda::stream_ref const& s) const
   {
     Derived result = derived_cast(*this);
-    result.stream  = s;
+    result.stream  = s.get();
     return result;
-  }
-
-  Derived on(::cuda::stream_ref const& s) const
-  {
-    return on(s.get());
   }
 
 private:
@@ -143,14 +132,9 @@ struct par_t
 
   using stream_attachment_type = execute_on_stream;
 
-  THRUST_RUNTIME_FUNCTION stream_attachment_type on(cudaStream_t const& stream) const
+  _CCCL_HOST_DEVICE stream_attachment_type on(::cuda::stream_ref const& s) const
   {
-    return execute_on_stream(stream);
-  }
-
-  stream_attachment_type on(::cuda::stream_ref const& s) const
-  {
-    return on(s.get());
+    return execute_on_stream(s.get());
   }
 };
 
@@ -166,14 +150,9 @@ struct par_nosync_t
 
   using stream_attachment_type = execute_on_stream_nosync;
 
-  THRUST_RUNTIME_FUNCTION stream_attachment_type on(cudaStream_t const& stream) const
+  _CCCL_HOST_DEVICE stream_attachment_type on(::cuda::stream_ref const& s) const
   {
-    return execute_on_stream_nosync(stream);
-  }
-
-  stream_attachment_type on(::cuda::stream_ref const& s) const
-  {
-    return on(s.get());
+    return execute_on_stream_nosync(s.get());
   }
 
 private:

--- a/thrust/thrust/system/cuda/detail/par.h
+++ b/thrust/thrust/system/cuda/detail/par.h
@@ -56,7 +56,7 @@ public:
       : stream(stream_)
   {}
 
-  _CCCL_HOST_DEVICE Derived on(::cuda::stream_ref const& s) const
+  _CCCL_HOST_DEVICE Derived on(::cuda::stream_ref s) const
   {
     Derived result = derived_cast(*this);
     result.stream  = s.get();
@@ -81,7 +81,7 @@ public:
       : stream(stream_)
   {}
 
-  _CCCL_HOST_DEVICE Derived on(::cuda::stream_ref const& s) const
+  _CCCL_HOST_DEVICE Derived on(::cuda::stream_ref s) const
   {
     Derived result = derived_cast(*this);
     result.stream  = s.get();
@@ -132,7 +132,7 @@ struct par_t
 
   using stream_attachment_type = execute_on_stream;
 
-  _CCCL_HOST_DEVICE stream_attachment_type on(::cuda::stream_ref const& s) const
+  _CCCL_HOST_DEVICE stream_attachment_type on(::cuda::stream_ref s) const
   {
     return execute_on_stream(s.get());
   }
@@ -150,7 +150,7 @@ struct par_nosync_t
 
   using stream_attachment_type = execute_on_stream_nosync;
 
-  _CCCL_HOST_DEVICE stream_attachment_type on(::cuda::stream_ref const& s) const
+  _CCCL_HOST_DEVICE stream_attachment_type on(::cuda::stream_ref s) const
   {
     return execute_on_stream_nosync(s.get());
   }


### PR DESCRIPTION
There is no reason we should not be able to construct it or extract the pointer out of it on device.

Use that to drop the `cudaStream_t` constructors for thrust execution policies