### PR TITLE
Move libcudacxx endian macros to cccl

### DIFF
--- a/libcudacxx/include/cuda/std/__bit/endian.h
+++ b/libcudacxx/include/cuda/std/__bit/endian.h
@@ -25,15 +25,9 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 enum class endian
 {
-  little = 0xDEAD,
-  big    = 0xFACE,
-#if defined(_LIBCUDACXX_LITTLE_ENDIAN)
-  native = little
-#elif defined(_LIBCUDACXX_BIG_ENDIAN)
-  native = big
-#else
-  native = 0xCAFE
-#endif
+  little = _CCCL_ENDIAN_LITTLE(),
+  big    = _CCCL_ENDIAN_BIG(),
+  native = _CCCL_ENDIAN_NATIVE(),
 };
 
 _LIBCUDACXX_END_NAMESPACE_STD

--- a/libcudacxx/include/cuda/std/__cccl/architecture.h
+++ b/libcudacxx/include/cuda/std/__cccl/architecture.h
@@ -45,19 +45,11 @@
 #define _CCCL_ENDIAN_BIG()    0xFACE
 #define _CCCL_ENDIAN_PDP()    0xBEEF
 
-#if _CCCL_COMPILER(NVRTC) || (_CCCL_COMPILER(MSVC) && (_CCCL_ARCH(X86_64) || _CCCL_ARCH(ARM64)))
+#if _CCCL_COMPILER(NVRTC) || (_CCCL_COMPILER(MSVC) && (_CCCL_ARCH(X86_64) || _CCCL_ARCH(ARM64))) || __LITTLE_ENDIAN__
 #  define _CCCL_ENDIAN_NATIVE() _CCCL_ENDIAN_LITTLE()
-#endif // _CCCL_COMPILER(NVRTC)
-
-#if !defined(_CCCL_ENDIAN_NATIVE) && __LITTLE_ENDIAN__
-#  define _CCCL_ENDIAN_NATIVE() _CCCL_ENDIAN_LITTLE()
-#endif // !_CCCL_ENDIAN_NATIVE && __LITTLE_ENDIAN__
-
-#if !defined(_CCCL_ENDIAN_NATIVE) && __BIG_ENDIAN__
+#elif __BIG_ENDIAN__
 #  define _CCCL_ENDIAN_NATIVE() _CCCL_ENDIAN_BIG()
-#endif // !_CCCL_ENDIAN_NATIVE && __BIG_ENDIAN__
-
-#if !defined(_CCCL_ENDIAN_NATIVE) && defined(__BYTE_ORDER__)
+#elif defined(__BYTE_ORDER__)
 #  if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 #    define _CCCL_ENDIAN_NATIVE() _CCCL_ENDIAN_LITTLE()
 #  elif __BYTE_ORDER__ == __ORDER_PDP_ENDIAN__
@@ -65,9 +57,7 @@
 #  elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 #    define _CCCL_ENDIAN_NATIVE() _CCCL_ENDIAN_BIG()
 #  endif // __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-#endif // !_CCCL_ENDIAN_NATIVE && defined(__BYTE_ORDER__)
-
-#if !defined(_CCCL_ENDIAN_NATIVE) && _CCCL_HAS_INCLUDE(<endian.h>)
+#elif _CCCL_HAS_INCLUDE(<endian.h>)
 #  include <endian.h>
 #  if __BYTE_ORDER == __LITTLE_ENDIAN
 #    define _CCCL_ENDIAN_NATIVE() _CCCL_ENDIAN_LITTLE()
@@ -76,10 +66,11 @@
 #  elif __BYTE_ORDER == __BIG_ENDIAN
 #    define _CCCL_ENDIAN_NATIVE() _CCCL_ENDIAN_BIG()
 #  endif // __BYTE_ORDER == __BIG_ENDIAN
