### PR TITLE
Use more libcu++ includes in thrust

### DIFF
--- a/thrust/thrust/allocate_unique.h
+++ b/thrust/thrust/allocate_unique.h
@@ -46,7 +46,7 @@ struct allocator_delete final
   {}
   template <typename U, typename UAllocator>
   allocator_delete(allocator_delete<U, UAllocator>&& other) noexcept
-      : alloc_(std::move(other.get_allocator()))
+      : alloc_(::cuda::std::move(other.get_allocator()))
   {}
 
   template <typename U, typename UAllocator>
@@ -58,7 +58,7 @@ struct allocator_delete final
   template <typename U, typename UAllocator>
   allocator_delete& operator=(allocator_delete<U, UAllocator>&& other) noexcept
   {
-    alloc_ = std::move(other.get_allocator());
+    alloc_ = ::cuda::std::move(other.get_allocator());
     return *this;
   }
 
@@ -119,7 +119,7 @@ struct array_allocator_delete final
   {}
   template <typename U, typename UAllocator>
   array_allocator_delete(array_allocator_delete<U, UAllocator>&& other) noexcept
-      : alloc_(std::move(other.get_allocator()))
+      : alloc_(::cuda::std::move(other.get_allocator()))
       , count_(other.count_)
   {}
 
@@ -133,7 +133,7 @@ struct array_allocator_delete final
   template <typename U, typename UAllocator>
   array_allocator_delete& operator=(array_allocator_delete<U, UAllocator>&& other) noexcept
   {
-    alloc_ = std::move(other.get_allocator());
+    alloc_ = ::cuda::std::move(other.get_allocator());
     count_ = other.count_;
     return *this;
   }
@@ -218,7 +218,7 @@ allocate_unique(Allocator const& alloc, Args&&... args)
 
   traits::construct(alloc_T, thrust::raw_pointer_cast(hold.get()), THRUST_FWD(args)...);
   auto deleter = allocator_delete<T, typename traits::allocator_type>(alloc);
-  return std::unique_ptr<T, decltype(deleter)>(hold.release(), std::move(deleter));
+  return std::unique_ptr<T, decltype(deleter)>(hold.release(), ::cuda::std::move(deleter));
 }
 
 //! Creates a \p std::unique_ptr holding storage for a new object of type \p T without constructing it, using \p alloc
@@ -242,7 +242,7 @@ uninitialized_allocate_unique(Allocator const& alloc)
   auto hold         = hold_t(traits::allocate(alloc_T, 1), hold_deleter);
 
   auto deleter = uninitialized_allocator_delete<T, typename traits::allocator_type>(alloc_T);
-  return std::unique_ptr<T, decltype(deleter)>(hold.release(), std::move(deleter));
+  return std::unique_ptr<T, decltype(deleter)>(hold.release(), ::cuda::std::move(deleter));
 }
 
 //! Creates a \p std::unique_ptr holding an array of objects of type \p T, each one constructed with \p args, using \p
@@ -267,7 +267,7 @@ allocate_unique_n(Allocator const& alloc, Size n, Args&&... args)
 
   uninitialized_construct_n_with_allocator(alloc_T, hold.get(), n, THRUST_FWD(args)...);
   auto deleter = array_allocator_delete<T, typename traits::allocator_type>(alloc_T, n);
-  return std::unique_ptr<T[], decltype(deleter)>(hold.release(), std::move(deleter));
+  return std::unique_ptr<T[], decltype(deleter)>(hold.release(), ::cuda::std::move(deleter));
 }
 
 //! Creates a \p std::unique_ptr holding storage for an array of objects of type \p T without constructing them, using
@@ -291,7 +291,7 @@ uninitialized_allocate_unique_n(Allocator const& alloc, Size n)
   auto hold         = hold_t(traits::allocate(alloc_T, n), hold_deleter);
 
   auto deleter = uninitialized_array_allocator_delete<T, typename traits::allocator_type>(alloc_T, n);
-  return std::unique_ptr<T[], decltype(deleter)>(hold.release(), std::move(deleter));
+  return std::unique_ptr<T[], decltype(deleter)>(hold.release(), ::cuda::std::move(deleter));
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/thrust/thrust/complex.h
+++ b/thrust/thrust/complex.h
@@ -34,9 +34,12 @@
 #include <thrust/detail/type_traits.h>
 #include <thrust/type_traits/is_trivially_relocatable.h>
 
-#include <cmath>
-#include <complex>
-#include <sstream>
+#include <cuda/std/cmath>
+
+#if !_CCCL_COMPILER(NVRTC)
+#  include <complex>
+#  include <sstream>
+#endif // !_CCCL_COMPILER(NVRTC)
 
 #define THRUST_STD_COMPLEX_REAL(z) \
   reinterpret_cast<const typename ::cuda::std::remove_reference_t<decltype(z)>::value_type(&)[2]>(z)[0]
@@ -113,12 +116,13 @@ public:
   template <typename U>
   _CCCL_HOST_DEVICE complex(const complex<U>& z);
 
+#if !_CCCL_COMPILER(NVRTC)
   /*! This converting copy constructor copies from a <tt>std::complex</tt> with
    *  a type that is convertible to this \p complex's \c value_type.
    *
    *  \param z The \p complex to copy from.
    */
-  _CCCL_HOST THRUST_STD_COMPLEX_DEVICE complex(const std::complex<T>& z);
+  _CCCL_HOST THRUST_STD_COMPLEX_DEVICE complex(const ::std::complex<T>& z);
 
   /*! This converting copy constructor copies from a <tt>std::complex</tt> with
    *  a type that is convertible to this \p complex's \c value_type.
@@ -128,7 +132,8 @@ public:
    *  \tparam U is convertible to \c value_type.
    */
   template <typename U>
-  _CCCL_HOST THRUST_STD_COMPLEX_DEVICE complex(const std::complex<U>& z);
+  _CCCL_HOST THRUST_STD_COMPLEX_DEVICE complex(const ::std::complex<U>& z);
+#endif // !_CCCL_COMPILER(NVRTC)
 
   /* --- Assignment Operators --- */
 
@@ -156,12 +161,13 @@ public:
   template <typename U>
   _CCCL_HOST_DEVICE complex& operator=(const complex<U>& z);
 
+#if !_CCCL_COMPILER(NVRTC)
   /*! Assign `z.real()` and `z.imag()` to the real and imaginary parts of this
    *  \p complex respectively.
    *
    *  \param z The \p complex to copy from.
    */
-  _CCCL_HOST THRUST_STD_COMPLEX_DEVICE complex& operator=(const std::complex<T>& z);
+  _CCCL_HOST THRUST_STD_COMPLEX_DEVICE complex& operator=(const ::std::complex<T>& z);
 
   /*! Assign `z.real()` and `z.imag()` to the real and imaginary parts of this
    *  \p complex respectively.
@@ -171,7 +177,8 @@ public:
    *  \tparam U is convertible to \c value_type.
    */
   template <typename U>
-  _CCCL_HOST THRUST_STD_COMPLEX_DEVICE complex& operator=(const std::complex<U>& z);
+  _CCCL_HOST THRUST_STD_COMPLEX_DEVICE complex& operator=(const ::std::complex<U>& z);
+#endif // !_CCCL_COMPILER(NVRTC)
 
   /* --- Compound Assignment Operators --- */
 
@@ -329,14 +336,16 @@ public:
     data.y = im;
   }
 
+#if !_CCCL_COMPILER(NVRTC)
   /* --- Casting functions --- */
 
   /*! Casts this \p complex to a <tt>std::complex</tt> of the same type.
    */
-  _CCCL_HOST operator std::complex<T>() const
+  _CCCL_HOST operator ::std::complex<T>() const
   {
-    return std::complex<T>(real(), imag());
+    return ::std::complex<T>(real(), imag());
   }
+#endif // !_CCCL_COMPILER(NVRTC)
 
 private:
   struct alignas(sizeof(T) * 2) storage
@@ -718,6 +727,7 @@ _CCCL_HOST_DEVICE complex<T> asinh(const complex<T>& z);
 template <typename T>
 _CCCL_HOST_DEVICE complex<T> atanh(const complex<T>& z);
 
+#if !_CCCL_COMPILER(NVRTC)
 /* --- Stream Operators --- */
 
 /*! Writes to an output stream a \p complex number in the form (real, imaginary).
@@ -741,7 +751,8 @@ std::basic_ostream<CharT, Traits>& operator<<(std::basic_ostream<CharT, Traits>&
  *  \param z The \p complex number to set.
  */
 template <typename T, typename CharT, typename Traits>
-_CCCL_HOST std::basic_istream<CharT, Traits>& operator>>(std::basic_istream<CharT, Traits>& is, complex<T>& z);
+_CCCL_HOST ::std::basic_istream<CharT, Traits>& operator>>(std::basic_istream<CharT, Traits>& is, complex<T>& z);
+#endif // !_CCCL_COMPILER(NVRTC)
 
 /* --- Equality Operators --- */
 
