### PR TITLE
Implement P0466R5 from C++20

### DIFF
--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -456,6 +456,22 @@
 #  define _CCCL_BUILTIN_IS_CONSTANT_EVALUATED(...) __builtin_is_constant_evaluated(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(builtin_is_constant_evaluated)
 
+#if _CCCL_CHECK_BUILTIN(builtin_is_corresponding_member)
+#  define _CCCL_BUILTIN_IS_CORRESPONDING_MEMBER(_C1, _C2, _MPtr1, _MPtr2) \
+    __builtin_is_corresponding_member(_MPtr1, _MPtr2)
+#elif _CCCL_COMPILER(MSVC, >=, 19, 29)
+#  define _CCCL_BUILTIN_IS_CORRESPONDING_MEMBER(_C1, _C2, _MPtr1, _MPtr2) \
+    __is_corresponding_member(_C1, _C2, _MPtr1, _MPtr2)
+#endif // ^^^ _CCCL_COMPILER(MSVC, >=, 19, 29) ^^^
+
+#if _CCCL_CHECK_BUILTIN(builtin_is_pointer_interconvertible_with_class)
+#  define _CCCL_BUILTIN_IS_POINTER_INTERCONVERTIBLE_WITH_CLASS(_S, _MPtr) \
+    __builtin_is_pointer_interconvertible_with_class(_MPtr)
+#elif _CCCL_COMPILER(MSVC, >=, 19, 29)
+#  define _CCCL_BUILTIN_IS_POINTER_INTERCONVERTIBLE_WITH_CLASS(_S, _MPtr) \
+    __is_pointer_interconvertible_with_class(_S, _MPtr)
+#endif // ^^^ _CCCL_COMPILER(MSVC, >=, 19, 29) ^^^
+
 #if _CCCL_CHECK_BUILTIN(builtin_isfinite) || _CCCL_COMPILER(GCC) || _CCCL_COMPILER(NVRTC, >, 12, 2)
 #  define _CCCL_BUILTIN_ISFINITE(...) __builtin_isfinite(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(isfinite)
@@ -997,6 +1013,10 @@
 #  define _CCCL_BUILTIN_IS_INTEGRAL(...) __is_integral(__VA_ARGS__)
 #endif // _CCCL_HAS_BUILTIN(__is_integral)
 
+#if _CCCL_CHECK_BUILTIN(is_layout_compatible) || _CCCL_COMPILER(MSVC, >=, 19, 29)
+#  define _CCCL_BUILTIN_IS_LAYOUT_COMPATIBLE(...) __is_layout_compatible(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(is_layout_compatible) || _CCCL_COMPILER(MSVC, >=, 19, 29)
+
 #if _CCCL_CHECK_BUILTIN(is_literal_type) || _CCCL_COMPILER(GCC, >=, 4, 6) || _CCCL_COMPILER(MSVC) \
   || _CCCL_COMPILER(NVRTC)
 #  define _CCCL_BUILTIN_IS_LITERAL(...) __is_literal_type(__VA_ARGS__)
@@ -1042,6 +1062,10 @@
 #if 0 // _CCCL_HAS_BUILTIN(__is_pointer)
 #  define _CCCL_BUILTIN_IS_POINTER(...) __is_pointer(__VA_ARGS__)
 #endif // _CCCL_HAS_BUILTIN(__is_pointer)
+
+#if _CCCL_CHECK_BUILTIN(is_pointer_interconvertible_base_of) || _CCCL_COMPILER(MSVC, >=, 19, 29)
+#  define _CCCL_BUILTIN_IS_POINTER_INTERCONVERTIBLE_BASE_OF(...) __is_pointer_interconvertible_base_of(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(is_pointer_interconvertible_base_of) || _CCCL_COMPILER(MSVC, >=, 19, 29)
 
 #if _CCCL_CHECK_BUILTIN(is_polymorphic) || _CCCL_COMPILER(GCC, >=, 4, 3) || _CCCL_COMPILER(MSVC) \
   || _CCCL_COMPILER(NVRTC)

--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -460,7 +460,9 @@
 #  define _CCCL_BUILTIN_IS_CORRESPONDING_MEMBER(_C1, _C2, _MPtr1, _MPtr2) \
     __builtin_is_corresponding_member(_MPtr1, _MPtr2)
 #elif _CCCL_COMPILER(MSVC, >=, 19, 29)
-#  define _CCCL_BUILTIN_IS_CORRESPONDING_MEMBER(_C1, _C2, _MPtr1, _MPtr2) \
+// using __is_corresponding_member with msvc outside of constexpr context causes linker errors, see
+// https://developercommunity.visualstudio.com/t/Using-compiler-builtins-causes-linking-n/10888080
+// #  define _CCCL_BUILTIN_IS_CORRESPONDING_MEMBER(_C1, _C2, _MPtr1, _MPtr2) \
     __is_corresponding_member(_C1, _C2, _MPtr1, _MPtr2)
 #endif // ^^^ _CCCL_COMPILER(MSVC, >=, 19, 29) ^^^
 
@@ -468,7 +470,9 @@
 #  define _CCCL_BUILTIN_IS_POINTER_INTERCONVERTIBLE_WITH_CLASS(_S, _MPtr) \
     __builtin_is_pointer_interconvertible_with_class(_MPtr)
 #elif _CCCL_COMPILER(MSVC, >=, 19, 29)
-#  define _CCCL_BUILTIN_IS_POINTER_INTERCONVERTIBLE_WITH_CLASS(_S, _MPtr) \
+// using __is_pointer_interconvertible_with_class with msvc outside of constexpr context causes linker errors, see
+// https://developercommunity.visualstudio.com/t/Using-compiler-builtins-causes-linking-n/10888080
+// #  define _CCCL_BUILTIN_IS_POINTER_INTERCONVERTIBLE_WITH_CLASS(_S, _MPtr) \
     __is_pointer_interconvertible_with_class(_S, _MPtr)
 #endif // ^^^ _CCCL_COMPILER(MSVC, >=, 19, 29) ^^^
 

--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -462,8 +462,8 @@
 #elif _CCCL_COMPILER(MSVC, >=, 19, 29)
 // using __is_corresponding_member with msvc outside of constexpr context causes linker errors, see
 // https://developercommunity.visualstudio.com/t/Using-compiler-builtins-causes-linking-n/10888080
-// #  define _CCCL_BUILTIN_IS_CORRESPONDING_MEMBER(_C1, _C2, _MPtr1, _MPtr2) \
-    __is_corresponding_member(_C1, _C2, _MPtr1, _MPtr2)
+// #  define _CCCL_BUILTIN_IS_CORRESPONDING_MEMBER(_C1, _C2, _MPtr1, _MPtr2) __is_corresponding_member(_C1, _C2, _MPtr1,
+// _MPtr2)
 #endif // ^^^ _CCCL_COMPILER(MSVC, >=, 19, 29) ^^^
 
 #if _CCCL_CHECK_BUILTIN(builtin_is_pointer_interconvertible_with_class)
@@ -472,8 +472,8 @@
 #elif _CCCL_COMPILER(MSVC, >=, 19, 29)
 // using __is_pointer_interconvertible_with_class with msvc outside of constexpr context causes linker errors, see
 // https://developercommunity.visualstudio.com/t/Using-compiler-builtins-causes-linking-n/10888080
