### PR TITLE
fix `basic_any` on nvhpc when not compiling as CUDA

### DIFF
--- a/cudax/include/cuda/experimental/__utility/basic_any/semiregular.cuh
+++ b/cudax/include/cuda/experimental/__utility/basic_any/semiregular.cuh
@@ -46,7 +46,7 @@
 _CCCL_PUSH_MACROS
 #undef interface
 
-#if _CCCL_CUDA_COMPILER(NVCC) || _CCCL_CUDA_COMPILER(NVHPC)
+#if _CCCL_CUDA_COMPILER(NVCC) || _CCCL_COMPILER(NVHPC)
 // WAR for NVBUG #4924416
 #  define _CUDAX_FNPTR_CONSTANT_WAR(...) ::cuda::experimental::__constant_war(__VA_ARGS__)
 namespace cuda::experimental
@@ -57,10 +57,10 @@ template <class _Tp>
   return __val;
 }
 } // namespace cuda::experimental
-#else // ^^^ _CCCL_CUDA_COMPILER(NVCC) || _CCCL_CUDA_COMPILER(NVHPC) ^^^ /
-      // vvv !_CCCL_CUDA_COMPILER(NVCC) && !_CCCL_CUDA_COMPILER(NVHPC) vvv
+#else // ^^^ _CCCL_CUDA_COMPILER(NVCC) || _CCCL_COMPILER(NVHPC) ^^^ /
+      // vvv !_CCCL_CUDA_COMPILER(NVCC) && !_CCCL_COMPILER(NVHPC) vvv
 #  define _CUDAX_FNPTR_CONSTANT_WAR(...) __VA_ARGS__
-#endif // !_CCCL_CUDA_COMPILER(NVCC) && !_CCCL_CUDA_COMPILER(NVHPC)
+#endif // !_CCCL_CUDA_COMPILER(NVCC) && !_CCCL_COMPILER(NVHPC)
 
 namespace cuda::experimental
 {

--- a/cudax/include/cuda/experimental/__utility/basic_any/semiregular.cuh
+++ b/cudax/include/cuda/experimental/__utility/basic_any/semiregular.cuh
@@ -46,7 +46,7 @@
 _CCCL_PUSH_MACROS
 #undef interface
 
-#if _CCCL_COMPILER(NVHPC)
+#if _CCCL_CUDA_COMPILER(NVCC) || _CCCL_COMPILER(NVHPC)
 // WAR for NVBUG #4924416
 #  define _CUDAX_FNPTR_CONSTANT_WAR(...) ::cuda::experimental::__constant_war(__VA_ARGS__)
 namespace cuda::experimental
@@ -57,9 +57,10 @@ template <class _Tp>
   return __val;
 }
 } // namespace cuda::experimental
-#else // ^^^ _CCCL_COMPILER(NVHPC) ^^^ / vvv !_CCCL_COMPILER(NVHPC) vvv
+#else // ^^^ _CCCL_CUDA_COMPILER(NVCC) || _CCCL_COMPILER(NVHPC) ^^^ /
+      // vvv !_CCCL_CUDA_COMPILER(NVCC) && !_CCCL_COMPILER(NVHPC) vvv
 #  define _CUDAX_FNPTR_CONSTANT_WAR(...) __VA_ARGS__
-#endif // !_CCCL_COMPILER(NVHPC)
+#endif // !_CCCL_CUDA_COMPILER(NVCC) && !_CCCL_COMPILER(NVHPC)
 
 namespace cuda::experimental
 {

--- a/cudax/include/cuda/experimental/__utility/basic_any/semiregular.cuh
+++ b/cudax/include/cuda/experimental/__utility/basic_any/semiregular.cuh
@@ -46,7 +46,7 @@
 _CCCL_PUSH_MACROS
 #undef interface
 
-#if _CCCL_CUDA_COMPILER(NVCC) || _CCCL_COMPILER(NVHPC)
+#if _CCCL_COMPILER(NVHPC)
 // WAR for NVBUG #4924416
 #  define _CUDAX_FNPTR_CONSTANT_WAR(...) ::cuda::experimental::__constant_war(__VA_ARGS__)
 namespace cuda::experimental
@@ -57,10 +57,9 @@ template <class _Tp>
   return __val;
 }
 } // namespace cuda::experimental
-#else // ^^^ _CCCL_CUDA_COMPILER(NVCC) || _CCCL_COMPILER(NVHPC) ^^^ /
-      // vvv !_CCCL_CUDA_COMPILER(NVCC) && !_CCCL_COMPILER(NVHPC) vvv
+#else // ^^^ _CCCL_COMPILER(NVHPC) ^^^ / vvv !_CCCL_COMPILER(NVHPC) vvv
 #  define _CUDAX_FNPTR_CONSTANT_WAR(...) __VA_ARGS__
-#endif // !_CCCL_CUDA_COMPILER(NVCC) && !_CCCL_COMPILER(NVHPC)
+#endif // !_CCCL_COMPILER(NVHPC)
 
 namespace cuda::experimental
 {


### PR DESCRIPTION
there is a workaround in `basic_any` for nvbug#4924416 for nvcc and nvhpc. unfortunately, the workaround is only applied for nvhpc when compiling for CUDA.

this commit changes the PP guard from:

    _CCCL_CUDA_COMPILER(NVHPC)

to:

    _CCCL_COMPILER(NVHPC)