-#endif // !_CCCL_ENDIAN_NATIVE
+#endif // ^^^ has endian.h ^^^
 
 #if !defined(_CCCL_ENDIAN_NATIVE)
-#  error "failed to determine the endianness of the host architecture"
+_CCCL_WARNING("failed to determine the endianness of the host architecture, defaulting to little-endian")
+#  define _CCCL_ENDIAN_NATIVE() _CCCL_ENDIAN_LITTLE()
 #endif // !_CCCL_ENDIAN_NATIVE
 
 #define _CCCL_ENDIAN(_NAME) (_CCCL_ENDIAN_NATIVE() == _CCCL_ENDIAN_##_NAME())

--- a/libcudacxx/include/cuda/std/__cccl/architecture.h
+++ b/libcudacxx/include/cuda/std/__cccl/architecture.h
@@ -11,6 +11,9 @@
 #ifndef __CCCL_ARCH_H
 #define __CCCL_ARCH_H
 
+#include <cuda/std/__cccl/compiler.h>
+#include <cuda/std/__cccl/preprocessor.h>
+
 // The header provides the following macros to determine the host architecture:
 //
 // _CCCL_ARCH(ARM64)     ARM64
@@ -35,5 +38,50 @@
 #endif
 
 #define _CCCL_ARCH(...) _CCCL_ARCH_##__VA_ARGS__##_()
+
+// Determine the endianness
+
+#define _CCCL_ENDIAN_LITTLE() 0xDEAD
+#define _CCCL_ENDIAN_BIG()    0xFACE
+#define _CCCL_ENDIAN_PDP()    0xBEEF
+
+#if _CCCL_COMPILER(NVRTC) || (_CCCL_COMPILER(MSVC) && (_CCCL_ARCH(X86_64) || _CCCL_ARCH(ARM64)))
+#  define _CCCL_ENDIAN_NATIVE() _CCCL_ENDIAN_LITTLE()
+#endif // _CCCL_COMPILER(NVRTC)
+
+#if !defined(_CCCL_ENDIAN_NATIVE) && __LITTLE_ENDIAN__
+#  define _CCCL_ENDIAN_NATIVE() _CCCL_ENDIAN_LITTLE()
+#endif // !_CCCL_ENDIAN_NATIVE && __LITTLE_ENDIAN__
+
+#if !defined(_CCCL_ENDIAN_NATIVE) && __BIG_ENDIAN__
+#  define _CCCL_ENDIAN_NATIVE() _CCCL_ENDIAN_BIG()
+#endif // !_CCCL_ENDIAN_NATIVE && __BIG_ENDIAN__
+
+#if !defined(_CCCL_ENDIAN_NATIVE) && defined(__BYTE_ORDER__)
+#  if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#    define _CCCL_ENDIAN_NATIVE() _CCCL_ENDIAN_LITTLE()
+#  elif __BYTE_ORDER__ == __ORDER_PDP_ENDIAN__
+#    define _CCCL_ENDIAN_NATIVE() _CCCL_ENDIAN_PDP()
+#  elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#    define _CCCL_ENDIAN_NATIVE() _CCCL_ENDIAN_BIG()
+#  endif // __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#endif // !_CCCL_ENDIAN_NATIVE && defined(__BYTE_ORDER__)
+
+#if !defined(_CCCL_ENDIAN_NATIVE) && _CCCL_HAS_INCLUDE(<endian.h>)
+#  include <endian.h>
+#  if __BYTE_ORDER == __LITTLE_ENDIAN
+#    define _CCCL_ENDIAN_NATIVE() _CCCL_ENDIAN_LITTLE()
+#  elif __BYTE_ORDER == __PDP_ENDIAN
+#    define _CCCL_ENDIAN_NATIVE() _CCCL_ENDIAN_PDP()
+#  elif __BYTE_ORDER == __BIG_ENDIAN
+#    define _CCCL_ENDIAN_NATIVE() _CCCL_ENDIAN_BIG()
+#  endif // __BYTE_ORDER == __BIG_ENDIAN
+#endif // !_CCCL_ENDIAN_NATIVE
+
+#if !defined(_CCCL_ENDIAN_NATIVE)
+#  error "failed to determine the endianness of the host architecture"
+#endif // !_CCCL_ENDIAN_NATIVE
+
+#define _CCCL_ENDIAN(_NAME) (_CCCL_ENDIAN_NATIVE() == _CCCL_ENDIAN_##_NAME())
 
 #endif // __CCCL_ARCH_H