-// #  define _CCCL_BUILTIN_IS_POINTER_INTERCONVERTIBLE_WITH_CLASS(_S, _MPtr) \
-    __is_pointer_interconvertible_with_class(_S, _MPtr)
+// #  define _CCCL_BUILTIN_IS_POINTER_INTERCONVERTIBLE_WITH_CLASS(_S, _MPtr)
+// __is_pointer_interconvertible_with_class(_S, _MPtr)
 #endif // ^^^ _CCCL_COMPILER(MSVC, >=, 19, 29) ^^^
 
 #if _CCCL_CHECK_BUILTIN(builtin_isfinite) || _CCCL_COMPILER(GCC) || _CCCL_COMPILER(NVRTC, >, 12, 2)

--- a/libcudacxx/include/cuda/std/__type_traits/is_corresponding_member.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_corresponding_member.h
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___TYPE_TRAITS_IS_CORRESPONDING_MEMBER_H
+#define _LIBCUDACXX___TYPE_TRAITS_IS_CORRESPONDING_MEMBER_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+_LIBCUDACXX_BEGIN_NAMESPACE_STD
+
+#if defined(_CCCL_BUILTIN_IS_CORRESPONDING_MEMBER)
+
+template <class _S1, class _S2, class _M1, class _M2>
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr bool
+is_corresponding_member(_M1 _S1::* __m1_ptr, _M2 _S2::* __m2_ptr) noexcept
+{
+  return _CCCL_BUILTIN_IS_CORRESPONDING_MEMBER(_S1, _S2, __m1_ptr, __m2_ptr);
+}
+
+#endif // _CCCL_BUILTIN_IS_CORRESPONDING_MEMBER
+
+_LIBCUDACXX_END_NAMESPACE_STD
+
+#endif // _LIBCUDACXX___TYPE_TRAITS_IS_CORRESPONDING_MEMBER_H

--- a/libcudacxx/include/cuda/std/__type_traits/is_layout_compatible.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_layout_compatible.h
@@ -31,7 +31,7 @@ template <class _Tp, class _Up>
 inline constexpr bool is_layout_compatible_v = _CCCL_BUILTIN_IS_LAYOUT_COMPATIBLE(_Tp, _Up);
 
 template <class _Tp, class _Up>
-struct is_layout_compatible : bool_constant<is_layout_compatible_v<_Tp, _Up>>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_layout_compatible : bool_constant<is_layout_compatible_v<_Tp, _Up>>
 {};
 
 #endif // _CCCL_BUILTIN_IS_LAYOUT_COMPATIBLE

--- a/libcudacxx/include/cuda/std/__type_traits/is_layout_compatible.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_layout_compatible.h
@@ -1,0 +1,41 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___TYPE_TRAITS_IS_LAYOUT_COMPATIBLE_H
+#define _LIBCUDACXX___TYPE_TRAITS_IS_LAYOUT_COMPATIBLE_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__type_traits/integral_constant.h>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_STD
+
+#if defined(_CCCL_BUILTIN_IS_LAYOUT_COMPATIBLE)
+
+template <class _Tp, class _Up>
+inline constexpr bool is_layout_compatible_v = _CCCL_BUILTIN_IS_LAYOUT_COMPATIBLE(_Tp, _Up);
+
+template <class _Tp, class _Up>
+struct is_layout_compatible : bool_constant<is_layout_compatible_v<_Tp, _Up>>
+{};
+
+#endif // _CCCL_BUILTIN_IS_LAYOUT_COMPATIBLE
+
+_LIBCUDACXX_END_NAMESPACE_STD
+
+#endif // _LIBCUDACXX___TYPE_TRAITS_IS_LAYOUT_COMPATIBLE_H

--- a/libcudacxx/include/cuda/std/__type_traits/is_pointer_interconvertible_base_of.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_pointer_interconvertible_base_of.h
@@ -1,0 +1,42 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___TYPE_TRAITS_IS_POINTER_INTERCONVERTIBLE_BASE_OF_H
+#define _LIBCUDACXX___TYPE_TRAITS_IS_POINTER_INTERCONVERTIBLE_BASE_OF_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__type_traits/integral_constant.h>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_STD
+
+#if defined(_CCCL_BUILTIN_IS_POINTER_INTERCONVERTIBLE_BASE_OF)
+
+template <class _Tp, class _Up>
+inline constexpr bool is_pointer_interconvertible_base_of_v =
+  _CCCL_BUILTIN_IS_POINTER_INTERCONVERTIBLE_BASE_OF(_Tp, _Up);
+
+template <class _Tp, class _Up>
+struct is_pointer_interconvertible_base_of : bool_constant<is_pointer_interconvertible_base_of_v<_Tp, _Up>>
+{};
+
+#endif // _CCCL_BUILTIN_IS_POINTER_INTERCONVERTIBLE_BASE_OF
+
+_LIBCUDACXX_END_NAMESPACE_STD
+
+#endif // _LIBCUDACXX___TYPE_TRAITS_IS_POINTER_INTERCONVERTIBLE_BASE_OF_H

--- a/libcudacxx/include/cuda/std/__type_traits/is_pointer_interconvertible_base_of.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_pointer_interconvertible_base_of.h
@@ -22,6 +22,7 @@
 #endif // no system header
 
 #include <cuda/std/__type_traits/integral_constant.h>
+#include <cuda/std/__type_traits/is_class.h>
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
@@ -30,6 +31,29 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 template <class _Tp, class _Up>
 inline constexpr bool is_pointer_interconvertible_base_of_v =
   _CCCL_BUILTIN_IS_POINTER_INTERCONVERTIBLE_BASE_OF(_Tp, _Up);
+
+#  if _CCCL_COMPILER(CLANG)
+// clang's builtin evaluates is_pointer_interconvertible_base_of_v<T, T> to be false which is not right
+template <class _Tp>
+inline constexpr bool is_pointer_interconvertible_base_of_v<_Tp, _Tp> = _CCCL_TRAIT(is_class, _Tp);
+template <class _Tp>
+inline constexpr bool is_pointer_interconvertible_base_of_v<_Tp, const _Tp> = _CCCL_TRAIT(is_class, _Tp);
+template <class _Tp>
+inline constexpr bool is_pointer_interconvertible_base_of_v<_Tp, const volatile _Tp> = _CCCL_TRAIT(is_class, _Tp);
+template <class _Tp>
+inline constexpr bool is_pointer_interconvertible_base_of_v<const _Tp, _Tp> = _CCCL_TRAIT(is_class, _Tp);
+template <class _Tp>
+inline constexpr bool is_pointer_interconvertible_base_of_v<const _Tp, const _Tp> = _CCCL_TRAIT(is_class, _Tp);
+template <class _Tp>
+inline constexpr bool is_pointer_interconvertible_base_of_v<const _Tp, const volatile _Tp> = _CCCL_TRAIT(is_class, _Tp);
+template <class _Tp>
+inline constexpr bool is_pointer_interconvertible_base_of_v<const volatile _Tp, _Tp> = _CCCL_TRAIT(is_class, _Tp);
+template <class _Tp>
+inline constexpr bool is_pointer_interconvertible_base_of_v<const volatile _Tp, const _Tp> = _CCCL_TRAIT(is_class, _Tp);
+template <class _Tp>
+inline constexpr bool is_pointer_interconvertible_base_of_v<const volatile _Tp, const volatile _Tp> =
+  _CCCL_TRAIT(is_class, _Tp);
+#  endif // _CCCL_COMPILER(CLANG)
 
 template <class _Tp, class _Up>
 struct is_pointer_interconvertible_base_of : bool_constant<is_pointer_interconvertible_base_of_v<_Tp, _Up>>

