### PR TITLE
Implement `<cuda/std/charconv>` classes

### DIFF
--- a/libcudacxx/include/cuda/std/__charconv/chars_format.h
+++ b/libcudacxx/include/cuda/std/__charconv/chars_format.h
@@ -1,0 +1,78 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___CHARCONV_CHARS_FORMAT_H
+#define _LIBCUDACXX___CHARCONV_CHARS_FORMAT_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__utility/to_underlying.h>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_STD
+
+enum class chars_format
+{
+  // We intentionally don't use `to_underlying(std::chars_format::XXX)` for XXX values because we want to avoid the risk
+  // of the value mismatch between host's standard library and our definitions for NVRTC
+  scientific = 0x1,
+  fixed      = 0x2,
+  hex        = 0x4,
+  general    = fixed | scientific,
+};
+
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr chars_format operator~(chars_format __v) noexcept
+{
+  return chars_format(~_CUDA_VSTD::to_underlying(__v));
+}
+
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr chars_format operator&(chars_format __lhs, chars_format __rhs) noexcept
+{
+  return chars_format(_CUDA_VSTD::to_underlying(__lhs) & _CUDA_VSTD::to_underlying(__rhs));
+}
+
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr chars_format operator|(chars_format __lhs, chars_format __rhs) noexcept
+{
+  return chars_format(_CUDA_VSTD::to_underlying(__lhs) | _CUDA_VSTD::to_underlying(__rhs));
+}
+
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr chars_format operator^(chars_format __lhs, chars_format __rhs) noexcept
+{
+  return chars_format(_CUDA_VSTD::to_underlying(__lhs) ^ _CUDA_VSTD::to_underlying(__rhs));
+}
+
+_LIBCUDACXX_HIDE_FROM_ABI constexpr chars_format& operator&=(chars_format& __lhs, chars_format __rhs) noexcept
+{
+  __lhs = __lhs & __rhs;
+  return __lhs;
+}
+
+_LIBCUDACXX_HIDE_FROM_ABI constexpr chars_format& operator|=(chars_format& __lhs, chars_format __rhs) noexcept
+{
+  __lhs = __lhs | __rhs;
+  return __lhs;
+}
+
+_LIBCUDACXX_HIDE_FROM_ABI constexpr chars_format& operator^=(chars_format& __lhs, chars_format __rhs) noexcept
+{
+  __lhs = __lhs ^ __rhs;
+  return __lhs;
+}
+
+_LIBCUDACXX_END_NAMESPACE_STD
+
+#endif // _LIBCUDACXX___CHARCONV_CHARS_FORMAT_H

--- a/libcudacxx/include/cuda/std/__charconv/from_chars_result.h
+++ b/libcudacxx/include/cuda/std/__charconv/from_chars_result.h
@@ -1,0 +1,41 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___CHARCONV_FROM_CHARS_RESULT_H
+#define _LIBCUDACXX___CHARCONV_FROM_CHARS_RESULT_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__system_error/errc.h>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_STD
+
+struct _CCCL_TYPE_VISIBILITY_DEFAULT from_chars_result
+{
+  const char* ptr;
+  errc ec;
+
+  _LIBCUDACXX_HIDE_FROM_ABI constexpr explicit operator bool() const noexcept
+  {
+    return ec == errc{};
+  }
+};
+
+_LIBCUDACXX_END_NAMESPACE_STD
+
+#endif // _LIBCUDACXX___CHARCONV_FROM_CHARS_RESULT_H

