### PR TITLE
cuda.parallel: Exclude allocation times from pytest-benchmarks + add struct benchmarks

### DIFF
--- a/python/cuda_parallel/benchmarks/bench_merge_sort.py
+++ b/python/cuda_parallel/benchmarks/bench_merge_sort.py
@@ -103,7 +103,9 @@ def bench_merge_sort_iterator(benchmark, size):
     output_vals = cp.empty(size, dtype="int64")
 
     def run():
-        merge_sort_iterator(size, keys, vals, output_keys, output_vals, build_only=False)
+        merge_sort_iterator(
+            size, keys, vals, output_keys, output_vals, build_only=False
+        )
 
     benchmark(run)
 

--- a/python/cuda_parallel/benchmarks/bench_merge_sort.py
+++ b/python/cuda_parallel/benchmarks/bench_merge_sort.py
@@ -22,14 +22,7 @@ def merge_sort_pointer(keys, vals, output_keys, output_vals, build_only):
     cp.cuda.runtime.deviceSynchronize()
 
 
-def merge_sort_iterator(size, output_keys, output_vals, build_only):
-    keys_dt = cp.int32
-    vals_dt = cp.int64
-    keys = iterators.CountingIterator(np.int32(0))
-    vals = iterators.CountingIterator(np.int64(0))
-    output_keys = cp.empty(size, dtype=keys_dt)
-    output_vals = cp.empty(size, dtype=vals_dt)
-
+def merge_sort_iterator(size, keys, vals, output_keys, output_vals, build_only):
     def my_cmp(a: np.int32, b: np.int32) -> np.int32:
         return np.int32(a < b)
 
@@ -80,11 +73,13 @@ def bench_compile_merge_sort_pointer(compile_benchmark):
 
 def bench_compile_merge_sort_iterator(compile_benchmark):
     size = 100
+    keys = iterators.CountingIterator(np.int32(0))
+    vals = iterators.CountingIterator(np.int64(0))
     output_keys = cp.empty(size, dtype="int32")
     output_vals = cp.empty(size, dtype="int64")
 
     def run():
-        merge_sort_iterator(size, output_keys, output_vals, build_only=True)
+        merge_sort_iterator(size, keys, vals, output_keys, output_vals, build_only=True)
 
     compile_benchmark(algorithms.merge_sort, run)
 
@@ -102,11 +97,13 @@ def bench_merge_sort_pointer(benchmark, size):
 
 
 def bench_merge_sort_iterator(benchmark, size):
+    keys = iterators.CountingIterator(np.int32(0))
+    vals = iterators.CountingIterator(np.int64(0))
     output_keys = cp.empty(size, dtype="int32")
     output_vals = cp.empty(size, dtype="int64")
 
     def run():
-        merge_sort_iterator(size, output_keys, output_vals, build_only=False)
+        merge_sort_iterator(size, keys, vals, output_keys, output_vals, build_only=False)
 
     benchmark(run)
 

--- a/python/cuda_parallel/benchmarks/bench_merge_sort.py
+++ b/python/cuda_parallel/benchmarks/bench_merge_sort.py
@@ -13,10 +13,10 @@ def merge_sort_pointer(keys, vals, output_keys, output_vals, build_only):
         return np.int32(a < b)
 
     alg = algorithms.merge_sort(keys, vals, output_keys, output_vals, my_cmp)
-    temp_bytes = alg(None, keys, vals, output_keys, output_vals, size)
-    scratch = cp.empty(temp_bytes, dtype=cp.uint8)
 
     if not build_only:
+        temp_bytes = alg(None, keys, vals, output_keys, output_vals, size)
+        scratch = cp.empty(temp_bytes, dtype=cp.uint8)
         alg(scratch, keys, vals, output_keys, output_vals, size)
 
     cp.cuda.runtime.deviceSynchronize()
@@ -34,10 +34,10 @@ def merge_sort_iterator(size, output_keys, output_vals, build_only):
         return np.int32(a < b)
 
     alg = algorithms.merge_sort(keys, vals, output_keys, output_vals, my_cmp)
-    temp_bytes = alg(None, keys, vals, output_keys, output_vals, size)
-    scratch = cp.empty(temp_bytes, dtype=cp.uint8)
 
     if not build_only:
