### PR TITLE
Change streaming algorithms to use operator+= from using operator+

### DIFF
--- a/cub/cub/device/dispatch/dispatch_advance_iterators.cuh
+++ b/cub/cub/device/dispatch/dispatch_advance_iterators.cuh
@@ -5,8 +5,6 @@
 
 #include <cub/config.cuh>
 
-#include <cuda/std/type_traits>
-
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
@@ -14,6 +12,8 @@
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
 #  pragma system_header
 #endif // no system header
+
+#include <cuda/std/type_traits>
 
 CUB_NAMESPACE_BEGIN
 

--- a/cub/cub/device/dispatch/dispatch_advance_iterators.cuh
+++ b/cub/cub/device/dispatch/dispatch_advance_iterators.cuh
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#pragma once
+
+#include <cub/config.cuh>
+
+#include <cuda/std/type_traits>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+CUB_NAMESPACE_BEGIN
+
+namespace detail
+{
+template <typename T, typename U, typename = void>
+struct has_plus_operator : ::cuda::std::false_type
+{};
+
+template <typename T, typename U>
+struct has_plus_operator<T, U, ::cuda::std::void_t<decltype(::cuda::std::declval<T>() + ::cuda::std::declval<U>())>>
+    : ::cuda::std::true_type
+{};
+
+template <typename T, typename U>
+constexpr bool has_plus_operator_v = has_plus_operator<T, U>::value;
+
+// Helper function that advances a given iterator only if it supports being advanced by the given offset
+template <typename IteratorT, typename OffsetT>
+CUB_RUNTIME_FUNCTION _CCCL_VISIBILITY_HIDDEN _CCCL_FORCEINLINE IteratorT
+advance_iterators_if_supported(IteratorT iter, [[maybe_unused]] OffsetT offset)
+{
+  if constexpr (has_plus_operator_v<IteratorT, OffsetT>)
+  {
+    // If operator+ is valid, advance the iterator.
+    return iter + offset;
+  }
+  else
+  {
+    // Otherwise, return iter unmodified.
+    return iter;
+  }
+}
+
+template <typename T, typename U, typename = void>
+struct has_add_assign_operator : ::cuda::std::false_type
+{};
+
+template <typename T, typename U>
+struct has_add_assign_operator<T,
+                               U,
+                               ::cuda::std::void_t<decltype(::cuda::std::declval<T&>() += ::cuda::std::declval<U>())>>
+    : ::cuda::std::true_type
+{};
+
+template <typename T, typename U>
+constexpr bool has_add_assign_operator_v = has_add_assign_operator<T, U>::value;
+
+// Helper function that advances a given iterator only if it supports being advanced by the given offset
+template <typename IteratorT, typename OffsetT>
+CUB_RUNTIME_FUNCTION _CCCL_VISIBILITY_HIDDEN _CCCL_FORCEINLINE void
+advance_iterators_inplace_if_supported(IteratorT& iter, [[maybe_unused]] OffsetT offset)
+{
+  if constexpr (has_add_assign_operator_v<IteratorT, OffsetT>)
+  {
+    // If operator+ is valid, advance the iterator.
+    iter += offset;
+  }
+}
+
+// Helper function that checks whether all of the given iterators support the + operator with the given offset
+template <typename OffsetT, typename... Iterators>
+CUB_RUNTIME_FUNCTION _CCCL_VISIBILITY_HIDDEN _CCCL_FORCEINLINE bool
+all_iterators_support_plus_operator(OffsetT /*offset*/, Iterators... /*iters*/)
+{
+  if constexpr ((has_plus_operator_v<Iterators, OffsetT> && ...))
+  {
+    return true;
+  }
+  else
+  {
+    return false;
+  }
+}
+
+// Helper function that checks whether all of the given iterators support the + operator with the given offset
+template <typename OffsetT, typename... Iterators>
+CUB_RUNTIME_FUNCTION _CCCL_VISIBILITY_HIDDEN _CCCL_FORCEINLINE bool
+all_iterators_support_add_assign_operator(OffsetT /*offset*/, Iterators... /*iters*/)
+{
+  if constexpr ((has_add_assign_operator_v<Iterators, OffsetT> && ...))
+  {
+    return true;
+  }
+  else
+  {
+    return false;
+  }
+}
+
+} // namespace detail
+
+CUB_NAMESPACE_END

--- a/cub/cub/device/dispatch/dispatch_common.cuh
+++ b/cub/cub/device/dispatch/dispatch_common.cuh
@@ -7,8 +7,6 @@
 
 #include <cuda/std/type_traits>
 