--- a/libcudacxx/include/cuda/std/__charconv/to_chars_result.h
+++ b/libcudacxx/include/cuda/std/__charconv/to_chars_result.h
@@ -1,0 +1,41 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___CHARCONV_TO_CHARS_RESULT_H
+#define _LIBCUDACXX___CHARCONV_TO_CHARS_RESULT_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__system_error/errc.h>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_STD
+
+struct _CCCL_TYPE_VISIBILITY_DEFAULT to_chars_result
+{
+  char* ptr;
+  errc ec;
+
+  _LIBCUDACXX_HIDE_FROM_ABI constexpr explicit operator bool() const noexcept
+  {
+    return ec == errc{};
+  }
+};
+
+_LIBCUDACXX_END_NAMESPACE_STD
+
+#endif // _LIBCUDACXX___CHARCONV_TO_CHARS_RESULT_H

--- a/libcudacxx/include/cuda/std/__charconv_
+++ b/libcudacxx/include/cuda/std/__charconv_
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_CHARCONV
+#define _CUDA_STD_CHARCONV
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+_CCCL_PUSH_MACROS
+
+#include <cuda/std/__charconv/chars_format.h>
+#include <cuda/std/__charconv/from_chars_result.h>
+#include <cuda/std/__charconv/to_chars_result.h>
+#include <cuda/std/version>
+
+_CCCL_POP_MACROS
+
+#endif // _CUDA_STD_NEW

--- a/libcudacxx/include/cuda/std/__system_error/errc.h
+++ b/libcudacxx/include/cuda/std/__system_error/errc.h
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___SYSTEM_ERROR_ERRC_H
+#define _LIBCUDACXX___SYSTEM_ERROR_ERRC_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+_LIBCUDACXX_BEGIN_NAMESPACE_STD
+
+enum class errc
+{
+  invalid_argument    = 22,
+  result_out_of_range = 34,
+#if _CCCL_OS(WINDOWS)
+  value_too_large = 132,
+#else // ^^^ _CCCL_OS(WINDOWS) ^^^ / vvv !_CCCL_OS(WINDOWS) vvv
+  value_too_large = 75,
+#endif // ^^^ !_CCCL_OS(WINDOWS) ^^^
+};
+
+_LIBCUDACXX_END_NAMESPACE_STD
+
+#endif // _LIBCUDACXX___SYSTEM_ERROR_ERRC_H

