### PR TITLE
Add transform python wrappers

### DIFF
--- a/c/parallel/include/cccl/c/transform.h
+++ b/c/parallel/include/cccl/c/transform.h
@@ -47,7 +47,7 @@ CCCL_C_API CUresult cccl_device_unary_transform(
   cccl_device_transform_build_result_t build,
   cccl_iterator_t d_in,
   cccl_iterator_t d_out,
-  unsigned long long num_items,
+  uint64_t num_items,
   cccl_op_t op,
   CUstream stream);
 
@@ -69,7 +69,7 @@ CCCL_C_API CUresult cccl_device_binary_transform(
   cccl_iterator_t d_in1,
   cccl_iterator_t d_in2,
   cccl_iterator_t d_out,
-  unsigned long long num_items,
+  uint64_t num_items,
   cccl_op_t op,
   CUstream stream);
 

--- a/c/parallel/src/transform.cu
+++ b/c/parallel/src/transform.cu
@@ -222,8 +222,8 @@ CUresult cccl_device_unary_transform_build(
 struct __align__({1}) input_storage_t {{
   char data[{0}];
 }};
-struct __align__({2}) output_storage_t {{
-  char data[{3}];
+struct __align__({3}) output_storage_t {{
+  char data[{2}];
 }};
 {8}
 {9}

--- a/c/parallel/src/transform.cu
+++ b/c/parallel/src/transform.cu
@@ -318,7 +318,7 @@ CUresult cccl_device_unary_transform(
   cccl_device_transform_build_result_t build,
   cccl_iterator_t d_in,
   cccl_iterator_t d_out,
-  unsigned long long num_items,
+  uint64_t num_items,
   cccl_op_t op,
   CUstream stream)
 {
@@ -509,7 +509,7 @@ CUresult cccl_device_binary_transform(
   cccl_iterator_t d_in1,
   cccl_iterator_t d_in2,
   cccl_iterator_t d_out,
-  unsigned long long num_items,
+  uint64_t num_items,
   cccl_op_t op,
   CUstream stream)
 {

--- a/python/cuda_parallel/benchmarks/bench_transform.py
+++ b/python/cuda_parallel/benchmarks/bench_transform.py
@@ -1,0 +1,99 @@
+import cupy as cp
+import numpy as np
+
+import cuda.parallel.experimental.algorithms as algorithms
+import cuda.parallel.experimental.iterators as iterators
+
+
+def unary_transform_pointer(size, build_only):
+    d_in = cp.arange(size, dtype="i4")
+    d_out = cp.empty_like(d_in)
+
+    def op(a):
+        return a + 1
+
+    transform = algorithms.unary_transform(d_in, d_out, op)
+
+    if not build_only:
+        transform(d_in, d_out, size)
+
+    cp.cuda.runtime.deviceSynchronize()
+
+
+def unary_transform_iterator(size, build_only):
+    d_in = iterators.CountingIterator(np.int32(0))
+    d_out = cp.empty(size, dtype=np.int32)
+
+    def op(a):
+        return a + 1
+
+    transform = algorithms.unary_transform(d_in, d_out, op)
+
+    if not build_only:
+        transform(d_in, d_out, size)
+
+    cp.cuda.runtime.deviceSynchronize()
+
+
+def binary_transform_pointer(size, build_only):
+    d_in1 = cp.arange(size, dtype="i4")
+    d_in2 = cp.arange(size, dtype="i4")
+    d_out = cp.empty_like(d_in1)
+
+    def op(a, b):
+        return a + b
+
+    transform = algorithms.binary_transform(d_in1, d_in2, d_out, op)
+
+    if not build_only:
+        transform(d_in1, d_in2, d_out, size)
+
+    cp.cuda.runtime.deviceSynchronize()
+
+
+def binary_transform_iterator(size, build_only):
+    d_in1 = iterators.CountingIterator(np.int32(0))
+    d_in2 = iterators.CountingIterator(np.int32(1))
+    d_out = cp.empty(size, dtype=np.int32)
+
+    def op(a, b):
+        return a + b
+
+    transform = algorithms.binary_transform(d_in1, d_in2, d_out, op)
+
+    if not build_only:
+        transform(d_in1, d_in2, d_out, size)
+
+    cp.cuda.runtime.deviceSynchronize()
+
+
+def bench_compile_unary_transform_pointer(compile_benchmark):
+    compile_benchmark(algorithms.unary_transform, unary_transform_pointer)
+
+
+def bench_compile_unary_transform_iterator(compile_benchmark):
+    compile_benchmark(algorithms.unary_transform, unary_transform_iterator)
+
+
+def bench_compile_binary_transform_pointer(compile_benchmark):
+    compile_benchmark(algorithms.binary_transform, binary_transform_pointer)
+
+
+def bench_compile_binary_transform_iterator(compile_benchmark):
+    compile_benchmark(algorithms.binary_transform, binary_transform_iterator)
+
+
+def bench_unary_transform_pointer(benchmark, size):
+    benchmark(unary_transform_pointer, size, build_only=False)
+
+
+def bench_unary_transform_iterator(benchmark, size):
+    benchmark(unary_transform_iterator, size, build_only=False)
+
+
+def bench_binary_transform_pointer(benchmark, size):
+    benchmark(binary_transform_pointer, size, build_only=False)
+
+
+def bench_binary_transform_iterator(benchmark, size):
+    benchmark(binary_transform_iterator, size, build_only=False)

--- a/python/cuda_parallel/cuda/parallel/experimental/_bindings.pyi
+++ b/python/cuda_parallel/cuda/parallel/experimental/_bindings.pyi
@@ -310,3 +310,45 @@ class DeviceUniqueByKeyBuildResult:
         num_items: int,
         stream,
     ) -> tuple[int, int]: ...
+
+# --------------------
+# DeviceUnaryTransform
+# --------------------
+
+class DeviceUnaryTransform:
+    def __init__(
+        self,
+        d_in: Iterator,
+        d_out: Iterator,
+        op: Op,
+        info: CommonData,
+    ): ...
+    def compute(
+        self,
+        d_in: Iterator,
+        d_out: Iterator,
+        num_items: int,
+        stream,
+    ) -> tuple[int, int]: ...
+
+# ---------------------
+# DeviceBinaryTransform
+# ---------------------
+
+class DeviceBinaryTransform:
+    def __init__(
+        self,
+        d_in1: Iterator,
+        d_in2: Iterator,
+        d_out: Iterator,
+        op: Op,
+        info: CommonData,
+    ): ...
+    def compute(
+        self,
+        d_in1: Iterator,
+        d_in2: Iterator,
+        d_out: Iterator,
+        num_items: int,
+        stream,
+    ) -> tuple[int, int]: ...

--- a/python/cuda_parallel/cuda/parallel/experimental/_bindings.pyi
+++ b/python/cuda_parallel/cuda/parallel/experimental/_bindings.pyi
@@ -329,7 +329,7 @@ class DeviceUnaryTransform:
         d_out: Iterator,
         num_items: int,
         stream,
-    ) -> tuple[int, int]: ...
+    ) -> None: ...
 
 # ---------------------
 # DeviceBinaryTransform
@@ -351,4 +351,4 @@ class DeviceBinaryTransform:
         d_out: Iterator,
         num_items: int,
         stream,
-    ) -> tuple[int, int]: ...
+    ) -> None: ...

