### PR TITLE
Add support for large num_segments to `DeviceSegmentedReduce` with fixed segment size

### DIFF
--- a/cub/cub/device/device_segmented_reduce.cuh
+++ b/cub/cub/device/device_segmented_reduce.cuh
@@ -344,7 +344,7 @@ public:
     size_t& temp_storage_bytes,
     InputIteratorT d_in,
     OutputIteratorT d_out,
-    int num_segments,
+    ::cuda::std::int64_t num_segments,
     int segment_size,
     ReductionOpT reduction_op,
     T initial_value,

--- a/cub/cub/device/dispatch/dispatch_reduce.cuh
+++ b/cub/cub/device/dispatch/dispatch_reduce.cuh
@@ -1182,7 +1182,7 @@ struct DispatchFixedSizeSegmentedReduce
               detail::advance_iterators_if_supported(d_in, current_seg_offset * segment_size),
               detail::advance_iterators_if_supported(d_out, current_seg_offset),
               segment_size,
-              num_current_segments,
+              static_cast<::cuda::std::int32_t>(num_current_segments),
               reduction_op,
               init);
 

--- a/cub/cub/device/dispatch/dispatch_reduce.cuh
+++ b/cub/cub/device/dispatch/dispatch_reduce.cuh
@@ -1053,7 +1053,7 @@ struct DispatchFixedSizeSegmentedReduce
   OutputIteratorT d_out;
 
   /// The number of segments that comprise the segmented reduction data
-  int num_segments;
+  ::cuda::std::int64_t num_segments;
 
   /// The fixed segment size for each segment
   OffsetT segment_size;
@@ -1083,7 +1083,7 @@ struct DispatchFixedSizeSegmentedReduce
     size_t& temp_storage_bytes,
     InputIteratorT d_in,
     OutputIteratorT d_out,
-    int num_segments,
+    ::cuda::std::int64_t num_segments,
     OffsetT segment_size,
     ReductionOpT reduction_op,
     InitT init,
@@ -1140,27 +1140,70 @@ struct DispatchFixedSizeSegmentedReduce
       return cudaSuccess;
     }
 
-    int blocks = num_segments; // assume large segment size problem
-    if (segment_size <= small_items_per_tile)
-    {
-      blocks = ::cuda::ceil_div(num_segments, ActivePolicyT::SmallReducePolicy::SEGMENTS_PER_BLOCK);
-    }
-    else if (segment_size <= medium_items_per_tile)
-    {
-      blocks = ::cuda::ceil_div(num_segments, ActivePolicyT::MediumReducePolicy::SEGMENTS_PER_BLOCK);
-    }
+    // assume large segment size problem
+    ::cuda::std::int64_t num_blocks = num_segments;
+    int num_segments_per_block      = 1;
 
-    launcher_factory(blocks, ActivePolicyT::ReducePolicy::BLOCK_THREADS, 0, stream)
-      .doit(fixed_size_segmented_reduce_kernel, d_in, d_out, segment_size, num_segments, reduction_op, init);
-
-    cudaError error = CubDebug(cudaPeekAtLastError());
-    if (cudaSuccess != error)
+    if (segment_size <= small_items_per_tile) // small segment size problem
     {
-      return error;
+      num_segments_per_block = ActivePolicyT::SmallReducePolicy::SEGMENTS_PER_BLOCK;
+      num_blocks             = ::cuda::ceil_div(num_segments, num_segments_per_block);
+    }
+    else if (segment_size <= medium_items_per_tile) // medium segment size problem
+    {
+      num_segments_per_block = ActivePolicyT::MediumReducePolicy::SEGMENTS_PER_BLOCK;
+      num_blocks             = ::cuda::ceil_div(num_segments, num_segments_per_block);
     }
 