--- a/libcudacxx/include/cuda/std/__cccl/compiler.h
+++ b/libcudacxx/include/cuda/std/__cccl/compiler.h
@@ -181,4 +181,10 @@
 
 #define _CCCL_PRAGMA_NOUNROLL() _CCCL_PRAGMA_UNROLL(1)
 
+#if _CCCL_COMPILER(MSVC)
+#  define _CCCL_WARNING(_MSG) _CCCL_PRAGMA(message(__FILE__ ":" _CCCL_TO_STRING(__LINE__) ": warning: " _MSG))
+#else // ^^^ _CCCL_COMPILER(MSVC) ^^^ / vvv !_CCCL_COMPILER(MSVC) vvv
+#  define _CCCL_WARNING(_MSG) _CCCL_PRAGMA(GCC warning _MSG)
+#endif // !_CCCL_COMPILER(MSVC)
+
 #endif // __CCCL_COMPILER_H

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__config
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__config
@@ -38,59 +38,6 @@ extern "C++" {
 #    define __has_extension(__x) 0
 #  endif
 
-#  ifdef __LITTLE_ENDIAN__
-#    if __LITTLE_ENDIAN__
-#      define _LIBCUDACXX_LITTLE_ENDIAN
-#    endif // __LITTLE_ENDIAN__
-#  endif // __LITTLE_ENDIAN__
-
-#  ifdef __BIG_ENDIAN__
-#    if __BIG_ENDIAN__
-#      define _LIBCUDACXX_BIG_ENDIAN
-#    endif // __BIG_ENDIAN__
-#  endif // __BIG_ENDIAN__
-
-#  ifdef __BYTE_ORDER__
-#    if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-#      define _LIBCUDACXX_LITTLE_ENDIAN
-#    elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-#      define _LIBCUDACXX_BIG_ENDIAN
-#    endif // __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-#  endif // __BYTE_ORDER__
-
-#  if defined(_WIN32)
-#    define _LIBCUDACXX_LITTLE_ENDIAN
-#    if (defined(_M_AMD64) || defined(__x86_64__)) || (defined(_M_ARM) || defined(__arm__))
-#      define _LIBCUDACXX_HAS_BITSCAN64
-#    endif
-
-// Some CRT APIs are unavailable to store apps
-#    if defined(WINAPI_FAMILY)
-#      include <winapifamily.h>
-#      if !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) \
-        && (!defined(WINAPI_PARTITION_SYSTEM) || !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_SYSTEM))
-#        define _LIBCUDACXX_WINDOWS_STORE_APP
-#      endif
-#    endif
-#  endif // defined(_WIN32)
-
-#  ifndef _LIBCUDACXX_LITTLE_ENDIAN
-#    if _CCCL_COMPILER(NVRTC)
-#      define _LIBCUDACXX_LITTLE_ENDIAN
-#    endif
-#  endif // _LIBCUDACXX_LITTLE_ENDIAN
-
-#  if !defined(_LIBCUDACXX_LITTLE_ENDIAN) && !defined(_LIBCUDACXX_BIG_ENDIAN)
-#    include <endian.h>
-#    if __BYTE_ORDER == __LITTLE_ENDIAN
-#      define _LIBCUDACXX_LITTLE_ENDIAN
-#    elif __BYTE_ORDER == __BIG_ENDIAN
-#      define _LIBCUDACXX_BIG_ENDIAN
-#    else // __BYTE_ORDER == __BIG_ENDIAN
-#      error unable to determine endian
-#    endif
-#  endif // !defined(_LIBCUDACXX_LITTLE_ENDIAN) && !defined(_LIBCUDACXX_BIG_ENDIAN)
-
 #  if _CCCL_HAS_ATTRIBUTE(__no_sanitize__) && !_CCCL_COMPILER(GCC)
 #    define _LIBCUDACXX_NO_CFI __attribute__((__no_sanitize__("cfi")))
 #  else

