### PR TITLE
[STF] Add a unit test with a logical data of an  mdspan with static size extents

### DIFF
--- a/cudax/include/cuda/experimental/__stf/internal/context.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/context.cuh
@@ -1318,6 +1318,30 @@ UNITTEST("logical data slice const")
   ctx.finalize();
 };
 
+// Ensure we can manipulate mdspan with static extents
+UNITTEST("mdspan static extents")
+{
+  context ctx;
+  using index_t = ::std::size_t;
+  ::std::array<int, 16 * 32> data{};
+  cuda::std::mdspan<int, cuda::std::extents<index_t, 16, 32>> m(data.data());
+
+  static_assert(decltype(m)::extents_type::static_extent(0) == 16);
+  static_assert(decltype(m)::extents_type::static_extent(1) == 32);
+
+  auto lm = ctx.logical_data(m);
+
+  ctx.task(lm.rw())->*[](cudaStream_t stream, auto dm)
+  {
+     static_assert(decltype(dm)::extents_type::static_extent(0) == 16);
+     static_assert(decltype(dm)::extents_type::static_extent(1) == 32);
+  };
+
+  ctx.finalize();
+};
+
+
+
 inline void unit_test_partitioner_product()
 {
   context ctx;


### PR DESCRIPTION
## Description

We want to make sure we do not loose the nice properties of mdspan when manipulating thing by the means of logical data facilitie

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes <!-- Link issue here -->

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
