### PR TITLE
Drop `_CCCL_NO_INLINE_VARIABLES`

### DIFF
--- a/libcudacxx/include/cuda/std/__cccl/dialect.h
+++ b/libcudacxx/include/cuda/std/__cccl/dialect.h
@@ -80,11 +80,6 @@
 #  define _CCCL_NO_CONCEPTS
 #endif // _CCCL_STD_VER <= 2017 || __cpp_concepts < 201907L
 
-// Inline variables are only available from C++17 onwards
-#if __cpp_inline_variables < 201606L
-#  define _CCCL_NO_INLINE_VARIABLES
-#endif // __cpp_inline_variables < 201606L
-
 // Three way comparison is only available from C++20 onwards
 #if _CCCL_STD_VER <= 2017 || __cpp_impl_three_way_comparison < 201907L
 #  define _CCCL_NO_THREE_WAY_COMPARISON

--- a/libcudacxx/include/cuda/std/__type_traits/is_extended_floating_point.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_extended_floating_point.h
@@ -30,22 +30,15 @@ struct __is_extended_floating_point : false_type
 {};
 
 template <class _Tp>
-inline constexpr bool __is_extended_floating_point_v
-#if defined(_CCCL_NO_INLINE_VARIABLES)
-  = __is_extended_floating_point<_Tp>::value;
-#else // ^^^ _CCCL_NO_INLINE_VARIABLES ^^^ / vvv !_CCCL_NO_INLINE_VARIABLES vvv
-  = false;
-#endif // !_CCCL_NO_INLINE_VARIABLES
+inline constexpr bool __is_extended_floating_point_v = __is_extended_floating_point<_Tp>::value;
 
 #if _CCCL_HAS_NVFP16()
 template <>
 struct __is_extended_floating_point<__half> : true_type
 {};
 
-#  ifndef _CCCL_NO_INLINE_VARIABLES
 template <>
 inline constexpr bool __is_extended_floating_point_v<__half> = true;
-#  endif // !_CCCL_NO_INLINE_VARIABLES
 #endif // _CCCL_HAS_NVFP16
 
 #if _CCCL_HAS_NVBF16()
@@ -53,10 +46,8 @@ template <>
 struct __is_extended_floating_point<__nv_bfloat16> : true_type
 {};
 
-#  ifndef _CCCL_NO_INLINE_VARIABLES
 template <>
 inline constexpr bool __is_extended_floating_point_v<__nv_bfloat16> = true;
-#  endif // !_CCCL_NO_INLINE_VARIABLES
 #endif // _CCCL_HAS_NVBF16
 
 #if _CCCL_HAS_NVFP8_E4M3()
@@ -75,20 +66,18 @@ struct __is_extended_floating_point<__nv_fp8_e8m0> : true_type
 {};
 #endif // _CCCL_HAS_NVFP8_E8M0()
 
-#ifndef _CCCL_NO_INLINE_VARIABLES
-#  if _CCCL_HAS_NVFP8_E4M3()
+#if _CCCL_HAS_NVFP8_E4M3()
 template <>
 inline constexpr bool __is_extended_floating_point_v<__nv_fp8_e4m3> = true;
-#  endif // _CCCL_HAS_NVFP8_E4M3()
-#  if _CCCL_HAS_NVFP8_E5M2()
+#endif // _CCCL_HAS_NVFP8_E4M3()
+#if _CCCL_HAS_NVFP8_E5M2()
 template <>
 inline constexpr bool __is_extended_floating_point_v<__nv_fp8_e5m2> = true;
-#  endif // _CCCL_HAS_NVFP8_E5M2()
-#  if _CCCL_HAS_NVFP8_E8M0()
+#endif // _CCCL_HAS_NVFP8_E5M2()
+#if _CCCL_HAS_NVFP8_E8M0()
 template <>
 inline constexpr bool __is_extended_floating_point_v<__nv_fp8_e8m0> = true;