-    // Sync the stream if specified to flush runtime errors
-    error = CubDebug(detail::DebugSyncStream(stream));
+    const auto num_blocks_per_invocation =
+      static_cast<::cuda::std::int64_t>(::cuda::std::numeric_limits<::cuda::std::int32_t>::max());
+
+    const ::cuda::std::int64_t num_invocations = ::cuda::ceil_div(num_blocks, num_blocks_per_invocation);
+
+    // If we need multiple passes over the segments but the iterators do not support the + operator, we cannot use the
+    // streaming approach and have to fail, returning cudaErrorInvalidValue. This is because c.parallel passes
+    // indirect_arg_t as the iterator type, which does not support the + operator.
+    // TODO (srinivas/elstehle): Remove this check once https://github.com/NVIDIA/cccl/issues/4148 is resolved.
+    if (num_invocations > 1 && !detail::all_iterators_support_plus_operator(::cuda::std::int64_t{}, d_in, d_out))
+    {
+      return cudaErrorInvalidValue;
+    }
+
+    const auto num_segments_per_invocation = num_blocks_per_invocation * num_segments_per_block;
+
+    cudaError error = cudaSuccess;
+    for (::cuda::std::int64_t invocation_index = 0; invocation_index < num_invocations; invocation_index++)
+    {
+      const auto current_seg_offset = invocation_index * num_segments_per_invocation;
+
+      const auto num_current_segments =
+        ::cuda::std::min(num_segments_per_invocation, num_segments - current_seg_offset);
+
+      const auto num_current_blocks = ::cuda::ceil_div(num_current_segments, num_segments_per_block);
+
+      launcher_factory(
+        static_cast<::cuda::std::int32_t>(num_current_blocks), ActivePolicyT::ReducePolicy::BLOCK_THREADS, 0, stream)
+        .doit(fixed_size_segmented_reduce_kernel,
+              detail::advance_iterators_if_supported(d_in, current_seg_offset * segment_size),
+              detail::advance_iterators_if_supported(d_out, current_seg_offset),
+              segment_size,
+              num_current_segments,
+              reduction_op,
+              init);
+
+      error = CubDebug(cudaPeekAtLastError());
+      if (cudaSuccess != error)
+      {
+        break;
+      }
+
+      // Sync the stream if specified to flush runtime errors
+      error = CubDebug(detail::DebugSyncStream(stream));
+      if (cudaSuccess != error)
+      {
+        break;
+      }
+    }
     return error;
   }
 
@@ -1214,7 +1257,7 @@ struct DispatchFixedSizeSegmentedReduce
     size_t& temp_storage_bytes,
     InputIteratorT d_in,
     OutputIteratorT d_out,
-    int num_segments,
+    ::cuda::std::int64_t num_segments,
     OffsetT segment_size,
     ReductionOpT reduction_op,
     InitT init,

