### PR TITLE
Add multi-dimensional support to block_scan routines.

### DIFF
--- a/python/cuda_cooperative/cuda/cooperative/experimental/_common.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/_common.py
@@ -6,7 +6,7 @@ import re
 import tempfile
 from collections import namedtuple
 from enum import Enum
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Tuple, Union
 
 # Import for type checking only
 if TYPE_CHECKING:
@@ -106,11 +106,64 @@ def find_dim3(name, txt):
     )
 
 
-def normalize_dim_param(dim):
-    x = dim[0] if type(dim) is not int else dim
-    y = dim[1] if type(dim) is not int and len(dim) >= 2 else 1
-    z = dim[2] if type(dim) is not int and len(dim) >= 3 else 1
-    return (x, y, z)
+def normalize_dim_param(
+    dim: Union[dim3, int, Tuple[int, int], Tuple[int, int, int]],
+) -> dim3:
+    """
+    Normalize the dim parameter to a `dim3` (x, y, z) instance.
+
+    The logic for this routine is as follows:
+
+    - If the dim is already a `dim3` instance, return it as is.
+    - If the dim is a positive integer, return a 1D `dim3` instance with the
+      integer value as the x-dimension.  If the dim is a negative integer,
+      raise a ValueError.
+    - If the dim is a tuple:
+        - If the tuple has two elements, return a 2D `dim3` instance with the
+          tuple values as the x and y dimensions.  If either value is
+          negative, raise a ValueError.
+        - If the tuple has three elements, return a 3D `dim3` instance with
+          the tuple values as the x, y, and z dimensions.  If any value is
+          negative, raise a ValueError.
+
+    Args:
+        dim: Supplies the dim parameter to normalize.
+
+    Returns:
+        The normalized dim parameter as a `dim3` instance.
+
+    Raises:
+        ValueError: If the dim is invalid.
+
+    """
+    if isinstance(dim, dim3):
+        return dim
+
+    if isinstance(dim, int):
+        if dim < 0:
+            msg = f"Dimension value must be non-negative, got {dim}"
+            raise ValueError(msg)
+        return dim3(dim, 1, 1)
+
+    if isinstance(dim, tuple):
+        if len(dim) == 2:
+            x, y = dim
+            z = 1
+            if x < 0 or y < 0:
+                msg = f"Dimension values must be non-negative, got {dim}"
+                raise ValueError(msg)
+            return dim3(x, y, z)
+        elif len(dim) == 3:
+            x, y, z = dim
+            if x < 0 or y < 0 or z < 0:
+                msg = f"Dimension values must be non-negative, got {dim}"
+                raise ValueError(msg)
+            return dim3(x, y, z)
+        else:
+            msg = f"Tuple dimension must have 2 or 3 elements, got {len(dim)}"
+            raise ValueError(msg)
+
+    raise ValueError(f"Unsupported dimension type: {type(dim)}")
 
 
 def normalize_dtype_param(

--- a/python/cuda_cooperative/cuda/cooperative/experimental/_common.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/_common.py
@@ -6,7 +6,9 @@ import re
 import tempfile
 from collections import namedtuple
 from enum import Enum
-from typing import TYPE_CHECKING, Tuple, Union
+from typing import TYPE_CHECKING, Union
+
+from ._typing import DimType
 
 # Import for type checking only
 if TYPE_CHECKING:
@@ -106,9 +108,7 @@ def find_dim3(name, txt):
     )
 
 
-def normalize_dim_param(
-    dim: Union[dim3, int, Tuple[int, int], Tuple[int, int, int]],
-) -> dim3:
+def normalize_dim_param(dim: DimType) -> dim3:
     """
     Normalize the dim parameter to a `dim3` (x, y, z) instance.
 

--- a/python/cuda_cooperative/cuda/cooperative/experimental/_typing.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/_typing.py
@@ -1,0 +1,12 @@
+# Copyright (c) 2025CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from typing import TYPE_CHECKING, Tuple, Union
+
+if TYPE_CHECKING:
+    from cuda.cooperative.experimental._common import dim3
+
+# Type alias for dimension parameters that can be passed to CUDA functions
+DimType = Union["dim3", int, Tuple[int, int], Tuple[int, int, int]]

--- a/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_scan.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_scan.py
@@ -195,7 +195,61 @@ def exclusive_sum(
     algorithm: Literal["raking", "raking_memoize", "warp_scans"] = "raking",
 ) -> Callable:
     """
