### PR TITLE
Cleanup `<cuda/std/version>`

### DIFF
--- a/libcudacxx/include/cuda/std/version
+++ b/libcudacxx/include/cuda/std/version
@@ -401,7 +401,7 @@
 // C++ library extensions
 
 #ifdef CCCL_ENABLE_OPTIONAL_REF
-#  define __cpp_lib_optional_ref 202602L
+#  define __cccl_lib_optional_ref 202602L
 #endif // CCCL_ENABLE_OPTIONAL_REF
 
 #endif // _CUDA_STD_VERSION

--- a/libcudacxx/include/cuda/std/version
+++ b/libcudacxx/include/cuda/std/version
@@ -29,228 +29,361 @@
 #  include <ciso646> // otherwise go for the smallest possible header
 #endif // !_CCCL_COMPILER(NVRTC)
 
-#define __cccl_lib_bitops                       201907L
-#define __cccl_lib_bool_constant                201505L
-#define __cccl_lib_bounded_array_traits         201902L
-#define __cccl_lib_byte                         201603L
-#define __cccl_lib_byteswap                     202110L
-#define __cccl_lib_clamp                        201603L
-#define __cccl_lib_endian                       201907L
-#define __cccl_lib_forward_like                 202207L
-#define __cccl_lib_gcd_lcm                      201606L
-#define __cccl_lib_integer_comparison_functions 202002L
-#define __cccl_lib_integer_sequence             201304L
-#define __cccl_lib_integral_constant_callable   201304L
-#define __cccl_lib_is_final                     201402L
-#define __cccl_lib_is_nothrow_convertible       201806L
-#define __cccl_lib_is_null_pointer              201309L
-#define __cccl_lib_is_scoped_enum               202011L
-#define __cccl_lib_is_swappable                 201603L
-#define __cccl_lib_launder                      201606L
-#define __cccl_lib_logical_traits               201510L
-#define __cccl_lib_math_constants               201907L
-#if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY) \
-  && defined(_CCCL_BUILTIN_REFERENCE_CONVERTS_FROM_TEMPORARY)
-#  define __cpp_lib_reference_from_temporary 202202L
-#endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY && _CCCL_BUILTIN_REFERENCE_CONVERTS_FROM_TEMPORARY
-#define __cccl_lib_shift                        201806L
-#define __cccl_lib_to_address                   201711L
-#define __cccl_lib_to_array                     201907L
-#define __cccl_lib_to_underlying                202102L
-#define __cccl_lib_transparent_operators        201210L
-#define __cccl_lib_transformation_trait_aliases 201304L
-#define __cccl_lib_tuple_element_t              201402L
-// #define __cpp_lib_tuple_like                    202311L // P2819R2 is implemented, but P2165R4 is not yet
-#define __cccl_lib_type_identity                 201806L
-#define __cccl_lib_type_trait_variable_templates 201510L
-#define __cccl_lib_unreachable                   202202L
-#define __cccl_lib_void_t                        201411L
+// C++14 library features
 
-#define __cccl_lib_as_const     201510L
-#define __cccl_lib_bit_cast     201806L
-#define __cccl_lib_chrono_udls  201304L
-#define __cccl_lib_complex_udls 201309L
-#ifdef _CCCL_BUILTIN_IS_CONSTANT_EVALUATED
-#  define __cccl_lib_constexpr_complex 201711L
-#endif // _CCCL_BUILTIN_IS_CONSTANT_EVALUATED
-#define __cccl_lib_concepts          202002L
+#define __cccl_lib_chrono_udls       201304L
+#define __cccl_lib_complex_udls      201309L
 #define __cccl_lib_exchange_function 201304L
-#define __cccl_lib_expected          202211L
-// # define __cccl_lib_generic_associative_lookup           201304L
-#define __cccl_lib_invoke                201411L
-#define __cccl_lib_invoke_r              202106L
-#define __cccl_lib_is_invocable          201703L
-#define __cccl_lib_make_reverse_iterator 201402L
-// # define __cccl_lib_make_unique                          201304L
-#define __cccl_lib_mdspan         202207L
+// #define __cccl_lib_generic_associative_lookup 201304L
+#define __cccl_lib_integer_sequence           201304L
+#define __cccl_lib_integral_constant_callable 201304L
+#define __cccl_lib_is_final                   201402L
+#define __cccl_lib_make_reverse_iterator      201402L
+// #define __cccl_lib_make_unique 201304L
 #define __cccl_lib_null_iterators 201304L
-#define __cccl_lib_optional       202110L
-#ifdef CCCL_ENABLE_OPTIONAL_REF
-#  define __cpp_lib_optional_ref 202602L
-#endif // CCCL_ENABLE_OPTIONAL_REF
-// # define __cccl_lib_quoted_string_io                     201304L
+// #define __cccl_lib_quoted_string_io 201304L
 #define __cccl_lib_result_of_sfinae            201210L
 #define __cccl_lib_robust_nonmodifying_seq_ops 201304L
-#ifndef _LIBCUDACXX_HAS_NO_THREADS
-// #   define __cccl_lib_shared_timed_mutex                 201402L
-#endif // !_LIBCUDACXX_HAS_NO_THREADS
-#define __cccl_lib_source_location       201907L
-#define __cccl_lib_span                  202311L
-#define __cccl_lib_span_initializer_list 202311L
-// # define __cccl_lib_string_udls                          201304L
-#define __cccl_lib_submdspan      202207L
-#define __cccl_lib_tuples_by_type 201304L
-
+#define __cccl_lib_shared_timed_mutex          201402L
+// #define __cccl_lib_string_udls 201304L
+#define __cccl_lib_transformation_trait_aliases 201304L
+#define __cccl_lib_transparent_operators        201210L
+#define __cccl_lib_tuple_element_t              201402L
+#define __cccl_lib_tuples_by_type               201304L
+#define __cccl_lib_is_null_pointer              201309L
 #ifdef _CCCL_BUILTIN_ADDRESSOF
 #  define __cccl_lib_addressof_constexpr 201603L
 #endif // _CCCL_BUILTIN_ADDRESSOF
-// # define __cccl_lib_allocator_traits_is_always_equal     201411L
-// # define __cccl_lib_any                                  201606L
-#define __cccl_lib_apply           201603L
-#define __cccl_lib_array_constexpr 201603L
+
+// C++17 library features
+
+// #define __cccl_lib_allocator_traits_is_always_equal 201411L
+// #define __cccl_lib_any 201606L
+#define __cccl_lib_apply 201603L
+// #define __cccl_lib_array_constexpr 201603L // newer version is always available
+#define __cccl_lib_as_const 201510L
 #ifndef _LIBCUDACXX_HAS_NO_THREADS
 #  define __cccl_lib_atomic_is_always_lock_free 201603L
 #endif // _LIBCUDACXX_HAS_NO_THREADS
