### PR TITLE
Add `_CCCL_NO_SPECIALIZATIONS` attribute

### DIFF
--- a/libcudacxx/include/cuda/std/__cccl/attributes.h
+++ b/libcudacxx/include/cuda/std/__cccl/attributes.h
@@ -98,4 +98,15 @@
 #  define _CCCL_ASSUME(...) _CCCL_BUILTIN_ASSUME(__VA_ARGS__)
 #endif // ^^^ !_CCCL_COMPILER(MSVC) ^^^
 
+#if _CCCL_HAS_CPP_ATTRIBUTE(clang::no_specializations)
+#  define _CCCL_NO_SPECIALIZATIONS_BECAUSE(_MSG) [[clang::no_specializations(_MSG)]]
+#elif _CCCL_HAS_CPP_ATTRIBUTE(msvc::no_specializations)
+#  define _CCCL_NO_SPECIALIZATIONS_BECAUSE(_MSG) [[msvc::no_specializations(_MSG)]]
+#else // ^^^ has attribute no_specializations ^^^ / vvv hasn't attribute no_specializations vvv
+#  define _CCCL_NO_SPECIALIZATIONS_BECAUSE(_MSG)
+#endif // ^^^ hasn't attribute no_specializations ^^^
+
+#define _CCCL_NO_SPECIALIZATIONS \
+  _CCCL_NO_SPECIALIZATIONS_BECAUSE("Users are not allowed to specialize this cccl entity")
+
 #endif // __CCCL_ATTRIBUTES_H

--- a/libcudacxx/include/cuda/std/__cccl/attributes.h
+++ b/libcudacxx/include/cuda/std/__cccl/attributes.h
@@ -99,11 +99,14 @@
 #endif // ^^^ !_CCCL_COMPILER(MSVC) ^^^
 
 #if _CCCL_HAS_CPP_ATTRIBUTE(clang::no_specializations)
-#  define _CCCL_NO_SPECIALIZATIONS_BECAUSE(_MSG) [[clang::no_specializations(_MSG)]]
+#  define _CCCL_NO_SPECIALIZATIONS_BECAUSE(_MSG)   [[clang::no_specializations(_MSG)]]
+#  define _CCCL_HAS_ATTRIBUTE_NO_SPECIALIZATIONS() 1
 #elif _CCCL_HAS_CPP_ATTRIBUTE(msvc::no_specializations)
-#  define _CCCL_NO_SPECIALIZATIONS_BECAUSE(_MSG) [[msvc::no_specializations(_MSG)]]
+#  define _CCCL_NO_SPECIALIZATIONS_BECAUSE(_MSG)   [[msvc::no_specializations(_MSG)]]
+#  define _CCCL_HAS_ATTRIBUTE_NO_SPECIALIZATIONS() 1
 #else // ^^^ has attribute no_specializations ^^^ / vvv hasn't attribute no_specializations vvv
 #  define _CCCL_NO_SPECIALIZATIONS_BECAUSE(_MSG)
+#  define _CCCL_HAS_ATTRIBUTE_NO_SPECIALIZATIONS() 0
 #endif // ^^^ hasn't attribute no_specializations ^^^
 
 #define _CCCL_NO_SPECIALIZATIONS \