--- a/libcudacxx/include/cuda/std/__type_traits/is_pointer_interconvertible_base_of.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_pointer_interconvertible_base_of.h
@@ -39,24 +39,41 @@ inline constexpr bool is_pointer_interconvertible_base_of_v<_Tp, _Tp> = _CCCL_TR
 template <class _Tp>
 inline constexpr bool is_pointer_interconvertible_base_of_v<_Tp, const _Tp> = _CCCL_TRAIT(is_class, _Tp);
 template <class _Tp>
+inline constexpr bool is_pointer_interconvertible_base_of_v<_Tp, volatile _Tp> = _CCCL_TRAIT(is_class, _Tp);
+template <class _Tp>
 inline constexpr bool is_pointer_interconvertible_base_of_v<_Tp, const volatile _Tp> = _CCCL_TRAIT(is_class, _Tp);
 template <class _Tp>
 inline constexpr bool is_pointer_interconvertible_base_of_v<const _Tp, _Tp> = _CCCL_TRAIT(is_class, _Tp);
 template <class _Tp>
 inline constexpr bool is_pointer_interconvertible_base_of_v<const _Tp, const _Tp> = _CCCL_TRAIT(is_class, _Tp);
 template <class _Tp>
+inline constexpr bool is_pointer_interconvertible_base_of_v<const _Tp, volatile _Tp> = _CCCL_TRAIT(is_class, _Tp);
+template <class _Tp>
 inline constexpr bool is_pointer_interconvertible_base_of_v<const _Tp, const volatile _Tp> = _CCCL_TRAIT(is_class, _Tp);
+template <class _Tp>
+inline constexpr bool is_pointer_interconvertible_base_of_v<volatile _Tp, _Tp> = _CCCL_TRAIT(is_class, _Tp);
+template <class _Tp>
+inline constexpr bool is_pointer_interconvertible_base_of_v<volatile _Tp, const _Tp> = _CCCL_TRAIT(is_class, _Tp);
+template <class _Tp>
+inline constexpr bool is_pointer_interconvertible_base_of_v<volatile _Tp, volatile _Tp> = _CCCL_TRAIT(is_class, _Tp);
+template <class _Tp>
+inline constexpr bool is_pointer_interconvertible_base_of_v<volatile _Tp, const volatile _Tp> =
+  _CCCL_TRAIT(is_class, _Tp);
 template <class _Tp>
 inline constexpr bool is_pointer_interconvertible_base_of_v<const volatile _Tp, _Tp> = _CCCL_TRAIT(is_class, _Tp);
 template <class _Tp>
 inline constexpr bool is_pointer_interconvertible_base_of_v<const volatile _Tp, const _Tp> = _CCCL_TRAIT(is_class, _Tp);
+template <class _Tp>
+inline constexpr bool is_pointer_interconvertible_base_of_v<const volatile _Tp, volatile _Tp> =
+  _CCCL_TRAIT(is_class, _Tp);
 template <class _Tp>
 inline constexpr bool is_pointer_interconvertible_base_of_v<const volatile _Tp, const volatile _Tp> =
   _CCCL_TRAIT(is_class, _Tp);
 #  endif // _CCCL_COMPILER(CLANG)
 
 template <class _Tp, class _Up>
-struct is_pointer_interconvertible_base_of : bool_constant<is_pointer_interconvertible_base_of_v<_Tp, _Up>>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_pointer_interconvertible_base_of
+    : bool_constant<is_pointer_interconvertible_base_of_v<_Tp, _Up>>
 {};
 
 #endif // _CCCL_BUILTIN_IS_POINTER_INTERCONVERTIBLE_BASE_OF

--- a/libcudacxx/include/cuda/std/__type_traits/is_pointer_interconvertible_with_class.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_pointer_interconvertible_with_class.h
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___TYPE_TRAITS_IS_POINTER_INTERCONVERTIBLE_WITH_CLASS_H
+#define _LIBCUDACXX___TYPE_TRAITS_IS_POINTER_INTERCONVERTIBLE_WITH_CLASS_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+_LIBCUDACXX_BEGIN_NAMESPACE_STD
+
+#if defined(_CCCL_BUILTIN_IS_POINTER_INTERCONVERTIBLE_WITH_CLASS)
+
+template <class _Sp, class _Mp>
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr bool
+is_pointer_interconvertible_with_class(_Mp _Sp::* __m_ptr) noexcept
+{
+  return _CCCL_BUILTIN_IS_POINTER_INTERCONVERTIBLE_WITH_CLASS(_Sp, __m_ptr);
+}
+
+#endif // _CCCL_BUILTIN_IS_POINTER_INTERCONVERTIBLE_WITH_CLASS
+
+_LIBCUDACXX_END_NAMESPACE_STD
+
+#endif // _LIBCUDACXX___TYPE_TRAITS_IS_POINTER_INTERCONVERTIBLE_WITH_CLASS_H

--- a/libcudacxx/include/cuda/std/type_traits
+++ b/libcudacxx/include/cuda/std/type_traits
@@ -21,8 +21,6 @@
 #  pragma system_header
 #endif // no system header
 
-_CCCL_PUSH_MACROS
-
 #include <cuda/std/__algorithm/iter_swap.h>
 #include <cuda/std/__functional/identity.h>
 #include <cuda/std/__functional/invoke.h>
@@ -172,7 +170,5 @@ _CCCL_PUSH_MACROS
 #include <cuda/std/cstddef>
 #include <cuda/std/cstdint>
 #include <cuda/std/version>
-
-_CCCL_POP_MACROS
 
 #endif // _CUDA_STD_TYPE_TRAITS

--- a/libcudacxx/include/cuda/std/type_traits
+++ b/libcudacxx/include/cuda/std/type_traits
@@ -21,6 +21,8 @@
 #  pragma system_header
 #endif // no system header
 
+_CCCL_PUSH_MACROS
+
 #include <cuda/std/__algorithm/iter_swap.h>
 #include <cuda/std/__functional/identity.h>
 #include <cuda/std/__functional/invoke.h>
@@ -72,6 +74,7 @@
 #include <cuda/std/__type_traits/is_copy_assignable.h>
 #include <cuda/std/__type_traits/is_copy_constructible.h>
 #include <cuda/std/__type_traits/is_core_convertible.h>
+#include <cuda/std/__type_traits/is_corresponding_member.h>
 #include <cuda/std/__type_traits/is_default_constructible.h>
 #include <cuda/std/__type_traits/is_destructible.h>
 #include <cuda/std/__type_traits/is_empty.h>
@@ -84,6 +87,7 @@
 #include <cuda/std/__type_traits/is_implicitly_default_constructible.h>
 #include <cuda/std/__type_traits/is_integer.h>
 #include <cuda/std/__type_traits/is_integral.h>
+#include <cuda/std/__type_traits/is_layout_compatible.h>
 #include <cuda/std/__type_traits/is_literal_type.h>
 #include <cuda/std/__type_traits/is_member_function_pointer.h>
 #include <cuda/std/__type_traits/is_member_object_pointer.h>