-#  endif // _CCCL_HAS_NVFP8_E8M0()
-#endif // !_CCCL_NO_INLINE_VARIABLES
+#endif // _CCCL_HAS_NVFP8_E8M0()
 
 #if _CCCL_HAS_NVFP6_E2M3()
 template <>
@@ -100,40 +89,34 @@ template <>
 struct __is_extended_floating_point<__nv_fp6_e3m2> : true_type
 {};
 #endif // _CCCL_HAS_NVFP6_E3M2()
-#ifndef _CCCL_NO_INLINE_VARIABLES
-#  if _CCCL_HAS_NVFP6_E2M3()
+#if _CCCL_HAS_NVFP6_E2M3()
 template <>
 inline constexpr bool __is_extended_floating_point_v<__nv_fp6_e2m3> = true;
-#  endif // _CCCL_HAS_NVFP6_E2M3()
-#  if _CCCL_HAS_NVFP6_E3M2()
+#endif // _CCCL_HAS_NVFP6_E2M3()
+#if _CCCL_HAS_NVFP6_E3M2()
 template <>
 inline constexpr bool __is_extended_floating_point_v<__nv_fp6_e3m2> = true;
-#  endif // _CCCL_HAS_NVFP6_E3M2()
-#endif // !_CCCL_NO_INLINE_VARIABLES
+#endif // _CCCL_HAS_NVFP6_E3M2()
 
 #if _CCCL_HAS_NVFP4_E2M1()
 template <>
 struct __is_extended_floating_point<__nv_fp4_e2m1> : true_type
 {};
 #endif // _CCCL_HAS_NVFP4_E2M1()
-#ifndef _CCCL_NO_INLINE_VARIABLES
-#  if _CCCL_HAS_NVFP4_E2M1()
+#if _CCCL_HAS_NVFP4_E2M1()
 template <>
 inline constexpr bool __is_extended_floating_point_v<__nv_fp4_e2m1> = true;
-#  endif // _CCCL_HAS_NVFP4_E2M1()
-#endif // !_CCCL_NO_INLINE_VARIABLES
+#endif // _CCCL_HAS_NVFP4_E2M1()
 
 #if _CCCL_HAS_FLOAT128()
 template <>
 struct __is_extended_floating_point<__float128> : true_type
 {};
 #endif // _CCCL_HAS_FLOAT128()
-#ifndef _CCCL_NO_INLINE_VARIABLES
-#  if _CCCL_HAS_FLOAT128()
+#if _CCCL_HAS_FLOAT128()
 template <>
 inline constexpr bool __is_extended_floating_point_v<__float128> = true;
-#  endif // _CCCL_HAS_FLOAT128()
-#endif // !_CCCL_NO_INLINE_VARIABLES
+#endif // _CCCL_HAS_FLOAT128()
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/type_list.h
+++ b/libcudacxx/include/cuda/std/__type_traits/type_list.h
@@ -313,10 +313,8 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_list
 
 // Before the addition of inline variables, it was necessary to
 // provide a definition for constexpr class static data members.
-#  ifndef _CCCL_NO_INLINE_VARIABLES
 template <class... _Ts>
 constexpr size_t const __type_list<_Ts...>::__size;
-#  endif // !_CCCL_NO_INLINE_VARIABLES
 
 //! \brief A pointer to a type list, often used as a function argument.
 template <class... _Ts>

--- a/libcudacxx/include/cuda/std/__utility/typeid.h
+++ b/libcudacxx/include/cuda/std/__utility/typeid.h
@@ -140,10 +140,8 @@ struct __static_nameof
   static constexpr __sstring<_Np> value = _CUDA_VSTD::__make_pretty_name<_Tp>(integral_constant<size_t, _Np>());
 };
 
-#  if defined(_CCCL_NO_INLINE_VARIABLES)
 template <class _Tp, size_t _Np>
 constexpr __sstring<_Np> __static_nameof<_Tp, _Np>::value;
-#  endif // _CCCL_NO_INLINE_VARIABLES
 
 #endif // _CCCL_COMPILER(GCC, <, 9)
 


### PR DESCRIPTION
We already use it almost unconditionally. Replace the last occurences
