### PR TITLE
Allow rapids to avoid unrolling some loops in sort

### DIFF
--- a/cub/cub/block/block_merge_sort.cuh
+++ b/cub/cub/block/block_merge_sort.cuh
@@ -97,7 +97,7 @@ _CCCL_DEVICE _CCCL_FORCEINLINE void SerialMerge(
   KeyT key1 = keys_shared[keys1_beg];
   KeyT key2 = keys_shared[keys2_beg];
 
-  _CCCL_PRAGMA_UNROLL_FULL()
+  _CCCL_SORT_MAYBE_UNROLL()
   for (int item = 0; item < ITEMS_PER_THREAD; ++item)
   {
     const bool p  = (keys2_beg < keys2_end) && ((keys1_beg >= keys1_end) || compare_op(key2, key1));
@@ -376,7 +376,7 @@ public:
       //
       KeyT max_key = oob_default;
 
-      _CCCL_PRAGMA_UNROLL_FULL()
+      _CCCL_SORT_MAYBE_UNROLL()
       for (int item = 1; item < ITEMS_PER_THREAD; ++item)
       {
         if (ITEMS_PER_THREAD * linear_tid + item < valid_items)

--- a/cub/cub/thread/thread_sort.cuh
+++ b/cub/cub/thread/thread_sort.cuh
@@ -79,10 +79,10 @@ StableOddEvenSort(KeyT (&keys)[ITEMS_PER_THREAD], ValueT (&items)[ITEMS_PER_THRE
 {
   constexpr bool KEYS_ONLY = ::cuda::std::is_same_v<ValueT, NullType>;
 
-  _CCCL_PRAGMA_UNROLL_FULL()
+  _CCCL_SORT_MAYBE_UNROLL()
   for (int i = 0; i < ITEMS_PER_THREAD; ++i)
   {
-    _CCCL_PRAGMA_UNROLL_FULL()
+    _CCCL_SORT_MAYBE_UNROLL()
     for (int j = 1 & i; j < ITEMS_PER_THREAD - 1; j += 2)
     {
       if (compare_op(keys[j + 1], keys[j]))

--- a/cub/cub/util_macro.cuh
+++ b/cub/cub/util_macro.cuh
@@ -81,4 +81,11 @@ _CCCL_DIAG_SUPPRESS_NVHPC(attribute_requires_external_linkage)
     }
 #endif
 
+// RAPIDS cuDF needs to avoid unrolling some loops in sort to prevent compile time issues
+#if defined(CCCL_AVOID_SORT_UNROLL)
+#  define _CCCL_SORT_MAYBE_UNROLL() _CCCL_PRAGMA_NOUNROLL()
+#else // ^^^ CCCL_AVOID_SORT_UNROLL ^^^ / vvv !CCCL_AVOID_SORT_UNROLL vvv
+#  define _CCCL_SORT_MAYBE_UNROLL() _CCCL_PRAGMA_UNROLL_FULL()
+#endif // !CCCL_AVOID_SORT_UNROLL
+
 CUB_NAMESPACE_END


### PR DESCRIPTION
This avoids one of the last remaining patches they need to apply to CCCL
