### PR TITLE
c/parallel should be built with CUB_DISABLE_CDP

### DIFF
--- a/c/parallel/CMakeLists.txt
+++ b/c/parallel/CMakeLists.txt
@@ -41,7 +41,7 @@ target_link_libraries(cccl.c.parallel PRIVATE
   Thrust::Thrust
 )
 target_compile_definitions(cccl.c.parallel PUBLIC CCCL_C_EXPERIMENTAL=1 _CUB_HAS_TRANSFORM_UBLKCP=0)
-target_compile_definitions(cccl.c.parallel PRIVATE NVRTC_GET_TYPE_NAME=1)
+target_compile_definitions(cccl.c.parallel PRIVATE NVRTC_GET_TYPE_NAME=1 CUB_DISABLE_CDP=1)
 target_compile_options(cccl.c.parallel PRIVATE $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:--extended-lambda>)
 
 target_include_directories(cccl.c.parallel PUBLIC "include")


### PR DESCRIPTION
Library functions launch kernels from the host only. Setting this variable causes CUB_RUNTIME_FUNCTION to be _CCCL_HOST, and hence compiler won't generate CUB dispatch functions for the device, speeding up compilation.

## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes #4421

<!-- Provide a standalone description of changes in this PR. -->

This PR changes `c/parallel/CMakeLists.txt` to set `CUB_DISABLE_CDP=1` when building the library.

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
