### PR TITLE
Change to allow cccl/c/parallel/unique_by_key.h to compile by C compiler

### DIFF
--- a/c/parallel/include/cccl/c/unique_by_key.h
+++ b/c/parallel/include/cccl/c/unique_by_key.h
@@ -18,6 +18,7 @@
 
 #include <cccl/c/extern_c.h>
 #include <cccl/c/types.h>
+#include <stdint.h>
 
 CCCL_C_EXTERN_C_BEGIN
 
@@ -46,7 +47,7 @@ CCCL_C_API CUresult cccl_device_unique_by_key_build(
   const char* cub_path,
   const char* thrust_path,
   const char* libcudacxx_path,
-  const char* ctk_path) noexcept;
+  const char* ctk_path);
 
 CCCL_C_API CUresult cccl_device_unique_by_key(
   cccl_device_unique_by_key_build_result_t build,
@@ -58,9 +59,9 @@ CCCL_C_API CUresult cccl_device_unique_by_key(
   cccl_iterator_t d_values_out,
   cccl_iterator_t d_num_selected_out,
   cccl_op_t op,
-  unsigned long long num_items,
-  CUstream stream) noexcept;
+  uint64_t num_items,
+  CUstream stream);
 
-CCCL_C_API CUresult cccl_device_unique_by_key_cleanup(cccl_device_unique_by_key_build_result_t* bld_ptr) noexcept;
+CCCL_C_API CUresult cccl_device_unique_by_key_cleanup(cccl_device_unique_by_key_build_result_t* bld_ptr);
 
 CCCL_C_EXTERN_C_END

--- a/c/parallel/src/unique_by_key.cu
+++ b/c/parallel/src/unique_by_key.cu
@@ -230,7 +230,7 @@ CUresult cccl_device_unique_by_key_build(
   const char* cub_path,
   const char* thrust_path,
   const char* libcudacxx_path,
-  const char* ctk_path) noexcept
+  const char* ctk_path)
 {
   CUresult error = CUDA_SUCCESS;
 
@@ -407,8 +407,8 @@ CUresult cccl_device_unique_by_key(
   cccl_iterator_t d_values_out,
   cccl_iterator_t d_num_selected_out,
   cccl_op_t op,
-  unsigned long long num_items,
-  CUstream stream) noexcept
+  uint64_t num_items,
+  CUstream stream)
 {
   CUresult error = CUDA_SUCCESS;
   bool pushed    = false;
@@ -463,7 +463,7 @@ CUresult cccl_device_unique_by_key(
   return error;
 }
 
-CUresult cccl_device_unique_by_key_cleanup(cccl_device_unique_by_key_build_result_t* build_ptr) noexcept
+CUresult cccl_device_unique_by_key_cleanup(cccl_device_unique_by_key_build_result_t* build_ptr)
 {
   try
   {

--- a/c/parallel/test/test_header.c
+++ b/c/parallel/test/test_header.c
@@ -5,6 +5,7 @@
 #include <cccl/c/reduce.h>
 #include <cccl/c/scan.h>
 #include <cccl/c/segmented_reduce.h>
+#include <cccl/c/unique_by_key.h>
 
 int main(void)
 {


### PR DESCRIPTION
1. Remove noexcept
2. Use uint64_t instead of unsigned long long (no required to allow compilation by C compiler, but adopted throughout to one day support compilation on Windows)
3. Add `#include <unique_by_key.h>` to `test_headers.c` test file

## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes #4258 

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