--- a/libcudacxx/test/libcudacxx/std/cccl/attributes/no_specializations.fail.cpp
+++ b/libcudacxx/test/libcudacxx/std/cccl/attributes/no_specializations.fail.cpp
@@ -1,0 +1,63 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/__cccl/attributes.h>
+
+#if _CCCL_HAS_CPP_ATTRIBUTE(clang::no_specializations) || _CCCL_HAS_CPP_ATTRIBUTE(msvc::no_specializations)
+
+// 1. Attribute applied to a template class
+
+template <class T>
+struct _CCCL_NO_SPECIALIZATIONS Struct
+{
+  static constexpr bool value = false;
+};
+
+// This should fail to compile
+template <>
+struct Struct<int>
+{
+  static constexpr bool value = false;
+};
+
+// 2. Attribute applied to a template variable
+
+template <class T>
+_CCCL_NO_SPECIALIZATIONS inline constexpr bool variable = false;
+
+// This should fail to compile
+template <>
+inline constexpr bool variable<int> = false;
+
+// 3. Attribute applied to a template function
+
+template <class T>
+_CCCL_NO_SPECIALIZATIONS __host__ __device__ T function()
+{
+  return T{0};
+}
+
+// This should fail to compile
+template <>
+__host__ __device__ int function<int>()
+{
+  return 1;
+}
+
+#else // ^^^ has no_specializations attribute ^^^ / vvv hasn't no_specializations attribute vvv
+
+static_assert(false, "no_specializations attribute not supported");
+
+#endif // _CCCL_HAS_CPP_ATTRIBUTE(clang::no_specializations) || _CCCL_HAS_CPP_ATTRIBUTE(msvc::no_specializations)
+
+int main(int, char**)
+{
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/cccl/attributes/no_specializations.fail.cpp
+++ b/libcudacxx/test/libcudacxx/std/cccl/attributes/no_specializations.fail.cpp
@@ -10,7 +10,7 @@
 
 #include <cuda/std/__cccl/attributes.h>
 
-#if _CCCL_HAS_CPP_ATTRIBUTE(clang::no_specializations) || _CCCL_HAS_CPP_ATTRIBUTE(msvc::no_specializations)
+#if _CCCL_HAS_ATTRIBUTE_NO_SPECIALIZATIONS()
 
 // 1. Attribute applied to a template class
 
@@ -51,11 +51,11 @@ __host__ __device__ int function<int>()
   return 1;
 }
 
-#else // ^^^ has no_specializations attribute ^^^ / vvv hasn't no_specializations attribute vvv
+#else // ^^^ _CCCL_HAS_ATTRIBUTE_NO_SPECIALIZATIONS() ^^^ / vvv !_CCCL_HAS_ATTRIBUTE_NO_SPECIALIZATIONS() vvv
 
 static_assert(false, "no_specializations attribute not supported");
 
-#endif // _CCCL_HAS_CPP_ATTRIBUTE(clang::no_specializations) || _CCCL_HAS_CPP_ATTRIBUTE(msvc::no_specializations)
+#endif // ^^^ !_CCCL_HAS_ATTRIBUTE_NO_SPECIALIZATIONS() ^^^
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/cccl/attributes/no_specializations.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/cccl/attributes/no_specializations.pass.cpp
@@ -1,0 +1,41 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/__cccl/attributes.h>
+
+#if _CCCL_HAS_CPP_ATTRIBUTE(clang::no_specializations) || _CCCL_HAS_CPP_ATTRIBUTE(msvc::no_specializations)
+
+// 1. Attribute applied to a template class
+
+template <class T>
+struct _CCCL_NO_SPECIALIZATIONS Struct
+{
+  static constexpr bool value = false;
+};
+
+// 2. Attribute applied to a template variable
+
+template <class T>
+_CCCL_NO_SPECIALIZATIONS inline constexpr bool variable = false;
+
+// 3. Attribute applied to a template function
+
+template <class T>
+_CCCL_NO_SPECIALIZATIONS __host__ __device__ T function()
+{
+  return T{0};
+}
+
+#endif // _CCCL_HAS_CPP_ATTRIBUTE(clang::no_specializations) || _CCCL_HAS_CPP_ATTRIBUTE(msvc::no_specializations)
+
+int main(int, char**)
+{
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/cccl/attributes/no_specializations.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/cccl/attributes/no_specializations.pass.cpp
@@ -10,7 +10,7 @@
 
 #include <cuda/std/__cccl/attributes.h>
 
-#if _CCCL_HAS_CPP_ATTRIBUTE(clang::no_specializations) || _CCCL_HAS_CPP_ATTRIBUTE(msvc::no_specializations)
+#if _CCCL_HAS_ATTRIBUTE_NO_SPECIALIZATIONS()
 
 // 1. Attribute applied to a template class
 
@@ -33,7 +33,7 @@ _CCCL_NO_SPECIALIZATIONS __host__ __device__ T function()
   return T{0};
 }
 
-#endif // _CCCL_HAS_CPP_ATTRIBUTE(clang::no_specializations) || _CCCL_HAS_CPP_ATTRIBUTE(msvc::no_specializations)
+#endif // _CCCL_HAS_ATTRIBUTE_NO_SPECIALIZATIONS()
 
 int main(int, char**)
 {


### PR DESCRIPTION
This PR introduces `_CCCL_NO_SPECIALIZATIONS` attribute to cccl. It allows to disable specializations of class, variable and function definitions.

It will be a useful tool to prevent user's specializations of instances that are not intended to be specialized.

This attribute is currently supported by clang 20+ and msvc 19.44+, so we should wait untill they make it into the CI matrix.