### PR TITLE
Fix vectorized loading and storing for warpLoad, warpStore and blockS…

### DIFF
--- a/cub/cub/block/block_store.cuh
+++ b/cub/cub/block/block_store.cuh
@@ -197,12 +197,12 @@ StoreDirectBlockedVectorized(int linear_tid, T* block_ptr, T (&items)[ITEMS_PER_
     Vector raw_vector[VECTORS_PER_THREAD];
     T* raw_items = reinterpret_cast<T*>(raw_vector);
 
-  // Copy
-  _CCCL_PRAGMA_UNROLL_FULL()
-  for (int ITEM = 0; ITEM < ITEMS_PER_THREAD; ITEM++)
-  {
-    raw_items[ITEM] = items[ITEM];
-  }
+    // Copy
+    _CCCL_PRAGMA_UNROLL_FULL()
+    for (int ITEM = 0; ITEM < ITEMS_PER_THREAD; ITEM++)
+    {
+      raw_items[ITEM] = items[ITEM];
+    }
 
     // Direct-store using vector types
     StoreDirectBlocked(linear_tid, block_ptr_vectors, raw_vector);

--- a/cub/cub/block/block_store.cuh
+++ b/cub/cub/block/block_store.cuh
@@ -187,12 +187,15 @@ StoreDirectBlockedVectorized(int linear_tid, T* block_ptr, T (&items)[ITEMS_PER_
   // Vector type
   using Vector = typename CubVector<T, VEC_SIZE>::Type;
 
-  // Alias global pointer
-  Vector* block_ptr_vectors = reinterpret_cast<Vector*>(const_cast<T*>(block_ptr));
+  // Add the alignment check to ensure the vectorized storing can proceed.
+  if (reinterpret_cast<uintptr_t>(block_ptr) % (alignof(Vector)) == 0)
+  {
+    // Alias global pointer
+    Vector* block_ptr_vectors = reinterpret_cast<Vector*>(const_cast<T*>(block_ptr));
 
-  // Alias pointers (use "raw" array here which should get optimized away to prevent conservative PTXAS lmem spilling)
-  Vector raw_vector[VECTORS_PER_THREAD];
-  T* raw_items = reinterpret_cast<T*>(raw_vector);
+    // Alias pointers (use "raw" array here which should get optimized away to prevent conservative PTXAS lmem spilling)
+    Vector raw_vector[VECTORS_PER_THREAD];
+    T* raw_items = reinterpret_cast<T*>(raw_vector);
 
   // Copy
   _CCCL_PRAGMA_UNROLL_FULL()
@@ -201,8 +204,14 @@ StoreDirectBlockedVectorized(int linear_tid, T* block_ptr, T (&items)[ITEMS_PER_
     raw_items[ITEM] = items[ITEM];
   }
 
-  // Direct-store using vector types
-  StoreDirectBlocked(linear_tid, block_ptr_vectors, raw_vector);
+    // Direct-store using vector types
+    StoreDirectBlocked(linear_tid, block_ptr_vectors, raw_vector);
+  }
+  else
+  {
+    // Direct-store using original type when the address is misaligned
+    StoreDirectBlocked(linear_tid, block_ptr, items);
+  }
 }
 
 //! @}  end member group

--- a/cub/cub/warp/warp_load.cuh
+++ b/cub/cub/warp/warp_load.cuh
@@ -310,13 +310,11 @@ private:
         : linear_tid(linear_tid)
     {}
 
-    template <typename InputIteratorT>
     _CCCL_DEVICE _CCCL_FORCEINLINE void Load(InputT* block_ptr, InputT (&items)[ITEMS_PER_THREAD])
     {
       InternalLoadDirectBlockedVectorized<LOAD_DEFAULT>(linear_tid, block_ptr, items);
     }
 
-    template <typename InputIteratorT>
     _CCCL_DEVICE _CCCL_FORCEINLINE void Load(const InputT* block_ptr, InputT (&items)[ITEMS_PER_THREAD])
     {
       InternalLoadDirectBlockedVectorized<LOAD_DEFAULT>(linear_tid, block_ptr, items);

--- a/cub/test/catch2_test_block_store.cu
+++ b/cub/test/catch2_test_block_store.cu
@@ -275,25 +275,26 @@ C2H_TEST("Block store works with caching iterators", "[store][block]", items_per
 }
 
 #if IPT == 1
-C2H_TEST("Vectorized block store with different alignment cases", "[store][block]")
+C2H_TEST("Vectorized block store with different alignment cases", "[store][block]", c2h::enum_type_list<int, 1, 4, 7>)
 {
-  using type                                                = int;
-  constexpr int items_per_thread                            = 4;
+  using type                     = int;
+  constexpr int items_per_thread = c2h::get<0, TestType>::value;
+  ;
   constexpr int threads_in_block                            = 64;
   constexpr int tile_size                                   = items_per_thread * threads_in_block;
   static constexpr cub::BlockStoreAlgorithm store_algorithm = cub::BlockStoreAlgorithm::BLOCK_STORE_VECTORIZE;
   const int offset_for_elements                             = GENERATE_COPY(0, 1, 2, 3, 4);
 
   c2h::device_vector<type> d_input(tile_size);
-  c2h::gen(C2H_SEED(10), d_input);
+  c2h::gen(C2H_SEED(2), d_input);
 
-  printf("offset_for_elements=%d tile_size=%d \n", offset_for_elements, tile_size);
+  CAPTURE(offset_for_elements, tile_size);
   c2h::device_vector<type> d_input_ref(tile_size + offset_for_elements);
   thrust::copy_n(d_input.begin(), tile_size, d_input_ref.begin() + offset_for_elements);
-  thrust::uninitialized_fill_n(d_input_ref.begin(), offset_for_elements, 0);
+  thrust::fill_n(d_input_ref.begin(), offset_for_elements, 0);
 
   c2h::device_vector<type> d_output(d_input.size() + offset_for_elements);
-  thrust::uninitialized_fill_n(d_output.begin(), offset_for_elements, 0);
+  thrust::fill_n(d_output.begin(), offset_for_elements, 0);
 
   block_store<items_per_thread, threads_in_block, store_algorithm>(
     thrust::raw_pointer_cast(d_input.data()),

--- a/cub/test/catch2_test_block_store.cu
+++ b/cub/test/catch2_test_block_store.cu
@@ -273,3 +273,33 @@ C2H_TEST("Block store works with caching iterators", "[store][block]", items_per
 
   REQUIRE(d_input == d_output);
 }
+
+#if IPT == 1
+C2H_TEST("Vectorized block store with different alignment cases", "[store][block]")
+{
+  using type                                                = int;
+  constexpr int items_per_thread                            = 4;
+  constexpr int threads_in_block                            = 64;
+  constexpr int tile_size                                   = items_per_thread * threads_in_block;
+  static constexpr cub::BlockStoreAlgorithm store_algorithm = cub::BlockStoreAlgorithm::BLOCK_STORE_VECTORIZE;
+  const int offset_for_elements                             = GENERATE_COPY(0, 1, 2, 3, 4);
+
+  c2h::device_vector<type> d_input(tile_size);
+  c2h::gen(C2H_SEED(10), d_input);
+
+  printf("offset_for_elements=%d tile_size=%d \n", offset_for_elements, tile_size);
+  c2h::device_vector<type> d_input_ref(tile_size + offset_for_elements);
+  thrust::copy_n(d_input.begin(), tile_size, d_input_ref.begin() + offset_for_elements);
+  thrust::uninitialized_fill_n(d_input_ref.begin(), offset_for_elements, 0);
+
+  c2h::device_vector<type> d_output(d_input.size() + offset_for_elements);
+  thrust::uninitialized_fill_n(d_output.begin(), offset_for_elements, 0);
+
+  block_store<items_per_thread, threads_in_block, store_algorithm>(
+    thrust::raw_pointer_cast(d_input.data()),
+    thrust::raw_pointer_cast(d_output.data()) + offset_for_elements,
+    static_cast<int>(d_input.size()));
+
+  REQUIRE(d_input_ref == d_output);
+}
+#endif

--- a/cub/test/catch2_test_warp_load.cu
+++ b/cub/test/catch2_test_warp_load.cu
@@ -343,7 +343,7 @@ C2H_TEST("Warp load unguarded range works with cache modified iterator",
 #if ALGO_TYPE == 3 // Test for cub::WarpLoadAlgorithm::WARP_LOAD_VECTORIZE;
 C2H_TEST("Vectorized warp load with const and non-const datatype and different alignment cases",
          "[store][warp]",
-         c2h::type_list<int*>, // c2h::type_list<const int*, int*>,
+         c2h::type_list<const int*, int*>,
          logical_warp_threads,
          items_per_thread,
          algorithm)

--- a/cub/test/catch2_test_warp_load.cu
+++ b/cub/test/catch2_test_warp_load.cu
@@ -339,3 +339,40 @@ C2H_TEST("Warp load unguarded range works with cache modified iterator",
   constexpr int expected_error_count = 0;
   REQUIRE(num_errors == expected_error_count);
 }
+
+#if ALGO_TYPE == 3 // Test for cub::WarpLoadAlgorithm::WARP_LOAD_VECTORIZE;
+C2H_TEST("Vectorized warp load with const and non-const datatype and different alignment cases",
+         "[store][warp]",
+         c2h::type_list<int*>, // c2h::type_list<const int*, int*>,
+         logical_warp_threads,
+         items_per_thread,
+         algorithm)
+{
+  using params         = params_t<TestType>;
+  using type           = int;
+  using input_ptr_type = typename params::type;
+
+  using delegate_t              = unguarded_load_t;
+  const int offset_for_elements = GENERATE_COPY(0, 1, 2, 3, 4);
+
+  auto d_in_ref =
+    generate_input<params::algorithm, params::logical_warp_threads, params::items_per_thread, params::total_warps, type>();
+  c2h::device_vector<int> d_error_counter(1, 0);
+
+  c2h::device_vector<type> d_in(params::total_item_count + offset_for_elements);
+  thrust::copy_n(d_in_ref.begin(), params::total_item_count, d_in.begin() + offset_for_elements);
+
+  warp_load<params::algorithm,
+            params::logical_warp_threads,
+            params::items_per_thread,
+            params::total_warps,
+            type,
+            input_ptr_type>(thrust::raw_pointer_cast(d_in.data()) + offset_for_elements,
+                            delegate_t{},
+                            thrust::raw_pointer_cast(d_error_counter.data()));
+
+  const auto num_errors              = d_error_counter[0];
+  constexpr int expected_error_count = 0;
+  REQUIRE(num_errors == expected_error_count);
+}
+#endif

--- a/cub/test/catch2_test_warp_store.cu
+++ b/cub/test/catch2_test_warp_store.cu
@@ -300,7 +300,7 @@ C2H_TEST("Vectorized warp store with different alignment cases",
   auto out = thrust::raw_pointer_cast(d_out.data());
 
   warp_store<params::algorithm, params::logical_warp_threads, params::items_per_thread, params::total_warps, type>(
-    thrust::raw_pointer_cast(d_out.data()) + offset_for_elements, unguarded_store_t{});
+    out + offset_for_elements, unguarded_store_t{});
   thrust::copy_n(d_out.begin() + offset_for_elements, params::total_item_count, d_out_ref.begin());
 
   auto d_expected_output =

--- a/cub/test/catch2_test_warp_store.cu
+++ b/cub/test/catch2_test_warp_store.cu
@@ -280,3 +280,34 @@ C2H_TEST("Warp store unguarded range works with cache modified iterator",
       valid_items);
   REQUIRE(d_expected_output == d_out);
 }
+
+#if ALGO_TYPE == 3 // cub::WarpStoreAlgorithm::WARP_STORE_VECTORIZE
+C2H_TEST("Vectorized warp store with different alignment cases",
+         "[store][warp]",
+         c2h::type_list<std::int32_t>,
+         logical_warp_threads,
+         items_per_thread,
+         algorithm)
+{
+  using params = params_t<TestType>;
+  using type   = typename params::type;
+
+  c2h::device_vector<type> d_out_ref(params::total_item_count, type{});
+  constexpr int valid_items = params::tile_size;
+
+  const int offset_for_elements = GENERATE_COPY(0, 1, 2, 3, 4);
+  c2h::device_vector<type> d_out(params::total_item_count + offset_for_elements, type{});
+  auto out = thrust::raw_pointer_cast(d_out.data());
+
+  warp_store<params::algorithm, params::logical_warp_threads, params::items_per_thread, params::total_warps, type>(
+    thrust::raw_pointer_cast(d_out.data()) + offset_for_elements, unguarded_store_t{});
+  thrust::copy_n(d_out.begin() + offset_for_elements, params::total_item_count, d_out_ref.begin());
+
+  auto d_expected_output =
+    compute_reference<params::algorithm, params::logical_warp_threads, params::items_per_thread, params::total_warps, type>(
+      valid_items);
+
+  REQUIRE(d_expected_output == d_out_ref);
+}
+
+#endif


### PR DESCRIPTION
Closes https://github.com/NVIDIA/cccl/issues/431. 

## Description
This work is a follow-up to the previous PR [#3517](https://github.com/NVIDIA/cccl/pull/3517).  After fixing the vectorized loading issue in BlockLoad, we found that there are similar issues in WarpLoad, WarpStore, and BlockStore. Specifically, this PR attempts to address the following issues.

### WarpLoad
We fixed the bug mentioned in [#431](https://github.com/NVIDIA/cccl/issues/431). 
1) Remove the `template <typename InputIteratorT>` so that the vectorized loading can make use of the function `InternalLoadDirectBlockedVectorized()`.
2) Add unit test in [catch2_test_warp_load.cu](https://github.com/ChristinaZ/cccl/blob/christinaz/fix_more_vectorized_storing_loading/cub/test/catch2_test_warp_load.cu#L343) 

### WarpStore and BlockStore
1) Add the alignment check in function [StoreDirectBlockedVectorized()](https://github.com/ChristinaZ/cccl/blob/christinaz/fix_more_vectorized_storing_loading/cub/cub/block/block_store.cuh#L190). And when the check fails, it falls back to direct storing as we mentioned ([fall back to `cub::BLOCK_STORE_DIRECT`](https://nvidia.github.io/cccl/cub/api/enum_namespacecub_1a839b145451e9eec3d44172e3c3619700.html#_CPPv4N3cub19BlockStoreAlgorithm21BLOCK_STORE_VECTORIZEE)).
In function[ InternalLoadDirectBlockedVectorized()](https://github.com/ChristinaZ/cccl/blob/christinaz/fix_more_vectorized_storing_loading/cub/cub/block/block_load.cuh#L213), we have added a similar check.

2) Add unit tests in file [catch2_test_warp_store.cu](https://github.com/ChristinaZ/cccl/blob/christinaz/fix_more_vectorized_storing_loading/cub/test/catch2_test_warp_store.cu#L284) and [catch2_test_block_store.cu](https://github.com/ChristinaZ/cccl/blob/christinaz/fix_more_vectorized_storing_loading/cub/test/catch2_test_block_store.cu#L277)
<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