@@ -753,13 +764,14 @@ _CCCL_HOST std::basic_istream<CharT, Traits>& operator>>(std::basic_istream<Char
 template <typename T0, typename T1>
 _CCCL_HOST_DEVICE bool operator==(const complex<T0>& x, const complex<T1>& y);
 
+#if !_CCCL_COMPILER(NVRTC)
 /*! Returns true if two \p complex numbers are equal and false otherwise.
  *
  *  \param x The first \p complex.
  *  \param y The second \p complex.
  */
 template <typename T0, typename T1>
-_CCCL_HOST THRUST_STD_COMPLEX_DEVICE bool operator==(const complex<T0>& x, const std::complex<T1>& y);
+_CCCL_HOST THRUST_STD_COMPLEX_DEVICE bool operator==(const complex<T0>& x, const ::std::complex<T1>& y);
 
 /*! Returns true if two \p complex numbers are equal and false otherwise.
  *
@@ -767,7 +779,8 @@ _CCCL_HOST THRUST_STD_COMPLEX_DEVICE bool operator==(const complex<T0>& x, const
  *  \param y The second \p complex.
  */
 template <typename T0, typename T1>
-_CCCL_HOST THRUST_STD_COMPLEX_DEVICE bool operator==(const std::complex<T0>& x, const complex<T1>& y);
+_CCCL_HOST THRUST_STD_COMPLEX_DEVICE bool operator==(const ::std::complex<T0>& x, const complex<T1>& y);
+#endif // !_CCCL_COMPILER(NVRTC)
 
 /*! Returns true if the imaginary part of the \p complex number is zero and
  *  the real part is equal to the scalar. Returns false otherwise.
@@ -795,13 +808,14 @@ _CCCL_HOST_DEVICE bool operator==(const complex<T0>& x, const T1& y);
 template <typename T0, typename T1>
 _CCCL_HOST_DEVICE bool operator!=(const complex<T0>& x, const complex<T1>& y);
 
+#if !_CCCL_COMPILER(NVRTC)
 /*! Returns true if two \p complex numbers are different and false otherwise.
  *
  *  \param x The first \p complex.
  *  \param y The second \p complex.
  */
 template <typename T0, typename T1>
-_CCCL_HOST THRUST_STD_COMPLEX_DEVICE bool operator!=(const complex<T0>& x, const std::complex<T1>& y);
+_CCCL_HOST THRUST_STD_COMPLEX_DEVICE bool operator!=(const complex<T0>& x, const ::std::complex<T1>& y);
 
 /*! Returns true if two \p complex numbers are different and false otherwise.
  *
@@ -809,7 +823,8 @@ _CCCL_HOST THRUST_STD_COMPLEX_DEVICE bool operator!=(const complex<T0>& x, const
  *  \param y The second \p complex.
  */
 template <typename T0, typename T1>
-_CCCL_HOST THRUST_STD_COMPLEX_DEVICE bool operator!=(const std::complex<T0>& x, const complex<T1>& y);
+_CCCL_HOST THRUST_STD_COMPLEX_DEVICE bool operator!=(const ::std::complex<T0>& x, const complex<T1>& y);
+#endif // !_CCCL_COMPILER(NVRTC)
 
 /*! Returns true if the imaginary part of the \p complex number is not zero or
  *  the real part is different from the scalar. Returns false otherwise.

--- a/thrust/thrust/detail/allocator/tagged_allocator.inl
+++ b/thrust/thrust/detail/allocator/tagged_allocator.inl
@@ -27,7 +27,7 @@
 #endif // no system header
 #include <thrust/detail/allocator/tagged_allocator.h>
 
-#include <limits>
+#include <cuda/std/limits>
 
 THRUST_NAMESPACE_BEGIN
 namespace detail
@@ -67,7 +67,7 @@ tagged_allocator<T, Tag, Pointer>::address(const_reference x) const
 template <typename T, typename Tag, typename Pointer>
 typename tagged_allocator<T, Tag, Pointer>::size_type tagged_allocator<T, Tag, Pointer>::max_size() const
 {
-  return (std::numeric_limits<size_type>::max)() / sizeof(T);
+  return (::cuda::std::numeric_limits<size_type>::max)() / sizeof(T);
 }
 
 template <typename T1, typename Pointer1, typename T2, typename Pointer2, typename Tag>

--- a/thrust/thrust/detail/allocator/temporary_allocator.inl
+++ b/thrust/thrust/detail/allocator/temporary_allocator.inl
@@ -29,7 +29,7 @@
 #include <thrust/detail/temporary_buffer.h>
 #include <thrust/system/detail/bad_alloc.h>
 
-#include <cassert>
+#include <cuda/std/cassert>
 
 #include <nv/target>
 

--- a/thrust/thrust/detail/complex/arithmetic.h
+++ b/thrust/thrust/detail/complex/arithmetic.h
@@ -22,8 +22,8 @@
 #include <thrust/complex.h>
 #include <thrust/detail/complex/c99math.h>
 
-#include <cfloat>
-#include <cmath>
+#include <cuda/std/cfloat>
+#include <cuda/std/cmath>
 
 THRUST_NAMESPACE_BEGIN
 

--- a/thrust/thrust/detail/complex/c99math.h
+++ b/thrust/thrust/detail/complex/c99math.h
@@ -20,7 +20,7 @@
 
 #include <thrust/detail/complex/math_private.h>
 
-#include <cmath>
+#include <cuda/std/cmath>
 
 #include <math.h>
 
@@ -37,182 +37,25 @@ namespace complex
 // Some platforms define these as macros, others as free functions.
 // Avoid using the std:: form of these as nvcc may treat std::foo() as __host__ functions.
 
-using ::acos;
-using ::asin;
-using ::atan;
-using ::cos;
-using ::cosh;
-using ::exp;
-using ::log;
-using ::sin;
-using ::sinh;
-using ::sqrt;
-using ::tan;
-
-template <typename T>
-inline _CCCL_HOST_DEVICE T infinity();
-
-template <>
-inline _CCCL_HOST_DEVICE float infinity<float>()
-{
-  float res;
-  set_float_word(res, 0x7f800000);
-  return res;
-}
-
-template <>
-inline _CCCL_HOST_DEVICE double infinity<double>()
-{
-  double res;
-  insert_words(res, 0x7ff00000, 0);
-  return res;
-}
-
-#if defined _MSC_VER
-_CCCL_HOST_DEVICE inline int isinf(float x)
-{
-  return std::abs(x) == infinity<float>();
-}
-
-_CCCL_HOST_DEVICE inline int isinf(double x)
-{
-  return std::abs(x) == infinity<double>();
-}
-
-_CCCL_HOST_DEVICE inline int isnan(float x)
-{
-  return x != x;
-}
-
-_CCCL_HOST_DEVICE inline int isnan(double x)
-{
-  return x != x;
-}
-
-_CCCL_HOST_DEVICE inline int signbit(float x)
-{
-  return ((*((uint32_t*) &x)) & 0x80000000) != 0 ? 1 : 0;
-}
-
-_CCCL_HOST_DEVICE inline int signbit(double x)
-{
-  return ((*((uint64_t*) &x)) & 0x8000000000000000) != 0ull ? 1 : 0;
-}
-
-_CCCL_HOST_DEVICE inline int isfinite(float x)
-{
-  return !isnan(x) && !isinf(x);
-}
-
-_CCCL_HOST_DEVICE inline int isfinite(double x)
-{
-  return !isnan(x) && !isinf(x);
-}
-
-#else
-
-#  if defined(__CUDACC__) && !(defined(__CUDA__) && defined(__clang__)) && !defined(_NVHPC_CUDA)
-// NVCC implements at least some signature of these as functions not macros.
-using ::isfinite;
-using ::isinf;
-using ::isnan;
-using ::signbit;
-#  else
-// Some compilers do not provide these in the global scope, because they are
-// supposed to be macros. The versions in `std` are supposed to be functions.
-// Since we're not compiling with nvcc, it's safe to use the functions in std::
-using std::isfinite;
-using std::isinf;
-using std::isnan;
-using std::signbit;
-#  endif // __CUDACC__
-#endif // _MSC_VER
-
-using ::atanh;
-
-#if defined _MSC_VER
-
-_CCCL_HOST_DEVICE inline double copysign(double x, double y)
-{
-  uint32_t hx, hy;
-  get_high_word(hx, x);
-  get_high_word(hy, y);
-  set_high_word(x, (hx & 0x7fffffff) | (hy & 0x80000000));
-  return x;
-}
-
-_CCCL_HOST_DEVICE inline float copysignf(float x, float y)
-{
-  uint32_t ix, iy;
-  get_float_word(ix, x);
-  get_float_word(iy, y);
-  set_float_word(x, (ix & 0x7fffffff) | (iy & 0x80000000));
-  return x;
-}
-
-#  if !defined(__CUDACC__) && !defined(_NVHPC_CUDA)
-
-// Simple approximation to log1p as Visual Studio is lacking one
-inline double log1p(double x)
-{
-  double u = 1.0 + x;
-  if (u == 1.0)
-  {
-    return x;
-  }
-  else
-  {
-    if (u > 2.0)
-    {
-      // Use normal log for large arguments
-      return log(u);
-    }
-    else
-    {
-      return log(u) * (x / (u - 1.0));
-    }
-  }
-}
-
-inline float log1pf(float x)
-{
-  float u = 1.0f + x;
-  if (u == 1.0f)
-  {
-    return x;
-  }
-  else
-  {
-    if (u > 2.0f)
-    {
-      // Use normal log for large arguments
-      return logf(u);
-    }
-    else
-    {
-      return logf(u) * (x / (u - 1.0f));
-    }
-  }
-}
-
-#    if _MSV_VER <= 1500
-#      include <complex>
-
-inline float hypotf(float x, float y)
-{
-  return abs(std::complex<float>(x, y));
-}
-
-inline double hypot(double x, double y)
-{
-  return _hypot(x, y);
-}
-
-#    endif // _MSC_VER <= 1500
-
-#  endif // __CUDACC__
-
-#endif // _MSC_VER
+using ::cuda::std::acos;
+using ::cuda::std::asin;
+using ::cuda::std::atan;
+using ::cuda::std::atanh;
+using ::cuda::std::copysign;
+using ::cuda::std::cos;
+using ::cuda::std::cosh;
+using ::cuda::std::exp;
+using ::cuda::std::hypot;
+using ::cuda::std::isfinite;
+using ::cuda::std::isinf;
+using ::cuda::std::isnan;
+using ::cuda::std::log;
+using ::cuda::std::log1p;
+using ::cuda::std::signbit;
+using ::cuda::std::sin;
+using ::cuda::std::sinh;
+using ::cuda::std::sqrt;
+using ::cuda::std::tan;
 
 } // namespace complex
 

--- a/thrust/thrust/detail/complex/catrig.h
+++ b/thrust/thrust/detail/complex/catrig.h
@@ -53,8 +53,9 @@
 #include <thrust/complex.h>
 #include <thrust/detail/complex/math_private.h>
 
-#include <cfloat>
-#include <cmath>
+#include <cuda/std/cfloat>
+#include <cuda/std/cmath>
+#include <cuda/std/limits>
 
 THRUST_NAMESPACE_BEGIN
 namespace detail
@@ -430,7 +431,7 @@ _CCCL_HOST_DEVICE inline complex<double> cacos(complex<double> z)
     /* cacos(+-Inf + I*NaN) = NaN + I*opt(-)Inf */
     if (isinf(x))
     {
-      return (complex<double>(y + y, -infinity<double>()));
+      return (complex<double>(y + y, -::cuda::std::numeric_limits<double>::infinity()));
     }
     /* cacos(NaN + I*+-Inf) = NaN + I*-+Inf */
     if (isinf(y))

--- a/thrust/thrust/detail/complex/catrigf.h
+++ b/thrust/thrust/detail/complex/catrigf.h
@@ -53,8 +53,9 @@
 #include <thrust/complex.h>
 #include <thrust/detail/complex/math_private.h>
 
-#include <cfloat>
-#include <cmath>
+#include <cuda/std/cfloat>
+#include <cuda/std/cmath>
+#include <cuda/std/limits>
 
 THRUST_NAMESPACE_BEGIN
 namespace detail
@@ -278,7 +279,7 @@ _CCCL_HOST_DEVICE inline complex<float> cacosf(complex<float> z)
   {
     if (isinf(x))
     {
-      return (complex<float>(y + y, -infinity<float>()));
+      return (complex<float>(y + y, -::cuda::std::numeric_limits<float>::infinity()));
     }
     if (isinf(y))
     {

--- a/thrust/thrust/detail/complex/complex.inl
+++ b/thrust/thrust/detail/complex/complex.inl
@@ -49,8 +49,9 @@ _CCCL_HOST_DEVICE complex<T>::complex(const complex<U>& z)
     : data{T(z.real()), T(z.imag())}
 {}
 
+#if !_CCCL_COMPILER(NVRTC)
 template <typename T>
-_CCCL_HOST THRUST_STD_COMPLEX_DEVICE complex<T>::complex(const std::complex<T>& z)
+_CCCL_HOST THRUST_STD_COMPLEX_DEVICE complex<T>::complex(const ::std::complex<T>& z)
     // Initialize the storage in the member initializer list using C++ unicorn
     // initialization. This allows `complex<T const>` to work.
     : data{THRUST_STD_COMPLEX_REAL(z), THRUST_STD_COMPLEX_IMAG(z)}
@@ -58,12 +59,13 @@ _CCCL_HOST THRUST_STD_COMPLEX_DEVICE complex<T>::complex(const std::complex<T>& 
 
 template <typename T>
 template <typename U>
-_CCCL_HOST THRUST_STD_COMPLEX_DEVICE complex<T>::complex(const std::complex<U>& z)
+_CCCL_HOST THRUST_STD_COMPLEX_DEVICE complex<T>::complex(const ::std::complex<U>& z)
     // Initialize the storage in the member initializer list using C++ unicorn
     // initialization. This allows `complex<T const>` to work.
     // We do a functional-style cast here to suppress conversion warnings.
     : data{T(THRUST_STD_COMPLEX_REAL(z)), T(THRUST_STD_COMPLEX_IMAG(z))}
 {}
+#endif // !_CCCL_COMPILER(NVRTC)
 
 /* --- Assignment Operators --- */
 
@@ -84,8 +86,9 @@ _CCCL_HOST_DEVICE complex<T>& complex<T>::operator=(const complex<U>& z)
   return *this;
 }
 
+#if !_CCCL_COMPILER(NVRTC)
 template <typename T>
-_CCCL_HOST THRUST_STD_COMPLEX_DEVICE complex<T>& complex<T>::operator=(const std::complex<T>& z)
+_CCCL_HOST THRUST_STD_COMPLEX_DEVICE complex<T>& complex<T>::operator=(const ::std::complex<T>& z)
 {
   real(THRUST_STD_COMPLEX_REAL(z));
   imag(THRUST_STD_COMPLEX_IMAG(z));
@@ -94,12 +97,13 @@ _CCCL_HOST THRUST_STD_COMPLEX_DEVICE complex<T>& complex<T>::operator=(const std
 
 template <typename T>
 template <typename U>
-_CCCL_HOST THRUST_STD_COMPLEX_DEVICE complex<T>& complex<T>::operator=(const std::complex<U>& z)
+_CCCL_HOST THRUST_STD_COMPLEX_DEVICE complex<T>& complex<T>::operator=(const ::std::complex<U>& z)
 {
   real(T(THRUST_STD_COMPLEX_REAL(z)));
   imag(T(THRUST_STD_COMPLEX_IMAG(z)));
   return *this;
 }
+#endif // !_CCCL_COMPILER(NVRTC)
 
 /* --- Compound Assignment Operators --- */
 
@@ -175,17 +179,19 @@ _CCCL_HOST_DEVICE bool operator==(const complex<T0>& x, const complex<T1>& y)
   return x.real() == y.real() && x.imag() == y.imag();
 }
 
+#if !_CCCL_COMPILER(NVRTC)
 template <typename T0, typename T1>
-_CCCL_HOST THRUST_STD_COMPLEX_DEVICE bool operator==(const complex<T0>& x, const std::complex<T1>& y)
+_CCCL_HOST THRUST_STD_COMPLEX_DEVICE bool operator==(const complex<T0>& x, const ::std::complex<T1>& y)
 {
   return x.real() == THRUST_STD_COMPLEX_REAL(y) && x.imag() == THRUST_STD_COMPLEX_IMAG(y);
 }
 
 template <typename T0, typename T1>
-_CCCL_HOST THRUST_STD_COMPLEX_DEVICE bool operator==(const std::complex<T0>& x, const complex<T1>& y)
+_CCCL_HOST THRUST_STD_COMPLEX_DEVICE bool operator==(const ::std::complex<T0>& x, const complex<T1>& y)
 {
   return THRUST_STD_COMPLEX_REAL(x) == y.real() && THRUST_STD_COMPLEX_IMAG(x) == y.imag();
 }
+#endif // !_CCCL_COMPILER(NVRTC)
 
 template <typename T0, typename T1>
 _CCCL_HOST_DEVICE bool operator==(const T0& x, const complex<T1>& y)
@@ -205,17 +211,19 @@ _CCCL_HOST_DEVICE bool operator!=(const complex<T0>& x, const complex<T1>& y)
   return !(x == y);
 }
 
+#if !_CCCL_COMPILER(NVRTC)
 template <typename T0, typename T1>
-_CCCL_HOST THRUST_STD_COMPLEX_DEVICE bool operator!=(const complex<T0>& x, const std::complex<T1>& y)
+_CCCL_HOST THRUST_STD_COMPLEX_DEVICE bool operator!=(const complex<T0>& x, const ::std::complex<T1>& y)
 {
   return !(x == y);
 }
 
 template <typename T0, typename T1>
-_CCCL_HOST THRUST_STD_COMPLEX_DEVICE bool operator!=(const std::complex<T0>& x, const complex<T1>& y)
+_CCCL_HOST THRUST_STD_COMPLEX_DEVICE bool operator!=(const ::std::complex<T0>& x, const complex<T1>& y)
 {
   return !(x == y);
 }
+#endif // !_CCCL_COMPILER(NVRTC)
 
 template <typename T0, typename T1>
 _CCCL_HOST_DEVICE bool operator!=(const T0& x, const complex<T1>& y)

--- a/thrust/thrust/detail/complex/cproj.h
+++ b/thrust/thrust/detail/complex/cproj.h
@@ -37,7 +37,7 @@ _CCCL_HOST_DEVICE inline complex<float> cprojf(const complex<float>& z)
   }
   else
   {
-    // std::numeric_limits<T>::infinity() doesn't run on the GPU
+    // ::cuda::std::numeric_limits<T>::infinity() doesn't run on the GPU
     return complex<float>(infinity<float>(), copysignf(0.0, z.imag()));
   }
 }
@@ -50,7 +50,7 @@ _CCCL_HOST_DEVICE inline complex<double> cproj(const complex<double>& z)
   }
   else
   {
-    // std::numeric_limits<T>::infinity() doesn't run on the GPU
+    // ::cuda::std::numeric_limits<T>::infinity() doesn't run on the GPU
     return complex<double>(infinity<double>(), copysign(0.0, z.imag()));
   }
 }