@@ -103,6 +107,8 @@
 #include <cuda/std/__type_traits/is_object.h>
 #include <cuda/std/__type_traits/is_pod.h>
 #include <cuda/std/__type_traits/is_pointer.h>
+#include <cuda/std/__type_traits/is_pointer_interconvertible_base_of.h>
+#include <cuda/std/__type_traits/is_pointer_interconvertible_with_class.h>
 #include <cuda/std/__type_traits/is_polymorphic.h>
 #include <cuda/std/__type_traits/is_primary_template.h>
 #include <cuda/std/__type_traits/is_reference.h>
@@ -166,5 +172,7 @@
 #include <cuda/std/cstddef>
 #include <cuda/std/cstdint>
 #include <cuda/std/version>
+
+_CCCL_POP_MACROS
 
 #endif // _CUDA_STD_TYPE_TRAITS

--- a/libcudacxx/include/cuda/std/version
+++ b/libcudacxx/include/cuda/std/version
@@ -126,6 +126,13 @@
 #ifndef _LIBCUDACXX_HAS_NO_IS_AGGREGATE
 #  define __cccl_lib_is_aggregate 201703L
 #endif // _LIBCUDACXX_HAS_NO_IS_AGGREGATE
+#if defined(_CCCL_BUILTIN_IS_LAYOUT_COMPATIBLE) && defined(_CCCL_BUILTIN_IS_CORRESPONDING_MEMBER)
+#  define __cccl_lib_is_layout_compatible 201907L
+#endif // _CCCL_BUILTIN_IS_LAYOUT_COMPATIBLE && _CCCL_BUILTIN_IS_CORRESPONDING_MEMBER
+#if defined(_CCCL_BUILTIN_IS_POINTER_INTERCONVERTIBLE_BASE_OF) \
+  && defined(_CCCL_BUILTIN_IS_POINTER_INTERCONVERTIBLE_WITH_CLASS)
+#  define __cccl_lib_is_pointer_interconvertible 201907L
+#endif // _BUILTIN_IS_POINTER_INTERCONVERTIBLE_BASE_OF && _CCCL_BUILTIN_IS_POINTER_INTERCONVERTIBLE_WITH_CLASS
 #define __cccl_lib_make_from_tuple 201606L
 // # define __cccl_lib_map_try_emplace                      201411L
 // # define __cccl_lib_math_special_functions               201603L
@@ -196,8 +203,6 @@
 #  ifdef _CCCL_BUILTIN_IS_CONSTANT_EVALUATED
 #    define __cccl_lib_is_constant_evaluated 201811L
 #  endif // _CCCL_BUILTIN_IS_CONSTANT_EVALUATED
-// # define __cccl_lib_is_layout_compatible                 201907L
-// # define __cccl_lib_is_pointer_interconvertible          201907L
 #  if !defined(_LIBCUDACXX_HAS_NO_THREADS)
 // #   define __cccl_lib_jthread                            201911L
 #  endif

--- a/libcudacxx/test/libcudacxx/std/utilities/meta/meta.member/is_corresponding_member.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/meta/meta.member/is_corresponding_member.pass.cpp
@@ -18,7 +18,7 @@ struct A
   float m3;
   double m4;
 
-  void fn() {}
+  __host__ __device__ void fn() {}
 };
 
 struct B
@@ -28,14 +28,14 @@ struct B
   float m3;
   double m4;
 
-  void fn() {}
+  __host__ __device__ void fn() {}
 };
 
 struct NonStandard
     : A
     , B
 {
-  virtual ~NonStandard() {}
+  virtual ~NonStandard() = default;
 
   int m;
 };

