### PR TITLE
[Thrust]  `reduce_into`

### DIFF
--- a/thrust/testing/reduce.cu
+++ b/thrust/testing/reduce.cu
@@ -16,15 +16,6 @@ struct plus_mod_10
   }
 };
 
-template <typename T>
-struct is_equal_div_10_reduce
-{
-  _CCCL_HOST_DEVICE bool operator()(const T x, const T& y) const
-  {
-    return ((int) x / 10) == ((int) y / 10);
-  }
-};
-
 template <class Vector>
 void TestReduceSimple()
 {

--- a/thrust/testing/reduce_into.cu
+++ b/thrust/testing/reduce_into.cu
@@ -1,0 +1,205 @@
+#include <thrust/iterator/constant_iterator.h>
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/iterator/retag.h>
+#include <thrust/reduce.h>
+
+#include <limits>
+
+#include <unittest/unittest.h>
+
+template <typename T>
+struct plus_mod_10
+{
+  _CCCL_HOST_DEVICE T operator()(T lhs, T rhs) const
+  {
+    return ((lhs % 10) + (rhs % 10)) % 10;
+  }
+};
+
+template <class Vector>
+void TestReduceIntoSimple()
+{
+  using T = typename Vector::value_type;
+
+  Vector i{1, -2, 3};
+  Vector o(1);
+
+  // no initializer
+  thrust::reduce_into(i.begin(), i.end(), o.begin());
+  ASSERT_EQUAL(o[0], 2);
+
+  // with initializer
+  thrust::reduce_into(i.begin(), i.end(), o.begin(), T(10));
+  ASSERT_EQUAL(o[0], 12);
+}
+DECLARE_VECTOR_UNITTEST(TestReduceIntoSimple);
+
+template <typename InputIterator, typename OutputIterator>
+void reduce_into(my_system& system, InputIterator, InputIterator, OutputIterator output)
+{
+  system.validate_dispatch();
+  *output = 13;
+}
+
+void TestReduceIntoDispatchExplicit()
+{
+  thrust::device_vector<int> i;
+  thrust::device_vector<int> o(1);
+
+  my_system sys(0);
+  thrust::reduce_into(sys, i.begin(), i.end(), o.begin());
+
+  ASSERT_EQUAL(true, sys.is_valid());
+  ASSERT_EQUAL(o[0], 13);
+}
+DECLARE_UNITTEST(TestReduceIntoDispatchExplicit);
+
+template <typename InputIterator, typename OutputIterator>
+void reduce_into(my_tag, InputIterator, InputIterator, OutputIterator output)
+{
+  *output = 13;
+}
+
+void TestReduceIntoDispatchImplicit()
+{
+  thrust::device_vector<int> i;
+  thrust::device_vector<int> o(1);
+
+  thrust::reduce_into(
+    thrust::retag<my_tag>(i.begin()), thrust::retag<my_tag>(i.end()), thrust::retag<my_tag>(o.begin()));
+
+  ASSERT_EQUAL(o[0], 13);
+}
+DECLARE_UNITTEST(TestReduceIntoDispatchImplicit);
+
+template <typename T>
+struct TestReduceInto
+{
+  void operator()(const size_t n)
+  {
+    thrust::host_vector<T> h_data(unittest::random_integers<T>(n));
+    thrust::device_vector<T> d_data(h_data);
+    thrust::host_vector<T> h_result(1);
+    thrust::device_vector<T> d_result(1);
+
+    T init = 13;
+
+    thrust::reduce_into(h_data.begin(), h_data.end(), h_result.begin(), init);
+    thrust::reduce_into(d_data.begin(), d_data.end(), d_result.begin(), init);
+
+    ASSERT_EQUAL(h_result, d_result);
+  }
+};
+VariableUnitTest<TestReduceInto, IntegralTypes> TestReduceIntoInstance;
+
+void TestReduceIntoMixedTypesHost()
+{
+  // make sure we get types for default args and operators correct
+  thrust::host_vector<int> int_input{1, 2, 3, 4};
+
+  thrust::host_vector<float> float_input{1.5, 2.5, 3.5, 4.5};
+
+  // float -> int should use using plus<int> operator by default
+  thrust::host_vector<int> int_output(1);
+  thrust::reduce_into(float_input.begin(), float_input.end(), int_output.begin(), int(0));
+  ASSERT_EQUAL(int_output[0], 10);
+
+  // int -> float should use using plus<float> operator by default
+  thrust::host_vector<float> float_output(1);
+  thrust::reduce_into(int_input.begin(), int_input.end(), float_output.begin(), float(0.5));
+  ASSERT_EQUAL(float_output[0], 10.5);
+}
+DECLARE_UNITTEST(TestReduceIntoMixedTypesHost);
+void TestReduceIntoMixedTypesDevice()
+{
+  // make sure we get types for default args and operators correct
+  thrust::device_vector<int> int_input{1, 2, 3, 4};
+
+  thrust::device_vector<float> float_input{1.5, 2.5, 3.5, 4.5};
+
+  // float -> int should use using plus<int> operator by default
+  thrust::device_vector<int> int_output(1);
+  thrust::reduce_into(float_input.begin(), float_input.end(), int_output.begin(), int(0));
+  ASSERT_EQUAL(int_output[0], 10);
+
+  // int -> float should use using plus<float> operator by default
+  thrust::device_vector<float> float_output(1);
+  thrust::reduce_into(int_input.begin(), int_input.end(), float_output.begin(), float(0.5));
+  ASSERT_EQUAL(float_output[0], 10.5);
+}
+DECLARE_UNITTEST(TestReduceIntoMixedTypesDevice);
+
+template <typename T>
+struct TestReduceIntoWithOperator
+{
+  void operator()(const size_t n)
+  {
+    thrust::host_vector<T> h_data   = unittest::random_integers<T>(n);
+    thrust::device_vector<T> d_data = h_data;
+    thrust::host_vector<T> h_result(1);
+    thrust::device_vector<T> d_result(1);
+
+    T init = 3;
+
+    thrust::reduce_into(h_data.begin(), h_data.end(), h_result.begin(), init, plus_mod_10<T>());
+    thrust::reduce_into(d_data.begin(), d_data.end(), d_result.begin(), init, plus_mod_10<T>());
+
+    ASSERT_EQUAL(h_result, d_result);
+  }
+};
+VariableUnitTest<TestReduceIntoWithOperator, UnsignedIntegralTypes> TestReduceIntoWithOperatorInstance;
+
+template <typename T>
+struct plus_mod3
+{
+  T* table;
+
+  plus_mod3(T* table)
+      : table(table)
+  {}
+
+  _CCCL_HOST_DEVICE T operator()(T a, T b)
+  {
+    return table[(int) (a + b)];
+  }
+};
+
+template <typename Vector>
+void TestReduceIntoWithIndirection()
+{
+  // add numbers modulo 3 with external lookup table
+  using T = typename Vector::value_type;
+
+  Vector data{0, 1, 2, 1, 2, 0, 1};
+
+  Vector table{0, 1, 2, 0, 1, 2};
+
+  Vector result(1);
+
+  thrust::reduce_into(data.begin(), data.end(), result.begin(), T(0), plus_mod3<T>(thrust::raw_pointer_cast(&table[0])));
+
+  ASSERT_EQUAL(result[0], T(1));
+}
+DECLARE_INTEGRAL_VECTOR_UNITTEST(TestReduceIntoWithIndirection);
+
+template <typename T>
+void TestReduceIntoCountingIterator()
+{
+  size_t const n = 15 * sizeof(T);
+
+  ASSERT_LEQUAL(T(n), unittest::truncate_to_max_representable<T>(n));
+
+  thrust::counting_iterator<T, thrust::host_system_tag> h_first   = thrust::make_counting_iterator<T>(0);
+  thrust::counting_iterator<T, thrust::device_system_tag> d_first = thrust::make_counting_iterator<T>(0);
+  thrust::host_vector<T> h_result(1);
+  thrust::device_vector<T> d_result(1);
+
+  T init = unittest::random_integer<T>();
+
+  thrust::reduce_into(h_first, h_first + n, h_result.begin(), init);
+  thrust::reduce_into(d_first, d_first + n, d_result.begin(), init);
+
+  // we use ASSERT_ALMOST_EQUAL because we're testing floating point types
+  ASSERT_ALMOST_EQUAL(h_result, d_result);
+}
+DECLARE_GENERIC_UNITTEST(TestReduceIntoCountingIterator);

--- a/thrust/thrust/detail/reduce.inl
+++ b/thrust/thrust/detail/reduce.inl
@@ -68,6 +68,45 @@ _CCCL_HOST_DEVICE T reduce(
 } // end reduce()
 
 _CCCL_EXEC_CHECK_DISABLE
+template <typename DerivedPolicy, typename InputIterator, typename OutputIterator>
+_CCCL_HOST_DEVICE void reduce_into(
+  const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
+  InputIterator first,
+  InputIterator last,
+  OutputIterator output)
+{
+  using thrust::system::detail::generic::reduce_into;
+  reduce_into(thrust::detail::derived_cast(thrust::detail::strip_const(exec)), first, last, output);
+} // end reduce_into()
+
+_CCCL_EXEC_CHECK_DISABLE
+template <typename DerivedPolicy, typename InputIterator, typename OutputIterator, typename T>
+_CCCL_HOST_DEVICE void reduce_into(
+  const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
+  InputIterator first,
+  InputIterator last,
+  OutputIterator output,
+  T init)
+{
+  using thrust::system::detail::generic::reduce_into;
+  reduce_into(thrust::detail::derived_cast(thrust::detail::strip_const(exec)), first, last, output, init);
+} // end reduce_into()
+
+_CCCL_EXEC_CHECK_DISABLE
+template <typename DerivedPolicy, typename InputIterator, typename OutputIterator, typename T, typename BinaryFunction>
+_CCCL_HOST_DEVICE void reduce_into(
+  const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
+  InputIterator first,
+  InputIterator last,
+  OutputIterator output,
+  T init,
+  BinaryFunction binary_op)
+{
+  using thrust::system::detail::generic::reduce_into;
+  reduce_into(thrust::detail::derived_cast(thrust::detail::strip_const(exec)), first, last, output, init, binary_op);
+} // end reduce_into()
+
+_CCCL_EXEC_CHECK_DISABLE
 template <typename DerivedPolicy,
           typename InputIterator1,
           typename InputIterator2,
@@ -182,6 +221,48 @@ T reduce(InputIterator first, InputIterator last, T init, BinaryFunction binary_
   System system;
 
   return thrust::reduce(select_system(system), first, last, init, binary_op);
+}
+
+template <typename InputIterator, typename OutputIterator>
+void reduce_into(InputIterator first, InputIterator last, OutputIterator output)
+{
+  using thrust::system::detail::generic::select_system;
+
+  using System1 = typename thrust::iterator_system<InputIterator>::type;
+  using System2 = typename thrust::iterator_system<OutputIterator>::type;
+
+  System1 system1;
+  System2 system2;
+
+  thrust::reduce_into(select_system(system1, system2), first, last, output);
+}
+
+template <typename InputIterator, typename OutputIterator, typename T>
+void reduce_into(InputIterator first, InputIterator last, OutputIterator output, T init)
+{
+  using thrust::system::detail::generic::select_system;
+
+  using System1 = typename thrust::iterator_system<InputIterator>::type;
+  using System2 = typename thrust::iterator_system<OutputIterator>::type;
+
+  System1 system1;
+  System2 system2;
+
+  thrust::reduce_into(select_system(system1, system2), first, last, output, init);
+}
+
+template <typename InputIterator, typename OutputIterator, typename T, typename BinaryFunction>
+void reduce_into(InputIterator first, InputIterator last, OutputIterator output, T init, BinaryFunction binary_op)
+{
+  using thrust::system::detail::generic::select_system;
+
+  using System1 = typename thrust::iterator_system<InputIterator>::type;
+  using System2 = typename thrust::iterator_system<OutputIterator>::type;
+
+  System1 system1;
+  System2 system2;
+
+  thrust::reduce_into(select_system(system1, system2), first, last, output, init, binary_op);
 }
 
 template <typename InputIterator1, typename InputIterator2, typename OutputIterator1, typename OutputIterator2>

--- a/thrust/thrust/reduce.h
+++ b/thrust/thrust/reduce.h
@@ -322,6 +322,359 @@ _CCCL_HOST_DEVICE T reduce(
 template <typename InputIterator, typename T, typename BinaryFunction>
 T reduce(InputIterator first, InputIterator last, T init, BinaryFunction binary_op);
 
+/*! \p reduce_into is a generalization of summation: it computes the sum (or some
+ *  other binary operation) of all the elements in the range <tt>[first,
+ *  last)</tt>. This version of \p reduce_into uses \c 0 as the initial value of the
+ *  reduction. \p reduce_into is similar to the C++ Standard Template Library's
+ *  <tt>std::accumulate</tt>. The primary difference between the two functions
+ *  is that <tt>std::accumulate</tt> guarantees the order of summation, while
+ *  \p reduce_into requires associativity of the binary operation to parallelize
+ *  the reduction.
+ *
+ *  Note that \p reduce_into also assumes that the binary reduction operator (in this
+ *  case operator+) is commutative. If the reduction operator is not commutative
+ *  then \p reduce_into should not be used. Instead, one could use \p inclusive_scan
+ *  (which does not require commutativity) and select the last element of the
+ *  output array.
+ *
+ *  Unlike \p reduce, \p reduce_into does not return the reduction result.
+ *  Instead, it is written to <tt>*output</tt>. Thus, when \p exec is
+ *  \p thrust::cuda::par_nosync, this algorithm does not wait for the work it
+ *  launches to complete. Additionally, you can use \p reduce_into to avoid
+ *  copying the reduction result from device memory to host memory.
+ *
+ *  The algorithm's execution is parallelized as determined by \p exec.
+ *
+ *  \param exec The execution policy to use for parallelization.
+ *  \param first The beginning of the sequence.
+ *  \param last The end of the sequence.
+ *  \param output The location the reduction will be written to.
+ *
+ *  \tparam DerivedPolicy The name of the derived execution policy.
+ *  \tparam InputIterator is a model of <a href="https://en.cppreference.com/w/cpp/iterator/input_iterator">Input
+ * Iterator</a> and if \c x and \c y are objects of \p InputIterator's \c value_type, then <tt>x + y</tt> is defined and
+ * is convertible to \p InputIterator's \c value_type. If \c T is \c InputIterator's \c value_type, then <tt>T(0)</tt>
+ * is defined.
+ *  \tparam OutputIterator is a model of <a href="https://en.cppreference.com/w/cpp/iterator/output_iterator">Output
+ * Iterator</a> and \c OutputIterator's \c value_type is assignable from \c InputIterator's \c value_type.
+ *
+ *  The following code snippet demonstrates how to use \p reduce_into to compute
+ *  the sum of a sequence of integers using the \p thrust::device execution policy for parallelization:
+ *
+ *  \code
+ *  #include <thrust/reduce.h>
+ *  #include <thrust/device_vector.h>
+ *  #include <thrust/execution_policy.h>
+ *
+ *  thrust::device_vector<int> data{1, 0, 2, 2, 1, 3};
+ *  thrust::device_vector<int> output(1);
+ *  thrust::reduce_into(thrust::device, data.begin(), data.end(), output.begin());
+ *  // output[0] == 9
+ *  \endcode
+ *
+ *  \see https://en.cppreference.com/w/cpp/algorithm/accumulate
+ *  \see reduce
+ */
+template <typename DerivedPolicy, typename InputIterator, typename OutputIterator>
+_CCCL_HOST_DEVICE void reduce_into(
+  const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
+  InputIterator first,
+  InputIterator last,
+  OutputIterator output);
+
+/*! \p reduce_into is a generalization of summation: it computes the sum (or some
+ *  other binary operation) of all the elements in the range <tt>[first,
+ *  last)</tt>. This version of \p reduce_into uses \c 0 as the initial value of the
+ *  reduction. \p reduce_into is similar to the C++ Standard Template Library's
+ *  <tt>std::accumulate</tt>. The primary difference between the two functions
+ *  is that <tt>std::accumulate</tt> guarantees the order of summation, while
+ *  \p reduce_into requires associativity of the binary operation to parallelize
+ *  the reduction.
+ *
+ *  Note that \p reduce_into also assumes that the binary reduction operator (in this
+ *  case operator+) is commutative. If the reduction operator is not commutative
+ *  then \p reduce_into should not be used. Instead, one could use \p inclusive_scan
+ *  (which does not require commutativity) and select the last element of the
+ *  output array.
+ *
+ *  Unlike \p reduce, \p reduce_into does not return the reduction result.
+ *  Instead, it is written to <tt>*output</tt>. Thus, when \p exec is
+ *  \p thrust::cuda::par_nosync, this algorithm does not wait for the work it
+ *  launches to complete. Additionally, you can use \p reduce_into to avoid
+ *  copying the reduction result from device memory to host memory.
+ *
+ *  \param first The beginning of the sequence.
+ *  \param last The end of the sequence.
+ *  \param output The location the reduction will be written to.
+ *
+ *  \tparam InputIterator is a model of <a href="https://en.cppreference.com/w/cpp/iterator/input_iterator">Input
+ * Iterator</a> and if \c x and \c y are objects of \p InputIterator's \c value_type, then <tt>x + y</tt> is defined and
+ * is convertible to \p InputIterator's \c value_type. If \c T is \c InputIterator's \c value_type, then <tt>T(0)</tt>
+ * is defined.
+ *  \tparam OutputIterator is a model of <a href="https://en.cppreference.com/w/cpp/iterator/output_iterator">Output
+ * Iterator</a> and \c OutputIterator's \c value_type is assignable from \c InputIterator's \c value_type.
+ *
+ *  The following code snippet demonstrates how to use \p reduce_into to compute
+ *  the sum of a sequence of integers.
+ *
+ *  \code
+ *  #include <thrust/reduce.h>
+ *  #include <thrust/device_vector.h>
+ *  #include <thrust/execution_policy.h>
+ *
+ *  thrust::device_vector<int> data{1, 0, 2, 2, 1, 3};
+ *  thrust::device_vector<int> output(1);
+ *  thrust::reduce_into(data.begin(), data.end(), output.begin());
+ *  // output[0] == 9
+ *  \endcode
+ *
+ *  \see https://en.cppreference.com/w/cpp/algorithm/accumulate
+ *  \see reduce
+ */
+template <typename InputIterator, typename OutputIterator>
+void reduce_into(InputIterator first, InputIterator last, OutputIterator output);
+
+/*! \p reduce_into is a generalization of summation: it computes the sum (or some
+ *  other binary operation) of all the elements in the range <tt>[first,
+ *  last)</tt>. This version of \p reduce_into uses \p init as the initial value of the
+ *  reduction. \p reduce_into is similar to the C++ Standard Template Library's
+ *  <tt>std::accumulate</tt>. The primary difference between the two functions
+ *  is that <tt>std::accumulate</tt> guarantees the order of summation, while
+ *  \p reduce_into requires associativity of the binary operation to parallelize
+ *  the reduction.
+ *
+ *  Note that \p reduce_into also assumes that the binary reduction operator (in this
+ *  case operator+) is commutative. If the reduction operator is not commutative
+ *  then \p reduce_into should not be used. Instead, one could use \p inclusive_scan
+ *  (which does not require commutativity) and select the last element of the
+ *  output array.
+ *
+ *  Unlike \p reduce, \p reduce_into does not return the reduction result.
+ *  Instead, it is written to <tt>*output</tt>. Thus, when \p exec is
+ *  \p thrust::cuda::par_nosync, this algorithm does not wait for the work it
+ *  launches to complete. Additionally, you can use \p reduce_into to avoid
+ *  copying the reduction result from device memory to host memory.
+ *
+ *  The algorithm's execution is parallelized as determined by \p exec.
+ *
+ *  \param exec The execution policy to use for parallelization.
+ *  \param first The beginning of the input sequence.
+ *  \param last The end of the input sequence.
+ *  \param output The location the reduction will be written to.
+ *  \param init The initial value.
+ *
+ *  \tparam DerivedPolicy The name of the derived execution policy.
+ *  \tparam InputIterator is a model of <a href="https://en.cppreference.com/w/cpp/iterator/input_iterator">Input
+ * Iterator</a> and if \c x and \c y are objects of \p InputIterator's \c value_type, then <tt>x + y</tt> is defined and
+ * is convertible to \p T.
+ *  \tparam OutputIterator is a model of <a href="https://en.cppreference.com/w/cpp/iterator/output_iterator">Output
+ * Iterator</a> and \c OutputIterator's \c value_type is assignable from \c T.
+ *  \tparam T is convertible to \p InputIterator's \c value_type.
+ *
+ *  The following code snippet demonstrates how to use \p reduce_into to compute
+ *  the sum of a sequence of integers including an initialization value using the
+ *  \p thrust::device execution policy for parallelization:
+ *
+ *  \code
+ *  #include <thrust/reduce.h>
+ *  #include <thrust/device_vector.h>
+ *  #include <thrust/execution_policy.h>
+ *
+ *  thrust::device_vector<int> data{1, 0, 2, 2, 1, 3};
+ *  thrust::device_vector<int> output(1);
+ *  thrust::reduce_into(thrust::device, data.begin(), data.end(), output.begin(), 1);
+ *  // output[0] == 10
+ *  \endcode
+ *
+ *  \see https://en.cppreference.com/w/cpp/algorithm/accumulate
+ *  \see reduce
+ */
+template <typename DerivedPolicy, typename InputIterator, typename OutputIterator, typename T>
+_CCCL_HOST_DEVICE void reduce_into(
+  const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
+  InputIterator first,
+  InputIterator last,
+  OutputIterator output,
+  T init);
+
+/*! \p reduce_into is a generalization of summation: it computes the sum (or some
+ *  other binary operation) of all the elements in the range <tt>[first,
+ *  last)</tt>. This version of \p reduce_into uses \p init as the initial value of the
+ *  reduction. \p reduce_into is similar to the C++ Standard Template Library's
+ *  <tt>std::accumulate</tt>. The primary difference between the two functions
+ *  is that <tt>std::accumulate</tt> guarantees the order of summation, while
+ *  \p reduce_into requires associativity of the binary operation to parallelize
+ *  the reduction.
+ *
+ *  Note that \p reduce_into also assumes that the binary reduction operator (in this
+ *  case operator+) is commutative. If the reduction operator is not commutative
+ *  then \p reduce_into should not be used. Instead, one could use \p inclusive_scan
+ *  (which does not require commutativity) and select the last element of the
+ *  output array.
+ *
+ *  Unlike \p reduce, \p reduce_into does not return the reduction result.
+ *  Instead, it is written to <tt>*output</tt>. Thus, when \p exec is
+ *  \p thrust::cuda::par_nosync, this algorithm does not wait for the work it
+ *  launches to complete. Additionally, you can use \p reduce_into to avoid
+ *  copying the reduction result from device memory to host memory.
+ *
+ *  \param first The beginning of the input sequence.
+ *  \param last The end of the input sequence.
+ *  \param output The location the reduction will be written to.
+ *  \param init The initial value.
+ *
+ *  \tparam InputIterator is a model of <a href="https://en.cppreference.com/w/cpp/iterator/input_iterator">Input
+ * Iterator</a> and if \c x and \c y are objects of \p InputIterator's \c value_type, then <tt>x + y</tt> is defined and
+ * is convertible to \p T.
+ *  \tparam OutputIterator is a model of <a href="https://en.cppreference.com/w/cpp/iterator/output_iterator">Output
+ * Iterator</a> and \c OutputIterator's \c value_type is assignable from \c T.
+ *  \tparam T is convertible to \p InputIterator's \c value_type.
+ *
+ *  The following code snippet demonstrates how to use \p reduce_into to compute
+ *  the sum of a sequence of integers including an initialization value.
+ *
+ *  \code
+ *  #include <thrust/reduce.h>
+ *  #include <thrust/device_vector.h>
+ *  #include <thrust/execution_policy.h>
+ *
+ *  thrust::device_vector<int> data{1, 0, 2, 2, 1, 3};
+ *  thrust::device_vector<int> output(1);
+ *  thrust::reduce_into(data.begin(), data.end(), output.begin(), 1);
+ *  // output[0] == 10
+ *  \endcode
+ *
+ *  \see https://en.cppreference.com/w/cpp/algorithm/accumulate
+ *  \see reduce
+ */
+template <typename InputIterator, typename OutputIterator, typename T>
+void reduce_into(InputIterator first, InputIterator last, OutputIterator output, T init);
+
+/*! \p reduce_into is a generalization of summation: it computes the sum (or some
+ *  other binary operation) of all the elements in the range <tt>[first,
+ *  last)</tt>. This version of \p reduce_into uses \p init as the initial value of the
+ *  reduction and \p binary_op as the binary function used for summation. \p reduce_into
+ *  is similar to the C++ Standard Template Library's <tt>std::accumulate</tt>.
+ *  The primary difference between the two functions is that <tt>std::accumulate</tt>
+ *  guarantees the order of summation, while \p reduce_into requires associativity of
+ *  \p binary_op to parallelize the reduction.
+ *
+ *  Note that \p reduce_into also assumes that the binary reduction operator (in this
+ *  case \p binary_op) is commutative. If the reduction operator is not commutative
+ *  then \p reduce_into should not be used. Instead, one could use \p inclusive_scan
+ *  (which does not require commutativity) and select the last element of the
+ *  output array.
+ *
+ *  Unlike \p reduce, \p reduce_into does not return the reduction result.
+ *  Instead, it is written to <tt>*output</tt>. Thus, when \p exec is
+ *  \p thrust::cuda::par_nosync, this algorithm does not wait for the work it
+ *  launches to complete. Additionally, you can use \p reduce_into to avoid
+ *  copying the reduction result from device memory to host memory.
+ *
+ *  The algorithm's execution is parallelized as determined by \p exec.
+ *
+ *  \param exec The execution policy to use for parallelization.
+ *  \param first The beginning of the input sequence.
+ *  \param last The end of the input sequence.
+ *  \param output The location the reduction will be written to.
+ *  \param init The initial value.
+ *  \param binary_op The binary function used to 'sum' values.
+ *  \return The result of the reduction.
+ *
+ *  \tparam DerivedPolicy The name of the derived execution policy.
+ *  \tparam InputIterator is a model of <a href="https://en.cppreference.com/w/cpp/iterator/input_iterator">Input
+ * Iterator</a> and \c InputIterator's \c value_type is convertible to \c T.
+ *  \tparam OutputIterator is a model of <a href="https://en.cppreference.com/w/cpp/iterator/output_iterator">Output
+ * Iterator</a> and \c OutputIterator's \c value_type is assignable from \c T.
+ *  \tparam T is a model of <a href="https://en.cppreference.com/w/cpp/named_req/CopyAssignable">Assignable</a>, and is
+ * convertible to \p BinaryFunction's first and second argument type.
+ *  \tparam BinaryFunction The function's return type must be convertible to \p OutputType.
+ *
+ *  The following code snippet demonstrates how to use \p reduce_into to
+ *  compute the maximum value of a sequence of integers using the \p thrust::device
+ *  execution policy for parallelization:
+ *
+ *  \code
+ *  #include <cuda/functional>
+ *  #include <thrust/reduce.h>
+ *  #include <thrust/device_vector.h>
+ *  #include <thrust/execution_policy.h>
+ *
+ *  thrust::device_vector<int> data{1, 0, 2, 2, 1, 3};
+ *  thrust::device_vector<int> output(1);
+ *  thrust::reduce_into(thrust::device,
+ *                      data.begin(), data.end(), output.begin(), -1,
+ *                      cuda::maximum{});
+ *  // output[0] == 3
+ *  \endcode
+ *
+ *  \see https://en.cppreference.com/w/cpp/algorithm/accumulate
+ *  \see reduce
+ *  \see transform_reduce
+ *  \see transform_reduce_into
+ */
+template <typename DerivedPolicy, typename InputIterator, typename OutputIterator, typename T, typename BinaryFunction>
+_CCCL_HOST_DEVICE void reduce_into(
+  const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
+  InputIterator first,
+  InputIterator last,
+  OutputIterator output,
+  T init,
+  BinaryFunction binary_op);
+
+/*! \p reduce_into is a generalization of summation: it computes the sum (or some
+ *  other binary operation) of all the elements in the range <tt>[first,
+ *  last)</tt>. This version of \p reduce_into uses \p init as the initial value of the
+ *  reduction and \p binary_op as the binary function used for summation. \p reduce_into
+ *  is similar to the C++ Standard Template Library's <tt>std::accumulate</tt>.
+ *  The primary difference between the two functions is that <tt>std::accumulate</tt>
+ *  guarantees the order of summation, while \p reduce_into requires associativity of
+ *  \p binary_op to parallelize the reduction.
+ *
+ *  Note that \p reduce_into also assumes that the binary reduction operator (in this
+ *  case \p binary_op) is commutative.  If the reduction operator is not commutative
+ *  then \p thrust::reduce_into should not be used.  Instead, one could use
+ *  \p inclusive_scan (which does not require commutativity) and select the
+ *  last element of the output array.
+ *
+ *  \param first The beginning of the input sequence.
+ *  \param last The end of the input sequence.
+ *  \param init The initial value.
+ *  \param binary_op The binary function used to 'sum' values.
+ *  \return The result of the reduction.
+ *
+ *  \tparam InputIterator is a model of <a href="https://en.cppreference.com/w/cpp/iterator/input_iterator">Input
+ * Iterator</a> and \c InputIterator's \c value_type is convertible to \c T.
+ *  \tparam OutputIterator is a model of <a href="https://en.cppreference.com/w/cpp/iterator/output_iterator">Output
+ * Iterator</a> and \c OutputIterator's \c value_type is assignable from \c T.
+ *  \tparam T is a model of <a href="https://en.cppreference.com/w/cpp/named_req/CopyAssignable">Assignable</a>, and is
+ * convertible to \p BinaryFunction's first and second argument type.
+ *  \tparam BinaryFunction The function's return type must be convertible to \p OutputType.
+ *
+ *  The following code snippet demonstrates how to use \p reduce_into to
+ *  compute the maximum value of a sequence of integers.
+ *
+ *  \code
+ *  #include <cuda/functional>
+ *  #include <thrust/reduce.h>
+ *  #include <thrust/device_vector.h>
+ *  #include <thrust/execution_policy.h>
+ *
+ *  thrust::device_vector<int> data{1, 0, 2, 2, 1, 3};
+ *  thrust::device_vector<int> output(1);
+ *  thrust::reduce_into(data.begin(), data.end(), output.begin(), -1,
+ *                      cuda::maximum{});
+ *  // output[0] == 3
+ *  \endcode
+ *
+ *  \see https://en.cppreference.com/w/cpp/algorithm/accumulate
+ *  \see reduce
+ *  \see transform_reduce
+ *  \see transform_reduce_into
+ */
+template <typename InputIterator, typename OutputIterator, typename T, typename BinaryFunction>
+void reduce_into(InputIterator first, InputIterator last, OutputIterator output, T init, BinaryFunction binary_op);
+
 /*! \p reduce_by_key is a generalization of \p reduce to key-value pairs.
  *  For each group of consecutive keys in the range <tt>[keys_first, keys_last)</tt>
  *  that are equal, \p reduce_by_key copies the first element of the group to the

--- a/thrust/thrust/system/cuda/detail/reduce.h
+++ b/thrust/thrust/system/cuda/detail/reduce.h
@@ -933,7 +933,7 @@ reduce_into(execution_policy<Derived>& policy, InputIt first, InputIt last, Outp
 {
   using size_type = thrust::detail::it_difference_t<InputIt>;
   // FIXME: Check for RA iterator.
-  size_type num_items = static_cast<size_type>(thrust::distance(first, last));
+  size_type num_items = static_cast<size_type>(::cuda::std::distance(first, last));
   cuda_cub::reduce_n_into(policy, first, num_items, output, init, binary_op);
 }
 

--- a/thrust/thrust/system/cuda/detail/reduce.h
+++ b/thrust/thrust/system/cuda/detail/reduce.h
@@ -60,8 +60,7 @@
 
 THRUST_NAMESPACE_BEGIN
 
-// forward declare generic reduce
-// to circumvent circular dependency
+// Forward declare generic reduce circumvent circular dependency.
 template <typename DerivedPolicy, typename InputIterator, typename T, typename BinaryFunction>
 T _CCCL_HOST_DEVICE
 reduce(const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
@@ -69,6 +68,15 @@ reduce(const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
        InputIterator last,
        T init,
        BinaryFunction binary_op);
+
+template <typename DerivedPolicy, typename InputIterator, typename OutputIterator, typename T, typename BinaryFunction>
+void _CCCL_HOST_DEVICE reduce_into(
+  const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
+  InputIterator first,
+  InputIterator last,
+  OutputIterator output,
+  T init,
+  BinaryFunction binary_op);
 
 namespace cuda_cub
 {
@@ -780,13 +788,11 @@ namespace detail
 {
 
 template <typename Derived, typename InputIt, typename Size, typename T, typename BinaryOp>
-THRUST_RUNTIME_FUNCTION T
-reduce_n_impl(execution_policy<Derived>& policy, InputIt first, Size num_items, T init, BinaryOp binary_op)
+THRUST_RUNTIME_FUNCTION size_t get_reduce_n_temporary_storage_size(
+  execution_policy<Derived>& policy, InputIt first, Size num_items, T init, BinaryOp binary_op)
 {
   cudaStream_t stream = cuda_cub::stream(policy);
   cudaError_t status;
-
-  // Determine temporary device storage requirements.
 
   size_t tmp_size = 0;
 
@@ -795,22 +801,35 @@ reduce_n_impl(execution_policy<Derived>& policy, InputIt first, Size num_items, 
     cub::DeviceReduce::Reduce,
     num_items,
     (nullptr, tmp_size, first, static_cast<T*>(nullptr), num_items_fixed, binary_op, init, stream));
-  cuda_cub::throw_on_error(status, "after reduction step 1");
+  cuda_cub::throw_on_error(status, "after determining reduce temporary storage size");
+
+  return tmp_size;
+}
+
+template <typename Derived, typename InputIt, typename Size, typename T, typename BinaryOp>
+THRUST_RUNTIME_FUNCTION T
+reduce_n_impl(execution_policy<Derived>& policy, InputIt first, Size num_items, T init, BinaryOp binary_op)
+{
+  cudaStream_t stream = cuda_cub::stream(policy);
+  cudaError_t status;
+
+  // Determine temporary device storage requirements.
+
+  size_t tmp_size = get_reduce_n_temporary_storage_size(policy, first, num_items, init, binary_op);
 
   // Allocate temporary storage.
 
-  thrust::detail::temporary_array<std::uint8_t, Derived> tmp(policy, sizeof(T) + tmp_size);
-
-  // Run reduction.
-
-  // `tmp.begin()` yields a `normal_iterator`, which dereferences to a
-  // `reference`, which has an `operator&` that returns a `pointer`, which
-  // has a `.get` method that returns a raw pointer, which we can (finally)
-  // `static_cast` to `void*`.
+  // We allocate both the temporary storage needed for the algorithm, and a `T`
+  // to store the result.
   //
   // The array was dynamically allocated, so we assume that it's suitably
   // aligned for any type of data. `malloc`/`cudaMalloc`/`new`/`std::allocator`
   // make this guarantee.
+
+  thrust::detail::temporary_array<std::uint8_t, Derived> tmp(policy, tmp_size + sizeof(T));
+
+  // Run reduction.
+
   T* ret_ptr    = thrust::detail::aligned_reinterpret_cast<T*>(tmp.data().get());
   void* tmp_ptr = static_cast<void*>((tmp.data() + sizeof(T)).get());
   THRUST_INDEX_TYPE_DISPATCH(
@@ -818,22 +837,44 @@ reduce_n_impl(execution_policy<Derived>& policy, InputIt first, Size num_items, 
     cub::DeviceReduce::Reduce,
     num_items,
     (tmp_ptr, tmp_size, first, ret_ptr, num_items_fixed, binary_op, init, stream));
-  cuda_cub::throw_on_error(status, "after reduction step 2");
+  cuda_cub::throw_on_error(status, "after reduce invocation");
 
   // Synchronize the stream and get the value.
 
   status = cuda_cub::synchronize(policy);
   cuda_cub::throw_on_error(status, "reduce failed to synchronize");
-
-  // `tmp.begin()` yields a `normal_iterator`, which dereferences to a
-  // `reference`, which has an `operator&` that returns a `pointer`, which
-  // has a `.get` method that returns a raw pointer, which we can (finally)
-  // `static_cast` to `void*`.
-  //
-  // The array was dynamically allocated, so we assume that it's suitably
-  // aligned for any type of data. `malloc`/`cudaMalloc`/`new`/`std::allocator`
-  // make this guarantee.
   return thrust::cuda_cub::get_value(policy, thrust::detail::aligned_reinterpret_cast<T*>(tmp.data().get()));
+}
+
+template <typename Derived, typename InputIt, typename Size, typename OutputIt, typename T, typename BinaryOp>
+THRUST_RUNTIME_FUNCTION void reduce_n_into_impl(
+  execution_policy<Derived>& policy, InputIt first, Size num_items, OutputIt output, T init, BinaryOp binary_op)
+{
+  cudaStream_t stream = cuda_cub::stream(policy);
+  cudaError_t status;
+
+  // Determine temporary device storage requirements.
+
+  size_t tmp_size = get_reduce_n_temporary_storage_size(policy, first, num_items, init, binary_op);
+
+  // Allocate temporary storage.
+
+  thrust::detail::temporary_array<std::uint8_t, Derived> tmp(policy, tmp_size);
+
+  // Run reduction.
+
+  void* tmp_ptr = thrust::raw_pointer_cast(tmp.data());
+  THRUST_INDEX_TYPE_DISPATCH(
+    status,
+    cub::DeviceReduce::Reduce,
+    num_items,
+    (tmp_ptr, tmp_size, first, output, num_items_fixed, binary_op, init, stream));
+  cuda_cub::throw_on_error(status, "after reduce invocation");
+
+  // Synchronize the stream and get the value.
+
+  status = cuda_cub::synchronize_optional(policy);
+  cuda_cub::throw_on_error(status, "reduce failed to synchronize");
 }
 
 } // namespace detail
@@ -851,6 +892,16 @@ reduce_n(execution_policy<Derived>& policy, InputIt first, Size num_items, T ini
     (init = thrust::cuda_cub::detail::reduce_n_impl(policy, first, num_items, init, binary_op);),
     (init = thrust::reduce(cvt_to_seq(derived_cast(policy)), first, first + num_items, init, binary_op);));
   return init;
+}
+
+_CCCL_EXEC_CHECK_DISABLE
+template <typename Derived, typename InputIt, typename Size, typename OutputIt, typename T, typename BinaryOp>
+_CCCL_HOST_DEVICE void reduce_n_into(
+  execution_policy<Derived>& policy, InputIt first, Size num_items, OutputIt output, T init, BinaryOp binary_op)
+{
+  THRUST_CDP_DISPATCH(
+    (thrust::cuda_cub::detail::reduce_n_into_impl(policy, first, num_items, output, init, binary_op);),
+    (thrust::reduce_into(cvt_to_seq(derived_cast(policy)), first, first + num_items, output, init, binary_op);));
 }
 
 template <class Derived, class InputIt, class T, class BinaryOp>
@@ -874,6 +925,30 @@ reduce(execution_policy<Derived>& policy, InputIt first, InputIt last)
 {
   using value_type = thrust::detail::it_value_t<InputIt>;
   return cuda_cub::reduce(policy, first, last, value_type(0));
+}
+
+template <class Derived, class InputIt, class OutputIt, class T, class BinaryOp>
+_CCCL_HOST_DEVICE void
+reduce_into(execution_policy<Derived>& policy, InputIt first, InputIt last, OutputIt output, T init, BinaryOp binary_op)
+{
+  using size_type = thrust::detail::it_difference_t<InputIt>;
+  // FIXME: Check for RA iterator.
+  size_type num_items = static_cast<size_type>(thrust::distance(first, last));
+  cuda_cub::reduce_n_into(policy, first, num_items, output, init, binary_op);
+}
+
+template <class Derived, class InputIt, class OutputIt, class T>
+_CCCL_HOST_DEVICE void
+reduce_into(execution_policy<Derived>& policy, InputIt first, InputIt last, OutputIt output, T init)
+{
+  cuda_cub::reduce_into(policy, first, last, output, init, ::cuda::std::plus<T>());
+}
+
+template <class Derived, class InputIt, class OutputIt>
+_CCCL_HOST_DEVICE void reduce_into(execution_policy<Derived>& policy, InputIt first, InputIt last, OutputIt output)
+{
+  using value_type = thrust::detail::it_value_t<InputIt>;
+  return cuda_cub::reduce_into(policy, first, last, output, value_type(0));
 }
 
 } // namespace cuda_cub

--- a/thrust/thrust/system/detail/generic/reduce.h
+++ b/thrust/thrust/system/detail/generic/reduce.h
@@ -52,6 +52,23 @@ _CCCL_HOST_DEVICE T reduce(
   T init,
   BinaryFunction binary_op);
 
+template <typename DerivedPolicy, typename InputIterator, typename OutputIterator>
+_CCCL_HOST_DEVICE void reduce_into(
+  thrust::execution_policy<DerivedPolicy>& exec, InputIterator first, InputIterator last, OutputIterator output);
+
+template <typename DerivedPolicy, typename InputIterator, typename OutputIterator, typename T>
+_CCCL_HOST_DEVICE void reduce_into(
+  thrust::execution_policy<DerivedPolicy>& exec, InputIterator first, InputIterator last, OutputIterator output, T init);
+
+template <typename DerivedPolicy, typename InputIterator, typename OutputIterator, typename T, typename BinaryFunction>
+_CCCL_HOST_DEVICE void reduce_into(
+  thrust::execution_policy<DerivedPolicy>& exec,
+  InputIterator first,
+  InputIterator last,
+  OutputIterator output,
+  T init,
+  BinaryFunction binary_op);
+
 } // end namespace generic
 } // end namespace detail
 } // end namespace system

--- a/thrust/thrust/system/detail/generic/reduce.inl
+++ b/thrust/thrust/system/detail/generic/reduce.inl
@@ -44,10 +44,10 @@ template <typename ExecutionPolicy, typename InputIterator>
 _CCCL_HOST_DEVICE thrust::detail::it_value_t<InputIterator>
 reduce(thrust::execution_policy<ExecutionPolicy>& exec, InputIterator first, InputIterator last)
 {
-  using InputType = thrust::detail::it_value_t<InputIterator>;
+  using T = thrust::detail::it_value_t<InputIterator>;
 
-  // use InputType(0) as init by default
-  return thrust::reduce(exec, first, last, InputType(0));
+  // use T(0) as init by default
+  return thrust::reduce(exec, first, last, T(0));
 } // end reduce()
 
 template <typename ExecutionPolicy, typename InputIterator, typename T>
@@ -58,14 +58,47 @@ reduce(thrust::execution_policy<ExecutionPolicy>& exec, InputIterator first, Inp
   return thrust::reduce(exec, first, last, init, ::cuda::std::plus<T>());
 } // end reduce()
 
-template <typename ExecutionPolicy, typename RandomAccessIterator, typename OutputType, typename BinaryFunction>
-_CCCL_HOST_DEVICE OutputType reduce(
-  thrust::execution_policy<ExecutionPolicy>&, RandomAccessIterator, RandomAccessIterator, OutputType, BinaryFunction)
+template <typename ExecutionPolicy, typename InputIterator, typename T, typename BinaryFunction>
+_CCCL_HOST_DEVICE T reduce(thrust::execution_policy<ExecutionPolicy>&, InputIterator, InputIterator, T, BinaryFunction)
 {
-  static_assert(thrust::detail::depend_on_instantiation<RandomAccessIterator, false>::value,
-                "unimplemented for this system");
-  return OutputType();
+  static_assert(thrust::detail::depend_on_instantiation<InputIterator, false>::value, "unimplemented for this system");
+  return T();
 } // end reduce()
+
+template <typename ExecutionPolicy, typename InputIterator, typename OutputIterator>
+_CCCL_HOST_DEVICE void reduce_into(
+  thrust::execution_policy<ExecutionPolicy>& exec, InputIterator first, InputIterator last, OutputIterator output)
+{
+  using T = thrust::detail::it_value_t<InputIterator>;
+
+  // use T(0) as init by default
+  thrust::reduce_into(exec, first, last, output, T(0));
+} // end reduce_into()
+
+template <typename ExecutionPolicy, typename InputIterator, typename OutputIterator, typename T>
+_CCCL_HOST_DEVICE void reduce_into(
+  thrust::execution_policy<ExecutionPolicy>& exec,
+  InputIterator first,
+  InputIterator last,
+  OutputIterator output,
+  T init)
+{
+  // use plus<T> by default
+  thrust::reduce_into(exec, first, last, output, init, ::cuda::std::plus<T>());
+} // end reduce_into()
+
+template <typename ExecutionPolicy, typename InputIterator, typename OutputIterator, typename T, typename BinaryFunction>
+_CCCL_HOST_DEVICE void reduce_into(
+  thrust::execution_policy<ExecutionPolicy>& exec,
+  InputIterator first,
+  InputIterator last,
+  OutputIterator output,
+  T init,
+  BinaryFunction binary_op)
+{
+  // use reduce by default
+  *output = thrust::reduce(exec, first, last, init, binary_op);
+} // end reduce_into()
 
 } // end namespace generic
 } // end namespace detail


### PR DESCRIPTION
```
template <typename InputIt, typename T, typename Op>
T reduce(InputIt first, InputIt last, T init, Op op);

template <typename InputIt, typename OutputIt, typename T, typename Op>
void reduce(InputIt first, InputIt last, OutputIt output, T init, Op op);
```

`reduce_into` is a variant of `reduce` that assigns the reduction result to an iterator. Because it's result is not computation dependent, it is asynchronous when invoked with `par_nosync`. It can be used to avoid transferring the reduction result off the device.

This is the first step in addressing #4056.

