### PR TITLE
[CUDAX] rename wait() to sync() in various types.

### DIFF
--- a/cudax/examples/simple_p2p.cu
+++ b/cudax/examples/simple_p2p.cu
@@ -100,7 +100,7 @@ void benchmark_cross_device_ping_pong_copy(
   }
 
   auto end_event = dev1_stream.record_timed_event();
-  dev1_stream.wait();
+  dev1_stream.sync();
   cuda::std::chrono::duration<double> duration(end_event - start_event);
   printf("Peer copy between GPU%d and GPU%d: %.2fGB/s\n",
          dev0_stream.get_device().get(),
@@ -152,7 +152,7 @@ void test_cross_device_access_from_kernel(
   // Copy data back to host and verify
   printf("Copy data back to host from GPU%d and verify results...\n", dev0.get());
   cudax::copy_bytes(dev0_stream, dev0_buffer, host_buffer);
-  dev0_stream.wait();
+  dev0_stream.sync();
 
   int error_count = 0;
   for (size_t i = 0; i < host_buffer.size(); i++)

--- a/cudax/examples/vector.cuh
+++ b/cudax/examples/vector.cuh
@@ -83,7 +83,7 @@ private:
     if (__p != detail::__param_kind::_in)
     {
       // TODO: use a memcpy async here
-      __str.wait(); // wait for the kernel to finish executing
+      __str.sync(); // wait for the kernel to finish executing
       __h_ = __d_;
     }
   }

--- a/cudax/examples/vector_add.cu
+++ b/cudax/examples/vector_add.cu
@@ -100,7 +100,7 @@ try
   cudax::launch(stream, config, vectorAdd, in(A), in(B), out(C));
 
   printf("waiting for the stream to finish\n");
-  stream.wait();
+  stream.sync();
 
   printf("verifying the results\n");
   // Verify that the result vector is correct

--- a/cudax/include/cuda/experimental/__container/async_buffer.cuh
+++ b/cudax/include/cuda/experimental/__container/async_buffer.cuh
@@ -197,7 +197,7 @@ private:
       // FIXME: Something is fishy here. We need to wait otherwise the data is not properly set.
       // The test passes fine with compute-sanitizer but we really do not want to take the performance hit for this.
       // See https://github.com/NVIDIA/cccl/issues/3814
-      __buf_.get_stream().wait();
+      __buf_.get_stream().sync();
       _CCCL_TRY_CUDA_API(
         ::cudaMemcpyAsync,
         "cudax::async_buffer::__copy_cross: failed to copy data",
@@ -555,7 +555,7 @@ public:
   [[nodiscard]] _CCCL_HIDE_FROM_ABI reference get(const size_type __n) noexcept
   {
     _CCCL_ASSERT(__n < __size_, "cuda::experimental::async_vector::get out of range!");
-    this->wait();
+    this->sync();
     return begin()[__n];
   }
 
@@ -565,7 +565,7 @@ public:
   [[nodiscard]] _CCCL_HIDE_FROM_ABI const_reference get(const size_type __n) const noexcept
   {
     _CCCL_ASSERT(__n < __size_, "cuda::experimental::async_vector::get out of range!");
-    this->wait();
+    this->sync();
     return begin()[__n];
   }
 
@@ -648,10 +648,10 @@ public:
     __policy_ = __new_policy;
   }
 
-  //! @brief Waits on the currently stored stream
-  _CCCL_HIDE_FROM_ABI void wait() const
+  //! @brief Synchronizes the currently stored stream
+  _CCCL_HIDE_FROM_ABI void sync() const
   {
-    __buf_.get_stream().wait();
+    __buf_.get_stream().sync();
   }
 
   //! @}
@@ -755,8 +755,8 @@ public:
     if constexpr (__is_host_only)
     {
       // need to wait here because `host_launch` does not return values, so we cannot easily put it in stream order
-      __lhs.wait();
-      __rhs.wait();
+      __lhs.sync();
+      __rhs.sync();
       return _CUDA_VSTD::equal(
         __lhs.__unwrapped_begin(), __lhs.__unwrapped_end(), __rhs.__unwrapped_begin(), __rhs.__unwrapped_end());
     }
@@ -806,7 +806,7 @@ async_buffer<_Tp, _TargetProperties...> make_async_buffer(
 {
   env_t<_TargetProperties...> __env{__mr, __stream};
   async_buffer<_Tp, _TargetProperties...> __res{__env, __source.size(), uninit};
-  __source.wait();
+  __source.sync();
 
   _CCCL_TRY_CUDA_API(
     ::cudaMemcpyAsync,

--- a/cudax/include/cuda/experimental/__container/uninitialized_async_buffer.cuh
+++ b/cudax/include/cuda/experimental/__container/uninitialized_async_buffer.cuh
@@ -330,7 +330,7 @@ public:
   {
     if (__new_stream != __stream_)
     {
-      __stream_.wait();
+      __stream_.sync();
     }
     __stream_ = __new_stream;
   }

--- a/cudax/include/cuda/experimental/__event/event_ref.cuh
+++ b/cudax/include/cuda/experimental/__event/event_ref.cuh
@@ -85,18 +85,18 @@ public:
   //! @throws cuda_error if waiting for the event fails
   void sync() const
   {
-    _CCCL_ASSERT(__event_ != nullptr, "cuda::experimental::event_ref::wait no event set");
+    _CCCL_ASSERT(__event_ != nullptr, "cuda::experimental::event_ref::sync no event set");
     _CCCL_TRY_CUDA_API(::cudaEventSynchronize, "Failed to wait for CUDA event", __event_);
   }
 
   //! @brief Checks if all the work in the stream prior to the record of the event has completed.
   //!
-  //! If is_done returns true, calling wait() on this event will return immediately
+  //! If is_done returns true, calling sync() on this event will return immediately
   //!
   //! @throws cuda_error if the event query fails
   [[nodiscard]] bool is_done() const
   {
-    _CCCL_ASSERT(__event_ != nullptr, "cuda::experimental::event_ref::wait no event set");
+    _CCCL_ASSERT(__event_ != nullptr, "cuda::experimental::event_ref::sync no event set");
     cudaError_t __status = ::cudaEventQuery(__event_);
     if (__status == cudaSuccess)
     {

--- a/cudax/include/cuda/experimental/__event/event_ref.cuh
+++ b/cudax/include/cuda/experimental/__event/event_ref.cuh
@@ -80,11 +80,10 @@ public:
     detail::driver::eventRecord(__event_, __stream.get());
   }
 
-  //! @brief Waits until all the work in the stream prior to the record of the
-  //!        event has completed.
+  //! @brief Synchronizes the event
   //!
   //! @throws cuda_error if waiting for the event fails
-  void wait() const
+  void sync() const
   {
     _CCCL_ASSERT(__event_ != nullptr, "cuda::experimental::event_ref::wait no event set");
     _CCCL_TRY_CUDA_API(::cudaEventSynchronize, "Failed to wait for CUDA event", __event_);

--- a/cudax/include/cuda/experimental/__memory_resource/memory_resource_base.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/memory_resource_base.cuh
@@ -87,7 +87,7 @@ public:
       __bytes,
       __pool_,
       __cccl_allocation_stream().get());
-    __cccl_allocation_stream().wait();
+    __cccl_allocation_stream().sync();
     return __ptr;
   }
 
@@ -103,7 +103,7 @@ public:
     _CCCL_ASSERT(__is_valid_alignment(__alignment), "Invalid alignment passed to __memory_resource_base::deallocate.");
     _CCCL_ASSERT_CUDA_API(
       ::cudaFreeAsync, "__memory_resource_base::deallocate failed", __ptr, __cccl_allocation_stream().get());
-    __cccl_allocation_stream().wait();
+    __cccl_allocation_stream().sync();
   }
 
   //! @brief Allocate device memory of size at least \p __bytes via `cudaMallocFromPoolAsync`.

--- a/cudax/include/cuda/experimental/__stream/stream_ref.cuh
+++ b/cudax/include/cuda/experimental/__stream/stream_ref.cuh
@@ -98,14 +98,7 @@ struct stream_ref : ::cuda::stream_ref
     return timed_event(*this, __flags);
   }
 
-  //! \brief Synchronizes the wrapped stream.
-  //!
-  //! \throws cuda::cuda_error if synchronization fails.
-  //!
-  _CUDAX_TRIVIAL_HOST_API void wait() const
-  {
-    this->::cuda::stream_ref::wait();
-  }
+  using ::cuda::stream_ref::sync;
 
   //! @brief Make all future work submitted into this stream depend on completion of the specified event
   //!

--- a/cudax/test/algorithm/common.cuh
+++ b/cudax/test/algorithm/common.cuh
@@ -36,7 +36,7 @@ void check_result_and_erase(cudax::stream_ref stream, Result&& result, uint8_t p
 {
   int expected = get_expected_value(pattern_byte);
 
-  stream.wait();
+  stream.sync();
   for (int& i : result)
   {
     CUDAX_REQUIRE(i == expected);

--- a/cudax/test/algorithm/copy.cu
+++ b/cudax/test/algorithm/copy.cu
@@ -97,7 +97,7 @@ TEST_CASE("1d Copy", "[data_manipulation]")
     ::std::vector<int> vec(buffer_size, 0xbeef);
 
     cudax::copy_bytes(_stream, host_buffer, vec);
-    _stream.wait();
+    _stream.sync();
 
     CUDAX_REQUIRE(vec[0] == get_expected_value(fill_byte));
     CUDAX_REQUIRE(vec[1] == 0xbeef);
@@ -123,7 +123,7 @@ void test_mdspan_copy_bytes(
   }
 
   cudax::copy_bytes(stream, std::move(src), dst);
-  stream.wait();
+  stream.sync();
 
   for (int i = 0; i < static_cast<int>(dst.extent(1)); i++)
   {
@@ -164,7 +164,7 @@ TEST_CASE("Mdspan copy", "[data_manipulation]")
       host_resource, mdspan.mapping().required_span_size()};
 
     cudax::copy_bytes(stream, mdspan, buffer);
-    stream.wait();
+    stream.sync();
     CUDAX_REQUIRE(!memcmp(mdspan_buffer.data(), buffer.data, mdspan_buffer.size()));
   }
 }

--- a/cudax/test/containers/async_buffer/access.cu
+++ b/cudax/test/containers/async_buffer/access.cu
@@ -66,7 +66,7 @@ TEMPLATE_TEST_CASE("cudax::async_buffer access",
 
     {
       Buffer buf{env, {T(1), T(42), T(1337), T(0)}};
-      buf.wait();
+      buf.sync();
       auto& res = buf.get_unsynchronized(2);
       CUDAX_CHECK(compare_value<Buffer::__is_host_only>(res, T(1337)));
       CUDAX_CHECK(static_cast<size_t>(cuda::std::addressof(res) - buf.data()) == 2);
@@ -85,14 +85,14 @@ TEMPLATE_TEST_CASE("cudax::async_buffer access",
 
     { // Works without allocation
       Buffer buf{env};
-      buf.wait();
+      buf.sync();
       CUDAX_CHECK(buf.data() == nullptr);
       CUDAX_CHECK(cuda::std::as_const(buf).data() == nullptr);
     }
 
     { // Works with allocation
       Buffer buf{env, {T(1), T(42), T(1337), T(0)}};
-      buf.wait();
+      buf.sync();
       CUDAX_CHECK(buf.data() != nullptr);
       CUDAX_CHECK(cuda::std::as_const(buf).data() != nullptr);
       CUDAX_CHECK(cuda::std::as_const(buf).data() == buf.data());

--- a/cudax/test/containers/async_buffer/helper.h
+++ b/cudax/test/containers/async_buffer/helper.h
@@ -34,7 +34,7 @@ constexpr bool equal_range(const Buffer& buf)
 {
   if constexpr (Buffer::__is_host_only)
   {
-    buf.wait();
+    buf.sync();
     return cuda::std::equal(buf.begin(), buf.end(), cuda::std::begin(host_data), cuda::std::end(host_data));
   }
   else
@@ -104,7 +104,7 @@ constexpr bool equal_size_value(const Buffer& buf, const size_t size, const int 
 {
   if constexpr (Buffer::__is_host_only)
   {
-    buf.wait();
+    buf.sync();
     return buf.size() == size
         && cuda::std::equal(buf.begin(), buf.end(), cuda::std::begin(host_data), equal_to_value{value});
   }
@@ -125,7 +125,7 @@ constexpr bool equal_range(const Range1& range1, const Range2& range2)
 {
   if constexpr (Range1::__is_host_only)
   {
-    range1.wait();
+    range1.sync();
     return cuda::std::equal(range1.begin(), range1.end(), range2.begin(), range2.end());
   }
   else

--- a/cudax/test/containers/async_buffer/transform.cu
+++ b/cudax/test/containers/async_buffer/transform.cu
@@ -120,7 +120,7 @@ TEMPLATE_LIST_TEST_CASE(
   REQUIRE(
     cudaMemcpyAsync(result_h.data(), result.data(), num_items * sizeof(type), cudaMemcpyDeviceToHost, stream.get())
     == cudaSuccess);
-  stream.wait();
+  stream.sync();
 
   // compute reference and verify
   thrust::host_vector<type> reference_h(num_items);

--- a/cudax/test/containers/uninitialized_async_buffer.cu
+++ b/cudax/test/containers/uninitialized_async_buffer.cu
@@ -184,7 +184,7 @@ TEMPLATE_TEST_CASE(
     if constexpr (!cuda::std::is_same_v<TestType, do_not_construct>)
     {
       uninitialized_async_buffer buf{resource, stream, 42};
-      stream.wait();
+      stream.sync();
       thrust::fill(thrust::device, buf.begin(), buf.end(), TestType{2});
       const auto res = thrust::reduce(thrust::device, buf.begin(), buf.end(), TestType{0}, thrust::plus<int>());
       CUDAX_CHECK(res == TestType{84});

--- a/cudax/test/event/event_smoke.cu
+++ b/cudax/test/event/event_smoke.cu
@@ -76,11 +76,11 @@ TEST_CASE("can use event_ref to record and wait on an event", "[event]")
   cudax::stream stream;
   cudax::launch(stream, ::test::one_thread_dims, ::test::assign_42{}, i.get());
   ref.record(stream);
-  ref.wait();
+  ref.sync();
   CUDAX_REQUIRE(ref.is_done());
   CUDAX_REQUIRE(*i == 42);
 
-  stream.wait();
+  stream.sync();
   CUDAX_REQUIRE(::cudaEventDestroy(ev) == ::cudaSuccess);
 }
 
@@ -97,10 +97,10 @@ TEST_CASE("can wait on an event", "[event]")
   ::test::managed<int> i(0);
   cudax::launch(stream, ::test::one_thread_dims, ::test::assign_42{}, i.get());
   cudax::event ev(stream);
-  ev.wait();
+  ev.sync();
   CUDAX_REQUIRE(ev.is_done());
   CUDAX_REQUIRE(*i == 42);
-  stream.wait();
+  stream.sync();
 }
 
 TEST_CASE("can take the difference of two timed_event objects", "[event]")
@@ -110,13 +110,13 @@ TEST_CASE("can take the difference of two timed_event objects", "[event]")
   cudax::timed_event start(stream);
   cudax::launch(stream, ::test::one_thread_dims, ::test::assign_42{}, i.get());
   cudax::timed_event end(stream);
-  end.wait();
+  end.sync();
   CUDAX_REQUIRE(end.is_done());
   CUDAX_REQUIRE(*i == 42);
   auto elapsed = end - start;
   CUDAX_REQUIRE(elapsed.count() >= 0);
   STATIC_REQUIRE(_CUDA_VSTD::is_same_v<decltype(elapsed), _CUDA_VSTD::chrono::nanoseconds>);
-  stream.wait();
+  stream.sync();
 }
 
 TEST_CASE("can observe the event in not ready state", "[event]")
@@ -130,6 +130,6 @@ TEST_CASE("can observe the event in not ready state", "[event]")
   cudax::event ev(stream);
   CUDAX_REQUIRE(!ev.is_done());
   atomic_i.store(80);
-  ev.wait();
+  ev.sync();
   CUDAX_REQUIRE(ev.is_done());
 }

--- a/cudax/test/launch/configuration.cu
+++ b/cudax/test/launch/configuration.cu
@@ -169,7 +169,7 @@ auto configuration_test(
     }
     cudax::launch(stream, config, empty_kernel, 0);
   }
-  stream.wait();
+  stream.sync();
 }
 
 TEST_CASE("Launch configuration", "[launch]")

--- a/cudax/test/launch/launch_smoke.cu
+++ b/cudax/test/launch/launch_smoke.cu
@@ -288,19 +288,19 @@ void test_default_config()
     static_assert(cudax::__kernel_has_default_config<decltype(kernel)>);
 
     cudax::launch(stream, cudax::make_config(), kernel, verify_lambda);
-    stream.wait();
+    stream.sync();
   }
   SECTION("Combine with no overlap")
   {
     kernel_with_default_config kernel{cudax::make_config(block)};
     cudax::launch(stream, cudax::make_config(grid, cudax::cooperative_launch()), kernel, verify_lambda);
-    stream.wait();
+    stream.sync();
   }
   SECTION("Combine with overlap")
   {
     kernel_with_default_config kernel{cudax::make_config(cudax::block_dims<1>, cudax::cooperative_launch())};
     cudax::launch(stream, cudax::make_config(block, grid, cudax::cooperative_launch()), kernel, verify_lambda);
-    stream.wait();
+    stream.sync();
   }
 }
 
@@ -322,7 +322,7 @@ void unblock_and_wait_stream(cudax::stream_ref stream, cuda::atomic<int>& atomic
 {
   CUDAX_REQUIRE(!stream.ready());
   atomic = 1;
-  stream.wait();
+  stream.sync();
   atomic = 0;
 }
 
@@ -411,7 +411,7 @@ TEST_CASE("Host launch")
         CUDAX_REQUIRE(s == str_arg);
       },
       s);
-    stream.wait();
+    stream.sync();
   }
 
   SECTION("Confirm no const added to the callable")
@@ -421,7 +421,7 @@ TEST_CASE("Host launch")
     });
 
     cudax::host_launch(stream, wrapped_lambda);
-    stream.wait();
+    stream.sync();
     CUDAX_REQUIRE(i == 21)
   }
 

--- a/cudax/test/memory_resource/common_tests.cuh
+++ b/cudax/test/memory_resource/common_tests.cuh
@@ -30,5 +30,5 @@ void test_deallocate_async(ResourceType& resource)
   resource.deallocate_async(allocation, sizeof(int), stream);
 
   atomic_i.store(80);
-  stream.wait();
+  stream.sync();
 }

