### PR TITLE
Implement `cuda::uabs`

### DIFF
--- a/docs/libcudacxx/extended_api/math.rst
+++ b/docs/libcudacxx/extended_api/math.rst
@@ -48,5 +48,5 @@ Math
 
    * - :ref:`uabs <libcudacxx-extended-api-math-uabs>`
      - Unsigned absolute value
-     - CCCL 3.0.0
-     - CUDA 13.0
+     - CCCL 3.1.0
+     - CUDA 13.1

--- a/docs/libcudacxx/extended_api/math.rst
+++ b/docs/libcudacxx/extended_api/math.rst
@@ -45,3 +45,8 @@ Math
      - Integer logarithm to the base 10
      - CCCL 3.0.0
      - CUDA 13.0
+
+   * - :ref:`uabs <libcudacxx-extended-api-math-uabs>`
+     - Unsigned absolute value
+     - CCCL 3.0.0
+     - CUDA 13.0

--- a/docs/libcudacxx/extended_api/math.rst
+++ b/docs/libcudacxx/extended_api/math.rst
@@ -11,6 +11,7 @@ Math
    math/round_up
    math/round_down
    math/ilog
+   math/uabs
 
 .. list-table::
    :widths: 25 45 30 30

--- a/docs/libcudacxx/extended_api/math/uabs.rst
+++ b/docs/libcudacxx/extended_api/math/uabs.rst
@@ -1,0 +1,50 @@
+.. _libcudacxx-extended-api-math-uabs:
+
+``cuda::uabs``
+====================================
+
+.. code:: cpp
+
+   template <typename T>
+   [[nodiscard]] __host__ __device__ inline constexpr
+   cuda::std::make_unsigned_t<T> uabs(T value) noexcept;
+
+The functions compute the absolute value of the input value. The result is returned as an unsigned integer type of the same size as the input value. In comparison to the standard ``abs`` function, the ``uabs`` eliminates the undefined behaviour when a signed ``T_MIN`` is passed as an input.
+
+**Parameters**
+
+- ``value``: The input value.
+
+**Return value**
+
+- The unsigned absolute value of the input value.
+
+**Constraints**
+
+- ``T`` is an integer type.
+
+Example
+-------
+
+.. code:: cpp
+
+    #include <cuda/cmath>
+    #include <cuda/std/cassert>
+    #include <cuda/std/limits>
+
+    __global__ void uabs_kernel() {
+        using cuda::std::numeric_limits;
+
+        assert(cuda::uabs(20) == 20u);
+        assert(cuda::uabs(-32) == 32u);
+        assert(cuda::uabs(numeric_limits<int>::max()) == static_cast<unsigned>(numeric_limits<int>::max()));
+        assert(cuda::uabs(numeric_limits<int>::min()) == static_cast<unsigned>(numeric_limits<int>::max()) + 1);
+    }
+
+    int main() {
+        uabs_kernel<<<1, 1>>>();
+        cudaDeviceSynchronize();
+        return 0;
+    }
+
+`See it on Godbolt 🔗 <https://godbolt.org/z/vPbrKKqMd>`_

--- a/docs/libcudacxx/extended_api/math/uabs.rst
+++ b/docs/libcudacxx/extended_api/math/uabs.rst
@@ -9,7 +9,7 @@
    [[nodiscard]] __host__ __device__ inline constexpr
    cuda::std::make_unsigned_t<T> uabs(T value) noexcept;
 
-The functions compute the absolute value of the input value. The result is returned as an unsigned integer type of the same size as the input value. In comparison to the standard ``abs`` function, the ``uabs`` eliminates the undefined behaviour when a signed ``T_MIN`` is passed as an input.
+The function computes the absolute value of the input value. The result is returned as an unsigned integer type of the same size as the input value. In comparison to the standard ``abs`` function, the ``uabs`` eliminates the undefined behaviour when a signed ``T_MIN`` is passed as an input.
 
 **Parameters**
 

