### PR TITLE
WAR unused variable warning on gcc9.

### DIFF
--- a/cudax/include/cuda/experimental/__async/sender/completion_signatures.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/completion_signatures.cuh
@@ -204,6 +204,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT completion_signatures
   {
     if constexpr (sizeof...(_OtherSigs) == 0) // short-circuit some common cases
     {
+      (void) __other;
       return *this;
     }
     else if constexpr (sizeof...(_Sigs) == 0)


### PR DESCRIPTION
https://github.com/NVIDIA/cccl/actions/runs/14257245793/job/39962092908#step:5:1649

```
  /home/coder/cccl/cudax/include/cuda/experimental/__async/sender/completion_signatures.cuh:203:50: error: parameter ‘__other’ set but not used [-Werror=unused-but-set-parameter]
    203 |   _CUDAX_API constexpr auto operator+(completion_signatures<_OtherSigs...> __other) const noexcept
        |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
```