### PR TITLE
avoid use of `NV_IF_TARGET` in constexpr `char_traits<char>::length`

### DIFF
--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__string
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__string
@@ -266,9 +266,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT char_traits<char>
     }
 #endif
 #if defined(_CCCL_BUILTIN_STRLEN)
-    NV_IF_ELSE_TARGET(NV_IS_DEVICE,
-                      (size_t __len = 0; for (; !eq(*__s, char(0)); ++__s)++ __len; return __len;),
-                      (return _CCCL_BUILTIN_STRLEN(__s);))
+    return _CCCL_BUILTIN_STRLEN(__s);
 #else
     size_t __len = 0;
     for (; !eq(*__s, char(0)); ++__s)


### PR DESCRIPTION
## Description

`_CCCL_TYPEID` is busted when compiling as CUDA with nvc++. that's because it indirectly depends on `char_traits<char>::length`, requiring it to be `constexpr`. but that function uses `NV_IF_TARGET`, which cannot be `constexpr` on nvc++:

```
note: cannot call non-constexpr function "__builtin_is_device_code" (declared implicitly)
      NV_IF_ELSE_TARGET(NV_IS_DEVICE,
      ^
```

this PR is an experiment to see what breaks when we remove the `NV_IF_TARGET`. i know it's there for a reason.