### PR TITLE
add `_CCCL_UNREACHABLE` after returning uses of `NV_DISPATCH_TARGET`

### DIFF
--- a/libcudacxx/include/cuda/__barrier/barrier_block_scope.h
+++ b/libcudacxx/include/cuda/__barrier/barrier_block_scope.h
@@ -359,6 +359,7 @@ private:
       NV_ANY_TARGET,
       (return _CUDA_VSTD::__cccl_thread_poll_with_backoff(
                 _CUDA_VSTD::__barrier_poll_tester_parity<barrier>(this, __phase_parity), __nanosec);))
+    _CCCL_UNREACHABLE();
   }
 
 public:

--- a/libcudacxx/include/cuda/__memcpy_async/try_get_barrier_handle.h
+++ b/libcudacxx/include/cuda/__memcpy_async/try_get_barrier_handle.h
@@ -47,6 +47,7 @@ __try_get_barrier_handle<::cuda::thread_scope_block, _CUDA_VSTD::__empty_complet
 {
   NV_DISPATCH_TARGET(
     NV_IS_DEVICE, (return ::cuda::device::barrier_native_handle(__barrier);), NV_ANY_TARGET, (return nullptr;));
+  _CCCL_UNREACHABLE();
 }
 
 _LIBCUDACXX_END_NAMESPACE_CUDA

--- a/libcudacxx/include/cuda/std/__atomic/types/base.h
+++ b/libcudacxx/include/cuda/std/__atomic/types/base.h
@@ -106,6 +106,7 @@ _CCCL_HOST_DEVICE inline auto __atomic_load_dispatch(const _Sto* __a, memory_ord
     (return __atomic_load_n_cuda(__a->get(), static_cast<__memory_order_underlying_t>(__order), _Sco{});),
     NV_IS_HOST,
     (return __atomic_load_host(__a->get(), __order);))
+  _CCCL_UNREACHABLE();
 }
 
 template <typename _Sto, typename _Up, typename _Sco, __atomic_storage_is_base<_Sto> = 0>
@@ -117,6 +118,7 @@ _CCCL_HOST_DEVICE inline auto __atomic_exchange_dispatch(_Sto* __a, _Up __value,
     (return __atomic_exchange_n_cuda(__a->get(), __value, static_cast<__memory_order_underlying_t>(__order), _Sco{});),
     NV_IS_HOST,
     (return __atomic_exchange_host(__a->get(), __value, __order);))
+  _CCCL_UNREACHABLE();
 }
 
 template <typename _Sto, typename _Up, typename _Sco, __atomic_storage_is_base<_Sto> = 0>
@@ -168,6 +170,7 @@ _CCCL_HOST_DEVICE inline auto __atomic_fetch_add_dispatch(_Sto* __a, _Up __delta
     (return __atomic_fetch_add_cuda(__a->get(), __delta, static_cast<__memory_order_underlying_t>(__order), _Sco{});),
     NV_IS_HOST,
     (return __atomic_fetch_add_host(__a->get(), __delta, __order);))
+  _CCCL_UNREACHABLE();
 }
 
 template <typename _Sto, typename _Up, typename _Sco, __atomic_storage_is_base<_Sto> = 0>
@@ -179,6 +182,7 @@ _CCCL_HOST_DEVICE inline auto __atomic_fetch_sub_dispatch(_Sto* __a, _Up __delta
     (return __atomic_fetch_sub_cuda(__a->get(), __delta, static_cast<__memory_order_underlying_t>(__order), _Sco{});),
     NV_IS_HOST,
     (return __atomic_fetch_sub_host(__a->get(), __delta, __order);))
+  _CCCL_UNREACHABLE();
 }
 
 template <typename _Sto, typename _Up, typename _Sco, __atomic_storage_is_base<_Sto> = 0>
