### PR TITLE
Remove few remaining qualifiers _CCCL_NODISCARD

### DIFF
--- a/libcudacxx/include/cuda/std/__floating_point/arithmetic.h
+++ b/libcudacxx/include/cuda/std/__floating_point/arithmetic.h
@@ -28,7 +28,7 @@
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp __fp_neg(const _Tp& __v) noexcept
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp __fp_neg(const _Tp& __v) noexcept
 {
   if constexpr (__fp_is_native_type_v<_Tp>)
   {

--- a/libcudacxx/include/cuda/std/__floating_point/cccl_fp.h
+++ b/libcudacxx/include/cuda/std/__floating_point/cccl_fp.h
@@ -104,14 +104,14 @@ public:
 };
 
 template <__fp_format _Fmt>
-_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr __cccl_fp<_Fmt> operator+(__cccl_fp<_Fmt> __v) noexcept
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr __cccl_fp<_Fmt> operator+(__cccl_fp<_Fmt> __v) noexcept
 {
   return __v;
 }
 
 _CCCL_TEMPLATE(__fp_format _Fmt)
 _CCCL_REQUIRES(__fp_is_signed_v<_Fmt>)
-_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr __cccl_fp<_Fmt> operator-(__cccl_fp<_Fmt> __v) noexcept
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr __cccl_fp<_Fmt> operator-(__cccl_fp<_Fmt> __v) noexcept
 {
   return _CUDA_VSTD::__fp_neg(__v);
 }


### PR DESCRIPTION
This fixes the build, after the macro definition was removed in #4265

## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes gh-4273

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