--- a/libcudacxx/test/libcudacxx/std/utilities/meta/meta.member/is_corresponding_member.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/meta/meta.member/is_corresponding_member.pass.cpp
@@ -1,0 +1,91 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/type_traits>
+
+struct A
+{
+  int m1;
+  unsigned m2;
+  float m3;
+  double m4;
+
+  void fn() {}
+};
+
+struct B
+{
+  int m1;
+  unsigned m2;
+  float m3;
+  double m4;
+
+  void fn() {}
+};
+
+struct NonStandard
+    : A
+    , B
+{
+  virtual ~NonStandard() {}
+
+  int m;
+};
+
+__host__ __device__ constexpr bool test()
+{
+#if defined(_CCCL_BUILTIN_IS_CORRESPONDING_MEMBER)
+  // 1. Test struct A members to be corresponding with itself
+  static_assert(cuda::std::is_corresponding_member(&A::m1, &A::m1));
+  static_assert(cuda::std::is_corresponding_member(&A::m2, &A::m2));
+  static_assert(cuda::std::is_corresponding_member(&A::m3, &A::m3));
+  static_assert(cuda::std::is_corresponding_member(&A::m4, &A::m4));
+
+  // 2. Test struct A members to be corresponding with struct B members
+  static_assert(cuda::std::is_corresponding_member(&A::m1, &B::m1));
+  static_assert(cuda::std::is_corresponding_member(&A::m2, &B::m2));
+  static_assert(cuda::std::is_corresponding_member(&A::m3, &B::m3));
+  static_assert(cuda::std::is_corresponding_member(&A::m4, &B::m4));
+
+  // 3. Test struct A members not to be corresponding with each other
+  static_assert(!cuda::std::is_corresponding_member(&A::m1, &A::m2));
+  static_assert(!cuda::std::is_corresponding_member(&A::m1, &A::m3));
+  static_assert(!cuda::std::is_corresponding_member(&A::m1, &A::m4));
+  static_assert(!cuda::std::is_corresponding_member(&A::m2, &A::m1));
+  static_assert(!cuda::std::is_corresponding_member(&A::m2, &A::m3));
+  static_assert(!cuda::std::is_corresponding_member(&A::m2, &A::m4));
+  static_assert(!cuda::std::is_corresponding_member(&A::m3, &A::m1));
+  static_assert(!cuda::std::is_corresponding_member(&A::m3, &A::m2));
+  static_assert(!cuda::std::is_corresponding_member(&A::m3, &A::m4));
+  static_assert(!cuda::std::is_corresponding_member(&A::m4, &A::m1));
+  static_assert(!cuda::std::is_corresponding_member(&A::m4, &A::m2));
+  static_assert(!cuda::std::is_corresponding_member(&A::m4, &A::m3));
+
+  // 4. Member functions should not be corresponding
+  static_assert(!cuda::std::is_corresponding_member(&A::fn, &A::fn));
+
+  // 5. If nullptr is passed, it should not be corresponding
+  static_assert(!cuda::std::is_corresponding_member(static_cast<int A::*>(nullptr), static_cast<int A::*>(nullptr)));
+  static_assert(!cuda::std::is_corresponding_member(&A::m1, static_cast<int A::*>(nullptr)));
+  static_assert(!cuda::std::is_corresponding_member(static_cast<int A::*>(nullptr), &A::m1));
+
+  // 6. Non-standard layout types always return false
+  static_assert(!cuda::std::is_corresponding_member(&NonStandard::m, &NonStandard::m));
+#endif // _CCCL_BUILTIN_IS_CORRESPONDING_MEMBER
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/utilities/meta/meta.member/is_corresponding_member.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/meta/meta.member/is_corresponding_member.pass.cpp
@@ -8,6 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <cuda/std/cassert>
 #include <cuda/std/type_traits>
 
 struct A
@@ -43,41 +44,41 @@ __host__ __device__ constexpr bool test()
 {
 #if defined(_CCCL_BUILTIN_IS_CORRESPONDING_MEMBER)
   // 1. Test struct A members to be corresponding with itself
-  static_assert(cuda::std::is_corresponding_member(&A::m1, &A::m1));
-  static_assert(cuda::std::is_corresponding_member(&A::m2, &A::m2));
-  static_assert(cuda::std::is_corresponding_member(&A::m3, &A::m3));
-  static_assert(cuda::std::is_corresponding_member(&A::m4, &A::m4));
+  assert(cuda::std::is_corresponding_member(&A::m1, &A::m1));
+  assert(cuda::std::is_corresponding_member(&A::m2, &A::m2));
+  assert(cuda::std::is_corresponding_member(&A::m3, &A::m3));
+  assert(cuda::std::is_corresponding_member(&A::m4, &A::m4));
 
   // 2. Test struct A members to be corresponding with struct B members
-  static_assert(cuda::std::is_corresponding_member(&A::m1, &B::m1));
-  static_assert(cuda::std::is_corresponding_member(&A::m2, &B::m2));
-  static_assert(cuda::std::is_corresponding_member(&A::m3, &B::m3));
-  static_assert(cuda::std::is_corresponding_member(&A::m4, &B::m4));
+  assert(cuda::std::is_corresponding_member(&A::m1, &B::m1));
+  assert(cuda::std::is_corresponding_member(&A::m2, &B::m2));
+  assert(cuda::std::is_corresponding_member(&A::m3, &B::m3));
+  assert(cuda::std::is_corresponding_member(&A::m4, &B::m4));
 
   // 3. Test struct A members not to be corresponding with each other
-  static_assert(!cuda::std::is_corresponding_member(&A::m1, &A::m2));
-  static_assert(!cuda::std::is_corresponding_member(&A::m1, &A::m3));
-  static_assert(!cuda::std::is_corresponding_member(&A::m1, &A::m4));
-  static_assert(!cuda::std::is_corresponding_member(&A::m2, &A::m1));
-  static_assert(!cuda::std::is_corresponding_member(&A::m2, &A::m3));
-  static_assert(!cuda::std::is_corresponding_member(&A::m2, &A::m4));
-  static_assert(!cuda::std::is_corresponding_member(&A::m3, &A::m1));
-  static_assert(!cuda::std::is_corresponding_member(&A::m3, &A::m2));
-  static_assert(!cuda::std::is_corresponding_member(&A::m3, &A::m4));
-  static_assert(!cuda::std::is_corresponding_member(&A::m4, &A::m1));
-  static_assert(!cuda::std::is_corresponding_member(&A::m4, &A::m2));
-  static_assert(!cuda::std::is_corresponding_member(&A::m4, &A::m3));
+  assert(!cuda::std::is_corresponding_member(&A::m1, &A::m2));
+  assert(!cuda::std::is_corresponding_member(&A::m1, &A::m3));
+  assert(!cuda::std::is_corresponding_member(&A::m1, &A::m4));
+  assert(!cuda::std::is_corresponding_member(&A::m2, &A::m1));
+  assert(!cuda::std::is_corresponding_member(&A::m2, &A::m3));
+  assert(!cuda::std::is_corresponding_member(&A::m2, &A::m4));
+  assert(!cuda::std::is_corresponding_member(&A::m3, &A::m1));
+  assert(!cuda::std::is_corresponding_member(&A::m3, &A::m2));
+  assert(!cuda::std::is_corresponding_member(&A::m3, &A::m4));
+  assert(!cuda::std::is_corresponding_member(&A::m4, &A::m1));
+  assert(!cuda::std::is_corresponding_member(&A::m4, &A::m2));
+  assert(!cuda::std::is_corresponding_member(&A::m4, &A::m3));
 
   // 4. Member functions should not be corresponding
-  static_assert(!cuda::std::is_corresponding_member(&A::fn, &A::fn));
+  assert(!cuda::std::is_corresponding_member(&A::fn, &A::fn));
 
   // 5. If nullptr is passed, it should not be corresponding
-  static_assert(!cuda::std::is_corresponding_member(static_cast<int A::*>(nullptr), static_cast<int A::*>(nullptr)));
-  static_assert(!cuda::std::is_corresponding_member(&A::m1, static_cast<int A::*>(nullptr)));
-  static_assert(!cuda::std::is_corresponding_member(static_cast<int A::*>(nullptr), &A::m1));
+  assert(!cuda::std::is_corresponding_member(static_cast<int A::*>(nullptr), static_cast<int A::*>(nullptr)));
+  assert(!cuda::std::is_corresponding_member(&A::m1, static_cast<int A::*>(nullptr)));
+  assert(!cuda::std::is_corresponding_member(static_cast<int A::*>(nullptr), &A::m1));
 
   // 6. Non-standard layout types always return false
-  static_assert(!cuda::std::is_corresponding_member(&NonStandard::m, &NonStandard::m));
+  assert(!cuda::std::is_corresponding_member(&NonStandard::m, &NonStandard::m));
 #endif // _CCCL_BUILTIN_IS_CORRESPONDING_MEMBER
 
   return true;

--- a/libcudacxx/test/libcudacxx/std/utilities/meta/meta.member/is_pointer_interconvertible_with_class.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/meta/meta.member/is_pointer_interconvertible_with_class.pass.cpp
@@ -16,7 +16,7 @@ struct A
   int ma1;
   unsigned ma2;
 
-  void fn() {}
+  __host__ __device__ void fn() {}
 };
 
 struct B
@@ -24,7 +24,7 @@ struct B
   int mb1;
   unsigned mb2;
 
-  void fn() {}
+  __host__ __device__ void fn() {}
 };
 
 union U
@@ -37,7 +37,7 @@ struct NonStandard
     : A
     , B
 {
-  virtual ~NonStandard() {}
+  virtual ~NonStandard() = default;
 
   int mns1;
 };

