### PR TITLE
Implement `cuda::std::is_virtual_base_of`

### DIFF
--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -180,6 +180,15 @@
 // __is_pointer_interconvertible_with_class(_S, _MPtr)
 #endif // ^^^ _CCCL_COMPILER(MSVC, >=, 19, 29) ^^^
 
+#if _CCCL_CHECK_BUILTIN(builtin_is_virtual_base_of)
+#  define _CCCL_BUILTIN_IS_VIRTUAL_BASE_OF(...) __builtin_is_virtual_base_of(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_is_virtual_base_of)
+
+// nvcc < 13.3 doesn't implement __builtin_is_virtual_base_of
+#if _CCCL_CUDA_COMPILER(NVCC, <, 13, 3)
+#  undef _CCCL_BUILTIN_IS_VIRTUAL_BASE_OF
+#endif // _CCCL_CUDA_COMPILER(NVCC, <, 13, 3)
+
 #if _CCCL_CHECK_BUILTIN(builtin_nanf) || _CCCL_COMPILER(MSVC) || _CCCL_COMPILER(GCC, <, 10)
 #  define _CCCL_BUILTIN_NANF(...) __builtin_nanf(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(builtin_nanf)

--- a/libcudacxx/include/cuda/std/__type_traits/is_virtual_base_of.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_virtual_base_of.h
@@ -1,0 +1,58 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the libcu++ Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD___TYPE_TRAITS_IS_VIRTUAL_BASE_OF_H
+#define _CUDA_STD___TYPE_TRAITS_IS_VIRTUAL_BASE_OF_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__type_traits/always_false.h>
+#include <cuda/std/__type_traits/integral_constant.h>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD
+
+#if defined(_CCCL_BUILTIN_IS_VIRTUAL_BASE_OF)
+
+template <class _Base, class _Derived>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT
+is_virtual_base_of : bool_constant<_CCCL_BUILTIN_IS_VIRTUAL_BASE_OF(_Base, _Derived)>
+{};
+
+template <class _Base, class _Derived>
+inline constexpr bool is_virtual_base_of_v = _CCCL_BUILTIN_IS_VIRTUAL_BASE_OF(_Base, _Derived);
+
+#else // ^^^ _CCCL_BUILTIN_IS_VIRTUAL_BASE_OF ^^^ / vvv !_CCCL_BUILTIN_IS_VIRTUAL_BASE_OF vvv
+
+template <class _Base, class _Derived>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_virtual_base_of : false_type
+{
+  static_assert(__always_false_v<_Base>,
+                "cuda::std::is_virtual_base_of: compiler support is required to implement this trait");
+};
+
+template <class _Base, class _Derived>
+inline constexpr bool is_virtual_base_of_v = is_virtual_base_of<_Base, _Derived>::value;
+
+#endif // ^^^ !_CCCL_BUILTIN_IS_VIRTUAL_BASE_OF ^^^
+
+_CCCL_END_NAMESPACE_CUDA_STD
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA_STD___TYPE_TRAITS_IS_VIRTUAL_BASE_OF_H

--- a/libcudacxx/include/cuda/std/type_traits
+++ b/libcudacxx/include/cuda/std/type_traits
@@ -135,6 +135,7 @@
 #include <cuda/std/__type_traits/is_unsigned.h>
 #include <cuda/std/__type_traits/is_unsigned_integer.h>
 #include <cuda/std/__type_traits/is_valid_expansion.h>
+#include <cuda/std/__type_traits/is_virtual_base_of.h>
 #include <cuda/std/__type_traits/is_void.h>
 #include <cuda/std/__type_traits/is_volatile.h>
 #include <cuda/std/__type_traits/lazy.h>

--- a/libcudacxx/include/cuda/std/version
+++ b/libcudacxx/include/cuda/std/version
@@ -46,9 +46,12 @@
 #define __cccl_lib_is_null_pointer              201309L
 #define __cccl_lib_is_scoped_enum               202011L
 #define __cccl_lib_is_swappable                 201603L
