### PR TITLE
[BACKPORT 2.8] Allow rapids to avoid unrolling some loops in sort (#4253)

### DIFF
--- a/cub/cub/block/block_merge_sort.cuh
+++ b/cub/cub/block/block_merge_sort.cuh
@@ -97,7 +97,7 @@ _CCCL_DEVICE _CCCL_FORCEINLINE void SerialMerge(
   KeyT key1 = keys_shared[keys1_beg];
   KeyT key2 = keys_shared[keys2_beg];
 
-#pragma unroll
+  _CCCL_SORT_MAYBE_UNROLL()
   for (int item = 0; item < ITEMS_PER_THREAD; ++item)
   {
     const bool p  = (keys2_beg < keys2_end) && ((keys1_beg >= keys1_end) || compare_op(key2, key1));
@@ -376,7 +376,7 @@ public:
       //
       KeyT max_key = oob_default;
 
-#pragma unroll
+      _CCCL_SORT_MAYBE_UNROLL()
       for (int item = 1; item < ITEMS_PER_THREAD; ++item)
       {
         if (ITEMS_PER_THREAD * linear_tid + item < valid_items)

--- a/cub/cub/thread/thread_sort.cuh
+++ b/cub/cub/thread/thread_sort.cuh
@@ -88,10 +88,10 @@ StableOddEvenSort(KeyT (&keys)[ITEMS_PER_THREAD], ValueT (&items)[ITEMS_PER_THRE
 {
   constexpr bool KEYS_ONLY = ::cuda::std::is_same<ValueT, NullType>::value;
 
-#pragma unroll
+  _CCCL_SORT_MAYBE_UNROLL()
   for (int i = 0; i < ITEMS_PER_THREAD; ++i)
   {
-#pragma unroll
+    _CCCL_SORT_MAYBE_UNROLL()
     for (int j = 1 & i; j < ITEMS_PER_THREAD - 1; j += 2)
     {
       if (compare_op(keys[j + 1], keys[j]))

--- a/cub/cub/util_macro.cuh
+++ b/cub/cub/util_macro.cuh
@@ -144,4 +144,11 @@ _CCCL_DIAG_SUPPRESS_NVHPC(attribute_requires_external_linkage)
     }
 #endif
 
+// RAPIDS cuDF needs to avoid unrolling some loops in sort to prevent compile time issues
+#if defined(CCCL_AVOID_SORT_UNROLL)
+#  define _CCCL_SORT_MAYBE_UNROLL() _CCCL_PRAGMA_NOUNROLL()
+#else // ^^^ CCCL_AVOID_SORT_UNROLL ^^^ / vvv !CCCL_AVOID_SORT_UNROLL vvv
+#  define _CCCL_SORT_MAYBE_UNROLL() _CCCL_PRAGMA_UNROLL_FULL()
+#endif // !CCCL_AVOID_SORT_UNROLL
+
 CUB_NAMESPACE_END

--- a/libcudacxx/include/cuda/std/__cccl/compiler.h
+++ b/libcudacxx/include/cuda/std/__cccl/compiler.h
@@ -120,4 +120,22 @@
 #  endif // !__ELF__
 #endif // _CCCL_COMPILER(NVHPC) || _CCCL_COMPILER(NVRTC)
 
+#if (_CCCL_CUDA_COMPILER(NVCC) && defined(__CUDA_ARCH__)) || _CCCL_COMPILER(NVHPC) || _CCCL_COMPILER(NVRTC) \
+  || _CCCL_COMPILER(CLANG)
+#  define _CCCL_PRAGMA_UNROLL(_N)    _CCCL_PRAGMA(unroll _N)
+#  define _CCCL_PRAGMA_UNROLL_FULL() _CCCL_PRAGMA(unroll)
+#elif _CCCL_COMPILER(GCC, >=, 8)
+// gcc supports only #pragma GCC unroll, but that causes problems when compiling with nvcc. So, we use #pragma unroll
+// when compiling device code, and #pragma GCC unroll when compiling host code, but we need to suppress the warning
+// about the unknown pragma for nvcc.
+// #pragma GCC unroll does not support full unrolling, so we use the maximum value that it supports.
+#  define _CCCL_PRAGMA_UNROLL(_N)    _CCCL_NV_DIAG_SUPPRESS(1675) _CCCL_PRAGMA(GCC unroll _N) _CCCL_NV_DIAG_DEFAULT(1675)
+#  define _CCCL_PRAGMA_UNROLL_FULL() _CCCL_PRAGMA_UNROLL(65534)
+#else // ^^^ has pragma unroll support ^^^ / vvv no pragma unroll support vvv
+#  define _CCCL_PRAGMA_UNROLL(_N)
+#  define _CCCL_PRAGMA_UNROLL_FULL()
+#endif // ^^^ no pragma unroll support ^^^
+
+#define _CCCL_PRAGMA_NOUNROLL() _CCCL_PRAGMA_UNROLL(1)
+
 #endif // __CCCL_COMPILER_H


### PR DESCRIPTION
This avoids one of the last remaining patches they need to apply to CCCL

This would allow rapids to drop all remaining patches to CCCL when they move towards 2.8