### PR TITLE
Drop `_LIBCUDACXX_HAS_NO_WIDE_CHARACTERS`

### DIFF
--- a/libcudacxx/include/cuda/std/__functional/hash.h
+++ b/libcudacxx/include/cuda/std/__functional/hash.h
@@ -451,7 +451,6 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT hash<char32_t> : public __unary_function<ch
 };
 #  endif // _LIBCUDACXX_HAS_NO_UNICODE_CHARS
 
-#  ifndef _LIBCUDACXX_HAS_NO_WIDE_CHARACTERS
 template <>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT hash<wchar_t> : public __unary_function<wchar_t, size_t>
 {
@@ -460,7 +459,6 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT hash<wchar_t> : public __unary_function<wch
     return static_cast<size_t>(__v);
   }
 };
-#  endif // _LIBCUDACXX_HAS_NO_WIDE_CHARACTERS
 
 template <>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT hash<short> : public __unary_function<short, size_t>

--- a/libcudacxx/include/cuda/std/__fwd/string.h
+++ b/libcudacxx/include/cuda/std/__fwd/string.h
@@ -38,11 +38,8 @@ template <>
 struct char_traits<char16_t>;
 template <>
 struct char_traits<char32_t>;
-
-#ifndef _LIBCUDACXX_HAS_NO_WIDE_CHARACTERS
 template <>
 struct char_traits<wchar_t>;
-#endif
 
 template <class _Tp>
 class _CCCL_TYPE_VISIBILITY_DEFAULT allocator;
@@ -50,11 +47,8 @@ class _CCCL_TYPE_VISIBILITY_DEFAULT allocator;
 template <class _CharT, class _Traits = char_traits<_CharT>, class _Allocator = allocator<_CharT>>
 class _CCCL_TYPE_VISIBILITY_DEFAULT basic_string;
 
-using string = basic_string<char>;
-
-#ifndef _LIBCUDACXX_HAS_NO_WIDE_CHARACTERS
+using string  = basic_string<char>;
 using wstring = basic_string<wchar_t>;
-#endif
 
 #if _LIBCUDACXX_HAS_CHAR8_T()
 using u8string = basic_string<char8_t>;
@@ -68,11 +62,8 @@ namespace pmr
 template <class _CharT, class _Traits = char_traits<_CharT>>
 using basic_string = std::basic_string<_CharT, _Traits, polymorphic_allocator<_CharT>>;
 
-using string = basic_string<char>;
-
-#ifndef _LIBCUDACXX_HAS_NO_WIDE_CHARACTERS
+using string  = basic_string<char>;
 using wstring = basic_string<wchar_t>;
-#endif // !_LIBCUDACXX_HAS_NO_WIDE_CHARACTERS
 
 #if _LIBCUDACXX_HAS_CHAR8_T()
 using u8string = basic_string<char8_t>;
@@ -86,18 +77,14 @@ using u32string = basic_string<char32_t>;
 // clang-format off
 template <class _CharT, class _Traits, class _Allocator>
 class _LIBCUDACXX_PREFERRED_NAME(string)
-#ifndef _LIBCUDACXX_HAS_NO_WIDE_CHARACTERS
       _LIBCUDACXX_PREFERRED_NAME(wstring)
-#endif // !_LIBCUDACXX_HAS_NO_WIDE_CHARACTERS
 #if _LIBCUDACXX_HAS_CHAR8_T()
       _LIBCUDACXX_PREFERRED_NAME(u8string)
 #endif // _LIBCUDACXX_HAS_CHAR8_T()
       _LIBCUDACXX_PREFERRED_NAME(u16string)
       _LIBCUDACXX_PREFERRED_NAME(u32string)
       _LIBCUDACXX_PREFERRED_NAME(pmr::string)
-#  ifndef _LIBCUDACXX_HAS_NO_WIDE_CHARACTERS
       _LIBCUDACXX_PREFERRED_NAME(pmr::wstring)
-#  endif // !_LIBCUDACXX_HAS_NO_WIDE_CHARACTERS
 #  if _LIBCUDACXX_HAS_CHAR8_T()
       _LIBCUDACXX_PREFERRED_NAME(pmr::u8string)
 #  endif // _LIBCUDACXX_HAS_CHAR8_T()

--- a/libcudacxx/include/cuda/std/__fwd/string_view.h
+++ b/libcudacxx/include/cuda/std/__fwd/string_view.h
@@ -34,16 +34,12 @@ using u8string_view = basic_string_view<char8_t>;
 #endif // _LIBCUDACXX_HAS_CHAR8_T()
 using u16string_view = basic_string_view<char16_t>;
 using u32string_view = basic_string_view<char32_t>;
-#ifndef _LIBCUDACXX_HAS_NO_WIDE_CHARACTERS
-using wstring_view = basic_string_view<wchar_t>;
-#endif
+using wstring_view   = basic_string_view<wchar_t>;
 
 // clang-format off
 template <class _CharT, class _Traits>
 class _LIBCUDACXX_PREFERRED_NAME(string_view)
-#ifndef _LIBCUDACXX_HAS_NO_WIDE_CHARACTERS
       _LIBCUDACXX_PREFERRED_NAME(wstring_view)
-#endif
 #if _LIBCUDACXX_HAS_CHAR8_T()
       _LIBCUDACXX_PREFERRED_NAME(u8string_view)
 #endif // _LIBCUDACXX_HAS_CHAR8_T()


### PR DESCRIPTION
It is never defined.