### PR TITLE
[BACKPORT]: tweak the cccl compiler version check macros to better agree with intuition (#4279)

### DIFF
--- a/cudax/include/cuda/experimental/__detail/config.cuh
+++ b/cudax/include/cuda/experimental/__detail/config.cuh
@@ -24,7 +24,7 @@
 // Debuggers do not step into functions marked with __attribute__((__artificial__)).
 // This is useful for small wrapper functions that just dispatch to other functions and
 // that are inlined into the caller.
-#if _CCCL_HAS_ATTRIBUTE(__artificial__) && !_CCCL_CUDACC
+#if _CCCL_HAS_ATTRIBUTE(__artificial__) && !_CCCL_HAS_CUDA_COMPILER
 #  define _CUDAX_ARTIFICIAL __attribute__((__artificial__))
 #else // ^^^ _CCCL_HAS_ATTRIBUTE(__artificial__) ^^^ / vvv !_CCCL_HAS_ATTRIBUTE(__artificial__) vvv
 #  define _CUDAX_ARTIFICIAL

--- a/docs/cccl/development/macro.rst
+++ b/docs/cccl/development/macro.rst
@@ -33,7 +33,9 @@ The ``_CCCL_COMPILER`` function-like macro can also be used to check the version
    _CCCL_COMPILER(MSVC, <, 19, 24)
    _CCCL_COMPILER(GCC, >=, 9)
 
-*Pitfalls*: ``_CCCL_COMPILER(GCC, >, 9)`` internally expands ``_CCCL_COMPILER(GCC, >, 9, 0)`` to matches any GCC 9.x. Avoid using ``>`` and rather use ``>=``
+*Note*: When used without specifying a minor version number, the macro will only test against
+the compiler's major version number. For example, when the compiler is ``gcc-9.1``, the macro
+``_CCCL_COMPILER(GCC, >, 9)`` will be ``false`` even though ``9.1`` is greater than ``9``.
 
 **CUDA compiler macros**:
 

--- a/libcudacxx/include/cuda/std/__cccl/compiler.h
+++ b/libcudacxx/include/cuda/std/__cccl/compiler.h
@@ -11,19 +11,33 @@
 #ifndef __CCCL_COMPILER_H
 #define __CCCL_COMPILER_H
 
+#include <cuda/std/__cccl/preprocessor.h>
+
 // Utility to compare version numbers. To use:
-// 1) Define a macro that makes a version number from major and minor numbers, e. g.:
+// 1) Define a macro that makes a pair of (major, minor) numbers:
 //    #define MYPRODUCT_MAKE_VERSION(_MAJOR, _MINOR) (_MAJOR * 100 + _MINOR)
-// 2) Define a macro that you will use to compare versions, e. g.:
+// 2) Define a macro that you will use to compare versions, e.g.:
 //    #define MYPRODUCT(...) _CCCL_VERSION_COMPARE(MYPRODUCT, MYPRODUCT_##__VA_ARGS__)
 //    Signatures:
 //       MYPRODUCT(_PROD)                      - is the product _PROD version non-zero?
-//       MYPRODUCT(_PROD, _OP, _MAJOR)         - compare the product _PROD version to _MAJOR using operator _OP
+//       MYPRODUCT(_PROD, _OP, _MAJOR)         - compare the product _PROD major version to _MAJOR using operator _OP
 //       MYPRODUCT(_PROD, _OP, _MAJOR, _MINOR) - compare the product _PROD version to _MAJOR._MINOR using operator _OP
-#define _CCCL_VERSION_COMPARE_1(_PREFIX, _VER)              (_VER != 0)
-#define _CCCL_VERSION_COMPARE_3(_PREFIX, _VER, _OP, _MAJOR) _CCCL_VERSION_COMPARE_4(_PREFIX, _VER, _OP, _MAJOR, 0)
+// 3) Define the product version macros as a function-like macro that returns the version number or
+//    _CCCL_VERSION_INVALID() if the version cannot be determined, e. g.:
+//    #define MYPRODUCT_<_PROD>() (1, 2)
+//      or
+//    #define MYPRODUCT_<_PROD>() _CCCL_VERSION_INVALID()
+#define _CCCL_VERSION_MAJOR_(_MAJOR, _MINOR)   _MAJOR
+#define _CCCL_VERSION_MAJOR(_PAIR)             _CCCL_VERSION_MAJOR_ _PAIR
+#define _CCCL_VERSION_INVALID()                (-1, -1)
+#define _CCCL_MAKE_VERSION(_PREFIX, _PAIR)     (_CCCL_PP_EVAL(_CCCL_PP_CAT(_PREFIX, MAKE_VERSION), _CCCL_PP_EXPAND _PAIR))
+#define _CCCL_VERSION_IS_INVALID(_PAIR)        (_CCCL_VERSION_MAJOR(_PAIR) == _CCCL_VERSION_MAJOR(_CCCL_VERSION_INVALID()))
+#define _CCCL_VERSION_COMPARE_1(_PREFIX, _VER) (!_CCCL_VERSION_IS_INVALID(_VER()))
+#define _CCCL_VERSION_COMPARE_3(_PREFIX, _VER, _OP, _MAJOR) \
+  (!_CCCL_VERSION_IS_INVALID(_VER()) && (_CCCL_VERSION_MAJOR(_VER()) _OP _MAJOR))
 #define _CCCL_VERSION_COMPARE_4(_PREFIX, _VER, _OP, _MAJOR, _MINOR) \
-  (_CCCL_VERSION_COMPARE_1(_PREFIX, _VER) && (_VER _OP _PREFIX##MAKE_VERSION(_MAJOR, _MINOR)))
+  (!_CCCL_VERSION_IS_INVALID(_VER())                                \
+   && (_CCCL_MAKE_VERSION(_PREFIX, _VER()) _OP _CCCL_MAKE_VERSION(_PREFIX, (_MAJOR, _MINOR))))
 #define _CCCL_VERSION_SELECT_COUNT(_ARG1, _ARG2, _ARG3, _ARG4, _ARG5, ...) _ARG5
 #define _CCCL_VERSION_SELECT2(_ARGS)                                       _CCCL_VERSION_SELECT_COUNT _ARGS
 // MSVC traditonal preprocessor requires an extra level of indirection
@@ -40,6 +54,14 @@
 #define _CCCL_COMPILER_MAKE_VERSION(_MAJOR, _MINOR) ((_MAJOR) * 100 + (_MINOR))
 #define _CCCL_COMPILER(...)                         _CCCL_VERSION_COMPARE(_CCCL_COMPILER_, _CCCL_COMPILER_##__VA_ARGS__)
 
+#define _CCCL_COMPILER_NVHPC()    _CCCL_VERSION_INVALID()
+#define _CCCL_COMPILER_CLANG()    _CCCL_VERSION_INVALID()
+#define _CCCL_COMPILER_GCC()      _CCCL_VERSION_INVALID()
+#define _CCCL_COMPILER_MSVC()     _CCCL_VERSION_INVALID()
+#define _CCCL_COMPILER_MSVC2019() _CCCL_VERSION_INVALID()
+#define _CCCL_COMPILER_MSVC2022() _CCCL_VERSION_INVALID()
+#define _CCCL_COMPILER_NVRTC()    _CCCL_VERSION_INVALID()
+
 // Determine the host compiler and its version
 #if defined(__INTEL_COMPILER)
 #  ifndef CCCL_IGNORE_DEPRECATED_COMPILER
@@ -47,42 +69,58 @@
       "The Intel C++ Compiler Classic (icc/icpc) is not supported by CCCL. Define CCCL_IGNORE_DEPRECATED_COMPILER to suppress this message."
 #  endif // !CCCL_IGNORE_DEPRECATED_COMPILER
 #elif defined(__NVCOMPILER)
-#  define _CCCL_COMPILER_NVHPC _CCCL_COMPILER_MAKE_VERSION(__NVCOMPILER_MAJOR__, __NVCOMPILER_MINOR__)
+#  undef _CCCL_COMPILER_NVHPC
+#  define _CCCL_COMPILER_NVHPC() (__NVCOMPILER_MAJOR__, __NVCOMPILER_MINOR__)
 #elif defined(__clang__)
-#  define _CCCL_COMPILER_CLANG _CCCL_COMPILER_MAKE_VERSION(__clang_major__, __clang_minor__)
+#  undef _CCCL_COMPILER_CLANG
+#  define _CCCL_COMPILER_CLANG() (__clang_major__, __clang_minor__)
 #elif defined(__GNUC__)
-#  define _CCCL_COMPILER_GCC _CCCL_COMPILER_MAKE_VERSION(__GNUC__, __GNUC_MINOR__)
+#  undef _CCCL_COMPILER_GCC
+#  define _CCCL_COMPILER_GCC() (__GNUC__, __GNUC_MINOR__)
 #elif defined(_MSC_VER)
-#  define _CCCL_COMPILER_MSVC _CCCL_COMPILER_MAKE_VERSION(_MSC_VER / 100, _MSC_VER % 100)
-#  if (_CCCL_COMPILER_MSVC < _CCCL_COMPILER_MAKE_VERSION(19, 20))
+#  undef _CCCL_COMPILER_MSVC
+#  define _CCCL_COMPILER_MSVC() (_MSC_VER / 100, _MSC_VER % 100)
+#  if _CCCL_COMPILER(MSVC, <, 19, 20)
 #    ifndef CCCL_IGNORE_DEPRECATED_COMPILER
 #      error \
         "Visual Studio 2017 (MSC_VER < 1920) and older are not supported by CCCL. Define CCCL_IGNORE_DEPRECATED_COMPILER to suppress this error."
 #    endif
-#  endif
-#  define _CCCL_COMPILER_MSVC2019                               \
-    (_CCCL_COMPILER_MSVC >= _CCCL_COMPILER_MAKE_VERSION(19, 20) \
-     && _CCCL_COMPILER_MSVC < _CCCL_COMPILER_MAKE_VERSION(19, 30))
-#  define _CCCL_COMPILER_MSVC2022                               \
-    (_CCCL_COMPILER_MSVC >= _CCCL_COMPILER_MAKE_VERSION(19, 30) \
-     && _CCCL_COMPILER_MSVC < _CCCL_COMPILER_MAKE_VERSION(19, 40))
+#  endif // _CCCL_COMPILER(MSVC, <, 19, 20)
+#  if _CCCL_COMPILER(MSVC, >=, 19, 20) && _CCCL_COMPILER(MSVC, <, 19, 30)
+#    undef _CCCL_COMPILER_MSVC2019
+#    define _CCCL_COMPILER_MSVC2019() _CCCL_COMPILER_MSVC()
+#  endif // _CCCL_COMPILER(MSVC, >=, 19, 20) && _CCCL_COMPILER(MSVC, <, 19, 30)
+#  if _CCCL_COMPILER(MSVC, >=, 19, 30) && _CCCL_COMPILER(MSVC, <, 19, 40)
+#    undef _CCCL_COMPILER_MSVC2022
+#    define _CCCL_COMPILER_MSVC2022() _CCCL_COMPILER_MSVC()
+#  endif // _CCCL_COMPILER(MSVC, >=, 19, 30) && _CCCL_COMPILER(MSVC, <, 19, 40)
 #elif defined(__CUDACC_RTC__)
-#  define _CCCL_COMPILER_NVRTC _CCCL_COMPILER_MAKE_VERSION(__CUDACC_VER_MAJOR__, __CUDACC_VER_MINOR__)
+#  undef _CCCL_COMPILER_NVRTC
+#  define _CCCL_COMPILER_NVRTC() (__CUDACC_VER_MAJOR__, __CUDACC_VER_MINOR__)
 #endif
 
 // The CUDA compiler version shares the implementation with the C++ compiler
 #define _CCCL_CUDA_COMPILER_MAKE_VERSION(_MAJOR, _MINOR) _CCCL_COMPILER_MAKE_VERSION(_MAJOR, _MINOR)
 #define _CCCL_CUDA_COMPILER(...)                         _CCCL_VERSION_COMPARE(_CCCL_CUDA_COMPILER_, _CCCL_CUDA_COMPILER_##__VA_ARGS__)
 
+#define _CCCL_CUDA_COMPILER_NVCC()  _CCCL_VERSION_INVALID()
+#define _CCCL_CUDA_COMPILER_NVHPC() _CCCL_VERSION_INVALID()
+#define _CCCL_CUDA_COMPILER_CLANG() _CCCL_VERSION_INVALID()
+#define _CCCL_CUDA_COMPILER_NVRTC() _CCCL_VERSION_INVALID()
+
 // Determine the cuda compiler
 #if defined(__NVCC__)
-#  define _CCCL_CUDA_COMPILER_NVCC _CCCL_CUDA_COMPILER_MAKE_VERSION(__CUDACC_VER_MAJOR__, __CUDACC_VER_MINOR__)
+#  undef _CCCL_CUDA_COMPILER_NVCC
+#  define _CCCL_CUDA_COMPILER_NVCC() (__CUDACC_VER_MAJOR__, __CUDACC_VER_MINOR__)
 #elif defined(_NVHPC_CUDA)
-#  define _CCCL_CUDA_COMPILER_NVHPC _CCCL_COMPILER_NVHPC
+#  undef _CCCL_CUDA_COMPILER_NVHPC
+#  define _CCCL_CUDA_COMPILER_NVHPC() _CCCL_COMPILER_NVHPC()
 #elif defined(__CUDA__) && _CCCL_COMPILER(CLANG)
-#  define _CCCL_CUDA_COMPILER_CLANG _CCCL_COMPILER_CLANG
+#  undef _CCCL_CUDA_COMPILER_CLANG
+#  define _CCCL_CUDA_COMPILER_CLANG() _CCCL_COMPILER_CLANG()
 #elif _CCCL_COMPILER(NVRTC)
-#  define _CCCL_CUDA_COMPILER_NVRTC _CCCL_COMPILER_NVRTC
+#  undef _CCCL_CUDA_COMPILER_NVRTC
+#  define _CCCL_CUDA_COMPILER_NVRTC() _CCCL_COMPILER_NVRTC()
 #endif
 
 #define _CCCL_CUDACC_MAKE_VERSION(_MAJOR, _MINOR) ((_MAJOR) * 1000 + (_MINOR) * 10)
@@ -90,26 +128,26 @@
 // clang-cuda does not define __CUDACC_VER_MAJOR__ and friends. They are instead retrieved from the CUDA_VERSION macro
 // defined in "cuda.h". clang-cuda automatically pre-includes "__clang_cuda_runtime_wrapper.h" which includes "cuda.h"
 #if _CCCL_CUDA_COMPILER(NVCC) || _CCCL_CUDA_COMPILER(NVHPC) || _CCCL_CUDA_COMPILER(NVRTC)
-#  define _CCCL_CUDACC _CCCL_CUDACC_MAKE_VERSION(__CUDACC_VER_MAJOR__, __CUDACC_VER_MINOR__)
+#  define _CCCL_CUDACC() (__CUDACC_VER_MAJOR__, __CUDACC_VER_MINOR__)
 #elif _CCCL_CUDA_COMPILER(CLANG)
-#  define _CCCL_CUDACC _CCCL_CUDACC_MAKE_VERSION(CUDA_VERSION / 1000, (CUDA_VERSION % 1000) / 10)
-#endif
+#  define _CCCL_CUDACC() (CUDA_VERSION / 1000, (CUDA_VERSION % 1000) / 10)
+#else // ^^^ has cuda compiler ^^^ / vvv no cuda compiler vvv
+#  define _CCCL_CUDACC() _CCCL_VERSION_INVALID()
+#endif // ^^^ no cuda compiler ^^^
 
 #define _CCCL_CUDACC_BELOW(...)    _CCCL_VERSION_COMPARE(_CCCL_CUDACC_, _CCCL_CUDACC, <, __VA_ARGS__)
 #define _CCCL_CUDACC_AT_LEAST(...) _CCCL_VERSION_COMPARE(_CCCL_CUDACC_, _CCCL_CUDACC, >=, __VA_ARGS__)
 
-#if defined(_CCCL_CUDACC)
+#if _CCCL_VERSION_IS_INVALID(_CCCL_CUDACC())
+#  define _CCCL_HAS_CUDA_COMPILER 0
+#else // ^^^ has cuda compiler ^^^ / vvv no cuda compiler vvv
 #  define _CCCL_HAS_CUDA_COMPILER 1
-#endif
+#endif // ^^^ no cuda compiler ^^^
 
 #if defined(_CCCL_HAS_CUDA_COMPILER) && _CCCL_CUDACC_BELOW(12) && !defined(CCCL_IGNORE_DEPRECATED_CUDA_BELOW_12)
 #  error "CUDA versions below 12 are not supported." \
 "Define CCCL_IGNORE_DEPRECATED_CUDA_BELOW_12 to suppress this message."
 #endif
-
-// Convert parameter to string
-#define _CCCL_TO_STRING2(_STR) #_STR
-#define _CCCL_TO_STRING(_STR)  _CCCL_TO_STRING2(_STR)
 
 // Define the pragma for the host compiler
 #if _CCCL_COMPILER(MSVC)
@@ -125,11 +163,10 @@
 #  endif // !__ELF__
 #endif // _CCCL_COMPILER(NVHPC) || _CCCL_COMPILER(NVRTC)
 
-#if (_CCCL_COMPILER(NVCC) && defined(__CUDA_ARCH__)) || _CCCL_COMPILER(NVHPC) || _CCCL_COMPILER(NVRTC) \
+#if (_CCCL_CUDA_COMPILER(NVCC) && defined(__CUDA_ARCH__)) || _CCCL_COMPILER(NVHPC) || _CCCL_COMPILER(NVRTC) \
   || _CCCL_COMPILER(CLANG)
 #  define _CCCL_PRAGMA_UNROLL(_N)    _CCCL_PRAGMA(unroll _N)
 #  define _CCCL_PRAGMA_UNROLL_FULL() _CCCL_PRAGMA(unroll)
-
 #elif _CCCL_COMPILER(GCC, >=, 8)
 // gcc supports only #pragma GCC unroll, but that causes problems when compiling with nvcc. So, we use #pragma unroll
 // when compiling device code, and #pragma GCC unroll when compiling host code, but we need to suppress the warning

--- a/libcudacxx/include/cuda/std/__cccl/preprocessor.h
+++ b/libcudacxx/include/cuda/std/__cccl/preprocessor.h
@@ -11,17 +11,6 @@
 #ifndef __CCCL_PREPROCESSOR_H
 #define __CCCL_PREPROCESSOR_H
 
-#include <cuda/std/__cccl/compiler.h>
-#include <cuda/std/__cccl/system_header.h>
-
-#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
-#  pragma GCC system_header
-#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
-#  pragma clang system_header
-#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
-#  pragma system_header
-#endif // no system header
-
 #ifdef __has_include
 #  define _CCCL_HAS_INCLUDE(_X) __has_include(_X)
 #else
@@ -33,6 +22,10 @@
 #else
 #  define _CCCL_COUNTER() __LINE__
 #endif
+
+// Convert parameter to string
+#define _CCCL_TO_STRING2(_STR) #_STR
+#define _CCCL_TO_STRING(_STR)  _CCCL_TO_STRING2(_STR)
 
 #define _CCCL_PP_EXPAND(...) __VA_ARGS__
 #define _CCCL_PP_EAT(...)

--- a/libcudacxx/test/support/test_iterators.h
+++ b/libcudacxx/test/support/test_iterators.h
@@ -1129,11 +1129,6 @@ public:
       : it_(it)
   {}
 
-#if !TEST_COMPILER(MSVC2017) // MSVC2017 has issues determining common_reference
-  cpp20_output_iterator(cpp20_output_iterator&&)            = default;
-  cpp20_output_iterator& operator=(cpp20_output_iterator&&) = default;
-#endif // !TEST_COMPILER(MSVC2017)
-
   __host__ __device__ constexpr decltype(auto) operator*() const
   {
     return *it_;


### PR DESCRIPTION
* tweak the cccl compiler version check macros to better agree with intuition

prior to this commit, a compiler check such as:

```c++
```

would fail if the compiler was actually v19.1. that is because 19.1 is
greater than 19. what the author of this code probably intended was to
check only the compiler's major version number, in which case the check
would have succeed.

this commit changes the behavior of the following macros when only a
major version number is specified:

* `_CCCL_COMPILER`
* `_CCCL_CUDA_COMPILER`
* `_CCCL_CUDACC_BELOW`
* `_CCCL_CUDACC_AT_LEAST`

* guard `_CCCL_COMPILER(FOO)` with an extra set of parens