-#define __cccl_lib_bind_front 201907L
-// # define __cccl_lib_boyer_moore_searcher                 201603L
+#define __cccl_lib_bool_constant 201505L
+// #define __cccl_lib_boyer_moore_searcher 201603L
+#define __cccl_lib_byte 201603L
+// #define __cccl_lib_chrono 201510L // newer version is always available
 #define __cccl_lib_chrono 201611L
-// # define __cccl_lib_enable_shared_from_this              201603L
-// # define __cccl_lib_execution                            201603L
-// # define __cccl_lib_filesystem                           201703L
-// #  define __cccl_lib_hardware_interference_size 201703L
+#define __cccl_lib_clamp  201603L
+// #define __cccl_lib_constexpr_string 201611L
+// #define __cccl_lib_enable_shared_from_this 201603L
+// #define __cccl_lib_execution 201603L
+// #define __cccl_lib_filesystem 201703L
+#define __cccl_lib_gcd_lcm 201606L
+// #define __cccl_lib_hardware_interference_size 201703L
 #ifdef _CCCL_BUILTIN_HAS_UNIQUE_OBJECT_REPRESENTATIONS
 #  define __cccl_lib_has_unique_object_representations 201606L
 #endif // _CCCL_BUILTIN_HAS_UNIQUE_OBJECT_REPRESENTATIONS
 #define __cccl_lib_hypot 201603L
-// # define __cccl_lib_incomplete_container_elements        201505L
-#ifndef _LIBCUDACXX_HAS_NO_IS_AGGREGATE
-#  define __cccl_lib_is_aggregate 201703L
-#endif // _LIBCUDACXX_HAS_NO_IS_AGGREGATE
+// #define __cccl_lib_incomplete_container_elements 201505L
+#define __cccl_lib_invoke          201411L
+#define __cccl_lib_is_aggregate    201703L
+#define __cccl_lib_is_invocable    201703L
+#define __cccl_lib_is_swappable    201603L
+#define __cccl_lib_launder         201606L
+#define __cccl_lib_logical_traits  201510L
 #define __cccl_lib_make_from_tuple 201606L
-// # define __cccl_lib_map_try_emplace                      201411L
-// # define __cccl_lib_math_special_functions               201603L
-// # define __cccl_lib_memory_resource                      201603L
-// # define __cccl_lib_node_extract                         201606L
-// # define __cccl_lib_nonmember_container_access           201411L
+// #define __cccl_lib_map_try_emplace 201411L
+// #define __cccl_lib_math_special_functions 201603L
+// #define __cccl_lib_memory_resource 201603L
+// #define __cccl_lib_node_extract 201606L
+// #define __cccl_lib_nonmember_container_access 201411L
 #define __cccl_lib_not_fn 201603L
-// # define __cccl_lib_parallel_algorithm                   201603L
-// # define __cccl_lib_raw_memory_algorithms                201606L
-// # define __cccl_lib_sample                               201603L
-// # define __cccl_lib_scoped_lock                          201703L
-#if !defined(_LIBCUDACXX_HAS_NO_THREADS)
-// #   define __cccl_lib_shared_mutex                       201505L
-#endif
-// # define __cccl_lib_shared_ptr_arrays                    201611L
-// # define __cccl_lib_shared_ptr_weak_type                 201606L
-// # define __cccl_lib_string_view                          201606L
-// # define __cccl_lib_to_chars                             201611L
-// #  define __cccl_lib_uncaught_exceptions           201411L
-// #  define __cccl_lib_unordered_map_try_emplace     201411L
+// #define __cccl_lib_optional 201606L // newer version is always available
+// #define __cccl_lib_parallel_algorithm 201603L
+// #define __cccl_lib_raw_memory_algorithms 201606L
+// #define __cccl_lib_sample 201603L
+// #define __cccl_lib_scoped_lock 201703L
+// #define __cccl_lib_shared_mutex 201505L
+// #define __cccl_lib_shared_ptr_arrays 201611L
+// #define __cccl_lib_shared_ptr_weak_type 201606L
+// #define __cccl_lib_string_view 201606L
+// #define __cccl_lib_to_chars 201611L
+// #define __cccl_lib_transparent_operators 201510L
+#define __cccl_lib_type_trait_variable_templates 201510L
+// #define __cccl_lib_uncaught_exceptions 201411L
+// #define __cccl_lib_unordered_map_try_emplace 201411L
 #define __cccl_lib_variant 201606L
+#define __cccl_lib_void_t  201411L
 