--- a/libcudacxx/include/cuda/__cmath/uabs.h
+++ b/libcudacxx/include/cuda/__cmath/uabs.h
@@ -1,0 +1,52 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA___CMATH_UABS_H
+#define _CUDA___CMATH_UABS_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__concepts/concept_macros.h>
+#include <cuda/std/__type_traits/is_integer.h>
+#include <cuda/std/__type_traits/is_signed.h>
+#include <cuda/std/__type_traits/make_unsigned.h>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_CUDA
+
+//! @brief Returns the *unsigned* absolute value of the given number.
+//! @param __v The input number
+//! @pre \p __v must be an integer type
+//! @return The unsigned absolute value of \p __v
+_CCCL_TEMPLATE(class _Tp)
+_CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::__cccl_is_integer, _Tp))
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _CUDA_VSTD::make_unsigned_t<_Tp> uabs(_Tp __v) noexcept
+{
+  if constexpr (_CCCL_TRAIT(_CUDA_VSTD::is_signed, _Tp))
+  {
+    using _Up = _CUDA_VSTD::make_unsigned_t<_Tp>;
+    return (__v < _Tp(0)) ? static_cast<_Up>(~static_cast<_Up>(__v) + 1) : static_cast<_Up>(__v);
+  }
+  else
+  {
+    return __v;
+  }
+}
+
+_LIBCUDACXX_END_NAMESPACE_CUDA
+
+#endif // _CUDA___CMATH_UABS_H

--- a/libcudacxx/include/cuda/cmath
+++ b/libcudacxx/include/cuda/cmath
@@ -25,6 +25,7 @@
 #include <cuda/__cmath/ilog.h>
 #include <cuda/__cmath/round_down.h>
 #include <cuda/__cmath/round_up.h>
+#include <cuda/__cmath/uabs.h>
 #include <cuda/std/cmath>
 
 #endif // _CUDA_CMATH

--- a/libcudacxx/test/libcudacxx/cuda/cmath/uabs.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/cmath/uabs.pass.cpp
@@ -1,0 +1,71 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/cmath>
+#include <cuda/std/cassert>
+#include <cuda/std/limits>
+#include <cuda/std/type_traits>
+
+template <class T, class U>
+__host__ __device__ constexpr void test_uabs(T input, U ref)
+{
+  assert(cuda::uabs(input) == ref);
+}
+
+template <class T>
+__host__ __device__ constexpr void test_type()
+{
+  using U = cuda::std::make_unsigned_t<T>;
+
+  static_assert(cuda::std::is_same_v<decltype(cuda::uabs(T{})), U>);
+  static_assert(noexcept(cuda::uabs(T{})));
+
+  test_uabs(T(0), U(0));
+  test_uabs(T(1), U(1));
+  test_uabs(T(100), U(100));
+  if constexpr (cuda::std::is_signed_v<T>)
+  {
+    test_uabs(T(-1), U(1));
+    test_uabs(T(-100), U(100));
+    test_uabs(T(cuda::std::numeric_limits<T>::min() + 1), static_cast<U>(cuda::std::numeric_limits<T>::max()));
+    test_uabs(cuda::std::numeric_limits<T>::min(), U(static_cast<U>(cuda::std::numeric_limits<T>::max()) + 1));
+  }
+  test_uabs(cuda::std::numeric_limits<T>::max(), static_cast<U>(cuda::std::numeric_limits<T>::max()));
+}
+
+__host__ __device__ constexpr bool test()
+{
+  test_type<signed char>();
+  test_type<signed short>();
+  test_type<signed int>();
+  test_type<signed long>();
+  test_type<signed long long>();
+#if _CCCL_HAS_INT128()
+  test_type<__int128_t>();
+#endif // _CCCL_HAS_INT128()
+
+  test_type<unsigned char>();
+  test_type<unsigned short>();
+  test_type<unsigned int>();
+  test_type<unsigned long>();
+  test_type<unsigned long long>();
+#if _CCCL_HAS_INT128()
+  test_type<__uint128_t>();
+#endif // _CCCL_HAS_INT128()
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  // NV_IF_TARGET(NV_IS_HOST, static_assert(test());)
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/cmath/uabs.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/cmath/uabs.pass.cpp
@@ -66,6 +66,6 @@ __host__ __device__ constexpr bool test()
 int main(int, char**)
 {
   test();
-  // NV_IF_TARGET(NV_IS_HOST, static_assert(test());)
+  static_assert(test());
   return 0;
 }


### PR DESCRIPTION
This PR implements a `cuda::uabs` utility that computes an unsigned absolute value of an integer input. The main feature is that it eliminates the UB of `std::abs` when a signed `T_MIN` is passed as an input.

Rust has a similar function, just called `unsigned_abs`.