### PR TITLE
Implement `cuda::__unegate` utility

### DIFF
--- a/libcudacxx/include/cuda/__cmath/unegate.h
+++ b/libcudacxx/include/cuda/__cmath/unegate.h
@@ -1,0 +1,49 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA___CMATH_UNEGATE_H
+#define _CUDA___CMATH_UNEGATE_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__concepts/concept_macros.h>
+#include <cuda/std/__type_traits/is_signed.h>
+#include <cuda/std/__type_traits/is_unsigned_integer.h>
+#include <cuda/std/__type_traits/make_signed.h>
+#include <cuda/std/limits>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_CUDA
+
+//! @brief Returns the *signed* negative value of the given *unsigned* number.
+//! @param __v The input number
+//! @pre \p __v must be an unsigned integer type
+//! @pre \p __v must be less than or equal to the maximum representable value of the signed type + 1
+//! @return The signed negative value of \p __v
+_CCCL_TEMPLATE(class _Up)
+_CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::__cccl_is_cv_unsigned_integer, _Up))
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _CUDA_VSTD::make_signed_t<_Up> __unegate(_Up __v) noexcept
+{
+  using _Tp           = _CUDA_VSTD::make_signed_t<_Up>;
+  constexpr _Up __max = static_cast<_Up>(_CUDA_VSTD::numeric_limits<_Tp>::max()) + 1;
+  _CCCL_ASSERT(__v <= __max, "__unegate called with a value greater than the maximum representable value");
+  return (__v == __max) ? std::numeric_limits<_Tp>::min() : -static_cast<_Tp>(__v);
+}
+
+_LIBCUDACXX_END_NAMESPACE_CUDA
+
+#endif // _CUDA___CMATH_UNEGATE_H

--- a/libcudacxx/include/cuda/cmath
+++ b/libcudacxx/include/cuda/cmath
@@ -26,6 +26,7 @@
 #include <cuda/__cmath/round_down.h>
 #include <cuda/__cmath/round_up.h>
 #include <cuda/__cmath/uabs.h>
+#include <cuda/__cmath/unegate.h>
 #include <cuda/std/cmath>
 
 #endif // _CUDA_CMATH

--- a/libcudacxx/test/libcudacxx/libcxx/numerics/c.math/unegate.fail.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/numerics/c.math/unegate.fail.cpp
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/cmath>
+#include <cuda/std/cassert>
+#include <cuda/std/limits>
+
+template <class T>
+__host__ __device__ constexpr void test_type()
+{
+  using U = cuda::std::make_unsigned_t<T>;
+
+  cuda::__unegate(U(U(cuda::std::numeric_limits<T>::max()) + 2));
+  cuda::__unegate(cuda::std::numeric_limits<U>::max());
+}
+
+__host__ __device__ constexpr bool test()
+{
+  test_type<signed char>();
+  test_type<signed short>();
+  test_type<signed int>();
+  test_type<signed long>();
+  test_type<signed long long>();
+#if _CCCL_HAS_INT128()
+  test_type<__int128_t>();
+#endif // _CCCL_HAS_INT128()
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/numerics/c.math/unegate.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/numerics/c.math/unegate.pass.cpp
@@ -1,0 +1,56 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/cmath>
+#include <cuda/std/cassert>
+#include <cuda/std/limits>
+#include <cuda/std/type_traits>
+
+template <class U, class T>
+__host__ __device__ constexpr void test_unegate(U input, T ref)
+{
+  assert(cuda::__unegate(input) == ref);
+}
+
+template <class T>
+__host__ __device__ constexpr void test_type()
+{
+  using U = cuda::std::make_unsigned_t<T>;
+
+  static_assert(cuda::std::is_same_v<decltype(cuda::__unegate(U{})), T>);
+  static_assert(noexcept(cuda::uabs(T{})));
+
+  test_unegate(U(0), T(0));
+  test_unegate(U(1), T(-1));
+  test_unegate(U(100), T(-100));
+  test_unegate(U(cuda::std::numeric_limits<T>::max()), T(cuda::std::numeric_limits<T>::min() + 1));
+  test_unegate(U(U(cuda::std::numeric_limits<T>::max()) + 1), cuda::std::numeric_limits<T>::min());
+}
+
+__host__ __device__ constexpr bool test()
+{
+  test_type<signed char>();
+  test_type<signed short>();
+  test_type<signed int>();
+  test_type<signed long>();
+  test_type<signed long long>();
+#if _CCCL_HAS_INT128()
+  test_type<__int128_t>();
+#endif // _CCCL_HAS_INT128()
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+  return 0;
+}


### PR DESCRIPTION
This PR implements `cuda::__unegate` utility that negates an unsigned value to a signed value enabling to use all of the signed range without triggering undefined behaviour.