-#if _CCCL_STD_VER >= 2020
-#  undef __cccl_lib_array_constexpr
-#  define __cccl_lib_array_constexpr 201811L
-// # define __cccl_lib_assume_aligned                       201811L
-#  define __cccl_lib_atomic_flag_test              201907L
-#  define __cccl_lib_atomic_float                  201711L
-#  define __cccl_lib_atomic_lock_free_type_aliases 201907L
-#  ifndef _LIBCUDACXX_HAS_NO_THREADS
-#    define __cccl_lib_atomic_ref 201806L
-#  endif // !_LIBCUDACXX_HAS_NO_THREADS
-// # define __cccl_lib_atomic_shared_ptr                    201711L
-#  define __cccl_lib_atomic_value_initialization 201911L
-#  define __cccl_lib_atomic_wait                 201907L
-#  ifndef _LIBCUDACXX_HAS_NO_THREADS
-#    define __cccl_lib_barrier 201907L
-#  endif // !_LIBCUDACXX_HAS_NO_THREADS
-#  define __cccl_lib_bit_cast 201806L
-#  if _LIBCUDACXX_HAS_CHAR8_T()
-#    define __cccl_lib_char8_t 201811L
-#  endif // _LIBCUDACXX_HAS_CHAR8_T()
-// # define __cccl_lib_constexpr_algorithms                 201806L
-// # define __cccl_lib_constexpr_dynamic_alloc              201907L
-#  define __cccl_lib_constexpr_functional 201907L
-// # define __cccl_lib_constexpr_iterator                   201811L
-// # define __cccl_lib_constexpr_memory                     201811L
-// # define __cccl_lib_constexpr_misc                       201811L
-// # define __cccl_lib_constexpr_numeric                    201911L
-// # define __cccl_lib_constexpr_string                     201907L
-// # define __cccl_lib_constexpr_string_view                201811L
-// # define __cccl_lib_constexpr_swap_algorithms            201806L
-// # define __cccl_lib_constexpr_tuple                      201811L
-// # define __cccl_lib_constexpr_utility                    201811L
-// # define __cccl_lib_constexpr_vector                     201907L
-// # define __cccl_lib_coroutine                            201902L
-#  if defined(__cpp_impl_destroying_delete) && __cpp_impl_destroying_delete >= 201806L \
-    && defined(__cpp_lib_destroying_delete)
-#    define __cccl_lib_destroying_delete 201806L
-#  endif
-// # define __cccl_lib_erase_if                             201811L
-// # undef  __cccl_lib_execution
-// # define __cccl_lib_execution                            201902L
-// #   define __cccl_lib_format                             202106L
-// # define __cccl_lib_generic_unordered_lookup             201811L
-// # define __cccl_lib_int_pow2                             202002L
-// # define __cccl_lib_interpolate                          201902L
-#  ifdef _CCCL_BUILTIN_IS_CONSTANT_EVALUATED
-#    define __cccl_lib_is_constant_evaluated 201811L
-#  endif // _CCCL_BUILTIN_IS_CONSTANT_EVALUATED
-// # define __cccl_lib_is_layout_compatible                 201907L
-// # define __cccl_lib_is_pointer_interconvertible          201907L
-#  if !defined(_LIBCUDACXX_HAS_NO_THREADS)
-// #   define __cccl_lib_jthread                            201911L
-#  endif
-#  ifndef _LIBCUDACXX_HAS_NO_THREADS
-// #   define __cccl_lib_latch                              201907L
-#  endif // !_LIBCUDACXX_HAS_NO_THREADS
-// # define __cccl_lib_list_remove_return_type              201806L
-// # define __cccl_lib_polymorphic_allocator                201902L
-// # define __cccl_lib_ranges                               201811L
-// # define __cccl_lib_remove_cvref                         201711L
-#  ifndef _LIBCUDACXX_HAS_NO_THREADS
-// #   define __cccl_lib_semaphore                          201907L
-#  endif // !_LIBCUDACXX_HAS_NO_THREADS
-// # undef  __cccl_lib_shared_ptr_arrays
-// # define __cccl_lib_shared_ptr_arrays                    201707L
-// # define __cccl_lib_smart_ptr_for_overwrite              202002L
-// # define __cccl_lib_source_location                      201907L
-// # define __cccl_lib_ssize                                201902L
-// # define __cccl_lib_starts_ends_with                     201711L
-// # undef  __cccl_lib_string_view
-// # define __cccl_lib_string_view                          201803L
-// # define __cccl_lib_syncbuf                              201803L
-// # define __cccl_lib_three_way_comparison                 201907L
-#  define __cccl_lib_unwrap_ref 201811L
-#endif // _CCCL_STD_VER >= 2020
+// C++20 library features
 
