### PR TITLE
Implement `cuda::isqrt`

### DIFF
--- a/docs/libcudacxx/extended_api/math.rst
+++ b/docs/libcudacxx/extended_api/math.rst
@@ -11,6 +11,7 @@ Math
    math/round_up
    math/round_down
    math/ilog
+   math/isqrt
    math/uabs
 
 .. list-table::
@@ -46,6 +47,11 @@ Math
      - Integer logarithm to the base 10
      - CCCL 3.0.0
      - CUDA 13.0
+
+   * - :ref:`isqrt <libcudacxx-extended-api-math-isqrt>`
+     - Integer square root
+     - CCCL 3.1.0
+     - CUDA 13.1
 
    * - :ref:`uabs <libcudacxx-extended-api-math-uabs>`
      - Unsigned absolute value

--- a/docs/libcudacxx/extended_api/math/isqrt.rst
+++ b/docs/libcudacxx/extended_api/math/isqrt.rst
@@ -1,0 +1,48 @@
+.. _libcudacxx-extended-api-math-isqrt:
+
+``cuda::isqrt``
+====================================
+
+.. code:: cpp
+
+   template <typename T>
+   [[nodiscard]] __host__ __device__ inline constexpr
+   T isqrt(T value) noexcept;
+
+The function computes the integer square root of the input value rounded down.
+
+**Parameters**
+
+- ``value``: The input value.
+
+**Return value**
+
+- The square root value of the input value rounded down.
+
+**Constraints**
+
+- ``T`` is an integer type.
+- ``value`` is non-negative.
+
+Example
+-------
+
+.. code:: cpp
+
+    #include <cuda/cmath>
+    #include <cuda/std/cassert>
+
+    __global__ void isqrt_kernel() {
+        assert(cuda::isqrt(1) == 1);
+        assert(cuda::isqrt(4) == 2);
+        assert(cuda::isqrt(42) == 6);
+        assert(cuda::isqrt(99) == 9);
+        assert(cuda::isqrt(100) == 10);
+    }
+
+    int main() {
+        isqrt_kernel<<<1, 1>>>();
+        cudaDeviceSynchronize();
+    }
+
+`See it on Godbolt 🔗 <https://godbolt.org/z/enP8cW6nY>`_

--- a/docs/libcudacxx/extended_api/math/isqrt.rst
+++ b/docs/libcudacxx/extended_api/math/isqrt.rst
@@ -22,6 +22,9 @@ The function computes the integer square root of the input value rounded down.
 **Constraints**
 
 - ``T`` is an integer type.
+
+**Preconditions**
+
 - ``value`` is non-negative.
 
 Example

--- a/libcudacxx/include/cuda/__cmath/isqrt.h
+++ b/libcudacxx/include/cuda/__cmath/isqrt.h
@@ -1,0 +1,68 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA___CMATH_ISQRT_H
+#define _CUDA___CMATH_ISQRT_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__bit/integral.h>
+#include <cuda/std/__concepts/concept_macros.h>
+#include <cuda/std/__type_traits/is_integer.h>
+#include <cuda/std/__type_traits/is_signed.h>
+#include <cuda/std/__type_traits/make_unsigned.h>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_CUDA
+
+//! @brief Returns the square root of the given non-negative integer rounded down
+//! @param __v The input number
+//! @pre \p __v must be an integer type
+//! @pre \p __v must be non-negative
+//! @return The square root of \p __v rounded down
+//! @warning If \p __v is negative, the behavior is undefined
+_CCCL_TEMPLATE(class _Tp)
+_CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::__cccl_is_integer, _Tp))
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp isqrt(const _Tp __v) noexcept
+{
+  if constexpr (_CCCL_TRAIT(_CUDA_VSTD::is_signed, _Tp))
+  {
+    _CCCL_ASSERT(__v >= _Tp{0}, "cuda::isqrt requires non-negative input");
+  }
+
+  using _Up = _CUDA_VSTD::make_unsigned_t<_Tp>;
+
+  if (__v <= _Tp{1})
+  {
+    return __v;
+  }
+
+  _Up __current{0};
+  _Up __next{_Up(_Up{1} << ((_CUDA_VSTD::bit_width(_Up(__v - 1)) + 1) / 2))};
+
+  do
+  {
+    __current = __next;
+    __next    = _Up((__current + _Up(__v) / __current) / 2);
+  } while (__next < __current);
+
+  return static_cast<_Tp>(__current);
+}
+
+_LIBCUDACXX_END_NAMESPACE_CUDA
+
+#endif // _CUDA___CMATH_ISQRT_H

