### PR TITLE
Fix cccl integer traits

### DIFF
--- a/libcudacxx/include/cuda/__bit/bit_reverse.h
+++ b/libcudacxx/include/cuda/__bit/bit_reverse.h
@@ -150,7 +150,7 @@ template <typename _Tp>
 template <typename _Tp>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp bit_reverse(_Tp __value) noexcept
 {
-  static_assert(_CUDA_VSTD::__cccl_is_unsigned_integer_v<_Tp>, "bit_reverse() requires unsigned integer types");
+  static_assert(_CUDA_VSTD::__cccl_is_cv_unsigned_integer_v<_Tp>, "bit_reverse() requires unsigned integer types");
   if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
   {
     NV_IF_TARGET(NV_IS_DEVICE, (return ::cuda::__bit_reverse_device(__value);))

--- a/libcudacxx/include/cuda/__bit/bitfield.h
+++ b/libcudacxx/include/cuda/__bit/bitfield.h
@@ -67,7 +67,7 @@ template <typename _Tp>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp
 bitfield_insert(const _Tp __dest, const _Tp __source, int __start, int __width) noexcept
 {
-  static_assert(_CUDA_VSTD::__cccl_is_unsigned_integer_v<_Tp>, "bitfield_insert() requires unsigned integer types");
+  static_assert(_CUDA_VSTD::__cccl_is_cv_unsigned_integer_v<_Tp>, "bitfield_insert() requires unsigned integer types");
   [[maybe_unused]] constexpr auto __digits = _CUDA_VSTD::numeric_limits<_Tp>::digits;
   _CCCL_ASSERT(__width >= 0 && __width <= __digits, "width out of range");
   _CCCL_ASSERT(__start >= 0 && __start <= __digits, "start position out of range");
@@ -93,7 +93,7 @@ template <typename _Tp>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp
 bitfield_extract(const _Tp __value, int __start, int __width) noexcept
 {
-  static_assert(_CUDA_VSTD::__cccl_is_unsigned_integer_v<_Tp>, "bitfield_extract() requires unsigned integer types");
+  static_assert(_CUDA_VSTD::__cccl_is_cv_unsigned_integer_v<_Tp>, "bitfield_extract() requires unsigned integer types");
   [[maybe_unused]] constexpr auto __digits = _CUDA_VSTD::numeric_limits<_Tp>::digits;
   _CCCL_ASSERT(__width >= 0 && __width <= __digits, "width out of range");
   _CCCL_ASSERT(__start >= 0 && __start <= __digits, "start position out of range");

--- a/libcudacxx/include/cuda/__cmath/ilog.h
+++ b/libcudacxx/include/cuda/__cmath/ilog.h
@@ -36,7 +36,7 @@
 _LIBCUDACXX_BEGIN_NAMESPACE_CUDA
 
 _CCCL_TEMPLATE(typename _Tp)
-_CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::__cccl_is_integer, _Tp))
+_CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::__cccl_is_cv_integer, _Tp))
 _LIBCUDACXX_HIDE_FROM_ABI constexpr int ilog2(_Tp __t) noexcept
 {
   using _Up = _CUDA_VSTD::make_unsigned_t<_Tp>;
@@ -133,7 +133,7 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr int ilog2(_Tp __t) noexcept
 #endif // _CCCL_HAS_INT128()
 
 _CCCL_TEMPLATE(typename _Tp)
-_CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::__cccl_is_integer, _Tp))
+_CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::__cccl_is_cv_integer, _Tp))
 _LIBCUDACXX_HIDE_FROM_ABI constexpr int ilog10(_Tp __t) noexcept
 {
   _CCCL_ASSERT(__t > 0, "ilog10() argument must be strictly positive");

--- a/libcudacxx/include/cuda/__cmath/uabs.h
+++ b/libcudacxx/include/cuda/__cmath/uabs.h
@@ -33,7 +33,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_CUDA
 //! @pre \p __v must be an integer type
 //! @return The unsigned absolute value of \p __v
 _CCCL_TEMPLATE(class _Tp)
-_CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::__cccl_is_integer, _Tp))
+_CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::__cccl_is_cv_integer, _Tp))
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _CUDA_VSTD::make_unsigned_t<_Tp> uabs(_Tp __v) noexcept
 {
   if constexpr (_CCCL_TRAIT(_CUDA_VSTD::is_signed, _Tp))

--- a/libcudacxx/include/cuda/__numeric/overflow_cast.h
+++ b/libcudacxx/include/cuda/__numeric/overflow_cast.h
@@ -35,7 +35,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_CUDA
 //! occurred
 _CCCL_TEMPLATE(class _To, class _From)
 _CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::__cccl_is_integer, _To)