-#include "cuda/std/__cccl/execution_space.h"
-
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
@@ -43,51 +41,5 @@ enum class SelectImpl
   // Partition, keeping rejected items. It's required that memory of input and output are disjoint.
   Partition
 };
-
-namespace detail
-{
-template <typename T, typename U, typename = void>
-struct has_plus_operator : ::cuda::std::false_type
-{};
-
-template <typename T, typename U>
-struct has_plus_operator<T, U, ::cuda::std::void_t<decltype(::cuda::std::declval<T>() + ::cuda::std::declval<U>())>>
-    : ::cuda::std::true_type
-{};
-
-template <typename T, typename U>
-constexpr bool has_plus_operator_v = has_plus_operator<T, U>::value;
-
-// Helper function that advances a given iterator only if it supports being advanced by the given offset
-template <typename IteratorT, typename OffsetT>
-_CCCL_HOST_DEVICE IteratorT advance_iterators_if_supported(IteratorT iter, [[maybe_unused]] OffsetT offset)
-{
-  if constexpr (has_plus_operator_v<IteratorT, OffsetT>)
-  {
-    // If operator+ is valid, advance the iterator.
-    return iter + offset;
-  }
-  else
-  {
-    // Otherwise, return iter unmodified.
-    return iter;
-  }
-}
-
-// Helper function that checks whether all of the given iterators support the + operator with the given offset
-template <typename OffsetT, typename... Iterators>
-_CCCL_HOST_DEVICE bool all_iterators_support_plus_operator(OffsetT /*offset*/, Iterators... /*iters*/)
-{
-  if constexpr ((has_plus_operator_v<Iterators, OffsetT> && ...))
-  {
-    return true;
-  }
-  else
-  {
-    return false;
-  }
-}
-
-} // namespace detail
 
 CUB_NAMESPACE_END

--- a/cub/cub/device/dispatch/dispatch_common.cuh
+++ b/cub/cub/device/dispatch/dispatch_common.cuh
@@ -5,8 +5,6 @@
 
 #include <cub/config.cuh>
 
-#include <cuda/std/type_traits>
-
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)

--- a/cub/cub/device/dispatch/dispatch_radix_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_radix_sort.cuh
@@ -1264,6 +1264,9 @@ struct DispatchSegmentedRadixSort
       return cudaErrorInvalidValue;
     }
 
+    BeginOffsetIteratorT begin_offsets_current_it = d_begin_offsets;
+    EndOffsetIteratorT end_offsets_current_it     = d_end_offsets;
+
     // Iterate over chunks of segments
     for (::cuda::std::int64_t invocation_index = 0; invocation_index < num_invocations; invocation_index++)
     {
@@ -1293,8 +1296,8 @@ struct DispatchSegmentedRadixSort
               d_keys_out,
               d_values_in,
               d_values_out,
-              d_begin_offsets,
-              d_end_offsets,
+              begin_offsets_current_it,
+              end_offsets_current_it,
               current_bit,
               pass_bits,
               decomposer);
@@ -1308,8 +1311,8 @@ struct DispatchSegmentedRadixSort
 
       if (invocation_index + 1 < num_invocations)
       {
-        detail::advance_iterators_inplace_if_supported(d_begin_offsets, num_current_segments);
-        detail::advance_iterators_inplace_if_supported(d_end_offsets, num_current_segments);
+        detail::advance_iterators_inplace_if_supported(begin_offsets_current_it, num_current_segments);
+        detail::advance_iterators_inplace_if_supported(end_offsets_current_it, num_current_segments);
       }
 
       // Sync the stream if specified to flush runtime errors


### PR DESCRIPTION
1. Changed streaming algorithm to support num_segments in segmented_reduce that is greater than INT_MAX from using operator+ to increment iterators on the host to using operator+= to save constructor/copy calls.

2. Introduce `void advance_iterators_inplace_if_supported(IteratorT &iter, OffsetT diff)` that use operator+= alongside existing `IteratorT advance_iterators_if_supported(IteratorT iter, OffsetT diff)`.

3. Since these are used from dispatcher functions annotated as CUB_RUNTIME_FUNCTION, changed these functions's annotations from _CCCL_HOST_DEVICE to CUB_RUNTIME_FUNCTION.

   This change broke test_nvrtc test since dispatch_common.cuh header file where these functions are defined is used in agent_select_if.cuh file that must be compiled by NVRTC.

4. Hence I moved functions for advancing iterators from dispatch_common.cuh into a new header file dispatch_advance_iterators.cuh which are included from dispatch_reduce.cuh and dispatch_radix_sort.cuh and moved definitiosn of relevant functions from dispatch_common to dispatch_advance_iterators

## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes <!-- Link issue here -->

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
