### PR TITLE
Implement equality operators for charconv result types

### DIFF
--- a/libcudacxx/include/cuda/std/__charconv/from_chars_result.h
+++ b/libcudacxx/include/cuda/std/__charconv/from_chars_result.h
@@ -34,6 +34,18 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT from_chars_result
   {
     return ec == errc{};
   }
+
+  _CCCL_NODISCARD_FRIEND _LIBCUDACXX_HIDE_FROM_ABI constexpr bool
+  operator==(const from_chars_result& __lhs, const from_chars_result& __rhs) noexcept
+  {
+    return __lhs.ptr == __rhs.ptr && __lhs.ec == __rhs.ec;
+  }
+
+  _CCCL_NODISCARD_FRIEND _LIBCUDACXX_HIDE_FROM_ABI constexpr bool
+  operator!=(const from_chars_result& __lhs, const from_chars_result& __rhs) noexcept
+  {
+    return !(__lhs == __rhs);
+  }
 };
 
 _LIBCUDACXX_END_NAMESPACE_STD

--- a/libcudacxx/include/cuda/std/__charconv/to_chars_result.h
+++ b/libcudacxx/include/cuda/std/__charconv/to_chars_result.h
@@ -34,6 +34,18 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT to_chars_result
   {
     return ec == errc{};
   }
+
+  _CCCL_NODISCARD_FRIEND _LIBCUDACXX_HIDE_FROM_ABI constexpr bool
+  operator==(const to_chars_result& __lhs, const to_chars_result& __rhs) noexcept
+  {
+    return __lhs.ptr == __rhs.ptr && __lhs.ec == __rhs.ec;
+  }
+
+  _CCCL_NODISCARD_FRIEND _LIBCUDACXX_HIDE_FROM_ABI constexpr bool
+  operator!=(const to_chars_result& __lhs, const to_chars_result& __rhs) noexcept
+  {
+    return !(__lhs == __rhs);
+  }
 };
 
 _LIBCUDACXX_END_NAMESPACE_STD

--- a/libcudacxx/test/libcudacxx/std/utilities/charconv/charconv.syn/from_chars_result.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/charconv/charconv.syn/from_chars_result.pass.cpp
@@ -12,11 +12,8 @@
 #include <cuda/std/cassert>
 #include <cuda/std/type_traits>
 
-__host__ __device__ constexpr bool test()
+__host__ __device__ constexpr void test_members()
 {
-  static_assert(!cuda::std::is_convertible_v<cuda::std::from_chars_result, bool>);
-  static_assert(cuda::std::is_constructible_v<bool, cuda::std::from_chars_result>);
-
   cuda::std::from_chars_result x{nullptr, cuda::std::errc{}};
 
   auto [ptr, ec] = x;
@@ -26,18 +23,61 @@ __host__ __device__ constexpr bool test()
 
   static_assert(cuda::std::is_same_v<decltype(ec), cuda::std::errc>);
   assert(ec == x.ec);
+}
+
+__host__ __device__ constexpr void test_operator_bool()
+{
+  static_assert(!cuda::std::is_convertible_v<cuda::std::from_chars_result, bool>);
+  static_assert(cuda::std::is_constructible_v<bool, cuda::std::from_chars_result>);
 
   {
     cuda::std::from_chars_result value{nullptr, cuda::std::errc{}};
     assert(bool(value) == true);
     static_assert(noexcept(bool(value)) == true);
   }
-
   {
     cuda::std::from_chars_result value{nullptr, cuda::std::errc::value_too_large};
     assert(bool(value) == false);
     static_assert(noexcept(bool(value)) == true);
   }
+}
+
+__host__ __device__ constexpr void test_operator_eq_and_neq()
+{
+  const char a[]{'a'};
+  const char b[]{'b'};
+
+  {
+    cuda::std::from_chars_result lhs{a, cuda::std::errc::value_too_large};
+    cuda::std::from_chars_result rhs{a, cuda::std::errc::value_too_large};
+    assert(lhs == rhs);
+    assert(!(lhs != rhs));
+  }
+  {
+    cuda::std::from_chars_result lhs{a, cuda::std::errc::value_too_large};
+    cuda::std::from_chars_result rhs{a, cuda::std::errc::invalid_argument};
+    assert(!(lhs == rhs));
+    assert(lhs != rhs);
+  }
+  {
+    cuda::std::from_chars_result lhs{a, cuda::std::errc::value_too_large};
+    cuda::std::from_chars_result rhs{b, cuda::std::errc::value_too_large};
+    assert(!(lhs == rhs));
+    assert(lhs != rhs);
+  }
+  {
+    cuda::std::from_chars_result lhs{a, cuda::std::errc::value_too_large};
+    cuda::std::from_chars_result rhs{b, cuda::std::errc::invalid_argument};
+    assert(!(lhs == rhs));
+    assert(lhs != rhs);
+  }
+}
+
+__host__ __device__ constexpr bool test()
+{
+  test_members();
+  test_operator_bool();
+  test_operator_eq_and_neq();
 
   return true;
 }

