### PR TITLE
Remove extra semicolons in Thrust

### DIFF
--- a/thrust/testing/copy.cu
+++ b/thrust/testing/copy.cu
@@ -442,7 +442,7 @@ struct always_true
   _CCCL_HOST_DEVICE bool operator()(const object_with_non_trivial_ctor&)
   {
     return true;
-  };
+  }
 };
 
 } // namespace

--- a/thrust/testing/unittest/testframework.h
+++ b/thrust/testing/unittest/testframework.h
@@ -179,7 +179,7 @@ public:
   DEFINE_OPERATOR(>)
   DEFINE_OPERATOR(>=)
   DEFINE_OPERATOR(&&)
-  DEFINE_OPERATOR(||);
+  DEFINE_OPERATOR(||)
 
 #undef DEFINE_OPERATOR
 
@@ -320,7 +320,7 @@ protected:
   virtual bool post_test_smoke_check(const UnitTest& test, bool concise);
 
 public:
-  inline virtual ~UnitTestDriver() {};
+  inline virtual ~UnitTestDriver() {}
 
   void register_test(UnitTest* test);
   virtual bool run_tests(const ArgumentSet& args, const ArgumentMap& kwargs);

--- a/thrust/thrust/detail/contiguous_storage.h
+++ b/thrust/thrust/detail/contiguous_storage.h
@@ -205,7 +205,7 @@ public:
   // allow move assignment for a sane implementation of allocator propagation
   _CCCL_HOST_DEVICE contiguous_storage& operator=(contiguous_storage&& other);
 
-  _CCCL_SYNTHESIZE_SEQUENCE_ACCESS(contiguous_storage, const_iterator);
+  _CCCL_SYNTHESIZE_SEQUENCE_ACCESS(contiguous_storage, const_iterator)
 
 private:
   // XXX we could inherit from this to take advantage of empty base class optimization

--- a/thrust/thrust/detail/range/head_flags.h
+++ b/thrust/thrust/detail/range/head_flags.h
@@ -92,7 +92,7 @@ public:
     return *(begin() + i);
   }
 
-  _CCCL_SYNTHESIZE_SEQUENCE_ACCESS(head_flags, iterator);
+  _CCCL_SYNTHESIZE_SEQUENCE_ACCESS(head_flags, iterator)
 
 private:
   iterator m_begin;

--- a/thrust/thrust/detail/range/tail_flags.h
+++ b/thrust/thrust/detail/range/tail_flags.h
@@ -107,7 +107,7 @@ public:
     return *(begin() + i);
   }
 
-  _CCCL_SYNTHESIZE_SEQUENCE_ACCESS(tail_flags, iterator);
+  _CCCL_SYNTHESIZE_SEQUENCE_ACCESS(tail_flags, iterator)
 
 private:
   iterator m_begin, m_end;

--- a/thrust/thrust/detail/vector_base.h
+++ b/thrust/thrust/detail/vector_base.h
@@ -480,8 +480,8 @@ public:
    */
   allocator_type get_allocator() const;
 
-  _CCCL_SYNTHESIZE_SEQUENCE_ACCESS(vector_base, const_iterator);
-  _CCCL_SYNTHESIZE_SEQUENCE_REVERSE_ACCESS(vector_base, const_reverse_iterator);
+  _CCCL_SYNTHESIZE_SEQUENCE_ACCESS(vector_base, const_iterator)
+  _CCCL_SYNTHESIZE_SEQUENCE_REVERSE_ACCESS(vector_base, const_reverse_iterator)
 
 protected:
   // Our storage

--- a/thrust/thrust/system/detail/bad_alloc.h
+++ b/thrust/thrust/system/detail/bad_alloc.h
@@ -48,7 +48,7 @@ public:
     m_what += w;
   } // end bad_alloc()
 
-  inline virtual ~bad_alloc() noexcept {};
+  inline virtual ~bad_alloc() noexcept {}
 
   inline virtual const char* what() const noexcept
   {

--- a/thrust/thrust/system/system_error.h
+++ b/thrust/thrust/system/system_error.h
@@ -146,7 +146,7 @@ public:
 
   /*! Destructor does not throw.
    */
-  inline virtual ~system_error() noexcept {};
+  inline virtual ~system_error() noexcept {}
 
   /*! Returns an object encoding the error.
    *  \return <tt>ec</tt> or <tt>error_code(ev, ecat)</tt>, from the


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes https://github.com/NVIDIA/cccl/issues/826

<!-- Provide a standalone description of changes in this PR. -->
Removes extra semicolons that are caught as errors when building with:
`./ci/build_thrust.sh -cmake-options "-DCMAKE_CXX_FLAGS=-Wextra-semi"`

I considered adding the semicolon build flag somewhere to avoid these cropping up again, but wasn't sure where it would belong (so I haven't changed anything related to that in this PR).

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