-#if _CCCL_STD_VER >= 2023
-// # define __cccl_lib_adaptor_iterator_pair_constructor    202106L
-// # define __cccl_lib_allocate_at_least                    202106L
-// # define __cccl_lib_associative_heterogeneous_erasure    202110L
-// # define __cccl_lib_bind_back                            202202L
-// # define __cccl_lib_constexpr_bitset                     202207L
-// # define __cccl_lib_constexpr_charconv                   202207L
-// # define __cccl_lib_constexpr_cmath                      202202L
-// # undef  __cccl_lib_constexpr_memory
-// # define __cccl_lib_constexpr_memory                     202202L
-// # define __cccl_lib_constexpr_typeinfo                   202106L
-// # define __cccl_lib_move_only_function                   202110L
-// # define __cccl_lib_out_ptr                              202106L
-// # define __cccl_lib_ranges_chunk                         202202L
-// # define __cccl_lib_ranges_chunk_by                      202202L
-// # define __cccl_lib_ranges_iota                          202202L
-// # define __cccl_lib_ranges_join_with                     202202L
-// # define __cccl_lib_ranges_slide                         202202L
-// # define __cccl_lib_ranges_starts_ends_with              202106L
-// # define __cccl_lib_ranges_to_container                  202202L
-// # define __cccl_lib_ranges_zip                           202110L
-// # define __cccl_lib_reference_from_temporary             202202L
-// # define __cccl_lib_spanstream                           202106L
-// # define __cccl_lib_stacktrace                           202011L
-// # define __cccl_lib_stdatomic_h                          202011L
-// # define __cccl_lib_string_contains                      202011L
-// # define __cccl_lib_string_resize_and_overwrite          202110L
-#endif // _CCCL_STD_VER >= 2023
+#define __cccl_lib_array_constexpr               201811L
+#define __cccl_lib_assume_aligned                201811L
+#define __cccl_lib_atomic_flag_test              201907L
+#define __cccl_lib_atomic_float                  201711L
+#define __cccl_lib_atomic_lock_free_type_aliases 201907L
+#ifndef _LIBCUDACXX_HAS_NO_THREADS
+#  define __cccl_lib_atomic_ref 201806L
+#endif // !_LIBCUDACXX_HAS_NO_THREADS
+// #define __cccl_lib_atomic_shared_ptr 201711L
+#define __cccl_lib_atomic_value_initialization 201911L
+#define __cccl_lib_atomic_wait                 201907L
+#ifndef _LIBCUDACXX_HAS_NO_THREADS
+#  define __cccl_lib_barrier 201907L
+#endif // !_LIBCUDACXX_HAS_NO_THREADS
+#define __cccl_lib_bind_front           201907L
+#define __cccl_lib_bit_cast             201806L
+#define __cccl_lib_bitops               201907L
+#define __cccl_lib_bounded_array_traits 201902L
+#if _LIBCUDACXX_HAS_CHAR8_T()
+#  define __cccl_lib_char8_t 201907L
+#endif // _LIBCUDACXX_HAS_CHAR8_T()
+// #define __cccl_lib_chrono 201907L
+#define __cccl_lib_concepts 202002L
+// #define __cccl_lib_constexpr_algorithms 201806L
+#ifdef _CCCL_BUILTIN_IS_CONSTANT_EVALUATED
+#  define __cccl_lib_constexpr_complex 201711L
+#endif // _CCCL_BUILTIN_IS_CONSTANT_EVALUATED
+// #define __cccl_lib_constexpr_dynamic_alloc 201907L
+#define __cccl_lib_constexpr_functional 201907L
+// #define __cccl_lib_constexpr_iterator 201811L
+// #define __cccl_lib_constexpr_memory 201811L
+// #define __cccl_lib_constexpr_numeric 201911L
+// #define __cccl_lib_constexpr_string 201907L
+// #define __cccl_lib_constexpr_string_view 201811L
+// #define __cccl_lib_constexpr_tuple 201811L
+// #define __cccl_lib_constexpr_utility 201811L
+// #define __cccl_lib_constexpr_vector 201907L
+// #define __cccl_lib_coroutine 201902L
+#if _CCCL_STD_VER >= 2020 && defined(__cpp_impl_destroying_delete) && __cpp_impl_destroying_delete >= 201806L \
+  && defined(__cpp_lib_destroying_delete)
+#  define __cccl_lib_destroying_delete 201806L
+#endif // ^^^ has destroying_delete ^^
+#define __cccl_lib_endian 201907L
+// #define __cccl_lib_erase_if 202002L
+// #define __cccl_lib_execution 201902L
+// #define __cccl_lib_format 201907L
+// #define 201811L
+#define __cccl_lib_int_pow2                     202002L
+#define __cccl_lib_integer_comparison_functions 202002L
+// #define __cccl_lib_interpolate 201902L
+#ifdef _CCCL_BUILTIN_IS_CONSTANT_EVALUATED
+#  define __cccl_lib_is_constant_evaluated 201811L
+#endif // _CCCL_BUILTIN_IS_CONSTANT_EVALUATED
+// #define __cccl_lib_is_layout_compatible 201907L
+#define __cccl_lib_is_nothrow_convertible 201806L
+// #define __cccl_lib_is_pointer_interconvertible 201907L
+// #define __cccl_lib_jthread 201911L
+#ifndef _LIBCUDACXX_HAS_NO_THREADS
+#  define __cccl_lib_latch 201907L
+#endif // !_LIBCUDACXX_HAS_NO_THREADS
+// #define __cccl_lib_list_remove_return_type 201806L
+#define __cccl_lib_math_constants 201907L
+// #define __cccl_lib_polymorphic_allocator 201902L
+// #define __cccl_lib_ranges 201911L
+#define __cccl_lib_remove_cvref 201711L
+#ifndef _LIBCUDACXX_HAS_NO_THREADS
+#  define __cccl_lib_semaphore 201907L
+#endif // !_LIBCUDACXX_HAS_NO_THREADS
+// #define __cccl_lib_shared_ptr_arrays 201707L
+#define __cccl_lib_shift 201806L
+// #define __cccl_lib_smart_ptr_for_overwrite 202002L
+#define __cccl_lib_source_location 201907L
+// #define __cccl_lib_span 202002L // newer version is always available
+#define __cccl_lib_ssize 201902L
+// #define __cccl_lib_starts_ends_with 201711L
+// #define __cccl_lib_string_view 201803L
+// #define __cccl_lib_syncbuf 201803L
+// #define __cccl_lib_three_way_comparison 201907L
+#define __cccl_lib_to_address    201711L
+#define __cccl_lib_to_array      201907L
+#define __cccl_lib_type_identity 201806L
+#define __cccl_lib_unwrap_ref    201811L
+
+// C++23 library features
+
+// #define __cccl_lib_adaptor_iterator_pair_constructor 202106L
+// #define __cccl_lib_algorithm_iterator_requirements 202207L
+// #define __cccl_lib_allocate_at_least 202302L
+// #define __cccl_lib_associative_heterogeneous_erasure 202110L
+// #define __cccl_lib_barrier 202302L
+// #define __cccl_lib_bind_back 202202L
+#define __cccl_lib_byteswap 202110L
+// #define __cccl_lib_common_reference 202302L
+// #define __cccl_lib_common_reference_wrapper 202302L
+// #define __cccl_lib_concepts 202207L
+// #define __cccl_lib_constexpr_bitset 202207L
+// #define __cccl_lib_constexpr_charconv 202207L
+// #define __cccl_lib_constexpr_cmath 202202L
+// #define __cccl_lib_constexpr_memory 202202L
+// #define __cccl_lib_constexpr_typeinfo 202106L
+// #define __cccl_lib_containers_ranges 202202L
+// #define __cccl_lib_expected 202202L // newer version is always available
+#define __cccl_lib_expected 202211L
+// #define __cccl_lib_flat_map 202207L
+// #define __cccl_lib_flat_set 202207L
+// #define __cccl_lib_format 202207L
+// #define __cccl_lib_format_ranges 202207L
+// #define __cccl_lib_formatters 202302L
+#define __cccl_lib_forward_like 202207L
+// #define __cccl_lib_generator 202207L
+#define __cccl_lib_invoke_r 202106L
+// #define __cccl_lib_ios_noreplace 202207L
+// #define __cccl_lib_is_implicit_lifetime 202302L
+#define __cccl_lib_is_scoped_enum 202011L
+#define __cccl_lib_mdspan         202207L
+// #define __cccl_lib_modules 202207L
+// #define __cccl_lib_move_iterator_concept 202207L
+// #define __cccl_lib_move_only_function 202110L
+#define __cccl_lib_optional 202110L
+// #define __cccl_lib_out_ptr 202106L
+// #define __cccl_lib_print 202207L
+// #define __cccl_lib_ranges 202202L
+// #define __cccl_lib_ranges 202207L
+// #define __cccl_lib_ranges 202211L
+// #define __cccl_lib_ranges 202302L
+// #define __cccl_lib_ranges_as_const 202207L
+// #define __cccl_lib_ranges_as_rvalue 202207L
+// #define __cccl_lib_ranges_cartesian_product 202207L
+// #define __cccl_lib_ranges_chunk 202202L
+// #define __cccl_lib_ranges_chunk_by 202202L
+// #define __cccl_lib_ranges_contains 202207L
+// #define __cccl_lib_ranges_enumerate 202302L
+// #define __cccl_lib_ranges_find_last 202207L
+// #define __cccl_lib_ranges_fold 202207L
+// #define __cccl_lib_ranges_iota 202202L
+// #define __cccl_lib_ranges_join_with 202202L
+// #define __cccl_lib_ranges_repeat 202207L
+// #define __cccl_lib_ranges_slide 202202L
+// #define __cccl_lib_ranges_starts_ends_with 202106L
+// #define __cccl_lib_ranges_stride 202207L
+// #define __cccl_lib_ranges_to_container 202202L
+// #define __cccl_lib_ranges_zip 202110L
+#if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY) \
+  && defined(_CCCL_BUILTIN_REFERENCE_CONVERTS_FROM_TEMPORARY)
+#  define __cccl_lib_reference_from_temporary 202202L
+#endif // ^^^ has reference_from_temporary ^^^
+// #define __cccl_lib_shift 202202L
+// #define __cccl_lib_spanstream 202106L
+// #define __cccl_lib_stacktrace 202011L
+// #define __cccl_lib_start_lifetime_as 202207L
+// #define __cccl_lib_stdatomic_h 202011L
+// #define __cccl_lib_string_contains 202011L
+// #define __cccl_lib_string_resize_and_overwrite 202110L
+#define __cccl_lib_to_underlying 202102L
+// #define __cccl_lib_tuple_like 202207L
+#define __cccl_lib_unreachable 202202L
+// #define __cccl_lib_variant 202102L
+// #define __cccl_lib_format 202106L
+// #define __cccl_lib_format 202110L
+// #define __cccl_lib_optional 202106L
+// #define __cccl_lib_ranges 202106L
+// #define __cccl_lib_ranges 202110L
+// #define __cccl_lib_variant 202106L
+
+// C++26 library features
+
+// #define __cccl_lib_algorithm_default_value_type 202403L
+#define __cccl_lib_aligned_accessor 202411L
+// #define __cccl_lib_associative_heterogeneous_insertion 202306L
+// #define __cccl_lib_atomic_min_max 202403L
+// #define __cccl_lib_atomic_ref 202411L
+// #define __cccl_lib_bind_back 202306L
+// #define __cccl_lib_bind_front 202306L
+// #define __cccl_lib_bitset 202306L
+// #define __cccl_lib_chrono 202306L
+// #define __cccl_lib_constexpr_algorithms 202306L
+// #define __cccl_lib_constexpr_atomic 202411L
+// #define __cccl_lib_constexpr_cmath 202306L
+// #define __cccl_lib_constexpr_complex 202306L
+// #define __cccl_lib_constexpr_containers 202502L
+// #define __cccl_lib_constexpr_exceptions 202411L
+// #define __cccl_lib_constexpr_exceptions 202502L
+// #define __cccl_lib_constexpr_inplace_vector 202502L
+// #define __cccl_lib_constexpr_new 202406L
+// #define __cccl_lib_constrained_equality 202403L
+// #define __cccl_lib_constrained_equality 202411L
+// #define __cccl_lib_contracts 202502L
+// #define __cccl_lib_copyable_function 202306L
+// #define __cccl_lib_debugging 202311L
+// #define __cccl_lib_debugging 202403L
+// #define __cccl_lib_format 202304L
+// #define __cccl_lib_format 202305L
+// #define __cccl_lib_format 202306L
+// #define __cccl_lib_format 202311L
+// #define __cccl_lib_format_path 202403L
+// #define __cccl_lib_format_uchar 202311L
+// #define __cccl_lib_freestanding_algorithm 202311L
+// #define __cccl_lib_freestanding_array 202311L
+// #define __cccl_lib_freestanding_char_traits 202306L
+// #define __cccl_lib_freestanding_charconv 202306L
+// #define __cccl_lib_freestanding_cstdlib 202306L
+// #define __cccl_lib_freestanding_cstring 202306L
+// #define __cccl_lib_freestanding_cstring 202311L
+// #define __cccl_lib_freestanding_cwchar 202306L
+// #define __cccl_lib_freestanding_errc 202306L
+// #define __cccl_lib_freestanding_expected 202311L
+// #define __cccl_lib_freestanding_feature_test_macros 202306L
+// #define __cccl_lib_freestanding_functional 202306L
+// #define __cccl_lib_freestanding_iterator 202306L
+// #define __cccl_lib_freestanding_mdspan 202311L
+// #define __cccl_lib_freestanding_memory 202306L
+// #define __cccl_lib_freestanding_numeric 202311L
+// #define __cccl_lib_freestanding_operator_new 202306L
+// #define __cccl_lib_freestanding_optional 202311L
+// #define __cccl_lib_freestanding_ranges 202306L
+// #define __cccl_lib_freestanding_ratio 202306L
+// #define __cccl_lib_freestanding_string_view 202311L
+// #define __cccl_lib_freestanding_tuple 202306L
+// #define __cccl_lib_freestanding_utility 202306L
+// #define __cccl_lib_freestanding_variant 202311L
+// #define __cccl_lib_fstream_native_handle 202306L
+// #define __cccl_lib_function_ref 202306L
+// #define __cccl_lib_hive 202502L
+// #define __cccl_lib_hazard_pointer 202306L
+// #define __cccl_lib_indirect 202502L
+#define __cccl_lib_inplace_vector          202406L
+#define __cccl_lib_is_sufficiently_aligned 202411L
+// #define __cccl_lib_is_virtual_base_of 202406L
+// #define __cccl_lib_is_within_lifetime 202306L
+// #define __cccl_lib_linalg 202311L
+// #define __cccl_lib_mdspan 202406L
+// #define __cccl_lib_not_fn 202306L
+// #define __cccl_lib_optional_range_support 202406L
+// #define __cccl_lib_out_ptr 202311L
+// #define __cccl_lib_polymorphic 202502L
+// #define __cccl_lib_print 202403L
+// #define __cccl_lib_philox_engine 202406L
+// #define __cccl_lib_ranges_as_const 202311L
+// #define __cccl_lib_ranges_cache_latest 202411L
+// #define __cccl_lib_ranges_concat 202403L
+// #define __cccl_lib_ranges_generate_random 202403L
+// #define __cccl_lib_ranges_reserve_hint 202502L
+// #define __cccl_lib_ranges_to_input 202502L
+// #define __cccl_lib_ratio 202306L
+// #define __cccl_lib_raw_memory_algorithms 202411L
+// #define __cccl_lib_rcu 202306L
+// #define __cccl_lib_reference_wrapper 202403L
+// #define __cccl_lib_saturation_arithmetic 202311L
+// #define __cccl_lib_senders 202406L
+// #define __cccl_lib_simd 202411L
+// #define __cccl_lib_smart_ptr_owner_equality 202306L
+#define __cccl_lib_span                  202311L
+#define __cccl_lib_span_initializer_list 202311L
+// #define __cccl_lib_sstream_from_string_view 202306L
+// #define __cccl_lib_string_view 202403L
+// #define __cccl_lib_submdspan 202306L // newer version is always available
+#define __cccl_lib_submdspan 202403L
+// #define __cccl_lib_text_encoding 202306L
+// #define __cccl_lib_to_chars 202306L
+// #define __cccl_lib_to_string 202306L
+// #define __cccl_lib_trivially_relocatable 202502L
+// #define __cccl_lib_tuple_like 202311L
+// #define __cccl_lib_variant 202306L
+// #define __cccl_lib_ranges 202406L
+// #define __cccl_lib_print 202403L
+
+// C++ library extensions
+
+#ifdef CCCL_ENABLE_OPTIONAL_REF
+#  define __cpp_lib_optional_ref 202602L
+#endif // CCCL_ENABLE_OPTIONAL_REF
 
 #endif // _CUDA_STD_VERSION