@@ -190,6 +194,7 @@ _CCCL_HOST_DEVICE inline auto __atomic_fetch_and_dispatch(_Sto* __a, _Up __patte
     (return __atomic_fetch_and_cuda(__a->get(), __pattern, static_cast<__memory_order_underlying_t>(__order), _Sco{});),
     NV_IS_HOST,
     (return __atomic_fetch_and_host(__a->get(), __pattern, __order);))
+  _CCCL_UNREACHABLE();
 }
 
 template <typename _Sto, typename _Up, typename _Sco, __atomic_storage_is_base<_Sto> = 0>
@@ -201,6 +206,7 @@ _CCCL_HOST_DEVICE inline auto __atomic_fetch_or_dispatch(_Sto* __a, _Up __patter
     (return __atomic_fetch_or_cuda(__a->get(), __pattern, static_cast<__memory_order_underlying_t>(__order), _Sco{});),
     NV_IS_HOST,
     (return __atomic_fetch_or_host(__a->get(), __pattern, __order);))
+  _CCCL_UNREACHABLE();
 }
 
 template <typename _Sto, typename _Up, typename _Sco, __atomic_storage_is_base<_Sto> = 0>
@@ -212,6 +218,7 @@ _CCCL_HOST_DEVICE inline auto __atomic_fetch_xor_dispatch(_Sto* __a, _Up __patte
     (return __atomic_fetch_xor_cuda(__a->get(), __pattern, static_cast<__memory_order_underlying_t>(__order), _Sco{});),
     NV_IS_HOST,
     (return __atomic_fetch_xor_host(__a->get(), __pattern, __order);))
+  _CCCL_UNREACHABLE();
 }
 
 template <typename _Sto, typename _Up, typename _Sco, __atomic_storage_is_base<_Sto> = 0>

--- a/libcudacxx/include/cuda/std/__atomic/types/common.h
+++ b/libcudacxx/include/cuda/std/__atomic/types/common.h
@@ -93,6 +93,7 @@ _CCCL_HOST_DEVICE inline int __atomic_memcmp(void const* __lhs, void const* __rh
      } return 0;),
     NV_IS_HOST,
     (return _CUDA_VSTD::memcmp(__lhs, __rhs, __count);))
+  _CCCL_UNREACHABLE();
 }
 
 _LIBCUDACXX_END_NAMESPACE_STD

--- a/libcudacxx/include/cuda/std/__cuda/chrono.h
+++ b/libcudacxx/include/cuda/std/__cuda/chrono.h
@@ -38,6 +38,7 @@ _LIBCUDACXX_HIDE_FROM_ABI system_clock::time_point system_clock::now() noexcept
     (return time_point(duration_cast<duration>(nanoseconds(
       ::std::chrono::duration_cast<::std::chrono::nanoseconds>(::std::chrono::system_clock::now().time_since_epoch())
         .count())));));
+  _CCCL_UNREACHABLE();
 }
 
 _LIBCUDACXX_HIDE_FROM_ABI time_t system_clock::to_time_t(const system_clock::time_point& __t) noexcept


### PR DESCRIPTION
## Description

like #4416 , this PR is a mitigation for a nasty bug in the HPC compiler involving `pragma diagnostic [push|pop]` that can cause the front end to hang in specific circumstances. (nvidians can see [nvbugs#5216501](https://nvbugspro.nvidia.com/bug/5216501) for the details.) 

although the problem is specifically with pushing and popping diagnostic state, the problem only seems to happen when attempting to emit a suppressed diagnostic. one such source of diagnostics with nvc++ is the following usage pattern of `NV_DISPATCH_TARGET`:

```c++
int some_function( some arguments... )
{
  NV_DISPATCH_TARGET(
    NV_IF_HOST,
    (return something;),
    NV_IF_DEVICE,
    (return something_else;))
}
```

nvc++ thinks this function is missing a return statement. cccl often suppresses that warning on nvc++, so code like this is likely to trigger the compiler bug.

this PR fixes such places by adding `_CCCL_UNREACHABLE()` in places where this pattern would cause nvc++ to issue a diagnostic.