--- a/libcudacxx/test/libcudacxx/std/utilities/meta/meta.member/is_pointer_interconvertible_with_class.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/meta/meta.member/is_pointer_interconvertible_with_class.pass.cpp
@@ -1,0 +1,79 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/type_traits>
+
+struct A
+{
+  int ma1;
+  unsigned ma2;
+
+  void fn() {}
+};
+
+struct B
+{
+  int mb1;
+  unsigned mb2;
+
+  void fn() {}
+};
+
+union U
+{
+  int mu1;
+  unsigned mu2;
+};
+
+struct NonStandard
+    : A
+    , B
+{
+  virtual ~NonStandard() {}
+
+  int mns1;
+};
+
+__host__ __device__ constexpr bool test()
+{
+#if defined(_CCCL_BUILTIN_IS_POINTER_INTERCONVERTIBLE_WITH_CLASS)
+  // 1. Only the first member of a class is pointer interconvertible with the class itself
+  static_assert(cuda::std::is_pointer_interconvertible_with_class(&A::ma1));
+  static_assert(cuda::std::is_pointer_interconvertible_with_class(&B::mb1));
+
+  // 2. Rest of the members of a class are not pointer interconvertible with the class itself
+  static_assert(!cuda::std::is_pointer_interconvertible_with_class(&A::ma2));
+  static_assert(!cuda::std::is_pointer_interconvertible_with_class(&B::mb2));
+
+  // 3. All union members are pointer interconvertible with the union itself
+  static_assert(cuda::std::is_pointer_interconvertible_with_class(&U::mu1));
+  static_assert(cuda::std::is_pointer_interconvertible_with_class(&U::mu2));
+
+  // 4. Non-standard layout class members are not pointer interconvertible with the class itself
+  static_assert(!cuda::std::is_pointer_interconvertible_with_class(&NonStandard::mns1));
+
+  // 5. Member functions are not pointer interconvertible with the class itself
+  static_assert(!cuda::std::is_pointer_interconvertible_with_class(&A::fn));
+  static_assert(!cuda::std::is_pointer_interconvertible_with_class(&B::fn));
+
+  // 7. is_pointer_interconvertible_with_class always returns false for nullptr
+  static_assert(!cuda::std::is_pointer_interconvertible_with_class(static_cast<int A::*>(nullptr)));
+  static_assert(!cuda::std::is_pointer_interconvertible_with_class(static_cast<int B::*>(nullptr)));
+#endif // _CCCL_BUILTIN_IS_POINTER_INTERCONVERTIBLE_WITH_CLASS
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/utilities/meta/meta.member/is_pointer_interconvertible_with_class.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/meta/meta.member/is_pointer_interconvertible_with_class.pass.cpp
@@ -8,6 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <cuda/std/cassert>
 #include <cuda/std/type_traits>
 
 struct A
@@ -45,27 +46,27 @@ __host__ __device__ constexpr bool test()
 {
 #if defined(_CCCL_BUILTIN_IS_POINTER_INTERCONVERTIBLE_WITH_CLASS)
   // 1. Only the first member of a class is pointer interconvertible with the class itself
-  static_assert(cuda::std::is_pointer_interconvertible_with_class(&A::ma1));
-  static_assert(cuda::std::is_pointer_interconvertible_with_class(&B::mb1));
+  assert(cuda::std::is_pointer_interconvertible_with_class(&A::ma1));
+  assert(cuda::std::is_pointer_interconvertible_with_class(&B::mb1));
 
   // 2. Rest of the members of a class are not pointer interconvertible with the class itself
-  static_assert(!cuda::std::is_pointer_interconvertible_with_class(&A::ma2));
-  static_assert(!cuda::std::is_pointer_interconvertible_with_class(&B::mb2));
+  assert(!cuda::std::is_pointer_interconvertible_with_class(&A::ma2));
+  assert(!cuda::std::is_pointer_interconvertible_with_class(&B::mb2));
 
   // 3. All union members are pointer interconvertible with the union itself
-  static_assert(cuda::std::is_pointer_interconvertible_with_class(&U::mu1));
-  static_assert(cuda::std::is_pointer_interconvertible_with_class(&U::mu2));
+  assert(cuda::std::is_pointer_interconvertible_with_class(&U::mu1));
+  assert(cuda::std::is_pointer_interconvertible_with_class(&U::mu2));
 
   // 4. Non-standard layout class members are not pointer interconvertible with the class itself
-  static_assert(!cuda::std::is_pointer_interconvertible_with_class(&NonStandard::mns1));
+  assert(!cuda::std::is_pointer_interconvertible_with_class(&NonStandard::mns1));
 
   // 5. Member functions are not pointer interconvertible with the class itself
-  static_assert(!cuda::std::is_pointer_interconvertible_with_class(&A::fn));
-  static_assert(!cuda::std::is_pointer_interconvertible_with_class(&B::fn));
+  assert(!cuda::std::is_pointer_interconvertible_with_class(&A::fn));
+  assert(!cuda::std::is_pointer_interconvertible_with_class(&B::fn));
 
   // 7. is_pointer_interconvertible_with_class always returns false for nullptr
-  static_assert(!cuda::std::is_pointer_interconvertible_with_class(static_cast<int A::*>(nullptr)));
-  static_assert(!cuda::std::is_pointer_interconvertible_with_class(static_cast<int B::*>(nullptr)));
+  assert(!cuda::std::is_pointer_interconvertible_with_class(static_cast<int A::*>(nullptr)));
+  assert(!cuda::std::is_pointer_interconvertible_with_class(static_cast<int B::*>(nullptr)));
 #endif // _CCCL_BUILTIN_IS_POINTER_INTERCONVERTIBLE_WITH_CLASS
 
   return true;

--- a/libcudacxx/test/libcudacxx/std/utilities/meta/meta.rel/is_layout_compatible.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/meta/meta.rel/is_layout_compatible.pass.cpp
@@ -1,0 +1,124 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/cassert>
+#include <cuda/std/type_traits>
+
+struct A
+{
+  int m1;
+  unsigned m2;
+  float m3;
+  double m4;
+
+  void fn() {}
+};
+
+struct B
+{
+  int m1;
+  unsigned m2;
+  float m3;
+  double m4;
+
+  void fn() {}
+};
+
+struct NonStandard
+    : A
+    , B
+{
+  virtual ~NonStandard() {}
+
+  int m;
+};
+
+enum E1 : int
+{
+};
+enum E2 : unsigned
+{
+};
+
+enum class EC1 : int
+{
+};
+enum class EC2 : unsigned
+{
+};
+
+template <class T, class U>
+__host__ __device__ constexpr void test_is_layout_compatible(bool expected)
+{
+#if defined(_CCCL_BUILTIN_IS_LAYOUT_COMPATIBLE)
+  assert((cuda::std::is_layout_compatible<T, U>::value == expected));
+  assert((cuda::std::is_layout_compatible<T, const U>::value == expected));
+  assert((cuda::std::is_layout_compatible<T, const volatile U>::value == expected));
+  assert((cuda::std::is_layout_compatible<const T, U>::value == expected));
+  assert((cuda::std::is_layout_compatible<const T, const U>::value == expected));
+  assert((cuda::std::is_layout_compatible<const T, const volatile U>::value == expected));
+  assert((cuda::std::is_layout_compatible<const volatile T, U>::value == expected));
+  assert((cuda::std::is_layout_compatible<const volatile T, const U>::value == expected));
+  assert((cuda::std::is_layout_compatible<const volatile T, const volatile U>::value == expected));
+
+  assert((cuda::std::is_layout_compatible_v<T, U> == expected));
+  assert((cuda::std::is_layout_compatible_v<T, const U> == expected));
+  assert((cuda::std::is_layout_compatible_v<T, const volatile U> == expected));
+  assert((cuda::std::is_layout_compatible_v<const T, U> == expected));
+  assert((cuda::std::is_layout_compatible_v<const T, const U> == expected));
+  assert((cuda::std::is_layout_compatible_v<const T, const volatile U> == expected));
+  assert((cuda::std::is_layout_compatible_v<const volatile T, U> == expected));
+  assert((cuda::std::is_layout_compatible_v<const volatile T, const U> == expected));
+  assert((cuda::std::is_layout_compatible_v<const volatile T, const volatile U> == expected));
+#endif // _CCCL_BUILTIN_IS_LAYOUT_COMPATIBLE
+}
+
+__host__ __device__ constexpr bool test()
+{
+  // 1. Signed integer type and its unsigned counterpart are not layout-compatible
+  test_is_layout_compatible<int, int>(true);
+  test_is_layout_compatible<unsigned, unsigned>(true);
+  test_is_layout_compatible<int, unsigned>(false);
+  test_is_layout_compatible<unsigned, int>(false);
+
+  // 2. char is layout-compatible with neither signed char nor unsigned char
+  test_is_layout_compatible<char, signed char>(false);
+  test_is_layout_compatible<char, unsigned char>(false);
+  test_is_layout_compatible<signed char, unsigned char>(false);
+  test_is_layout_compatible<signed char, char>(false);
+
+  // 3. Similar types are not layout-compatible if they are not the same type
+  test_is_layout_compatible<const int* const*, int**>(false);
+
+  // 4. An enumeration type and its underlying type are not layout-compatible
+  test_is_layout_compatible<E1, int>(false);
+  test_is_layout_compatible<E2, unsigned>(false);
+  test_is_layout_compatible<EC1, int>(false);
+  test_is_layout_compatible<EC2, unsigned>(false);
+
+  // 5. Enums with same underlying type are layout-compatible
+  test_is_layout_compatible<E1, EC1>(true);
+  test_is_layout_compatible<E2, EC2>(true);
+
+  // 6. Structs with the same layout are layout-compatible
+  test_is_layout_compatible<A, A>(true);
+  test_is_layout_compatible<A, B>(true);
+  test_is_layout_compatible<B, A>(true);
+  test_is_layout_compatible<B, B>(true);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/utilities/meta/meta.rel/is_layout_compatible.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/meta/meta.rel/is_layout_compatible.pass.cpp
@@ -18,7 +18,7 @@ struct A
   float m3;
   double m4;
 
-  void fn() {}
+  __host__ __device__ void fn() {}
 };
 
 struct B
@@ -28,14 +28,14 @@ struct B
   float m3;
   double m4;
 
-  void fn() {}
+  __host__ __device__ void fn() {}
 };
 
 struct NonStandard
     : A
     , B
 {
-  virtual ~NonStandard() {}
+  virtual ~NonStandard() = default;
 
   int m;
 };

--- a/libcudacxx/test/libcudacxx/std/utilities/meta/meta.rel/is_layout_compatible.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/meta/meta.rel/is_layout_compatible.pass.cpp
@@ -60,22 +60,36 @@ __host__ __device__ constexpr void test_is_layout_compatible(bool expected)
 #if defined(_CCCL_BUILTIN_IS_LAYOUT_COMPATIBLE)
   assert((cuda::std::is_layout_compatible<T, U>::value == expected));
   assert((cuda::std::is_layout_compatible<T, const U>::value == expected));
+  assert((cuda::std::is_layout_compatible<T, volatile U>::value == expected));
   assert((cuda::std::is_layout_compatible<T, const volatile U>::value == expected));
   assert((cuda::std::is_layout_compatible<const T, U>::value == expected));
   assert((cuda::std::is_layout_compatible<const T, const U>::value == expected));
+  assert((cuda::std::is_layout_compatible<const T, volatile U>::value == expected));
   assert((cuda::std::is_layout_compatible<const T, const volatile U>::value == expected));
+  assert((cuda::std::is_layout_compatible<volatile T, U>::value == expected));
+  assert((cuda::std::is_layout_compatible<volatile T, const U>::value == expected));
+  assert((cuda::std::is_layout_compatible<volatile T, volatile U>::value == expected));
+  assert((cuda::std::is_layout_compatible<volatile T, const volatile U>::value == expected));
   assert((cuda::std::is_layout_compatible<const volatile T, U>::value == expected));
   assert((cuda::std::is_layout_compatible<const volatile T, const U>::value == expected));
+  assert((cuda::std::is_layout_compatible<const volatile T, volatile U>::value == expected));
   assert((cuda::std::is_layout_compatible<const volatile T, const volatile U>::value == expected));
 
   assert((cuda::std::is_layout_compatible_v<T, U> == expected));
   assert((cuda::std::is_layout_compatible_v<T, const U> == expected));
+  assert((cuda::std::is_layout_compatible_v<T, volatile U> == expected));
   assert((cuda::std::is_layout_compatible_v<T, const volatile U> == expected));
   assert((cuda::std::is_layout_compatible_v<const T, U> == expected));
   assert((cuda::std::is_layout_compatible_v<const T, const U> == expected));
+  assert((cuda::std::is_layout_compatible_v<const T, volatile U> == expected));
   assert((cuda::std::is_layout_compatible_v<const T, const volatile U> == expected));
+  assert((cuda::std::is_layout_compatible_v<volatile T, U> == expected));
+  assert((cuda::std::is_layout_compatible_v<volatile T, const U> == expected));
+  assert((cuda::std::is_layout_compatible_v<volatile T, volatile U> == expected));
+  assert((cuda::std::is_layout_compatible_v<volatile T, const volatile U> == expected));
   assert((cuda::std::is_layout_compatible_v<const volatile T, U> == expected));
   assert((cuda::std::is_layout_compatible_v<const volatile T, const U> == expected));
+  assert((cuda::std::is_layout_compatible_v<const volatile T, volatile U> == expected));
   assert((cuda::std::is_layout_compatible_v<const volatile T, const volatile U> == expected));
 #endif // _CCCL_BUILTIN_IS_LAYOUT_COMPATIBLE
 }

