### PR TITLE
Improve `_CCCL_UNREACHABLE`

### DIFF
--- a/docs/cccl/development/macro.rst
+++ b/docs/cccl/development/macro.rst
@@ -276,6 +276,8 @@ Usage example:
 **Portable Builtin Macros**:
 
 +---------------------------------------+--------------------------------------------+
+| ``_CCCL_UNREACHABLE()``               | Portable ``__builtin_unreachable()``       |
++---------------------------------------+--------------------------------------------+
 | ``_CCCL_BUILTIN_ASSUME(X)``           | Portable ``__builtin_assume(X)``           |
 +---------------------------------------+--------------------------------------------+
 | ``_CCCL_BUILTIN_EXPECT(X)``           | Portable ``__builtin_expected(X)``         |

--- a/docs/cccl/development/macro.rst
+++ b/docs/cccl/development/macro.rst
@@ -276,8 +276,6 @@ Usage example:
 **Portable Builtin Macros**:
 
 +---------------------------------------+--------------------------------------------+
-| ``_CCCL_UNREACHABLE()``               | Portable ``__builtin_unreachable()``       |
-+---------------------------------------+--------------------------------------------+
 | ``_CCCL_BUILTIN_ASSUME(X)``           | Portable ``__builtin_assume(X)``           |
 +---------------------------------------+--------------------------------------------+
 | ``_CCCL_BUILTIN_EXPECT(X)``           | Portable ``__builtin_expected(X)``         |

--- a/libcudacxx/include/cuda/std/__cccl/unreachable.h
+++ b/libcudacxx/include/cuda/std/__cccl/unreachable.h
@@ -26,17 +26,21 @@
 #include <cuda/std/__cccl/visibility.h>
 
 #if _CCCL_COMPILER(MSVC) && !defined(__CUDA_ARCH__)
+
 #  define _CCCL_UNREACHABLE()             \
     {                                     \
       __assume(0);                        \
       _CCCL_ASSERT(false, "unreachable"); \
     }
-#else // ^^^ _CCCL_COMPILER(MSVC) ^^^ / vvv !_CCCL_COMPILER(MSVC) vvv
+
+#else
+
 #  define _CCCL_UNREACHABLE()             \
     {                                     \
       __builtin_unreachable();            \
       _CCCL_ASSERT(false, "unreachable"); \
     }
-#endif // !_CCCL_COMPILER(MSVC)
+
+#endif // _CCCL_COMPILER(MSVC) && !defined(__CUDA_ARCH__)
 
 #endif // __CCCL_UNREACHABLE_H

--- a/libcudacxx/include/cuda/std/__cccl/unreachable.h
+++ b/libcudacxx/include/cuda/std/__cccl/unreachable.h
@@ -4,16 +4,17 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
 #ifndef __CCCL_UNREACHABLE_H
 #define __CCCL_UNREACHABLE_H
 
-#include <cuda/std/__cccl/assert.h>
 #include <cuda/std/__cccl/compiler.h>
 #include <cuda/std/__cccl/system_header.h>
+
+#include <nv/target>
 
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
@@ -23,24 +24,10 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/std/__cccl/visibility.h>
-
-#if _CCCL_COMPILER(MSVC) && !defined(__CUDA_ARCH__)
-
-#  define _CCCL_UNREACHABLE()             \
-    {                                     \
-      _CCCL_ASSERT(false, "unreachable"); \
-      __assume(0);                        \
-    }
-
+#if _CCCL_COMPILER(MSVC)
+#  define _CCCL_UNREACHABLE() NV_IF_ELSE_TARGET(NV_IS_HOST, (__assume(0);), (__builtin_unreachable();))
 #else
-
-#  define _CCCL_UNREACHABLE()             \
-    {                                     \
-      _CCCL_ASSERT(false, "unreachable"); \
-      __builtin_unreachable();            \
-    }
-
-#endif // _CCCL_COMPILER(MSVC) && !defined(__CUDA_ARCH__)
+#  define _CCCL_UNREACHABLE() __builtin_unreachable()
+#endif
 
 #endif // __CCCL_UNREACHABLE_H

--- a/libcudacxx/include/cuda/std/__cccl/unreachable.h
+++ b/libcudacxx/include/cuda/std/__cccl/unreachable.h
@@ -14,8 +14,6 @@
 #include <cuda/std/__cccl/compiler.h>
 #include <cuda/std/__cccl/system_header.h>
 
-#include <nv/target>
-
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
@@ -24,8 +22,8 @@
 #  pragma system_header
 #endif // no system header
 
-#if _CCCL_COMPILER(MSVC)
-#  define _CCCL_UNREACHABLE() NV_IF_ELSE_TARGET(NV_IS_HOST, (__assume(0);), (__builtin_unreachable();))
+#if _CCCL_COMPILER(MSVC) && !defined(__CUDA_ARCH__)
+#  define _CCCL_UNREACHABLE() __assume(0)
 #else
 #  define _CCCL_UNREACHABLE() __builtin_unreachable()
 #endif

