### PR TITLE
cuda.parallel: cmake build script to avoid using find_program

### DIFF
--- a/python/cuda_parallel/CMakeLists.txt
+++ b/python/cuda_parallel/CMakeLists.txt
@@ -28,14 +28,8 @@ install(
 find_package(Python3 COMPONENTS Interpreter Development.Module REQUIRED)
 
 get_filename_component(_python_path "${Python3_EXECUTABLE}" PATH)
-find_program(
-    CYTHON_EXECUTABLE
-    NAMES cython cython.bat cython3
-    HINTS "${_python_path}"
-    DOC "path to the cython executable"
-)
 
-set(CYTHON_version_command "${CYTHON_EXECUTABLE}" --version)
+set(CYTHON_version_command "${Python3_EXECUTABLE}" -m cython --version)
 execute_process(COMMAND ${CYTHON_version_command}
     OUTPUT_VARIABLE CYTHON_version_output
     ERROR_VARIABLE CYTHON_version_error
@@ -71,7 +65,7 @@ set(_generated_extension_src "${cuda_parallel_BINARY_DIR}/_bindings.c")
 set(_depfile "${cuda_parallel_BINARY_DIR}/_bindings.c.dep")
 add_custom_command(
     OUTPUT "${_generated_extension_src}"
-    COMMAND ${CYTHON_EXECUTABLE}
+    COMMAND "${Python3_EXECUTABLE}" -m cython
     ARGS ${CYTHON_FLAGS_LIST} "${pyx_source_file}" --output-file ${_generated_extension_src}
     DEPENDS "${pyx_source_file}"
     DEPFILE "${_depfile}"


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes gh-4381

<!-- Provide a standalone description of changes in this PR. -->

Get rid of `CYTHON_EXECUTABLE` variable and use of `find_program` to set it. Use `"${Python3_EXECUTABLE}" -m cython` instead.

**N.B.**: An attempt to use `Python3::Interpreter -m cython` did not work.

<details>
<summary>CMakeLists.txt that uses Python3::Interpreter</summary>

```
cmake_minimum_required(VERSION 3.27)
project(
    Test
    DESCRIPTION "Test"
)

find_package(Python3 COMPONENTS Interpreter Development.Module REQUIRED)

execute_process(
    COMMAND Python3::Interpreter -m cython --version
    OUTPUT_VARIABLE CYTHON_version_output
    ERROR_VARIABLE CYTHON_version_error
    RESULT_VARIABLE CYTHON_version_result
    OUTPUT_STRIP_TRAILING_WHITESPACE
    ERROR_STRIP_TRAILING_WHITESPACE
)

message(STATUS "Output: ${CYTHON_version_output}")
message(STATUS "Error:  ${CYTHON_version_error}")
message(STATUS "RESULT: ${CYTHON_version_result}")
```

Using it:

```
$ cmake -B build .
-- The C compiler identification is GNU 13.1.0
-- The CXX compiler identification is GNU 13.1.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/g++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found Python3: /tmp/cuda_parallel_venv/bin/python3.10 (found version "3.10.12") found components: Interpreter Development.Module
-- Output: 
-- Error:  
-- RESULT: no such file or directory
-- Configuring done (0.9s)
-- Generating done (0.0s)
-- Build files have been written to: /home/coder/cccl/python/cuda_parallel/tmp/build
```
</details>

Changing `Python3` to `Python` also did not work, so my solution was to use `"${Python3_EXECUTABLE}"` instead of `Python3::Interpreter`.

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