--- a/thrust/thrust/detail/complex/cproj.h
+++ b/thrust/thrust/detail/complex/cproj.h
@@ -22,7 +22,8 @@
 #include <thrust/complex.h>
 #include <thrust/detail/complex/math_private.h>
 
-#include <cmath>
+#include <cuda/std/cmath>
+#include <cuda/std/limits>
 
 THRUST_NAMESPACE_BEGIN
 namespace detail
@@ -38,7 +39,7 @@ _CCCL_HOST_DEVICE inline complex<float> cprojf(const complex<float>& z)
   else
   {
     // ::cuda::std::numeric_limits<T>::infinity() doesn't run on the GPU
-    return complex<float>(infinity<float>(), copysignf(0.0, z.imag()));
+    return complex<float>(::cuda::std::numeric_limits<float>::infinity(), copysignf(0.0, z.imag()));
   }
 }
 
@@ -51,7 +52,7 @@ _CCCL_HOST_DEVICE inline complex<double> cproj(const complex<double>& z)
   else
   {
     // ::cuda::std::numeric_limits<T>::infinity() doesn't run on the GPU
-    return complex<double>(infinity<double>(), copysign(0.0, z.imag()));
+    return complex<double>(::cuda::std::numeric_limits<double>::infinity(), copysign(0.0, z.imag()));
   }
 }
 

--- a/thrust/thrust/detail/complex/csinh.h
+++ b/thrust/thrust/detail/complex/csinh.h
@@ -53,6 +53,8 @@
 #include <thrust/detail/complex/cexp.h>
 #include <thrust/detail/complex/math_private.h>
 
