### PR TITLE
Drop `_LIBCUDACXX_HAS_NO_UNICODE_CHARS`

### DIFF
--- a/libcudacxx/include/cuda/std/__functional/hash.h
+++ b/libcudacxx/include/cuda/std/__functional/hash.h
@@ -431,7 +431,6 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT hash<unsigned char> : public __unary_functi
   }
 };
 
-#  ifndef _LIBCUDACXX_HAS_NO_UNICODE_CHARS
 template <>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT hash<char16_t> : public __unary_function<char16_t, size_t>
 {
@@ -449,7 +448,6 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT hash<char32_t> : public __unary_function<ch
     return static_cast<size_t>(__v);
   }
 };
-#  endif // _LIBCUDACXX_HAS_NO_UNICODE_CHARS
 
 #  ifndef _LIBCUDACXX_HAS_NO_WIDE_CHARACTERS
 template <>

--- a/libcudacxx/include/cuda/std/__type_traits/is_integral.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_integral.h
@@ -59,14 +59,12 @@ template <>
 struct __cccl_is_integral<char8_t> : public true_type
 {};
 #  endif // _LIBCUDACXX_HAS_CHAR8_T()
-#  ifndef _LIBCUDACXX_HAS_NO_UNICODE_CHARS
 template <>
 struct __cccl_is_integral<char16_t> : public true_type
 {};
 template <>
 struct __cccl_is_integral<char32_t> : public true_type
 {};