+        temp_bytes = alg(None, keys, vals, output_keys, output_vals, size)
+        scratch = cp.empty(temp_bytes, dtype=cp.uint8)
         alg(scratch, keys, vals, output_keys, output_vals, size)
 
     cp.cuda.runtime.deviceSynchronize()

--- a/python/cuda_parallel/benchmarks/bench_merge_sort.py
+++ b/python/cuda_parallel/benchmarks/bench_merge_sort.py
@@ -5,57 +5,84 @@ import cuda.parallel.experimental.algorithms as algorithms
 import cuda.parallel.experimental.iterators as iterators
 
 
-def merge_sort_pointer(size, build_only):
-    keys = cp.arange(size, dtype="i4")
-    vals = cp.arange(size, dtype="i8")
-    res_keys = cp.empty_like(keys)
-    res_vals = cp.empty_like(vals)
+def merge_sort_pointer(keys, vals, output_keys, output_vals, build_only):
+    size = len(keys)
 
     def my_cmp(a: np.int32, b: np.int32) -> np.int32:
         return np.int32(a < b)
 
-    alg = algorithms.merge_sort(keys, vals, res_keys, res_vals, my_cmp)
-    temp_bytes = alg(None, keys, vals, res_keys, res_vals, size)
+    alg = algorithms.merge_sort(keys, vals, output_keys, output_vals, my_cmp)
+    temp_bytes = alg(None, keys, vals, output_keys, output_vals, size)
     scratch = cp.empty(temp_bytes, dtype=cp.uint8)
 
     if not build_only:
-        alg(scratch, keys, vals, res_keys, res_vals, size)
+        alg(scratch, keys, vals, output_keys, output_vals, size)
 
     cp.cuda.runtime.deviceSynchronize()
 
 
-def merge_sort_iterator(size, build_only):
+def merge_sort_iterator(size, output_keys, output_vals, build_only):
     keys_dt = cp.int32
     vals_dt = cp.int64
     keys = iterators.CountingIterator(np.int32(0))
     vals = iterators.CountingIterator(np.int64(0))
-    res_keys = cp.empty(size, dtype=keys_dt)
-    res_vals = cp.empty(size, dtype=vals_dt)
+    output_keys = cp.empty(size, dtype=keys_dt)
+    output_vals = cp.empty(size, dtype=vals_dt)
 
     def my_cmp(a: np.int32, b: np.int32) -> np.int32:
         return np.int32(a < b)
 
-    alg = algorithms.merge_sort(keys, vals, res_keys, res_vals, my_cmp)
-    temp_bytes = alg(None, keys, vals, res_keys, res_vals, size)
+    alg = algorithms.merge_sort(keys, vals, output_keys, output_vals, my_cmp)
+    temp_bytes = alg(None, keys, vals, output_keys, output_vals, size)
     scratch = cp.empty(temp_bytes, dtype=cp.uint8)
 
     if not build_only:
-        alg(scratch, keys, vals, res_keys, res_vals, size)
+        alg(scratch, keys, vals, output_keys, output_vals, size)
 
     cp.cuda.runtime.deviceSynchronize()
 
 
 def bench_compile_merge_sort_pointer(compile_benchmark):
-    compile_benchmark(algorithms.merge_sort, merge_sort_pointer)
+    size = 100
+    keys = cp.random.randint(0, 10, size)
+    vals = cp.random.randint(0, 10, size)
+    output_keys = cp.empty_like(keys)
+    output_vals = cp.empty_like(vals)
+
+    def run():
+        merge_sort_pointer(keys, vals, output_keys, output_vals, build_only=True)
+
+    compile_benchmark(algorithms.merge_sort, run)
 
 
 def bench_compile_merge_sort_iterator(compile_benchmark):
-    compile_benchmark(algorithms.merge_sort, merge_sort_iterator)
+    size = 100
+    output_keys = cp.zeros(size, dtype="int32")
+    output_vals = cp.zeros(size, dtype="int64")
+
+    def run():
+        merge_sort_iterator(size, output_keys, output_vals, build_only=True)
+
+    compile_benchmark(algorithms.merge_sort, run)
 
 
 def bench_merge_sort_pointer(benchmark, size):
