### PR TITLE
Fix use of `__builtin_popcount`

### DIFF
--- a/libcudacxx/include/cuda/std/__bit/popc.h
+++ b/libcudacxx/include/cuda/std/__bit/popc.h
@@ -36,13 +36,13 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 // optimized version of runtime popc that is used in device code.
 _LIBCUDACXX_HIDE_FROM_ABI constexpr int __constexpr_popc_32bit(uint32_t __x) noexcept
 {
-#if defined(_CCCL_BUILTIN_POPC)
-  return _CCCL_BUILTIN_POPC(__x);
-#else
+#if defined(_CCCL_BUILTIN_POPCOUNT)
+  return _CCCL_BUILTIN_POPCOUNT(__x);
+#else // ^^^ _CCCL_BUILTIN_POPCOUNT ^^^ / vvv !_CCCL_BUILTIN_POPCOUNT vvv
   __x = __x - ((__x >> 1) & 0x55555555);
   __x = (__x & 0x33333333) + ((__x >> 2) & 0x33333333);
   return (((__x + (__x >> 4)) & 0xF0F0F0F) * 0x1010101) >> 24;
-#endif // _CCCL_BUILTIN_POPC
+#endif // ^^^ !_CCCL_BUILTIN_POPCOUNT ^^^
 }
 
 template <typename _Tp>
@@ -51,38 +51,33 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr int __constexpr_popc(_Tp __x) noexcept
   static_assert(is_same_v<_Tp, uint32_t> || is_same_v<_Tp, uint64_t>);
   if constexpr (is_same_v<_Tp, uint32_t>)
   {
-    return __constexpr_popc_32bit(__x);
+    return _CUDA_VSTD::__constexpr_popc_32bit(__x);
   }
   else
   {
-#if defined(_CCCL_BUILTIN_POPCLL)
-    return _CCCL_BUILTIN_POPCLL(__x);
-#else
-    return __constexpr_popc_32bit(static_cast<uint32_t>(__x))
-         + __constexpr_popc_32bit(static_cast<uint32_t>(__x >> 32));
-#endif // defined(_CCCL_BUILTIN_POPCLL)
+#if defined(_CCCL_BUILTIN_POPCOUNTLL)
+    return _CCCL_BUILTIN_POPCOUNTLL(__x);
+#else // ^^^ _CCCL_BUILTIN_POPCOUNTLL ^^^ / vvv !_CCCL_BUILTIN_POPCOUNTLL vvv
+    return _CUDA_VSTD::__constexpr_popc_32bit(static_cast<uint32_t>(__x))
+         + _CUDA_VSTD::__constexpr_popc_32bit(static_cast<uint32_t>(__x >> 32));
+#endif // ^^^ !_CCCL_BUILTIN_POPCOUNTLL ^^^
   }
 }
 
 #if !_CCCL_COMPILER(NVRTC)
 
 template <typename _Tp>
-_CCCL_HIDE_FROM_ABI int __host_runtime_popc(_Tp __x) noexcept
+_CCCL_HIDE_FROM_ABI _CCCL_HOST int __host_runtime_popc(_Tp __x) noexcept
 {
-#  if _CCCL_COMPILER(MSVC)
-#    if !defined(_M_ARM64)
-  auto __ret = sizeof(_Tp) == sizeof(uint32_t) //
-               ? __popcnt(static_cast<uint32_t>(__x))
-               : __popcnt64(static_cast<uint64_t>(__x));
-#    else
-  auto __ret = sizeof(_Tp) == sizeof(uint32_t) //
-               ? _CountOneBits(static_cast<uint32_t>(__x))
-               : _CountOneBits64(static_cast<uint64_t>(__x));
-#    endif // !defined(_M_ARM64)
-  return static_cast<int>(__ret);
-#  else
-  return __constexpr_popc(__x);
-#  endif
+#  if _CCCL_COMPILER(MSVC) && _CCCL_ARCH(X86_64)
+  return static_cast<int>(sizeof(_Tp) == sizeof(uint32_t) ? ::__popcnt(static_cast<uint32_t>(__x))
+                                                          : ::__popcnt64(static_cast<uint64_t>(__x)));
+#  elif _CCCL_COMPILER(MSVC) && _CCCL_ARCH(ARM64)
+  return static_cast<int>(sizeof(_Tp) == sizeof(uint32_t) ? ::_CountOneBits(static_cast<uint32_t>(__x))
+                                                          : ::_CountOneBits64(static_cast<uint64_t>(__x)));
+#  else // ^^^ msvc intrinsics ^^^ / vvv other vvv
+  return _CUDA_VSTD::__constexpr_popc(__x);
+#  endif // ^^^ other ^^^
 }
 
 #endif // !_CCCL_COMPILER(NVRTC)
@@ -91,8 +86,8 @@ template <typename _Tp>
 _LIBCUDACXX_HIDE_FROM_ABI int __runtime_popc(_Tp __x) noexcept
 {
   NV_IF_ELSE_TARGET(NV_IS_DEVICE,
-                    (return sizeof(_Tp) == sizeof(uint32_t) ? __popc(static_cast<uint32_t>(__x)) //
-                                                            : __popcll(static_cast<uint64_t>(__x));),
+                    (return sizeof(_Tp) == sizeof(uint32_t) ? ::__popc(static_cast<uint32_t>(__x))
+                                                            : ::__popcll(static_cast<uint64_t>(__x));),
                     (return _CUDA_VSTD::__host_runtime_popc(__x);))
 }
 
@@ -100,11 +95,12 @@ template <class _Tp>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr int __cccl_popc(_Tp __x) noexcept
 {
   static_assert(is_same_v<_Tp, uint32_t> || is_same_v<_Tp, uint64_t>);
-#if defined(_CCCL_BUILTIN_IS_CONSTANT_EVALUATED)
-  return is_constant_evaluated() ? _CUDA_VSTD::__constexpr_popc(__x) : _CUDA_VSTD::__runtime_popc(__x);
-#else
+
+  if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
+  {
+    return _CUDA_VSTD::__runtime_popc(__x);
+  }
   return _CUDA_VSTD::__constexpr_popc(__x);
-#endif
 }
 
 _LIBCUDACXX_END_NAMESPACE_STD


### PR DESCRIPTION
We checked for `_CCCL_BUILTIN_POPC` instead of `_CCCL_BUILTIN_POPCOUNT`...

I've also refactored the code a bit.