-#  endif // _LIBCUDACXX_HAS_NO_UNICODE_CHARS
 template <>
 struct __cccl_is_integral<short> : public true_type
 {};

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__config
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__config
@@ -134,11 +134,6 @@ extern "C++" {
 
 #  endif //  _CCCL_COMPILER(CLANG)
 
-#  ifdef _LIBCUDACXX_HAS_NO_UNICODE_CHARS
-using char16_t = unsigned short;
-using char32_t = unsigned int;
-#  endif // _LIBCUDACXX_HAS_NO_UNICODE_CHARS
-
 #  ifdef _LIBCUDACXX_DEBUG
 #    if _LIBCUDACXX_DEBUG == 0
 #      define _LIBCUDACXX_DEBUG_LEVEL 1

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__string
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__string
@@ -638,18 +638,16 @@ char_traits<char8_t>::find(const char_type* __s, size_t __n, const char_type& __
 
 #endif // _LIBCUDACXX_HAS_CHAR8_T()
 
-#ifndef _LIBCUDACXX_HAS_NO_UNICODE_CHARS
-
 template <>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT char_traits<char16_t>
 {
   typedef char16_t char_type;
   typedef uint_least16_t int_type;
   typedef streamoff off_type;
-#  if _LIBCUDACXX_HAS_WCHAR_H()
+#if _LIBCUDACXX_HAS_WCHAR_H()
   typedef u16streampos pos_type;
   typedef mbstate_t state_type;
-#  endif // _LIBCUDACXX_HAS_WCHAR_H()
+#endif // _LIBCUDACXX_HAS_WCHAR_H()
 
   _LIBCUDACXX_HIDE_FROM_ABI static constexpr void assign(char_type& __c1, const char_type& __c2) noexcept
   {
@@ -787,10 +785,10 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT char_traits<char32_t>
   typedef char32_t char_type;
   typedef uint_least32_t int_type;
   typedef streamoff off_type;
-#  if _LIBCUDACXX_HAS_WCHAR_H()
+#if _LIBCUDACXX_HAS_WCHAR_H()
   typedef u32streampos pos_type;
   typedef mbstate_t state_type;
-#  endif // _LIBCUDACXX_HAS_WCHAR_H()
+#endif // _LIBCUDACXX_HAS_WCHAR_H()
 
   _LIBCUDACXX_HIDE_FROM_ABI static constexpr void assign(char_type& __c1, const char_type& __c2) noexcept
   {
@@ -921,8 +919,6 @@ _LIBCUDACXX_HIDE_FROM_ABI char32_t* char_traits<char32_t>::assign(char_type* __s
   }
   return __r;
 }
-
-#endif // _LIBCUDACXX_HAS_NO_UNICODE_CHARS
 
 // helper fns for basic_string and string_view
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/iosfwd
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/iosfwd
@@ -184,10 +184,8 @@ typedef fpos<mbstate_t> wstreampos;
 #  if _LIBCUDACXX_HAS_CHAR8_T()
 typedef fpos<mbstate_t> u8streampos;
 #  endif // _LIBCUDACXX_HAS_CHAR8_T()
-#  ifndef _LIBCUDACXX_HAS_NO_UNICODE_CHARS
 typedef fpos<mbstate_t> u16streampos;
 typedef fpos<mbstate_t> u32streampos;
-#  endif // _LIBCUDACXX_HAS_NO_UNICODE_CHARS
 #endif // _LIBCUDACXX_HAS_WCHAR_H()
 
 #if defined(_NEWLIB_VERSION)

--- a/libcudacxx/test/libcudacxx/cuda/atomics/atomic.ext/atomic_helpers.h
+++ b/libcudacxx/test/libcudacxx/cuda/atomics/atomic.ext/atomic_helpers.h
@@ -51,10 +51,8 @@ struct TestEachIntegralType
     TestFunctor<long long, Selector, Scope>()();
     TestFunctor<unsigned long long, Selector, Scope>()();
     TestFunctor<wchar_t, Selector, Scope>();
-#ifndef _LIBCUDACXX_HAS_NO_UNICODE_CHARS
     TestFunctor<char16_t, Selector, Scope>()();
     TestFunctor<char32_t, Selector, Scope>()();
-#endif
     TestFunctor<int8_t, Selector, Scope>()();
     TestFunctor<uint8_t, Selector, Scope>()();
     TestFunctor<int16_t, Selector, Scope>()();

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/integral/2b_integral_cuda.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/integral/2b_integral_cuda.pass.cpp
@@ -104,9 +104,7 @@ __host__ __device__ void test_for_all_types()
   test<Atomic<short, Scope>, short, Selector>();
   test<Atomic<unsigned short, Scope>, unsigned short, Selector>();
 
-#ifndef _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<Atomic<char16_t, Scope>, char16_t, Selector>();
-#endif // _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<Atomic<wchar_t, Scope>, wchar_t, Selector>();
 
   test<Atomic<int16_t, Scope>, int16_t, Selector>();

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/integral/2b_integral_std.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/integral/2b_integral_std.pass.cpp
@@ -104,9 +104,7 @@ __host__ __device__ void test_for_all_types()
   test<Atomic<short, Scope>, short, Selector>();
   test<Atomic<unsigned short, Scope>, unsigned short, Selector>();
 
-#ifndef _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<Atomic<char16_t, Scope>, char16_t, Selector>();
-#endif // _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<Atomic<wchar_t, Scope>, wchar_t, Selector>();
 
   test<Atomic<int16_t, Scope>, int16_t, Selector>();

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/integral/4b_integral_cuda.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/integral/4b_integral_cuda.pass.cpp
@@ -103,10 +103,7 @@ __host__ __device__ void test_for_all_types()
 {
   test<Atomic<int, Scope>, int, Selector>();
   test<Atomic<unsigned int, Scope>, unsigned int, Selector>();
-#ifndef _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<Atomic<char16_t, Scope>, char16_t, Selector>();
-#endif // _LIBCUDACXX_HAS_NO_UNICODE_CHARS
-
   test<Atomic<int32_t, Scope>, int32_t, Selector>();
   test<Atomic<uint32_t, Scope>, uint32_t, Selector>();
 }

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/integral/4b_integral_std.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/integral/4b_integral_std.pass.cpp
@@ -103,9 +103,7 @@ __host__ __device__ void test_for_all_types()
 {
   test<Atomic<int, Scope>, int, Selector>();
   test<Atomic<unsigned int, Scope>, unsigned int, Selector>();
-#ifndef _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<Atomic<char16_t, Scope>, char16_t, Selector>();
-#endif // _LIBCUDACXX_HAS_NO_UNICODE_CHARS
 
   test<Atomic<int32_t, Scope>, int32_t, Selector>();
   test<Atomic<uint32_t, Scope>, uint32_t, Selector>();

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/integral/integral_ref.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/integral/integral_ref.pass.cpp
@@ -172,9 +172,7 @@ __host__ __device__ void test_for_all_types()
   test<Atomic<unsigned long, Scope>, unsigned long, Selector>();
   test<Atomic<long long, Scope>, long long, Selector>();
   test<Atomic<unsigned long long, Scope>, unsigned long long, Selector>();
-#ifndef _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<Atomic<char32_t, Scope>, char32_t, Selector>();
-#endif // _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<Atomic<int8_t, Scope>, int8_t, Selector>();
   test<Atomic<uint8_t, Scope>, uint8_t, Selector>();
   test<Atomic<int16_t, Scope>, int16_t, Selector>();

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/integral/integral_ref_constness.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/integral/integral_ref_constness.pass.cpp
@@ -172,9 +172,7 @@ __host__ __device__ void test_for_all_types()
   test<Atomic<unsigned long, Scope>, unsigned long, Selector>();
   test<Atomic<long long, Scope>, long long, Selector>();
   test<Atomic<unsigned long long, Scope>, unsigned long long, Selector>();
-#ifndef _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<Atomic<char32_t, Scope>, char32_t, Selector>();
-#endif // _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<Atomic<int8_t, Scope>, int8_t, Selector>();
   test<Atomic<uint8_t, Scope>, uint8_t, Selector>();
   test<Atomic<int16_t, Scope>, int16_t, Selector>();

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/integral_typedefs.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/integral_typedefs.pass.cpp
@@ -57,10 +57,8 @@ int main(int, char**)
   static_assert((cuda::std::is_same<cuda::std::atomic<long long>, cuda::std::atomic_llong>::value), "");
   static_assert((cuda::std::is_same<cuda::std::atomic<unsigned long long>, cuda::std::atomic_ullong>::value), "");
   static_assert((cuda::std::is_same<cuda::std::atomic<wchar_t>, cuda::std::atomic_wchar_t>::value), "");
-#ifndef _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   static_assert((cuda::std::is_same<cuda::std::atomic<char16_t>, cuda::std::atomic_char16_t>::value), "");
   static_assert((cuda::std::is_same<cuda::std::atomic<char32_t>, cuda::std::atomic_char32_t>::value), "");
-#endif // _LIBCUDACXX_HAS_NO_UNICODE_CHARS
 
   //  Added by LWG 2441
   static_assert((cuda::std::is_same<cuda::std::atomic<intptr_t>, cuda::std::atomic_intptr_t>::value), "");

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_helpers.h
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_helpers.h
@@ -52,10 +52,8 @@ struct TestEachIntegralType
     TestFunctor<long long, Selector, Scope>()();
     TestFunctor<unsigned long long, Selector, Scope>()();
     TestFunctor<wchar_t, Selector, Scope>();
-#ifndef _LIBCUDACXX_HAS_NO_UNICODE_CHARS
     TestFunctor<char16_t, Selector, Scope>()();
     TestFunctor<char32_t, Selector, Scope>()();
-#endif
     TestFunctor<int8_t, Selector, Scope>()();
     TestFunctor<uint8_t, Selector, Scope>()();
     TestFunctor<int16_t, Selector, Scope>()();
@@ -119,9 +117,7 @@ struct TestEachIntegralRefType
     TestFunctor<unsigned long, Selector, Scope>()();
     TestFunctor<long long, Selector, Scope>()();
     TestFunctor<unsigned long long, Selector, Scope>()();
-#ifndef _LIBCUDACXX_HAS_NO_UNICODE_CHARS
     TestFunctor<char32_t, Selector, Scope>()();
-#endif
     TestFunctor<int32_t, Selector, Scope>()();
     TestFunctor<uint32_t, Selector, Scope>()();
     TestFunctor<int64_t, Selector, Scope>()();

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/is_specialized.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/is_specialized.pass.cpp
@@ -45,10 +45,8 @@ int main(int, char**)
   test<bool>();
   test<char>();
   test<wchar_t>();
-#ifndef _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<char16_t>();
   test<char32_t>();
-#endif // _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<signed char>();
   test<unsigned char>();
   test<signed short>();

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/denorm_min.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/denorm_min.pass.cpp
@@ -37,10 +37,8 @@ int main(int, char**)
 #if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
   test<char8_t>(0);
 #endif
-#ifndef _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<char16_t>(0);
   test<char32_t>(0);
-#endif // _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<short>(0);
   test<unsigned short>(0);
   test<int>(0);

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/digits.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/digits.pass.cpp
@@ -34,10 +34,8 @@ int main(int, char**)
 #if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
   test<char8_t, 8>();
 #endif
-#ifndef _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<char16_t, 16>();
   test<char32_t, 32>();
-#endif // _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<short, 15>();
   test<unsigned short, 16>();
   test<int, 31>();

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/digits10.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/digits10.pass.cpp
@@ -53,10 +53,8 @@ int main(int, char**)
 #if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
   test<char8_t>();
 #endif
-#ifndef _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<char16_t>();
   test<char32_t>();
-#endif // _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<short>();
   test<unsigned short>();
   test<int>();

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/epsilon.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/epsilon.pass.cpp
@@ -37,10 +37,8 @@ int main(int, char**)
 #if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
   test<char8_t>(0);
 #endif
-#ifndef _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<char16_t>(0);
   test<char32_t>(0);
-#endif // _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<short>(0);
   test<unsigned short>(0);
   test<int>(0);

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/has_denorm.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/has_denorm.pass.cpp
@@ -33,10 +33,8 @@ int main(int, char**)
 #if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
   test<char8_t, cuda::std::denorm_absent>();
 #endif
-#ifndef _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<char16_t, cuda::std::denorm_absent>();
   test<char32_t, cuda::std::denorm_absent>();
-#endif // _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<short, cuda::std::denorm_absent>();
   test<unsigned short, cuda::std::denorm_absent>();
   test<int, cuda::std::denorm_absent>();

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/has_denorm_loss.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/has_denorm_loss.pass.cpp
@@ -33,10 +33,8 @@ int main(int, char**)
 #if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
   test<char8_t, false>();
 #endif
-#ifndef _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<char16_t, false>();
   test<char32_t, false>();
-#endif // _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<short, false>();
   test<unsigned short, false>();
   test<int, false>();

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/has_infinity.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/has_infinity.pass.cpp
@@ -33,10 +33,8 @@ int main(int, char**)
 #if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
   test<char8_t, false>();
 #endif
-#ifndef _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<char16_t, false>();
   test<char32_t, false>();
-#endif // _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<short, false>();
   test<unsigned short, false>();
   test<int, false>();

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/has_quiet_NaN.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/has_quiet_NaN.pass.cpp
@@ -33,10 +33,8 @@ int main(int, char**)
 #if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
   test<char8_t, false>();
 #endif
-#ifndef _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<char16_t, false>();
   test<char32_t, false>();
-#endif // _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<short, false>();
   test<unsigned short, false>();
   test<int, false>();

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/has_signaling_NaN.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/has_signaling_NaN.pass.cpp
@@ -33,10 +33,8 @@ int main(int, char**)
 #if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
   test<char8_t, false>();
 #endif
-#ifndef _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<char16_t, false>();
   test<char32_t, false>();
-#endif // _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<short, false>();
   test<unsigned short, false>();
   test<int, false>();

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/infinity.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/infinity.pass.cpp
@@ -47,10 +47,8 @@ int main(int, char**)
 #if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
   test<char8_t>(0);
 #endif
-#ifndef _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<char16_t>(0);
   test<char32_t>(0);
-#endif // _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<short>(0);
   test<unsigned short>(0);
   test<int>(0);

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/is_bounded.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/is_bounded.pass.cpp
@@ -33,10 +33,8 @@ int main(int, char**)
 #if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
   test<char8_t, true>();
 #endif
-#ifndef _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<char16_t, true>();
   test<char32_t, true>();
-#endif // _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<short, true>();
   test<unsigned short, true>();
   test<int, true>();

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/is_exact.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/is_exact.pass.cpp
@@ -33,10 +33,8 @@ int main(int, char**)
 #if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
   test<char8_t, true>();
 #endif
-#ifndef _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<char16_t, true>();
   test<char32_t, true>();
-#endif // _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<short, true>();
   test<unsigned short, true>();
   test<int, true>();

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/is_iec559.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/is_iec559.pass.cpp
@@ -33,10 +33,8 @@ int main(int, char**)
 #if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
   test<char8_t, false>();
 #endif
-#ifndef _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<char16_t, false>();
   test<char32_t, false>();
-#endif // _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<short, false>();
   test<unsigned short, false>();
   test<int, false>();

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/is_integer.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/is_integer.pass.cpp
@@ -33,10 +33,8 @@ int main(int, char**)
 #if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
   test<char8_t, true>();
 #endif
-#ifndef _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<char16_t, true>();
   test<char32_t, true>();
-#endif // _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<short, true>();
   test<unsigned short, true>();
   test<int, true>();

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/is_modulo.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/is_modulo.pass.cpp
@@ -33,10 +33,8 @@ int main(int, char**)
 #if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
   test<char8_t, true>();
 #endif
-#ifndef _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<char16_t, true>();
   test<char32_t, true>();
-#endif // _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<short, false>();
   test<unsigned short, true>();
   test<int, false>();

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/is_signed.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/is_signed.pass.cpp
@@ -33,10 +33,8 @@ int main(int, char**)
 #if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
   test<char8_t, false>();
 #endif
-#ifndef _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<char16_t, false>();
   test<char32_t, false>();
-#endif // _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<short, true>();
   test<unsigned short, false>();
   test<int, true>();

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/lowest.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/lowest.pass.cpp
@@ -46,10 +46,8 @@ int main(int, char**)
 #if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
   test<char8_t>(0);
 #endif
-#ifndef _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<char16_t>(0);
   test<char32_t>(0);
-#endif // _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<short>(SHRT_MIN);
   test<unsigned short>(0);
   test<int>(INT_MIN);

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/max.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/max.pass.cpp
@@ -45,10 +45,8 @@ int main(int, char**)
 #if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
   test<char8_t>(UCHAR_MAX); // ??
 #endif
-#ifndef _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<char16_t>(USHRT_MAX);
   test<char32_t>(UINT_MAX);
-#endif // _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<short>(SHRT_MAX);
   test<unsigned short>(USHRT_MAX);
   test<int>(INT_MAX);

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/max_digits10.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/max_digits10.pass.cpp
@@ -48,10 +48,8 @@ int main(int, char**)
 #if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
   test<char8_t>();
 #endif
-#ifndef _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<char16_t>();
   test<char32_t>();
-#endif // _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<short>();
   test<unsigned short>();
   test<int>();

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/max_exponent.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/max_exponent.pass.cpp
@@ -41,10 +41,8 @@ int main(int, char**)
 #if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
   test<char8_t>();
 #endif
-#ifndef _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<char16_t>();
   test<char32_t>();
-#endif // _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<short>();
   test<unsigned short>();
   test<int>();

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/max_exponent10.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/max_exponent10.pass.cpp
@@ -41,10 +41,8 @@ int main(int, char**)
 #if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
   test<char8_t>();
 #endif
-#ifndef _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<char16_t>();
   test<char32_t>();
-#endif // _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<short>();
   test<unsigned short>();
   test<int>();

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/min.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/min.pass.cpp
@@ -46,10 +46,8 @@ int main(int, char**)
 #if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
   test<char8_t>(0);
 #endif
-#ifndef _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<char16_t>(0);
   test<char32_t>(0);
-#endif // _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<short>(SHRT_MIN);
   test<unsigned short>(0);
   test<int>(INT_MIN);

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/min_exponent.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/min_exponent.pass.cpp
@@ -41,10 +41,8 @@ int main(int, char**)
 #if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
   test<char8_t>();
 #endif
-#ifndef _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<char16_t>();
   test<char32_t>();
-#endif // _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<short>();
   test<unsigned short>();
   test<int>();

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/min_exponent10.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/min_exponent10.pass.cpp
@@ -41,10 +41,8 @@ int main(int, char**)
 #if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
   test<char8_t>();
 #endif
-#ifndef _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<char16_t>();
   test<char32_t>();
-#endif // _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<short>();
   test<unsigned short>();
   test<int>();

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/quiet_NaN.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/quiet_NaN.pass.cpp
@@ -52,10 +52,8 @@ int main(int, char**)
 #if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
   test<char8_t>();
 #endif
-#ifndef _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<char16_t>();
   test<char32_t>();
-#endif // _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<short>();
   test<unsigned short>();
   test<int>();

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/radix.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/radix.pass.cpp
@@ -34,10 +34,8 @@ int main(int, char**)
 #if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
   test<char8_t, 2>();
 #endif
-#ifndef _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<char16_t, 2>();
   test<char32_t, 2>();
-#endif // _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<short, 2>();
   test<unsigned short, 2>();
   test<int, 2>();

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/round_error.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/round_error.pass.cpp
@@ -36,10 +36,8 @@ int main(int, char**)
 #if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
   test<char8_t>(0);
 #endif
-#ifndef _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<char16_t>(0);
   test<char32_t>(0);
-#endif // _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<short>(0);
   test<unsigned short>(0);
   test<int>(0);

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/round_style.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/round_style.pass.cpp
@@ -33,10 +33,8 @@ int main(int, char**)
 #if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
   test<char8_t, cuda::std::round_toward_zero>();
 #endif
-#ifndef _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<char16_t, cuda::std::round_toward_zero>();
   test<char32_t, cuda::std::round_toward_zero>();
-#endif // _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<short, cuda::std::round_toward_zero>();
   test<unsigned short, cuda::std::round_toward_zero>();
   test<int, cuda::std::round_toward_zero>();

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/signaling_NaN.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/signaling_NaN.pass.cpp
@@ -52,10 +52,8 @@ int main(int, char**)
 #if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
   test<char8_t>();
 #endif
-#ifndef _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<char16_t>();
   test<char32_t>();
-#endif // _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<short>();
   test<unsigned short>();
   test<int>();

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/tinyness_before.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/tinyness_before.pass.cpp
@@ -33,10 +33,8 @@ int main(int, char**)
 #if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
   test<char8_t, false>();
 #endif
-#ifndef _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<char16_t, false>();
   test<char32_t, false>();
-#endif // _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<short, false>();
   test<unsigned short, false>();
   test<int, false>();

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/traps.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/traps.pass.cpp
@@ -39,10 +39,8 @@ int main(int, char**)
 #if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
   test<char8_t, integral_types_trap>();
 #endif
-#ifndef _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<char16_t, integral_types_trap>();
   test<char32_t, integral_types_trap>();
-#endif // _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   test<short, integral_types_trap>();
   test<unsigned short, integral_types_trap>();
   test<int, integral_types_trap>();

--- a/libcudacxx/test/support/poisoned_hash_helper.h
+++ b/libcudacxx/test/support/poisoned_hash_helper.h
@@ -61,10 +61,8 @@ using LibraryHashTypes = TypeList<
   signed char,
   unsigned char,
   wchar_t,
-#ifndef _LIBCUDACXX_HAS_NO_UNICODE_CHARS
   char16_t,
   char32_t,
-#endif
   short,
   unsigned short,
   int,


### PR DESCRIPTION
We should always have them and the macro is never defined.