### PR TITLE
change version check in `type_list.h` so that *NO* clang-19.X compilers try to use pack indexing

### DIFF
--- a/libcudacxx/include/cuda/std/__type_traits/type_list.h
+++ b/libcudacxx/include/cuda/std/__type_traits/type_list.h
@@ -448,7 +448,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_try_catch
 };
 
 // Implementation for indexing into a list of types:
-#  if defined(__cpp_pack_indexing) && !_CCCL_CUDA_COMPILER(NVCC) && !_CCCL_COMPILER(CLANG, <=, 19)
+#  if defined(__cpp_pack_indexing) && !_CCCL_CUDA_COMPILER(NVCC) && !_CCCL_COMPILER(CLANG, <, 20)
 
 _CCCL_DIAG_PUSH
 _CCCL_DIAG_SUPPRESS_CLANG("-Wc++26-extensions")


### PR DESCRIPTION
closes nvbugs#5188914

## Description

clang-19 purports to support pack indexing a-la C++26. but even trivial uses of the feature cause clang to fall over. e.g.,

```c++
template <int I, class... Ts>
using at = Ts...[I]; // error: invalid index 1 for pack 'Ts' of size 1

template <class... Ts>
auto fn() -> at<1, Ts...> {
  return {};
}
```

clang-20 does not have this problem. see: https://godbolt.org/z/Gx4rva9rT

PR #3888 attempted to fix the pack indexing issue by prohibiting clang-19 from trying to use it in its `__type_list` implementation, but that PR got it wrong:

```c++
// Implementation for indexing into a list of types:
#  if defined(__cpp_pack_indexing) && !_CCCL_CUDA_COMPILER(NVCC) && !_CCCL_COMPILER(CLANG, <=, 19)

template <size_t _Ip, class... _Ts>
using __type_index_c = _Ts...[_Ip];
```

the problem with the code above is that on clang-19.1, `_CCCL_COMPILER(CLANG, <=, 19)` is `0` because `19.1` is greater than `19`. (this is a pitfall with the current semantics of the compiler version check macros. addressing that is beyond the scope of this PR.)

this PR changes the version check to `_CCCL_COMPILER(CLANG, <, 20)`, which is `1` for clang-19.1.