+#include <cuda/std/limits>
+
 THRUST_NAMESPACE_BEGIN
 namespace detail
 {
@@ -167,7 +169,7 @@ _CCCL_HOST_DEVICE inline complex<double> csinh(const complex<double>& z)
     {
       return (complex<double>(x * x, x * (y - y)));
     }
-    return (complex<double>(x * cos(y), infinity<double>() * sin(y)));
+    return (complex<double>(x * cos(y), ::cuda::std::numeric_limits<double>::infinity() * sin(y)));
   }
 
   /*

--- a/thrust/thrust/detail/complex/csinhf.h
+++ b/thrust/thrust/detail/complex/csinhf.h
@@ -54,6 +54,8 @@
 #include <thrust/detail/complex/cexpf.h>
 #include <thrust/detail/complex/math_private.h>
 
+#include <cuda/std/limits>
+
 THRUST_NAMESPACE_BEGIN
 namespace detail
 {
@@ -135,7 +137,7 @@ _CCCL_HOST_DEVICE inline complex<float> csinhf(const complex<float>& z)
     {
       return (complex<float>(x * x, x * (y - y)));
     }
-    return (complex<float>(x * cosf(y), infinity<float>() * sinf(y)));
+    return (complex<float>(x * cosf(y), ::cuda::std::numeric_limits<float>::infinity() * sinf(y)));
   }
 
   return (complex<float>((x * x) * (y - y), (x + x) * (y - y)));

--- a/thrust/thrust/detail/complex/csqrt.h
+++ b/thrust/thrust/detail/complex/csqrt.h
@@ -53,7 +53,8 @@
 #include <thrust/complex.h>
 #include <thrust/detail/complex/math_private.h>
 
-#include <cmath>
+#include <cuda/std/cmath>
+#include <cuda/std/limits>
 
 THRUST_NAMESPACE_BEGIN
 namespace detail
@@ -83,7 +84,7 @@ _CCCL_HOST_DEVICE inline complex<double> csqrt(const complex<double>& z)
   }
   if (isinf(b))
   {
-    return (complex<double>(infinity<double>(), b));
+    return (complex<double>(::cuda::std::numeric_limits<double>::infinity(), b));
   }
   if (isnan(a))
   {

--- a/thrust/thrust/detail/complex/csqrtf.h
+++ b/thrust/thrust/detail/complex/csqrtf.h
@@ -53,7 +53,8 @@
 #include <thrust/complex.h>
 #include <thrust/detail/complex/math_private.h>
 
-#include <cmath>
+#include <cuda/std/cmath>
+#include <cuda/std/limits>
 
 THRUST_NAMESPACE_BEGIN
 namespace detail
@@ -80,7 +81,7 @@ _CCCL_HOST_DEVICE inline complex<float> csqrtf(const complex<float>& z)
   }
   if (isinf(b))
   {
-    return (complex<float>(infinity<float>(), b));
+    return (complex<float>(::cuda::std::numeric_limits<float>::infinity(), b));
   }
   if (isnan(a))
   {

--- a/thrust/thrust/detail/complex/ctanh.h
+++ b/thrust/thrust/detail/complex/ctanh.h
@@ -92,7 +92,7 @@
 #include <thrust/complex.h>
 #include <thrust/detail/complex/math_private.h>
 
-#include <cmath>
+#include <cuda/std/cmath>
 
 THRUST_NAMESPACE_BEGIN
 namespace detail

--- a/thrust/thrust/detail/complex/ctanhf.h
+++ b/thrust/thrust/detail/complex/ctanhf.h
@@ -57,7 +57,7 @@
 #include <thrust/complex.h>
 #include <thrust/detail/complex/math_private.h>
 
-#include <cmath>
+#include <cuda/std/cmath>
 
 THRUST_NAMESPACE_BEGIN
 namespace detail

--- a/thrust/thrust/detail/complex/math_private.h
+++ b/thrust/thrust/detail/complex/math_private.h
@@ -35,7 +35,7 @@
 
 #include <thrust/complex.h>
 
-#include <cstdint>
+#include <cuda/std/cstdint>
 
 THRUST_NAMESPACE_BEGIN
 namespace detail

--- a/thrust/thrust/detail/config/memory_resource.h
+++ b/thrust/thrust/detail/config/memory_resource.h
@@ -28,7 +28,7 @@
 
 #include <thrust/detail/alignment.h>
 
-#include <cstddef>
+#include <cuda/std/cstddef>
 
 #define THRUST_MR_DEFAULT_ALIGNMENT alignof(THRUST_NS_QUALIFIER::detail::max_align_t)
 

--- a/thrust/thrust/detail/contiguous_storage.inl
+++ b/thrust/thrust/detail/contiguous_storage.inl
@@ -32,8 +32,9 @@
 #include <thrust/detail/allocator/value_initialize_range.h>
 #include <thrust/detail/contiguous_storage.h>
 
+#include <cuda/std/utility> // for use of std::swap in the WAR below
+
 #include <stdexcept> // for std::runtime_error
-#include <utility> // for use of std::swap in the WAR below
 
 #include <nv/target>
 
@@ -258,8 +259,8 @@ _CCCL_HOST_DEVICE contiguous_storage<T, Alloc>& contiguous_storage<T, Alloc>::op
     m_allocator = ::cuda::std::move(other.m_allocator);
   }
 
-  m_begin = std::move(other.m_begin);
-  m_size  = std::move(other.m_size);
+  m_begin = ::cuda::std::move(other.m_begin);
+  m_size  = ::cuda::std::move(other.m_size);
 
   other.m_begin = pointer(static_cast<T*>(0));
   other.m_size  = 0;

--- a/thrust/thrust/detail/integer_math.h
+++ b/thrust/thrust/detail/integer_math.h
@@ -27,9 +27,8 @@
 #endif // no system header
 #include <thrust/detail/type_deduction.h>
 
+#include <cuda/std/limits>
 #include <cuda/std/type_traits>
-
-#include <limits>
 
 #include <nv/target>
 

--- a/thrust/thrust/detail/memory_algorithms.h
+++ b/thrust/thrust/detail/memory_algorithms.h
@@ -23,9 +23,9 @@
 #include <thrust/iterator/iterator_traits.h>
 
 #include <cuda/std/__memory/addressof.h>
+#include <cuda/std/utility>
 
 #include <new>
-#include <utility>
 
 #include <nv/target>
 
@@ -42,8 +42,8 @@ _CCCL_HOST_DEVICE void destroy_at(T* location) noexcept
 template <typename Allocator, typename T>
 _CCCL_HOST_DEVICE void destroy_at(Allocator const& alloc, T* location) noexcept
 {
-  using traits = typename detail::allocator_traits<
-    ::cuda::std::remove_cv_t<::cuda::std::remove_reference_t<Allocator>>>::template rebind_traits<T>::other;
+  using traits =
+    typename detail::allocator_traits<::cuda::std::remove_cvref_t<Allocator>>::template rebind_traits<T>::other;
 
   typename traits::allocator_type alloc_T(alloc);
 
@@ -64,9 +64,9 @@ _CCCL_HOST_DEVICE ForwardIt destroy(ForwardIt first, ForwardIt last) noexcept
 template <typename Allocator, typename ForwardIt>
 _CCCL_HOST_DEVICE ForwardIt destroy(Allocator const& alloc, ForwardIt first, ForwardIt last) noexcept
 {
-  using T      = detail::it_value_t<ForwardIt>;
-  using traits = typename detail::allocator_traits<
-    ::cuda::std::remove_cv_t<::cuda::std::remove_reference_t<Allocator>>>::template rebind_traits<T>::other;
+  using T = detail::it_value_t<ForwardIt>;
+  using traits =
+    typename detail::allocator_traits<::cuda::std::remove_cvref_t<Allocator>>::template rebind_traits<T>::other;
 
   typename traits::allocator_type alloc_T(alloc);
 
@@ -92,9 +92,9 @@ _CCCL_HOST_DEVICE ForwardIt destroy_n(ForwardIt first, Size n) noexcept
 template <typename Allocator, typename ForwardIt, typename Size>
 _CCCL_HOST_DEVICE ForwardIt destroy_n(Allocator const& alloc, ForwardIt first, Size n) noexcept
 {
-  using T      = detail::it_value_t<ForwardIt>;
-  using traits = typename detail::allocator_traits<
-    ::cuda::std::remove_cv_t<::cuda::std::remove_reference_t<Allocator>>>::template rebind_traits<T>::other;
+  using T = detail::it_value_t<ForwardIt>;
+  using traits =
+    typename detail::allocator_traits<::cuda::std::remove_cvref_t<Allocator>>::template rebind_traits<T>::other;
 
   typename traits::allocator_type alloc_T(alloc);
 
@@ -133,8 +133,7 @@ template <typename Allocator, typename ForwardIt, typename... Args>
 void uninitialized_construct_with_allocator(Allocator const& alloc, ForwardIt first, ForwardIt last, Args const&... args)
 {
   using T      = detail::it_value_t<ForwardIt>;
-  using traits = typename detail::allocator_traits<
-    typename std::remove_cv<typename std::remove_reference<Allocator>::type>::type>::template rebind_traits<T>;
+  using traits = typename detail::allocator_traits<::cuda::std::remove_cvref_t<Allocator>>::template rebind_traits<T>;
 
   typename traits::allocator_type alloc_T(alloc);
 
@@ -183,8 +182,7 @@ template <typename Allocator, typename ForwardIt, typename Size, typename... Arg
 void uninitialized_construct_n_with_allocator(Allocator const& alloc, ForwardIt first, Size n, Args const&... args)
 {
   using T      = detail::it_value_t<ForwardIt>;
-  using traits = typename detail::allocator_traits<
-    typename std::remove_cv<typename std::remove_reference<Allocator>::type>::type>::template rebind_traits<T>;
+  using traits = typename detail::allocator_traits<::cuda::std::remove_cvref_t<Allocator>>::template rebind_traits<T>;
 
   typename traits::allocator_type alloc_T(alloc);
 

--- a/thrust/thrust/detail/pointer.h
+++ b/thrust/thrust/detail/pointer.h
@@ -38,9 +38,9 @@
 #include <thrust/iterator/detail/iterator_traversal_tags.h>
 #include <thrust/iterator/iterator_adaptor.h>
 
+#include <cuda/std/cstddef>
 #include <cuda/std/type_traits>
 
-#include <cstddef>
 #include <ostream>
 
 THRUST_NAMESPACE_BEGIN

--- a/thrust/thrust/detail/reference.h
+++ b/thrust/thrust/detail/reference.h
@@ -201,7 +201,7 @@ public:
   {
     value_type tmp    = *this;
     value_type result = tmp++;
-    *this             = std::move(tmp);
+    *this             = ::cuda::std::move(tmp);
     return result;
   }
 
@@ -212,7 +212,7 @@ public:
     // system, is to get a copy of it, modify the copy, and then update it.
     value_type tmp = *this;
     --tmp;
-    *this = std::move(tmp);
+    *this = ::cuda::std::move(tmp);
     return derived();
   }
 
@@ -220,7 +220,7 @@ public:
   {
     value_type tmp    = *this;
     value_type result = tmp--;
-    *this             = std::move(tmp);
+    *this             = ::cuda::std::move(tmp);
     return derived();
   }
 

--- a/thrust/thrust/detail/type_traits/has_member_function.h
+++ b/thrust/thrust/detail/type_traits/has_member_function.h
@@ -28,7 +28,7 @@
 
 #include <thrust/detail/type_traits.h>
 
-#include <utility> // for std::declval
+#include <cuda/std/utility> // for std::declval
 
 #define __THRUST_DEFINE_HAS_MEMBER_FUNCTION(trait_name, member_function_name)                                       \
   template <typename T, typename Signature, typename = void>                                                        \

--- a/thrust/thrust/detail/util/align.h
+++ b/thrust/thrust/detail/util/align.h
@@ -26,7 +26,7 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cstdint>
+#include <cuda/std/cstdint>
 
 // functions to handle memory alignment
 

--- a/thrust/thrust/detail/vector_base.h
+++ b/thrust/thrust/detail/vector_base.h
@@ -38,9 +38,9 @@
 #include <thrust/iterator/reverse_iterator.h>
 
 #include <cuda/std/__iterator/iterator_traits.h>
+#include <cuda/std/initializer_list>
 #include <cuda/std/utility>
 
-#include <initializer_list>
 #include <vector>
 
 THRUST_NAMESPACE_BEGIN
@@ -140,18 +140,18 @@ public:
   /*! This constructor builds a \p vector_base from an intializer_list.
    *  \param il The intializer_list.
    */
-  vector_base(std::initializer_list<T> il);
+  vector_base(::cuda::std::initializer_list<T> il);
 
   /*! This constructor builds a \p vector_base from an intializer_list.
    *  \param il The intializer_list.
    *  \param alloc The allocator to use by this device_vector.
    */
-  vector_base(std::initializer_list<T> il, const Alloc& alloc);
+  vector_base(::cuda::std::initializer_list<T> il, const Alloc& alloc);
 
   /*! Assign operator copies from an initializer_list
    *  \param il The initializer_list.
    */