--- a/cub/cub/device/dispatch/kernels/segmented_reduce.cuh
+++ b/cub/cub/device/dispatch/kernels/segmented_reduce.cuh
@@ -223,7 +223,7 @@ __launch_bounds__(int(ChainedPolicyT::ActivePolicy::ReducePolicy::BLOCK_THREADS)
   InputIteratorT d_in,
   OutputIteratorT d_out,
   OffsetT segment_size,
-  int num_segments,
+  ::cuda::std::int64_t num_segments,
   ReductionOpT reduction_op,
   InitT init)
 {
@@ -260,9 +260,9 @@ __launch_bounds__(int(ChainedPolicyT::ActivePolicy::ReducePolicy::BLOCK_THREADS)
 
   if (segment_size <= small_items_per_tile)
   {
-    const int sid_within_block  = tid / small_threads_per_warp;
-    const int lane_id           = tid % small_threads_per_warp;
-    const int global_segment_id = bid * segments_per_small_block + sid_within_block;
+    const int sid_within_block   = tid / small_threads_per_warp;
+    const int lane_id            = tid % small_threads_per_warp;
+    const auto global_segment_id = static_cast<::cuda::std::int64_t>(bid) * segments_per_small_block + sid_within_block;
 
     const ::cuda::std::int64_t segment_begin = global_segment_id * segment_size;
 
@@ -294,9 +294,10 @@ __launch_bounds__(int(ChainedPolicyT::ActivePolicy::ReducePolicy::BLOCK_THREADS)
   }
   else if (segment_size <= medium_items_per_tile)
   {
-    const int sid_within_block  = tid / medium_threads_per_warp;
-    const int lane_id           = tid % medium_threads_per_warp;
-    const int global_segment_id = bid * segments_per_medium_block + sid_within_block;
+    const int sid_within_block = tid / medium_threads_per_warp;
+    const int lane_id          = tid % medium_threads_per_warp;
+    const auto global_segment_id =
+      static_cast<::cuda::std::int64_t>(bid) * segments_per_medium_block + sid_within_block;
 
     const ::cuda::std::int64_t segment_begin = global_segment_id * segment_size;
 
@@ -318,7 +319,7 @@ __launch_bounds__(int(ChainedPolicyT::ActivePolicy::ReducePolicy::BLOCK_THREADS)
   }
   else
   {
-    const ::cuda::std::int64_t segment_begin = bid * segment_size;
+    const auto segment_begin = static_cast<::cuda::std::int64_t>(bid) * segment_size;
 
     // Consume input tiles
     AccumT block_aggregate = AgentReduceT(temp_storage.large_storage, d_in + segment_begin, reduction_op)

--- a/cub/cub/device/dispatch/kernels/segmented_reduce.cuh
+++ b/cub/cub/device/dispatch/kernels/segmented_reduce.cuh
@@ -223,7 +223,7 @@ __launch_bounds__(int(ChainedPolicyT::ActivePolicy::ReducePolicy::BLOCK_THREADS)
   InputIteratorT d_in,
   OutputIteratorT d_out,
   OffsetT segment_size,
-  ::cuda::std::int64_t num_segments,
+  int num_segments,
   ReductionOpT reduction_op,
   InitT init)
 {
@@ -255,17 +255,16 @@ __launch_bounds__(int(ChainedPolicyT::ActivePolicy::ReducePolicy::BLOCK_THREADS)
     typename AgentSmallReduceT::TempStorage small_storage[segments_per_small_block];
   } temp_storage;
 
-  const auto bid = static_cast<::cuda::std::int64_t>(blockIdx.x);
-  const int tid  = threadIdx.x;
+  const int bid = blockIdx.x;
+  const int tid = threadIdx.x;
 
   if (segment_size <= small_items_per_tile)
   {
-    const int sid_within_block   = tid / small_threads_per_warp;
-    const int lane_id            = tid % small_threads_per_warp;
-    const auto global_segment_id = bid * segments_per_small_block + sid_within_block;
+    const int sid_within_block  = tid / small_threads_per_warp;
+    const int lane_id           = tid % small_threads_per_warp;
+    const int global_segment_id = bid * segments_per_small_block + sid_within_block;
 
-    const ::cuda::std::int64_t segment_begin = global_segment_id * segment_size;
-
+    const auto segment_begin = static_cast<::cuda::std::int64_t>(global_segment_id) * segment_size;
     // If empty segment, write out the initial value
     if (segment_size == 0)
     {
@@ -294,11 +293,11 @@ __launch_bounds__(int(ChainedPolicyT::ActivePolicy::ReducePolicy::BLOCK_THREADS)
   }
   else if (segment_size <= medium_items_per_tile)
   {
-    const int sid_within_block   = tid / medium_threads_per_warp;
-    const int lane_id            = tid % medium_threads_per_warp;
-    const auto global_segment_id = bid * segments_per_medium_block + sid_within_block;
+    const int sid_within_block  = tid / medium_threads_per_warp;
+    const int lane_id           = tid % medium_threads_per_warp;
+    const int global_segment_id = bid * segments_per_medium_block + sid_within_block;
 
-    const ::cuda::std::int64_t segment_begin = global_segment_id * segment_size;
+    const auto segment_begin = static_cast<::cuda::std::int64_t>(global_segment_id) * segment_size;
 
     if (global_segment_id < num_segments)
     {
@@ -318,7 +317,7 @@ __launch_bounds__(int(ChainedPolicyT::ActivePolicy::ReducePolicy::BLOCK_THREADS)
   }
   else
   {
-    const auto segment_begin = bid * segment_size;
+    const auto segment_begin = static_cast<::cuda::std::int64_t>(bid) * segment_size;
 
     // Consume input tiles
     AccumT block_aggregate = AgentReduceT(temp_storage.large_storage, d_in + segment_begin, reduction_op)

--- a/cub/test/catch2_test_device_segmented_reduce_large_offsets.cu
+++ b/cub/test/catch2_test_device_segmented_reduce_large_offsets.cu
@@ -11,6 +11,8 @@
 #include <thrust/iterator/discard_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
 
+#include <cuda/std/tuple>
+
 #include "catch2_large_problem_helper.cuh"
 #include "catch2_segmented_sort_helper.cuh"
 #include "catch2_test_launch_helper.h"

--- a/cub/test/catch2_test_device_segmented_reduce_large_offsets.cu
+++ b/cub/test/catch2_test_device_segmented_reduce_large_offsets.cu
@@ -244,3 +244,53 @@ C2H_TEST("Device reduce works with a very large number of segments", "[reduce][d
     check_result_helper.check_all_results_correct();
   }
 }
+
+C2H_TEST("Device fixed size segmented reduce works with a very large number of segments", "[reduce][device]")
+{
+  using offset_t        = ::cuda::std::int64_t;
+  using segment_index_t = ::cuda::std::int64_t;
+  using segment_size_t  = int; // fixed size segmented reduce supports only `int` as segment size
+
+  CAPTURE(c2h::type_name<offset_t>());
+
+  const auto num_segments = static_cast<segment_index_t>(::cuda::std::numeric_limits<std::int32_t>::max()) + 1;
+  constexpr segment_size_t segment_size = 257; // smallest large segment size which will use block reduction
+  const ::cuda::std::int64_t num_items  = num_segments * segment_size;
+
+  // // Input data
+  const auto segment_index_it = thrust::make_counting_iterator(segment_index_t{});
+
+  // Segment offsets
+  segment_index_to_offset_op<offset_t, segment_index_t> index_to_offset_op{0, num_segments, segment_size, num_items};
+  auto offsets_it = thrust::make_transform_iterator(segment_index_it, index_to_offset_op);
+
+  CAPTURE(c2h::type_name<offset_t>(), c2h::type_name<segment_index_t>(), num_segments, segment_size, num_items);
+
+  SECTION("segmented reduce")
+  {
+    using sum_t = ::cuda::std::int64_t;
+
+    // Use a custom operator to increase test coverage
+    using op_t = custom_sum_op;
+
+    // Initial value of reduction
+    const auto init_val = sum_t{0};
+
+    // Binary reduction operator
+    const auto reduction_op = op_t{};
+
+    // Prepare helper to check results
+    auto get_sum_from_offset_pair_op = thrust::make_zip_function(get_gaussian_sum_from_offset_op{});
+    auto offset_pair_it              = thrust::make_zip_iterator(thrust::make_tuple(offsets_it, offsets_it + 1));
+    auto expected_result_it          = thrust::make_transform_iterator(offset_pair_it, get_sum_from_offset_pair_op);
+    auto check_result_helper         = detail::large_problem_test_helper(num_segments);
+    auto check_result_it             = check_result_helper.get_flagging_output_iterator(expected_result_it);
+
+    // Run test
+    const auto input_it = thrust::make_counting_iterator(sum_t{});
+    device_segmented_reduce(input_it, check_result_it, num_segments, segment_size, reduction_op, init_val);
+
+    // Verify all results were written as expected
+    check_result_helper.check_all_results_correct();
+  }
+}

--- a/cub/test/catch2_test_device_segmented_reduce_large_offsets.cu
+++ b/cub/test/catch2_test_device_segmented_reduce_large_offsets.cu
@@ -302,9 +302,9 @@ C2H_TEST("Device fixed size segmented reduce works with a very large number of s
     using policy_hub_t = cub::detail::fixed_size_segmented_reduce::policy_hub<sum_t, offset_t, op_t>;
 
     // Get small and medium segment size thresholds from dispatch helper
-    const auto thresholds = dispatch_helper<policy_hub_t>::get_thresholds();
-    const auto small      = ::cuda::std::get<0>(thresholds);
-    const auto medium     = ::cuda::std::get<1>(thresholds);
+    const ::cuda::std::tuple<int, int> thresholds = dispatch_helper<policy_hub_t>::get_thresholds();
+    const auto small                              = ::cuda::std::get<0>(thresholds);
+    const auto medium                             = ::cuda::std::get<1>(thresholds);
 
     // Take one random segment size from each of the segment sizes
     const segment_size_t segment_size =

--- a/cub/test/catch2_test_device_segmented_reduce_large_offsets.cu
+++ b/cub/test/catch2_test_device_segmented_reduce_large_offsets.cu
@@ -251,13 +251,11 @@ C2H_TEST("Device fixed size segmented reduce works with a very large number of s
   using segment_index_t = ::cuda::std::int64_t;
   using segment_size_t  = int; // fixed size segmented reduce supports only `int` as segment size
 
-  CAPTURE(c2h::type_name<offset_t>());
-
   const auto num_segments = static_cast<segment_index_t>(::cuda::std::numeric_limits<std::int32_t>::max()) + 1;
   constexpr segment_size_t segment_size = 257; // smallest large segment size which will use block reduction
   const ::cuda::std::int64_t num_items  = num_segments * segment_size;
 
-  // // Input data
+  // Input data
   const auto segment_index_it = thrust::make_counting_iterator(segment_index_t{});
 
   // Segment offsets

--- a/cub/test/catch2_test_device_segmented_reduce_large_offsets.cu
+++ b/cub/test/catch2_test_device_segmented_reduce_large_offsets.cu
@@ -270,8 +270,7 @@ struct dispatch_helper
     REQUIRE(error == cudaSuccess);
 
     dispatch_helper dispatch{};
-    typename PolicyHub::MaxPolicy max_policy{};
-    error = max_policy.Invoke(ptx_version, dispatch);
+    error = PolicyHub::MaxPolicy::Invoke(ptx_version, dispatch);
     REQUIRE(error == cudaSuccess);
     return dispatch.thresholds;
   }
@@ -303,12 +302,14 @@ C2H_TEST("Device fixed size segmented reduce works with a very large number of s
 
     // Get small and medium segment size thresholds from dispatch helper
     const ::cuda::std::tuple<int, int> thresholds = dispatch_helper<policy_hub_t>::get_thresholds();
-    const int small                               = ::cuda::std::get<0>(thresholds);
-    const int medium                              = ::cuda::std::get<1>(thresholds);
+    const int small_segment_size                  = ::cuda::std::get<0>(thresholds);
+    const int medium_segment_size                 = ::cuda::std::get<1>(thresholds);
 
     // Take one random segment size from each of the segment sizes
-    const segment_size_t segment_size =
-      GENERATE_COPY(take(1, random(1, small)), take(1, random(small, medium)), take(1, random(medium, medium * 2)));
+    const segment_size_t segment_size = GENERATE_COPY(
+      take(1, random(1, small_segment_size)),
+      take(1, random(small_segment_size, medium_segment_size)),
+      take(1, random(medium_segment_size, medium_segment_size * 2)));
 
     const ::cuda::std::int64_t num_items = num_segments * segment_size;
 

--- a/cub/test/catch2_test_device_segmented_reduce_large_offsets.cu
+++ b/cub/test/catch2_test_device_segmented_reduce_large_offsets.cu
@@ -303,8 +303,8 @@ C2H_TEST("Device fixed size segmented reduce works with a very large number of s
 
     // Get small and medium segment size thresholds from dispatch helper
     const ::cuda::std::tuple<int, int> thresholds = dispatch_helper<policy_hub_t>::get_thresholds();
-    const auto small                              = ::cuda::std::get<0>(thresholds);
-    const auto medium                             = ::cuda::std::get<1>(thresholds);
+    const int small                               = ::cuda::std::get<0>(thresholds);
+    const int medium                              = ::cuda::std::get<1>(thresholds);
 
     // Take one random segment size from each of the segment sizes
     const segment_size_t segment_size =


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes #4233

<!-- Provide a standalone description of changes in this PR. -->
This PR add's support for large number of segments `(> INT_MAX)` to `DeviceSegmentedReduce` with **fixed segment size**. 

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