--- a/cudax/test/memory_resource/device_memory_resource.cu
+++ b/cudax/test/memory_resource/device_memory_resource.cu
@@ -246,7 +246,7 @@ TEST_CASE("device_memory_resource allocation", "[memory_resource]")
     auto* ptr = res.allocate_async(42, stream);
     static_assert(cuda::std::is_same<decltype(ptr), void*>::value, "");
 
-    stream.wait();
+    stream.sync();
     ensure_device_ptr(ptr);
 
     res.deallocate_async(ptr, 42, stream);
@@ -261,7 +261,7 @@ TEST_CASE("device_memory_resource allocation", "[memory_resource]")
     auto* ptr = res.allocate_async(42, 4, stream);
     static_assert(cuda::std::is_same<decltype(ptr), void*>::value, "");
 
-    stream.wait();
+    stream.sync();
     ensure_device_ptr(ptr);
 
     res.deallocate_async(ptr, 42, 4, stream);
@@ -479,7 +479,7 @@ TEST_CASE("Async memory resource access")
         auto config = cudax::distribute<1>(1);
         cudax::launch(stream, config, test::assign_42{}, (int*) ptr1);
         cudax::launch(stream, config, test::assign_42{}, (int*) ptr2);
-        stream.wait();
+        stream.sync();
         resource.deallocate_async(ptr1, sizeof(int), stream);
         resource.deallocate(ptr2, sizeof(int));
       };