--- a/libcudacxx/include/cuda/std/version
+++ b/libcudacxx/include/cuda/std/version
@@ -31,21 +31,17 @@
 
 // C++14 library features
 
-#define __cccl_lib_chrono_udls       201304L
-#define __cccl_lib_complex_udls      201309L
-#define __cccl_lib_exchange_function 201304L
-// #define __cccl_lib_generic_associative_lookup 201304L
-#define __cccl_lib_integer_sequence           201304L
-#define __cccl_lib_integral_constant_callable 201304L
-#define __cccl_lib_is_final                   201402L
-#define __cccl_lib_make_reverse_iterator      201402L
-// #define __cccl_lib_make_unique 201304L
-#define __cccl_lib_null_iterators 201304L
-// #define __cccl_lib_quoted_string_io 201304L
-#define __cccl_lib_result_of_sfinae            201210L
-#define __cccl_lib_robust_nonmodifying_seq_ops 201304L
-#define __cccl_lib_shared_timed_mutex          201402L
-// #define __cccl_lib_string_udls 201304L
+#define __cccl_lib_chrono_udls                  201304L
+#define __cccl_lib_complex_udls                 201309L
+#define __cccl_lib_exchange_function            201304L
+#define __cccl_lib_integer_sequence             201304L
+#define __cccl_lib_integral_constant_callable   201304L
+#define __cccl_lib_is_final                     201402L
+#define __cccl_lib_make_reverse_iterator        201402L
+#define __cccl_lib_null_iterators               201304L
+#define __cccl_lib_result_of_sfinae             201210L
+#define __cccl_lib_robust_nonmodifying_seq_ops  201304L
+#define __cccl_lib_shared_timed_mutex           201402L
 #define __cccl_lib_transformation_trait_aliases 201304L
 #define __cccl_lib_transparent_operators        201210L
 #define __cccl_lib_tuple_element_t              201402L