--- a/libcudacxx/include/cuda/__cmath/isqrt.h
+++ b/libcudacxx/include/cuda/__cmath/isqrt.h
@@ -51,7 +51,7 @@ _CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::__cccl_is_integer, _Tp))
 
   using _Up = _CUDA_VSTD::make_unsigned_t<_Tp>;
 
-  const _Up __uv = static_cast<_Up>(__v);
+  _Up __uv = static_cast<_Up>(__v);
   _Up __ret{};
   _Up __bit = static_cast<_Up>(_Up{1} << ((_CUDA_VSTD::bit_width(__uv) - 1) & (~1)));
 

--- a/libcudacxx/include/cuda/cmath
+++ b/libcudacxx/include/cuda/cmath
@@ -23,6 +23,7 @@
 
 #include <cuda/__cmath/ceil_div.h>
 #include <cuda/__cmath/ilog.h>
+#include <cuda/__cmath/isqrt.h>
 #include <cuda/__cmath/round_down.h>
 #include <cuda/__cmath/round_up.h>
 #include <cuda/__cmath/uabs.h>

--- a/libcudacxx/test/libcudacxx/cuda/cmath/isqrt.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/cmath/isqrt.pass.cpp
@@ -1,0 +1,76 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/cmath>
+#include <cuda/std/cassert>
+#include <cuda/std/limits>
+#include <cuda/std/type_traits>
+#include <cuda/std/utility>
+
+template <class T, class In, class Ref>
+__host__ __device__ constexpr void test_isqrt(In input, Ref ref)
+{
+  if (cuda::std::in_range<T>(input))
+  {
+    assert(cuda::isqrt(static_cast<T>(input)) == static_cast<T>(ref));
+  }
+}
+
+template <class T>
+__host__ __device__ constexpr void test_type()
+{
+  static_assert(cuda::std::is_same_v<decltype(cuda::isqrt(T{})), T>);
+  static_assert(noexcept(cuda::isqrt(T{})));
+
+  test_isqrt<T>(0, 0);
+  test_isqrt<T>(1, 1);
+  test_isqrt<T>(2, 1);
+  test_isqrt<T>(4, 2);
+  test_isqrt<T>(6, 2);
+  test_isqrt<T>(43, 6);
+  test_isqrt<T>(70, 8);
+  test_isqrt<T>(99, 9);
+  test_isqrt<T>(100, 10);
+  test_isqrt<T>(2115, 45);
+  test_isqrt<T>(2116, 46);
+  test_isqrt<T>(9801, 99);
+  test_isqrt<T>(2147483647, 46340);
+  test_isqrt<T>(9223372036854775807, 3037000499);
+}
+
+__host__ __device__ constexpr bool test()
+{
+  test_type<signed char>();
+  test_type<signed short>();
+  test_type<signed int>();
+  test_type<signed long>();
+  test_type<signed long long>();
+#if _CCCL_HAS_INT128()
+  test_type<__int128_t>();
+#endif // _CCCL_HAS_INT128()
+
+  test_type<unsigned char>();
+  test_type<unsigned short>();
+  test_type<unsigned int>();
+  test_type<unsigned long>();
+  test_type<unsigned long long>();
+#if _CCCL_HAS_INT128()
+  test_type<__uint128_t>();
+#endif // _CCCL_HAS_INT128()
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+  return 0;
+}


### PR DESCRIPTION
This PR introduces `cuda::isqrt` function which computes the integer square root of a given input.

The implementation is based on reference implementation from [P3605R0](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3605r0.pdf) proposal, I am a bit unsure whether I am able to reuse it.