--- a/cudax/test/memory_resource/managed_memory_resource.cu
+++ b/cudax/test/memory_resource/managed_memory_resource.cu
@@ -81,7 +81,7 @@ TEST_CASE("managed_memory_resource allocation", "[memory_resource]")
     auto* ptr = res.allocate_async(42, stream);
     static_assert(cuda::std::is_same<decltype(ptr), void*>::value, "");
 
-    stream.wait();
+    stream.sync();
     ensure_managed_ptr(ptr);
 
     res.deallocate_async(ptr, 42, stream);
@@ -91,7 +91,7 @@ TEST_CASE("managed_memory_resource allocation", "[memory_resource]")
     auto* ptr = res.allocate_async(42, 4, stream);
     static_assert(cuda::std::is_same<decltype(ptr), void*>::value, "");
 
-    stream.wait();
+    stream.sync();
     ensure_managed_ptr(ptr);
 
     res.deallocate_async(ptr, 42, 4, stream);

--- a/cudax/test/memory_resource/memory_pools.cu
+++ b/cudax/test/memory_resource/memory_pools.cu
@@ -347,7 +347,7 @@ TEMPLATE_TEST_CASE("device_memory_pool accessors", "[memory_resource]", TEST_TYP
 
     // Allocate a buffer to prime
     auto* ptr = resource.allocate_async(256 * sizeof(int), stream);
-    stream.wait();
+    stream.sync();
 
     { // cudaMemPoolAttrReservedMemHigh
       // Get the attribute value
@@ -410,7 +410,7 @@ TEMPLATE_TEST_CASE("device_memory_pool accessors", "[memory_resource]", TEST_TYP
     // Reallocate as the checks above have screwed with the allocation count
     resource.deallocate_async(ptr, 256 * sizeof(int), stream);
     ptr = resource.allocate_async(2048 * sizeof(int), stream);
-    stream.wait();
+    stream.sync();
 
     { // cudaMemPoolAttrReservedMemCurrent
       // Get the attribute value
@@ -458,7 +458,7 @@ TEMPLATE_TEST_CASE("device_memory_pool accessors", "[memory_resource]", TEST_TYP
 
     // Free the last allocation
     resource.deallocate_async(ptr, 2048 * sizeof(int), stream);
-    stream.wait();
+    stream.sync();
   }
 
   SECTION("device_memory_pool::trim_to")
@@ -473,7 +473,7 @@ TEMPLATE_TEST_CASE("device_memory_pool accessors", "[memory_resource]", TEST_TYP
     auto* ptr1 = resource.allocate_async(2048 * sizeof(int), stream);
     auto* ptr2 = resource.allocate_async(2048 * sizeof(int), stream);
     resource.deallocate_async(ptr1, 2048 * sizeof(int), stream);
-    stream.wait();
+    stream.sync();
 
     // Ensure that we still hold some memory, otherwise everything is freed
     auto backing_size = pool.get_attribute(::cudaMemPoolAttrReservedMemCurrent);
@@ -503,7 +503,7 @@ TEMPLATE_TEST_CASE("device_memory_pool accessors", "[memory_resource]", TEST_TYP
 
     // Free the last allocation
     resource.deallocate_async(ptr2, 2048 * sizeof(int), stream);
-    stream.wait();
+    stream.sync();
 
     // There is nothing allocated anymore, so all memory is released
     auto no_backing = pool.get_attribute(::cudaMemPoolAttrReservedMemCurrent);

--- a/cudax/test/memory_resource/pinned_memory_resource.cu
+++ b/cudax/test/memory_resource/pinned_memory_resource.cu
@@ -87,7 +87,7 @@ TEMPLATE_TEST_CASE("pinned_memory_resource allocation", "[memory_resource]", TES
       auto* ptr = res.allocate_async(42, stream);
       static_assert(cuda::std::is_same<decltype(ptr), void*>::value, "");
 
-      stream.wait();
+      stream.sync();
       ensure_pinned_ptr(ptr);
 
       res.deallocate_async(ptr, 42, stream);
@@ -97,7 +97,7 @@ TEMPLATE_TEST_CASE("pinned_memory_resource allocation", "[memory_resource]", TES
       auto* ptr = res.allocate_async(42, 4, stream);
       static_assert(cuda::std::is_same<decltype(ptr), void*>::value, "");
 
-      stream.wait();
+      stream.sync();
       ensure_pinned_ptr(ptr);
 
       res.deallocate_async(ptr, 42, 4, stream);

--- a/cudax/test/stream/stream_smoke.cu
+++ b/cudax/test/stream/stream_smoke.cu
@@ -19,7 +19,7 @@ TEST_CASE("Can create a stream and launch work into it", "[stream]")
   cudax::stream str;
   ::test::managed<int> i(0);
   cudax::launch(str, ::test::one_thread_dims, ::test::assign_42{}, i.get());
-  str.wait();
+  str.sync();
   CUDAX_REQUIRE(*i == 42);
 }
 
@@ -32,7 +32,7 @@ TEST_CASE("From native handle", "[stream]")
 
     ::test::managed<int> i(0);
     cudax::launch(stream, ::test::one_thread_dims, ::test::assign_42{}, i.get());
-    stream.wait();
+    stream.sync();
     CUDAX_REQUIRE(*i == 42);
     (void) stream.release();
   }
@@ -55,8 +55,8 @@ void add_dependency_test(const StreamType& waiter, const StreamType& waitee)
     CUDAX_REQUIRE(atomic_i.load() != 42);
     CUDAX_REQUIRE(!waiter.ready());
     atomic_i.store(80);
-    waiter.wait();
-    waitee.wait();
+    waiter.sync();
+    waitee.sync();
   };
 
   SECTION("Stream wait declared event")

--- a/libcudacxx/include/cuda/stream_ref
+++ b/libcudacxx/include/cuda/stream_ref
@@ -140,9 +140,20 @@ public:
    * \throws cuda::cuda_error if synchronization fails.
    *
    */
-  void wait() const
+  void sync() const
   {
     _CCCL_TRY_CUDA_API(::cudaStreamSynchronize, "Failed to synchronize stream.", get());
+  }
+
+  /**
+   * \brief Deprecated. Use sync() instead.
+   *
+   * \deprecated Use sync() instead.
+   */
+  [[deprecated("Use sync() instead.")]]
+  void wait() const
+  {
+    sync();
   }
 
   /**

--- a/libcudacxx/test/libcudacxx/cuda/stream_ref/stream_ref.sync.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/stream_ref/stream_ref.sync.pass.cpp
@@ -10,8 +10,6 @@
 
 // UNSUPPORTED: nvrtc
 
-#define
-
 #include <cuda/std/cassert>
 #include <cuda/stream_ref>
 
@@ -21,9 +19,6 @@
 
 #include "test_macros.h"
 
-TEST_DIAG_SUPPRESS_CLANG("-Wdeprecated-declarations")
-TEST_DIAG_SUPPRESS_NVHPC(deprecated_entity_with_custom_message)
-
 void CUDART_CB callback(cudaStream_t, cudaError_t, void* flag)
 {
   std::chrono::milliseconds sleep_duration{1000};
@@ -31,19 +26,19 @@ void CUDART_CB callback(cudaStream_t, cudaError_t, void* flag)
   assert(!reinterpret_cast<std::atomic_flag*>(flag)->test_and_set());
 }
 
-void test_wait(cuda::stream_ref& ref)
+void test_sync(cuda::stream_ref& ref)
 {
 #if TEST_HAS_EXCEPTIONS()
   try
   {
-    ref.wait();
+    ref.sync();
   }
   catch (...)
   {
     assert(false && "Should not have thrown");
   }
 #else
-  ref.wait();
+  ref.sync();
 #endif // TEST_HAS_EXCEPTIONS()
 }
 
@@ -55,7 +50,7 @@ int main(int argc, char** argv)
       cudaStream_t stream; cudaStreamCreate(&stream); std::atomic_flag flag = ATOMIC_FLAG_INIT;
       cudaStreamAddCallback(stream, callback, &flag, 0);
       cuda::stream_ref ref{stream};
-      test_wait(ref);
+      test_sync(ref);
       assert(flag.test_and_set());
       cudaStreamDestroy(stream);))
 

--- a/libcudacxx/test/libcudacxx/cuda/stream_ref/stream_ref.wait.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/stream_ref/stream_ref.wait.pass.cpp
@@ -10,8 +10,6 @@
 
 // UNSUPPORTED: nvrtc
 
-#define
-
 #include <cuda/std/cassert>
 #include <cuda/stream_ref>
 


### PR DESCRIPTION
Currently we have `wait()` and `wait(event/stream)` with completely different meaning, which will be confusing.

For this case we decided that the CUDA terminology coming from `cudaStreamSynchronize()` is more important than the C++ `wait()` precedent. For example in `async_buffer` we have `get_unsynchronized` and not `get_unwaited`, which suggests the intuitive wording for operation of blocking the CPU thread until a stream drains should be called synchronization of the stream.

This PR renames the argument less `wait()` to `sync()` for all types that have `wait()` in cudax.

We also have `cuda::stream_ref` and for it we can't just remove `wait()`, instead it was deprecated and will be removed in some future major version.