### PR TITLE
Deprecate `numeric_limits::has_denorm` in C++23

### DIFF
--- a/libcudacxx/include/cuda/std/__limits/numeric_limits.h
+++ b/libcudacxx/include/cuda/std/__limits/numeric_limits.h
@@ -41,7 +41,7 @@ enum float_round_style
   round_toward_neg_infinity = 3
 };
 
-enum float_denorm_style
+enum _LIBCUDACXX_DEPRECATED_IN_CXX23 float_denorm_style
 {
   denorm_indeterminate = -1,
   denorm_absent        = 0,
@@ -118,11 +118,11 @@ public:
   static constexpr int max_exponent   = 0;
   static constexpr int max_exponent10 = 0;
 
-  static constexpr bool has_infinity             = false;
-  static constexpr bool has_quiet_NaN            = false;
-  static constexpr bool has_signaling_NaN        = false;
-  static constexpr float_denorm_style has_denorm = denorm_absent;
-  static constexpr bool has_denorm_loss          = false;
+  static constexpr bool has_infinity                                             = false;
+  static constexpr bool has_quiet_NaN                                            = false;
+  static constexpr bool has_signaling_NaN                                        = false;
+  _LIBCUDACXX_DEPRECATED_IN_CXX23 static constexpr float_denorm_style has_denorm = denorm_absent;
+  _LIBCUDACXX_DEPRECATED_IN_CXX23 static constexpr bool has_denorm_loss          = false;
   _LIBCUDACXX_HIDE_FROM_ABI static constexpr type infinity() noexcept
   {
     return type();
@@ -207,11 +207,11 @@ public:
   static constexpr int max_exponent   = 0;
   static constexpr int max_exponent10 = 0;
 
-  static constexpr bool has_infinity             = false;
-  static constexpr bool has_quiet_NaN            = false;
-  static constexpr bool has_signaling_NaN        = false;
-  static constexpr float_denorm_style has_denorm = denorm_absent;
-  static constexpr bool has_denorm_loss          = false;
+  static constexpr bool has_infinity                                             = false;
+  static constexpr bool has_quiet_NaN                                            = false;
+  static constexpr bool has_signaling_NaN                                        = false;
+  _LIBCUDACXX_DEPRECATED_IN_CXX23 static constexpr float_denorm_style has_denorm = denorm_absent;
+  _LIBCUDACXX_DEPRECATED_IN_CXX23 static constexpr bool has_denorm_loss          = false;
   _LIBCUDACXX_HIDE_FROM_ABI static constexpr type infinity() noexcept
   {
     return type(0);
@@ -285,11 +285,11 @@ public:
   static constexpr int max_exponent   = 0;
   static constexpr int max_exponent10 = 0;
 
-  static constexpr bool has_infinity             = false;
-  static constexpr bool has_quiet_NaN            = false;
-  static constexpr bool has_signaling_NaN        = false;
-  static constexpr float_denorm_style has_denorm = denorm_absent;
-  static constexpr bool has_denorm_loss          = false;
+  static constexpr bool has_infinity                                             = false;
+  static constexpr bool has_quiet_NaN                                            = false;
+  static constexpr bool has_signaling_NaN                                        = false;
+  _LIBCUDACXX_DEPRECATED_IN_CXX23 static constexpr float_denorm_style has_denorm = denorm_absent;
+  _LIBCUDACXX_DEPRECATED_IN_CXX23 static constexpr bool has_denorm_loss          = false;
   _LIBCUDACXX_HIDE_FROM_ABI static constexpr type infinity() noexcept
   {
     return type(0);
@@ -358,11 +358,11 @@ public:
   static constexpr int max_exponent   = FLT_MAX_EXP;
   static constexpr int max_exponent10 = FLT_MAX_10_EXP;
 
-  static constexpr bool has_infinity             = true;
-  static constexpr bool has_quiet_NaN            = true;
-  static constexpr bool has_signaling_NaN        = true;
-  static constexpr float_denorm_style has_denorm = denorm_present;
-  static constexpr bool has_denorm_loss          = false;
+  static constexpr bool has_infinity                                             = true;
+  static constexpr bool has_quiet_NaN                                            = true;
+  static constexpr bool has_signaling_NaN                                        = true;
+  _LIBCUDACXX_DEPRECATED_IN_CXX23 static constexpr float_denorm_style has_denorm = denorm_present;
+  _LIBCUDACXX_DEPRECATED_IN_CXX23 static constexpr bool has_denorm_loss          = false;
 
 #if defined(_CCCL_BUILTIN_HUGE_VALF)
   _LIBCUDACXX_HIDE_FROM_ABI static constexpr type infinity() noexcept
@@ -457,11 +457,11 @@ public:
   static constexpr int max_exponent   = DBL_MAX_EXP;
   static constexpr int max_exponent10 = DBL_MAX_10_EXP;
 
-  static constexpr bool has_infinity             = true;
-  static constexpr bool has_quiet_NaN            = true;
-  static constexpr bool has_signaling_NaN        = true;
-  static constexpr float_denorm_style has_denorm = denorm_present;
-  static constexpr bool has_denorm_loss          = false;
+  static constexpr bool has_infinity                                             = true;
+  static constexpr bool has_quiet_NaN                                            = true;
+  static constexpr bool has_signaling_NaN                                        = true;
+  _LIBCUDACXX_DEPRECATED_IN_CXX23 static constexpr float_denorm_style has_denorm = denorm_present;
+  _LIBCUDACXX_DEPRECATED_IN_CXX23 static constexpr bool has_denorm_loss          = false;
 
 #if defined(_CCCL_BUILTIN_HUGE_VAL)
   _LIBCUDACXX_HIDE_FROM_ABI static constexpr type infinity() noexcept
@@ -558,11 +558,11 @@ public:
   static constexpr int max_exponent   = LDBL_MAX_EXP;
   static constexpr int max_exponent10 = LDBL_MAX_10_EXP;
 
-  static constexpr bool has_infinity             = true;
-  static constexpr bool has_quiet_NaN            = true;
-  static constexpr bool has_signaling_NaN        = true;
-  static constexpr float_denorm_style has_denorm = denorm_present;
-  static constexpr bool has_denorm_loss          = false;
+  static constexpr bool has_infinity                                             = true;
+  static constexpr bool has_quiet_NaN                                            = true;
+  static constexpr bool has_signaling_NaN                                        = true;
+  _LIBCUDACXX_DEPRECATED_IN_CXX23 static constexpr float_denorm_style has_denorm = denorm_present;
+  _LIBCUDACXX_DEPRECATED_IN_CXX23 static constexpr bool has_denorm_loss          = false;
   _LIBCUDACXX_HIDE_FROM_ABI static constexpr type infinity() noexcept
   {
     return _CCCL_BUILTIN_HUGE_VALL();

--- a/libcudacxx/include/cuda/std/__limits/numeric_limits_ext.h
+++ b/libcudacxx/include/cuda/std/__limits/numeric_limits_ext.h
@@ -73,11 +73,11 @@ public:
   static constexpr int max_exponent   = 16;
   static constexpr int max_exponent10 = 4;
 
-  static constexpr bool has_infinity             = true;
-  static constexpr bool has_quiet_NaN            = true;
-  static constexpr bool has_signaling_NaN        = true;
-  static constexpr float_denorm_style has_denorm = denorm_present;
-  static constexpr bool has_denorm_loss          = false;
+  static constexpr bool has_infinity                                             = true;
+  static constexpr bool has_quiet_NaN                                            = true;
+  static constexpr bool has_signaling_NaN                                        = true;
+  _LIBCUDACXX_DEPRECATED_IN_CXX23 static constexpr float_denorm_style has_denorm = denorm_present;
+  _LIBCUDACXX_DEPRECATED_IN_CXX23 static constexpr bool has_denorm_loss          = false;
   _LIBCUDACXX_HIDE_FROM_ABI static constexpr type infinity() noexcept
   {
     return _CUDA_VSTD::__fp_from_storage<__half>(uint16_t(0x7c00u));
@@ -150,11 +150,11 @@ public:
   static constexpr int max_exponent   = 128;
   static constexpr int max_exponent10 = 38;
 
-  static constexpr bool has_infinity             = true;
-  static constexpr bool has_quiet_NaN            = true;
-  static constexpr bool has_signaling_NaN        = true;
-  static constexpr float_denorm_style has_denorm = denorm_present;
-  static constexpr bool has_denorm_loss          = false;
+  static constexpr bool has_infinity                                             = true;
+  static constexpr bool has_quiet_NaN                                            = true;
+  static constexpr bool has_signaling_NaN                                        = true;
+  _LIBCUDACXX_DEPRECATED_IN_CXX23 static constexpr float_denorm_style has_denorm = denorm_present;
+  _LIBCUDACXX_DEPRECATED_IN_CXX23 static constexpr bool has_denorm_loss          = false;
   _LIBCUDACXX_HIDE_FROM_ABI static constexpr type infinity() noexcept
   {
     return _CUDA_VSTD::__fp_from_storage<__nv_bfloat16>(uint16_t(0x7f80u));
@@ -227,11 +227,11 @@ public:
   static constexpr int max_exponent   = 8;
   static constexpr int max_exponent10 = 2;
 
-  static constexpr bool has_infinity             = false;
-  static constexpr bool has_quiet_NaN            = true;
-  static constexpr bool has_signaling_NaN        = false;
-  static constexpr float_denorm_style has_denorm = denorm_present;
-  static constexpr bool has_denorm_loss          = false;
+  static constexpr bool has_infinity                                             = false;
+  static constexpr bool has_quiet_NaN                                            = true;
+  static constexpr bool has_signaling_NaN                                        = false;
+  _LIBCUDACXX_DEPRECATED_IN_CXX23 static constexpr float_denorm_style has_denorm = denorm_present;
+  _LIBCUDACXX_DEPRECATED_IN_CXX23 static constexpr bool has_denorm_loss          = false;
   _LIBCUDACXX_HIDE_FROM_ABI static constexpr type infinity() noexcept
   {
     return type{};
@@ -304,11 +304,11 @@ public:
   static constexpr int max_exponent   = 15;
   static constexpr int max_exponent10 = 4;
 
-  static constexpr bool has_infinity             = true;
-  static constexpr bool has_quiet_NaN            = true;
-  static constexpr bool has_signaling_NaN        = true;
-  static constexpr float_denorm_style has_denorm = denorm_present;
-  static constexpr bool has_denorm_loss          = false;
+  static constexpr bool has_infinity                                             = true;
+  static constexpr bool has_quiet_NaN                                            = true;
+  static constexpr bool has_signaling_NaN                                        = true;
+  _LIBCUDACXX_DEPRECATED_IN_CXX23 static constexpr float_denorm_style has_denorm = denorm_present;
+  _LIBCUDACXX_DEPRECATED_IN_CXX23 static constexpr bool has_denorm_loss          = false;
   _LIBCUDACXX_HIDE_FROM_ABI static constexpr type infinity() noexcept
   {
     return _CUDA_VSTD::__fp_from_storage<__nv_fp8_e5m2>(uint8_t(0x7cu));
@@ -381,11 +381,11 @@ public:
   static constexpr int max_exponent   = 127;
   static constexpr int max_exponent10 = 38;
 
-  static constexpr bool has_infinity             = false;
-  static constexpr bool has_quiet_NaN            = true;
-  static constexpr bool has_signaling_NaN        = false;
-  static constexpr float_denorm_style has_denorm = denorm_absent;
-  static constexpr bool has_denorm_loss          = false;
+  static constexpr bool has_infinity                                             = false;
+  static constexpr bool has_quiet_NaN                                            = true;
+  static constexpr bool has_signaling_NaN                                        = false;
+  _LIBCUDACXX_DEPRECATED_IN_CXX23 static constexpr float_denorm_style has_denorm = denorm_absent;
+  _LIBCUDACXX_DEPRECATED_IN_CXX23 static constexpr bool has_denorm_loss          = false;
   _LIBCUDACXX_HIDE_FROM_ABI static constexpr type infinity() noexcept
   {
     return type{};
@@ -458,11 +458,11 @@ public:
   static constexpr int max_exponent   = 2;
   static constexpr int max_exponent10 = 0;
 
-  static constexpr bool has_infinity             = false;
-  static constexpr bool has_quiet_NaN            = false;
-  static constexpr bool has_signaling_NaN        = false;
-  static constexpr float_denorm_style has_denorm = denorm_present;
-  static constexpr bool has_denorm_loss          = false;
+  static constexpr bool has_infinity                                             = false;
+  static constexpr bool has_quiet_NaN                                            = false;
+  static constexpr bool has_signaling_NaN                                        = false;
+  _LIBCUDACXX_DEPRECATED_IN_CXX23 static constexpr float_denorm_style has_denorm = denorm_present;
+  _LIBCUDACXX_DEPRECATED_IN_CXX23 static constexpr bool has_denorm_loss          = false;
   _LIBCUDACXX_HIDE_FROM_ABI static constexpr type infinity() noexcept
   {
     return type{};
@@ -535,11 +535,11 @@ public:
   static constexpr int max_exponent   = 4;
   static constexpr int max_exponent10 = 1;
 
-  static constexpr bool has_infinity             = false;
-  static constexpr bool has_quiet_NaN            = false;
-  static constexpr bool has_signaling_NaN        = false;
-  static constexpr float_denorm_style has_denorm = denorm_present;
-  static constexpr bool has_denorm_loss          = false;
+  static constexpr bool has_infinity                                             = false;
+  static constexpr bool has_quiet_NaN                                            = false;
+  static constexpr bool has_signaling_NaN                                        = false;
+  _LIBCUDACXX_DEPRECATED_IN_CXX23 static constexpr float_denorm_style has_denorm = denorm_present;
+  _LIBCUDACXX_DEPRECATED_IN_CXX23 static constexpr bool has_denorm_loss          = false;
   _LIBCUDACXX_HIDE_FROM_ABI static constexpr type infinity() noexcept
   {
     return type{};
@@ -612,11 +612,11 @@ public:
   static constexpr int max_exponent   = 2;
   static constexpr int max_exponent10 = 0;
 
-  static constexpr bool has_infinity             = false;
-  static constexpr bool has_quiet_NaN            = false;
-  static constexpr bool has_signaling_NaN        = false;
-  static constexpr float_denorm_style has_denorm = denorm_present;
-  static constexpr bool has_denorm_loss          = false;
+  static constexpr bool has_infinity                                             = false;
+  static constexpr bool has_quiet_NaN                                            = false;
+  static constexpr bool has_signaling_NaN                                        = false;
+  _LIBCUDACXX_DEPRECATED_IN_CXX23 static constexpr float_denorm_style has_denorm = denorm_present;
+  _LIBCUDACXX_DEPRECATED_IN_CXX23 static constexpr bool has_denorm_loss          = false;
   _LIBCUDACXX_HIDE_FROM_ABI static constexpr type infinity() noexcept
   {
     return type{};
@@ -711,11 +711,11 @@ public:
   static constexpr int max_exponent   = 16384;
   static constexpr int max_exponent10 = 4932;
 
-  static constexpr bool has_infinity             = true;
-  static constexpr bool has_quiet_NaN            = true;
-  static constexpr bool has_signaling_NaN        = true;
-  static constexpr float_denorm_style has_denorm = denorm_present;
-  static constexpr bool has_denorm_loss          = false;
+  static constexpr bool has_infinity                                             = true;
+  static constexpr bool has_quiet_NaN                                            = true;
+  static constexpr bool has_signaling_NaN                                        = true;
+  _LIBCUDACXX_DEPRECATED_IN_CXX23 static constexpr float_denorm_style has_denorm = denorm_present;
+  _LIBCUDACXX_DEPRECATED_IN_CXX23 static constexpr bool has_denorm_loss          = false;
 
 #  if defined(_CCCL_BUILTIN_HUGE_VALF128)
   _LIBCUDACXX_HIDE_FROM_ABI static constexpr type infinity() noexcept

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__config
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__config
@@ -172,6 +172,12 @@ extern "C++" {
 #    define _LIBCUDACXX_DEPRECATED_IN_CXX20
 #  endif // ^^^ _CCCL_STD_VER < 2020 ^^^
 
+#  if _CCCL_STD_VER >= 2023
+#    define _LIBCUDACXX_DEPRECATED_IN_CXX23 _LIBCUDACXX_DEPRECATED
+#  else // ^^^ _CCCL_STD_VER >= 2023 ^^^ / vvv _CCCL_STD_VER < 2023 vvv
+#    define _LIBCUDACXX_DEPRECATED_IN_CXX23
+#  endif // ^^^ _CCCL_STD_VER < 2023 ^^^
+
 // Thread API
 #  ifndef _LIBCUDACXX_HAS_THREAD_API_EXTERNAL
 #    if _CCCL_COMPILER(NVRTC) || defined(__EMSCRIPTEN__)


### PR DESCRIPTION
This PR implements *"Deprecating std::numeric_limits::has_denorm"* [P2614R2](https://wg21.link/P2614R2) from C++23.