--- a/libcudacxx/include/cuda/std/__cccl/unreachable.h
+++ b/libcudacxx/include/cuda/std/__cccl/unreachable.h
@@ -29,16 +29,16 @@
 
 #  define _CCCL_UNREACHABLE()             \
     {                                     \
-      __assume(0);                        \
       _CCCL_ASSERT(false, "unreachable"); \
+      __assume(0);                        \
     }
 
 #else
 
 #  define _CCCL_UNREACHABLE()             \
     {                                     \
-      __builtin_unreachable();            \
       _CCCL_ASSERT(false, "unreachable"); \
+      __builtin_unreachable();            \
     }
 
 #endif // _CCCL_COMPILER(MSVC) && !defined(__CUDA_ARCH__)

--- a/libcudacxx/include/cuda/std/__cccl/unreachable.h
+++ b/libcudacxx/include/cuda/std/__cccl/unreachable.h
@@ -11,6 +11,7 @@
 #ifndef __CCCL_UNREACHABLE_H
 #define __CCCL_UNREACHABLE_H
 
+#include <cuda/std/__cccl/assert.h>
 #include <cuda/std/__cccl/compiler.h>
 #include <cuda/std/__cccl/system_header.h>
 
@@ -24,16 +25,18 @@
 
 #include <cuda/std/__cccl/visibility.h>
 
-#if _CCCL_CUDA_COMPILER(CLANG)
-#  define _CCCL_UNREACHABLE() __builtin_unreachable()
-#elif defined(__CUDA_ARCH__)
-#  define _CCCL_UNREACHABLE() __builtin_unreachable()
-#else // ^^^ __CUDA_ARCH__ ^^^ / vvv !__CUDA_ARCH__ vvv
-#  if _CCCL_COMPILER(MSVC)
-#    define _CCCL_UNREACHABLE() __assume(0)
-#  else // ^^^ _CCCL_COMPILER(MSVC) ^^^ / vvv !_CCCL_COMPILER(MSVC) vvv
-#    define _CCCL_UNREACHABLE() __builtin_unreachable()
-#  endif // !_CCCL_COMPILER(MSVC)
-#endif // !__CUDA_ARCH__
+#if _CCCL_COMPILER(MSVC) && !defined(__CUDA_ARCH__)
+#  define _CCCL_UNREACHABLE()             \
+    {                                     \
+      __assume(0);                        \
+      _CCCL_ASSERT(false, "unreachable"); \
+    }
+#else // ^^^ _CCCL_COMPILER(MSVC) ^^^ / vvv !_CCCL_COMPILER(MSVC) vvv
+#  define _CCCL_UNREACHABLE()             \
+    {                                     \
+      __builtin_unreachable();            \
+      _CCCL_ASSERT(false, "unreachable"); \
+    }
+#endif // !_CCCL_COMPILER(MSVC)
 
 #endif // __CCCL_UNREACHABLE_H

--- a/libcudacxx/include/cuda/std/__utility/unreachable.h
+++ b/libcudacxx/include/cuda/std/__utility/unreachable.h
@@ -24,9 +24,10 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 [[noreturn]] _LIBCUDACXX_HIDE_FROM_ABI void unreachable()
 {
+  _CCCL_ASSERT(false, "unreachable");
   _CCCL_UNREACHABLE();
 }
 
 _LIBCUDACXX_END_NAMESPACE_STD
 
-#endif
+#endif // _LIBCUDACXX___UTILITY_UNREACHABLE_H

--- a/libcudacxx/test/libcudacxx/std/utilities/utility/utility.unreachable/unreachable.runfail.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/utility/utility.unreachable/unreachable.runfail.cpp
@@ -6,6 +6,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
+// UNSUPPORTED: msvc-19.29, msvc-19.42
 
 #include <cuda/std/utility>
 

--- a/libcudacxx/test/libcudacxx/std/utilities/utility/utility.unreachable/unreachable.runfail.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/utility/utility.unreachable/unreachable.runfail.cpp
@@ -6,7 +6,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: msvc-19.29, msvc-19.42
+// UNSUPPORTED: msvc
 
 #include <cuda/std/utility>
 

--- a/libcudacxx/test/libcudacxx/std/utilities/utility/utility.unreachable/unreachable.runfail.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/utility/utility.unreachable/unreachable.runfail.cpp
@@ -3,16 +3,14 @@
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
-#include <cuda/std/type_traits>
 #include <cuda/std/utility>
-
-static_assert(cuda::std::is_same_v<decltype(cuda::std::unreachable()), void>);
 
 int main(int, char**)
 {
+  cuda::std::unreachable();
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/std/utilities/utility/utility.unreachable/unreachable.verify.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/utility/utility.unreachable/unreachable.verify.cpp
@@ -9,8 +9,6 @@
 
 #include <cuda/std/utility>
 
-#include "test_macros.h"
-
 [[noreturn]] void unreachable()
 {
   cuda::std::unreachable();


### PR DESCRIPTION
## Description

~The PR adds a run-time assertion to `_CCCL_UNREACHABLE` to check if the path is reached during the execution. This helps to prevent potential errors, especially with non-trivial branch logic.~

The PR ensures that the built-in is used in all cases and simplify the conditions