-    benchmark(merge_sort_pointer, size, build_only=False)
+    keys = cp.random.randint(0, 10, size)
+    vals = cp.random.randint(0, 10, size)
+    output_keys = cp.empty_like(keys)
+    output_vals = cp.empty_like(vals)
+
+    def run():
+        merge_sort_pointer(keys, vals, output_keys, output_vals, build_only=False)
+
+    benchmark(run)
 
 
 def bench_merge_sort_iterator(benchmark, size):
-    benchmark(merge_sort_iterator, size, build_only=False)
+    output_keys = cp.zeros(size, dtype="int32")
+    output_vals = cp.zeros(size, dtype="int64")
+
+    def run():
+        merge_sort_iterator(size, output_keys, output_vals, build_only=False)
+
+    benchmark(run)

--- a/python/cuda_parallel/benchmarks/bench_merge_sort.py
+++ b/python/cuda_parallel/benchmarks/bench_merge_sort.py
@@ -57,8 +57,8 @@ def bench_compile_merge_sort_pointer(compile_benchmark):
 
 def bench_compile_merge_sort_iterator(compile_benchmark):
     size = 100
-    output_keys = cp.zeros(size, dtype="int32")
-    output_vals = cp.zeros(size, dtype="int64")
+    output_keys = cp.empty(size, dtype="int32")
+    output_vals = cp.empty(size, dtype="int64")
 
     def run():
         merge_sort_iterator(size, output_keys, output_vals, build_only=True)
@@ -79,8 +79,8 @@ def bench_merge_sort_pointer(benchmark, size):
 
 
 def bench_merge_sort_iterator(benchmark, size):
-    output_keys = cp.zeros(size, dtype="int32")
-    output_vals = cp.zeros(size, dtype="int64")
+    output_keys = cp.empty(size, dtype="int32")
+    output_vals = cp.empty(size, dtype="int64")
 
     def run():
         merge_sort_iterator(size, output_keys, output_vals, build_only=False)

--- a/python/cuda_parallel/benchmarks/bench_reduce.py
+++ b/python/cuda_parallel/benchmarks/bench_reduce.py
@@ -42,21 +42,20 @@ def reduce_struct(input_array, build_only):
     cp.cuda.runtime.deviceSynchronize()
 
 
-def reduce_iterator(size, build_only):
+def reduce_iterator(inp, size, build_only):
     dt = cp.int32
-    d = iterators.CountingIterator(np.int32(0))
     res = cp.empty(tuple(), dtype=dt)
     h_init = np.zeros(tuple(), dtype=dt)
 
     def my_add(a, b):
         return a + b
 
-    alg = algorithms.reduce_into(d, res, my_add, h_init)
+    alg = algorithms.reduce_into(inp, res, my_add, h_init)
 
     if not build_only:
-        temp_bytes = alg(None, d, res, size, h_init)
+        temp_bytes = alg(None, inp, res, size, h_init)
         scratch = cp.empty(temp_bytes, dtype=cp.uint8)
-        alg(scratch, d, res, size, h_init)
+        alg(scratch, inp, res, size, h_init)
 
     cp.cuda.runtime.deviceSynchronize()
 
@@ -77,8 +76,11 @@ def bench_compile_reduce_pointer(compile_benchmark):
 
 
 def bench_compile_reduce_iterator(compile_benchmark):
+
+    inp = iterators.CountingIterator(np.int32(0))
+    
     def run():
-        reduce_iterator(10, build_only=True)
+        reduce_iterator(inp, 10, build_only=True)
 
     compile_benchmark(algorithms.reduce_into, run)
 
@@ -93,8 +95,10 @@ def bench_reduce_pointer(benchmark, size):
 
 
 def bench_reduce_iterator(benchmark, size):
+    inp = iterators.CountingIterator(np.int32(0))
+
     def run():
-        reduce_iterator(size, build_only=False)
+        reduce_iterator(inp, size, build_only=False)
 
     benchmark(run)
 

