### PR TITLE
Streamline algorithm class in Cython

### DIFF
--- a/python/cuda_parallel/cuda/parallel/experimental/_bindings.pyi
+++ b/python/cuda_parallel/cuda/parallel/experimental/_bindings.pyi
@@ -167,15 +167,14 @@ class CommonData:
 # ------------
 
 class DeviceReduceBuildResult:
-    def __init__(self): ...
-    def build(
+    def __init__(
         self,
         d_in: Iterator,
         d_out: Iterator,
         binary_op: Op,
         h_init: Value,
         info: CommonData,
-    ) -> int: ...
+    ): ...
     def compute(
         self,
         temp_storage_ptr: int | None,
@@ -186,15 +185,14 @@ class DeviceReduceBuildResult:
         binary_op: Op,
         h_init: Value,
         stream,
-    ) -> tuple[int, int]: ...
+    ) -> int: ...
 
 # ----------
 # DeviceScan
 # ----------
 
 class DeviceScanBuildResult:
-    def __init__(self): ...
-    def build(
+    def __init__(
         self,
         d_in: Iterator,
         d_out: Iterator,
@@ -202,7 +200,7 @@ class DeviceScanBuildResult:
         h_init: Value,
         force_inclusive: bool,
         info: CommonData,
-    ) -> int: ...
+    ): ...
     def compute_inclusive(
         self,
         temp_storage_ptr: int | None,
@@ -213,7 +211,7 @@ class DeviceScanBuildResult:
         binary_op: Op,
         h_init: Value,
         stream,
-    ) -> tuple[int, int]: ...
+    ) -> int: ...
     def compute_exclusive(
         self,
         temp_storage_ptr: int | None,
@@ -224,15 +222,14 @@ class DeviceScanBuildResult:
         binary_op: Op,
         h_init: Value,
         stream,
-    ) -> tuple[int, int]: ...
+    ) -> int: ...
 
 # ---------------------
 # DeviceSegmentedReduce
 # ---------------------
 
 class DeviceSegmentedReduceBuildResult:
-    def __init__(self): ...
-    def build(
+    def __init__(
         self,
         d_in: Iterator,
         d_out: Iterator,
@@ -241,7 +238,7 @@ class DeviceSegmentedReduceBuildResult:
         binary_op: Op,
         h_init: Value,
         info: CommonData,
-    ) -> int: ...
+    ): ...
     def compute(
         self,
         temp_storage_ptr: int | None,
@@ -254,7 +251,7 @@ class DeviceSegmentedReduceBuildResult:
         binary_op: Op,
         h_init: Value,
         stream,
-    ) -> tuple[int, int]: ...
+    ) -> int: ...
 
 # ---------------
 # DeviceMergeSort

--- a/python/cuda_parallel/cuda/parallel/experimental/algorithms/_reduce.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/algorithms/_reduce.py
@@ -9,7 +9,6 @@ from typing import Callable
 
 import numba
 import numpy as np
-from numba.cuda.cudadrv import enums
 
 from .. import _bindings
 from .. import _cccl_interop as cccl
@@ -38,8 +37,6 @@ class _Reduce:
         op: Callable,
         h_init: np.ndarray | GpuStruct,
     ):
-        self.build_result = _bindings.DeviceReduceBuildResult()
-
         self.d_in_cccl = cccl.to_cccl_iter(d_in)
         self.d_out_cccl = cccl.to_cccl_iter(d_out)
         self.h_init_cccl = cccl.to_cccl_value(h_init)
@@ -49,15 +46,13 @@ class _Reduce:
             value_type = numba.typeof(h_init)
         sig = (value_type, value_type)
         self.op_wrapper = cccl.to_cccl_op(op, sig)