-  vector_base& operator=(std::initializer_list<T> il);
+  vector_base& operator=(::cuda::std::initializer_list<T> il);
 
   /*! Copy constructor copies from an exemplar vector_base with different
    *  type.

--- a/thrust/thrust/detail/vector_base.inl
+++ b/thrust/thrust/detail/vector_base.inl
@@ -116,7 +116,7 @@ vector_base<T, Alloc>::vector_base(vector_base&& v)
     : m_storage(copy_allocator_t(), v.m_storage)
     , m_size(0)
 {
-  *this = std::move(v);
+  *this = ::cuda::std::move(v);
 } // end vector_base::vector_base()
 
 template <typename T, typename Alloc>
@@ -139,8 +139,8 @@ template <typename T, typename Alloc>
 vector_base<T, Alloc>& vector_base<T, Alloc>::operator=(vector_base&& v)
 {
   m_storage.destroy(begin(), end());
-  m_storage = std::move(v.m_storage);
-  m_size    = std::move(v.m_size);
+  m_storage = ::cuda::std::move(v.m_storage);
+  m_size    = ::cuda::std::move(v.m_size);
 
   v.m_storage = contiguous_storage<T, Alloc>(copy_allocator_t(), m_storage);
   v.m_size    = 0;
@@ -185,7 +185,7 @@ vector_base<T, Alloc>& vector_base<T, Alloc>::operator=(const std::vector<OtherT
 } // end vector_base::operator=()
 
 template <typename T, typename Alloc>
-vector_base<T, Alloc>::vector_base(std::initializer_list<T> il)
+vector_base<T, Alloc>::vector_base(::cuda::std::initializer_list<T> il)
     : m_storage()
     , m_size(0)
 {
@@ -193,7 +193,7 @@ vector_base<T, Alloc>::vector_base(std::initializer_list<T> il)
 } // end vector_base::vector_base()
 
 template <typename T, typename Alloc>
-vector_base<T, Alloc>::vector_base(std::initializer_list<T> il, const Alloc& alloc)
+vector_base<T, Alloc>::vector_base(::cuda::std::initializer_list<T> il, const Alloc& alloc)
     : m_storage(alloc)
     , m_size(0)
 {
@@ -201,7 +201,7 @@ vector_base<T, Alloc>::vector_base(std::initializer_list<T> il, const Alloc& all
 } // end vector_base::vector_base()
 
 template <typename T, typename Alloc>
-vector_base<T, Alloc>& vector_base<T, Alloc>::operator=(std::initializer_list<T> il)
+vector_base<T, Alloc>& vector_base<T, Alloc>::operator=(::cuda::std::initializer_list<T> il)
 {
   assign(il.begin(), il.end());
 

--- a/thrust/thrust/device_allocator.h
+++ b/thrust/thrust/device_allocator.h
@@ -34,7 +34,8 @@
 #include <thrust/mr/allocator.h>
 #include <thrust/mr/device_memory_resource.h>
 
-#include <limits>
+#include <cuda/std/limits>
+
 #include <stdexcept>
 
 THRUST_NAMESPACE_BEGIN

--- a/thrust/thrust/device_allocator.h
+++ b/thrust/thrust/device_allocator.h
@@ -36,8 +36,6 @@
 
 #include <cuda/std/limits>
 
-#include <stdexcept>
-
 THRUST_NAMESPACE_BEGIN
 
 /** \addtogroup allocators Allocators

--- a/thrust/thrust/device_malloc.h
+++ b/thrust/thrust/device_malloc.h
@@ -31,7 +31,7 @@
 #endif // no system header
 #include <thrust/device_ptr.h>
 
-#include <cstddef> // for std::size_t
+#include <cuda/std/cstddef> // for std::size_t
 
 THRUST_NAMESPACE_BEGIN
 

--- a/thrust/thrust/device_malloc_allocator.h
+++ b/thrust/thrust/device_malloc_allocator.h
@@ -34,7 +34,8 @@
 #include <thrust/device_ptr.h>
 #include <thrust/device_reference.h>
 
-#include <limits>
+#include <cuda/std/limits>
+
 #include <stdexcept>
 
 THRUST_NAMESPACE_BEGIN
@@ -164,7 +165,7 @@ public:
    */
   inline size_type max_size() const
   {
-    return (std::numeric_limits<size_type>::max)() / sizeof(T);
+    return (::cuda::std::numeric_limits<size_type>::max)() / sizeof(T);
   } // end max_size()
 
   /*! Compares against another \p device_malloc_allocator for equality.

--- a/thrust/thrust/device_malloc_allocator.h
+++ b/thrust/thrust/device_malloc_allocator.h
@@ -34,9 +34,8 @@
 #include <thrust/device_ptr.h>
 #include <thrust/device_reference.h>
 
+#include <cuda/std/__new/bad_alloc.h>
 #include <cuda/std/limits>
-
-#include <stdexcept>
 
 THRUST_NAMESPACE_BEGIN
 
@@ -143,7 +142,7 @@ public:
   {
     if (cnt > this->max_size())
     {
-      throw std::bad_alloc();
+      ::cuda::std::__throw_bad_alloc();
     } // end if
 
     return pointer(device_malloc<T>(cnt));

--- a/thrust/thrust/device_new.h
+++ b/thrust/thrust/device_new.h
@@ -33,7 +33,7 @@
 // #include this for size_t
 #include <thrust/device_ptr.h>
 
-#include <cstddef>
+#include <cuda/std/cstddef>
 
 THRUST_NAMESPACE_BEGIN
 

--- a/thrust/thrust/device_new_allocator.h
+++ b/thrust/thrust/device_new_allocator.h
@@ -34,10 +34,9 @@
 #include <thrust/device_ptr.h>
 #include <thrust/device_reference.h>
 
+#include <cuda/std/__new/bad_alloc.h>
 #include <cuda/std/cstdint>
 #include <cuda/std/limits>
-
-#include <stdexcept>
 
 THRUST_NAMESPACE_BEGIN
 
@@ -130,7 +129,7 @@ public:
   {
     if (cnt > this->max_size())
     {
-      throw std::bad_alloc();
+      ::cuda::std::__throw_bad_alloc();
     } // end if
 
     // use "::operator new" rather than keyword new

--- a/thrust/thrust/device_vector.h
+++ b/thrust/thrust/device_vector.h
@@ -33,8 +33,9 @@
 #include <thrust/detail/vector_base.h>
 #include <thrust/device_allocator.h>
 
-#include <initializer_list>
-#include <utility>
+#include <cuda/std/initializer_list>
+#include <cuda/std/utility>
+
 #include <vector>
 
 THRUST_NAMESPACE_BEGIN
@@ -143,7 +144,7 @@ public:
    *  \param v The device_vector to move.
    */
   device_vector(device_vector&& v)
-      : Parent(std::move(v))
+      : Parent(::cuda::std::move(v))
   {}
 
   /*! Move constructor moves from another \p device_vector.
@@ -151,7 +152,7 @@ public:
    *  \param alloc The allocator to use by this device_vector.
    */
   device_vector(device_vector&& v, const Alloc& alloc)
-      : Parent(std::move(v), alloc)
+      : Parent(::cuda::std::move(v), alloc)
   {}
 
   /*! Copy assign operator copies another \p device_vector with the same type.
@@ -168,7 +169,7 @@ public:
    */
   device_vector& operator=(device_vector&& v)
   {
-    Parent::operator=(std::move(v));
+    Parent::operator=(::cuda::std::move(v));
     return *this;
   }
 
@@ -231,7 +232,7 @@ public:
   /*! This constructor builds a \p device_vector from an intializer_list.
    *  \param il The intializer_list.
    */
-  device_vector(std::initializer_list<T> il)
+  device_vector(::cuda::std::initializer_list<T> il)
       : Parent(il)
   {}
 
@@ -239,14 +240,14 @@ public:
    *  \param il The intializer_list.
    *  \param alloc The allocator to use by this device_vector.
    */
-  device_vector(std::initializer_list<T> il, const Alloc& alloc)
+  device_vector(::cuda::std::initializer_list<T> il, const Alloc& alloc)
       : Parent(il, alloc)
   {}
 
   /*! Assign an \p intializer_list with a matching element type
    *  \param il The intializer_list.
    */