@@ -55,10 +51,13 @@
 #  define __cccl_lib_addressof_constexpr 201603L
 #endif // _CCCL_BUILTIN_ADDRESSOF
 
+// #define __cccl_lib_generic_associative_lookup 201304L
+// #define __cccl_lib_make_unique 201304L
+// #define __cccl_lib_quoted_string_io 201304L
+// #define __cccl_lib_string_udls 201304L
+
 // C++17 library features
 
-// #define __cccl_lib_allocator_traits_is_always_equal 201411L
-// #define __cccl_lib_any 201606L
 #define __cccl_lib_apply 201603L
 // #define __cccl_lib_array_constexpr 201603L // newer version is always available
 #define __cccl_lib_as_const 201510L
@@ -66,22 +65,15 @@
 #  define __cccl_lib_atomic_is_always_lock_free 201603L
 #endif // _LIBCUDACXX_HAS_NO_THREADS
 #define __cccl_lib_bool_constant 201505L
-// #define __cccl_lib_boyer_moore_searcher 201603L
-#define __cccl_lib_byte 201603L
+#define __cccl_lib_byte          201603L
 // #define __cccl_lib_chrono 201510L // newer version is always available
-#define __cccl_lib_chrono 201611L
-#define __cccl_lib_clamp  201603L
-// #define __cccl_lib_constexpr_string 201611L
-// #define __cccl_lib_enable_shared_from_this 201603L
-// #define __cccl_lib_execution 201603L
-// #define __cccl_lib_filesystem 201703L
+#define __cccl_lib_chrono  201611L
+#define __cccl_lib_clamp   201603L
 #define __cccl_lib_gcd_lcm 201606L
-// #define __cccl_lib_hardware_interference_size 201703L
 #ifdef _CCCL_BUILTIN_HAS_UNIQUE_OBJECT_REPRESENTATIONS
 #  define __cccl_lib_has_unique_object_representations 201606L
 #endif // _CCCL_BUILTIN_HAS_UNIQUE_OBJECT_REPRESENTATIONS
-#define __cccl_lib_hypot 201603L
-// #define __cccl_lib_incomplete_container_elements 201505L
+#define __cccl_lib_hypot           201603L
 #define __cccl_lib_invoke          201411L
 #define __cccl_lib_is_aggregate    201703L
 #define __cccl_lib_is_invocable    201703L
@@ -89,13 +81,26 @@
 #define __cccl_lib_launder         201606L
 #define __cccl_lib_logical_traits  201510L
 #define __cccl_lib_make_from_tuple 201606L
+#define __cccl_lib_not_fn          201603L
+// #define __cccl_lib_optional 201606L // newer version is always available
+#define __cccl_lib_type_trait_variable_templates 201510L
+#define __cccl_lib_variant                       201606L
+#define __cccl_lib_void_t                        201411L
+
+// #define __cccl_lib_allocator_traits_is_always_equal 201411L
+// #define __cccl_lib_any 201606L
+// #define __cccl_lib_boyer_moore_searcher 201603L
+// #define __cccl_lib_constexpr_string 201611L
+// #define __cccl_lib_enable_shared_from_this 201603L
+// #define __cccl_lib_execution 201603L
+// #define __cccl_lib_filesystem 201703L
+// #define __cccl_lib_hardware_interference_size 201703L
+// #define __cccl_lib_incomplete_container_elements 201505L
 // #define __cccl_lib_map_try_emplace 201411L
 // #define __cccl_lib_math_special_functions 201603L
 // #define __cccl_lib_memory_resource 201603L
 // #define __cccl_lib_node_extract 201606L
 // #define __cccl_lib_nonmember_container_access 201411L
-#define __cccl_lib_not_fn 201603L
-// #define __cccl_lib_optional 201606L // newer version is always available
 // #define __cccl_lib_parallel_algorithm 201603L
 // #define __cccl_lib_raw_memory_algorithms 201606L
 // #define __cccl_lib_sample 201603L
@@ -106,13 +111,10 @@
 // #define __cccl_lib_string_view 201606L
 // #define __cccl_lib_to_chars 201611L
 // #define __cccl_lib_transparent_operators 201510L
-#define __cccl_lib_type_trait_variable_templates 201510L
 // #define __cccl_lib_uncaught_exceptions 201411L
 // #define __cccl_lib_unordered_map_try_emplace 201411L
-#define __cccl_lib_variant 201606L
-#define __cccl_lib_void_t  201411L
 
-// C++20 library features
+// C++20 library features backported to C++17
 
 #define __cccl_lib_array_constexpr               201811L
 #define __cccl_lib_assume_aligned                201811L