--- a/python/cuda_parallel/cuda/parallel/experimental/_bindings.pyx
+++ b/python/cuda_parallel/cuda/parallel/experimental/_bindings.pyx
@@ -1616,12 +1616,7 @@ cdef class DeviceUniqueByKeyBuildResult:
 # --------------------------------------------
 cdef extern from "cccl/c/transform.h":
     cdef struct cccl_device_transform_build_result_t:
-        int cc
-        void *cubin
-        size_t cubin_size
-        CUlibrary library
-        CUkernel transform_kernel
-        int loaded_bytes_per_iteration
+        pass
 
     cdef CUresult cccl_device_unary_transform_build(
         cccl_device_transform_build_result_t *build_ptr,

--- a/python/cuda_parallel/cuda/parallel/experimental/_bindings.pyx
+++ b/python/cuda_parallel/cuda/parallel/experimental/_bindings.pyx
@@ -1630,7 +1630,7 @@ cdef extern from "cccl/c/transform.h":
       cccl_device_transform_build_result_t build,
       cccl_iterator_t d_in,
       cccl_iterator_t d_out,
-      unsigned long long num_items,
+      uint64_t num_items,
       cccl_op_t op,
       CUstream stream) nogil
 
@@ -1648,7 +1648,7 @@ cdef extern from "cccl/c/transform.h":
       cccl_iterator_t d_in1,
       cccl_iterator_t d_in2,
       cccl_iterator_t d_out,
-      unsigned long long num_items,
+      uint64_t num_items,
       cccl_op_t op,
       CUstream stream) nogil
 

--- a/python/cuda_parallel/cuda/parallel/experimental/algorithms/__init__.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/algorithms/__init__.py
@@ -8,6 +8,7 @@ from ._reduce import reduce_into as reduce_into
 from ._scan import exclusive_scan as exclusive_scan
 from ._scan import inclusive_scan as inclusive_scan
 from ._segmented_reduce import segmented_reduce
