### PR TITLE
Fix version detection in new MatX build functionality.

### DIFF
--- a/ci/matx/build_matx.sh
+++ b/ci/matx/build_matx.sh
@@ -38,7 +38,7 @@ else
     cccl_sha="$(git -C "${cccl_repo}" rev-parse HEAD)";
 fi
 
-readonly cccl_repo_version="$(git -C "${cccl_repo}" describe | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')"
+readonly cccl_repo_version="$(git -C "${cccl_repo}" describe ${cccl_sha}| grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')"
 
 # Define CCCL_VERSION to override the version used by rapids-cmake to patch CCCL.
 echo "CCCL_VERSION (override): ${CCCL_VERSION-}";


### PR DESCRIPTION
We only fetch the `CCCL_TAG` when defined, but don't check it out.
This change ensures that we're checking the correct SHA when detecting the version.