-    Computes an exclusive block-wide prefix sum.
+    Computes an exclusive block-wide prefix scan using addition (+) as the
+    scan operator.  The value of 0 is applied as the initial value, and is
+    assigned to the first output element in the first thread.
+
+    Example:
+        The code snippet below illustrates an exclusive prefix sum of 512
+        integer items that are partitioned in a
+        :ref:`blocked arrangement <flexible-data-arrangement>` across 128
+        threads where each thread owns 4 consecutive items.
+
+        .. literalinclude:: ../../python/cuda_cooperative/tests/test_block_scan_api.py
+            :language: python
+            :dedent:
+            :start-after: example-begin imports
+            :end-before: example-end imports
+
+        Below is the code snippet that demonstrates the usage of the
+        ``exclusive_sum`` API:
+
+        .. literalinclude:: ../../python/cuda_cooperative/tests/test_block_scan_api.py
+            :language: python
+            :dedent:
+            :start-after: example-begin exclusive-sum
+            :end-before: example-end exclusive-sum
+
+        Suppose the set of input ``thread_data`` across the block of threads is
+        ``{ [1, 1, 1, 1], [1, 1, 1, 1], ..., [1, 1, 1, 1] }``.
+
+        The corresponding output ``thread_data`` in those threads will be
+        ``{ [0, 1, 2, 3], [4, 5, 6, 7], ..., [508, 509, 510, 511] }``.
+
+    Args:
+        dtype: Supplies the data type of the input and output arrays.
+
+        threads_per_block: Supplies the number of threads in the block, either
+            as an integer for a 1D block or a tuple of two or three integers
+            for a 2D or 3D block, respectively.
+
+        items_per_thread: Supplies the number of items partitioned onto each
+            thread.
+
+        prefix_op: Optionally supplies a callable that will be invoked by the
+            first warp of threads in a block with the block aggregate value;
+            only the return value of the first lane in the warp is applied as
+            the prefix value.
+
+        algorithm: Optionally supplies the algorithm to use for the block-wide
+            scan.  Must be one of the following: ``"raking"``,
+            ``"raking_memoize"``, or ``"warp_scans"``.  The default is
+            ``"raking"``.
+
+    Returns:
+        A callable that can be linked to a CUDA kernel and invoked to perform
+        the block-wide exclusive prefix scan.
+
     """
     return _scan(
         dtype=dtype,
@@ -216,7 +270,32 @@ def inclusive_sum(
     algorithm: Literal["raking", "raking_memoize", "warp_scans"] = "raking",
 ) -> Callable:
     """
