### PR TITLE
Add `_CCCL_PURE` attribute

### DIFF
--- a/libcudacxx/include/cuda/std/__cccl/attributes.h
+++ b/libcudacxx/include/cuda/std/__cccl/attributes.h
@@ -94,9 +94,19 @@
 
 #if _CCCL_HAS_CPP_ATTRIBUTE(assume)
 #  define _CCCL_ASSUME(...) [[assume(__VA_ARGS__)]]
-#else // ^^^ _CCCL_COMPILER(MSVC) ^^^ / vvv !_CCCL_COMPILER(MSVC) vvv
+#else
 #  define _CCCL_ASSUME(...) _CCCL_BUILTIN_ASSUME(__VA_ARGS__)
-#endif // ^^^ !_CCCL_COMPILER(MSVC) ^^^
+#endif
+
+#if _CCCL_HAS_CPP_ATTRIBUTE(pure) || _CCCL_CUDA_COMPILER(CLANG)
+#  define _CCCL_PURE [[gnu::pure]]
+#elif _CCCL_CUDA_COMPILER(NVCC)
+#  define _CCCL_PURE __nv_pure__
+#elif _CCCL_COMPILER(MSVC)
+#  define _CCCL_PURE __declspec(noalias)
+#else
+#  define _CCCL_PURE
+#endif
 
 #if _CCCL_HAS_CPP_ATTRIBUTE(clang::no_specializations)
 #  define _CCCL_NO_SPECIALIZATIONS_BECAUSE(_MSG)   [[clang::no_specializations(_MSG)]]

--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -142,7 +142,7 @@
 #  undef _CCCL_BUILTIN_ASINHL
 #endif // _CCCL_CUDA_COMPILER(CLANG)
 
-#if _CCCL_CHECK_BUILTIN(builtin_assume) || _CCCL_COMPILER(CLANG) || _CCCL_COMPILER(NVHPC)
+#if _CCCL_CHECK_BUILTIN(builtin_assume) || _CCCL_COMPILER(CLANG) || _CCCL_COMPILER(NVHPC) || _CCCL_COMPILER(GCC)
 #  define _CCCL_BUILTIN_ASSUME(...) __builtin_assume(__VA_ARGS__)
 #elif _CCCL_COMPILER(GCC, >=, 13)
 #  define _CCCL_BUILTIN_ASSUME(...) \


### PR DESCRIPTION
## Description

_**Pure**_ functions have no side effects on its parameters and no external global references. This allows optimizations such as Common Sub-expression Elimination and Dead Code Elimination. GCC, Clang, MSVC provide the corresponding attribute. NVCC also allows the attribute for device function.
Follow-up PR will add `_CCCL_PURE` to relevant libcu++ functions that are _pure_.
 