### PR TITLE
Fix thrust::uniform_int_distribution last 12-bits always being 0

### DIFF
--- a/thrust/thrust/random/detail/uniform_int_distribution.inl
+++ b/thrust/thrust/random/detail/uniform_int_distribution.inl
@@ -75,7 +75,13 @@ uniform_int_distribution<IntType>::operator()(UniformRandomNumberGenerator& urng
   // XXX adding 1.0 to a potentially large floating point number seems like a bad idea
   uniform_real_distribution<float_type> real_dist(real_min, real_max + float_type(1));
 
-  return static_cast<result_type>(real_dist(urng));
+  // Get the base number from real distribution
+  result_type base = static_cast<result_type>(real_dist(urng));
+
+  // Add random lower bits to fix last 12-bits always being 0.
+  result_type lower_bits = static_cast<result_type>(urng()) & 0xFFF; // Get 12 **uniformly** random bits
+  return base | lower_bits; // Combine them
+
 } // end uniform_int_distribution::operator()()
 
 template <typename IntType>


### PR DESCRIPTION
fixes #758 

Due to `thrust::uniform_int_distribution` relying on `uniform_real_distribution` the last 12-bits, as suggested in the tracking issue, are always `0`. When I run the code from #758 (**but with a full `default_random_engine`**) I get output that looks like:

```bash
...
174c87445d321d00
37171a6adc5c6a00
bd4f637af53d9000
c674004319d0000
c0b13d9f02c4f800
cc428f1d310a4000
fa47ad89e91eb800
717b3fa7c5ed0000
e69896039a625800
dd6696cf759a5800
30ecb360c3b2ce0
9280a8c84a02a000
51d1ff8747480000
...
```

*I am still not entirely sure why 3rd to last (even the 2nd in some rare cases) digit sometimes is not `0`.*

If a full engine is used the trailing zeros will (*or at least should*) be 3 and this PR fixes that by bit-manipulation. After calculating the base as before, we produce a new `12-bit` uniformly random number that we add/append to the base. The result is a new uniformly random number.


> [!NOTE]
> User needs to take care to use a proper engine. The code from the issue is using a `48-bit` engine. That's why there are 4 trailing `0`s, and not 3 as expected when I run the source from the issue with `ranlux48`. Detailed explanation in the [comment under the issue](https://github.com/NVIDIA/cccl/issues/758#issuecomment-2791103349).

```bash
...
4d283257ce8e0000
c9a90e6b5ff70000
44b01f0ccee50000
9723c9f4702a0000
603b1435411f0000
511e574a66b70000
ad200f0af9a10000
e2ea32f7f0010000
c04d33ea804e0000
9363937ffa6b0000
ec1867ba4e5c0000
86751aecd9780000
c37205ce33b70000
9ead0d2b22500000
...
```