-#define __cccl_lib_launder                      201606L
-#define __cccl_lib_logical_traits               201510L
-#define __cccl_lib_math_constants               201907L
+#if defined(_CCCL_BUILTIN_IS_VIRTUAL_BASE_OF)
+#  define __cccl_lib_is_virtual_base_of 202406L
+#endif // _CCCL_BUILTIN_IS_VIRTUAL_BASE_OF
+#define __cccl_lib_launder        201606L
+#define __cccl_lib_logical_traits 201510L
+#define __cccl_lib_math_constants 201907L
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY) \
   && defined(_CCCL_BUILTIN_REFERENCE_CONVERTS_FROM_TEMPORARY)
 #  define __cccl_lib_reference_from_temporary 202202L

--- a/libcudacxx/test/libcudacxx/std/utilities/meta/meta.rel/is_virtual_base_of.compile.fail.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/meta/meta.rel/is_virtual_base_of.compile.fail.cpp
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the libcu++ Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/cassert>
+#include <cuda/std/type_traits>
+
+__host__ __device__ constexpr bool test()
+{
+#if !defined(_CCCL_BUILTIN_IS_VIRTUAL_BASE_OF)
+  static_assert(!cuda::std::is_virtual_base_of<int, int>::value);
+  static_assert(!cuda::std::is_virtual_base_of_v<int, int>);
+#else
+  static_assert(false);
+#endif
+  return true;
+}
+
+int main(int, char**)
+{
+  static_assert(test());
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/utilities/meta/meta.rel/is_virtual_base_of.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/meta/meta.rel/is_virtual_base_of.pass.cpp
@@ -1,0 +1,220 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the libcu++ Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/cassert>
+#include <cuda/std/type_traits>
+
+_CCCL_DIAG_SUPPRESS_MSVC(4594) // class C can never be instantiated - indirect virtual base class D is inaccessible
+_CCCL_DIAG_SUPPRESS_MSVC(4624) // class destructor was implicitly defined as deleted
+
+template <class Base, class Derived>
+__host__ __device__ constexpr void test_is_virtual_base_of(bool expected)
+{
+#if defined(_CCCL_BUILTIN_IS_VIRTUAL_BASE_OF)
+  // Test the type of the variables
+  {
+    static_assert(cuda::std::is_same_v<bool const, decltype(cuda::std::is_virtual_base_of<Base, Derived>::value)>);
+    static_assert(cuda::std::is_same_v<bool const, decltype(cuda::std::is_virtual_base_of_v<Base, Derived>)>);
+  }
+
+  // Test their value
+  {
+    assert((cuda::std::is_virtual_base_of<Base, Derived>::value == expected));
+    assert((cuda::std::is_virtual_base_of<Base, const Derived>::value == expected));
+    assert((cuda::std::is_virtual_base_of<Base, volatile Derived>::value == expected));
+    assert((cuda::std::is_virtual_base_of<Base, const volatile Derived>::value == expected));
+    assert((cuda::std::is_virtual_base_of<const Base, Derived>::value == expected));
+    assert((cuda::std::is_virtual_base_of<const Base, const Derived>::value == expected));
+    assert((cuda::std::is_virtual_base_of<const Base, volatile Derived>::value == expected));
+    assert((cuda::std::is_virtual_base_of<const Base, const volatile Derived>::value == expected));
+    assert((cuda::std::is_virtual_base_of<volatile Base, Derived>::value == expected));
+    assert((cuda::std::is_virtual_base_of<volatile Base, const Derived>::value == expected));
+    assert((cuda::std::is_virtual_base_of<volatile Base, volatile Derived>::value == expected));
+    assert((cuda::std::is_virtual_base_of<volatile Base, const volatile Derived>::value == expected));
+    assert((cuda::std::is_virtual_base_of<const volatile Base, Derived>::value == expected));
+    assert((cuda::std::is_virtual_base_of<const volatile Base, const Derived>::value == expected));
+    assert((cuda::std::is_virtual_base_of<const volatile Base, volatile Derived>::value == expected));
+    assert((cuda::std::is_virtual_base_of<const volatile Base, const volatile Derived>::value == expected));
+
+    assert((cuda::std::is_virtual_base_of_v<Base, Derived> == expected));
+    assert((cuda::std::is_virtual_base_of_v<Base, const Derived> == expected));
+    assert((cuda::std::is_virtual_base_of_v<Base, volatile Derived> == expected));
+    assert((cuda::std::is_virtual_base_of_v<Base, const volatile Derived> == expected));
+    assert((cuda::std::is_virtual_base_of_v<const Base, Derived> == expected));
+    assert((cuda::std::is_virtual_base_of_v<const Base, const Derived> == expected));
+    assert((cuda::std::is_virtual_base_of_v<const Base, volatile Derived> == expected));
+    assert((cuda::std::is_virtual_base_of_v<const Base, const volatile Derived> == expected));
+    assert((cuda::std::is_virtual_base_of_v<volatile Base, Derived> == expected));
+    assert((cuda::std::is_virtual_base_of_v<volatile Base, const Derived> == expected));
+    assert((cuda::std::is_virtual_base_of_v<volatile Base, volatile Derived> == expected));
+    assert((cuda::std::is_virtual_base_of_v<volatile Base, const volatile Derived> == expected));
+    assert((cuda::std::is_virtual_base_of_v<const volatile Base, Derived> == expected));
+    assert((cuda::std::is_virtual_base_of_v<const volatile Base, const Derived> == expected));
+    assert((cuda::std::is_virtual_base_of_v<const volatile Base, volatile Derived> == expected));
+    assert((cuda::std::is_virtual_base_of_v<const volatile Base, const volatile Derived> == expected));
+  }
+
+  // Check the relationship with is_base_of. If it's not a base of, it can't be a virtual base of.
+  {
+    assert((!cuda::std::is_base_of_v<Base, Derived> ? !cuda::std::is_virtual_base_of_v<Base, Derived> : true));
+  }
+
+  // Make sure they can be referenced at runtime
+  {
+    bool const& a = cuda::std::is_virtual_base_of<Base, Derived>::value;
+    bool const& b = cuda::std::is_virtual_base_of_v<Base, Derived>;
+    assert(a == expected);
+    assert(b == expected);
+  }
+#endif // defined(_CCCL_BUILTIN_IS_VIRTUAL_BASE_OF)
+}
+
+struct Incomplete;
+struct Unrelated
+{};
+union IncompleteUnion;
+union Union
+{
+  int i;
+  float f;
+};
+
+class Base
+{};
+class Derived : Base
+{};
+class Derived2 : Base
+{};
+class Derived2a : Derived
+{};
+class Derived2b : Derived
+{};
+class Derived3Virtual
+    : virtual Derived2a
+    , virtual Derived2b
+{};
+
+struct DerivedTransitiveViaNonVirtual : Derived3Virtual
+{};
+struct DerivedTransitiveViaVirtual : virtual Derived3Virtual
+{};
+
+template <typename T>
+struct CrazyDerived : T
+{};
+template <typename T>
+struct CrazyDerivedVirtual : virtual T
+{};
+
+struct DerivedPrivate : private virtual Base
+{};
+struct DerivedProtected : protected virtual Base
+{};
+struct DerivedPrivatePrivate : private DerivedPrivate
+{};
+struct DerivedPrivateProtected : private DerivedProtected
+{};
+struct DerivedProtectedPrivate : protected DerivedProtected
+{};
+struct DerivedProtectedProtected : protected DerivedProtected
+{};
+struct DerivedTransitivePrivate
+    : private Derived
+    , private Derived2
+{};
+
+__host__ __device__ constexpr bool test()
+{
+  // Test with non-virtual inheritance
+  {
+    test_is_virtual_base_of<Base, Base>(false);
+    test_is_virtual_base_of<Base, Derived>(false);
+    test_is_virtual_base_of<Base, Derived2>(false);
+    test_is_virtual_base_of<Derived, DerivedTransitivePrivate>(false);
+    test_is_virtual_base_of<Derived, Base>(false);
+    test_is_virtual_base_of<Incomplete, Derived>(false);
+  }
+
+  // Test with virtual inheritance
+  {
+    // gcc and clang don't agree on whether these 2 should be true or false - gcc (thus edg as well) says yes, clang
+    // says no. Let's just disable these and see what msvc does in the future.
+    // test_is_virtual_base_of<Base, Derived3Virtual>(false);
+    // test_is_virtual_base_of<Derived, Derived3Virtual>(false);
+    test_is_virtual_base_of<Derived2b, Derived3Virtual>(true);
+    test_is_virtual_base_of<Derived2a, Derived3Virtual>(true);
+    test_is_virtual_base_of<Base, DerivedPrivate>(true);
+    test_is_virtual_base_of<Base, DerivedProtected>(true);
+    test_is_virtual_base_of<Base, DerivedPrivatePrivate>(true);
+    test_is_virtual_base_of<Base, DerivedPrivateProtected>(true);
+    test_is_virtual_base_of<Base, DerivedProtectedPrivate>(true);
+    test_is_virtual_base_of<Base, DerivedProtectedProtected>(true);
+    test_is_virtual_base_of<Derived2a, DerivedTransitiveViaNonVirtual>(true);
+    test_is_virtual_base_of<Derived2b, DerivedTransitiveViaNonVirtual>(true);
+    test_is_virtual_base_of<Derived2a, DerivedTransitiveViaVirtual>(true);
+    test_is_virtual_base_of<Derived2b, DerivedTransitiveViaVirtual>(true);
+    test_is_virtual_base_of<Base, CrazyDerived<Base>>(false);
+    test_is_virtual_base_of<CrazyDerived<Base>, Base>(false);
+    test_is_virtual_base_of<Base, CrazyDerivedVirtual<Base>>(true);
+    test_is_virtual_base_of<CrazyDerivedVirtual<Base>, Base>(false);
+  }
+
+  // Test unrelated types
+  {
+    test_is_virtual_base_of<Base&, Derived&>(false);
+    test_is_virtual_base_of<Base[3], Derived[3]>(false);
+    test_is_virtual_base_of<Unrelated, Derived>(false);
+    test_is_virtual_base_of<Base, Unrelated>(false);
+    test_is_virtual_base_of<Base, void>(false);
+    test_is_virtual_base_of<void, Derived>(false);
+  }
+
+  // Test scalar types
+  {
+    test_is_virtual_base_of<int, Base>(false);
+    test_is_virtual_base_of<int, Derived>(false);
+    test_is_virtual_base_of<int, Incomplete>(false);
+    test_is_virtual_base_of<int, int>(false);
+
+    test_is_virtual_base_of<Base, int>(false);
+    test_is_virtual_base_of<Derived, int>(false);
+    test_is_virtual_base_of<Incomplete, int>(false);
+
+    test_is_virtual_base_of<int[], int[]>(false);
+    test_is_virtual_base_of<long, int>(false);
+    test_is_virtual_base_of<int, long>(false);
+  }
+
+  // Test unions
+  {
+    test_is_virtual_base_of<Union, Union>(false);
+    test_is_virtual_base_of<IncompleteUnion, IncompleteUnion>(false);
+    test_is_virtual_base_of<Union, IncompleteUnion>(false);
+    test_is_virtual_base_of<IncompleteUnion, Union>(false);
+    test_is_virtual_base_of<Incomplete, IncompleteUnion>(false);
+    test_is_virtual_base_of<IncompleteUnion, Incomplete>(false);
+    test_is_virtual_base_of<Unrelated, IncompleteUnion>(false);
+    test_is_virtual_base_of<IncompleteUnion, Unrelated>(false);
+    test_is_virtual_base_of<int, IncompleteUnion>(false);
+    test_is_virtual_base_of<IncompleteUnion, int>(false);
+    test_is_virtual_base_of<Unrelated, Union>(false);
+    test_is_virtual_base_of<Union, Unrelated>(false);
+    test_is_virtual_base_of<int, Unrelated>(false);
+    test_is_virtual_base_of<Union, int>(false);
+  }
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+  return 0;
+}


### PR DESCRIPTION
This PR implements *A type trait for detecting virtual base classes* [P2985R0](https://wg21.link/P2985R0) from C++26.

The implementation requires compiler builtins that are available in gcc >= 15 and clang >= 20, so we should postpone the testing when those compilers are added to the CI.