### PR TITLE
avoid EDG bug by moving diagnostic push & pop out of templates

### DIFF
--- a/libcudacxx/include/cuda/std/__bit/reference.h
+++ b/libcudacxx/include/cuda/std/__bit/reference.h
@@ -478,6 +478,9 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr __bit_iterator<_Cp, false> __copy_backward_a
   return __result;
 }
 
+_CCCL_DIAG_PUSH
+_CCCL_DIAG_SUPPRESS_MSVC(4146) // unary minus applied to unsigned type
+
 template <class _Cp, bool _IsConst>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr __bit_iterator<_Cp, false> __copy_backward_unaligned(
   __bit_iterator<_Cp, _IsConst> __first, __bit_iterator<_Cp, _IsConst> __last, __bit_iterator<_Cp, false> __result)
@@ -512,11 +515,8 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr __bit_iterator<_Cp, false> __copy_backward_u
         {
           *__result.__seg_ |= __b >> (__last.__ctz_ - __result.__ctz_);
         }
-        _CCCL_DIAG_PUSH
-        _CCCL_DIAG_SUPPRESS_MSVC(4146) // unary minus applied to unsigned type
         __result.__ctz_ =
           static_cast<unsigned>((((-__ddn & (__bits_per_word - 1)) + __result.__ctz_) % __bits_per_word).__data);
-        _CCCL_DIAG_POP
         __dn -= __ddn.__data;
       }
       if (__dn > 0)
@@ -570,11 +570,8 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr __bit_iterator<_Cp, false> __copy_backward_u
       __m                 = (~__storage_type(0) << (__result.__ctz_ - __dn)) & (~__storage_type(0) >> __clz_r);
       *__result.__seg_ &= ~__m;
       *__result.__seg_ |= __b >> (__bits_per_word - __result.__ctz_);
-      _CCCL_DIAG_PUSH
-      _CCCL_DIAG_SUPPRESS_MSVC(4146) // unary minus applied to unsigned type
       __result.__ctz_ =
         static_cast<unsigned>((((-__dn & (__bits_per_word - 1)) + __result.__ctz_) % __bits_per_word).__data);
-      _CCCL_DIAG_POP
       __n -= __dn.__data;
       if (__n > 0)
       {
@@ -589,6 +586,8 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr __bit_iterator<_Cp, false> __copy_backward_u
   }
   return __result;
 }
+
+_CCCL_DIAG_POP
 
 template <class _Cp, bool _IsConst>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr __bit_iterator<_Cp, false> copy_backward(

--- a/libcudacxx/include/cuda/std/array
+++ b/libcudacxx/include/cuda/std/array
@@ -221,6 +221,9 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT array
   }
 };
 
+_CCCL_DIAG_PUSH
+_CCCL_DIAG_SUPPRESS_MSVC(4702) // Unreachable code
+
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT array<_Tp, 0>
 {
@@ -332,8 +335,6 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT array<_Tp, 0>
     return true;
   }
 
-  _CCCL_DIAG_PUSH
-  _CCCL_DIAG_SUPPRESS_MSVC(4702) // Unreachable code
   // element access:
   [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr reference operator[](size_type) noexcept
   {
@@ -388,8 +389,9 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT array<_Tp, 0>
     _CCCL_UNREACHABLE();
     return *data();
   }
-  _CCCL_DIAG_POP
 };
+
+_CCCL_DIAG_POP
 
 _CCCL_TEMPLATE(class _Tp, class... _Args)
 _CCCL_REQUIRES((_CCCL_TRAIT(is_same, _Tp, _Args) && ...))

--- a/libcudacxx/include/cuda/std/bitset
+++ b/libcudacxx/include/cuda/std/bitset
@@ -50,6 +50,9 @@ _CCCL_PUSH_MACROS
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_DIAG_PUSH
+_CCCL_DIAG_SUPPRESS_MSVC(4146) // unary minus applied to an unsigned type
+
 template <class _Int>
 struct __avoid_promotions
 {
@@ -81,10 +84,7 @@ struct __avoid_promotions
   }
 
   _DEFINE_UNARY(~)
-  _CCCL_DIAG_PUSH
-  _CCCL_DIAG_SUPPRESS_MSVC(4146) // unary minus applied to an unsigned type
   _DEFINE_UNARY(-)
-  _CCCL_DIAG_POP
 #undef _DEFINE_UNARY
 
 #define _DEFINE_SHIFT(__op)                                                                                            \
@@ -175,6 +175,8 @@ struct __avoid_promotions
 
   _Int __data;
 };
+
+_CCCL_DIAG_POP
 
 static_assert(sizeof(__avoid_promotions<uint_least8_t>) == sizeof(uint_least8_t), "");
 static_assert(sizeof(__avoid_promotions<uint_least16_t>) == sizeof(uint_least16_t), "");
@@ -432,6 +434,9 @@ private:
   }
 };
 
+_CCCL_DIAG_PUSH
+_CCCL_DIAG_SUPPRESS_MSVC(4293) // shift count negative or too big
+                               // MSVC is slightly overeager with diagnosing that here
 template <size_t _Size>
 class __bitset<1, _Size>
 {
@@ -464,15 +469,11 @@ protected:
       : __first_(0)
   {}
 
-  _CCCL_DIAG_PUSH
-  _CCCL_DIAG_SUPPRESS_MSVC(4293) // shift count negative or too big
-                                 // MSVC is slightly overeager with diagnosing that here
   _LIBCUDACXX_HIDE_FROM_ABI explicit constexpr __bitset(unsigned long long __v) noexcept
       : __first_(_Size == __bits_per_word
                    ? static_cast<__storage_type>(__v)
                    : static_cast<__storage_type>(__v) & ((__storage_type(1) << _Size) - __storage_type(1)))
   {}
-  _CCCL_DIAG_POP
 
   _LIBCUDACXX_HIDE_FROM_ABI constexpr reference __make_ref(size_t __pos) noexcept
   {
@@ -559,6 +560,8 @@ protected:
     return __first_;
   }
 };
+
+_CCCL_DIAG_POP
 
 template <>
 class __bitset<0, 0>


### PR DESCRIPTION
## Description

i recently discovered a nasty bug in the HPC compiler involving `pragma diagnostic [push|pop]` that can cause the front end to hang in specific circumstances. (nvidians can see [nvbugs#5216501](https://nvbugspro.nvidia.com/bug/5216501) for the details.) the issue happens when the pushes and pops are in templates. to be safe, all pragma push/pops should be at namespace scope.

this PR fixes the few places in libstdcxx that were doing pushes and pops in templates.