--- a/libcudacxx/test/libcudacxx/std/diagnostics/syserr/syserr.syserr/errc.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/diagnostics/syserr/syserr.syserr/errc.pass.cpp
@@ -1,0 +1,24 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: nvrtc
+
+#include <cuda/std/__system_error/errc.h>
+
+#include <cerrno>
+
+int main(int, char**)
+{
+  static_assert(static_cast<int>(cuda::std::errc::invalid_argument) == EINVAL);
+  static_assert(static_cast<int>(cuda::std::errc::result_out_of_range) == ERANGE);
+  static_assert(static_cast<int>(cuda::std::errc::value_too_large) == EOVERFLOW);
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/utilities/charconv/charconv.syn/chars_format.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/charconv/charconv.syn/chars_format.pass.cpp
@@ -1,0 +1,67 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/__charconv_>
+#include <cuda/std/cassert>
+#include <cuda/std/type_traits>
+
+__host__ __device__ constexpr bool test()
+{
+  using cf = cuda::std::chars_format;
+  using ut = cuda::std::underlying_type<cf>::type;
+
+  {
+    cf x = cf::scientific;
+    x |= cf::fixed;
+    assert(x == cf::general);
+  }
+  {
+    cf x = cf::general;
+    x &= cf::fixed;
+    assert(x == cf::fixed);
+  }
+  {
+    cf x = cf::general;
+    x ^= cf::fixed;
+    assert(x == cf::scientific);
+  }
+
+  assert(static_cast<ut>(cf::scientific & (cf::fixed | cf::hex)) == 0);
+  assert(static_cast<ut>(cf::fixed & (cf::scientific | cf::hex)) == 0);
+  assert(static_cast<ut>(cf::hex & (cf::scientific | cf::fixed)) == 0);
+
+  assert((cf::scientific | cf::fixed) == cf::general);
+
+  assert(static_cast<ut>(cf::scientific & cf::fixed) == 0);
+
+  assert((cf::general ^ cf::fixed) == cf::scientific);
+
+  assert((~cf::hex & cf::general) == cf::general);
+
+  {
+    [[maybe_unused]] cuda::std::chars_format x{};
+    static_assert(cuda::std::is_same_v<cuda::std::chars_format, decltype(~x)>);
+    static_assert(cuda::std::is_same_v<cuda::std::chars_format, decltype(x & x)>);
+    static_assert(cuda::std::is_same_v<cuda::std::chars_format, decltype(x | x)>);
+    static_assert(cuda::std::is_same_v<cuda::std::chars_format, decltype(x ^ x)>);
+    static_assert(cuda::std::is_same_v<cuda::std::chars_format&, decltype(x &= x)>);
+    static_assert(cuda::std::is_same_v<cuda::std::chars_format&, decltype(x |= x)>);
+    static_assert(cuda::std::is_same_v<cuda::std::chars_format&, decltype(x ^= x)>);
+  }
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test(), "");
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/utilities/charconv/charconv.syn/from_chars_result.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/charconv/charconv.syn/from_chars_result.pass.cpp
@@ -1,0 +1,50 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/__charconv_>
+#include <cuda/std/cassert>
+#include <cuda/std/type_traits>
+
+__host__ __device__ constexpr bool test()
+{
+  static_assert(!cuda::std::is_convertible_v<cuda::std::from_chars_result, bool>);
+  static_assert(cuda::std::is_constructible_v<bool, cuda::std::from_chars_result>);
+
+  cuda::std::from_chars_result x{nullptr, cuda::std::errc{}};
+
+  auto [ptr, ec] = x;
+
+  static_assert(cuda::std::is_same_v<decltype(ptr), const char*>);
+  assert(ptr == x.ptr);
+
+  static_assert(cuda::std::is_same_v<decltype(ec), cuda::std::errc>);
+  assert(ec == x.ec);
+
+  {
+    cuda::std::from_chars_result value{nullptr, cuda::std::errc{}};
+    assert(bool(value) == true);
+    static_assert(noexcept(bool(value)) == true);
+  }
+
+  {
+    cuda::std::from_chars_result value{nullptr, cuda::std::errc::value_too_large};
+    assert(bool(value) == false);
+    static_assert(noexcept(bool(value)) == true);
+  }
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/utilities/charconv/charconv.syn/to_chars_result.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/charconv/charconv.syn/to_chars_result.pass.cpp
@@ -1,0 +1,50 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/__charconv_>
+#include <cuda/std/cassert>
+#include <cuda/std/type_traits>
+
+__host__ __device__ constexpr bool test()
+{
+  static_assert(!cuda::std::is_convertible_v<cuda::std::to_chars_result, bool>);
+  static_assert(cuda::std::is_constructible_v<bool, cuda::std::to_chars_result>);
+
+  cuda::std::to_chars_result x{nullptr, cuda::std::errc{}};
+
+  auto [ptr, ec] = x;
+
+  static_assert(cuda::std::is_same_v<decltype(ptr), char*>);
+  assert(ptr == x.ptr);
+
+  static_assert(cuda::std::is_same_v<decltype(ec), cuda::std::errc>);
+  assert(ec == x.ec);
+
+  {
+    cuda::std::to_chars_result value{nullptr, cuda::std::errc{}};
+    assert(bool(value) == true);
+    static_assert(noexcept(bool(value)) == true);
+  }
+
+  {
+    cuda::std::to_chars_result value{nullptr, cuda::std::errc::value_too_large};
+    assert(bool(value) == false);
+    static_assert(noexcept(bool(value)) == true);
+  }
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+  return 0;
+}


### PR DESCRIPTION
This PR implement `<cuda/std/charconv>` classes.

I had also introduce `errc` from `<system_error>` with only those values that are relevant for charconv. We may extend it in the future.