-                 _CCCL_AND _CCCL_TRAIT(_CUDA_VSTD::__cccl_is_integer, _From))
+                 _CCCL_AND _CCCL_TRAIT(_CUDA_VSTD::__cccl_is_cv_integer, _From))
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr overflow_result<_To> overflow_cast(const _From& __from) noexcept
 {
   bool __overflow = false;

--- a/libcudacxx/include/cuda/std/__type_traits/is_integer.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_integer.h
@@ -32,6 +32,10 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 template <class _Tp>
 inline constexpr bool __cccl_is_integer_v = __cccl_is_signed_integer_v<_Tp> || __cccl_is_unsigned_integer_v<_Tp>;
 
+template <class _Tp>
+inline constexpr bool __cccl_is_cv_integer_v =
+  __cccl_is_cv_signed_integer_v<_Tp> || __cccl_is_cv_unsigned_integer_v<_Tp>;
+
 _LIBCUDACXX_END_NAMESPACE_STD
 
 #endif // _LIBCUDACXX___TYPE_TRAITS_IS_INTEGER_H

--- a/libcudacxx/include/cuda/std/__type_traits/is_signed_integer.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_signed_integer.h
@@ -25,30 +25,30 @@
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-inline constexpr bool __cccl_is_signed_integer_impl_v = false;
+inline constexpr bool __cccl_is_signed_integer_v = false;
 
 template <>
-inline constexpr bool __cccl_is_signed_integer_impl_v<signed char> = true;
+inline constexpr bool __cccl_is_signed_integer_v<signed char> = true;
 
 template <>
-inline constexpr bool __cccl_is_signed_integer_impl_v<signed short> = true;
+inline constexpr bool __cccl_is_signed_integer_v<signed short> = true;
 
 template <>
-inline constexpr bool __cccl_is_signed_integer_impl_v<signed int> = true;
+inline constexpr bool __cccl_is_signed_integer_v<signed int> = true;
 
 template <>
-inline constexpr bool __cccl_is_signed_integer_impl_v<signed long> = true;
+inline constexpr bool __cccl_is_signed_integer_v<signed long> = true;
 
 template <>
-inline constexpr bool __cccl_is_signed_integer_impl_v<signed long long> = true;
+inline constexpr bool __cccl_is_signed_integer_v<signed long long> = true;
 
 #if _CCCL_HAS_INT128()
 template <>
-inline constexpr bool __cccl_is_signed_integer_impl_v<__int128_t> = true;
+inline constexpr bool __cccl_is_signed_integer_v<__int128_t> = true;
 #endif // _CCCL_HAS_INT128()
 
 template <class _Tp>
-inline constexpr bool __cccl_is_signed_integer_v = __cccl_is_signed_integer_impl_v<remove_cv_t<_Tp>>;
+inline constexpr bool __cccl_is_cv_signed_integer_v = __cccl_is_signed_integer_v<remove_cv_t<_Tp>>;
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_unsigned_integer.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_unsigned_integer.h
@@ -25,30 +25,30 @@
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-inline constexpr bool __cccl_is_unsigned_integer_impl_v = false;
+inline constexpr bool __cccl_is_unsigned_integer_v = false;
 
 template <>
-inline constexpr bool __cccl_is_unsigned_integer_impl_v<unsigned char> = true;
+inline constexpr bool __cccl_is_unsigned_integer_v<unsigned char> = true;
 
 template <>
-inline constexpr bool __cccl_is_unsigned_integer_impl_v<unsigned short> = true;
+inline constexpr bool __cccl_is_unsigned_integer_v<unsigned short> = true;
 
 template <>
-inline constexpr bool __cccl_is_unsigned_integer_impl_v<unsigned int> = true;
+inline constexpr bool __cccl_is_unsigned_integer_v<unsigned int> = true;
 
 template <>
-inline constexpr bool __cccl_is_unsigned_integer_impl_v<unsigned long> = true;
+inline constexpr bool __cccl_is_unsigned_integer_v<unsigned long> = true;
 
 template <>
-inline constexpr bool __cccl_is_unsigned_integer_impl_v<unsigned long long> = true;
+inline constexpr bool __cccl_is_unsigned_integer_v<unsigned long long> = true;
 
 #if _CCCL_HAS_INT128()
 template <>
-inline constexpr bool __cccl_is_unsigned_integer_impl_v<__uint128_t> = true;
+inline constexpr bool __cccl_is_unsigned_integer_v<__uint128_t> = true;
 #endif // _CCCL_HAS_INT128()
 
 template <class _Tp>
-inline constexpr bool __cccl_is_unsigned_integer_v = __cccl_is_unsigned_integer_impl_v<remove_cv_t<_Tp>>;
+inline constexpr bool __cccl_is_cv_unsigned_integer_v = __cccl_is_unsigned_integer_v<remove_cv_t<_Tp>>;
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__utility/cmp.h
+++ b/libcudacxx/include/cuda/std/__utility/cmp.h
@@ -36,7 +36,7 @@ _CCCL_PUSH_MACROS
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 _CCCL_TEMPLATE(class _Tp, class _Up)
-_CCCL_REQUIRES(__cccl_is_integer_v<_Tp> _CCCL_AND __cccl_is_integer_v<_Up>)
+_CCCL_REQUIRES(_CCCL_TRAIT(__cccl_is_integer, _Tp) _CCCL_AND _CCCL_TRAIT(__cccl_is_integer, _Up))
 _LIBCUDACXX_HIDE_FROM_ABI constexpr bool cmp_equal(_Tp __t, _Up __u) noexcept
 {
   if constexpr (_CCCL_TRAIT(is_signed, _Tp) == _CCCL_TRAIT(is_signed, _Up))
@@ -55,14 +55,14 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr bool cmp_equal(_Tp __t, _Up __u) noexcept
 }
 
 _CCCL_TEMPLATE(class _Tp, class _Up)
-_CCCL_REQUIRES(__cccl_is_integer_v<_Tp> _CCCL_AND __cccl_is_integer_v<_Up>)
+_CCCL_REQUIRES(_CCCL_TRAIT(__cccl_is_integer, _Tp) _CCCL_AND _CCCL_TRAIT(__cccl_is_integer, _Up))
 _LIBCUDACXX_HIDE_FROM_ABI constexpr bool cmp_not_equal(_Tp __t, _Up __u) noexcept
 {
   return !_CUDA_VSTD::cmp_equal(__t, __u);
 }
 
 _CCCL_TEMPLATE(class _Tp, class _Up)
-_CCCL_REQUIRES(__cccl_is_integer_v<_Tp> _CCCL_AND __cccl_is_integer_v<_Up>)
+_CCCL_REQUIRES(_CCCL_TRAIT(__cccl_is_integer, _Tp) _CCCL_AND _CCCL_TRAIT(__cccl_is_integer, _Up))
 _LIBCUDACXX_HIDE_FROM_ABI constexpr bool cmp_less(_Tp __t, _Up __u) noexcept
 {
   if constexpr (_CCCL_TRAIT(is_signed, _Tp) == _CCCL_TRAIT(is_signed, _Up))
@@ -81,28 +81,28 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr bool cmp_less(_Tp __t, _Up __u) noexcept
 }
 
 _CCCL_TEMPLATE(class _Tp, class _Up)
-_CCCL_REQUIRES(__cccl_is_integer_v<_Tp> _CCCL_AND __cccl_is_integer_v<_Up>)
+_CCCL_REQUIRES(_CCCL_TRAIT(__cccl_is_integer, _Tp) _CCCL_AND _CCCL_TRAIT(__cccl_is_integer, _Up))
 _LIBCUDACXX_HIDE_FROM_ABI constexpr bool cmp_greater(_Tp __t, _Up __u) noexcept
 {
   return _CUDA_VSTD::cmp_less(__u, __t);
 }
 
 _CCCL_TEMPLATE(class _Tp, class _Up)
-_CCCL_REQUIRES(__cccl_is_integer_v<_Tp> _CCCL_AND __cccl_is_integer_v<_Up>)
+_CCCL_REQUIRES(_CCCL_TRAIT(__cccl_is_integer, _Tp) _CCCL_AND _CCCL_TRAIT(__cccl_is_integer, _Up))
 _LIBCUDACXX_HIDE_FROM_ABI constexpr bool cmp_less_equal(_Tp __t, _Up __u) noexcept
 {
   return !_CUDA_VSTD::cmp_greater(__t, __u);
 }
 
 _CCCL_TEMPLATE(class _Tp, class _Up)
-_CCCL_REQUIRES(__cccl_is_integer_v<_Tp> _CCCL_AND __cccl_is_integer_v<_Up>)
+_CCCL_REQUIRES(_CCCL_TRAIT(__cccl_is_integer, _Tp) _CCCL_AND _CCCL_TRAIT(__cccl_is_integer, _Up))
 _LIBCUDACXX_HIDE_FROM_ABI constexpr bool cmp_greater_equal(_Tp __t, _Up __u) noexcept
 {
   return !_CUDA_VSTD::cmp_less(__t, __u);
 }
 
 _CCCL_TEMPLATE(class _Tp, class _Up)
-_CCCL_REQUIRES(__cccl_is_integer_v<_Tp> _CCCL_AND __cccl_is_integer_v<_Up>)
+_CCCL_REQUIRES(_CCCL_TRAIT(__cccl_is_integer, _Tp) _CCCL_AND _CCCL_TRAIT(__cccl_is_integer, _Up))
 _LIBCUDACXX_HIDE_FROM_ABI constexpr bool in_range(_Up __u) noexcept
 {
   return _CUDA_VSTD::cmp_less_equal(__u, numeric_limits<_Tp>::max())


### PR DESCRIPTION
The `__cccl_is_integer` trait (and signed/unsigned variants) are currently `true` even for cv-qualified types. However, the C++ standard often requires cv-unqualified types as function arguments.

This PR changes the `__cccl_is_(+-)_integer` traits to be `true` only for cv-unqualified types and replaces the old behaviour with `__cccl_is_cv_(+-)_integer` trait.