--- a/libcudacxx/test/libcudacxx/std/utilities/charconv/charconv.syn/to_chars_result.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/charconv/charconv.syn/to_chars_result.pass.cpp
@@ -12,11 +12,8 @@
 #include <cuda/std/cassert>
 #include <cuda/std/type_traits>
 
-__host__ __device__ constexpr bool test()
+__host__ __device__ constexpr void test_members()
 {
-  static_assert(!cuda::std::is_convertible_v<cuda::std::to_chars_result, bool>);
-  static_assert(cuda::std::is_constructible_v<bool, cuda::std::to_chars_result>);
-
   cuda::std::to_chars_result x{nullptr, cuda::std::errc{}};
 
   auto [ptr, ec] = x;
@@ -26,18 +23,61 @@ __host__ __device__ constexpr bool test()
 
   static_assert(cuda::std::is_same_v<decltype(ec), cuda::std::errc>);
   assert(ec == x.ec);
+}
+
+__host__ __device__ constexpr void test_operator_bool()
+{
+  static_assert(!cuda::std::is_convertible_v<cuda::std::to_chars_result, bool>);
+  static_assert(cuda::std::is_constructible_v<bool, cuda::std::to_chars_result>);
 
   {
     cuda::std::to_chars_result value{nullptr, cuda::std::errc{}};
     assert(bool(value) == true);
     static_assert(noexcept(bool(value)) == true);
   }
-
   {
     cuda::std::to_chars_result value{nullptr, cuda::std::errc::value_too_large};
     assert(bool(value) == false);
     static_assert(noexcept(bool(value)) == true);
   }
+}
+
+__host__ __device__ constexpr void test_operator_eq_and_neq()
+{
+  char a[]{'a'};
+  char b[]{'b'};
+
+  {
+    cuda::std::to_chars_result lhs{a, cuda::std::errc::value_too_large};
+    cuda::std::to_chars_result rhs{a, cuda::std::errc::value_too_large};
+    assert(lhs == rhs);
+    assert(!(lhs != rhs));
+  }
+  {
+    cuda::std::to_chars_result lhs{a, cuda::std::errc::value_too_large};
+    cuda::std::to_chars_result rhs{a, cuda::std::errc::invalid_argument};
+    assert(!(lhs == rhs));
+    assert(lhs != rhs);
+  }
+  {
+    cuda::std::to_chars_result lhs{a, cuda::std::errc::value_too_large};
+    cuda::std::to_chars_result rhs{b, cuda::std::errc::value_too_large};
+    assert(!(lhs == rhs));
+    assert(lhs != rhs);
+  }
+  {
+    cuda::std::to_chars_result lhs{a, cuda::std::errc::value_too_large};
+    cuda::std::to_chars_result rhs{b, cuda::std::errc::invalid_argument};
+    assert(!(lhs == rhs));
+    assert(lhs != rhs);
+  }
+}
+
+__host__ __device__ constexpr bool test()
+{
+  test_members();
+  test_operator_bool();
+  test_operator_eq_and_neq();
 
   return true;
 }


### PR DESCRIPTION
This PR implements operators `==` and `!=` for charconv result types and backports them to C++17.

This requires implementing the functions ourselves instead of `= default` them which is a deviation from the behaviour described in the standard.