-  device_vector& operator=(std::initializer_list<T> il)
+  device_vector& operator=(::cuda::std::initializer_list<T> il)
   {
     Parent::operator=(il);
     return *this;

--- a/thrust/thrust/host_vector.h
+++ b/thrust/thrust/host_vector.h
@@ -33,8 +33,9 @@
 #include <thrust/detail/memory_wrapper.h>
 #include <thrust/detail/vector_base.h>
 
-#include <initializer_list>
-#include <utility>
+#include <cuda/std/initializer_list>
+#include <cuda/std/utility>
+
 #include <vector>
 
 THRUST_NAMESPACE_BEGIN
@@ -144,7 +145,7 @@ public:
    *  \param v The host_vector to move.
    */
   _CCCL_HOST host_vector(host_vector&& v)
-      : Parent(std::move(v))
+      : Parent(::cuda::std::move(v))
   {}
 
   /*! Move constructor moves from another host_vector.
@@ -152,7 +153,7 @@ public:
    *  \param alloc The allocator to use by this host_vector.
    */
   _CCCL_HOST host_vector(host_vector&& v, const Alloc& alloc)
-      : Parent(std::move(v), alloc)
+      : Parent(::cuda::std::move(v), alloc)
   {}
 
   /*! Assign operator copies from an exemplar \p host_vector.
@@ -169,7 +170,7 @@ public:
    */
   _CCCL_HOST host_vector& operator=(host_vector&& v)
   {
-    Parent::operator=(std::move(v));
+    Parent::operator=(::cuda::std::move(v));
     return *this;
   }
 
@@ -233,7 +234,7 @@ public:
   /*! This constructor builds a \p host_vector from an intializer_list.
    *  \param il The intializer_list.
    */
-  host_vector(std::initializer_list<T> il)
+  host_vector(::cuda::std::initializer_list<T> il)
       : Parent(il)
   {}
 
@@ -241,14 +242,14 @@ public:
    *  \param il The intializer_list.
    *  \param alloc The allocator to use by this host_vector.
    */
-  host_vector(std::initializer_list<T> il, const Alloc& alloc)
+  host_vector(::cuda::std::initializer_list<T> il, const Alloc& alloc)
       : Parent(il, alloc)
   {}
 
   /*! Assign an \p intializer_list with a matching element type
    *  \param il The intializer_list.
    */
-  host_vector& operator=(std::initializer_list<T> il)
+  host_vector& operator=(::cuda::std::initializer_list<T> il)
   {
     Parent::operator=(il);
     return *this;

--- a/thrust/thrust/mr/allocator.h
+++ b/thrust/thrust/mr/allocator.h
@@ -37,7 +37,7 @@
 #include <thrust/mr/polymorphic_adaptor.h>
 #include <thrust/mr/validator.h>
 
-#include <limits>
+#include <cuda/std/limits>
 
 THRUST_NAMESPACE_BEGIN
 namespace mr
@@ -105,7 +105,7 @@ public:
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_HOST_DEVICE size_type max_size() const
   {
-    return (std::numeric_limits<size_type>::max)() / sizeof(T);
+    return (::cuda::std::numeric_limits<size_type>::max)() / sizeof(T);
   }
 
   /*! Constructor.

--- a/thrust/thrust/mr/disjoint_pool.h
+++ b/thrust/thrust/mr/disjoint_pool.h
@@ -41,9 +41,8 @@
 #include <thrust/mr/memory_resource.h>
 #include <thrust/mr/pool_options.h>
 
+#include <cuda/std/cassert>
 #include <cuda/std/cstdint>
-
-#include <cassert>
 
 THRUST_NAMESPACE_BEGIN
 namespace mr

--- a/thrust/thrust/mr/pool.h
+++ b/thrust/thrust/mr/pool.h
@@ -38,9 +38,8 @@
 #include <thrust/mr/memory_resource.h>
 #include <thrust/mr/pool_options.h>
 
+#include <cuda/std/cassert>
 #include <cuda/std/cstdint>
-
-#include <cassert>
 
 THRUST_NAMESPACE_BEGIN
 namespace mr

--- a/thrust/thrust/mr/pool_options.h
+++ b/thrust/thrust/mr/pool_options.h
@@ -34,7 +34,7 @@
 #include <thrust/detail/config/memory_resource.h>
 #include <thrust/detail/integer_math.h>
 
-#include <cstddef>
+#include <cuda/std/cstddef>
 
 THRUST_NAMESPACE_BEGIN
 namespace mr

--- a/thrust/thrust/random.h
+++ b/thrust/thrust/random.h
@@ -29,7 +29,7 @@
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
 #  pragma system_header
 #endif // no system header
-#include <cstdint>
+#include <cuda/std/cstdint>
 
 // RNGs
 #include <thrust/random/discard_block_engine.h>

--- a/thrust/thrust/random/detail/linear_congruential_engine_discard.h
+++ b/thrust/thrust/random/detail/linear_congruential_engine_discard.h
@@ -28,7 +28,7 @@
 
 #include <thrust/random/detail/mod.h>
 
-#include <cstdint>
+#include <cuda/std/cstdint>
 
 THRUST_NAMESPACE_BEGIN
 

--- a/thrust/thrust/random/detail/normal_distribution.inl
+++ b/thrust/thrust/random/detail/normal_distribution.inl
@@ -29,9 +29,8 @@
 #include <thrust/random/normal_distribution.h>
 #include <thrust/random/uniform_real_distribution.h>
 
+#include <cuda/std/cstdint>
 #include <cuda/std/limits>
-
-#include <cstdint>
 
 THRUST_NAMESPACE_BEGIN
 

--- a/thrust/thrust/random/detail/normal_distribution_base.h
+++ b/thrust/thrust/random/detail/normal_distribution_base.h
@@ -35,9 +35,8 @@
 #include <thrust/pair.h>
 #include <thrust/random/uniform_real_distribution.h>
 
+#include <cuda/std/cmath>
 #include <cuda/std/limits>
-
-#include <cmath>
 
 THRUST_NAMESPACE_BEGIN
 namespace random
@@ -115,10 +114,10 @@ protected:
   {
     // implementation from Boost
     // allow for Koenig lookup
-    using std::cos;
-    using std::log;
-    using std::sin;
-    using std::sqrt;
+    using ::cuda::std::cos;
+    using ::cuda::std::log;
+    using ::cuda::std::sin;
+    using ::cuda::std::sqrt;
 
     if (!m_valid)
     {

--- a/thrust/thrust/random/detail/normal_distribution_base.h
+++ b/thrust/thrust/random/detail/normal_distribution_base.h
@@ -35,8 +35,9 @@
 #include <thrust/pair.h>
 #include <thrust/random/uniform_real_distribution.h>
 
+#include <cuda/std/limits>
+
 #include <cmath>
-#include <limits>
 
 THRUST_NAMESPACE_BEGIN
 namespace random

--- a/thrust/thrust/random/detail/xor_combine_engine_max.h
+++ b/thrust/thrust/random/detail/xor_combine_engine_max.h
@@ -29,8 +29,8 @@
 #include <thrust/detail/mpl/math.h>
 #include <thrust/detail/type_traits.h>
 
-#include <cstddef>
-#include <limits>
+#include <cuda/std/cstddef>
+#include <cuda/std/limits>
 
 THRUST_NAMESPACE_BEGIN
 
@@ -69,7 +69,7 @@ struct lshift_w
 };
 
 template <typename UIntType, UIntType lhs, UIntType rhs>
-struct lshift : lshift_w<UIntType, std::numeric_limits<UIntType>::digits, lhs, rhs>
+struct lshift : lshift_w<UIntType, ::cuda::std::numeric_limits<UIntType>::digits, lhs, rhs>
 {};
 
 template <typename UIntType, int p>
@@ -193,7 +193,7 @@ struct xor_combine_engine_max_aux : xor_combine_engine_max_aux_1<result_type, a,
 template <typename Engine1, size_t s1, typename Engine2, size_t s2, typename result_type>
 struct xor_combine_engine_max
 {
-  static const size_t w = std::numeric_limits<result_type>::digits;
+  static const size_t w = ::cuda::std::numeric_limits<result_type>::digits;
 
   static const result_type m1 = math::
     min<result_type, result_type(Engine1::max - Engine1::min), two_to_the_power<result_type, w - s1>::value - 1>::value;

--- a/thrust/thrust/random/discard_block_engine.h
+++ b/thrust/thrust/random/discard_block_engine.h
@@ -33,7 +33,8 @@
 
 #include <thrust/random/detail/random_core_access.h>
 
-#include <cstdint>
+#include <cuda/std/cstdint>
+
 #include <iostream>
 
 THRUST_NAMESPACE_BEGIN

--- a/thrust/thrust/random/linear_congruential_engine.h
+++ b/thrust/thrust/random/linear_congruential_engine.h
@@ -32,7 +32,8 @@
 #include <thrust/random/detail/linear_congruential_engine_discard.h>
 #include <thrust/random/detail/random_core_access.h>
 
-#include <cstdint>
+#include <cuda/std/cstdint>
+
 #include <iostream>
 
 THRUST_NAMESPACE_BEGIN

--- a/thrust/thrust/random/linear_feedback_shift_engine.h
+++ b/thrust/thrust/random/linear_feedback_shift_engine.h
@@ -41,7 +41,8 @@
 #include <thrust/random/detail/linear_feedback_shift_engine_wordmask.h>
 #include <thrust/random/detail/random_core_access.h>
 
-#include <cstddef> // for size_t
+#include <cuda/std/cstddef> // for size_t
+
 #include <iostream>
 
 THRUST_NAMESPACE_BEGIN

--- a/thrust/thrust/random/subtract_with_carry_engine.h
+++ b/thrust/thrust/random/subtract_with_carry_engine.h
@@ -33,8 +33,9 @@
 
 #include <thrust/random/detail/random_core_access.h>
 
-#include <cstddef> // for size_t
-#include <cstdint>
+#include <cuda/std/cstddef> // for size_t
+#include <cuda/std/cstdint>
+
 #include <iostream>
 
 THRUST_NAMESPACE_BEGIN

--- a/thrust/thrust/random/xor_combine_engine.h
+++ b/thrust/thrust/random/xor_combine_engine.h
@@ -36,7 +36,8 @@
 #include <thrust/random/detail/random_core_access.h>
 #include <thrust/random/detail/xor_combine_engine_max.h>
 
-#include <cstddef> // for size_t
+#include <cuda/std/cstddef> // for size_t
+
 #include <iostream>
 
 THRUST_NAMESPACE_BEGIN

--- a/thrust/thrust/system/cpp/detail/memory.inl
+++ b/thrust/thrust/system/cpp/detail/memory.inl
@@ -28,7 +28,7 @@
 #include <thrust/system/cpp/detail/malloc_and_free.h>
 #include <thrust/system/cpp/memory.h>
 
-#include <limits>
+#include <cuda/std/limits>
 
 THRUST_NAMESPACE_BEGIN
 namespace system

--- a/thrust/thrust/system/cpp/detail/vector.inl
+++ b/thrust/thrust/system/cpp/detail/vector.inl
@@ -27,7 +27,7 @@
 #endif // no system header
 #include <thrust/system/cpp/vector.h>
 
-#include <utility>
+#include <cuda/std/utility>
 
 THRUST_NAMESPACE_BEGIN
 namespace system
@@ -57,7 +57,7 @@ vector<T, Allocator>::vector(const vector& x)
 
 template <typename T, typename Allocator>
 vector<T, Allocator>::vector(vector&& x)
-    : super_t(std::move(x))
+    : super_t(::cuda::std::move(x))
 {}
 
 template <typename T, typename Allocator>
@@ -88,22 +88,22 @@ vector<T, Allocator>& vector<T, Allocator>::operator=(const vector& x)
 template <typename T, typename Allocator>
 vector<T, Allocator>& vector<T, Allocator>::operator=(vector&& x)
 {
-  super_t::operator=(std::move(x));
+  super_t::operator=(::cuda::std::move(x));
   return *this;
 }
 
 template <typename T, typename Allocator>
-vector<T, Allocator>::vector(std::initializer_list<T> il)
+vector<T, Allocator>::vector(::cuda::std::initializer_list<T> il)
     : super_t(il)
 {}
 
 template <typename T, typename Allocator>
-vector<T, Allocator>::vector(std::initializer_list<T> il, const Allocator& alloc)
+vector<T, Allocator>::vector(::cuda::std::initializer_list<T> il, const Allocator& alloc)
     : super_t(il, alloc)
 {}
 
 template <typename T, typename Allocator>
-vector<T, Allocator>& vector<T, Allocator>::operator=(std::initializer_list<T> il)
+vector<T, Allocator>& vector<T, Allocator>::operator=(::cuda::std::initializer_list<T> il)
 {
   super_t::operator=(il);
   return *this;

--- a/thrust/thrust/system/cpp/pointer.h
+++ b/thrust/thrust/system/cpp/pointer.h
@@ -32,7 +32,7 @@
 #include <thrust/detail/reference.h>
 #include <thrust/system/cpp/detail/execution_policy.h>
 
-#include <type_traits>
+#include <cuda/std/type_traits>
 
 THRUST_NAMESPACE_BEGIN
 namespace system
@@ -88,7 +88,7 @@ using pointer = thrust::pointer<T, thrust::system::cpp::tag, thrust::tagged_refe
  *  \see raw_pointer_cast
  */
 template <typename T>
-using universal_pointer = thrust::pointer<T, thrust::system::cpp::tag, typename std::add_lvalue_reference<T>::type>;
+using universal_pointer = thrust::pointer<T, thrust::system::cpp::tag, ::cuda::std::add_lvalue_reference_t<T>>;
 
 /*! \p reference is a wrapped reference to an object stored in memory available
  *  to the \p cpp system. \p reference is the type of the result of

--- a/thrust/thrust/system/cuda/detail/adjacent_difference.h
+++ b/thrust/thrust/system/cuda/detail/adjacent_difference.h
@@ -53,9 +53,8 @@
 #  include <thrust/type_traits/is_contiguous_iterator.h>
 #  include <thrust/type_traits/unwrap_contiguous_iterator.h>
 
+#  include <cuda/std/cstdint>
 #  include <cuda/std/type_traits>
-
-#  include <cstdint>
 
 THRUST_NAMESPACE_BEGIN
 

--- a/thrust/thrust/system/cuda/detail/copy_if.h
+++ b/thrust/thrust/system/cuda/detail/copy_if.h
@@ -56,7 +56,7 @@
 #  include <thrust/system/cuda/detail/par_to_seq.h>
 #  include <thrust/system/cuda/detail/util.h>
 
-#  include <cstdint>
+#  include <cuda/std/cstdint>
 
 THRUST_NAMESPACE_BEGIN
 // XXX declare generic copy_if interface

--- a/thrust/thrust/system/cuda/detail/core/agent_launcher.h
+++ b/thrust/thrust/system/cuda/detail/core/agent_launcher.h
@@ -40,7 +40,7 @@
 #  include <thrust/system/cuda/detail/core/triple_chevron_launch.h>
 #  include <thrust/system/cuda/detail/core/util.h>
 
-#  include <cassert>
+#  include <cuda/std/cassert>
 
 #  include <nv/target>
 

--- a/thrust/thrust/system/cuda/detail/dispatch.h
+++ b/thrust/thrust/system/cuda/detail/dispatch.h
@@ -29,11 +29,11 @@
 #include <thrust/detail/integer_math.h>
 #include <thrust/detail/preprocessor.h>
 
+#include <cuda/std/cstdint>
 #include <cuda/std/detail/libcxx/include/stdexcept>
 #include <cuda/std/limits>
 #include <cuda/std/type_traits>
 
-#include <cstdint>
 #include <string>
 
 #if defined(THRUST_FORCE_32_BIT_OFFSET_TYPE) && defined(THRUST_FORCE_64_BIT_OFFSET_TYPE)

--- a/thrust/thrust/system/cuda/detail/extrema.h
+++ b/thrust/thrust/system/cuda/detail/extrema.h
@@ -51,9 +51,8 @@
 #  include <thrust/system/cuda/detail/cdp_dispatch.h>
 #  include <thrust/system/cuda/detail/reduce.h>
 
+#  include <cuda/std/cstdint>
 #  include <cuda/std/iterator>
-
-#  include <cstdint>
 
 THRUST_NAMESPACE_BEGIN
 namespace cuda_cub

--- a/thrust/thrust/system/cuda/detail/generate.h
+++ b/thrust/thrust/system/cuda/detail/generate.h
@@ -42,8 +42,6 @@
 #  include <thrust/distance.h>
 #  include <thrust/system/cuda/detail/for_each.h>
 
-#  include <iterator>
-
 THRUST_NAMESPACE_BEGIN
 namespace cuda_cub
 {

--- a/thrust/thrust/system/cuda/detail/memory.inl
+++ b/thrust/thrust/system/cuda/detail/memory.inl
@@ -28,7 +28,7 @@
 #include <thrust/system/cuda/detail/malloc_and_free.h>
 #include <thrust/system/cuda/memory.h>
 
-#include <limits>
+#include <cuda/std/limits>
 
 THRUST_NAMESPACE_BEGIN
 namespace cuda_cub

--- a/thrust/thrust/system/cuda/detail/merge.h
+++ b/thrust/thrust/system/cuda/detail/merge.h
@@ -47,7 +47,7 @@
 #  include <thrust/system/cuda/detail/dispatch.h>
 #  include <thrust/system/cuda/detail/util.h>
 
-#  include <cstdint>
+#  include <cuda/std/cstdint>
 
 THRUST_NAMESPACE_BEGIN
 namespace cuda_cub

--- a/thrust/thrust/system/cuda/detail/partition.h
+++ b/thrust/thrust/system/cuda/detail/partition.h
@@ -55,7 +55,7 @@
 #  include <thrust/system/cuda/detail/uninitialized_copy.h>
 #  include <thrust/system/cuda/detail/util.h>
 
-#  include <cstdint>
+#  include <cuda/std/cstdint>
 
 THRUST_NAMESPACE_BEGIN
 namespace cuda_cub

--- a/thrust/thrust/system/cuda/detail/reduce.h
+++ b/thrust/thrust/system/cuda/detail/reduce.h
@@ -56,7 +56,7 @@
 #  include <thrust/system/cuda/detail/par_to_seq.h>
 #  include <thrust/system/cuda/detail/util.h>
 
-#  include <cstdint>
+#  include <cuda/std/cstdint>
 
 THRUST_NAMESPACE_BEGIN
 

--- a/thrust/thrust/system/cuda/detail/reduce_by_key.h
+++ b/thrust/thrust/system/cuda/detail/reduce_by_key.h
@@ -58,9 +58,8 @@
 #  include <thrust/system/cuda/detail/par_to_seq.h>
 #  include <thrust/system/cuda/detail/util.h>
 
+#  include <cuda/std/cstdint>
 #  include <cuda/std/iterator>
-
-#  include <cstdint>
 
 THRUST_NAMESPACE_BEGIN
 

--- a/thrust/thrust/system/cuda/detail/scan.h
+++ b/thrust/thrust/system/cuda/detail/scan.h
@@ -50,7 +50,7 @@
 #  include <thrust/system/cuda/detail/cdp_dispatch.h>
 #  include <thrust/system/cuda/detail/dispatch.h>
 
-#  include <cstdint>
+#  include <cuda/std/cstdint>
 
 THRUST_NAMESPACE_BEGIN
 namespace cuda_cub

--- a/thrust/thrust/system/cuda/detail/scan_by_key.h
+++ b/thrust/thrust/system/cuda/detail/scan_by_key.h
@@ -55,7 +55,7 @@
 #  include <thrust/type_traits/is_contiguous_iterator.h>
 #  include <thrust/type_traits/unwrap_contiguous_iterator.h>
 
-#  include <cstdint>
+#  include <cuda/std/cstdint>
 
 THRUST_NAMESPACE_BEGIN
 namespace cuda_cub

--- a/thrust/thrust/system/cuda/detail/set_operations.h
+++ b/thrust/thrust/system/cuda/detail/set_operations.h
@@ -54,8 +54,7 @@
 
 #  include <cuda/std/__algorithm/max.h>
 #  include <cuda/std/__algorithm/min.h>
-
-#  include <cstdint>
+#  include <cuda/std/cstdint>
 
 THRUST_NAMESPACE_BEGIN
 

--- a/thrust/thrust/system/cuda/detail/sort.h
+++ b/thrust/thrust/system/cuda/detail/sort.h
@@ -59,8 +59,7 @@
 #  include <thrust/type_traits/is_contiguous_iterator.h>
 
 #  include <cuda/cmath>
-
-#  include <cstdint>
+#  include <cuda/std/cstdint>
 
 #  if _CCCL_HAS_NVFP16()
 #    include <cuda_fp16.h>

--- a/thrust/thrust/system/cuda/detail/swap_ranges.h
+++ b/thrust/thrust/system/cuda/detail/swap_ranges.h
@@ -45,8 +45,6 @@
 
 #  include <cuda/std/utility>
 
-#  include <iterator>
-
 THRUST_NAMESPACE_BEGIN
 
 namespace cuda_cub

--- a/thrust/thrust/system/cuda/detail/transform.h
+++ b/thrust/thrust/system/cuda/detail/transform.h
@@ -49,8 +49,7 @@
 #  include <thrust/zip_function.h>
 
 #  include <cuda/__functional/address_stability.h>
-
-#  include <cstdint>
+#  include <cuda/std/cstdint>
 
 THRUST_NAMESPACE_BEGIN
 

--- a/thrust/thrust/system/cuda/detail/transform_reduce.h
+++ b/thrust/thrust/system/cuda/detail/transform_reduce.h
@@ -57,8 +57,6 @@
 
 #  include <cuda/std/cstdint>
 
-#  include <iterator>
-
 THRUST_NAMESPACE_BEGIN
 namespace cuda_cub
 {

--- a/thrust/thrust/system/cuda/detail/transform_reduce.h
+++ b/thrust/thrust/system/cuda/detail/transform_reduce.h
@@ -55,7 +55,8 @@
 #  include <thrust/system/cuda/detail/par_to_seq.h>
 #  include <thrust/system/cuda/detail/util.h>
 
-#  include <cstdint>
+#  include <cuda/std/cstdint>
+
 #  include <iterator>
 
 THRUST_NAMESPACE_BEGIN

--- a/thrust/thrust/system/cuda/detail/transform_scan.h
+++ b/thrust/thrust/system/cuda/detail/transform_scan.h
@@ -44,8 +44,6 @@
 
 #  include <cuda/std/type_traits>
 
-#  include <iterator>
-
 THRUST_NAMESPACE_BEGIN
 
 namespace cuda_cub

--- a/thrust/thrust/system/cuda/detail/uninitialized_copy.h
+++ b/thrust/thrust/system/cuda/detail/uninitialized_copy.h
@@ -42,8 +42,6 @@
 #  include <thrust/system/cuda/detail/parallel_for.h>
 #  include <thrust/system/cuda/detail/util.h>
 
-#  include <iterator>
-
 THRUST_NAMESPACE_BEGIN
 
 namespace cuda_cub

--- a/thrust/thrust/system/cuda/detail/uninitialized_fill.h
+++ b/thrust/thrust/system/cuda/detail/uninitialized_fill.h
@@ -42,8 +42,6 @@
 #  include <thrust/system/cuda/detail/parallel_for.h>
 #  include <thrust/system/cuda/detail/util.h>
 
-#  include <iterator>
-
 THRUST_NAMESPACE_BEGIN
 
 namespace cuda_cub

--- a/thrust/thrust/system/cuda/detail/unique.h
+++ b/thrust/thrust/system/cuda/detail/unique.h
@@ -53,7 +53,7 @@
 #  include <thrust/system/cuda/detail/par_to_seq.h>
 #  include <thrust/system/cuda/detail/util.h>
 
-#  include <cstdint>
+#  include <cuda/std/cstdint>
 
 THRUST_NAMESPACE_BEGIN
 

--- a/thrust/thrust/system/cuda/detail/unique_by_key.h
+++ b/thrust/thrust/system/cuda/detail/unique_by_key.h
@@ -55,7 +55,7 @@
 #  include <thrust/system/cuda/detail/par_to_seq.h>
 #  include <thrust/system/cuda/detail/util.h>
 
-#  include <cstdint>
+#  include <cuda/std/cstdint>
 
 THRUST_NAMESPACE_BEGIN
 

--- a/thrust/thrust/system/cuda/pointer.h
+++ b/thrust/thrust/system/cuda/pointer.h
@@ -33,7 +33,7 @@
 #include <thrust/detail/reference.h>
 #include <thrust/system/cuda/detail/execution_policy.h>
 
-#include <type_traits>
+#include <cuda/std/type_traits>
 
 THRUST_NAMESPACE_BEGIN
 namespace cuda_cub
@@ -87,7 +87,7 @@ using pointer = thrust::pointer<T, thrust::cuda_cub::tag, thrust::tagged_referen
  *  \see raw_pointer_cast
  */
 template <typename T>
-using universal_pointer = thrust::pointer<T, thrust::cuda_cub::tag, typename std::add_lvalue_reference<T>::type>;
+using universal_pointer = thrust::pointer<T, thrust::cuda_cub::tag, ::cuda::std::add_lvalue_reference_t<T>>;
 
 /*! \p cuda::reference is a wrapped reference to an object stored in memory
  *  accessible by the \p cuda system. \p cuda::reference is the type of the

--- a/thrust/thrust/system/detail/generic/copy_if.inl
+++ b/thrust/thrust/system/detail/generic/copy_if.inl
@@ -40,8 +40,6 @@
 
 #include <cuda/std/limits>
 
-#include <limits>
-
 THRUST_NAMESPACE_BEGIN
 namespace system
 {

--- a/thrust/thrust/system/detail/generic/reduce_by_key.inl
+++ b/thrust/thrust/system/detail/generic/reduce_by_key.inl
@@ -38,8 +38,7 @@
 #include <thrust/transform.h>
 
 #include <cuda/std/iterator>
-
-#include <limits>
+#include <cuda/std/limits>
 
 THRUST_NAMESPACE_BEGIN
 namespace system

--- a/thrust/thrust/system/detail/generic/scan_by_key.inl
+++ b/thrust/thrust/system/detail/generic/scan_by_key.inl
@@ -35,7 +35,7 @@
 #include <thrust/system/detail/generic/scan_by_key.h>
 #include <thrust/transform.h>
 
-#include <cstdint>
+#include <cuda/std/cstdint>
 
 THRUST_NAMESPACE_BEGIN
 namespace system

--- a/thrust/thrust/system/detail/generic/sequence.inl
+++ b/thrust/thrust/system/detail/generic/sequence.inl
@@ -85,7 +85,8 @@ template <typename DerivedPolicy, typename ForwardIterator, typename T>
 _CCCL_HOST_DEVICE void
 sequence(thrust::execution_policy<DerivedPolicy>& exec, ForwardIterator first, ForwardIterator last, T init, T step)
 {
-  thrust::tabulate(exec, first, last, detail::compute_sequence_value<T>{std::move(init), std::move(step)});
+  thrust::tabulate(
+    exec, first, last, detail::compute_sequence_value<T>{::cuda::std::move(init), ::cuda::std::move(step)});
 } // end sequence()
 
 } // end namespace generic

--- a/thrust/thrust/system/detail/generic/shuffle.inl
+++ b/thrust/thrust/system/detail/generic/shuffle.inl
@@ -24,7 +24,7 @@
 #include <thrust/scan.h>
 #include <thrust/system/detail/generic/shuffle.h>
 
-#include <cstdint>
+#include <cuda/std/cstdint>
 
 THRUST_NAMESPACE_BEGIN
 namespace system

--- a/thrust/thrust/system/detail/sequential/malloc_and_free.h
+++ b/thrust/thrust/system/detail/sequential/malloc_and_free.h
@@ -28,7 +28,7 @@
 #include <thrust/detail/raw_pointer_cast.h>
 #include <thrust/system/detail/sequential/execution_policy.h>
 
-#include <cstdlib> // for malloc & free
+#include <cuda/std/cstdlib> // for malloc & free
 
 THRUST_NAMESPACE_BEGIN
 namespace system
@@ -41,13 +41,13 @@ namespace sequential
 template <typename DerivedPolicy>
 inline _CCCL_HOST_DEVICE void* malloc(execution_policy<DerivedPolicy>&, std::size_t n)
 {
-  return std::malloc(n);
+  return ::cuda::std::malloc(n);
 } // end mallc()
 
 template <typename DerivedPolicy, typename Pointer>
 inline _CCCL_HOST_DEVICE void free(sequential::execution_policy<DerivedPolicy>&, Pointer ptr)
 {
-  std::free(thrust::raw_pointer_cast(ptr));
+  ::cuda::std::free(thrust::raw_pointer_cast(ptr));
 } // end mallc()
 
 } // namespace sequential

--- a/thrust/thrust/system/detail/sequential/stable_radix_sort.inl
+++ b/thrust/thrust/system/detail/sequential/stable_radix_sort.inl
@@ -34,10 +34,9 @@
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/scatter.h>
 
+#include <cuda/std/cstdint>
+#include <cuda/std/limits>
 #include <cuda/std/utility>
-
-#include <cstdint>
-#include <limits>
 
 THRUST_NAMESPACE_BEGIN
 namespace system
@@ -63,7 +62,7 @@ struct RadixEncoder<char>
 {
   _CCCL_HOST_DEVICE unsigned char operator()(char x) const
   {
-    if (std::numeric_limits<char>::is_signed)
+    if (::cuda::std::numeric_limits<char>::is_signed)
     {
       return static_cast<unsigned char>(x) ^ static_cast<unsigned char>(1) << (8 * sizeof(unsigned char) - 1);
     }

--- a/thrust/thrust/system/detail/sequential/trivial_copy.h
+++ b/thrust/thrust/system/detail/sequential/trivial_copy.h
@@ -31,7 +31,7 @@
 #endif // no system header
 #include <thrust/system/detail/sequential/general_copy.h>
 
-#include <cstring>
+#include <cuda/std/cstring>
 
 #include <nv/target>
 
@@ -49,18 +49,13 @@ _CCCL_HOST_DEVICE T* trivial_copy_n(const T* first, std::ptrdiff_t n, T* result)
   if (n == 0)
   {
     // If `first` or `result` is an invalid pointer,
-    // the behavior of `std::memmove` is undefined, even if `n` is zero.
+    // the behavior of `cuda::std::memmove` is undefined, even if `n` is zero.
     return result;
   }
 
-  T* return_value = nullptr;
+  ::cuda::std::memmove(result, first, n * sizeof(T));
 
-  NV_IF_TARGET(NV_IS_HOST,
-               (std::memmove(result, first, n * sizeof(T)); return_value = result + n;),
-               ( // NV_IS_DEVICE:
-                 return_value = thrust::system::detail::sequential::general_copy_n(first, n, result);));
-
-  return return_value;
+  return result + n;
 } // end trivial_copy_n()
 
 } // end namespace sequential

--- a/thrust/thrust/system/omp/detail/memory.inl
+++ b/thrust/thrust/system/omp/detail/memory.inl
@@ -29,7 +29,7 @@
 #include <thrust/system/cpp/memory.h>
 #include <thrust/system/omp/memory.h>
 
-#include <limits>
+#include <cuda/std/limits>
 
 THRUST_NAMESPACE_BEGIN
 namespace system

--- a/thrust/thrust/system/omp/detail/reduce_intervals.inl
+++ b/thrust/thrust/system/omp/detail/reduce_intervals.inl
@@ -31,7 +31,7 @@
 #include <thrust/system/omp/detail/pragma_omp.h>
 #include <thrust/system/omp/detail/reduce_intervals.h>
 
-#include <cstdint>
+#include <cuda/std/cstdint>
 
 THRUST_NAMESPACE_BEGIN
 namespace system

--- a/thrust/thrust/system/omp/pointer.h
+++ b/thrust/thrust/system/omp/pointer.h
@@ -33,7 +33,7 @@
 #include <thrust/detail/reference.h>
 #include <thrust/system/omp/detail/execution_policy.h>
 
-#include <type_traits>
+#include <cuda/std/type_traits>
 
 THRUST_NAMESPACE_BEGIN
 namespace system
@@ -89,7 +89,7 @@ using pointer = thrust::pointer<T, thrust::system::omp::tag, thrust::tagged_refe
  *  \see raw_pointer_cast
  */
 template <typename T>
-using universal_pointer = thrust::pointer<T, thrust::system::omp::tag, typename std::add_lvalue_reference<T>::type>;
+using universal_pointer = thrust::pointer<T, thrust::system::omp::tag, ::cuda::std::add_lvalue_reference_t<T>>;
 
 /*! \p reference is a wrapped reference to an object stored in memory available
  *  to the \p omp system. \p reference is the type of the result of

--- a/thrust/thrust/system/tbb/detail/memory.inl
+++ b/thrust/thrust/system/tbb/detail/memory.inl
@@ -29,7 +29,7 @@
 #include <thrust/system/cpp/memory.h>
 #include <thrust/system/tbb/memory.h>
 
-#include <limits>
+#include <cuda/std/limits>
 
 THRUST_NAMESPACE_BEGIN
 namespace system

--- a/thrust/thrust/system/tbb/detail/reduce_by_key.inl
+++ b/thrust/thrust/system/tbb/detail/reduce_by_key.inl
@@ -37,8 +37,8 @@
 #include <cuda/std/__algorithm/max.h>
 #include <cuda/std/__algorithm/min.h>
 #include <cuda/std/__type_traits/void_t.h>
+#include <cuda/std/cassert>
 
-#include <cassert>
 #include <thread>
 
 #include <tbb/blocked_range.h>

--- a/thrust/thrust/system/tbb/detail/reduce_intervals.h
+++ b/thrust/thrust/system/tbb/detail/reduce_intervals.h
@@ -32,9 +32,8 @@
 #include <thrust/system/tbb/detail/execution_policy.h>
 
 #include <cuda/std/__algorithm/min.h>
-
-#include <cassert>
-#include <type_traits>
+#include <cuda/std/cassert>
+#include <cuda/std/type_traits>
 
 #include <tbb/parallel_for.h>
 
@@ -83,7 +82,7 @@ struct body
     RandomAccessIterator1 my_last  = first + offset_to_last;
 
     // carefully pass the init value for the interval with raw_reference_cast
-    using sum_type = typename std::decay<decltype(binary_op(*my_first, *my_first))>::type;
+    using sum_type = ::cuda::std::decay_t<decltype(binary_op(*my_first, *my_first))>;
     result[interval_idx] =
       thrust::reduce(thrust::seq, my_first + 1, my_last, sum_type(thrust::raw_reference_cast(*my_first)), binary_op);
   }

--- a/thrust/thrust/system/tbb/pointer.h
+++ b/thrust/thrust/system/tbb/pointer.h
@@ -33,7 +33,7 @@
 #include <thrust/detail/reference.h>
 #include <thrust/system/tbb/detail/execution_policy.h>
 
-#include <type_traits>
+#include <cuda/std/type_traits>
 
 THRUST_NAMESPACE_BEGIN
 namespace system
@@ -89,7 +89,7 @@ using pointer = thrust::pointer<T, thrust::system::tbb::tag, thrust::tagged_refe
  *  \see raw_pointer_cast
  */
 template <typename T>
-using universal_pointer = thrust::pointer<T, thrust::system::tbb::tag, typename std::add_lvalue_reference<T>::type>;
+using universal_pointer = thrust::pointer<T, thrust::system::tbb::tag, ::cuda::std::add_lvalue_reference_t<T>>;
 
 /*! \p reference is a wrapped reference to an object stored in memory available
  *  to the \p tbb system. \p reference is the type of the result of

--- a/thrust/thrust/zip_function.h
+++ b/thrust/thrust/zip_function.h
@@ -50,7 +50,7 @@ _CCCL_HOST_DEVICE decltype(auto) apply_impl(Function&& func, Tuple&& args, index
 template <typename Function, typename Tuple>
 _CCCL_HOST_DEVICE decltype(auto) apply(Function&& func, Tuple&& args)
 {
-  constexpr auto tuple_size = thrust::tuple_size<typename std::decay<Tuple>::type>::value;
+  constexpr auto tuple_size = thrust::tuple_size<::cuda::std::decay_t<Tuple>>::value;
   return apply_impl(THRUST_FWD(func), THRUST_FWD(args), make_index_sequence<tuple_size>{});
 }
 
@@ -126,7 +126,7 @@ public:
   zip_function() = default;
 
   _CCCL_HOST_DEVICE zip_function(Function func)
-      : func(std::move(func))
+      : func(::cuda::std::move(func))
   {}
 
   // Add workaround for decltype(auto) on C++11-only compilers:
@@ -155,9 +155,9 @@ private:
  *  \see zip_function
  */
 template <typename Function>
-_CCCL_HOST_DEVICE zip_function<typename std::decay<Function>::type> make_zip_function(Function&& fun)
+_CCCL_HOST_DEVICE zip_function<::cuda::std::decay_t<Function>> make_zip_function(Function&& fun)
 {
-  using func_t = typename std::decay<Function>::type;
+  using func_t = ::cuda::std::decay_t<Function>;
   return zip_function<func_t>(THRUST_FWD(fun));
 }
 


### PR DESCRIPTION
We want to be able to build parts of thrust with nvrtc, which prevents us to use includes from the host standard library.

Luckily libcu++ has most of the required features covered so that we can just use them as a drop in replacement for the standard includes