--- a/libcudacxx/test/libcudacxx/std/utilities/meta/meta.rel/is_pointer_interconvertible_base_of.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/meta/meta.rel/is_pointer_interconvertible_base_of.pass.cpp
@@ -17,20 +17,20 @@ struct BaseA
 struct BaseB
 {};
 
-struct A : BaseA
+struct _CCCL_DECLSPEC_EMPTY_BASES A : BaseA
 {};
 
-struct B : BaseB
+struct _CCCL_DECLSPEC_EMPTY_BASES B : BaseB
 {};
 
-struct C
+struct _CCCL_DECLSPEC_EMPTY_BASES C
     : A
     , B
 {
   float m;
 };
 
-struct NonStandard
+struct _CCCL_DECLSPEC_EMPTY_BASES NonStandard
     : BaseA
     , BaseB
 {

--- a/libcudacxx/test/libcudacxx/std/utilities/meta/meta.rel/is_pointer_interconvertible_base_of.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/meta/meta.rel/is_pointer_interconvertible_base_of.pass.cpp
@@ -1,0 +1,101 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/cassert>
+#include <cuda/std/type_traits>
+
+struct BaseA
+{};
+
+struct BaseB
+{};
+
+struct A : BaseA
+{};
+
+struct B : BaseB
+{};
+
+struct C
+    : A
+    , B
+{
+  float m;
+};
+
+struct NonStandard
+    : BaseA
+    , BaseB
+{
+  virtual ~NonStandard() {}
+
+  int m;
+};
+
+template <class T, class U>
+__host__ __device__ constexpr void test_is_pointer_interconvertible_base_of(bool expected)
+{
+#if defined(_CCCL_BUILTIN_IS_POINTER_INTERCONVERTIBLE_BASE_OF)
+  assert((cuda::std::is_pointer_interconvertible_base_of<T, U>::value == expected));
+  assert((cuda::std::is_pointer_interconvertible_base_of<T, const U>::value == expected));
+  assert((cuda::std::is_pointer_interconvertible_base_of<T, const volatile U>::value == expected));
+  assert((cuda::std::is_pointer_interconvertible_base_of<const T, U>::value == expected));
+  assert((cuda::std::is_pointer_interconvertible_base_of<const T, const U>::value == expected));
+  assert((cuda::std::is_pointer_interconvertible_base_of<const T, const volatile U>::value == expected));
+  assert((cuda::std::is_pointer_interconvertible_base_of<const volatile T, U>::value == expected));
+  assert((cuda::std::is_pointer_interconvertible_base_of<const volatile T, const U>::value == expected));
+  assert((cuda::std::is_pointer_interconvertible_base_of<const volatile T, const volatile U>::value == expected));
+
+  assert((cuda::std::is_pointer_interconvertible_base_of_v<T, U> == expected));
+  assert((cuda::std::is_pointer_interconvertible_base_of_v<T, const U> == expected));
+  assert((cuda::std::is_pointer_interconvertible_base_of_v<T, const volatile U> == expected));
+  assert((cuda::std::is_pointer_interconvertible_base_of_v<const T, U> == expected));
+  assert((cuda::std::is_pointer_interconvertible_base_of_v<const T, const U> == expected));
+  assert((cuda::std::is_pointer_interconvertible_base_of_v<const T, const volatile U> == expected));
+  assert((cuda::std::is_pointer_interconvertible_base_of_v<const volatile T, U> == expected));
+  assert((cuda::std::is_pointer_interconvertible_base_of_v<const volatile T, const U> == expected));
+  assert((cuda::std::is_pointer_interconvertible_base_of_v<const volatile T, const volatile U> == expected));
+#endif // _CCCL_BUILTIN_IS_POINTER_INTERCONVERTIBLE_BASE_OF
+}
+
+__host__ __device__ constexpr bool test()
+{
+  // 1. Structs have pointer-interconvertible
+  test_is_pointer_interconvertible_base_of<BaseA, BaseA>(true);
+  test_is_pointer_interconvertible_base_of<BaseB, BaseB>(true);
+  test_is_pointer_interconvertible_base_of<A, A>(true);
+  test_is_pointer_interconvertible_base_of<B, B>(true);
+  test_is_pointer_interconvertible_base_of<C, C>(true);
+
+  // 2. Test derived classes to be pointer-interconvertible with base classes
+  test_is_pointer_interconvertible_base_of<BaseA, A>(true);
+  test_is_pointer_interconvertible_base_of<BaseB, B>(true);
+  test_is_pointer_interconvertible_base_of<BaseA, C>(true);
+  test_is_pointer_interconvertible_base_of<BaseB, C>(true);
+  test_is_pointer_interconvertible_base_of<A, C>(true);
+  test_is_pointer_interconvertible_base_of<B, C>(true);
+
+  // 3. Test combinations returning false
+  test_is_pointer_interconvertible_base_of<A, B>(false);
+  test_is_pointer_interconvertible_base_of<B, A>(false);
+  test_is_pointer_interconvertible_base_of<C, NonStandard>(false);
+  test_is_pointer_interconvertible_base_of<NonStandard, C>(false);
+  test_is_pointer_interconvertible_base_of<int, int>(false);
+  test_is_pointer_interconvertible_base_of<int, A>(false);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/utilities/meta/meta.rel/is_pointer_interconvertible_base_of.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/meta/meta.rel/is_pointer_interconvertible_base_of.pass.cpp
@@ -34,7 +34,7 @@ struct NonStandard
     : BaseA
     , BaseB
 {
-  virtual ~NonStandard() {}
+  virtual ~NonStandard() = default;
 
   int m;
 };

--- a/libcudacxx/test/libcudacxx/std/utilities/meta/meta.rel/is_pointer_interconvertible_base_of.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/meta/meta.rel/is_pointer_interconvertible_base_of.pass.cpp
@@ -45,22 +45,36 @@ __host__ __device__ constexpr void test_is_pointer_interconvertible_base_of(bool
 #if defined(_CCCL_BUILTIN_IS_POINTER_INTERCONVERTIBLE_BASE_OF)
   assert((cuda::std::is_pointer_interconvertible_base_of<T, U>::value == expected));
   assert((cuda::std::is_pointer_interconvertible_base_of<T, const U>::value == expected));
+  assert((cuda::std::is_pointer_interconvertible_base_of<T, volatile U>::value == expected));
   assert((cuda::std::is_pointer_interconvertible_base_of<T, const volatile U>::value == expected));
   assert((cuda::std::is_pointer_interconvertible_base_of<const T, U>::value == expected));
   assert((cuda::std::is_pointer_interconvertible_base_of<const T, const U>::value == expected));
+  assert((cuda::std::is_pointer_interconvertible_base_of<const T, volatile U>::value == expected));
   assert((cuda::std::is_pointer_interconvertible_base_of<const T, const volatile U>::value == expected));
+  assert((cuda::std::is_pointer_interconvertible_base_of<volatile T, U>::value == expected));
+  assert((cuda::std::is_pointer_interconvertible_base_of<volatile T, const U>::value == expected));
+  assert((cuda::std::is_pointer_interconvertible_base_of<volatile T, volatile U>::value == expected));
+  assert((cuda::std::is_pointer_interconvertible_base_of<volatile T, const volatile U>::value == expected));
   assert((cuda::std::is_pointer_interconvertible_base_of<const volatile T, U>::value == expected));
   assert((cuda::std::is_pointer_interconvertible_base_of<const volatile T, const U>::value == expected));
+  assert((cuda::std::is_pointer_interconvertible_base_of<const volatile T, volatile U>::value == expected));
   assert((cuda::std::is_pointer_interconvertible_base_of<const volatile T, const volatile U>::value == expected));
 
   assert((cuda::std::is_pointer_interconvertible_base_of_v<T, U> == expected));
   assert((cuda::std::is_pointer_interconvertible_base_of_v<T, const U> == expected));
+  assert((cuda::std::is_pointer_interconvertible_base_of_v<T, volatile U> == expected));
   assert((cuda::std::is_pointer_interconvertible_base_of_v<T, const volatile U> == expected));
   assert((cuda::std::is_pointer_interconvertible_base_of_v<const T, U> == expected));
   assert((cuda::std::is_pointer_interconvertible_base_of_v<const T, const U> == expected));
+  assert((cuda::std::is_pointer_interconvertible_base_of_v<const T, volatile U> == expected));
   assert((cuda::std::is_pointer_interconvertible_base_of_v<const T, const volatile U> == expected));
+  assert((cuda::std::is_pointer_interconvertible_base_of_v<volatile T, U> == expected));
+  assert((cuda::std::is_pointer_interconvertible_base_of_v<volatile T, const U> == expected));
+  assert((cuda::std::is_pointer_interconvertible_base_of_v<volatile T, volatile U> == expected));
+  assert((cuda::std::is_pointer_interconvertible_base_of_v<volatile T, const volatile U> == expected));
   assert((cuda::std::is_pointer_interconvertible_base_of_v<const volatile T, U> == expected));
   assert((cuda::std::is_pointer_interconvertible_base_of_v<const volatile T, const U> == expected));
+  assert((cuda::std::is_pointer_interconvertible_base_of_v<const volatile T, volatile U> == expected));
   assert((cuda::std::is_pointer_interconvertible_base_of_v<const volatile T, const volatile U> == expected));
 #endif // _CCCL_BUILTIN_IS_POINTER_INTERCONVERTIBLE_BASE_OF
 }


### PR DESCRIPTION
This PR implements *Layout-compatibility and Pointer-interconvertibility Traits* ([P0466R5](https://wg21.link/P0466R5)) from C++20. It is backported to C++17.