### PR TITLE
Remove undefined variable from cmake.

### DIFF
--- a/cudax/cmake/cudaxBuildCompilerTargets.cmake
+++ b/cudax/cmake/cudaxBuildCompilerTargets.cmake
@@ -11,7 +11,7 @@
 #   be linked into the developer build targets, as they include both
 #   cudax.compiler_interface and cccl.compiler_interface_cppXX.
 
-find_package(Thrust ${cudax_VERSION} EXACT CONFIG REQUIRED
+find_package(Thrust CONFIG REQUIRED
   NO_DEFAULT_PATH # Only check the explicit path in HINTS:
   HINTS "${CCCL_SOURCE_DIR}/lib/cmake/thrust/"
 )


### PR DESCRIPTION
`${cudax_VERSION}` isn't defined at the point that this function is called.
Since we're explicitly looking up Thrust from the sibling source directory, it's not necessary to specify a version here anyway.

Fixes warning:
```
CMake Warning (dev) at cudax/cmake/cudaxBuildCompilerTargets.cmake:14 (find_package):
  Ignoring EXACT since no version is requested.
Call Stack (most recent call first):
  cudax/CMakeLists.txt:33 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.
```