-    Computes an inclusive block-wide prefix sum.
+    Computes an inclusive block-wide prefix scan using addition (+) as the
+    scan operator.
+
+    Args:
+        dtype: Supplies the data type of the input and output arrays.
+
+        threads_per_block: Supplies the number of threads in the block, either
+            as an integer for a 1D block or a tuple of two or three integers
+            for a 2D or 3D block, respectively.
+
+        items_per_thread: Supplies the number of items partitioned onto each
+            thread.
+
+        prefix_op: Optionally supplies a callable that will be invoked by the
+            first warp of threads in a block with the block aggregate value;
+            only the return value of the first lane in the warp is applied as
+            the prefix value.
+
+        algorithm: Optionally supplies the algorithm to use for the block-wide
+            scan.  Must be one of the following: ``"raking"``,
+            ``"raking_memoize"``, or ``"warp_scans"``.  The default is
+            ``"raking"``.
+
+    Returns:
+        A callable that can be linked to a CUDA kernel and invoked to perform
+        the block-wide inclusive prefix scan.
     """
     return _scan(
         dtype=dtype,

--- a/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_scan.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_scan.py
@@ -22,6 +22,7 @@ from cuda.cooperative.experimental._types import (
     Pointer,
     TemplateParameter,
 )
+from cuda.cooperative.experimental._typing import DimType
 
 if TYPE_CHECKING:
     import numpy as np
@@ -29,7 +30,7 @@ if TYPE_CHECKING:
 
 def _scan(
     dtype: Union[str, type, "np.dtype", "numba.types.Type"],
-    threads_per_block: int,
+    threads_per_block: DimType,
     items_per_thread: int = 1,
     mode: Literal["exclusive", "inclusive"] = "exclusive",
     scan_op: Literal["+"] = "+",
@@ -189,7 +190,7 @@ def _scan(
 
 def exclusive_sum(
     dtype: Union[str, type, "np.dtype", "numba.types.Type"],
-    threads_per_block: int,
+    threads_per_block: DimType,
     items_per_thread: int = 1,
     prefix_op: Callable = None,
     algorithm: Literal["raking", "raking_memoize", "warp_scans"] = "raking",
@@ -264,7 +265,7 @@ def exclusive_sum(
 
 def inclusive_sum(
     dtype: Union[str, type, "np.dtype", "numba.types.Type"],
-    threads_per_block: int,
+    threads_per_block: DimType,
     items_per_thread: int = 1,
     prefix_op: Callable = None,
     algorithm: Literal["raking", "raking_memoize", "warp_scans"] = "raking",

--- a/python/cuda_cooperative/tests/test_block_load.py
+++ b/python/cuda_cooperative/tests/test_block_load.py
@@ -18,7 +18,7 @@ numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
 
 
 @pytest.mark.parametrize("T", [types.int8, types.int16, types.uint32, types.uint64])
-@pytest.mark.parametrize("threads_per_block", [32, 128, 256, (4, 8), (2, 4, 8)])
+@pytest.mark.parametrize("threads_per_block", [32, 128, 256, (8, 16), (2, 4, 8)])
 @pytest.mark.parametrize("items_per_thread", [1, 3])
 @pytest.mark.parametrize(
     "algorithm",

--- a/python/cuda_cooperative/tests/test_block_merge_sort.py
+++ b/python/cuda_cooperative/tests/test_block_merge_sort.py
@@ -19,7 +19,7 @@ numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
 
 
 @pytest.mark.parametrize("T", [types.int8, types.int16, types.uint32, types.uint64])
-@pytest.mark.parametrize("threads_per_block", [32, 128, 256, 1024, (4, 8), (2, 4, 8)])
+@pytest.mark.parametrize("threads_per_block", [32, 128, 256, 1024, (8, 16), (2, 4, 8)])
 @pytest.mark.parametrize("items_per_thread", [1, 3])
 def test_block_merge_sort(T, threads_per_block, items_per_thread):
     def op(a, b):
@@ -71,7 +71,7 @@ def test_block_merge_sort(T, threads_per_block, items_per_thread):
 
 
 @pytest.mark.parametrize("T", [types.int8, types.int16, types.uint32, types.uint64])
-@pytest.mark.parametrize("threads_per_block", [32, 128, 256, 1024, (4, 8), (2, 4, 8)])
+@pytest.mark.parametrize("threads_per_block", [32, 128, 256, 1024, (8, 16), (2, 4, 8)])
 @pytest.mark.parametrize("items_per_thread", [1, 3])
 def test_block_merge_sort_descending(T, threads_per_block, items_per_thread):
     def op(a, b):

--- a/python/cuda_cooperative/tests/test_block_radix_sort.py
+++ b/python/cuda_cooperative/tests/test_block_radix_sort.py
@@ -18,7 +18,7 @@ numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
 
 
 @pytest.mark.parametrize("T", [types.int8, types.int16, types.uint32, types.uint64])
-@pytest.mark.parametrize("threads_per_block", [32, 128, 256, 1024, (4, 8), (2, 4, 8)])
+@pytest.mark.parametrize("threads_per_block", [32, 128, 256, 1024, (8, 16), (2, 4, 8)])
 @pytest.mark.parametrize("items_per_thread", [1, 3])
 def test_block_radix_sort_descending(T, threads_per_block, items_per_thread):
     begin_bit = numba.int32(0)
@@ -67,7 +67,7 @@ def test_block_radix_sort_descending(T, threads_per_block, items_per_thread):
 
 
 @pytest.mark.parametrize("T", [types.int8, types.int16, types.uint32, types.uint64])
-@pytest.mark.parametrize("threads_per_block", [32, 128, 256, 1024, (4, 8), (2, 4, 8)])
+@pytest.mark.parametrize("threads_per_block", [32, 128, 256, 1024, (8, 16), (2, 4, 8)])
 @pytest.mark.parametrize("items_per_thread", [1, 3])
 def test_block_radix_sort(T, threads_per_block, items_per_thread):
     items_per_tile = (

--- a/python/cuda_cooperative/tests/test_block_scan.py
+++ b/python/cuda_cooperative/tests/test_block_scan.py
@@ -31,7 +31,7 @@ patch.patch_numba_linker(lto=True)
 
 @pytest.mark.parametrize("T", [types.uint32, types.uint64])
 @pytest.mark.parametrize(
-    "threads_per_block", [32, 64, 128, 256, 512, 1024, (2, 4), (2, 4, 8)]
+    "threads_per_block", [32, 64, 128, 256, 512, 1024, (8, 16), (2, 4, 8)]
 )
 @pytest.mark.parametrize("items_per_thread", [1, 2, 3, 4])
 @pytest.mark.parametrize("mode", ["inclusive", "exclusive"])
@@ -153,7 +153,7 @@ def impl_block_prefix_callback_op(context, builder, sig, args):
 
 
 @pytest.mark.parametrize(
-    "threads_per_block", [32, 64, 128, 256, 512, 1024, (2, 4), (2, 4, 8)]
+    "threads_per_block", [32, 64, 128, 256, 512, 1024, (8, 16), (2, 4, 8)]
 )
 @pytest.mark.parametrize("items_per_thread", [1, 2, 3, 4])
 @pytest.mark.parametrize("mode", ["inclusive", "exclusive"])
@@ -277,7 +277,7 @@ def test_block_sum_prefix(threads_per_block, items_per_thread, mode, algorithm):
 
 
 @pytest.mark.parametrize(
-    "threads_per_block", [32, 64, 128, 256, 512, 1024, (2, 4), (2, 4, 8)]
+    "threads_per_block", [32, 64, 128, 256, 512, 1024, (8, 16), (2, 4, 8)]
 )
 @pytest.mark.parametrize("items_per_thread", [0, -1, -127])
 @pytest.mark.parametrize("mode", ["inclusive", "exclusive"])

--- a/python/cuda_cooperative/tests/test_block_scan.py
+++ b/python/cuda_cooperative/tests/test_block_scan.py
@@ -2,10 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+from functools import reduce
+from operator import mul
+
 import numba
 import numpy as np
 import pytest
-from helpers import NUMBA_TYPES_TO_NP, random_int
+from helpers import NUMBA_TYPES_TO_NP, random_int, row_major_tid
 from numba import cuda, types
 from numba.core import cgutils
 from numba.core.extending import (
@@ -27,12 +30,20 @@ patch.patch_numba_linker(lto=True)
 
 
 @pytest.mark.parametrize("T", [types.uint32, types.uint64])
-@pytest.mark.parametrize("threads_per_block", [32, 64, 128, 256, 512, 1024])
+@pytest.mark.parametrize(
+    "threads_per_block", [32, 64, 128, 256, 512, 1024, (2, 4), (2, 4, 8)]
+)
 @pytest.mark.parametrize("items_per_thread", [1, 2, 3, 4])
 @pytest.mark.parametrize("mode", ["inclusive", "exclusive"])
 @pytest.mark.parametrize("algorithm", ["raking", "raking_memoize", "warp_scans"])
 def test_block_sum(T, threads_per_block, items_per_thread, mode, algorithm):
-    if algorithm == "raking_memoize" and threads_per_block >= 512:
+    num_threads_per_block = (
+        threads_per_block
+        if isinstance(threads_per_block, int)
+        else reduce(mul, threads_per_block)
+    )
+
+    if algorithm == "raking_memoize" and num_threads_per_block >= 512:
         # We can hit CUDA_ERROR_LAUNCH_OUT_OF_RESOURCES with raking_memoize in
         # certain configurations, e.g.: 1024 threads_per_block, or 512
         # threads_per_block, 3 items_per_thread, and T == uint64, etc.
@@ -53,7 +64,7 @@ def test_block_sum(T, threads_per_block, items_per_thread, mode, algorithm):
 
     @cuda.jit(link=block_sum.files)
     def kernel(input, output):
-        tid = cuda.threadIdx.x
+        tid = row_major_tid()
         temp_storage = cuda.shared.array(shape=temp_storage_bytes, dtype="uint8")
         thread_data = cuda.local.array(shape=items_per_thread, dtype=T)
         for i in range(items_per_thread):
@@ -66,7 +77,7 @@ def test_block_sum(T, threads_per_block, items_per_thread, mode, algorithm):
             output[tid * items_per_thread + i] = thread_data[i]
 
     dtype_np = NUMBA_TYPES_TO_NP[T]
-    items_per_tile = threads_per_block * items_per_thread
+    items_per_tile = num_threads_per_block * items_per_thread
     h_input = random_int(items_per_tile, dtype_np)
     d_input = cuda.to_device(h_input)
     d_output = cuda.device_array(items_per_tile, dtype=dtype_np)
@@ -141,18 +152,26 @@ def impl_block_prefix_callback_op(context, builder, sig, args):
     return state._getvalue()
 
 
-@pytest.mark.parametrize("threads_per_block", [32, 64, 128, 256, 512, 1024])
+@pytest.mark.parametrize(
+    "threads_per_block", [32, 64, 128, 256, 512, 1024, (2, 4), (2, 4, 8)]
+)
 @pytest.mark.parametrize("items_per_thread", [1, 2, 3, 4])
 @pytest.mark.parametrize("mode", ["inclusive", "exclusive"])
 @pytest.mark.parametrize("algorithm", ["raking", "raking_memoize", "warp_scans"])
 def test_block_sum_prefix(threads_per_block, items_per_thread, mode, algorithm):
-    if algorithm == "raking_memoize" and threads_per_block >= 512:
+    num_threads_per_block = (
+        threads_per_block
+        if isinstance(threads_per_block, int)
+        else reduce(mul, threads_per_block)
+    )
+
+    if algorithm == "raking_memoize" and num_threads_per_block >= 512:
         # We can hit CUDA_ERROR_LAUNCH_OUT_OF_RESOURCES with raking_memoize in
         # certain configurations, e.g.: 1024 threads_per_block, or 512
         # threads_per_block, 3 items_per_thread, and T == uint64, etc.
         pytest.skip("raking_memoize: skipping threads_per_block >= 512")
 
-    tile_items = threads_per_block * items_per_thread
+    tile_items = num_threads_per_block * items_per_thread
     segment_size = 2 * 1024
     num_segments = 128
     num_elements = segment_size * num_segments
@@ -184,11 +203,12 @@ def test_block_sum_prefix(threads_per_block, items_per_thread, mode, algorithm):
         thread_input = cuda.local.array(shape=items_per_thread, dtype="int32")
         thread_output = cuda.local.array(shape=items_per_thread, dtype="int32")
 
+        tid = row_major_tid()
         tile_offset = 0
 
         while tile_offset < segment_size:
             for item in range(items_per_thread):
-                item_offset = tile_offset + cuda.threadIdx.x * items_per_thread + item
+                item_offset = tile_offset + tid * items_per_thread + item
                 thread_input[item] = (
                     input[segment_offset + item_offset]
                     if item_offset < segment_size
@@ -203,7 +223,7 @@ def test_block_sum_prefix(threads_per_block, items_per_thread, mode, algorithm):
                 block_sum(temp_storage, thread_input, thread_output, block_prefix_op)
 
             for item in range(items_per_thread):
-                item_offset = tile_offset + cuda.threadIdx.x * items_per_thread + item
+                item_offset = tile_offset + tid * items_per_thread + item
                 if item_offset < segment_size:
                     output[segment_offset + item_offset] = thread_output[item]
 
@@ -256,7 +276,9 @@ def test_block_sum_prefix(threads_per_block, items_per_thread, mode, algorithm):
     assert "STL" not in sass
 
 
-@pytest.mark.parametrize("threads_per_block", [32, 64, 128, 256, 512, 1024])
+@pytest.mark.parametrize(
+    "threads_per_block", [32, 64, 128, 256, 512, 1024, (2, 4), (2, 4, 8)]
+)
 @pytest.mark.parametrize("items_per_thread", [0, -1, -127])
 @pytest.mark.parametrize("mode", ["inclusive", "exclusive"])
 def test_block_scan_exclusive_sum_invalid_items_per_thread(

--- a/python/cuda_cooperative/tests/test_block_store.py
+++ b/python/cuda_cooperative/tests/test_block_store.py
@@ -18,7 +18,7 @@ numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
 
 
 @pytest.mark.parametrize("T", [types.int8, types.int16, types.uint32, types.uint64])
-@pytest.mark.parametrize("threads_per_block", [32, 128, 256, (4, 8), (2, 4, 8)])
+@pytest.mark.parametrize("threads_per_block", [32, 128, 256, (8, 16), (2, 4, 8)])
 @pytest.mark.parametrize("items_per_thread", [1, 3])
 @pytest.mark.parametrize(
     "algorithm",


### PR DESCRIPTION
This is the final PR in the set of multi-dimensional support changes.  It adds multi-dim support to the exclusive_sum and inclusive_sum routines of block_scan.  I've also added back in docstrings for both routines.  Tests have been updated accordingly.