--- a/python/cuda_parallel/benchmarks/bench_reduce.py
+++ b/python/cuda_parallel/benchmarks/bench_reduce.py
@@ -76,9 +76,8 @@ def bench_compile_reduce_pointer(compile_benchmark):
 
 
 def bench_compile_reduce_iterator(compile_benchmark):
-
     inp = iterators.CountingIterator(np.int32(0))
-    
+
     def run():
         reduce_iterator(inp, 10, build_only=True)
 

--- a/python/cuda_parallel/benchmarks/bench_reduce.py
+++ b/python/cuda_parallel/benchmarks/bench_reduce.py
@@ -15,10 +15,10 @@ def reduce_pointer(input_array, build_only):
         return a + b
 
     alg = algorithms.reduce_into(input_array, res, my_add, h_init)
-    temp_bytes = alg(None, input_array, res, size, h_init)
-    scratch = cp.empty(temp_bytes, dtype=cp.uint8)
 
     if not build_only:
+        temp_bytes = alg(None, input_array, res, size, h_init)
+        scratch = cp.empty(temp_bytes, dtype=cp.uint8)
         alg(scratch, input_array, res, size, h_init)
 
     cp.cuda.runtime.deviceSynchronize()

--- a/python/cuda_parallel/benchmarks/bench_transform.py
+++ b/python/cuda_parallel/benchmarks/bench_transform.py
@@ -5,95 +5,140 @@ import cuda.parallel.experimental.algorithms as algorithms
 import cuda.parallel.experimental.iterators as iterators
 
 
-def unary_transform_pointer(size, build_only):
-    d_in = cp.arange(size, dtype="i4")
-    d_out = cp.empty_like(d_in)
+def unary_transform_pointer(inp, out, build_only):
+    size = len(inp)
 
     def op(a):
         return a + 1
 
-    transform = algorithms.unary_transform(d_in, d_out, op)
+    transform = algorithms.unary_transform(inp, out, op)
 
     if not build_only:
-        transform(d_in, d_out, size)
+        transform(inp, out, size)
 
     cp.cuda.runtime.deviceSynchronize()
 
 
-def unary_transform_iterator(size, build_only):
+def unary_transform_iterator(size, out, build_only):
     d_in = iterators.CountingIterator(np.int32(0))
-    d_out = cp.empty(size, dtype=np.int32)
 
     def op(a):
         return a + 1
 
-    transform = algorithms.unary_transform(d_in, d_out, op)
+    transform = algorithms.unary_transform(d_in, out, op)
 
     if not build_only:
-        transform(d_in, d_out, size)
+        transform(d_in, out, size)
 
     cp.cuda.runtime.deviceSynchronize()
 
 
-def binary_transform_pointer(size, build_only):
-    d_in1 = cp.arange(size, dtype="i4")
-    d_in2 = cp.arange(size, dtype="i4")
-    d_out = cp.empty_like(d_in1)
+def binary_transform_pointer(inp1, inp2, out, build_only):
+    size = len(inp1)
 
     def op(a, b):
         return a + b
 
-    transform = algorithms.binary_transform(d_in1, d_in2, d_out, op)
+    transform = algorithms.binary_transform(inp1, inp2, out, op)
 
     if not build_only:
-        transform(d_in1, d_in2, d_out, size)
+        transform(inp1, inp2, out, size)
 
     cp.cuda.runtime.deviceSynchronize()
 
 
-def binary_transform_iterator(size, build_only):
+def binary_transform_iterator(size, out, build_only):
     d_in1 = iterators.CountingIterator(np.int32(0))
     d_in2 = iterators.CountingIterator(np.int32(1))
-    d_out = cp.empty(size, dtype=np.int32)
 
     def op(a, b):
         return a + b
 
-    transform = algorithms.binary_transform(d_in1, d_in2, d_out, op)
+    transform = algorithms.binary_transform(d_in1, d_in2, out, op)
 
     if not build_only:
-        transform(d_in1, d_in2, d_out, size)
+        transform(d_in1, d_in2, out, size)
 
     cp.cuda.runtime.deviceSynchronize()
 
 
 def bench_compile_unary_transform_pointer(compile_benchmark):
