### PR TITLE
Add scan_op support to cuda.coop block_store routines.

### DIFF
--- a/python/cuda_cooperative/cuda/cooperative/experimental/_common.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/_common.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-import operator
 import re
 import tempfile
 from collections import namedtuple
@@ -12,7 +11,7 @@ from typing import Union
 import numba
 import numpy as np
 
-from ._typing import DimType, ScanOpType
+from ._typing import DimType
 
 version = namedtuple("version", ("major", "minor"))
 code = namedtuple("code", ("kind", "version", "data"))
@@ -265,107 +264,3 @@ def normalize_dtype_param(
 
     # If we get here, the dtype is not recognized.
     raise ValueError(f"Unrecognized dtype format: {dtype}")
-
-
-class ScanOpCategory(Enum):
-    Sum = "Sum"
-    Known = "Known"
-    Callable = "Callable"
-
-
-CUDA_STD_PLUS = "::cuda::std::plus<T>"
-CUDA_STD_MULTIPLIES = "::cuda::std::multiplies<T>"
-CUDA_STD_MIN = "::cuda::std::min<T>"
-CUDA_STD_MAX = "::cuda::std::max<T>"
-CUDA_STD_BIT_AND = "::cuda::std::bit_and<T>"
-CUDA_STD_BIT_OR = "::cuda::std::bit_or<T>"
-CUDA_STD_BIT_XOR = "::cuda::std::bit_xor<T>"
-
-
-class ScanOp:
-    """
-    Represents an associative binary operator for a prefix scan operation.
-    """
-
-    # Set of all ops interpreted as sum (for (inclusive|exclusive)_sum).
-    SUM_OPS = {
-        "+",
-        "add",
-        "plus",
-        np.add,
-        operator.add,
-    }
-
-    # Map of all known (non-sum) operators to their C++ type representations.
-    KNOWN_OPS = {
-        # String names
-        "mul": CUDA_STD_MULTIPLIES,
-        "multiplies": CUDA_STD_MULTIPLIES,
-        "min": CUDA_STD_MIN,
-        "minimum": CUDA_STD_MIN,
-        "max": CUDA_STD_MAX,
-        "maximum": CUDA_STD_MAX,
-        "bit_and": CUDA_STD_BIT_AND,
-        "bit_or": CUDA_STD_BIT_OR,
-        "bit_xor": CUDA_STD_BIT_XOR,
-        # String operators
-        "*": CUDA_STD_MULTIPLIES,
-        "&": CUDA_STD_BIT_AND,
-        "|": CUDA_STD_BIT_OR,
-        "^": CUDA_STD_BIT_XOR,
-        # NumPy functions
-        np.multiply: CUDA_STD_MULTIPLIES,
-        np.minimum: CUDA_STD_MIN,
-        np.maximum: CUDA_STD_MAX,
-        np.bitwise_and: CUDA_STD_BIT_AND,
-        np.bitwise_or: CUDA_STD_BIT_OR,
-        np.bitwise_xor: CUDA_STD_BIT_XOR,
-        # Python operator module functions.
-        operator.mul: CUDA_STD_MULTIPLIES,
-    }
-
-    def __init__(self, op: ScanOpType):
-        self.op = op
-        self.op_category = None
-        self.op_cpp = None
-
-        # Handle string names and operators.
-        if isinstance(op, str):
-            if op in self.SUM_OPS:
-                self.op_category = ScanOpCategory.Sum
-                self.op_cpp = CUDA_STD_PLUS
-            elif op in self.KNOWN_OPS:
-                self.op_category = ScanOpCategory.Known
-                self.op_cpp = self.KNOWN_OPS[op]
-            else:
-                raise ValueError(f"Unsupported scan operator: {op}")
-
-        # Handle NumPy functions or other callables
-        elif callable(op):
-            # Check if it's a known function in our KNOWN_OPS dictionary
-            if op in self.SUM_OPS:
-                self.op_category = ScanOpCategory.Sum
-                self.op_cpp = CUDA_STD_PLUS
-            elif op in self.KNOWN_OPS:
-                self.op_category = ScanOpCategory.Known
-                self.op_cpp = self.KNOWN_OPS[op]
-            else:
-                # Custom callable; no op_cpp representation.
-                self.op_category = ScanOpCategory.Callable
-        else:
-            raise ValueError(f"Unsupported scan op type: {type(op)}")
-
-    def __repr__(self):
-        return f"ScanOp({self.op})"
-
-    @property
-    def is_sum(self):
-        return self.op_category == ScanOpCategory.Sum
-
-    @property
-    def is_known(self):
-        return self.op_category == ScanOpCategory.Known
-
-    @property
-    def is_callable(self):
-        return self.op_category == ScanOpCategory.Callable

--- a/python/cuda_cooperative/cuda/cooperative/experimental/_types.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/_types.py
@@ -380,7 +380,7 @@ class StatelessOperator:
         return False
 
 
-class DependentOperator:
+class DependentPythonOperator:
     def __init__(self, ret_dtype, arg_dtypes, op):
         self.ret_dtype = ret_dtype
         self.arg_dtypes = arg_dtypes

--- a/python/cuda_cooperative/cuda/cooperative/experimental/_types.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/_types.py
@@ -823,7 +823,7 @@ class Algorithm:
         device = cuda.get_current_device()
         cc_major, cc_minor = device.compute_capability
         cc = cc_major * 10 + cc_minor
-        print(src)
+        # print(src)
         _, lto_fn = nvrtc.compile(cpp=src, cc=cc, rdc=True, code="lto")
         lto_irs.append(lto_fn)
         return lto_irs

--- a/python/cuda_cooperative/cuda/cooperative/experimental/_typing.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/_typing.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from typing import TYPE_CHECKING, Callable, Literal, Tuple, TypeVar, Union
+from typing import TYPE_CHECKING, Callable, Literal, Tuple, Union
 
 if TYPE_CHECKING:
     import numba
@@ -13,8 +13,59 @@ if TYPE_CHECKING:
 
 # Type alias for dimension parameters that can be passed to CUDA functions.
 DimType = Union["dim3", int, Tuple[int, int], Tuple[int, int, int]]
+"""
+.. _DimType:
 
-T = TypeVar("T", bound="np.number")
+Dimension parameter specification for CUDA functions.
+
+This type alias accepts the following forms:
+
+- A single integer (1D thread/block configuration).
+- A tuple of two or three integers representing multi-dimensional
+  (2D/3D) CUDA dimensions.
+- A ``dim3`` object, which is a namedtuple with three fields: ``x``,
+  ``y``, and ``z``.
+
+Examples
+--------
+.. code-block:: python
+
+    threads = 128  # 1D
+    threads = (16, 16)  # 2D
+    threads = (8, 8, 4)  # 3D
+
+See Also
+--------
+- `CUDA dim3 documentation <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#dim3>`_
+"""
+
+DtypeType = Union[str, type, "np.number", "np.dtype", "numba.types.Type"]
+"""
+.. _DtypeType:
+
+Data type specification for CUDA kernel parameters and operations.
+
+Acceptable forms include:
+
+- Built-in Python numeric types (e.g., ``int``, ``float``).
+- NumPy scalar types (e.g., ``np.float32``) or NumPy dtypes (e.g.,
+  ``np.dtype('float32')``).
+- Numba types (e.g., ``numba.int32``).
+- Strings describing the data type (e.g., ``"float32"`` or ``"int64"``).
+
+Examples
+--------
+.. code-block:: python
+
+    dtype = np.float32
+    dtype = "int32"
+    dtype = numba.types.float64
+
+See Also
+--------
+- :mod:`numpy`
+- :mod:`numba.types`
+"""
 
 # Type alias for scan operators.
 ScanOpType = Union[
@@ -37,5 +88,20 @@ ScanOpType = Union[
     # Callable objects.
     Callable[["numba.types.Number", "numba.types.Number"], "numba.types.Number"],
     Callable[["np.ndarray", "np.ndarray"], "np.ndarray"],
-    Callable[[T, T], T],
+    Callable[["np.number", "np.number"], "np.number"],
 ]
+"""
+.. _ScanOpType:
+
+Specification for binary scan operator used in block-wide CUDA scan operations.
+
+This type can be one of the following:
+
+- **Named operators** (as strings): ``"add"``, ``"mul"``, ``"min"``,
+  ``"max"``, ``"bit_and"``, ``"bit_or"``, and ``"bit_xor"``.
+- **Symbolic short-hand operators**: ``"+"``, ``"*"``, ``"&"``,
+  ``"|"``, and ``"^"``.
+- **User-defined callable** that accepts two input values and returns a single
+  output value.
+
+"""

--- a/python/cuda_cooperative/cuda/cooperative/experimental/_typing.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/_typing.py
@@ -3,10 +3,39 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from typing import TYPE_CHECKING, Tuple, Union
+from typing import TYPE_CHECKING, Callable, Literal, Tuple, TypeVar, Union
 
 if TYPE_CHECKING:
+    import numba
+    import numpy as np
+
     from cuda.cooperative.experimental._common import dim3
 
-# Type alias for dimension parameters that can be passed to CUDA functions
+# Type alias for dimension parameters that can be passed to CUDA functions.
 DimType = Union["dim3", int, Tuple[int, int], Tuple[int, int, int]]
+
+T = TypeVar("T", bound="np.number")
+
+# Type alias for scan operators.
+ScanOpType = Union[
+    # Explicitly named operators.
+    Literal[
+        "add",
+        "plus",
+        "mul",
+        "multiplies",
+        "min",
+        "minimum",
+        "max",
+        "maximum",
+        "bit_and",
+        "bit_or",
+        "bit_xor",
+    ],
+    # Short-hand operators.
+    Literal["+", "*", "&", "|", "^"],
+    # Callable objects.
+    Callable[["numba.types.Number", "numba.types.Number"], "numba.types.Number"],
+    Callable[["np.ndarray", "np.ndarray"], "np.ndarray"],
+    Callable[[T, T], T],
+]

--- a/python/cuda_cooperative/cuda/cooperative/experimental/block/__init__.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/block/__init__.py
@@ -10,7 +10,9 @@ from cuda.cooperative.experimental.block._block_radix_sort import (
 )
 from cuda.cooperative.experimental.block._block_reduce import reduce, sum
 from cuda.cooperative.experimental.block._block_scan import (
+    exclusive_scan,
     exclusive_sum,
+    inclusive_scan,
     inclusive_sum,
 )
 
@@ -18,6 +20,8 @@ __all__ = [
     "merge_sort_keys",
     "reduce",
     "sum",
+    "exclusive_scan",
+    "inclusive_scan",
     "exclusive_sum",
     "inclusive_sum",
     "radix_sort_keys",

--- a/python/cuda_cooperative/cuda/cooperative/experimental/block/__init__.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/block/__init__.py
@@ -10,6 +10,7 @@ from cuda.cooperative.experimental.block._block_radix_sort import (
 )
 from cuda.cooperative.experimental.block._block_reduce import reduce, sum
 from cuda.cooperative.experimental.block._block_scan import (
+    block_scan,
     exclusive_scan,
     exclusive_sum,
     inclusive_scan,
@@ -20,6 +21,7 @@ __all__ = [
     "merge_sort_keys",
     "reduce",
     "sum",
+    "block_scan",
     "exclusive_scan",
     "inclusive_scan",
     "exclusive_sum",

--- a/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_merge_sort.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_merge_sort.py
@@ -16,7 +16,7 @@ from cuda.cooperative.experimental._types import (
     Constant,
     Dependency,
     DependentArray,
-    DependentOperator,
+    DependentPythonOperator,
     Invocable,
     Pointer,
     TemplateParameter,
@@ -94,7 +94,7 @@ def merge_sort_keys(
             [
                 Pointer(numba.uint8),
                 DependentArray(Dependency("KeyT"), Dependency("ITEMS_PER_THREAD")),
-                DependentOperator(
+                DependentPythonOperator(
                     Constant(numba.int8),
                     [Dependency("KeyT"), Dependency("KeyT")],
                     Dependency("Op"),

--- a/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_reduce.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_reduce.py
@@ -16,7 +16,7 @@ from cuda.cooperative.experimental._types import (
     Algorithm,
     Dependency,
     DependentArray,
-    DependentOperator,
+    DependentPythonOperator,
     DependentReference,
     Invocable,
     Pointer,
@@ -108,7 +108,7 @@ def _reduce(
                 [
                     Pointer(numba.uint8),
                     DependentReference(Dependency("T")),
-                    DependentOperator(
+                    DependentPythonOperator(
                         Dependency("T"),
                         [Dependency("T"), Dependency("T")],
                         Dependency("Op"),
@@ -119,7 +119,7 @@ def _reduce(
                 [
                     Pointer(numba.uint8),
                     DependentReference(Dependency("T")),
-                    DependentOperator(
+                    DependentPythonOperator(
                         Dependency("T"),
                         [Dependency("T"), Dependency("T")],
                         Dependency("Op"),
@@ -139,7 +139,7 @@ def _reduce(
                 [
                     Pointer(numba.uint8),
                     DependentArray(Dependency("T"), Dependency("ITEMS_PER_THREAD")),
-                    DependentOperator(
+                    DependentPythonOperator(
                         Dependency("T"),
                         [Dependency("T"), Dependency("T")],
                         Dependency("Op"),

--- a/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_scan.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_scan.py
@@ -318,10 +318,6 @@ def block_scan(
         user-defined types. The default is *None*.
     :type  methods: dict, optional
 
-    :returns: A callable that can be linked to a CUDA kernel and invoked to
-        perform the block-wide prefix scan.
-    :rtype: Callable
-
     :raises ValueError: If ``algorithm`` is not one of the supported algorithms
         (``"raking"``, ``"raking_memoize"``, or ``"warp_scans"``).
 
@@ -349,6 +345,10 @@ def block_scan(
         ``block_prefix_callback_op`` is *None*.  If not provided, the function
         will attempt to create a default value (``0``) for the given data type,
         but will raise an error if this is not possible.
+
+    :returns: A callable that can be linked to a CUDA kernel and invoked to
+        perform the block-wide prefix scan.
+    :rtype: Callable
     """
     if algorithm not in CUB_BLOCK_SCAN_ALGOS:
         raise ValueError(f"Unsupported algorithm: {algorithm}")
@@ -869,6 +869,11 @@ def exclusive_sum(
         user-defined types.  The default is *None*.
     :type  methods: dict, optional
 
+    :raises ValueError: If ``algorithm`` is not one of the supported algorithms
+        (``"raking"``, ``"raking_memoize"``, or ``"warp_scans"``).
+
+    :raises ValueError: If ``items_per_thread`` is less than 1.
+
     :returns: A callable that can be linked to a CUDA kernel and invoked to perform
         the block-wide exclusive prefix scan.
     :rtype: Callable
@@ -925,6 +930,11 @@ def inclusive_sum(
     :param methods: Optionally supplies a dictionary of methods to use for
         user-defined types.  The default is *None*.
     :type  methods: dict, optional
+
+    :raises ValueError: If ``algorithm`` is not one of the supported algorithms
+        (``"raking"``, ``"raking_memoize"``, or ``"warp_scans"``).
+
+    :raises ValueError: If ``items_per_thread`` is less than 1.
 
     :returns: A callable that can be linked to a CUDA kernel and invoked to perform
         the block-wide inclusive prefix scan.
@@ -992,6 +1002,26 @@ def exclusive_scan(
     :param methods: Optionally supplies a dictionary of methods to use for
         user-defined types.  The default is *None*.
     :type  methods: dict, optional
+
+    :raises ValueError: If ``algorithm`` is not one of the supported algorithms
+        (``"raking"``, ``"raking_memoize"``, or ``"warp_scans"``).
+
+    :raises ValueError: If ``items_per_thread`` is less than 1.
+
+    :raises ValueError: If ``scan_op`` is an unsupported operator type.
+
+    :raises ValueError: If ``initial_value`` is provided but the ``scan_op``
+        is a sum operator (sum operators do not support initial values).
+
+    :raises ValueError: If ``initial_value`` is provided with
+        ``items_per_thread=1``, and ``block_prefix_callback_op`` is not *None*
+        (this combination is not supported).
+
+    :raises ValueError: If ``initial_value`` is required but not provided.
+        An initial value is required when ``items_per_thread > 1`` and
+        ``block_prefix_callback_op`` is *None*.  If not provided, the function
+        will attempt to create a default value (``0``) for the given data type,
+        but will raise an error if this is not possible.
 
     :returns: A callable that can be linked to a CUDA kernel and invoked to
         perform the block-wide exclusive prefix scan.
@@ -1061,6 +1091,20 @@ def inclusive_scan(
     :param methods: Optionally supplies a dictionary of methods to use for
         user-defined types.  The default is *None*.
     :type  methods: dict, optional
+
+    :raises ValueError: If ``algorithm`` is not one of the supported algorithms
+        (``"raking"``, ``"raking_memoize"``, or ``"warp_scans"``).
+
+    :raises ValueError: If ``items_per_thread`` is less than 1.
+
+    :raises ValueError: If ``scan_op`` is an unsupported operator type.
+
+    :raises ValueError: If ``initial_value`` is provided but the ``scan_op``
+        is a sum operator (sum operators do not support initial values).
+
+    :raises ValueError: If ``initial_value`` is provided with
+        ``items_per_thread=1`` (initial values are not supported for inclusive
+        scans with a single item per thread).
 
     :returns: A callable that can be linked to a CUDA kernel and invoked to
         perform the block-wide inclusive prefix scan.

--- a/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_scan.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_scan.py
@@ -124,7 +124,7 @@ class ScanOpCategory(Enum):
 
     Callable = "Callable"
     """
-    Represents a user-defined callable operator.
+    Represents a user-defined callable operator (e.g. a Python function).
     """
 
 
@@ -203,7 +203,8 @@ class ScanOp:
 
         """
         if isinstance(op, ScanOp):
-            # If op is already a ScanOp instance, just return it.
+            # If op is already a ScanOp instance, just prime this instance
+            # with its values and return.
             self.op = op.op
             self.op_category = op.op_category
             self.op_cpp = op.op_cpp
@@ -224,9 +225,8 @@ class ScanOp:
             else:
                 raise ValueError(f"Unsupported scan operator: {op}")
 
-        # Handle NumPy functions or other callables
+        # Handle NumPy functions or other callables.
         elif callable(op):
-            # Check if it's a known function in our KNOWN_OPS dictionary
             if op in self.SUM_OPS:
                 self.op_category = ScanOpCategory.Sum
                 self.op_cpp = CUDA_STD_PLUS

--- a/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_scan.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_scan.py
@@ -44,8 +44,15 @@ Unsupported C++ APIs
 ++++++++++++++++++++
 
 This module does not support any of the :class:`cub.BlockScan` C++ APIs
-that take a block aggregate reference as an argument.  These APIs are
-as follows:
+that take a block aggregate reference as an argument.  That being said, the
+`BlockPrefixCallbackOp` callable is supported, and thus, block aggregates can
+be obtained using those measures.
+
+The reason the `T &block_aggregate` pattern is not supported as it will usually
+result in two output parameters, which we don't support in our underlying type
+machinery (i.e. _types.py).
+
+The unsupported APIs are as follows:
 
     ExclusiveSum(T input, T &output, T &block_aggregate)
     ExclusiveSum(T&)[ITEMS_PER_THREAD] input, T(&)[ITEMS_PER_THREAD] output, T &block_aggregate)

--- a/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_scan.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_scan.py
@@ -67,10 +67,6 @@ The unsupported APIs are as follows:
 
     InclusiveScan(T input, T &output, ScanOp scan_op, T &block_aggregate)
     InclusiveScan(T&)[ITEMS_PER_THREAD] input, T(&)[ITEMS_PER_THREAD] output, T initial_value, ScanOp scan_op, T &block_aggregate)
-
-TODO: 1. Link these APIs to the appropriate C++ APIs in the documentation.
-      2. Show Python examples for each C++ counterpart.
-
 """
 
 import operator
@@ -270,7 +266,7 @@ def block_scan(
     items_per_thread: int = 1,
     initial_value: Any = None,
     mode: Literal["exclusive", "inclusive"] = "exclusive",
-    scan_op: ScanOpType = ScanOp("+"),
+    scan_op: ScanOpType = "+",
     block_prefix_callback_op: Callable = None,
     algorithm: Literal["raking", "raking_memoize", "warp_scans"] = "raking",
     methods: dict = None,

--- a/python/cuda_cooperative/cuda/cooperative/experimental/warp/_warp_merge_sort.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/warp/_warp_merge_sort.py
@@ -10,7 +10,7 @@ from cuda.cooperative.experimental._types import (
     Constant,
     Dependency,
     DependentArray,
-    DependentOperator,
+    DependentPythonOperator,
     Invocable,
     Pointer,
     TemplateParameter,
@@ -70,7 +70,7 @@ def merge_sort_keys(
             [
                 Pointer(numba.uint8),
                 DependentArray(Dependency("KeyT"), Dependency("ITEMS_PER_THREAD")),
-                DependentOperator(
+                DependentPythonOperator(
                     Constant(numba.int8),
                     [Dependency("KeyT"), Dependency("KeyT")],
                     Dependency("Op"),

--- a/python/cuda_cooperative/cuda/cooperative/experimental/warp/_warp_reduce.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/warp/_warp_reduce.py
@@ -8,7 +8,7 @@ from cuda.cooperative.experimental._common import make_binary_tempfile
 from cuda.cooperative.experimental._types import (
     Algorithm,
     Dependency,
-    DependentOperator,
+    DependentPythonOperator,
     DependentReference,
     Invocable,
     Pointer,
@@ -64,7 +64,7 @@ def reduce(dtype, binary_op, threads_in_warp=32, methods=None):
             [
                 Pointer(numba.uint8),
                 DependentReference(Dependency("T")),
-                DependentOperator(
+                DependentPythonOperator(
                     Dependency("T"),
                     [Dependency("T"), Dependency("T")],
                     Dependency("Op"),

--- a/python/cuda_cooperative/tests/helpers.py
+++ b/python/cuda_cooperative/tests/helpers.py
@@ -2,8 +2,18 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+import numba
 import numpy as np
 from numba import cuda, types
+from numba.core import cgutils
+from numba.core.extending import (
+    lower_builtin,
+    make_attribute_wrapper,
+    models,
+    register_model,
+    type_callable,
+    typeof_impl,
+)
 
 NUMBA_TYPES_TO_NP = {
     types.int8: np.int8,
@@ -32,3 +42,59 @@ def row_major_tid():
         + (0 if dim.y == 1 else idx.y * dim.x)
         + idx.x
     )
+
+
+class Complex:
+    def __init__(self, real, imag):
+        self.real = real
+        self.imag = imag
+
+    def construct(this):
+        default_value = numba.int32(0)
+        this[0] = Complex(default_value, default_value)
+
+    def assign(this, that):
+        this[0] = Complex(that[0].real, that[0].imag)
+
+
+class ComplexType(types.Type):
+    def __init__(self):
+        super().__init__(name="Complex")
+
+
+complex_type = ComplexType()
+
+
+@typeof_impl.register(Complex)
+def typeof_complex(val, c):
+    return complex_type
+
+
+@type_callable(Complex)
+def type__complex(context):
+    def typer(real, imag):
+        if isinstance(real, types.Integer) and isinstance(imag, types.Integer):
+            return complex_type
+
+    return typer
+
+
+@register_model(ComplexType)
+class ComplexModel(models.StructModel):
+    def __init__(self, dmm, fe_type):
+        members = [("real", types.int32), ("imag", types.int32)]
+        models.StructModel.__init__(self, dmm, fe_type, members)
+
+
+make_attribute_wrapper(ComplexType, "real", "real")
+make_attribute_wrapper(ComplexType, "imag", "imag")
+
+
+@lower_builtin(Complex, types.Integer, types.Integer)
+def impl_complex(context, builder, sig, args):
+    typ = sig.return_type
+    real, imag = args
+    state = cgutils.create_struct_proxy(typ)(context, builder)
+    state.real = real
+    state.imag = imag
+    return state._getvalue()

--- a/python/cuda_cooperative/tests/test_block_scan.py
+++ b/python/cuda_cooperative/tests/test_block_scan.py
@@ -353,10 +353,6 @@ def test_block_sum_of_user_defined_type(
     )
     temp_storage_bytes = block_scan.temp_storage_bytes
 
-    print("--------------------------------")
-    print(block_scan.files)
-    print("--------------------------------")
-
     @cuda.jit(link=block_scan.files)
     def kernel(input, output):
         tid = row_major_tid()
@@ -486,24 +482,33 @@ def test_block_scan_initial_value_invariants(mode):
     else:
         target_scan = cudax.block.exclusive_scan
 
-    # Test 1: For inclusive scans with items_per_thread == 1, initial values are not supported
+    # Test 1: For inclusive scans with items_per_thread == 1, initial values are
+    # not supported
     if mode == "inclusive":
         with pytest.raises(
             ValueError,
-            match="initial_value is not supported for inclusive scans with items_per_thread == 1",
+            match=(
+                "initial_value is not supported for inclusive "
+                "scans with items_per_thread == 1"
+            ),
         ):
             target_scan(
                 numba.int32, 128, scan_op="+", initial_value=0, items_per_thread=1
             )
 
-    # Test 2: For exclusive scans with items_per_thread == 1 and a block prefix callback, initial values are not supported
+    # Test 2: For exclusive scans with items_per_thread == 1 and a block prefix
+    # callback, initial values are not supported.
     if mode == "exclusive":
         prefix_op = cudax.StatefulFunction(
             BlockPrefixCallbackOp, block_prefix_callback_op_type
         )
         with pytest.raises(
             ValueError,
-            match="initial_value is not supported for exclusive scans with items_per_thread == 1 and a block prefix callback operator",
+            match=(
+                "initial_value is not supported for exclusive "
+                "scans with items_per_thread == 1 and a block "
+                "prefix callback operator"
+            ),
         ):
             target_scan(
                 numba.int32,
@@ -514,10 +519,15 @@ def test_block_scan_initial_value_invariants(mode):
                 prefix_op=prefix_op,
             )
 
-    # Test 3: For both scan types with items_per_thread > 1 and no block prefix callback, initial values are required
+    # Test 3: For both scan types with items_per_thread > 1 and no block prefix
+    # callback, initial values are required.
     with pytest.raises(
         ValueError,
-        match="initial_value is required for both inclusive and exclusive scans when items_per_thread > 1 and no block prefix callback operator has been supplied",
+        match=(
+            "initial_value is required for both inclusive and "
+            "exclusive scans when items_per_thread > 1 and no "
+            "block prefix callback operator has been supplied"
+        ),
     ):
         target_scan(numba.int32, 128, scan_op="+", items_per_thread=2)
 
@@ -525,9 +535,10 @@ def test_block_scan_initial_value_invariants(mode):
 @pytest.mark.parametrize("T", [types.uint32])
 @pytest.mark.parametrize("threads_per_block", [32, 64])
 @pytest.mark.parametrize("items_per_thread", [2, 3])
+@pytest.mark.parametrize("initial_value", [-1, 0, 100])
 @pytest.mark.parametrize("mode", ["inclusive", "exclusive"])
 def test_block_scan_with_prefix_op_multi_items(
-    T, threads_per_block, items_per_thread, mode
+    T, threads_per_block, items_per_thread, initial_value, mode
 ):
     num_threads_per_block = (
         threads_per_block
@@ -566,7 +577,7 @@ def test_block_scan_with_prefix_op_multi_items(
             thread_data[i] = input[tid * items_per_thread + i]
 
         block_prefix_op = cuda.local.array(shape=1, dtype=block_prefix_callback_op_type)
-        block_prefix_op[0] = BlockPrefixCallbackOp(100)  # Start with prefix of 100
+        block_prefix_op[0] = BlockPrefixCallbackOp(initial_value)
 
         block_scan(temp_storage, thread_data, thread_data, block_prefix_op)
 
@@ -583,18 +594,19 @@ def test_block_scan_with_prefix_op_multi_items(
 
     output = d_output.copy_to_host()
 
-    # Calculate expected results with prefix of 100
+    # Calculate expected results with prefix of `initial_value`.
     if mode == "inclusive":
-        # For inclusive scan with prefix, we need to add the prefix to all elements
+        # For inclusive scan with prefix, we need to add the prefix to all
+        # elements.
         reference = np.zeros_like(h_input)
-        running_total = 100  # Initial prefix
+        running_total = initial_value
         for i in range(items_per_tile):
             running_total = running_total + h_input[i]
             reference[i] = running_total
     else:
-        # For exclusive scan with prefix, the first element gets the prefix
+        # For exclusive scan with prefix, the first element gets the prefix.
         reference = np.zeros_like(h_input)
-        running_total = 100  # Initial prefix
+        running_total = initial_value
         for i in range(items_per_tile):
             reference[i] = running_total
             running_total = running_total + h_input[i]

--- a/python/cuda_cooperative/tests/test_block_scan.py
+++ b/python/cuda_cooperative/tests/test_block_scan.py
@@ -111,17 +111,8 @@ def impl_block_prefix_callback_op(context, builder, sig, args):
     return state._getvalue()
 
 
-# @pytest.mark.parametrize("T", [types.uint32, types.uint64])
-# @pytest.mark.parametrize(
-#    "threads_per_block", [32, 64, 128, 256, 512, 1024, (8, 16), (2, 4, 8)]
-# )
-# @pytest.mark.parametrize("items_per_thread", [1, 2, 3, 4])
-# @pytest.mark.parametrize("mode", ["inclusive", "exclusive"])
-# @pytest.mark.parametrize("algorithm", ["raking", "raking_memoize", "warp_scans"])
-
-
 @pytest.mark.parametrize("T", [types.uint32])
-@pytest.mark.parametrize("threads_per_block", [32, (4, 8, 8)])
+@pytest.mark.parametrize("threads_per_block", [32, (4, 16), (4, 8, 8)])
 @pytest.mark.parametrize("items_per_thread", [1, 4])
 @pytest.mark.parametrize("mode", ["inclusive", "exclusive"])
 @pytest.mark.parametrize("algorithm", ["raking"])
@@ -195,15 +186,7 @@ def test_block_sum(T, threads_per_block, items_per_thread, mode, algorithm):
     assert "STL" not in sass
 
 
-# @pytest.mark.parametrize(
-#    "threads_per_block", [32, 64, 128, 256, 512, 1024, (8, 16), (2, 4, 8)]
-# )
-# @pytest.mark.parametrize("items_per_thread", [1, 2, 3, 4])
-# @pytest.mark.parametrize("mode", ["inclusive", "exclusive"])
-# @pytest.mark.parametrize("algorithm", ["raking", "raking_memoize", "warp_scans"])
-
-
-@pytest.mark.parametrize("threads_per_block", [32, (4, 8, 8)])
+@pytest.mark.parametrize("threads_per_block", [32, (4, 16), (4, 8, 8)])
 @pytest.mark.parametrize("items_per_thread", [1, 4])
 @pytest.mark.parametrize("mode", ["inclusive", "exclusive"])
 @pytest.mark.parametrize("algorithm", ["raking"])
@@ -311,9 +294,7 @@ def test_block_sum_prefix_op(threads_per_block, items_per_thread, mode, algorith
     assert "STL" not in sass
 
 
-@pytest.mark.parametrize(
-    "threads_per_block", [32, 64, 128, 256, 512, 1024, (8, 16), (2, 4, 8)]
-)
+@pytest.mark.parametrize("threads_per_block", [32, (8, 16), (2, 4, 8)])
 @pytest.mark.parametrize("items_per_thread", [0, -1, -127])
 @pytest.mark.parametrize("mode", ["inclusive", "exclusive"])
 def test_block_scan_sum_invalid_items_per_thread(
@@ -347,16 +328,8 @@ def test_block_scan_sum_invalid_algorithm(mode):
         sum_func(numba.int32, 128, algorithm="invalid_algorithm")
 
 
-# @pytest.mark.parametrize("items_per_thread", [1, 2, 3, 4])
-# @pytest.mark.parametrize(
-#    "threads_per_block", [32, 64, 128, 256, 512, 1024, (8, 16), (2, 4, 8)]
-# )
-# @pytest.mark.parametrize("mode", ["inclusive", "exclusive"])
-# @pytest.mark.parametrize("algorithm", ["raking", "raking_memoize", "warp_scans"])
-
-
 @pytest.mark.parametrize("initial_value", [None, Complex(0, 0), Complex(1, 1)])
-@pytest.mark.parametrize("threads_per_block", [32, (4, 8, 8)])
+@pytest.mark.parametrize("threads_per_block", [32, (4, 16), (4, 8, 8)])
 @pytest.mark.parametrize("items_per_thread", [1, 4])
 @pytest.mark.parametrize("mode", ["inclusive", "exclusive"])
 @pytest.mark.parametrize("algorithm", ["raking"])
@@ -431,7 +404,6 @@ def test_block_scan_user_defined_type(
             thread_in = cuda.local.array(items_per_thread, dtype=complex_type)
             thread_out = cuda.local.array(items_per_thread, dtype=complex_type)
 
-            # Load the input data.
             for i in range(items_per_thread):
                 thread_in[i] = Complex(
                     input_arr[tid * items_per_thread + i],
@@ -460,7 +432,6 @@ def test_block_scan_user_defined_type(
             thread_in = cuda.local.array(items_per_thread, dtype=complex_type)
             thread_out = cuda.local.array(items_per_thread, dtype=complex_type)
 
-            # Load the input data.
             for i in range(items_per_thread):
                 thread_in[i] = Complex(
                     input_arr[tid * items_per_thread + i],
@@ -492,11 +463,9 @@ def test_block_scan_user_defined_type(
         real_ref = np.cumsum(real_vals)
         imag_ref = np.cumsum(imag_vals)
     else:
-        # For exclusive scan, first element should be 0 (or initial value) and others should be shifted
         real_ref = np.zeros_like(real_vals)
         imag_ref = np.zeros_like(imag_vals)
 
-        # Set all elements except the first to be the cumulative sum up to the previous element
         if len(real_vals) > 1:
             real_ref[1:] = np.cumsum(real_vals)[:-1]
             imag_ref[1:] = np.cumsum(imag_vals)[:-1]
@@ -514,17 +483,8 @@ def test_block_scan_user_defined_type(
     assert "STL" not in sass
 
 
-# @pytest.mark.parametrize("items_per_thread", [1, 2, 3, 4])
-# @pytest.mark.parametrize("T", [types.uint32, types.uint64])
-# @pytest.mark.parametrize(
-#    "threads_per_block", [32, 64, 128, 256, 512, 1024, (8, 16), (2, 4, 8)]
-# )
-# @pytest.mark.parametrize("mode", ["inclusive", "exclusive"])
-# @pytest.mark.parametrize("algorithm", ["raking", "raking_memoize", "warp_scans"])
-
-
-@pytest.mark.parametrize("T", [types.uint32])
-@pytest.mark.parametrize("threads_per_block", [32, (4, 8, 8)])
+@pytest.mark.parametrize("T", [types.uint32, types.float64])
+@pytest.mark.parametrize("threads_per_block", [32, (4, 16), (4, 8, 8)])
 @pytest.mark.parametrize("items_per_thread", [1, 4])
 @pytest.mark.parametrize("mode", ["inclusive", "exclusive"])
 @pytest.mark.parametrize("algorithm", ["raking"])
@@ -609,7 +569,12 @@ def test_block_scan_with_callable(
         if len(h_input) > 1:
             ref[1:] = np.cumsum(h_input[:-1])
 
-    np.testing.assert_array_equal(output, ref)
+    # If T is an integer type, use assert_array_equal.  Otherwise, if
+    # floating point, use assert_array_almost_equal.
+    if isinstance(T, types.Integer):
+        np.testing.assert_array_equal(output, ref)
+    else:
+        np.testing.assert_array_almost_equal(output, ref)
 
     sig = (T[::1], T[::1])
     sass = kernel.inspect_sass(sig)

--- a/python/cuda_cooperative/tests/test_common.py
+++ b/python/cuda_cooperative/tests/test_common.py
@@ -2,23 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-import operator
 
 import numba
 import numpy as np
 import pytest
 
 from cuda.cooperative.experimental._common import (
-    CUDA_STD_BIT_AND,
-    CUDA_STD_BIT_OR,
-    CUDA_STD_BIT_XOR,
-    CUDA_STD_MAX,
-    CUDA_STD_MIN,
-    CUDA_STD_MULTIPLIES,
-    CUDA_STD_PLUS,
     CudaSharedMemConfig,
-    ScanOp,
-    ScanOpCategory,
     dim3,
     normalize_dim_param,
     normalize_dtype_param,
@@ -350,115 +340,3 @@ class TestCudaSharedMemConfig:
     def test_enum_lookup_by_value(self, value, expected_enum):
         """Test that we can look up enum values by value."""
         assert CudaSharedMemConfig(value) == expected_enum
-
-
-class TestScanOp:
-    @pytest.mark.parametrize(
-        "op, expected_category, expected_cpp",
-        [
-            ("add", ScanOpCategory.Sum, CUDA_STD_PLUS),
-            ("mul", ScanOpCategory.Known, CUDA_STD_MULTIPLIES),
-            ("multiplies", ScanOpCategory.Known, CUDA_STD_MULTIPLIES),
-            ("min", ScanOpCategory.Known, CUDA_STD_MIN),
-            ("minimum", ScanOpCategory.Known, CUDA_STD_MIN),
-            ("max", ScanOpCategory.Known, CUDA_STD_MAX),
-            ("maximum", ScanOpCategory.Known, CUDA_STD_MAX),
-            ("bit_and", ScanOpCategory.Known, CUDA_STD_BIT_AND),
-            ("bit_or", ScanOpCategory.Known, CUDA_STD_BIT_OR),
-            ("bit_xor", ScanOpCategory.Known, CUDA_STD_BIT_XOR),
-        ],
-    )
-    def test_string_names(self, op, expected_category, expected_cpp):
-        """Test that string operators are correctly processed."""
-        scan_op = ScanOp(op)
-        assert scan_op.op == op
-        assert scan_op.op_category == expected_category
-        assert scan_op.op_cpp == expected_cpp
-
-    @pytest.mark.parametrize(
-        "op, expected_category, expected_cpp",
-        [
-            ("+", ScanOpCategory.Sum, CUDA_STD_PLUS),
-            ("*", ScanOpCategory.Known, CUDA_STD_MULTIPLIES),
-            ("&", ScanOpCategory.Known, CUDA_STD_BIT_AND),
-            ("|", ScanOpCategory.Known, CUDA_STD_BIT_OR),
-            ("^", ScanOpCategory.Known, CUDA_STD_BIT_XOR),
-        ],
-    )
-    def test_string_operators(self, op, expected_category, expected_cpp):
-        """Test that string operators are correctly processed."""
-        scan_op = ScanOp(op)
-        assert scan_op.op == op
-        assert scan_op.op_category == expected_category
-        assert scan_op.op_cpp == expected_cpp
-
-    @pytest.mark.parametrize(
-        "op, expected_category, expected_cpp",
-        [
-            (np.add, ScanOpCategory.Sum, CUDA_STD_PLUS),
-            (np.multiply, ScanOpCategory.Known, CUDA_STD_MULTIPLIES),
-            (np.minimum, ScanOpCategory.Known, CUDA_STD_MIN),
-            (np.maximum, ScanOpCategory.Known, CUDA_STD_MAX),
-            (np.bitwise_and, ScanOpCategory.Known, CUDA_STD_BIT_AND),
-            (np.bitwise_or, ScanOpCategory.Known, CUDA_STD_BIT_OR),
-            (np.bitwise_xor, ScanOpCategory.Known, CUDA_STD_BIT_XOR),
-        ],
-    )
-    def test_numpy_functions(self, op, expected_category, expected_cpp):
-        """Test that NumPy functions are correctly processed."""
-        scan_op = ScanOp(op)
-        assert scan_op.op == op
-        assert scan_op.op_category == expected_category
-        assert scan_op.op_cpp == expected_cpp
-
-    # Implement test_python_operator_module_functions.
-    @pytest.mark.parametrize(
-        "op, expected_category, expected_cpp",
-        [
-            (operator.add, ScanOpCategory.Sum, CUDA_STD_PLUS),
-            (operator.mul, ScanOpCategory.Known, CUDA_STD_MULTIPLIES),
-        ],
-    )
-    def test_python_operator_module_functions(
-        self, op, expected_category, expected_cpp
-    ):
-        """Test that Python operator module functions are correctly processed."""
-        scan_op = ScanOp(op)
-        assert scan_op.op == op
-        assert scan_op.op_category == expected_category
-        assert scan_op.op_cpp == expected_cpp
-
-    def test_custom_callable(self):
-        """Test that custom callables are correctly processed."""
-
-        def custom_add(a, b):
-            return a + b
-
-        scan_op = ScanOp(custom_add)
-        assert scan_op.op == custom_add
-        assert scan_op.op_category == ScanOpCategory.Callable
-        assert scan_op.op_cpp is None
-
-    @pytest.mark.parametrize(
-        "op",
-        [
-            "unsupported_op",
-            123,
-            [1, 2, 3],
-            {"op": "+"},
-            None,
-        ],
-    )
-    def test_invalid_operators(self, op):
-        """Test that invalid operators raise ValueError."""
-        with pytest.raises(ValueError):
-            ScanOp(op)
-
-    def test_repr(self):
-        """Test the string representation of ScanOp."""
-        scan_op = ScanOp("+")
-        assert repr(scan_op) == "ScanOp(+)"
-
-        scan_op = ScanOp(np.add)
-        assert "ScanOp(" in repr(scan_op)
-        assert "add" in repr(scan_op)


### PR DESCRIPTION
This PR adds explicit scan_op support to the cuda.coop block_store module.  Posting as a draft PR to get some early feedback.