@@ -122,7 +124,6 @@
 #ifndef _LIBCUDACXX_HAS_NO_THREADS
 #  define __cccl_lib_atomic_ref 201806L
 #endif // !_LIBCUDACXX_HAS_NO_THREADS
-// #define __cccl_lib_atomic_shared_ptr 201711L
 #define __cccl_lib_atomic_value_initialization 201911L
 #define __cccl_lib_atomic_wait                 201907L
 #ifndef _LIBCUDACXX_HAS_NO_THREADS
@@ -135,14 +136,47 @@
 #if _LIBCUDACXX_HAS_CHAR8_T()
 #  define __cccl_lib_char8_t 201907L
 #endif // _LIBCUDACXX_HAS_CHAR8_T()
-// #define __cccl_lib_chrono 201907L
 #define __cccl_lib_concepts 202002L
-// #define __cccl_lib_constexpr_algorithms 201806L
 #ifdef _CCCL_BUILTIN_IS_CONSTANT_EVALUATED
 #  define __cccl_lib_constexpr_complex 201711L
 #endif // _CCCL_BUILTIN_IS_CONSTANT_EVALUATED
+#define __cccl_lib_constexpr_functional         201907L
+#define __cccl_lib_endian                       201907L
+#define __cccl_lib_int_pow2                     202002L
+#define __cccl_lib_integer_comparison_functions 202002L
+#ifdef _CCCL_BUILTIN_IS_CONSTANT_EVALUATED
+#  define __cccl_lib_is_constant_evaluated 201811L
+#endif // _CCCL_BUILTIN_IS_CONSTANT_EVALUATED
+#define __cccl_lib_is_nothrow_convertible 201806L
+#ifndef _LIBCUDACXX_HAS_NO_THREADS
+#  define __cccl_lib_latch 201907L
+#endif // !_LIBCUDACXX_HAS_NO_THREADS
+#define __cccl_lib_math_constants 201907L
+#define __cccl_lib_remove_cvref   201711L
+#ifndef _LIBCUDACXX_HAS_NO_THREADS
+#  define __cccl_lib_semaphore 201907L
+#endif // !_LIBCUDACXX_HAS_NO_THREADS
+#define __cccl_lib_shift           201806L
+#define __cccl_lib_source_location 201907L
+// #define __cccl_lib_span 202002L // newer version is always available
+#define __cccl_lib_ssize         201902L
+#define __cccl_lib_to_address    201711L
+#define __cccl_lib_to_array      201907L
+#define __cccl_lib_type_identity 201806L
+#define __cccl_lib_unwrap_ref    201811L
+
+// C++20 library features
+
+#if _CCCL_STD_VER >= 2020
+#  if defined(__cpp_impl_destroying_delete) && __cpp_impl_destroying_delete >= 201806L \
+    && defined(__cpp_lib_destroying_delete)
+#    define __cccl_lib_destroying_delete 201806L
+#  endif // ^^^ has destroying_delete ^^
+
+// #define __cccl_lib_atomic_shared_ptr 201711L
+// #define __cccl_lib_chrono 201907L
+// #define __cccl_lib_constexpr_algorithms 201806L
 // #define __cccl_lib_constexpr_dynamic_alloc 201907L
-#define __cccl_lib_constexpr_functional 201907L
 // #define __cccl_lib_constexpr_iterator 201811L
 // #define __cccl_lib_constexpr_memory 201811L
 // #define __cccl_lib_constexpr_numeric 201911L
@@ -152,60 +186,52 @@
 // #define __cccl_lib_constexpr_utility 201811L
 // #define __cccl_lib_constexpr_vector 201907L
 // #define __cccl_lib_coroutine 201902L
-#if _CCCL_STD_VER >= 2020 && defined(__cpp_impl_destroying_delete) && __cpp_impl_destroying_delete >= 201806L \
-  && defined(__cpp_lib_destroying_delete)
-#  define __cccl_lib_destroying_delete 201806L
-#endif // ^^^ has destroying_delete ^^
-#define __cccl_lib_endian 201907L
 // #define __cccl_lib_erase_if 202002L
 // #define __cccl_lib_execution 201902L
 // #define __cccl_lib_format 201907L
-// #define 201811L
-#define __cccl_lib_int_pow2                     202002L
-#define __cccl_lib_integer_comparison_functions 202002L
+// #define __cccl_lib_generic_unordered_lookup 201811L
 // #define __cccl_lib_interpolate 201902L
-#ifdef _CCCL_BUILTIN_IS_CONSTANT_EVALUATED
-#  define __cccl_lib_is_constant_evaluated 201811L
-#endif // _CCCL_BUILTIN_IS_CONSTANT_EVALUATED
 // #define __cccl_lib_is_layout_compatible 201907L
-#define __cccl_lib_is_nothrow_convertible 201806L
 // #define __cccl_lib_is_pointer_interconvertible 201907L
 // #define __cccl_lib_jthread 201911L
-#ifndef _LIBCUDACXX_HAS_NO_THREADS
-#  define __cccl_lib_latch 201907L
-#endif // !_LIBCUDACXX_HAS_NO_THREADS
 // #define __cccl_lib_list_remove_return_type 201806L
-#define __cccl_lib_math_constants 201907L
 // #define __cccl_lib_polymorphic_allocator 201902L
 // #define __cccl_lib_ranges 201911L
-#define __cccl_lib_remove_cvref 201711L
-#ifndef _LIBCUDACXX_HAS_NO_THREADS
-#  define __cccl_lib_semaphore 201907L
-#endif // !_LIBCUDACXX_HAS_NO_THREADS
 // #define __cccl_lib_shared_ptr_arrays 201707L
-#define __cccl_lib_shift 201806L
 // #define __cccl_lib_smart_ptr_for_overwrite 202002L
-#define __cccl_lib_source_location 201907L
-// #define __cccl_lib_span 202002L // newer version is always available
-#define __cccl_lib_ssize 201902L
 // #define __cccl_lib_starts_ends_with 201711L
 // #define __cccl_lib_string_view 201803L
 // #define __cccl_lib_syncbuf 201803L
 // #define __cccl_lib_three_way_comparison 201907L