-        error = call_build(
-            self.build_result.build,
+        self.build_result = call_build(
+            _bindings.DeviceReduceBuildResult,
             self.d_in_cccl,
             self.d_out_cccl,
             self.op_wrapper,
             self.h_init_cccl,
         )
-        if error != enums.CUDA_SUCCESS:
-            raise ValueError("Error building reduce")
 
     def __call__(
         self,
@@ -82,7 +77,7 @@ class _Reduce:
             temp_storage_bytes = temp_storage.nbytes
             d_temp_storage = get_data_pointer(temp_storage)
 
-        error, temp_storage_bytes = self.build_result.compute(
+        temp_storage_bytes = self.build_result.compute(
             d_temp_storage,
             temp_storage_bytes,
             self.d_in_cccl,
@@ -92,10 +87,6 @@ class _Reduce:
             self.h_init_cccl,
             stream_handle,
         )
-
-        if error != enums.CUDA_SUCCESS:
-            raise ValueError("Error reducing")
-
         return temp_storage_bytes
 
 

--- a/python/cuda_parallel/cuda/parallel/experimental/algorithms/_scan.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/algorithms/_scan.py
@@ -9,7 +9,6 @@ from typing import Callable
 
 import numba
 import numpy as np
-from numba.cuda.cudadrv import enums
 
 from .. import _bindings
 from .. import _cccl_interop as cccl
@@ -40,8 +39,6 @@ class _Scan:
         h_init: np.ndarray | GpuStruct,
         force_inclusive: bool,
     ):
-        self.build_result = _bindings.DeviceScanBuildResult()
-
         self.d_in_cccl = cccl.to_cccl_iter(d_in)
         self.d_out_cccl = cccl.to_cccl_iter(d_out)
         self.h_init_cccl = cccl.to_cccl_value(h_init)
@@ -51,8 +48,8 @@ class _Scan:
             value_type = numba.typeof(h_init)
         sig = (value_type, value_type)
         self.op_wrapper = cccl.to_cccl_op(op, sig)
-        error = call_build(
-            self.build_result.build,
+        self.build_result = call_build(
+            _bindings.DeviceScanBuildResult,
             self.d_in_cccl,
             self.d_out_cccl,
             self.op_wrapper,
@@ -65,8 +62,6 @@ class _Scan:
             if force_inclusive
             else self.build_result.compute_exclusive
         )
-        if error != enums.CUDA_SUCCESS:
-            raise ValueError("Error building scan")
 
     def __call__(
         self,
@@ -91,7 +86,7 @@ class _Scan:
             temp_storage_bytes = temp_storage.nbytes
             d_temp_storage = get_data_pointer(temp_storage)
 
-        error, temp_storage_bytes = self.device_scan_fn(
+        temp_storage_bytes = self.device_scan_fn(
             d_temp_storage,
             temp_storage_bytes,
             self.d_in_cccl,
@@ -101,10 +96,6 @@ class _Scan:
             self.h_init_cccl,
             stream_handle,
         )
-
-        if error != enums.CUDA_SUCCESS:
-            raise ValueError("Error reducing")
-
         return temp_storage_bytes
 
 


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes gh-4386

This is a follow up to gh-4325 inspired by changes from gh-4320

<!-- Provide a standalone description of changes in this PR. -->

Moved build step into class' __cinit__  which allows to eliminate _initialized member of boolean type.

Moved error handling into Cython, which allows
compute methods to return a single integer rather than a tuple of integers, improving performance of __call__ operator.

This saved about 50-60ns:

```
(cuda_parallel_venv) ~/cccl/python/cuda_parallel $ python data/benchmark_call.py -a reduce -k pointer --time
Time of __call__: 3033.83 ns per submission
(cuda_parallel_venv) ~/cccl/python/cuda_parallel $ python data/benchmark_call.py -a reduce -k pointer --time
Time of __call__: 3084.29 ns per submission
(cuda_parallel_venv) ~/cccl/python/cuda_parallel $ python data/benchmark_call.py -a reduce -k pointer --time
Time of __call__: 3061.69 ns per submission
```
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