+from ._transform import binary_transform, unary_transform
 from ._unique_by_key import unique_by_key as unique_by_key
 
 __all__ = [
@@ -17,4 +18,6 @@ __all__ = [
     "inclusive_scan",
     "segmented_reduce",
     "unique_by_key",
+    "binary_transform",
+    "unary_transform",
 ]

--- a/python/cuda_parallel/cuda/parallel/experimental/algorithms/_merge_sort.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/algorithms/_merge_sort.py
@@ -24,6 +24,10 @@ def make_cache_key(
     d_out_items: DeviceArrayLike | None,
     op: Callable,
 ):
+    d_in_keys, d_in_items, d_out_keys, d_out_items = scrub_duplicate_ltoirs(
+        d_in_keys, d_in_items, d_out_keys, d_out_items
+    )
+
     d_in_keys_key = (
         d_in_keys.kind
         if isinstance(d_in_keys, IteratorBase)

--- a/python/cuda_parallel/cuda/parallel/experimental/algorithms/_merge_sort.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/algorithms/_merge_sort.py
@@ -13,7 +13,7 @@ from .._caching import CachableFunction, cache_with_key
 from .._cccl_interop import call_build, set_cccl_iterator_state
 from .._utils import protocols
 from .._utils.protocols import get_data_pointer, validate_and_get_stream
-from ..iterators._iterators import IteratorBase
+from ..iterators._iterators import IteratorBase, scrub_duplicate_ltoirs
 from ..typing import DeviceArrayLike
 
 

--- a/python/cuda_parallel/cuda/parallel/experimental/algorithms/_transform.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/algorithms/_transform.py
@@ -1,0 +1,212 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from typing import Callable
+
+from .. import _bindings
+from .. import _cccl_interop as cccl
+from .._caching import CachableFunction, cache_with_key
+from .._utils import protocols
+from ..iterators._iterators import IteratorBase, scrub_duplicate_ltoirs
+from ..typing import DeviceArrayLike
+
+
+class _UnaryTransform:
+    __slots__ = [
+        "d_in_cccl",
+        "d_out_cccl",
+        "op_wrapper",
+        "build_result",
+    ]
+
+    def __init__(
+        self,
+        d_in: DeviceArrayLike | IteratorBase,
+        d_out: DeviceArrayLike | IteratorBase,
+        op: Callable,
+    ):
+        self.d_in_cccl = cccl.to_cccl_iter(d_in)
+        self.d_out_cccl = cccl.to_cccl_iter(d_out)
+        in_value_type = cccl.get_value_type(d_in)
+        out_value_type = cccl.get_value_type(d_out)
+        if not out_value_type.is_internal:
+            sig = (in_value_type,)
+        else:
+            sig = out_value_type(in_value_type)
+        self.op_wrapper = cccl.to_cccl_op(op, sig=sig)
+        self.build_result = cccl.call_build(
+            _bindings.DeviceUnaryTransform,
+            self.d_in_cccl,
+            self.d_out_cccl,
+            self.op_wrapper,
+        )
+
+    def __call__(
+        self,
+        d_in,
+        d_out,
+        num_items: int,
+        stream=None,
+    ):
+        cccl.set_cccl_iterator_state(self.d_in_cccl, d_in)
+        cccl.set_cccl_iterator_state(self.d_out_cccl, d_out)
+        stream_handle = protocols.validate_and_get_stream(stream)
+        self.build_result.compute(
+            self.d_in_cccl,
+            self.d_out_cccl,
+            num_items,
+            self.op_wrapper,
+            stream_handle,
+        )
+        return None
+
+
+class _BinaryTransform:
+    __slots__ = [
+        "d_in1_cccl",
+        "d_in2_cccl",
+        "d_out_cccl",
+        "op_wrapper",
+        "build_result",
+    ]
+
+    def __init__(
+        self,
+        d_in1: DeviceArrayLike | IteratorBase,
+        d_in2: DeviceArrayLike | IteratorBase,
+        d_out: DeviceArrayLike | IteratorBase,
+        op: Callable,
+    ):
+        d_in1, d_in2 = scrub_duplicate_ltoirs(d_in1, d_in2)
+
+        self.d_in1_cccl = cccl.to_cccl_iter(d_in1)
+        self.d_in2_cccl = cccl.to_cccl_iter(d_in2)
+        self.d_out_cccl = cccl.to_cccl_iter(d_out)
+        in1_value_type = cccl.get_value_type(d_in1)
+        in2_value_type = cccl.get_value_type(d_in2)
+        out_value_type = cccl.get_value_type(d_out)
+
+        if not out_value_type.is_internal:
+            sig = (in1_value_type, in2_value_type)
+        else:
+            sig = out_value_type(in1_value_type, in2_value_type)
+        self.op_wrapper = cccl.to_cccl_op(op, sig=sig)
+        self.build_result = cccl.call_build(
+            _bindings.DeviceBinaryTransform,
+            self.d_in1_cccl,
+            self.d_in2_cccl,
+            self.d_out_cccl,
+            self.op_wrapper,
+        )
+
+    def __call__(
+        self,
+        d_in1,
+        d_in2,
+        d_out,
+        num_items: int,
+        stream=None,
+    ):
+        cccl.set_cccl_iterator_state(self.d_in1_cccl, d_in1)
+        cccl.set_cccl_iterator_state(self.d_in2_cccl, d_in2)
+        cccl.set_cccl_iterator_state(self.d_out_cccl, d_out)
+        stream_handle = protocols.validate_and_get_stream(stream)
+        self.build_result.compute(
+            self.d_in1_cccl,
+            self.d_in2_cccl,
+            self.d_out_cccl,
+            num_items,
+            self.op_wrapper,
+            stream_handle,
+        )
+        return None
+
+
+def make_unary_transform_cache_key(
+    d_in: DeviceArrayLike | IteratorBase,
+    d_out: DeviceArrayLike,
+    op: Callable,
+):
+    d_in_key = (
+        d_in.kind if isinstance(d_in, IteratorBase) else protocols.get_dtype(d_in)
+    )
+    d_out_key = protocols.get_dtype(d_out)
+    op_key = CachableFunction(op)
+    return (d_in_key, d_out_key, op_key)
+
+
+def make_binary_transform_cache_key(
+    d_in1: DeviceArrayLike | IteratorBase,
+    d_in2: DeviceArrayLike | IteratorBase,
+    d_out: DeviceArrayLike,
+    op: Callable,
+):
+    d_in1_key = (
+        d_in1.kind if isinstance(d_in1, IteratorBase) else protocols.get_dtype(d_in1)
+    )
+    d_in2_key = (
+        d_in2.kind if isinstance(d_in2, IteratorBase) else protocols.get_dtype(d_in2)
+    )
+    d_out_key = protocols.get_dtype(d_out)
+    op_key = CachableFunction(op)
+    return (d_in1_key, d_in2_key, d_out_key, op_key)
+
+
+@cache_with_key(make_unary_transform_cache_key)
+def unary_transform(
+    d_in: DeviceArrayLike | IteratorBase,
+    d_out: DeviceArrayLike | IteratorBase,
+    op: Callable,
+):
+    """
+    Apply a transformation to each element of the input according to the
+    unary operation ``op``.
+
+    Example:
+        .. literalinclude:: ../../python/cuda_parallel/tests/test_transform.py
+           :language: python
+           :dedent:
+           :start-after: example-begin transform-unary
+           :end-before: example-end transform-unary
+
+    Args:
+        d_in: Device array or iterator containing the input sequence of data items.
+        d_out: Device array or iterator to store the result of the transformation.
+        op: Unary operation to apply to each element of the input.
+
+    Returns:
+        A callable that performs the transformation.
+    """
+    return _UnaryTransform(d_in, d_out, op)
+
+
+@cache_with_key(make_binary_transform_cache_key)
+def binary_transform(
+    d_in1: DeviceArrayLike | IteratorBase,
+    d_in2: DeviceArrayLike | IteratorBase,
+    d_out: DeviceArrayLike | IteratorBase,
+    op: Callable,
+):
+    """
+    Apply a transformation to the given pair of input sequences according to the
+    binary operation ``op``.
+
+    Example:
+        .. literalinclude:: ../../python/cuda_parallel/tests/test_transform.py
+           :language: python
+           :dedent:
+           :start-after: example-begin transform-binary
+           :end-before: example-end transform-binary
+
+    Args:
+        d_in1: Device array or iterator containing the first input sequence of data items.
+        d_in2: Device array or iterator containing the second input sequence of data items.
+        d_out: Device array or iterator to store the result of the transformation.
+        op: Binary operation to apply to each pair of items from the input sequences.
+
+    Returns:
+        A callable that performs the transformation.
+    """
+    return _BinaryTransform(d_in1, d_in2, d_out, op)

--- a/python/cuda_parallel/cuda/parallel/experimental/algorithms/_transform.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/algorithms/_transform.py
@@ -8,6 +8,7 @@ from typing import Callable
 from .. import _bindings
 from .. import _cccl_interop as cccl
 from .._caching import CachableFunction, cache_with_key
+from .._cccl_interop import set_cccl_iterator_state
 from .._utils import protocols
 from ..iterators._iterators import IteratorBase, scrub_duplicate_ltoirs
 from ..typing import DeviceArrayLike
@@ -50,8 +51,8 @@ class _UnaryTransform:
         num_items: int,
         stream=None,
     ):
-        cccl.set_cccl_iterator_state(self.d_in_cccl, d_in)
-        cccl.set_cccl_iterator_state(self.d_out_cccl, d_out)
+        set_cccl_iterator_state(self.d_in_cccl, d_in)
+        set_cccl_iterator_state(self.d_out_cccl, d_out)
         stream_handle = protocols.validate_and_get_stream(stream)
         self.build_result.compute(
             self.d_in_cccl,
@@ -109,9 +110,9 @@ class _BinaryTransform:
         num_items: int,
         stream=None,
     ):
-        cccl.set_cccl_iterator_state(self.d_in1_cccl, d_in1)
-        cccl.set_cccl_iterator_state(self.d_in2_cccl, d_in2)
-        cccl.set_cccl_iterator_state(self.d_out_cccl, d_out)
+        set_cccl_iterator_state(self.d_in1_cccl, d_in1)
+        set_cccl_iterator_state(self.d_in2_cccl, d_in2)
+        set_cccl_iterator_state(self.d_out_cccl, d_out)
         stream_handle = protocols.validate_and_get_stream(stream)
         self.build_result.compute(
             self.d_in1_cccl,

--- a/python/cuda_parallel/cuda/parallel/experimental/algorithms/_unique_by_key.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/algorithms/_unique_by_key.py
@@ -78,6 +78,9 @@ class _UniqueByKey:
         d_out_num_selected: DeviceArrayLike,
         op: Callable,
     ):
+        d_in_keys, d_in_items, d_out_keys, d_out_items = scrub_duplicate_ltoirs(
+            d_in_keys, d_in_items, d_out_keys, d_out_items
+        )
         self.d_in_keys_cccl = cccl.to_cccl_iter(d_in_keys)
         self.d_in_items_cccl = cccl.to_cccl_iter(d_in_items)
         self.d_out_keys_cccl = cccl.to_cccl_iter(d_out_keys)

--- a/python/cuda_parallel/cuda/parallel/experimental/algorithms/_unique_by_key.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/algorithms/_unique_by_key.py
@@ -13,7 +13,7 @@ from .._caching import CachableFunction, cache_with_key
 from .._cccl_interop import call_build, set_cccl_iterator_state
 from .._utils import protocols
 from .._utils.protocols import get_data_pointer, validate_and_get_stream
-from ..iterators._iterators import IteratorBase
+from ..iterators._iterators import IteratorBase, scrub_duplicate_ltoirs
 from ..typing import DeviceArrayLike
 
 

--- a/python/cuda_parallel/cuda/parallel/experimental/iterators/__init__.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/iterators/__init__.py
@@ -3,7 +3,7 @@ import numba
 from . import _iterators
 
 
-def CacheModifiedInputIterator(device_array, modifier, prefix=""):
+def CacheModifiedInputIterator(device_array, modifier):
     """Random Access Cache Modified Iterator that wraps a native device pointer.
 
     Similar to https://nvidia.github.io/cccl/cub/api/classcub_1_1CacheModifiedInputIterator.html
@@ -32,7 +32,6 @@ def CacheModifiedInputIterator(device_array, modifier, prefix=""):
     return _iterators.CacheModifiedPointer(
         device_array.__cuda_array_interface__["data"][0],
         numba.from_dtype(device_array.dtype),
-        prefix,
     )
 
 

--- a/python/cuda_parallel/cuda/parallel/experimental/iterators/_iterators.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/iterators/_iterators.py
@@ -112,8 +112,9 @@ class IteratorBase:
     @property
     def ltoirs(self) -> Dict[str, bytes]:
         if self._ltoirs is None:
-            advance_abi_name = "advance_" + _get_abi_suffix(self.kind)
-            deref_abi_name = "dereference_" + _get_abi_suffix(self.kind)
+            abi_suffix = _get_abi_suffix(self.kind)
+            advance_abi_name = f"advance_{abi_suffix}"
+            deref_abi_name = f"dereference_{abi_suffix}"
             advance_ltoir, _ = cached_compile(
                 self.__class__.advance,
                 (
@@ -477,14 +478,14 @@ def _get_last_element_ptr(device_array) -> int:
 
 def _replace_duplicate_values(*ds, replacement_value):
     # given a sequence of dictionaries, return a sequence of dictionaries
-    # such that for any found duplicate keys, the value is set to `scrub_value`.
+    # such that for any found duplicate keys, the value is set to `replacement_value`.
     if len(ds) <= 1:
         return ds
     seen = set(ds[0].keys())
     for d in ds[1:]:
         for key in d:
             if key in seen:
-                d[key] = b""
+                d[key] = replacement_value
         seen.update(d.keys())
     return ds
 

--- a/python/cuda_parallel/cuda/parallel/experimental/iterators/_iterators.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/iterators/_iterators.py
@@ -103,7 +103,7 @@ class IteratorBase:
         self.value_type = value_type
         self.kind_ = self.__class__.iterator_kind_type(self.value_type, self.state_type)
         self.state_ = IteratorState(self.cvalue)
-        self._ltoirs: Dict[str, bytes] | None = None        
+        self._ltoirs: Dict[str, bytes] | None = None
 
     @property
     def kind(self):
@@ -158,7 +158,9 @@ class IteratorBase:
 
     def copy(self):
         out = object.__new__(self.__class__)
-        IteratorBase.__init__(out, self.cvalue, self.numba_type, self.state_type, self.value_type)
+        IteratorBase.__init__(
+            out, self.cvalue, self.numba_type, self.state_type, self.value_type
+        )
         out.ltoirs = self.ltoirs
         return out
 
@@ -257,7 +259,12 @@ class CacheModifiedPointer(IteratorBase):
         value_type = ntype
         state_type = types.CPointer(value_type)
         numba_type = types.CPointer(state_type)
-        super().__init__(cvalue=cvalue, numba_type=numba_type, state_type=state_type, value_type=value_type)
+        super().__init__(
+            cvalue=cvalue,
+            numba_type=numba_type,
+            state_type=state_type,
+            value_type=value_type,
+        )
 
     @staticmethod
     def advance(state, distance):

--- a/python/cuda_parallel/cuda/parallel/experimental/iterators/_iterators.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/iterators/_iterators.py
@@ -2,7 +2,7 @@ import ctypes
 import operator
 import uuid
 from functools import lru_cache
-from typing import Callable, Dict
+from typing import Any, Callable, Dict
 
 import numba
 import numpy as np
@@ -83,7 +83,6 @@ class IteratorBase:
         numba_type: types.Type,
         state_type: types.Type,
         value_type: types.Type,
-        prefix: str = "",
     ):
         """
         Parameters
@@ -97,46 +96,50 @@ class IteratorBase:
           A numba type of the iterator state.
         value_type
           The numba type of the value returned by the dereference operation.
-        prefix
-          An optional prefix added to the iterator's methods to prevent name collisions.
         """
         self.cvalue = cvalue
         self.numba_type = numba_type
         self.state_type = state_type
         self.value_type = value_type
-        self.prefix = prefix
         self.kind_ = self.__class__.iterator_kind_type(self.value_type, self.state_type)
         self.state_ = IteratorState(self.cvalue)
+        self._ltoirs: Dict[str, bytes] | None = None        
 
     @property
     def kind(self):
         return self.kind_
 
-    # TODO: should we cache this? Current docs environment doesn't allow
-    # using Python > 3.7. We could use a hand-rolled cached_property if
-    # needed.
     @property
     def ltoirs(self) -> Dict[str, bytes]:
-        abi_suffix = _get_abi_suffix(self.kind)
-        advance_abi_name = f"{self.prefix}advance_{abi_suffix}"
-        deref_abi_name = f"{self.prefix}dereference_{abi_suffix}"
-        advance_ltoir, _ = cached_compile(
-            self.__class__.advance,
-            (
-                self.numba_type,
-                types.uint64,  # distance type
-            ),
-            output="ltoir",
-            abi_name=advance_abi_name,
-        )
+        if self._ltoirs is None:
+            advance_abi_name = "advance_" + _get_abi_suffix(self.kind)
+            deref_abi_name = "dereference_" + _get_abi_suffix(self.kind)
+            advance_ltoir, _ = cached_compile(
+                self.__class__.advance,
+                (
+                    self.numba_type,
+                    types.uint64,  # distance type
+                ),
+                output="ltoir",
+                abi_name=advance_abi_name,
+            )
 
-        deref_ltoir, _ = cached_compile(
-            self.__class__.dereference,
-            (self.numba_type,),
-            output="ltoir",
-            abi_name=deref_abi_name,
-        )
-        return {advance_abi_name: advance_ltoir, deref_abi_name: deref_ltoir}
+            deref_ltoir, _ = cached_compile(
+                self.__class__.dereference,
+                (self.numba_type,),
+                output="ltoir",
+                abi_name=deref_abi_name,
+            )
+            self._ltoirs = {
+                advance_abi_name: advance_ltoir,
+                deref_abi_name: deref_ltoir,
+            }
+        assert self._ltoirs is not None
+        return self._ltoirs
+
+    @ltoirs.setter
+    def ltoirs(self, value):
+        self._ltoirs = value
 
     @property
     def state(self) -> IteratorState:
@@ -152,6 +155,12 @@ class IteratorBase:
 
     def __add__(self, offset: int):
         return make_advanced_iterator(self, offset=offset)
+
+    def copy(self):
+        out = object.__new__(self.__class__)
+        IteratorBase.__init__(out, self.cvalue, self.numba_type, self.state_type, self.value_type)
+        out.ltoirs = self.ltoirs
+        return out
 
 
 def sizeof_pointee(context, ptr):
@@ -243,18 +252,12 @@ class CacheModifiedPointerKind(IteratorKind):
 class CacheModifiedPointer(IteratorBase):
     iterator_kind_type = CacheModifiedPointerKind
 
-    def __init__(self, ptr: int, ntype: types.Type, prefix: str):
+    def __init__(self, ptr: int, ntype: types.Type):
         cvalue = ctypes.c_void_p(ptr)
         value_type = ntype
         state_type = types.CPointer(value_type)
         numba_type = types.CPointer(state_type)
-        super().__init__(
-            cvalue=cvalue,
-            numba_type=numba_type,
-            state_type=state_type,
-            value_type=value_type,
-            prefix=prefix,
-        )
+        super().__init__(cvalue=cvalue, numba_type=numba_type, state_type=state_type, value_type=value_type)
 
     @staticmethod
     def advance(state, distance):
@@ -463,3 +466,39 @@ def _get_last_element_ptr(device_array) -> int:
 
     ptr = get_data_pointer(device_array)
     return ptr + offset_to_last_element
+
+
+def _replace_duplicate_values(*ds, replacement_value):
+    # given a sequence of dictionaries, return a sequence of dictionaries
+    # such that for any found duplicate keys, the value is set to `scrub_value`.
+    if len(ds) <= 1:
+        return ds
+    seen = set(ds[0].keys())
+    for d in ds[1:]:
+        for key in d:
+            if key in seen:
+                d[key] = b""
+        seen.update(d.keys())
+    return ds
+
+
+def scrub_duplicate_ltoirs(*maybe_iterators: Any) -> tuple[Any, ...]:
+    """
+    Scrub duplicate `ltoirs` from iterators in the provided sequence.
+
+    If the sequence contains iterators with duplicate advance/dereference
+    ltoirs, those are set to the empty byte string b"". This pre-processing
+    step ensures that NVRTC doesn't see the same symbol defined more than
+    once.
+    """
+    # extract just the iterators:
+    iterators = [it.copy() for it in maybe_iterators if isinstance(it, IteratorBase)]
+
+    # replace duplicate ltoirs with empty byte strings:
+    ltoirs = _replace_duplicate_values(
+        *(it.ltoirs for it in iterators), replacement_value=b""
+    )
+    for it, ltoir in zip(iterators, ltoirs):
+        it.ltoirs = ltoir
+
+    return maybe_iterators

--- a/python/cuda_parallel/tests/test_merge_sort.py
+++ b/python/cuda_parallel/tests/test_merge_sort.py
@@ -160,7 +160,7 @@ def test_merge_sort_pairs_copy(dtype, num_items):
     np.testing.assert_array_equal(h_out_items, h_in_items)
 
 
-@pytest.mark.xfail(
+@pytest.mark.skip(
     reason="Creating an array of gpu_struct keys does not work currently (see https://github.com/NVIDIA/cccl/issues/3789)"
 )
 def test_merge_sort_pairs_struct_type():
@@ -264,12 +264,8 @@ def test_merge_sort_pairs_copy_iterator_input(dtype, num_items):
     d_out_keys = numba.cuda.to_device(h_out_keys)
     d_out_items = numba.cuda.to_device(h_out_items)
 
-    i_input_keys = iterators.CacheModifiedInputIterator(
-        d_in_keys, modifier="stream", prefix="keys"
-    )
-    i_input_items = iterators.CacheModifiedInputIterator(
-        d_in_items, modifier="stream", prefix="items"
-    )
+    i_input_keys = iterators.CacheModifiedInputIterator(d_in_keys, modifier="stream")
+    i_input_items = iterators.CacheModifiedInputIterator(d_in_items, modifier="stream")
 
     merge_sort_device(
         i_input_keys, i_input_items, d_out_keys, d_out_items, compare_op, num_items

--- a/python/cuda_parallel/tests/test_transform.py
+++ b/python/cuda_parallel/tests/test_transform.py
@@ -1,0 +1,228 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import cupy as cp
+import numpy as np
+import pytest
+
+import cuda.parallel.experimental.algorithms as algorithms
+import cuda.parallel.experimental.iterators as iterators
+from cuda.parallel.experimental.struct import gpu_struct
+
+
+def unary_transform_host(h_input: np.ndarray, op):
+    return np.vectorize(op)(h_input)
+
+
+def unary_transform_device(d_input, d_output, num_items, op, stream=None):
+    transform = algorithms.unary_transform(d_input, d_output, op)
+    transform(d_input, d_output, num_items, stream=stream)
+
+
+def binary_transform_host(h_input1: np.ndarray, h_input2: np.ndarray, op):
+    return np.vectorize(op)(h_input1, h_input2)
+
+
+def binary_transform_device(d_input1, d_input2, d_output, num_items, op, stream=None):
+    transform = algorithms.binary_transform(d_input1, d_input2, d_output, op)
+    transform(d_input1, d_input2, d_output, num_items, stream=stream)
+
+
+def test_unary_transform(input_array):
+    # example-begin transform-unary
+    import numpy as np
+
+    def op(a):
+        return a + 1
+
+    d_in = input_array
+    d_out = cp.empty_like(d_in)
+
+    unary_transform_device(d_in, d_out, len(d_in), op)
+
+    got = d_out.get()
+    expected = unary_transform_host(d_in.get(), op)
+
+    np.testing.assert_allclose(expected, got, rtol=1e-5)
+    # example-end transform-unary
+
+
+def test_binary_transform(input_array):
+    # example-begin transform-binary
+    import numpy as np
+
+    def op(a, b):
+        return a + b
+
+    d_in1 = input_array
+    d_in2 = input_array
+    d_out = cp.empty_like(d_in1)
+
+    binary_transform_device(d_in1, d_in2, d_out, len(d_in1), op)
+
+    got = d_out.get()
+    expected = binary_transform_host(d_in1.get(), d_in2.get(), op)
+
+    np.testing.assert_allclose(expected, got, rtol=1e-5)
+    # example-end transform-binary
+
+
+@pytest.mark.skip(reason="https://github.com/NVIDIA/numba-cuda/issues/175")
+def test_unary_transform_struct_type():
+    import numpy as np
+
+    @gpu_struct
+    class MyStruct:
+        x: np.int16
+        y: np.uint64
+
+    def op(a):
+        return MyStruct(a.x * 2, a.y + 10)
+
+    num_values = 10_000
+
+    h_in = np.empty(num_values, dtype=MyStruct)
+    h_in["x"] = np.arange(num_values)
+    h_in["y"] = 1
+    d_in = cp.empty_like(h_in)
+
+    cp.cuda.runtime.memcpy(
+        d_in.data.ptr,
+        h_in.__array_interface__["data"][0],
+        h_in.nbytes,
+        cp.cuda.runtime.memcpyHostToDevice,
+    )
+
+    d_out = cp.empty_like(d_in)
+
+    transform = algorithms.unary_transform(d_in, d_out, op)
+    transform(d_in, d_out, len(d_in))
+
+    got = d_out.get()
+
+    np.testing.assert_allclose(got["x"], np.arange(num_values) * 2)
+    np.testing.assert_allclose(got["y"], np.ones(num_values) + 10)
+
+
+@pytest.mark.skip(reason="https://github.com/NVIDIA/numba-cuda/issues/175")
+def test_binary_transform_struct_type():
+    import numpy as np
+
+    @gpu_struct
+    class MyStruct:
+        x: np.int16
+        y: np.uint64
+
+    def op(a, b):
+        return MyStruct(a.x + b.x, a.y + b.y)
+
+    num_values = 10_000
+
+    h_in1 = np.empty(num_values, dtype=MyStruct)
+    h_in1["x"] = np.random.randint(0, num_values, num_values, dtype="int16")
+    h_in1["y"] = np.random.randint(0, num_values, num_values, dtype="uint64")
+
+    h_in2 = np.empty(num_values, dtype=MyStruct)
+    h_in2["x"] = np.random.randint(0, num_values, num_values, dtype="int16")
+    h_in2["y"] = np.random.randint(0, num_values, num_values, dtype="uint64")
+
+    d_in1 = cp.empty_like(h_in1)
+    d_in2 = cp.empty_like(h_in2)
+
+    cp.cuda.runtime.memcpy(
+        d_in1.data.ptr,
+        h_in1.__array_interface__["data"][0],
+        h_in1.nbytes,
+        cp.cuda.runtime.memcpyHostToDevice,
+    )
+    cp.cuda.runtime.memcpy(
+        d_in2.data.ptr,
+        h_in2.__array_interface__["data"][0],
+        h_in2.nbytes,
+        cp.cuda.runtime.memcpyHostToDevice,
+    )
+
+    d_out = cp.empty_like(d_in1)
+
+    transform = algorithms.binary_transform(d_in1, d_in2, d_out, op)
+    transform(d_in1, d_in2, d_out, len(d_in1))
+
+    got = d_out.get()
+
+    np.testing.assert_allclose(got["x"], h_in1["x"] + h_in2["x"])
+    np.testing.assert_allclose(got["y"], h_in1["y"] + h_in2["y"])
+
+
+def test_unary_transform_iterator_input():
+    def op(a):
+        return a + 1
+
+    d_in = iterators.CountingIterator(np.int32(0))
+
+    num_items = 1024
+    d_out = cp.empty(num_items, dtype=np.int32)
+
+    unary_transform_device(d_in, d_out, num_items, op)
+
+    got = d_out.get()
+    expected = np.arange(1, num_items + 1, dtype=np.int32)
+
+    np.testing.assert_allclose(expected, got)
+
+
+def test_binary_transform_iterator_input():
+    def op(a, b):
+        return a + b
+
+    d_in1 = iterators.CountingIterator(np.int32(0))
+    d_in2 = iterators.CountingIterator(np.int32(1))
+
+    num_items = 1024
+    d_out = cp.empty(num_items, dtype=np.int32)
+
+    binary_transform_device(d_in1, d_in2, d_out, num_items, op)
+
+    got = d_out.get()
+    expected = np.arange(0, num_items, dtype=np.int32) + np.arange(
+        1, num_items + 1, dtype=np.int32
+    )
+
+    np.testing.assert_allclose(expected, got)
+
+
+def test_unary_transform_with_stream(cuda_stream):
+    def op(a):
+        return a + 1
+
+    cp_stream = cp.cuda.ExternalStream(cuda_stream.ptr)
+
+    with cp_stream:
+        d_in = cp.arange(10, dtype=np.int32)
+        d_out = cp.empty_like(d_in)
+
+    unary_transform_device(d_in, d_out, len(d_in), op, stream=cuda_stream)
+
+    got = d_out.get()
+    expected = unary_transform_host(d_in.get(), op)
+
+    np.testing.assert_allclose(expected, got, rtol=1e-5)
+
+
+def test_binary_transform_with_stream(cuda_stream):
+    def op(a, b):
+        return a + b
+
+    cp_stream = cp.cuda.ExternalStream(cuda_stream.ptr)
+
+    with cp_stream:
+        d_in1 = cp.arange(10, dtype=np.int32)
+        d_in2 = cp.arange(10, dtype=np.int32)
+        d_out = cp.empty_like(d_in1)
+
+    binary_transform_device(d_in1, d_in2, d_out, len(d_in1), op, stream=cuda_stream)
+
+    got = d_out.get()
+    expected = binary_transform_host(d_in1.get(), d_in2.get(), op)
+
+    np.testing.assert_allclose(expected, got, rtol=1e-5)

--- a/python/cuda_parallel/tests/test_transform.py
+++ b/python/cuda_parallel/tests/test_transform.py
@@ -184,9 +184,7 @@ def test_binary_transform_iterator_input():
     binary_transform_device(d_in1, d_in2, d_out, num_items, op)
 
     got = d_out.get()
-    expected = np.arange(0, num_items, dtype=np.int32) + np.arange(
-        1, num_items + 1, dtype=np.int32
-    )
+    expected = np.arange(1, 2 * num_items + 1, step=2, dtype=np.int32)
 
     np.testing.assert_allclose(expected, got)
 
@@ -197,11 +195,13 @@ def test_unary_transform_with_stream(cuda_stream):
 
     cp_stream = cp.cuda.ExternalStream(cuda_stream.ptr)
 
+    n = 10
+
     with cp_stream:
-        d_in = cp.arange(10, dtype=np.int32)
+        d_in = cp.arange(n, dtype=np.int32)
         d_out = cp.empty_like(d_in)
 
-    unary_transform_device(d_in, d_out, len(d_in), op, stream=cuda_stream)
+    unary_transform_device(d_in, d_out, n, op, stream=cuda_stream)
 
     got = d_out.get()
     expected = unary_transform_host(d_in.get(), op)
@@ -215,12 +215,14 @@ def test_binary_transform_with_stream(cuda_stream):
 
     cp_stream = cp.cuda.ExternalStream(cuda_stream.ptr)
 
+    n = 10
+
     with cp_stream:
-        d_in1 = cp.arange(10, dtype=np.int32)
-        d_in2 = cp.arange(10, dtype=np.int32)
+        d_in1 = cp.arange(n, dtype=np.int32)
+        d_in2 = cp.arange(n, dtype=np.int32)
         d_out = cp.empty_like(d_in1)
 
-    binary_transform_device(d_in1, d_in2, d_out, len(d_in1), op, stream=cuda_stream)
+    binary_transform_device(d_in1, d_in2, d_out, n, op, stream=cuda_stream)
 
     got = d_out.get()
     expected = binary_transform_host(d_in1.get(), d_in2.get(), op)

--- a/python/cuda_parallel/tests/test_unique_by_key.py
+++ b/python/cuda_parallel/tests/test_unique_by_key.py
@@ -167,12 +167,8 @@ def test_unique_by_key_iterators(dtype, num_items):
     d_out_items = numba.cuda.to_device(h_out_items)
     d_out_num_selected = numba.cuda.to_device(h_out_num_selected)
 
-    i_in_keys = iterators.CacheModifiedInputIterator(
-        d_in_keys, modifier="stream", prefix="keys"
-    )
-    i_in_items = iterators.CacheModifiedInputIterator(
-        d_in_items, modifier="stream", prefix="items"
-    )
+    i_in_keys = iterators.CacheModifiedInputIterator(d_in_keys, modifier="stream")
+    i_in_items = iterators.CacheModifiedInputIterator(d_in_items, modifier="stream")
 
     unique_by_key_device(
         i_in_keys,
@@ -239,7 +235,7 @@ def test_unique_by_key_complex():
     np.testing.assert_array_equal(h_out_items, expected_items)
 
 
-@pytest.mark.xfail(
+@pytest.mark.skip(
     reason="Creating an array of gpu_struct keys does not work currently (see https://github.com/NVIDIA/cccl/issues/3789)"
 )
 def test_unique_by_key_struct_types():


### PR DESCRIPTION
## Description

Closes #3878 

This PR introduces Python wrappers for `transform` to `cuda.parallel`. Some notes:

- Unlike the CUB `DeviceTransform` API which can accept an arbitrary number of input sequences as arguments, `cuda.parallel` currently offers only two functions `unary_transform` and `binary_transform`, operating on one or two input sequences respectively.
  - to generalize, we need to figure out how to pass arbitrary number of arguments to the underlying C API 

- One problem that I ran into was that in `binary_transform`, the two input iterators could be of the same kind (e.g., two `CountingIterators[int32]`). Due to caching, the `advance` and `dereference` LTOIRS compiled for the first iterator would be reused for the second. However, during link time nvJitLink would complain that it sees two definitions of the same symbols.
  - to solve this, we introduce a helper `scrub_duplicate_ltoirs` to erase duplicate ltoirs found in the input/output iterators. Any algorithm that can accept multiple iterators of the same kind as arguments will likely need to call this as a pre-processing step before passing them to the underlying C library.


## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