-    compile_benchmark(algorithms.unary_transform, unary_transform_pointer)
+    size = 100
+    inp = cp.random.randint(0, 10, size)
+    out = cp.empty_like(inp)
+
+    def run():
+        unary_transform_pointer(inp, out, build_only=True)
+
+    compile_benchmark(algorithms.unary_transform, run)
 
 
 def bench_compile_unary_transform_iterator(compile_benchmark):
-    compile_benchmark(algorithms.unary_transform, unary_transform_iterator)
+    size = 100
+    out = cp.empty(size, dtype="int32")
+
+    def run():
+        unary_transform_iterator(size, out, build_only=True)
+
+    compile_benchmark(algorithms.unary_transform, run)
 
 
 def bench_compile_binary_transform_pointer(compile_benchmark):
-    compile_benchmark(algorithms.binary_transform, binary_transform_pointer)
+    size = 100
+    inp1 = cp.random.randint(0, 10, size)
+    inp2 = cp.random.randint(0, 10, size)
+    out = cp.empty_like(inp1)
+
+    def run():
+        binary_transform_pointer(inp1, inp2, out, build_only=True)
+
+    compile_benchmark(algorithms.binary_transform, run)
 
 
 def bench_compile_binary_transform_iterator(compile_benchmark):
-    compile_benchmark(algorithms.binary_transform, binary_transform_iterator)
+    size = 100
+    out = cp.empty(size, dtype="int32")
+
+    def run():
+        binary_transform_iterator(size, out, build_only=True)
+
+    compile_benchmark(algorithms.binary_transform, run)
 
 
 def bench_unary_transform_pointer(benchmark, size):
-    benchmark(unary_transform_pointer, size, build_only=False)
+    inp = cp.random.randint(0, 10, size)
+    out = cp.empty_like(inp)
+
+    def run():
+        unary_transform_pointer(inp, out, build_only=False)
+
+    benchmark(run)
 
 
 def bench_unary_transform_iterator(benchmark, size):
-    benchmark(unary_transform_iterator, size, build_only=False)
+    out = cp.empty(size, dtype="int32")
+
+    def run():
+        unary_transform_iterator(size, out, build_only=False)
+
+    benchmark(run)
 
 
 def bench_binary_transform_pointer(benchmark, size):
-    benchmark(binary_transform_pointer, size, build_only=False)
+    inp1 = cp.random.randint(0, 10, size)
+    inp2 = cp.random.randint(0, 10, size)
+    out = cp.empty_like(inp1)
+
+    def run():
+        binary_transform_pointer(inp1, inp2, out, build_only=False)
+
+    benchmark(run)
 
 
 def bench_binary_transform_iterator(benchmark, size):
-    benchmark(binary_transform_iterator, size, build_only=False)
+    out = cp.empty(size, dtype="int32")
+
+    def run():
+        binary_transform_iterator(size, out, build_only=False)
+
+    benchmark(run)

--- a/python/cuda_parallel/benchmarks/conftest.py
+++ b/python/cuda_parallel/benchmarks/conftest.py
@@ -21,7 +21,6 @@ def compile_benchmark(benchmark):
 
         benchmark.pedantic(
             function,
-            kwargs={"size": 10, "build_only": True},
             rounds=3,
             iterations=1,
             setup=setup,

--- a/python/cuda_parallel/cuda/parallel/experimental/algorithms/_merge_sort.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/algorithms/_merge_sort.py
@@ -79,12 +79,8 @@ class _MergeSort:
         self.d_out_keys_cccl = cccl.to_cccl_iter(d_out_keys)
         self.d_out_items_cccl = cccl.to_cccl_iter(d_out_items)
 
-        if isinstance(d_in_keys, IteratorBase):
-            value_type = d_in_keys.value_type
-        else:
-            value_type = numba.from_dtype(protocols.get_dtype(d_in_keys))
-
-        sig = (value_type, value_type)
+        value_type = cccl.get_value_type(d_in_keys)
+        sig = numba.types.int8(value_type, value_type)
         self.op_wrapper = cccl.to_cccl_op(op, sig)
 
         self.build_result = call_build(


### PR DESCRIPTION
## Description

This PR makes a modification to the cuda.parallel (Python) benchmarks so that allocations (for input and output arrays) are not included in the benchmark timings. 

Additionally, benchmarks for struct inputs are added.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
