### PR TITLE
[CUDAX] Remove all_devices.at() and add bounds checks to operator[]

### DIFF
--- a/cudax/include/cuda/experimental/__device/all_devices.cuh
+++ b/cudax/include/cuda/experimental/__device/all_devices.cuh
@@ -43,9 +43,7 @@ public:
 
   all_devices() = default;
 
-  [[nodiscard]] const device& operator[](size_type __i) const noexcept;
-
-  [[nodiscard]] const device& at(size_type __i) const;
+  [[nodiscard]] const device& operator[](size_type __i) const;
 
   [[nodiscard]] size_type size() const;
 
@@ -111,16 +109,11 @@ struct all_devices::__initializer_iterator
   }
 };
 
-[[nodiscard]] inline const device& all_devices::operator[](size_type __id_) const noexcept
-{
-  _CCCL_ASSERT(__id_ < size(), "cuda::experimental::all_devices::subscript device index out of range");
-  return __devices()[__id_];
-}
-
-[[nodiscard]] inline const device& all_devices::at(size_type __id_) const
+[[nodiscard]] inline const device& all_devices::operator[](size_type __id_) const
 {
   if (__id_ >= size())
   {
+    printf("device index out of range: %ld\n", __id_);
     _CUDA_VSTD::__throw_out_of_range("device index out of range");
   }
   return __devices()[__id_];

--- a/cudax/include/cuda/experimental/__device/all_devices.cuh
+++ b/cudax/include/cuda/experimental/__device/all_devices.cuh
@@ -113,8 +113,7 @@ struct all_devices::__initializer_iterator
 {
   if (__id_ >= size())
   {
-    printf("device index out of range: %ld\n", __id_);
-    _CUDA_VSTD::__throw_out_of_range("device index out of range");
+    _CUDA_VSTD::__throw_out_of_range("device index out of range: " + std::to_string(__id_));
   }
   return __devices()[__id_];
 }

--- a/cudax/include/cuda/experimental/__device/all_devices.cuh
+++ b/cudax/include/cuda/experimental/__device/all_devices.cuh
@@ -113,7 +113,15 @@ struct all_devices::__initializer_iterator
 {
   if (__id_ >= size())
   {
-    _CUDA_VSTD::__throw_out_of_range("device index out of range: " + std::to_string(__id_));
+    if (size() == 0)
+    {
+      _CUDA_VSTD::__throw_out_of_range("device was requested but no CUDA devices found");
+    }
+    else
+    {
+      _CUDA_VSTD::__throw_out_of_range(
+        (::std::string("device index out of range: ") + ::std::to_string(__id_)).c_str());
+    }
   }
   return __devices()[__id_];
 }

--- a/cudax/test/device/device_smoke.cu
+++ b/cudax/test/device/device_smoke.cu
@@ -327,7 +327,7 @@ TEST_CASE("global devices vector", "[device]")
 
   try
   {
-    [[maybe_unused]] const cudax::device& dev = cudax::devices.at(cudax::devices.size());
+    [[maybe_unused]] const cudax::device& dev = cudax::devices[cudax::devices.size()];
     CUDAX_REQUIRE(false); // should not get here
   }
   catch (const std::out_of_range&)


### PR DESCRIPTION
~~CUDA has two modes of initialization failure.
First one is when all APIs return an error like system not ready or version mismatch.
Second one is more subtle and happens when initialization of all devices in the system fails and CUDA reports device count of 0, without an explicit error.~~

Edit: I misremembered, if device count would be 0, CUDA_ERROR_NO_DEVICE (100) is returned. But I think we should still do this change.

In cudax we don't check for out of bounds device id with the `all_devices` type and can easily segfault in `operator[]`. Technically the current design is correct, we provide vector-like interface with `.at()` that have bounds checking and `operator[]` without bounds checking where user is supposed to make sure ahead of time that the number of devices matches what the code expects to not access out of bounds.
The problem is that CUDA historically does these bounds checking for you, for example when a device is set current. From the usage so far (even in our testing) we didn't follow the convention described above.

Access to the `all_devices` type through `operator[]` should not be very common or frequent in performance critical parts and the bounds check cost is low. In order to make handling of out of bounds devices this PR removes `all_devices.at()` and instead adds the bounds checks to `operator[]`.