--- a/libcudacxx/test/libcudacxx/std/numerics/bit/bit.endian/endian.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/bit/bit.endian/endian.pass.cpp
@@ -10,38 +10,30 @@
 // <cuda/std/bit>
 
 #include <cuda/std/bit>
-// #include <cuda/std/cstring>
 #include <cuda/std/cassert>
 #include <cuda/std/cstdint>
+#include <cuda/std/cstring>
 #include <cuda/std/type_traits>
 
 #include "test_macros.h"
 
 int main(int, char**)
 {
-  static_assert(cuda::std::is_enum<cuda::std::endian>::value, "");
-
-  // Check that E is a scoped enum by checking for conversions.
-  typedef cuda::std::underlying_type<cuda::std::endian>::type UT;
-  static_assert(!cuda::std::is_convertible<cuda::std::endian, UT>::value, "");
+  static_assert(cuda::std::is_scoped_enum_v<cuda::std::endian>);
 
   // test that the enumeration values exist
-  static_assert(cuda::std::endian::little == cuda::std::endian::little, "");
-  static_assert(cuda::std::endian::big == cuda::std::endian::big, "");
-  static_assert(cuda::std::endian::native == cuda::std::endian::native, "");
-  static_assert(cuda::std::endian::little != cuda::std::endian::big, "");
-
-  //  Technically not required, but true on all existing machines
-  static_assert(
-    cuda::std::endian::native == cuda::std::endian::little || cuda::std::endian::native == cuda::std::endian::big, "");
+  static_assert(cuda::std::endian::little == cuda::std::endian::little);
+  static_assert(cuda::std::endian::big == cuda::std::endian::big);
+  static_assert(cuda::std::endian::native == cuda::std::endian::native);
+  static_assert(cuda::std::endian::little != cuda::std::endian::big);
 
   //  Try to check at runtime
   {
-    uint32_t i = 0x01020304;
+    cuda::std::uint32_t i = 0x01020304;
     char c[4];
-    static_assert(sizeof(i) == sizeof(c), "");
-    memcpy(c, &i, sizeof(c));
+    static_assert(sizeof(i) == sizeof(c));
 
+    cuda::std::memcpy(c, &i, sizeof(c));
     assert((c[0] == 1) == (cuda::std::endian::native == cuda::std::endian::big));
   }
 

--- a/thrust/thrust/detail/config/cpp_dialect.h
+++ b/thrust/thrust/detail/config/cpp_dialect.h
@@ -41,11 +41,7 @@
 #define THRUST_CPP_DIALECT _CCCL_STD_VER
 
 // Define THRUST_COMPILER_DEPRECATION macro:
-#if _CCCL_COMPILER(MSVC) || _CCCL_COMPILER(NVRTC)
-#  define THRUST_COMP_DEPR_IMPL(msg) _CCCL_PRAGMA(message(__FILE__ ":" _CCCL_TO_STRING(__LINE__) ": warning: " #msg))
-#else // clang / gcc:
-#  define THRUST_COMP_DEPR_IMPL(msg) _CCCL_PRAGMA(GCC warning #msg)
-#endif
+#define THRUST_COMP_DEPR_IMPL(msg) _CCCL_WARNING(#msg)
 
 // Compiler checks:
 // clang-format off


### PR DESCRIPTION
This PR moves original libcudacxx endian macros to cccl and improves the host architecture detection.