-#define __cccl_lib_to_address    201711L
-#define __cccl_lib_to_array      201907L
-#define __cccl_lib_type_identity 201806L
-#define __cccl_lib_unwrap_ref    201811L
+#endif // _CCCL_STD_VER >= 2020
+
+// C++23 library features backported to C++17
+
+#define __cccl_lib_byteswap 202110L
+// #define __cccl_lib_expected 202202L // newer version is always available
+#define __cccl_lib_expected       202211L
+#define __cccl_lib_forward_like   202207L
+#define __cccl_lib_invoke_r       202106L
+#define __cccl_lib_is_scoped_enum 202011L
+#define __cccl_lib_mdspan         202207L
+// #define __cccl_lib_optional 202106L // newer version is always available
+#define __cccl_lib_optional 202110L
+#if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY) \
+  && defined(_CCCL_BUILTIN_REFERENCE_CONVERTS_FROM_TEMPORARY)
+#  define __cccl_lib_reference_from_temporary 202202L
+#endif // ^^^ has reference_from_temporary ^^^
+#define __cccl_lib_to_underlying 202102L
+#define __cccl_lib_unreachable   202202L
 
 // C++23 library features
 
+#if _CCCL_STD_VER >= 2023
 // #define __cccl_lib_adaptor_iterator_pair_constructor 202106L
 // #define __cccl_lib_algorithm_iterator_requirements 202207L
 // #define __cccl_lib_allocate_at_least 202302L
 // #define __cccl_lib_associative_heterogeneous_erasure 202110L
 // #define __cccl_lib_barrier 202302L
 // #define __cccl_lib_bind_back 202202L
-#define __cccl_lib_byteswap 202110L
 // #define __cccl_lib_common_reference 202302L
 // #define __cccl_lib_common_reference_wrapper 202302L
 // #define __cccl_lib_concepts 202207L
@@ -215,24 +241,17 @@
 // #define __cccl_lib_constexpr_memory 202202L
 // #define __cccl_lib_constexpr_typeinfo 202106L
 // #define __cccl_lib_containers_ranges 202202L
-// #define __cccl_lib_expected 202202L // newer version is always available
-#define __cccl_lib_expected 202211L
 // #define __cccl_lib_flat_map 202207L
 // #define __cccl_lib_flat_set 202207L
 // #define __cccl_lib_format 202207L
 // #define __cccl_lib_format_ranges 202207L
 // #define __cccl_lib_formatters 202302L
-#define __cccl_lib_forward_like 202207L
 // #define __cccl_lib_generator 202207L
-#define __cccl_lib_invoke_r 202106L
 // #define __cccl_lib_ios_noreplace 202207L
 // #define __cccl_lib_is_implicit_lifetime 202302L
-#define __cccl_lib_is_scoped_enum 202011L
-#define __cccl_lib_mdspan         202207L
 // #define __cccl_lib_modules 202207L
 // #define __cccl_lib_move_iterator_concept 202207L
 // #define __cccl_lib_move_only_function 202110L
-#define __cccl_lib_optional 202110L
 // #define __cccl_lib_out_ptr 202106L
 // #define __cccl_lib_print 202207L
 // #define __cccl_lib_ranges 202202L
@@ -256,10 +275,6 @@
 // #define __cccl_lib_ranges_stride 202207L
 // #define __cccl_lib_ranges_to_container 202202L
 // #define __cccl_lib_ranges_zip 202110L
-#if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY) \
-  && defined(_CCCL_BUILTIN_REFERENCE_CONVERTS_FROM_TEMPORARY)
-#  define __cccl_lib_reference_from_temporary 202202L
-#endif // ^^^ has reference_from_temporary ^^^
 // #define __cccl_lib_shift 202202L
 // #define __cccl_lib_spanstream 202106L
 // #define __cccl_lib_stacktrace 202011L
@@ -267,21 +282,29 @@
 // #define __cccl_lib_stdatomic_h 202011L
 // #define __cccl_lib_string_contains 202011L
 // #define __cccl_lib_string_resize_and_overwrite 202110L
-#define __cccl_lib_to_underlying 202102L
 // #define __cccl_lib_tuple_like 202207L
-#define __cccl_lib_unreachable 202202L
 // #define __cccl_lib_variant 202102L
 // #define __cccl_lib_format 202106L
 // #define __cccl_lib_format 202110L
-// #define __cccl_lib_optional 202106L
 // #define __cccl_lib_ranges 202106L
 // #define __cccl_lib_ranges 202110L
 // #define __cccl_lib_variant 202106L
+#endif // _CCCL_STD_VER >= 2023
+
+// C++26 library features backported to C++17
+
+#define __cccl_lib_aligned_accessor        202411L
+#define __cccl_lib_inplace_vector          202406L
+#define __cccl_lib_is_sufficiently_aligned 202411L
+#define __cccl_lib_span                    202311L
+#define __cccl_lib_span_initializer_list   202311L
+// #define __cccl_lib_submdspan 202306L // newer version is always available
+#define __cccl_lib_submdspan 202403L
 
 // C++26 library features
 
+#if _CCCL_STD_VER >= 2026
 // #define __cccl_lib_algorithm_default_value_type 202403L
-#define __cccl_lib_aligned_accessor 202411L
 // #define __cccl_lib_associative_heterogeneous_insertion 202306L
 // #define __cccl_lib_atomic_min_max 202403L
 // #define __cccl_lib_atomic_ref 202411L
@@ -339,8 +362,6 @@
 // #define __cccl_lib_hive 202502L
 // #define __cccl_lib_hazard_pointer 202306L
 // #define __cccl_lib_indirect 202502L
-#define __cccl_lib_inplace_vector          202406L
-#define __cccl_lib_is_sufficiently_aligned 202411L
 // #define __cccl_lib_is_virtual_base_of 202406L
 // #define __cccl_lib_is_within_lifetime 202306L
 // #define __cccl_lib_linalg 202311L
@@ -365,12 +386,8 @@
 // #define __cccl_lib_senders 202406L
 // #define __cccl_lib_simd 202411L
 // #define __cccl_lib_smart_ptr_owner_equality 202306L
-#define __cccl_lib_span                  202311L
-#define __cccl_lib_span_initializer_list 202311L
 // #define __cccl_lib_sstream_from_string_view 202306L
 // #define __cccl_lib_string_view 202403L
-// #define __cccl_lib_submdspan 202306L // newer version is always available
-#define __cccl_lib_submdspan 202403L
 // #define __cccl_lib_text_encoding 202306L
 // #define __cccl_lib_to_chars 202306L
 // #define __cccl_lib_to_string 202306L
@@ -379,6 +396,7 @@
 // #define __cccl_lib_variant 202306L
 // #define __cccl_lib_ranges 202406L
 // #define __cccl_lib_print 202403L
+#endif // _CCCL_STD_VER >= 2026
 
 // C++ library extensions
 


### PR DESCRIPTION
This PR implements cleanup of `<cuda/std/version>` header and adds missing feature test macros.