### PR TITLE
Implement internal constexpr cstring functions

### DIFF
--- a/libcudacxx/include/cuda/std/__string/constexpr_c_functions.h
+++ b/libcudacxx/include/cuda/std/__string/constexpr_c_functions.h
@@ -362,7 +362,7 @@ __cccl_memchr_impl_constexpr(_Tp* __ptr, _Tp __c, size_t __n) noexcept
 {
   while (__n--)
   {
-    if (*__ptr == static_cast<unsigned char>(__c))
+    if (*__ptr == __c)
     {
       return __ptr;
     }
@@ -435,7 +435,7 @@ __cccl_memmove_impl_host(_Tp* __dst, const _Tp* __src, size_t __n) noexcept
 #endif // !_CCCL_COMPILER(NVRTC)
 
 template <class _Tp>
-[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp* __cccl_memmove(_Tp* __dst, const _Tp* __src, size_t __n) noexcept
+_LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp* __cccl_memmove(_Tp* __dst, const _Tp* __src, size_t __n) noexcept
 {
   if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
   {
@@ -454,11 +454,13 @@ template <class _Tp>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr int
 __cccl_memcmp_impl_constexpr(const _Tp* __lhs, const _Tp* __rhs, size_t __n) noexcept
 {
+  using _Up = __make_nbit_uint_t<sizeof(_Tp) * CHAR_BIT>;
+
   while (__n--)
   {
     if (*__lhs != *__rhs)
     {
-      return *__lhs < *__rhs ? -1 : 1;
+      return static_cast<_Up>(*__lhs) < static_cast<_Up>(*__rhs) ? -1 : 1;
     }
     ++__lhs;
     ++__rhs;
@@ -471,7 +473,14 @@ template <class _Tp>
 [[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_HOST int
 __cccl_memcmp_impl_host(const _Tp* __lhs, const _Tp* __rhs, size_t __n) noexcept
 {
-  return ::memcmp(__lhs, __rhs, __n * sizeof(_Tp));
+  if constexpr (sizeof(_Tp) == 1)
+  {
+    return ::memcmp(__lhs, __rhs, __n);
+  }
+  else
+  {
+    return _CUDA_VSTD::__cccl_memcmp_impl_constexpr(__lhs, __rhs, __n);
+  }
 }
 #endif // !_CCCL_COMPILER(NVRTC)
 
@@ -515,7 +524,7 @@ __cccl_memcpy_impl_host(_Tp* _CCCL_RESTRICT __dst, const _Tp* _CCCL_RESTRICT __s
 #endif // !_CCCL_COMPILER(NVRTC)
 
 template <class _Tp>
-[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp*
+_LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp*
 __cccl_memcpy(_Tp* _CCCL_RESTRICT __dst, const _Tp* _CCCL_RESTRICT __src, size_t __n) noexcept
 {
   if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
@@ -560,7 +569,7 @@ template <class _Tp>
 #endif // !_CCCL_COMPILER(NVRTC)
 
 template <class _Tp>
-[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp* __cccl_memset(_Tp* __ptr, _Tp __c, size_t __n) noexcept
+_LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp* __cccl_memset(_Tp* __ptr, _Tp __c, size_t __n) noexcept
 {
   if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
   {

--- a/libcudacxx/include/cuda/std/__string/constexpr_c_functions.h
+++ b/libcudacxx/include/cuda/std/__string/constexpr_c_functions.h
@@ -35,9 +35,9 @@ template <class _CharT>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _CharT*
 __cccl_constexpr_strcpy(_CharT* _CCCL_RESTRICT __dst, const _CharT* _CCCL_RESTRICT __src) noexcept
 {
-  if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
+  if constexpr (sizeof(_CharT) == 1)
   {
-    if constexpr (sizeof(_CharT) == 1)
+    if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
     {
       NV_IF_TARGET(NV_IS_HOST, (return ::strcpy(__dst, __src);))
     }
@@ -54,9 +54,9 @@ template <class _CharT>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _CharT*
 __cccl_constexpr_strncpy(_CharT* _CCCL_RESTRICT __dst, const _CharT* _CCCL_RESTRICT __src, size_t __n) noexcept
 {
-  if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
+  if constexpr (sizeof(_CharT) == 1)
   {
-    if constexpr (sizeof(_CharT) == 1)
+    if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
     {
       NV_IF_TARGET(NV_IS_HOST, (return ::strncpy(__dst, __src, __n);))
     }
@@ -80,9 +80,9 @@ __cccl_constexpr_strncpy(_CharT* _CCCL_RESTRICT __dst, const _CharT* _CCCL_RESTR
 template <class _CharT>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr size_t __cccl_constexpr_strlen(const _CharT* __ptr) noexcept
 {
-  if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
+  if constexpr (sizeof(_CharT) == 1)
   {
-    if constexpr (sizeof(_CharT) == 1)
+    if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
     {
       NV_IF_TARGET(NV_IS_HOST, (return ::strlen(__ptr);))
     }
@@ -100,9 +100,9 @@ template <class _CharT>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr int
 __cccl_constexpr_strcmp(const _CharT* __lhs, const _CharT* __rhs) noexcept
 {
-  if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
+  if constexpr (sizeof(_CharT) == 1)
   {
-    if constexpr (sizeof(_CharT) == 1)
+    if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
     {
       NV_IF_TARGET(NV_IS_HOST, (return ::strcmp(__lhs, __rhs);))
     }
@@ -127,9 +127,9 @@ template <class _CharT>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr int
 __cccl_constexpr_strncmp(const _CharT* __lhs, const _CharT* __rhs, size_t __n) noexcept
 {
-  if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
+  if constexpr (sizeof(_CharT) == 1)
   {
-    if constexpr (sizeof(_CharT) == 1)
+    if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
     {
       NV_IF_TARGET(NV_IS_HOST, (return ::strncmp(__lhs, __rhs, __n);))
     }
@@ -158,9 +158,9 @@ __cccl_constexpr_strncmp(const _CharT* __lhs, const _CharT* __rhs, size_t __n) n
 template <class _CharT>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _CharT* __cccl_constexpr_strchr(_CharT* __ptr, _CharT __c) noexcept
 {
-  if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
+  if constexpr (sizeof(_CharT) == 1)
   {
-    if constexpr (sizeof(_CharT) == 1)
+    if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
     {
       NV_IF_TARGET(NV_IS_HOST, (return ::strchr(__ptr, static_cast<int>(__c));))
     }
@@ -180,9 +180,9 @@ template <class _CharT>
 template <class _CharT>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _CharT* __cccl_constexpr_strrchr(_CharT* __ptr, _CharT __c) noexcept
 {
-  if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
+  if constexpr (sizeof(_CharT) == 1)
   {
-    if constexpr (sizeof(_CharT) == 1)
+    if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
     {
       NV_IF_TARGET(NV_IS_HOST, (return ::strrchr(__ptr, static_cast<int>(__c));))
     }
@@ -208,9 +208,9 @@ template <class _CharT>
 template <class _Tp>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp* __cccl_constexpr_memchr(_Tp* __ptr, _Tp __c, size_t __n) noexcept
 {
-  if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
+  if constexpr (sizeof(_Tp) == 1)
   {
-    if constexpr (sizeof(_Tp) == 1)
+    if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
     {
       NV_IF_TARGET(NV_IS_HOST, (return reinterpret_cast<_Tp*>(::memchr(__ptr, static_cast<int>(__c), __n));))
     }

--- a/libcudacxx/include/cuda/std/__string/constexpr_c_functions.h
+++ b/libcudacxx/include/cuda/std/__string/constexpr_c_functions.h
@@ -33,20 +33,12 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+// __cccl_strcpy
+
 template <class _CharT>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _CharT*
-__cccl_constexpr_strcpy(_CharT* _CCCL_RESTRICT __dst, const _CharT* _CCCL_RESTRICT __src) noexcept
+__cccl_strcpy_impl_constexpr(_CharT* _CCCL_RESTRICT __dst, const _CharT* _CCCL_RESTRICT __src) noexcept
 {
-  if constexpr (sizeof(_CharT) == 1)
-  {
-    if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
-    {
-      NV_IF_TARGET(NV_IS_HOST,
-                   (return reinterpret_cast<_CharT*>(
-                             ::strcpy(reinterpret_cast<char*>(__dst), reinterpret_cast<const char*>(__src)));))
-    }
-  }
-
   _CharT* __dst_it = __dst;
   while ((*__dst_it++ = *__src++) != _CharT('\0'))
   {
@@ -54,20 +46,39 @@ __cccl_constexpr_strcpy(_CharT* _CCCL_RESTRICT __dst, const _CharT* _CCCL_RESTRI
   return __dst;
 }
 
+#if !_CCCL_COMPILER(NVRTC)
 template <class _CharT>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr _CharT*
-__cccl_constexpr_strncpy(_CharT* _CCCL_RESTRICT __dst, const _CharT* _CCCL_RESTRICT __src, size_t __n) noexcept
+_CCCL_HIDE_FROM_ABI _CCCL_HOST _CharT*
+__cccl_strcpy_impl_host(_CharT* _CCCL_RESTRICT __dst, const _CharT* _CCCL_RESTRICT __src) noexcept
 {
   if constexpr (sizeof(_CharT) == 1)
   {
-    if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
-    {
-      NV_IF_TARGET(NV_IS_HOST,
-                   (return reinterpret_cast<_CharT*>(
-                             ::strncpy(reinterpret_cast<char*>(__dst), reinterpret_cast<const char*>(__src), __n));))
-    }
+    return reinterpret_cast<_CharT*>(::strcpy(reinterpret_cast<char*>(__dst), reinterpret_cast<const char*>(__src)));
   }
+  else
+  {
+    return _CUDA_VSTD::__cccl_strcpy_impl_constexpr(__dst, __src);
+  }
+}
+#endif // !_CCCL_COMPILER(NVRTC)
 
+template <class _CharT>
+_LIBCUDACXX_HIDE_FROM_ABI constexpr _CharT*
+__cccl_strcpy(_CharT* _CCCL_RESTRICT __dst, const _CharT* _CCCL_RESTRICT __src) noexcept
+{
+  if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
+  {
+    NV_IF_TARGET(NV_IS_HOST, (return _CUDA_VSTD::__cccl_strcpy_impl_host(__dst, __src);))
+  }
+  return _CUDA_VSTD::__cccl_strcpy_impl_constexpr(__dst, __src);
+}
+
+// __cccl_strncpy
+
+template <class _CharT>
+_LIBCUDACXX_HIDE_FROM_ABI constexpr _CharT*
+__cccl_strncpy_impl_constexpr(_CharT* _CCCL_RESTRICT __dst, const _CharT* _CCCL_RESTRICT __src, size_t __n) noexcept
+{
   _CharT* __dst_it = __dst;
   while (__n--)
   {
@@ -83,17 +94,39 @@ __cccl_constexpr_strncpy(_CharT* _CCCL_RESTRICT __dst, const _CharT* _CCCL_RESTR
   return __dst;
 }
 
+#if !_CCCL_COMPILER(NVRTC)
 template <class _CharT>
-[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr size_t __cccl_constexpr_strlen(const _CharT* __ptr) noexcept
+_CCCL_HIDE_FROM_ABI _CCCL_HOST _CharT*
+__cccl_strncpy_impl_host(_CharT* _CCCL_RESTRICT __dst, const _CharT* _CCCL_RESTRICT __src, size_t __n) noexcept
 {
   if constexpr (sizeof(_CharT) == 1)
   {
-    if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
-    {
-      NV_IF_TARGET(NV_IS_HOST, (return ::strlen(reinterpret_cast<const char*>(__ptr));))
-    }
+    return reinterpret_cast<_CharT*>(
+      ::strncpy(reinterpret_cast<char*>(__dst), reinterpret_cast<const char*>(__src), __n));
   }
+  else
+  {
+    return _CUDA_VSTD::__cccl_strncpy_impl_constexpr(__dst, __src, __n);
+  }
+}
+#endif // !_CCCL_COMPILER(NVRTC)
 
+template <class _CharT>
+_LIBCUDACXX_HIDE_FROM_ABI constexpr _CharT*
+__cccl_strncpy(_CharT* _CCCL_RESTRICT __dst, const _CharT* _CCCL_RESTRICT __src, size_t __n) noexcept
+{
+  if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
+  {
+    NV_IF_TARGET(NV_IS_HOST, (return _CUDA_VSTD::__cccl_strncpy_impl_host(__dst, __src, __n);))
+  }
+  return _CUDA_VSTD::__cccl_strncpy_impl_constexpr(__dst, __src, __n);
+}
+
+// __cccl_strlen
+
+template <class _CharT>
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr size_t __cccl_strlen_impl_constexpr(const _CharT* __ptr) noexcept
+{
   size_t __len = 0;
   while (*__ptr++ != _CharT('\0'))
   {
@@ -102,19 +135,37 @@ template <class _CharT>
   return __len;
 }
 
+#if !_CCCL_COMPILER(NVRTC)
 template <class _CharT>
-[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr int
-__cccl_constexpr_strcmp(const _CharT* __lhs, const _CharT* __rhs) noexcept
+[[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_HOST size_t __cccl_strlen_impl_host(const _CharT* __ptr) noexcept
 {
   if constexpr (sizeof(_CharT) == 1)
   {
-    if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
-    {
-      NV_IF_TARGET(NV_IS_HOST,
-                   (return ::strcmp(reinterpret_cast<const char*>(__lhs), reinterpret_cast<const char*>(__rhs));))
-    }
+    return ::strlen(reinterpret_cast<const char*>(__ptr));
   }
+  else
+  {
+    return _CUDA_VSTD::__cccl_strlen_impl_constexpr(__ptr);
+  }
+}
+#endif // !_CCCL_COMPILER(NVRTC)
 
+template <class _CharT>
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr size_t __cccl_strlen(const _CharT* __ptr) noexcept
+{
+  if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
+  {
+    NV_IF_TARGET(NV_IS_HOST, (return _CUDA_VSTD::__cccl_strlen_impl_host(__ptr);))
+  }
+  return _CUDA_VSTD::__cccl_strlen_impl_constexpr(__ptr);
+}
+
+// __cccl_strcmp
+
+template <class _CharT>
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr int
+__cccl_strcmp_impl_constexpr(const _CharT* __lhs, const _CharT* __rhs) noexcept
+{
   using _UCharT = __make_nbit_uint_t<sizeof(_CharT) * CHAR_BIT>;
 
   while (*__lhs == *__rhs)
@@ -130,19 +181,38 @@ __cccl_constexpr_strcmp(const _CharT* __lhs, const _CharT* __rhs) noexcept
   return (static_cast<_UCharT>(*__lhs) < static_cast<_UCharT>(*__rhs)) ? -1 : 1;
 }
 
+#if !_CCCL_COMPILER(NVRTC)
 template <class _CharT>
-[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr int
-__cccl_constexpr_strncmp(const _CharT* __lhs, const _CharT* __rhs, size_t __n) noexcept
+[[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_HOST int
+__cccl_strcmp_impl_host(const _CharT* __lhs, const _CharT* __rhs) noexcept
 {
   if constexpr (sizeof(_CharT) == 1)
   {
-    if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
-    {
-      NV_IF_TARGET(NV_IS_HOST,
-                   (return ::strncmp(reinterpret_cast<const char*>(__lhs), reinterpret_cast<const char*>(__rhs), __n);))
-    }
+    return ::strcmp(reinterpret_cast<const char*>(__lhs), reinterpret_cast<const char*>(__rhs));
   }
+  else
+  {
+    return _CUDA_VSTD::__cccl_strcmp_impl_constexpr(__lhs, __rhs);
+  }
+}
+#endif // !_CCCL_COMPILER(NVRTC)
 
+template <class _CharT>
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr int __cccl_strcmp(const _CharT* __lhs, const _CharT* __rhs) noexcept
+{
+  if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
+  {
+    NV_IF_TARGET(NV_IS_HOST, (return _CUDA_VSTD::__cccl_strcmp_impl_host(__lhs, __rhs);))
+  }
+  return _CUDA_VSTD::__cccl_strcmp_impl_constexpr(__lhs, __rhs);
+}
+
+// __cccl_strncmp
+
+template <class _CharT>
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr int
+__cccl_strncmp_impl_constexpr(const _CharT* __lhs, const _CharT* __rhs, size_t __n) noexcept
+{
   using _UCharT = __make_nbit_uint_t<sizeof(_CharT) * CHAR_BIT>;
 
   while (__n--)
@@ -163,19 +233,39 @@ __cccl_constexpr_strncmp(const _CharT* __lhs, const _CharT* __rhs, size_t __n) n
   return 0;
 }
 
+#if !_CCCL_COMPILER(NVRTC)
 template <class _CharT>
-[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _CharT* __cccl_constexpr_strchr(_CharT* __ptr, _CharT __c) noexcept
+[[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_HOST int
+__cccl_strncmp_impl_host(const _CharT* __lhs, const _CharT* __rhs, size_t __n) noexcept
 {
   if constexpr (sizeof(_CharT) == 1)
   {
-    if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
-    {
-      NV_IF_TARGET(NV_IS_HOST,
-                   (return reinterpret_cast<_CharT*>(::strchr(
-                     reinterpret_cast<char*>(const_cast<remove_const_t<_CharT>*>(__ptr)), static_cast<int>(__c)));))
-    }
+    return ::strncmp(reinterpret_cast<const char*>(__lhs), reinterpret_cast<const char*>(__rhs), __n);
   }
+  else
+  {
+    return _CUDA_VSTD::__cccl_strncmp_impl_constexpr(__lhs, __rhs, __n);
+  }
+}
+#endif // !_CCCL_COMPILER(NVRTC)
 
+template <class _CharT>
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr int
+__cccl_strncmp(const _CharT* __lhs, const _CharT* __rhs, size_t __n) noexcept
+{
+  if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
+  {
+    NV_IF_TARGET(NV_IS_HOST, (return _CUDA_VSTD::__cccl_strncmp_impl_host(__lhs, __rhs, __n);))
+  }
+  return _CUDA_VSTD::__cccl_strncmp_impl_constexpr(__lhs, __rhs, __n);
+}
+
+// __cccl_strchr
+
+template <class _CharT>
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _CharT*
+__cccl_strchr_impl_constexpr(_CharT* __ptr, _CharT __c) noexcept
+{
   while (*__ptr != __c)
   {
     if (*__ptr == _CharT('\0'))
@@ -187,22 +277,42 @@ template <class _CharT>
   return __ptr;
 }
 
+#if !_CCCL_COMPILER(NVRTC)
 template <class _CharT>
-[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _CharT* __cccl_constexpr_strrchr(_CharT* __ptr, _CharT __c) noexcept
+[[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_HOST _CharT* __cccl_strchr_impl_host(_CharT* __ptr, _CharT __c) noexcept
 {
   if constexpr (sizeof(_CharT) == 1)
   {
-    if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
-    {
-      NV_IF_TARGET(NV_IS_HOST,
-                   (return reinterpret_cast<_CharT*>(::strrchr(
-                     reinterpret_cast<char*>(const_cast<remove_const_t<_CharT>*>(__ptr)), static_cast<int>(__c)));))
-    }
+    using _Up = remove_const_t<_CharT>;
+    return const_cast<_CharT*>(
+      reinterpret_cast<_Up*>(::strchr(reinterpret_cast<char*>(const_cast<_Up*>(__ptr)), static_cast<int>(__c))));
   }
+  else
+  {
+    return _CUDA_VSTD::__cccl_strchr_impl_constexpr<_CharT>(__ptr, __c);
+  }
+}
+#endif // !_CCCL_COMPILER(NVRTC)
 
+template <class _CharT>
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _CharT* __cccl_strchr(_CharT* __ptr, _CharT __c) noexcept
+{
+  if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
+  {
+    NV_IF_TARGET(NV_IS_HOST, (return _CUDA_VSTD::__cccl_strchr_impl_host<_CharT>(__ptr, __c);))
+  }
+  return _CUDA_VSTD::__cccl_strchr_impl_constexpr<_CharT>(__ptr, __c);
+}
+
+// __cccl_strrchr
+
+template <class _CharT>
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _CharT*
+__cccl_strrchr_impl_constexpr(_CharT* __ptr, _CharT __c) noexcept
+{
   if (__c == _CharT('\0'))
   {
-    return __ptr + _CUDA_VSTD::__cccl_constexpr_strlen(__ptr);
+    return __ptr + _CUDA_VSTD::__cccl_strlen(__ptr);
   }
 
   _CharT* __last{};
@@ -217,19 +327,39 @@ template <class _CharT>
   return __last;
 }
 
-template <class _Tp>
-[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp* __cccl_constexpr_memchr(_Tp* __ptr, _Tp __c, size_t __n) noexcept
+#if !_CCCL_COMPILER(NVRTC)
+template <class _CharT>
+[[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_HOST _CharT* __cccl_strrchr_impl_host(_CharT* __ptr, _CharT __c) noexcept
 {
-  if constexpr (sizeof(_Tp) == 1)
+  if constexpr (sizeof(_CharT) == 1)
   {
-    if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
-    {
-      NV_IF_TARGET(
-        NV_IS_HOST,
-        (return reinterpret_cast<_Tp*>(::memchr(const_cast<remove_const_t<_Tp>*>(__ptr), static_cast<int>(__c), __n));))
-    }
+    using _Up = remove_const_t<_CharT>;
+    return const_cast<_CharT*>(
+      reinterpret_cast<_Up*>(::strrchr(reinterpret_cast<char*>(const_cast<_Up*>(__ptr)), static_cast<int>(__c))));
   }
+  else
+  {
+    return _CUDA_VSTD::__cccl_strrchr_impl_constexpr<_CharT>(__ptr, __c);
+  }
+}
+#endif // !_CCCL_COMPILER(NVRTC)
 
+template <class _CharT>
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _CharT* __cccl_strrchr(_CharT* __ptr, _CharT __c) noexcept
+{
+  if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
+  {
+    NV_IF_TARGET(NV_IS_HOST, (return _CUDA_VSTD::__cccl_strrchr_impl_host<_CharT>(__ptr, __c);))
+  }
+  return _CUDA_VSTD::__cccl_strrchr_impl_constexpr<_CharT>(__ptr, __c);
+}
+
+// __cccl_memchr
+
+template <class _Tp>
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp*
+__cccl_memchr_impl_constexpr(_Tp* __ptr, _Tp __c, size_t __n) noexcept
+{
   while (__n--)
   {
     if (*__ptr == static_cast<unsigned char>(__c))
@@ -241,19 +371,38 @@ template <class _Tp>
   return nullptr;
 }
 
+#if !_CCCL_COMPILER(NVRTC)
 template <class _Tp>
-[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp*
-__cccl_constexpr_memmove(_Tp* __dst, const _Tp* __src, size_t __n) noexcept
+[[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_HOST _Tp* __cccl_memchr_impl_host(_Tp* __ptr, _Tp __c, size_t __n) noexcept
+{
+  if constexpr (sizeof(_Tp) == 1)
+  {
+    using _Up = remove_const_t<_Tp>;
+    return const_cast<_Tp*>(reinterpret_cast<_Up*>(::memchr(const_cast<_Up*>(__ptr), static_cast<int>(__c), __n)));
+  }
+  else
+  {
+    return _CUDA_VSTD::__cccl_memchr_impl_constexpr<_Tp>(__ptr, __c, __n);
+  }
+}
+#endif // !_CCCL_COMPILER(NVRTC)
+
+template <class _Tp>
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp* __cccl_memchr(_Tp* __ptr, _Tp __c, size_t __n) noexcept
 {
   if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
   {
-#if defined(_CCCL_BUILTIN_MEMMOVE)
-    return reinterpret_cast<_Tp*>(_CCCL_BUILTIN_MEMMOVE(__dst, __src, __n * sizeof(_Tp)));
-#else // ^^^ _CCCL_BUILTIN_MEMMOVE ^^^ / vvv !_CCCL_BUILTIN_MEMMOVE vvv
-    NV_IF_TARGET(NV_IS_HOST, (return reinterpret_cast<_Tp*>(::memmove(__dst, __src, __n * sizeof(_Tp)));))
-#endif // ^^^ !_CCCL_BUILTIN_MEMMOVE ^^^
+    NV_IF_TARGET(NV_IS_HOST, (return _CUDA_VSTD::__cccl_memchr_impl_host<_Tp>(__ptr, __c, __n);))
   }
+  return _CUDA_VSTD::__cccl_memchr_impl_constexpr<_Tp>(__ptr, __c, __n);
+}
 
+// __cccl_memmove
+
+template <class _Tp>
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp*
+__cccl_memmove_impl_constexpr(_Tp* __dst, const _Tp* __src, size_t __n) noexcept
+{
   const auto __dst_copy = __dst;
 
   if (__src < __dst && __dst < __src + __n)
@@ -276,19 +425,35 @@ __cccl_constexpr_memmove(_Tp* __dst, const _Tp* __src, size_t __n) noexcept
   return __dst_copy;
 }
 
+#if !_CCCL_COMPILER(NVRTC)
 template <class _Tp>
-[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr int
-__cccl_constexpr_memcmp(const _Tp* __lhs, const _Tp* __rhs, size_t __n) noexcept
+[[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_HOST _Tp*
+__cccl_memmove_impl_host(_Tp* __dst, const _Tp* __src, size_t __n) noexcept
+{
+  return reinterpret_cast<_Tp*>(::memmove(__dst, __src, __n * sizeof(_Tp)));
+}
+#endif // !_CCCL_COMPILER(NVRTC)
+
+template <class _Tp>
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp* __cccl_memmove(_Tp* __dst, const _Tp* __src, size_t __n) noexcept
 {
   if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
   {
-#if defined(_CCCL_BUILTIN_MEMCMP)
-    return _CCCL_BUILTIN_MEMCMP(__lhs, __rhs, __n * sizeof(_Tp));
-#else // ^^^ _CCCL_BUILTIN_MEMCMP ^^^ / vvv !_CCCL_BUILTIN_MEMCMP vvv
-    NV_IF_TARGET(NV_IS_HOST, (return ::memcmp(__lhs, __rhs, __n * sizeof(_Tp));))
-#endif // ^^^ !_CCCL_BUILTIN_MEMCMP ^^^
+#if defined(_CCCL_BUILTIN_MEMMOVE)
+    return reinterpret_cast<_Tp*>(_CCCL_BUILTIN_MEMMOVE(__dst, __src, __n * sizeof(_Tp)));
+#else // ^^^ _CCCL_BUILTIN_MEMMOVE ^^^ / vvv !_CCCL_BUILTIN_MEMMOVE vvv
+    NV_IF_TARGET(NV_IS_HOST, (return _CUDA_VSTD::__cccl_memmove_impl_host(__dst, __src, __n);))
+#endif // ^^^ !_CCCL_BUILTIN_MEMMOVE ^^^
   }
+  return _CUDA_VSTD::__cccl_memmove_impl_constexpr(__dst, __src, __n);
+}
 
+// __cccl_memcmp
+
+template <class _Tp>
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr int
+__cccl_memcmp_impl_constexpr(const _Tp* __lhs, const _Tp* __rhs, size_t __n) noexcept
+{
   while (__n--)
   {
     if (*__lhs != *__rhs)
@@ -301,19 +466,36 @@ __cccl_constexpr_memcmp(const _Tp* __lhs, const _Tp* __rhs, size_t __n) noexcept
   return 0;
 }
 
+#if !_CCCL_COMPILER(NVRTC)
 template <class _Tp>
-[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp*
-__cccl_constexpr_memcpy(_Tp* _CCCL_RESTRICT __dst, const _Tp* _CCCL_RESTRICT __src, size_t __n) noexcept
+[[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_HOST int
+__cccl_memcmp_impl_host(const _Tp* __lhs, const _Tp* __rhs, size_t __n) noexcept
+{
+  return ::memcmp(__lhs, __rhs, __n * sizeof(_Tp));
+}
+#endif // !_CCCL_COMPILER(NVRTC)
+
+template <class _Tp>
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr int
+__cccl_memcmp(const _Tp* __lhs, const _Tp* __rhs, size_t __n) noexcept
 {
   if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
   {
-#if defined(_CCCL_BUILTIN_MEMCPY)
-    return reinterpret_cast<_Tp*>(_CCCL_BUILTIN_MEMCPY(__dst, __src, __n * sizeof(_Tp)));
-#else // ^^^ _CCCL_BUILTIN_MEMCPY ^^^ / vvv !_CCCL_BUILTIN_MEMCPY vvv
-    NV_IF_TARGET(NV_IS_HOST, (return reinterpret_cast<_Tp*>(::memcpy(__dst, __src, __n * sizeof(_Tp)));))
-#endif // ^^^ !_CCCL_BUILTIN_MEMCPY ^^^
+#if defined(_CCCL_BUILTIN_MEMCMP)
+    return _CCCL_BUILTIN_MEMCMP(__lhs, __rhs, __n * sizeof(_Tp));
+#else // ^^^ _CCCL_BUILTIN_MEMCMP ^^^ / vvv !_CCCL_BUILTIN_MEMCMP vvv
+    NV_IF_TARGET(NV_IS_HOST, (return _CUDA_VSTD::__cccl_memcmp_impl_host(__lhs, __rhs, __n);))
+#endif // ^^^ !_CCCL_BUILTIN_MEMCMP ^^^
   }
+  return _CUDA_VSTD::__cccl_memcmp_impl_constexpr(__lhs, __rhs, __n);
+}
 
+// __cccl_memcpy
+
+template <class _Tp>
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp*
+__cccl_memcpy_impl_constexpr(_Tp* _CCCL_RESTRICT __dst, const _Tp* _CCCL_RESTRICT __src, size_t __n) noexcept
+{
   const auto __dst_copy = __dst;
 
   while (__n--)
@@ -323,18 +505,36 @@ __cccl_constexpr_memcpy(_Tp* _CCCL_RESTRICT __dst, const _Tp* _CCCL_RESTRICT __s
   return __dst_copy;
 }
 
+#if !_CCCL_COMPILER(NVRTC)
 template <class _Tp>
-[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp* __cccl_constexpr_memset(_Tp* __ptr, _Tp __c, size_t __n) noexcept
+[[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_HOST _Tp*
+__cccl_memcpy_impl_host(_Tp* _CCCL_RESTRICT __dst, const _Tp* _CCCL_RESTRICT __src, size_t __n) noexcept
 {
-  if constexpr (sizeof(_Tp) == 1)
-  {
-    if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
-    {
-      NV_IF_TARGET(NV_IS_HOST,
-                   (return reinterpret_cast<_Tp*>(::memset(__ptr, static_cast<int>(__c), __n * sizeof(_Tp)));))
-    }
-  }
+  return reinterpret_cast<_Tp*>(::memcpy(__dst, __src, __n * sizeof(_Tp)));
+}
+#endif // !_CCCL_COMPILER(NVRTC)
 
+template <class _Tp>
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp*
+__cccl_memcpy(_Tp* _CCCL_RESTRICT __dst, const _Tp* _CCCL_RESTRICT __src, size_t __n) noexcept
+{
+  if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
+  {
+#if defined(_CCCL_BUILTIN_MEMCPY)
+    return reinterpret_cast<_Tp*>(_CCCL_BUILTIN_MEMCPY(__dst, __src, __n * sizeof(_Tp)));
+#else // ^^^ _CCCL_BUILTIN_MEMCPY ^^^ / vvv !_CCCL_BUILTIN_MEMCPY vvv
+    NV_IF_TARGET(NV_IS_HOST, (return _CUDA_VSTD::__cccl_memcpy_impl_host(__dst, __src, __n);))
+#endif // ^^^ !_CCCL_BUILTIN_MEMCPY ^^^
+  }
+  return _CUDA_VSTD::__cccl_memcpy_impl_constexpr(__dst, __src, __n);
+}
+
+// __cccl_memset
+
+template <class _Tp>
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp*
+__cccl_memset_impl_constexpr(_Tp* __ptr, _Tp __c, size_t __n) noexcept
+{
   const auto __ptr_copy = __ptr;
 
   while (__n--)
@@ -342,6 +542,35 @@ template <class _Tp>
     *__ptr++ = __c;
   }
   return __ptr_copy;
+}
+
+#if !_CCCL_COMPILER(NVRTC)
+template <class _Tp>
+[[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_HOST _Tp* __cccl_memset_impl_host(_Tp* __ptr, _Tp __c, size_t __n) noexcept
+{
+  if constexpr (sizeof(_Tp) == 1)
+  {
+    return reinterpret_cast<_Tp*>(::memset(__ptr, static_cast<int>(__c), __n));
+  }
+  else
+  {
+    return _CUDA_VSTD::__cccl_memset_impl_constexpr(__ptr, __c, __n);
+  }
+}
+#endif // !_CCCL_COMPILER(NVRTC)
+
+template <class _Tp>
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp* __cccl_memset(_Tp* __ptr, _Tp __c, size_t __n) noexcept
+{
+  if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
+  {
+#if defined(_CCCL_BUILTIN_MEMSET)
+    return reinterpret_cast<_Tp*>(_CCCL_BUILTIN_MEMSET(__ptr, __c, __n * sizeof(_Tp)));
+#else // ^^^ _CCCL_BUILTIN_MEMSET ^^^ / vvv !_CCCL_BUILTIN_MEMSET vvv
+    NV_IF_TARGET(NV_IS_HOST, (return _CUDA_VSTD::__cccl_memset_impl_host(__ptr, __c, __n);))
+#endif // ^^^ !_CCCL_BUILTIN_MEMSET ^^^
+  }
+  return _CUDA_VSTD::__cccl_memset_impl_constexpr(__ptr, __c, __n);
 }
 
 _LIBCUDACXX_END_NAMESPACE_STD

--- a/libcudacxx/include/cuda/std/__string/constexpr_c_functions.h
+++ b/libcudacxx/include/cuda/std/__string/constexpr_c_functions.h
@@ -1,0 +1,335 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___STRING_CONSTEXPR_C_FUNCTIONS_H
+#define _LIBCUDACXX___STRING_CONSTEXPR_C_FUNCTIONS_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__cstddef/types.h>
+#include <cuda/std/__type_traits/is_constant_evaluated.h>
+#include <cuda/std/__type_traits/make_nbit_int.h>
+
+#if !_CCCL_COMPILER(NVRTC)
+#  include <cstring>
+#endif // !_CCCL_COMPILER(NVRTC)
+
+_LIBCUDACXX_BEGIN_NAMESPACE_STD
+
+template <class _CharT>
+_LIBCUDACXX_HIDE_FROM_ABI constexpr _CharT*
+__cccl_constexpr_strcpy(_CharT* _CCCL_RESTRICT __dst, const _CharT* _CCCL_RESTRICT __src) noexcept
+{
+  if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
+  {
+    if constexpr (sizeof(_CharT) == 1)
+    {
+      NV_IF_TARGET(NV_IS_HOST, (return ::strcpy(__dst, __src);))
+    }
+  }
+
+  _CharT* __dst_it = __dst;
+  while ((*__dst_it++ = *__src++) != _CharT('\0'))
+  {
+  }
+  return __dst;
+}
+
+template <class _CharT>
+_LIBCUDACXX_HIDE_FROM_ABI constexpr _CharT*
+__cccl_constexpr_strncpy(_CharT* _CCCL_RESTRICT __dst, const _CharT* _CCCL_RESTRICT __src, size_t __n) noexcept
+{
+  if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
+  {
+    if constexpr (sizeof(_CharT) == 1)
+    {
+      NV_IF_TARGET(NV_IS_HOST, (return ::strncpy(__dst, __src, __n);))
+    }
+  }
+
+  _CharT* __dst_it = __dst;
+  while (__n--)
+  {
+    if ((*__dst_it++ = *__src++) == _CharT('\0'))
+    {
+      while (__n--)
+      {
+        *__dst_it++ = _CharT('\0');
+      }
+      break;
+    }
+  }
+  return __dst;
+}
+
+template <class _CharT>
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr size_t __cccl_constexpr_strlen(const _CharT* __ptr) noexcept
+{
+  if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
+  {
+    if constexpr (sizeof(_CharT) == 1)
+    {
+      NV_IF_TARGET(NV_IS_HOST, (return ::strlen(__ptr);))
+    }
+  }
+
+  size_t __len = 0;
+  while (*__ptr++ != _CharT('\0'))
+  {
+    ++__len;
+  }
+  return __len;
+}
+
+template <class _CharT>
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr int
+__cccl_constexpr_strcmp(const _CharT* __lhs, const _CharT* __rhs) noexcept
+{
+  if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
+  {
+    if constexpr (sizeof(_CharT) == 1)
+    {
+      NV_IF_TARGET(NV_IS_HOST, (return ::strcmp(__lhs, __rhs);))
+    }
+  }
+
+  using _UCharT = __make_nbit_uint_t<sizeof(_CharT) * CHAR_BIT>;
+
+  while (*__lhs == *__rhs)
+  {
+    if (*__lhs == _CharT('\0'))
+    {
+      return 0;
+    }
+
+    ++__lhs;
+    ++__rhs;
+  }
+  return (static_cast<_UCharT>(*__lhs) < static_cast<_UCharT>(*__rhs)) ? -1 : 1;
+}
+
+template <class _CharT>
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr int
+__cccl_constexpr_strncmp(const _CharT* __lhs, const _CharT* __rhs, size_t __n) noexcept
+{
+  if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
+  {
+    if constexpr (sizeof(_CharT) == 1)
+    {
+      NV_IF_TARGET(NV_IS_HOST, (return ::strncmp(__lhs, __rhs, __n);))
+    }
+  }
+
+  using _UCharT = __make_nbit_uint_t<sizeof(_CharT) * CHAR_BIT>;
+
+  while (__n--)
+  {
+    if (*__lhs != *__rhs)
+    {
+      return (static_cast<_UCharT>(*__lhs) < static_cast<_UCharT>(*__rhs)) ? -1 : 1;
+    }
+
+    if (*__lhs == _CharT('\0'))
+    {
+      return 0;
+    }
+
+    ++__lhs;
+    ++__rhs;
+  }
+  return 0;
+}
+
+template <class _CharT>
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _CharT* __cccl_constexpr_strchr(_CharT* __ptr, _CharT __c) noexcept
+{
+  if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
+  {
+    if constexpr (sizeof(_CharT) == 1)
+    {
+      NV_IF_TARGET(NV_IS_HOST, (return ::strchr(__ptr, static_cast<int>(__c));))
+    }
+  }
+
+  while (*__ptr != __c)
+  {
+    if (*__ptr == _CharT('\0'))
+    {
+      return nullptr;
+    }
+    ++__ptr;
+  }
+  return __ptr;
+}
+
+template <class _CharT>
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _CharT* __cccl_constexpr_strrchr(_CharT* __ptr, _CharT __c) noexcept
+{
+  if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
+  {
+    if constexpr (sizeof(_CharT) == 1)
+    {
+      NV_IF_TARGET(NV_IS_HOST, (return ::strrchr(__ptr, static_cast<int>(__c));))
+    }
+  }
+
+  if (__c == _CharT('\0'))
+  {
+    return __ptr + _CUDA_VSTD::__cccl_constexpr_strlen(__ptr);
+  }
+
+  _CharT* __last{};
+  while (*__ptr != _CharT('\0'))
+  {
+    if (*__ptr == __c)
+    {
+      __last = __ptr;
+    }
+    ++__ptr;
+  }
+  return __last;
+}
+
+template <class _Tp>
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp* __cccl_constexpr_memchr(_Tp* __ptr, _Tp __c, size_t __n) noexcept
+{
+  if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
+  {
+    if constexpr (sizeof(_Tp) == 1)
+    {
+      NV_IF_TARGET(NV_IS_HOST, (return reinterpret_cast<_Tp*>(::memchr(__ptr, static_cast<int>(__c), __n));))
+    }
+  }
+
+  while (__n--)
+  {
+    if (*__ptr == static_cast<unsigned char>(__c))
+    {
+      return __ptr;
+    }
+    ++__ptr;
+  }
+  return nullptr;
+}
+
+template <class _Tp>
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp*
+__cccl_constexpr_memmove(_Tp* __dst, const _Tp* __src, size_t __n) noexcept
+{
+  if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
+  {
+#if defined(_CCCL_BUILTIN_MEMMOVE)
+    return reinterpret_cast<_Tp*>(_CCCL_BUILTIN_MEMMOVE(__dst, __src, __n * sizeof(_Tp)));
+#else // ^^^ _CCCL_BUILTIN_MEMMOVE ^^^ / vvv !_CCCL_BUILTIN_MEMMOVE vvv
+    NV_IF_TARGET(NV_IS_HOST, (return reinterpret_cast<_Tp*>(::memmove(__dst, __src, __n * sizeof(_Tp)));))
+#endif // ^^^ !_CCCL_BUILTIN_MEMMOVE ^^^
+  }
+
+  const auto __dst_copy = __dst;
+
+  if (__src < __dst && __dst < __src + __n)
+  {
+    __dst += __n;
+    __src += __n;
+
+    while (__n-- > 0)
+    {
+      *--__dst = *--__src;
+    }
+  }
+  else
+  {
+    while (__n-- > 0)
+    {
+      *__dst++ = *__src++;
+    }
+  }
+  return __dst_copy;
+}
+
+template <class _Tp>
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr int
+__cccl_constexpr_memcmp(const _Tp* __lhs, const _Tp* __rhs, size_t __n) noexcept
+{
+  if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
+  {
+#if defined(_CCCL_BUILTIN_MEMCMP)
+    return _CCCL_BUILTIN_MEMCMP(__lhs, __rhs, __n * sizeof(_Tp));
+#else // ^^^ _CCCL_BUILTIN_MEMCMP ^^^ / vvv !_CCCL_BUILTIN_MEMCMP vvv
+    NV_IF_TARGET(NV_IS_HOST, (return ::memcmp(__lhs, __rhs, __n * sizeof(_Tp));))
+#endif // ^^^ !_CCCL_BUILTIN_MEMCMP ^^^
+  }
+
+  while (__n--)
+  {
+    if (*__lhs != *__rhs)
+    {
+      return *__lhs < *__rhs ? -1 : 1;
+    }
+    ++__lhs;
+    ++__rhs;
+  }
+  return 0;
+}
+
+template <class _Tp>
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp*
+__cccl_constexpr_memcpy(_Tp* _CCCL_RESTRICT __dst, const _Tp* _CCCL_RESTRICT __src, size_t __n) noexcept
+{
+  if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
+  {
+#if defined(_CCCL_BUILTIN_MEMCPY)
+    return reinterpret_cast<_Tp*>(_CCCL_BUILTIN_MEMCPY(__dst, __src, __n * sizeof(_Tp)));
+#else // ^^^ _CCCL_BUILTIN_MEMCPY ^^^ / vvv !_CCCL_BUILTIN_MEMCPY vvv
+    NV_IF_TARGET(NV_IS_HOST, (return reinterpret_cast<_Tp*>(::memcpy(__dst, __src, __n * sizeof(_Tp)));))
+#endif // ^^^ !_CCCL_BUILTIN_MEMCPY ^^^
+  }
+
+  const auto __dst_copy = __dst;
+
+  while (__n--)
+  {
+    *__dst++ = *__src++;
+  }
+  return __dst_copy;
+}
+
+template <class _Tp>
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp* __cccl_constexpr_memset(_Tp* __ptr, _Tp __c, size_t __n) noexcept
+{
+  if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
+  {
+    if constexpr (sizeof(_Tp) == 1)
+    {
+      NV_IF_TARGET(NV_IS_HOST,
+                   (return reinterpret_cast<_Tp*>(::memset(__ptr, static_cast<int>(__c), __n * sizeof(_Tp)));))
+    }
+  }
+
+  const auto __ptr_copy = __ptr;
+
+  while (__n--)
+  {
+    *__ptr++ = __c;
+  }
+  return __ptr_copy;
+}
+
+_LIBCUDACXX_END_NAMESPACE_STD
+
+#endif // _LIBCUDACXX___STRING_CONSTEXPR_C_FUNCTIONS_H

--- a/libcudacxx/include/cuda/std/__string/constexpr_c_functions.h
+++ b/libcudacxx/include/cuda/std/__string/constexpr_c_functions.h
@@ -24,6 +24,7 @@
 #include <cuda/std/__cstddef/types.h>
 #include <cuda/std/__type_traits/is_constant_evaluated.h>
 #include <cuda/std/__type_traits/make_nbit_int.h>
+#include <cuda/std/climits>
 
 #if !_CCCL_COMPILER(NVRTC)
 #  include <cstring>
@@ -312,9 +313,9 @@ __cccl_constexpr_memcpy(_Tp* _CCCL_RESTRICT __dst, const _Tp* _CCCL_RESTRICT __s
 template <class _Tp>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp* __cccl_constexpr_memset(_Tp* __ptr, _Tp __c, size_t __n) noexcept
 {
-  if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
+  if constexpr (sizeof(_Tp) == 1)
   {
-    if constexpr (sizeof(_Tp) == 1)
+    if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
     {
       NV_IF_TARGET(NV_IS_HOST,
                    (return reinterpret_cast<_Tp*>(::memset(__ptr, static_cast<int>(__c), __n * sizeof(_Tp)));))

--- a/libcudacxx/include/cuda/std/__string/constexpr_c_functions.h
+++ b/libcudacxx/include/cuda/std/__string/constexpr_c_functions.h
@@ -24,6 +24,7 @@
 #include <cuda/std/__cstddef/types.h>
 #include <cuda/std/__type_traits/is_constant_evaluated.h>
 #include <cuda/std/__type_traits/make_nbit_int.h>
+#include <cuda/std/__type_traits/remove_const.h>
 #include <cuda/std/climits>
 
 #if !_CCCL_COMPILER(NVRTC)
@@ -40,7 +41,9 @@ __cccl_constexpr_strcpy(_CharT* _CCCL_RESTRICT __dst, const _CharT* _CCCL_RESTRI
   {
     if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
     {
-      NV_IF_TARGET(NV_IS_HOST, (return ::strcpy(__dst, __src);))
+      NV_IF_TARGET(NV_IS_HOST,
+                   (return reinterpret_cast<_CharT*>(
+                             ::strcpy(reinterpret_cast<char*>(__dst), reinterpret_cast<const char*>(__src)));))
     }
   }
 
@@ -59,7 +62,9 @@ __cccl_constexpr_strncpy(_CharT* _CCCL_RESTRICT __dst, const _CharT* _CCCL_RESTR
   {
     if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
     {
-      NV_IF_TARGET(NV_IS_HOST, (return ::strncpy(__dst, __src, __n);))
+      NV_IF_TARGET(NV_IS_HOST,
+                   (return reinterpret_cast<_CharT*>(
+                             ::strncpy(reinterpret_cast<char*>(__dst), reinterpret_cast<const char*>(__src), __n));))
     }
   }
 
@@ -85,7 +90,7 @@ template <class _CharT>
   {
     if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
     {
-      NV_IF_TARGET(NV_IS_HOST, (return ::strlen(__ptr);))
+      NV_IF_TARGET(NV_IS_HOST, (return ::strlen(reinterpret_cast<const char*>(__ptr));))
     }
   }
 
@@ -105,7 +110,8 @@ __cccl_constexpr_strcmp(const _CharT* __lhs, const _CharT* __rhs) noexcept
   {
     if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
     {
-      NV_IF_TARGET(NV_IS_HOST, (return ::strcmp(__lhs, __rhs);))
+      NV_IF_TARGET(NV_IS_HOST,
+                   (return ::strcmp(reinterpret_cast<const char*>(__lhs), reinterpret_cast<const char*>(__rhs));))
     }
   }
 
@@ -132,7 +138,8 @@ __cccl_constexpr_strncmp(const _CharT* __lhs, const _CharT* __rhs, size_t __n) n
   {
     if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
     {
-      NV_IF_TARGET(NV_IS_HOST, (return ::strncmp(__lhs, __rhs, __n);))
+      NV_IF_TARGET(NV_IS_HOST,
+                   (return ::strncmp(reinterpret_cast<const char*>(__lhs), reinterpret_cast<const char*>(__rhs), __n);))
     }
   }
 
@@ -163,7 +170,9 @@ template <class _CharT>
   {
     if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
     {
-      NV_IF_TARGET(NV_IS_HOST, (return ::strchr(__ptr, static_cast<int>(__c));))
+      NV_IF_TARGET(NV_IS_HOST,
+                   (return reinterpret_cast<_CharT*>(::strchr(
+                     reinterpret_cast<char*>(const_cast<remove_const_t<_CharT>*>(__ptr)), static_cast<int>(__c)));))
     }
   }
 
@@ -185,7 +194,9 @@ template <class _CharT>
   {
     if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
     {
-      NV_IF_TARGET(NV_IS_HOST, (return ::strrchr(__ptr, static_cast<int>(__c));))
+      NV_IF_TARGET(NV_IS_HOST,
+                   (return reinterpret_cast<_CharT*>(::strrchr(
+                     reinterpret_cast<char*>(const_cast<remove_const_t<_CharT>*>(__ptr)), static_cast<int>(__c)));))
     }
   }
 
@@ -213,7 +224,9 @@ template <class _Tp>
   {
     if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
     {
-      NV_IF_TARGET(NV_IS_HOST, (return reinterpret_cast<_Tp*>(::memchr(__ptr, static_cast<int>(__c), __n));))
+      NV_IF_TARGET(
+        NV_IS_HOST,
+        (return reinterpret_cast<_Tp*>(::memchr(const_cast<remove_const_t<_Tp>*>(__ptr), static_cast<int>(__c), __n));))
     }
   }
 

--- a/libcudacxx/include/cuda/std/cstring
+++ b/libcudacxx/include/cuda/std/cstring
@@ -23,7 +23,7 @@
 
 _CCCL_PUSH_MACROS
 
-#include <cuda/std/__type_traits/is_constant_evaluated.h>
+#include <cuda/std/__string/constexpr_c_functions.h>
 
 #if !_CCCL_COMPILER(NVRTC)
 #  include <cstring>
@@ -35,304 +35,74 @@ using ::memcpy;
 using ::memset;
 using ::size_t;
 
-// strcpy
-
-_LIBCUDACXX_HIDE_FROM_ABI constexpr char*
-__cccl_constexpr_strcpy(char* _CCCL_RESTRICT __dst, const char* _CCCL_RESTRICT __src) noexcept
-{
-  char* __dst_it = __dst;
-  while ((*__dst_it++ = *__src++) != '\0')
-  {
-  }
-  return __dst;
-}
-
 _LIBCUDACXX_HIDE_FROM_ABI constexpr char* strcpy(char* _CCCL_RESTRICT __dst, const char* _CCCL_RESTRICT __src)
 {
-  if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
-  {
-    NV_IF_TARGET(NV_IS_HOST, (return ::strcpy(__dst, __src);))
-  }
   return _CUDA_VSTD::__cccl_constexpr_strcpy(__dst, __src);
-}
-
-// strncpy
-
-_LIBCUDACXX_HIDE_FROM_ABI constexpr char*
-__cccl_constexpr_strncpy(char* _CCCL_RESTRICT __dst, const char* _CCCL_RESTRICT __src, size_t __n) noexcept
-{
-  char* __dst_it = __dst;
-  while (__n--)
-  {
-    if ((*__dst_it++ = *__src++) == '\0')
-    {
-      while (__n--)
-      {
-        *__dst_it++ = '\0';
-      }
-      break;
-    }
-  }
-  return __dst;
 }
 
 _LIBCUDACXX_HIDE_FROM_ABI constexpr char*
 strncpy(char* _CCCL_RESTRICT __dst, const char* _CCCL_RESTRICT __src, size_t __n)
 {
-  if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
-  {
-    NV_IF_TARGET(NV_IS_HOST, (return ::strncpy(__dst, __src, __n);))
-  }
   return _CUDA_VSTD::__cccl_constexpr_strncpy(__dst, __src, __n);
-}
-
-// strlen
-
-[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr size_t __cccl_constexpr_strlen(const char* __ptr) noexcept
-{
-  size_t __len = 0;
-  while (*__ptr++ != '\0')
-  {
-    ++__len;
-  }
-  return __len;
 }
 
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr size_t strlen(const char* __ptr)
 {
-  if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
-  {
-    NV_IF_TARGET(NV_IS_HOST, (return ::strlen(__ptr);))
-  }
   return _CUDA_VSTD::__cccl_constexpr_strlen(__ptr);
-}
-
-// strcmp
-
-[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr int
-__cccl_constexpr_strcmp(const char* __lhs, const char* __rhs) noexcept
-{
-  while (*__lhs == *__rhs)
-  {
-    if (*__lhs == '\0')
-    {
-      return 0;
-    }
-
-    ++__lhs;
-    ++__rhs;
-  }
-  return (static_cast<unsigned char>(*__lhs) < static_cast<unsigned char>(*__rhs)) ? -1 : 1;
 }
 
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr int strcmp(const char* __lhs, const char* __rhs)
 {
-  if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
-  {
-    NV_IF_TARGET(NV_IS_HOST, (return ::strcmp(__lhs, __rhs);))
-  }
   return _CUDA_VSTD::__cccl_constexpr_strcmp(__lhs, __rhs);
-}
-
-// strncmp
-
-[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr int
-__cccl_constexpr_strncmp(const char* __lhs, const char* __rhs, size_t __n) noexcept
-{
-  while (__n--)
-  {
-    if (*__lhs != *__rhs)
-    {
-      return (static_cast<unsigned char>(*__lhs) < static_cast<unsigned char>(*__rhs)) ? -1 : 1;
-    }
-
-    if (*__lhs == '\0')
-    {
-      return 0;
-    }
-
-    ++__lhs;
-    ++__rhs;
-  }
-  return 0;
 }
 
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr int strncmp(const char* __lhs, const char* __rhs, size_t __n)
 {
-  if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
-  {
-    NV_IF_TARGET(NV_IS_HOST, (return ::strncmp(__lhs, __rhs, __n);))
-  }
   return _CUDA_VSTD::__cccl_constexpr_strncmp(__lhs, __rhs, __n);
-}
-
-// strchr
-
-template <class _Tp>
-[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp* __cccl_constexpr_strchr(_Tp* __ptr, int __c) noexcept
-{
-  while (*__ptr != static_cast<char>(__c))
-  {
-    if (*__ptr == '\0')
-    {
-      return nullptr;
-    }
-    ++__ptr;
-  }
-  return __ptr;
 }
 
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr const char* strchr(const char* __ptr, int __c)
 {
-  if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
-  {
-    NV_IF_TARGET(NV_IS_HOST, (return ::strchr(__ptr, __c);))
-  }
-  return _CUDA_VSTD::__cccl_constexpr_strchr(__ptr, __c);
+  return _CUDA_VSTD::__cccl_constexpr_strchr<const char>(__ptr, static_cast<char>(__c));
 }
 
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr char* strchr(char* __ptr, int __c)
 {
-  if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
-  {
-    NV_IF_TARGET(NV_IS_HOST, (return ::strchr(__ptr, __c);))
-  }
-  return _CUDA_VSTD::__cccl_constexpr_strchr(__ptr, __c);
-}
-
-// strrchr
-
-template <class _Tp>
-[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp* __cccl_constexpr_strrchr(_Tp* __ptr, int __c) noexcept
-{
-  if (static_cast<char>(__c) == '\0')
-  {
-    return __ptr + _CUDA_VSTD::strlen(__ptr);
-  }
-
-  _Tp* __last{};
-  while (*__ptr != '\0')
-  {
-    if (*__ptr == static_cast<char>(__c))
-    {
-      __last = __ptr;
-    }
-    ++__ptr;
-  }
-  return __last;
+  return _CUDA_VSTD::__cccl_constexpr_strchr(__ptr, static_cast<char>(__c));
 }
 
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr const char* strrchr(const char* __ptr, int __c)
 {
-  if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
-  {
-    NV_IF_TARGET(NV_IS_HOST, (return ::strrchr(__ptr, __c);))
-  }
-  return _CUDA_VSTD::__cccl_constexpr_strrchr(__ptr, __c);
+  return _CUDA_VSTD::__cccl_constexpr_strrchr<const char>(__ptr, static_cast<char>(__c));
 }
 
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr char* strrchr(char* __ptr, int __c)
 {
-  if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
-  {
-    NV_IF_TARGET(NV_IS_HOST, (return ::strrchr(__ptr, __c);))
-  }
-  return _CUDA_VSTD::__cccl_constexpr_strrchr(__ptr, __c);
+  return _CUDA_VSTD::__cccl_constexpr_strrchr(__ptr, static_cast<char>(__c));
 }
-
-// memchr
-
-#if _CCCL_HAS_CUDA_COMPILER()
-_CCCL_HIDE_FROM_ABI _CCCL_DEVICE const void* __memchr_device(const void* __ptr, int __c, size_t __n) noexcept
-{
-  auto __p = static_cast<const unsigned char*>(__ptr);
-
-  while (__n--)
-  {
-    if (*__p == static_cast<unsigned char>(__c))
-    {
-      return __p;
-    }
-    ++__p;
-  }
-
-  return nullptr;
-}
-#endif // _CCCL_HAS_CUDA_COMPILER()
 
 _LIBCUDACXX_HIDE_FROM_ABI const void* memchr(const void* __ptr, int __c, size_t __n) noexcept
 {
-  NV_IF_ELSE_TARGET(
-    NV_IS_HOST, (return ::memchr(__ptr, __c, __n);), (return _CUDA_VSTD::__memchr_device(__ptr, __c, __n);))
+  return _CUDA_VSTD::__cccl_constexpr_memchr<const unsigned char>(
+    reinterpret_cast<const unsigned char*>(__ptr), static_cast<unsigned char>(__c), __n);
 }
 
 _LIBCUDACXX_HIDE_FROM_ABI void* memchr(void* __ptr, int __c, size_t __n) noexcept
 {
-  NV_IF_ELSE_TARGET(NV_IS_HOST,
-                    (return ::memchr(__ptr, __c, __n);),
-                    (return const_cast<void*>(_CUDA_VSTD::memchr(const_cast<const void*>(__ptr), __c, __n));))
+  return _CUDA_VSTD::__cccl_constexpr_memchr(
+    reinterpret_cast<unsigned char*>(__ptr), static_cast<unsigned char>(__c), __n);
 }
-
-// memmove
-
-#if _CCCL_HAS_CUDA_COMPILER()
-_CCCL_HIDE_FROM_ABI _CCCL_DEVICE void* __memmove_device(void* __dst, const void* __src, size_t __n) noexcept
-{
-  auto __d = (__dst <= __src) ? static_cast<unsigned char*>(__dst) : (static_cast<unsigned char*>(__dst) + __n - 1);
-  auto __s =
-    (__dst <= __src) ? static_cast<const unsigned char*>(__src) : (static_cast<const unsigned char*>(__src) + __n - 1);
-  const auto __inc = (__dst <= __src) ? 1 : -1;
-
-  while (__n--)
-  {
-    *__d = *__s;
-    __d += __inc;
-    __s += __inc;
-  }
-
-  return __dst;
-}
-#endif // _CCCL_HAS_CUDA_COMPILER()
 
 _LIBCUDACXX_HIDE_FROM_ABI void* memmove(void* __dst, const void* __src, size_t __n) noexcept
 {
-#if defined(_CCCL_BUILTIN_MEMMOVE)
-  return _CCCL_BUILTIN_MEMMOVE(__dst, __src, __n);
-#else // ^^^ _CCCL_BUILTIN_MEMMOVE ^^^ / vvv !_CCCL_BUILTIN_MEMMOVE vvv
-  NV_IF_ELSE_TARGET(
-    NV_IS_HOST, (return ::memmove(__dst, __src, __n);), (return _CUDA_VSTD::__memmove_device(__dst, __src, __n);))
-#endif // ^^^ !_CCCL_BUILTIN_MEMMOVE ^^^
+  return _CUDA_VSTD::__cccl_constexpr_memmove(
+    reinterpret_cast<unsigned char*>(__dst), reinterpret_cast<const unsigned char*>(__src), __n);
 }
 
-// memcmp
-
-#if _CCCL_HAS_CUDA_COMPILER()
-_CCCL_HIDE_FROM_ABI _CCCL_DEVICE int __memcmp_device(const void* __lhs, const void* __rhs, size_t __n) noexcept
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI int memcmp(const void* __lhs, const void* __rhs, size_t __n) noexcept
 {
-  auto __l = static_cast<const unsigned char*>(__lhs);
-  auto __r = static_cast<const unsigned char*>(__rhs);
-
-  while (__n--)
-  {
-    if (*__l != *__r)
-    {
-      return *__l < *__r ? -1 : 1;
-    }
-    ++__l;
-    ++__r;
-  }
-  return 0;
-}
-#endif // _CCCL_HAS_CUDA_COMPILER()
-
-_LIBCUDACXX_HIDE_FROM_ABI int memcmp(const void* __lhs, const void* __rhs, size_t __n) noexcept
-{
-#if defined(_CCCL_BUILTIN_MEMCMP)
-  return _CCCL_BUILTIN_MEMCMP(__lhs, __rhs, __n);
-#else // ^^^ _CCCL_BUILTIN_MEMCMP ^^^ / vvv !_CCCL_BUILTIN_MEMCMP vvv
-  NV_IF_ELSE_TARGET(
-    NV_IS_HOST, (return ::memcmp(__lhs, __rhs, __n);), (return _CUDA_VSTD::__memcmp_device(__lhs, __rhs, __n);))
-#endif // ^^^ !_CCCL_BUILTIN_MEMCMP ^^^
+  return _CUDA_VSTD::__cccl_constexpr_memcmp(
+    reinterpret_cast<const unsigned char*>(__lhs), reinterpret_cast<const unsigned char*>(__rhs), __n);
 }
 
 _LIBCUDACXX_END_NAMESPACE_STD

--- a/libcudacxx/include/cuda/std/cstring
+++ b/libcudacxx/include/cuda/std/cstring
@@ -37,71 +37,70 @@ using ::size_t;
 
 _LIBCUDACXX_HIDE_FROM_ABI constexpr char* strcpy(char* _CCCL_RESTRICT __dst, const char* _CCCL_RESTRICT __src)
 {
-  return _CUDA_VSTD::__cccl_constexpr_strcpy(__dst, __src);
+  return _CUDA_VSTD::__cccl_strcpy(__dst, __src);
 }
 
 _LIBCUDACXX_HIDE_FROM_ABI constexpr char*
 strncpy(char* _CCCL_RESTRICT __dst, const char* _CCCL_RESTRICT __src, size_t __n)
 {
-  return _CUDA_VSTD::__cccl_constexpr_strncpy(__dst, __src, __n);
+  return _CUDA_VSTD::__cccl_strncpy(__dst, __src, __n);
 }
 
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr size_t strlen(const char* __ptr)
 {
-  return _CUDA_VSTD::__cccl_constexpr_strlen(__ptr);
+  return _CUDA_VSTD::__cccl_strlen(__ptr);
 }
 
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr int strcmp(const char* __lhs, const char* __rhs)
 {
-  return _CUDA_VSTD::__cccl_constexpr_strcmp(__lhs, __rhs);
+  return _CUDA_VSTD::__cccl_strcmp(__lhs, __rhs);
 }
 
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr int strncmp(const char* __lhs, const char* __rhs, size_t __n)
 {
-  return _CUDA_VSTD::__cccl_constexpr_strncmp(__lhs, __rhs, __n);
+  return _CUDA_VSTD::__cccl_strncmp(__lhs, __rhs, __n);
 }
 
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr const char* strchr(const char* __ptr, int __c)
 {
-  return _CUDA_VSTD::__cccl_constexpr_strchr<const char>(__ptr, static_cast<char>(__c));
+  return _CUDA_VSTD::__cccl_strchr<const char>(__ptr, static_cast<char>(__c));
 }
 
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr char* strchr(char* __ptr, int __c)
 {
-  return _CUDA_VSTD::__cccl_constexpr_strchr(__ptr, static_cast<char>(__c));
+  return _CUDA_VSTD::__cccl_strchr(__ptr, static_cast<char>(__c));
 }
 
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr const char* strrchr(const char* __ptr, int __c)
 {
-  return _CUDA_VSTD::__cccl_constexpr_strrchr<const char>(__ptr, static_cast<char>(__c));
+  return _CUDA_VSTD::__cccl_strrchr<const char>(__ptr, static_cast<char>(__c));
 }
 
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr char* strrchr(char* __ptr, int __c)
 {
-  return _CUDA_VSTD::__cccl_constexpr_strrchr(__ptr, static_cast<char>(__c));
+  return _CUDA_VSTD::__cccl_strrchr(__ptr, static_cast<char>(__c));
 }
 
 _LIBCUDACXX_HIDE_FROM_ABI const void* memchr(const void* __ptr, int __c, size_t __n) noexcept
 {
-  return _CUDA_VSTD::__cccl_constexpr_memchr<const unsigned char>(
+  return _CUDA_VSTD::__cccl_memchr<const unsigned char>(
     reinterpret_cast<const unsigned char*>(__ptr), static_cast<unsigned char>(__c), __n);
 }
 
 _LIBCUDACXX_HIDE_FROM_ABI void* memchr(void* __ptr, int __c, size_t __n) noexcept
 {
-  return _CUDA_VSTD::__cccl_constexpr_memchr(
-    reinterpret_cast<unsigned char*>(__ptr), static_cast<unsigned char>(__c), __n);
+  return _CUDA_VSTD::__cccl_memchr(reinterpret_cast<unsigned char*>(__ptr), static_cast<unsigned char>(__c), __n);
 }
 
 _LIBCUDACXX_HIDE_FROM_ABI void* memmove(void* __dst, const void* __src, size_t __n) noexcept
 {
-  return _CUDA_VSTD::__cccl_constexpr_memmove(
+  return _CUDA_VSTD::__cccl_memmove(
     reinterpret_cast<unsigned char*>(__dst), reinterpret_cast<const unsigned char*>(__src), __n);
 }
 
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI int memcmp(const void* __lhs, const void* __rhs, size_t __n) noexcept
 {
-  return _CUDA_VSTD::__cccl_constexpr_memcmp(
+  return _CUDA_VSTD::__cccl_memcmp(
     reinterpret_cast<const unsigned char*>(__lhs), reinterpret_cast<const unsigned char*>(__rhs), __n);
 }
 

--- a/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/array_func/memchr.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/array_func/memchr.pass.cpp
@@ -1,0 +1,68 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/__string/constexpr_c_functions.h>
+#include <cuda/std/type_traits>
+
+constexpr int not_found = -1;
+
+template <class T>
+__host__ __device__ constexpr void test_memchr(const T* ptr, T c, size_t n, int expected_pos)
+{
+  const T* ret = cuda::std::__cccl_constexpr_memchr<const T>(ptr, c, n);
+
+  if (expected_pos == not_found)
+  {
+    assert(ret == nullptr);
+  }
+  else
+  {
+    assert(ret != nullptr);
+    assert(ret == ptr + expected_pos);
+  }
+}
+
+__host__ __device__ constexpr bool test()
+{
+  // char8
+  test_memchr<char>("abcde", '\0', 6, 5);
+  test_memchr<char>("abcde", '\0', 5, not_found);
+  test_memchr<char>("aaabb", 'b', 5, 3);
+  test_memchr<char>("aaabb", 'b', 4, 3);
+  test_memchr<char>("aaabb", 'b', 3, not_found);
+  test_memchr<char>("aaaa", 'b', 4, not_found);
+  test_memchr<char>("aaaa", 'a', 0, not_found);
+
+  // char16
+  test_memchr<char16_t>(u"abcde", u'\0', 6, 5);
+  test_memchr<char16_t>(u"abcde", u'\0', 5, not_found);
+  test_memchr<char16_t>(u"aaabb", u'b', 5, 3);
+  test_memchr<char16_t>(u"aaabb", u'b', 4, 3);
+  test_memchr<char16_t>(u"aaabb", u'b', 3, not_found);
+  test_memchr<char16_t>(u"aaaa", u'b', 4, not_found);
+  test_memchr<char16_t>(u"aaaa", u'a', 0, not_found);
+
+  // char32
+  test_memchr<char32_t>(U"abcde", U'\0', 6, 5);
+  test_memchr<char32_t>(U"abcde", U'\0', 5, not_found);
+  test_memchr<char32_t>(U"aaabb", U'b', 5, 3);
+  test_memchr<char32_t>(U"aaabb", U'b', 4, 3);
+  test_memchr<char32_t>(U"aaabb", U'b', 3, not_found);
+  test_memchr<char32_t>(U"aaaa", U'b', 4, not_found);
+  test_memchr<char32_t>(U"aaaa", U'a', 0, not_found);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/array_func/memchr.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/array_func/memchr.pass.cpp
@@ -30,7 +30,7 @@ __host__ __device__ constexpr void test_memchr(const T* ptr, T c, size_t n, int 
 
 __host__ __device__ constexpr bool test()
 {
-  // char8
+  // char
   test_memchr<char>("abcde", '\0', 6, 5);
   test_memchr<char>("abcde", '\0', 5, not_found);
   test_memchr<char>("aaabb", 'b', 5, 3);
@@ -39,7 +39,18 @@ __host__ __device__ constexpr bool test()
   test_memchr<char>("aaaa", 'b', 4, not_found);
   test_memchr<char>("aaaa", 'a', 0, not_found);
 
-  // char16
+#if _LIBCUDACXX_HAS_CHAR8_T()
+  // char8_t
+  test_memchr<char8_t>(u8"abcde", u8'\0', 6, 5);
+  test_memchr<char8_t>(u8"abcde", u8'\0', 5, not_found);
+  test_memchr<char8_t>(u8"aaabb", u8'b', 5, 3);
+  test_memchr<char8_t>(u8"aaabb", u8'b', 4, 3);
+  test_memchr<char8_t>(u8"aaabb", u8'b', 3, not_found);
+  test_memchr<char8_t>(u8"aaaa", u8'b', 4, not_found);
+  test_memchr<char8_t>(u8"aaaa", u8'a', 0, not_found);
+#endif // _LIBCUDACXX_HAS_CHAR8_T()
+
+  // char16_t
   test_memchr<char16_t>(u"abcde", u'\0', 6, 5);
   test_memchr<char16_t>(u"abcde", u'\0', 5, not_found);
   test_memchr<char16_t>(u"aaabb", u'b', 5, 3);
@@ -48,7 +59,7 @@ __host__ __device__ constexpr bool test()
   test_memchr<char16_t>(u"aaaa", u'b', 4, not_found);
   test_memchr<char16_t>(u"aaaa", u'a', 0, not_found);
 
-  // char32
+  // char32_t
   test_memchr<char32_t>(U"abcde", U'\0', 6, 5);
   test_memchr<char32_t>(U"abcde", U'\0', 5, not_found);
   test_memchr<char32_t>(U"aaabb", U'b', 5, 3);

--- a/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/array_func/memchr.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/array_func/memchr.pass.cpp
@@ -15,7 +15,7 @@ constexpr int not_found = -1;
 template <class T>
 __host__ __device__ constexpr void test_memchr(const T* ptr, T c, size_t n, int expected_pos)
 {
-  const T* ret = cuda::std::__cccl_constexpr_memchr<const T>(ptr, c, n);
+  const T* ret = cuda::std::__cccl_memchr<const T>(ptr, c, n);
 
   if (expected_pos == not_found)
   {

--- a/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/array_func/memcmp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/array_func/memcmp.pass.cpp
@@ -14,7 +14,7 @@
 template <class T>
 __host__ __device__ constexpr void test_memcmp(const T* lhs, const T* rhs, size_t n, int expected)
 {
-  const auto ret = cuda::std::__cccl_constexpr_memcmp(lhs, rhs, n);
+  const auto ret = cuda::std::__cccl_memcmp(lhs, rhs, n);
 
   if (expected == 0)
   {

--- a/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/array_func/memcmp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/array_func/memcmp.pass.cpp
@@ -32,7 +32,7 @@ __host__ __device__ constexpr void test_memcmp(const T* lhs, const T* rhs, size_
 
 __host__ __device__ constexpr bool test()
 {
-  // char8
+  // char
   test_memcmp<char>("abcde", "abcde", 5, 0);
   test_memcmp<char>("abcd1", "abcd0", 5, 1);
   test_memcmp<char>("abcd0", "abcd1", 5, -1);
@@ -42,7 +42,19 @@ __host__ __device__ constexpr bool test()
   test_memcmp<char>("abcde", "fghij", 0, 0);
   test_memcmp<char>(nullptr, nullptr, 0, 0);
 
-  // char16
+#if _LIBCUDACXX_HAS_CHAR8_T()
+  // char8_t
+  test_memcmp<char8_t>(u8"abcde", u8"abcde", 5, 0);
+  test_memcmp<char8_t>(u8"abcd1", u8"abcd0", 5, 1);
+  test_memcmp<char8_t>(u8"abcd0", u8"abcd1", 5, -1);
+  test_memcmp<char8_t>(u8"abcd1", u8"abcd0", 4, 0);
+  test_memcmp<char8_t>(u8"abcd0", u8"abcd1", 4, 0);
+  test_memcmp<char8_t>(u8"abcde", u8"fghij", 5, -1);
+  test_memcmp<char8_t>(u8"abcde", u8"fghij", 0, 0);
+  test_memcmp<char8_t>(nullptr, nullptr, 0, 0);
+#endif // _LIBCUDACXX_HAS_CHAR8_T()
+
+  // char16_t
   test_memcmp<char16_t>(u"abcde", u"abcde", 5, 0);
   test_memcmp<char16_t>(u"abcd1", u"abcd0", 5, 1);
   test_memcmp<char16_t>(u"abcd0", u"abcd1", 5, -1);
@@ -52,7 +64,7 @@ __host__ __device__ constexpr bool test()
   test_memcmp<char16_t>(u"abcde", u"fghij", 0, 0);
   test_memcmp<char16_t>(nullptr, nullptr, 0, 0);
 
-  // char32
+  // char32_t
   test_memcmp<char32_t>(U"abcde", U"abcde", 5, 0);
   test_memcmp<char32_t>(U"abcd1", U"abcd0", 5, 1);
   test_memcmp<char32_t>(U"abcd0", U"abcd1", 5, -1);

--- a/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/array_func/memcmp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/array_func/memcmp.pass.cpp
@@ -1,0 +1,73 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/__string/constexpr_c_functions.h>
+#include <cuda/std/cassert>
+#include <cuda/std/cstddef>
+
+template <class T>
+__host__ __device__ constexpr void test_memcmp(const T* lhs, const T* rhs, size_t n, int expected)
+{
+  const auto ret = cuda::std::__cccl_constexpr_memcmp(lhs, rhs, n);
+
+  if (expected == 0)
+  {
+    assert(ret == 0);
+  }
+  else if (expected < 0)
+  {
+    assert(ret < 0);
+  }
+  else
+  {
+    assert(ret > 0);
+  }
+}
+
+__host__ __device__ constexpr bool test()
+{
+  // char8
+  test_memcmp<char>("abcde", "abcde", 5, 0);
+  test_memcmp<char>("abcd1", "abcd0", 5, 1);
+  test_memcmp<char>("abcd0", "abcd1", 5, -1);
+  test_memcmp<char>("abcd1", "abcd0", 4, 0);
+  test_memcmp<char>("abcd0", "abcd1", 4, 0);
+  test_memcmp<char>("abcde", "fghij", 5, -1);
+  test_memcmp<char>("abcde", "fghij", 0, 0);
+  test_memcmp<char>(nullptr, nullptr, 0, 0);
+
+  // char16
+  test_memcmp<char16_t>(u"abcde", u"abcde", 5, 0);
+  test_memcmp<char16_t>(u"abcd1", u"abcd0", 5, 1);
+  test_memcmp<char16_t>(u"abcd0", u"abcd1", 5, -1);
+  test_memcmp<char16_t>(u"abcd1", u"abcd0", 4, 0);
+  test_memcmp<char16_t>(u"abcd0", u"abcd1", 4, 0);
+  test_memcmp<char16_t>(u"abcde", u"fghij", 5, -1);
+  test_memcmp<char16_t>(u"abcde", u"fghij", 0, 0);
+  test_memcmp<char16_t>(nullptr, nullptr, 0, 0);
+
+  // char32
+  test_memcmp<char32_t>(U"abcde", U"abcde", 5, 0);
+  test_memcmp<char32_t>(U"abcd1", U"abcd0", 5, 1);
+  test_memcmp<char32_t>(U"abcd0", U"abcd1", 5, -1);
+  test_memcmp<char32_t>(U"abcd1", U"abcd0", 4, 0);
+  test_memcmp<char32_t>(U"abcd0", U"abcd1", 4, 0);
+  test_memcmp<char32_t>(U"abcde", U"fghij", 5, -1);
+  test_memcmp<char32_t>(U"abcde", U"fghij", 0, 0);
+  test_memcmp<char32_t>(nullptr, nullptr, 0, 0);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/array_func/memcpy.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/array_func/memcpy.pass.cpp
@@ -1,0 +1,52 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/__string/constexpr_c_functions.h>
+#include <cuda/std/cassert>
+
+template <class T, size_t n>
+__host__ __device__ constexpr void test_memcpy(const T* src)
+{
+  T buf[n + 1]{}; // + 1 to prevent zero size buffer
+  assert(cuda::std::__cccl_constexpr_memcpy(buf, src, n) == buf);
+  assert(cuda::std::__cccl_constexpr_memcmp(buf, src, n) == 0);
+}
+
+__host__ __device__ constexpr bool test()
+{
+  // char8
+  test_memcpy<char, 0>("");
+  test_memcpy<char, 0>("asdf");
+  test_memcpy<char, 1>("a");
+  test_memcpy<char, 3>("abcde");
+  test_memcpy<char, 5>("abcde");
+
+  // char16
+  test_memcpy<char16_t, 0>(u"");
+  test_memcpy<char16_t, 0>(u"asdf");
+  test_memcpy<char16_t, 1>(u"a");
+  test_memcpy<char16_t, 3>(u"abcde");
+  test_memcpy<char16_t, 5>(u"abcde");
+
+  // char32_t
+  test_memcpy<char32_t, 0>(U"");
+  test_memcpy<char32_t, 0>(U"asdf");
+  test_memcpy<char32_t, 1>(U"a");
+  test_memcpy<char32_t, 3>(U"abcde");
+  test_memcpy<char32_t, 5>(U"abcde");
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/array_func/memcpy.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/array_func/memcpy.pass.cpp
@@ -20,14 +20,23 @@ __host__ __device__ constexpr void test_memcpy(const T* src)
 
 __host__ __device__ constexpr bool test()
 {
-  // char8
+  // char
   test_memcpy<char, 0>("");
   test_memcpy<char, 0>("asdf");
   test_memcpy<char, 1>("a");
   test_memcpy<char, 3>("abcde");
   test_memcpy<char, 5>("abcde");
 
-  // char16
+#if _LIBCUDACXX_HAS_CHAR8_T()
+  // char8_t
+  test_memcpy<char8_t, 0>(u8"");
+  test_memcpy<char8_t, 0>(u8"asdf");
+  test_memcpy<char8_t, 1>(u8"a");
+  test_memcpy<char8_t, 3>(u8"abcde");
+  test_memcpy<char8_t, 5>(u8"abcde");
+#endif // _LIBCUDACXX_HAS_CHAR8_T()
+
+  // char16_t
   test_memcpy<char16_t, 0>(u"");
   test_memcpy<char16_t, 0>(u"asdf");
   test_memcpy<char16_t, 1>(u"a");

--- a/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/array_func/memcpy.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/array_func/memcpy.pass.cpp
@@ -14,8 +14,8 @@ template <class T, size_t n>
 __host__ __device__ constexpr void test_memcpy(const T* src)
 {
   T buf[n + 1]{}; // + 1 to prevent zero size buffer
-  assert(cuda::std::__cccl_constexpr_memcpy(buf, src, n) == buf);
-  assert(cuda::std::__cccl_constexpr_memcmp(buf, src, n) == 0);
+  assert(cuda::std::__cccl_memcpy(buf, src, n) == buf);
+  assert(cuda::std::__cccl_memcmp(buf, src, n) == 0);
 }
 
 __host__ __device__ constexpr bool test()

--- a/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/array_func/memmove.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/array_func/memmove.pass.cpp
@@ -1,0 +1,111 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/__string/constexpr_c_functions.h>
+#include <cuda/std/cassert>
+
+template <class T>
+__host__ __device__ constexpr bool test_out_of_place();
+
+template <class T>
+__host__ __device__ constexpr bool test_in_place();
+
+#define TEST_SPECIALIZATION(T, P)                                                    \
+  template <>                                                                        \
+  __host__ __device__ constexpr bool test_out_of_place<T>()                          \
+  {                                                                                  \
+    T src[] = P##"1234567890";                                                       \
+                                                                                     \
+    {                                                                                \
+      T dest[] = P##"abcdefghij";                                                    \
+      T ref[]  = P##"1234567890";                                                    \
+      assert(cuda::std::__cccl_constexpr_memmove(dest, src, 10) == dest);            \
+      assert(cuda::std::__cccl_constexpr_memcmp(dest, ref, 10) == 0);                \
+    }                                                                                \
+                                                                                     \
+    {                                                                                \
+      T dest[] = P##"abcdefghij";                                                    \
+      T ref[]  = P##"abc123456j";                                                    \
+      assert(cuda::std::__cccl_constexpr_memmove(dest + 3, src, 6) == dest + 3);     \
+      assert(cuda::std::__cccl_constexpr_memcmp(dest, ref, 10) == 0);                \
+    }                                                                                \
+                                                                                     \
+    {                                                                                \
+      T dest[] = P##"abcdefghij";                                                    \
+      T ref[]  = P##"56789fghij";                                                    \
+      assert(cuda::std::__cccl_constexpr_memmove(dest, src + 4, 5) == dest);         \
+      assert(cuda::std::__cccl_constexpr_memcmp(dest, ref, 10) == 0);                \
+    }                                                                                \
+                                                                                     \
+    {                                                                                \
+      T dest[] = P##"abcdefghij";                                                    \
+      T ref[]  = P##"ab789fghij";                                                    \
+      assert(cuda::std::__cccl_constexpr_memmove(dest + 2, src + 6, 3) == dest + 2); \
+      assert(cuda::std::__cccl_constexpr_memcmp(dest, ref, 10) == 0);                \
+    }                                                                                \
+                                                                                     \
+    return true;                                                                     \
+  }                                                                                  \
+                                                                                     \
+  template <>                                                                        \
+  __host__ __device__ bool test_in_place<T>()                                        \
+  {                                                                                  \
+    {                                                                                \
+      T buf[] = P##"1234567890";                                                     \
+      T ref[] = P##"1234567890";                                                     \
+      assert(cuda::std::__cccl_constexpr_memmove(buf, buf, 10) == buf);              \
+      assert(cuda::std::__cccl_constexpr_memcmp(buf, ref, 10) == 0);                 \
+    }                                                                                \
+                                                                                     \
+    {                                                                                \
+      T buf[] = P##"1234567890";                                                     \
+      T ref[] = P##"1231234567";                                                     \
+      assert(cuda::std::__cccl_constexpr_memmove(buf + 3, buf, 7) == buf + 3);       \
+      assert(cuda::std::__cccl_constexpr_memcmp(buf, ref, 10) == 0);                 \
+    }                                                                                \
+                                                                                     \
+    {                                                                                \
+      T buf[] = P##"1234567890";                                                     \
+      T ref[] = P##"5678967890";                                                     \
+      assert(cuda::std::__cccl_constexpr_memmove(buf, buf + 4, 5) == buf);           \
+      assert(cuda::std::__cccl_constexpr_memcmp(buf, ref, 10) == 0);                 \
+    }                                                                                \
+                                                                                     \
+    {                                                                                \
+      T buf[] = P##"1234567890";                                                     \
+      T ref[] = P##"1234897890";                                                     \
+      assert(cuda::std::__cccl_constexpr_memmove(buf + 4, buf + 7, 2) == buf + 4);   \
+      assert(cuda::std::__cccl_constexpr_memcmp(buf, ref, 10) == 0);                 \
+    }                                                                                \
+                                                                                     \
+    return true;                                                                     \
+  }
+
+TEST_SPECIALIZATION(char, )
+TEST_SPECIALIZATION(char16_t, u)
+TEST_SPECIALIZATION(char32_t, U)
+
+__host__ __device__ bool test()
+{
+  test_out_of_place<char>();
+  test_out_of_place<char16_t>();
+  test_out_of_place<char32_t>();
+
+  test_in_place<char>();
+  test_in_place<char16_t>();
+  // test_in_place<char32_t>(); // crashing on device
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/array_func/memmove.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/array_func/memmove.pass.cpp
@@ -16,75 +16,75 @@ __host__ __device__ constexpr bool test_out_of_place();
 template <class T>
 __host__ __device__ constexpr bool test_in_place();
 
-#define TEST_SPECIALIZATION(T, P)                                                    \
-  template <>                                                                        \
-  __host__ __device__ constexpr bool test_out_of_place<T>()                          \
-  {                                                                                  \
-    T src[] = P##"1234567890";                                                       \
-                                                                                     \
-    {                                                                                \
-      T dest[] = P##"abcdefghij";                                                    \
-      T ref[]  = P##"1234567890";                                                    \
-      assert(cuda::std::__cccl_constexpr_memmove(dest, src, 10) == dest);            \
-      assert(cuda::std::__cccl_constexpr_memcmp(dest, ref, 10) == 0);                \
-    }                                                                                \
-                                                                                     \
-    {                                                                                \
-      T dest[] = P##"abcdefghij";                                                    \
-      T ref[]  = P##"abc123456j";                                                    \
-      assert(cuda::std::__cccl_constexpr_memmove(dest + 3, src, 6) == dest + 3);     \
-      assert(cuda::std::__cccl_constexpr_memcmp(dest, ref, 10) == 0);                \
-    }                                                                                \
-                                                                                     \
-    {                                                                                \
-      T dest[] = P##"abcdefghij";                                                    \
-      T ref[]  = P##"56789fghij";                                                    \
-      assert(cuda::std::__cccl_constexpr_memmove(dest, src + 4, 5) == dest);         \
-      assert(cuda::std::__cccl_constexpr_memcmp(dest, ref, 10) == 0);                \
-    }                                                                                \
-                                                                                     \
-    {                                                                                \
-      T dest[] = P##"abcdefghij";                                                    \
-      T ref[]  = P##"ab789fghij";                                                    \
-      assert(cuda::std::__cccl_constexpr_memmove(dest + 2, src + 6, 3) == dest + 2); \
-      assert(cuda::std::__cccl_constexpr_memcmp(dest, ref, 10) == 0);                \
-    }                                                                                \
-                                                                                     \
-    return true;                                                                     \
-  }                                                                                  \
-                                                                                     \
-  template <>                                                                        \
-  __host__ __device__ bool test_in_place<T>()                                        \
-  {                                                                                  \
-    {                                                                                \
-      T buf[] = P##"1234567890";                                                     \
-      T ref[] = P##"1234567890";                                                     \
-      assert(cuda::std::__cccl_constexpr_memmove(buf, buf, 10) == buf);              \
-      assert(cuda::std::__cccl_constexpr_memcmp(buf, ref, 10) == 0);                 \
-    }                                                                                \
-                                                                                     \
-    {                                                                                \
-      T buf[] = P##"1234567890";                                                     \
-      T ref[] = P##"1231234567";                                                     \
-      assert(cuda::std::__cccl_constexpr_memmove(buf + 3, buf, 7) == buf + 3);       \
-      assert(cuda::std::__cccl_constexpr_memcmp(buf, ref, 10) == 0);                 \
-    }                                                                                \
-                                                                                     \
-    {                                                                                \
-      T buf[] = P##"1234567890";                                                     \
-      T ref[] = P##"5678967890";                                                     \
-      assert(cuda::std::__cccl_constexpr_memmove(buf, buf + 4, 5) == buf);           \
-      assert(cuda::std::__cccl_constexpr_memcmp(buf, ref, 10) == 0);                 \
-    }                                                                                \
-                                                                                     \
-    {                                                                                \
-      T buf[] = P##"1234567890";                                                     \
-      T ref[] = P##"1234897890";                                                     \
-      assert(cuda::std::__cccl_constexpr_memmove(buf + 4, buf + 7, 2) == buf + 4);   \
-      assert(cuda::std::__cccl_constexpr_memcmp(buf, ref, 10) == 0);                 \
-    }                                                                                \
-                                                                                     \
-    return true;                                                                     \
+#define TEST_SPECIALIZATION(T, P)                                          \
+  template <>                                                              \
+  __host__ __device__ constexpr bool test_out_of_place<T>()                \
+  {                                                                        \
+    T src[] = P##"1234567890";                                             \
+                                                                           \
+    {                                                                      \
+      T dest[] = P##"abcdefghij";                                          \
+      T ref[]  = P##"1234567890";                                          \
+      assert(cuda::std::__cccl_memmove(dest, src, 10) == dest);            \
+      assert(cuda::std::__cccl_memcmp(dest, ref, 10) == 0);                \
+    }                                                                      \
+                                                                           \
+    {                                                                      \
+      T dest[] = P##"abcdefghij";                                          \
+      T ref[]  = P##"abc123456j";                                          \
+      assert(cuda::std::__cccl_memmove(dest + 3, src, 6) == dest + 3);     \
+      assert(cuda::std::__cccl_memcmp(dest, ref, 10) == 0);                \
+    }                                                                      \
+                                                                           \
+    {                                                                      \
+      T dest[] = P##"abcdefghij";                                          \
+      T ref[]  = P##"56789fghij";                                          \
+      assert(cuda::std::__cccl_memmove(dest, src + 4, 5) == dest);         \
+      assert(cuda::std::__cccl_memcmp(dest, ref, 10) == 0);                \
+    }                                                                      \
+                                                                           \
+    {                                                                      \
+      T dest[] = P##"abcdefghij";                                          \
+      T ref[]  = P##"ab789fghij";                                          \
+      assert(cuda::std::__cccl_memmove(dest + 2, src + 6, 3) == dest + 2); \
+      assert(cuda::std::__cccl_memcmp(dest, ref, 10) == 0);                \
+    }                                                                      \
+                                                                           \
+    return true;                                                           \
+  }                                                                        \
+                                                                           \
+  template <>                                                              \
+  __host__ __device__ bool test_in_place<T>()                              \
+  {                                                                        \
+    {                                                                      \
+      T buf[] = P##"1234567890";                                           \
+      T ref[] = P##"1234567890";                                           \
+      assert(cuda::std::__cccl_memmove(buf, buf, 10) == buf);              \
+      assert(cuda::std::__cccl_memcmp(buf, ref, 10) == 0);                 \
+    }                                                                      \
+                                                                           \
+    {                                                                      \
+      T buf[] = P##"1234567890";                                           \
+      T ref[] = P##"1231234567";                                           \
+      assert(cuda::std::__cccl_memmove(buf + 3, buf, 7) == buf + 3);       \
+      assert(cuda::std::__cccl_memcmp(buf, ref, 10) == 0);                 \
+    }                                                                      \
+                                                                           \
+    {                                                                      \
+      T buf[] = P##"1234567890";                                           \
+      T ref[] = P##"5678967890";                                           \
+      assert(cuda::std::__cccl_memmove(buf, buf + 4, 5) == buf);           \
+      assert(cuda::std::__cccl_memcmp(buf, ref, 10) == 0);                 \
+    }                                                                      \
+                                                                           \
+    {                                                                      \
+      T buf[] = P##"1234567890";                                           \
+      T ref[] = P##"1234897890";                                           \
+      assert(cuda::std::__cccl_memmove(buf + 4, buf + 7, 2) == buf + 4);   \
+      assert(cuda::std::__cccl_memcmp(buf, ref, 10) == 0);                 \
+    }                                                                      \
+                                                                           \
+    return true;                                                           \
   }
 
 TEST_SPECIALIZATION(char, )

--- a/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/array_func/memmove.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/array_func/memmove.pass.cpp
@@ -88,16 +88,25 @@ __host__ __device__ constexpr bool test_in_place();
   }
 
 TEST_SPECIALIZATION(char, )
+#if _LIBCUDACXX_HAS_CHAR8_T()
+TEST_SPECIALIZATION(char8_t, u8)
+#endif // _LIBCUDACXX_HAS_CHAR8_T()
 TEST_SPECIALIZATION(char16_t, u)
 TEST_SPECIALIZATION(char32_t, U)
 
 __host__ __device__ bool test()
 {
   test_out_of_place<char>();
+#if _LIBCUDACXX_HAS_CHAR8_T()
+  test_out_of_place<char8_t>();
+#endif // _LIBCUDACXX_HAS_CHAR8_T()
   test_out_of_place<char16_t>();
   test_out_of_place<char32_t>();
 
   test_in_place<char>();
+#if _LIBCUDACXX_HAS_CHAR8_T()
+  test_in_place<char8_t>();
+#endif // _LIBCUDACXX_HAS_CHAR8_T()
   test_in_place<char16_t>();
   // test_in_place<char32_t>(); // crashing on device
 

--- a/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/array_func/memset.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/array_func/memset.pass.cpp
@@ -58,6 +58,9 @@ __host__ __device__ constexpr void test_type()
 __host__ __device__ constexpr bool test()
 {
   test_type<char>();
+#if _LIBCUDACXX_HAS_CHAR8_T()
+  test_type<char8_t>();
+#endif // _LIBCUDACXX_HAS_CHAR8_T()
   test_type<char16_t>();
   test_type<char32_t>();
 

--- a/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/array_func/memset.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/array_func/memset.pass.cpp
@@ -1,0 +1,72 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/__string/constexpr_c_functions.h>
+#include <cuda/std/cassert>
+
+template <class T>
+__host__ __device__ constexpr void test_memset(T* ptr, T c, cuda::std::size_t n, const T* ref)
+{
+  assert(cuda::std::__cccl_constexpr_memset(ptr, c, n) == ptr);
+  assert(cuda::std::__cccl_constexpr_memcmp(ptr, ref, n) == 0);
+}
+
+template <class T>
+__host__ __device__ constexpr void test_type()
+{
+  {
+    test_memset<T>(nullptr, 1, 0, nullptr);
+  }
+  {
+    constexpr T value = 127;
+    T obj{127};
+    T ref{value};
+    test_memset(&obj, value, 1, &ref);
+  }
+  {
+    constexpr T value = 29;
+    T arr[]{127, 46, 7};
+    const T ref[]{127, 46, 7};
+    test_memset(arr, value, 0, ref);
+  }
+  {
+    constexpr T value = 29;
+    T arr[]{127, 46, 7};
+    const T ref[]{value, 46, 7};
+    test_memset(arr, value, 1, ref);
+  }
+  {
+    constexpr T value = 29;
+    T arr[]{127, 46, 7};
+    const T ref[]{value, value, 7};
+    test_memset(arr, value, 2, ref);
+  }
+  {
+    constexpr T value = 29;
+    T arr[]{127, 46, 7};
+    const T ref[]{value, value, value};
+    test_memset(arr, value, 3, ref);
+  }
+}
+
+__host__ __device__ constexpr bool test()
+{
+  test_type<char>();
+  test_type<char16_t>();
+  test_type<char32_t>();
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/array_func/memset.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/array_func/memset.pass.cpp
@@ -13,8 +13,8 @@
 template <class T>
 __host__ __device__ constexpr void test_memset(T* ptr, T c, cuda::std::size_t n, const T* ref)
 {
-  assert(cuda::std::__cccl_constexpr_memset(ptr, c, n) == ptr);
-  assert(cuda::std::__cccl_constexpr_memcmp(ptr, ref, n) == 0);
+  assert(cuda::std::__cccl_memset(ptr, c, n) == ptr);
+  assert(cuda::std::__cccl_memcmp(ptr, ref, n) == 0);
 }
 
 template <class T>

--- a/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/string_exam/strchr.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/string_exam/strchr.pass.cpp
@@ -1,0 +1,74 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/__string/constexpr_c_functions.h>
+#include <cuda/std/cassert>
+
+template <class T>
+__host__ __device__ constexpr void test_strchr(T* str, T c, T* expected_ret)
+{
+  const auto ret = cuda::std::__cccl_constexpr_strchr(str, c);
+  assert(ret == expected_ret);
+}
+
+template <class T>
+__host__ __device__ constexpr void test_type();
+
+#define TEST_SPECIALIZATION(T, P)                   \
+  template <>                                       \
+  __host__ __device__ constexpr void test_type<T>() \
+  {                                                 \
+    {                                               \
+      T str[]{P##""};                               \
+      test_strchr<T>(str, P##'\0', str);            \
+      test_strchr<T>(str, P##'a', nullptr);         \
+    }                                               \
+    {                                               \
+      T str[]{P##"a"};                              \
+      test_strchr<T>(str, P##'\0', str + 1);        \
+      test_strchr<T>(str, P##'a', str);             \
+      test_strchr<T>(str, P##'b', nullptr);         \
+    }                                               \
+    {                                               \
+      T str[]{P##"aaa"};                            \
+      test_strchr<T>(str, P##'\0', str + 3);        \
+      test_strchr<T>(str, P##'a', str);             \
+      test_strchr<T>(str, P##'b', nullptr);         \
+    }                                               \
+    {                                               \
+      T str[]{P##"abcdabcd"};                       \
+      test_strchr<T>(str, P##'\0', str + 8);        \
+      test_strchr<T>(str, P##'a', str);             \
+      test_strchr<T>(str, P##'b', str + 1);         \
+      test_strchr<T>(str, P##'c', str + 2);         \
+      test_strchr<T>(str, P##'d', str + 3);         \
+      test_strchr<T>(str, P##'e', nullptr);         \
+      test_strchr<T>(str, P##'f', nullptr);         \
+    }                                               \
+  }
+
+TEST_SPECIALIZATION(char, )
+TEST_SPECIALIZATION(char16_t, u)
+TEST_SPECIALIZATION(char32_t, U)
+
+__host__ __device__ constexpr bool test()
+{
+  test_type<char>();
+  test_type<char16_t>();
+  test_type<char32_t>();
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/string_exam/strchr.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/string_exam/strchr.pass.cpp
@@ -13,7 +13,7 @@
 template <class T>
 __host__ __device__ constexpr void test_strchr(T* str, T c, T* expected_ret)
 {
-  const auto ret = cuda::std::__cccl_constexpr_strchr(str, c);
+  const auto ret = cuda::std::__cccl_strchr(str, c);
   assert(ret == expected_ret);
 }
 

--- a/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/string_exam/strchr.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/string_exam/strchr.pass.cpp
@@ -54,12 +54,18 @@ __host__ __device__ constexpr void test_type();
   }
 
 TEST_SPECIALIZATION(char, )
+#if _LIBCUDACXX_HAS_CHAR8_T()
+TEST_SPECIALIZATION(char8_t, u8)
+#endif // _LIBCUDACXX_HAS_CHAR8_T()
 TEST_SPECIALIZATION(char16_t, u)
 TEST_SPECIALIZATION(char32_t, U)
 
 __host__ __device__ constexpr bool test()
 {
   test_type<char>();
+#if _LIBCUDACXX_HAS_CHAR8_T()
+  test_type<char8_t>();
+#endif // _LIBCUDACXX_HAS_CHAR8_T()
   test_type<char16_t>();
   test_type<char32_t>();
 

--- a/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/string_exam/strcmp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/string_exam/strcmp.pass.cpp
@@ -31,7 +31,7 @@ __host__ __device__ constexpr void test_strcmp(const T* lhs, const T* rhs, int e
 
 __host__ __device__ constexpr bool test()
 {
-  // char8
+  // char
   test_strcmp<char>("", "", 0);
   test_strcmp<char>("a", "", 1);
   test_strcmp<char>("", "a", -1);
@@ -43,7 +43,21 @@ __host__ __device__ constexpr bool test()
   test_strcmp<char>("abcd0", "abcd1", -1);
   test_strcmp<char>("ab1de", "abcd0", -1);
 
-  // char16
+#if _LIBCUDACXX_HAS_CHAR8_T()
+  // char8_t
+  test_strcmp<char8_t>(u8"", u8"", 0);
+  test_strcmp<char8_t>(u8"a", u8"", 1);
+  test_strcmp<char8_t>(u8"", u8"a", -1);
+  test_strcmp<char8_t>(u8"hi", u8"hi", 0);
+  test_strcmp<char8_t>(u8"hi", u8"ho", -1);
+  test_strcmp<char8_t>(u8"ho", u8"hi", 1);
+  test_strcmp<char8_t>(u8"abcde", u8"abcde", 0);
+  test_strcmp<char8_t>(u8"abcd1", u8"abcd0", 1);
+  test_strcmp<char8_t>(u8"abcd0", u8"abcd1", -1);
+  test_strcmp<char8_t>(u8"ab1de", u8"abcd0", -1);
+#endif // _LIBCUDACXX_HAS_CHAR8_T()
+
+  // char16_t
   test_strcmp<char16_t>(u"", u"", 0);
   test_strcmp<char16_t>(u"a", u"", 1);
   test_strcmp<char16_t>(u"", u"a", -1);
@@ -55,7 +69,7 @@ __host__ __device__ constexpr bool test()
   test_strcmp<char16_t>(u"abcd0", u"abcd1", -1);
   test_strcmp<char16_t>(u"ab1de", u"abcd0", -1);
 
-  // char32
+  // char32_t
   test_strcmp<char32_t>(U"", U"", 0);
   test_strcmp<char32_t>(U"a", U"", 1);
   test_strcmp<char32_t>(U"", U"a", -1);

--- a/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/string_exam/strcmp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/string_exam/strcmp.pass.cpp
@@ -1,0 +1,78 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/__string/constexpr_c_functions.h>
+#include <cuda/std/cassert>
+
+template <class T>
+__host__ __device__ constexpr void test_strcmp(const T* lhs, const T* rhs, int expected)
+{
+  const auto ret = cuda::std::__cccl_constexpr_strcmp(lhs, rhs);
+
+  if (expected == 0)
+  {
+    assert(ret == 0);
+  }
+  else if (expected < 0)
+  {
+    assert(ret < 0);
+  }
+  else
+  {
+    assert(ret > 0);
+  }
+}
+
+__host__ __device__ constexpr bool test()
+{
+  // char8
+  test_strcmp<char>("", "", 0);
+  test_strcmp<char>("a", "", 1);
+  test_strcmp<char>("", "a", -1);
+  test_strcmp<char>("hi", "hi", 0);
+  test_strcmp<char>("hi", "ho", -1);
+  test_strcmp<char>("ho", "hi", 1);
+  test_strcmp<char>("abcde", "abcde", 0);
+  test_strcmp<char>("abcd1", "abcd0", 1);
+  test_strcmp<char>("abcd0", "abcd1", -1);
+  test_strcmp<char>("ab1de", "abcd0", -1);
+
+  // char16
+  test_strcmp<char16_t>(u"", u"", 0);
+  test_strcmp<char16_t>(u"a", u"", 1);
+  test_strcmp<char16_t>(u"", u"a", -1);
+  test_strcmp<char16_t>(u"hi", u"hi", 0);
+  test_strcmp<char16_t>(u"hi", u"ho", -1);
+  test_strcmp<char16_t>(u"ho", u"hi", 1);
+  test_strcmp<char16_t>(u"abcde", u"abcde", 0);
+  test_strcmp<char16_t>(u"abcd1", u"abcd0", 1);
+  test_strcmp<char16_t>(u"abcd0", u"abcd1", -1);
+  test_strcmp<char16_t>(u"ab1de", u"abcd0", -1);
+
+  // char32
+  test_strcmp<char32_t>(U"", U"", 0);
+  test_strcmp<char32_t>(U"a", U"", 1);
+  test_strcmp<char32_t>(U"", U"a", -1);
+  test_strcmp<char32_t>(U"hi", U"hi", 0);
+  test_strcmp<char32_t>(U"hi", U"ho", -1);
+  test_strcmp<char32_t>(U"ho", U"hi", 1);
+  test_strcmp<char32_t>(U"abcde", U"abcde", 0);
+  test_strcmp<char32_t>(U"abcd1", U"abcd0", 1);
+  test_strcmp<char32_t>(U"abcd0", U"abcd1", -1);
+  test_strcmp<char32_t>(U"ab1de", U"abcd0", -1);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/string_exam/strcmp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/string_exam/strcmp.pass.cpp
@@ -13,7 +13,7 @@
 template <class T>
 __host__ __device__ constexpr void test_strcmp(const T* lhs, const T* rhs, int expected)
 {
-  const auto ret = cuda::std::__cccl_constexpr_strcmp(lhs, rhs);
+  const auto ret = cuda::std::__cccl_strcmp(lhs, rhs);
 
   if (expected == 0)
   {

--- a/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/string_exam/strlen.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/string_exam/strlen.pass.cpp
@@ -1,0 +1,73 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/__string/constexpr_c_functions.h>
+#include <cuda/std/cassert>
+#include <cuda/std/cstddef>
+
+template <class T>
+__host__ __device__ constexpr void test_strlen(const T* str, cuda::std::size_t expected)
+{
+  const auto ret = cuda::std::__cccl_constexpr_strlen(str);
+  assert(ret == expected);
+}
+
+__host__ __device__ constexpr bool test()
+{
+  // char8
+  test_strlen<char>("", 0);
+  test_strlen<char>("a", 1);
+  test_strlen<char>("hi", 2);
+  test_strlen<char>("asdfgh", 6);
+  test_strlen<char>("asdfasdfasdfgweyr", 17);
+  test_strlen<char>("asdfasdfasdfgweyr1239859102384", 30);
+  test_strlen<char>("\0\0", 0);
+  test_strlen<char>("a\0", 1);
+  test_strlen<char>("h\0i", 1);
+  test_strlen<char>("asdf\0g\0h", 4);
+  test_strlen<char>("asdfa\0sdfasdfg\0we\0yr", 5);
+  test_strlen<char>("asdfasdfasdfgweyr1239859102384\0\0", 30);
+
+  // char16
+  test_strlen<char16_t>(u"", 0);
+  test_strlen<char16_t>(u"a", 1);
+  test_strlen<char16_t>(u"hi", 2);
+  test_strlen<char16_t>(u"asdfgh", 6);
+  test_strlen<char16_t>(u"asdfasdfasdfgweyr", 17);
+  test_strlen<char16_t>(u"asdfasdfasdfgweyr1239859102384", 30);
+  test_strlen<char16_t>(u"\0\0", 0);
+  test_strlen<char16_t>(u"a\0", 1);
+  test_strlen<char16_t>(u"h\0i", 1);
+  test_strlen<char16_t>(u"asdf\0g\0h", 4);
+  test_strlen<char16_t>(u"asdfa\0sdfasdfg\0we\0yr", 5);
+  test_strlen<char16_t>(u"asdfasdfasdfgweyr1239859102384\0\0", 30);
+
+  // char32
+  test_strlen<char32_t>(U"", 0);
+  test_strlen<char32_t>(U"a", 1);
+  test_strlen<char32_t>(U"hi", 2);
+  test_strlen<char32_t>(U"asdfgh", 6);
+  test_strlen<char32_t>(U"asdfasdfasdfgweyr", 17);
+  test_strlen<char32_t>(U"asdfasdfasdfgweyr1239859102384", 30);
+  test_strlen<char32_t>(U"\0\0", 0);
+  test_strlen<char32_t>(U"a\0", 1);
+  test_strlen<char32_t>(U"h\0i", 1);
+  test_strlen<char32_t>(U"asdf\0g\0h", 4);
+  test_strlen<char32_t>(U"asdfa\0sdfasdfg\0we\0yr", 5);
+  test_strlen<char32_t>(U"asdfasdfasdfgweyr1239859102384\0\0", 30);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/string_exam/strlen.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/string_exam/strlen.pass.cpp
@@ -20,7 +20,7 @@ __host__ __device__ constexpr void test_strlen(const T* str, cuda::std::size_t e
 
 __host__ __device__ constexpr bool test()
 {
-  // char8
+  // char
   test_strlen<char>("", 0);
   test_strlen<char>("a", 1);
   test_strlen<char>("hi", 2);
@@ -34,7 +34,23 @@ __host__ __device__ constexpr bool test()
   test_strlen<char>("asdfa\0sdfasdfg\0we\0yr", 5);
   test_strlen<char>("asdfasdfasdfgweyr1239859102384\0\0", 30);
 
-  // char16
+#if _LIBCUDACXX_HAS_CHAR8_T()
+  // char8_t
+  test_strlen<char8_t>(u8"", 0);
+  test_strlen<char8_t>(u8"a", 1);
+  test_strlen<char8_t>(u8"hi", 2);
+  test_strlen<char8_t>(u8"asdfgh", 6);
+  test_strlen<char8_t>(u8"asdfasdfasdfgweyr", 17);
+  test_strlen<char8_t>(u8"asdfasdfasdfgweyr1239859102384", 30);
+  test_strlen<char8_t>(u8"\0\0", 0);
+  test_strlen<char8_t>(u8"a\0", 1);
+  test_strlen<char8_t>(u8"h\0i", 1);
+  test_strlen<char8_t>(u8"asdf\0g\0h", 4);
+  test_strlen<char8_t>(u8"asdfa\0sdfasdfg\0we\0yr", 5);
+  test_strlen<char8_t>(u8"asdfasdfasdfgweyr1239859102384\0\0", 30);
+#endif // _LIBCUDACXX_HAS_CHAR8_T()
+
+  // char16_t
   test_strlen<char16_t>(u"", 0);
   test_strlen<char16_t>(u"a", 1);
   test_strlen<char16_t>(u"hi", 2);
@@ -48,7 +64,7 @@ __host__ __device__ constexpr bool test()
   test_strlen<char16_t>(u"asdfa\0sdfasdfg\0we\0yr", 5);
   test_strlen<char16_t>(u"asdfasdfasdfgweyr1239859102384\0\0", 30);
 
-  // char32
+  // char32_t
   test_strlen<char32_t>(U"", 0);
   test_strlen<char32_t>(U"a", 1);
   test_strlen<char32_t>(U"hi", 2);

--- a/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/string_exam/strlen.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/string_exam/strlen.pass.cpp
@@ -14,7 +14,7 @@
 template <class T>
 __host__ __device__ constexpr void test_strlen(const T* str, cuda::std::size_t expected)
 {
-  const auto ret = cuda::std::__cccl_constexpr_strlen(str);
+  const auto ret = cuda::std::__cccl_strlen(str);
   assert(ret == expected);
 }
 

--- a/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/string_exam/strncmp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/string_exam/strncmp.pass.cpp
@@ -16,7 +16,7 @@
 template <class T>
 __host__ __device__ constexpr void test_strncmp(const T* lhs, const T* rhs, cuda::std::size_t n, int expected)
 {
-  const auto ret = cuda::std::__cccl_constexpr_strncmp(lhs, rhs, n);
+  const auto ret = cuda::std::__cccl_strncmp(lhs, rhs, n);
 
   if (expected == 0)
   {

--- a/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/string_exam/strncmp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/string_exam/strncmp.pass.cpp
@@ -1,0 +1,95 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/__string/constexpr_c_functions.h>
+#include <cuda/std/cassert>
+#include <cuda/std/cstddef>
+
+#include "test_macros.h"
+
+template <class T>
+__host__ __device__ constexpr void test_strncmp(const T* lhs, const T* rhs, cuda::std::size_t n, int expected)
+{
+  const auto ret = cuda::std::__cccl_constexpr_strncmp(lhs, rhs, n);
+
+  if (expected == 0)
+  {
+    assert(ret == 0);
+  }
+  else if (expected < 0)
+  {
+    assert(ret < 0);
+  }
+  else
+  {
+    assert(ret > 0);
+  }
+}
+
+template <class T>
+__host__ __device__ constexpr void test_type();
+
+#define TEST_SPECIALIZATION(T, P)                       \
+  template <>                                           \
+  __host__ __device__ constexpr void test_type<T>()     \
+  {                                                     \
+    test_strncmp<T>(P##"", P##"", 0, 0);                \
+    test_strncmp<T>(P##"", P##"", 1, 0);                \
+                                                        \
+    test_strncmp<T>(P##"a", P##"", 0, 0);               \
+    test_strncmp<T>(P##"", P##"a", 0, 0);               \
+    test_strncmp<T>(P##"a", P##"", 1, 1);               \
+    test_strncmp<T>(P##"", P##"a", 1, -1);              \
+                                                        \
+    test_strncmp<T>(P##"hi", P##"hi", 0, 0);            \
+    test_strncmp<T>(P##"hi", P##"ho", 0, 0);            \
+    test_strncmp<T>(P##"ho", P##"hi", 0, 0);            \
+                                                        \
+    test_strncmp<T>(P##"hi", P##"hi", 1, 0);            \
+    test_strncmp<T>(P##"hi", P##"ho", 1, 0);            \
+    test_strncmp<T>(P##"ho", P##"hi", 1, 0);            \
+                                                        \
+    test_strncmp<T>(P##"hi", P##"hi", 2, 0);            \
+    test_strncmp<T>(P##"hi", P##"ho", 2, -1);           \
+    test_strncmp<T>(P##"ho", P##"hi", 2, 1);            \
+                                                        \
+    test_strncmp<T>(P##"hi", P##"hi", 3, 0);            \
+    test_strncmp<T>(P##"hi", P##"ho", 3, -1);           \
+    test_strncmp<T>(P##"ho", P##"hi", 3, 1);            \
+                                                        \
+    test_strncmp<T>(P##"abcde", P##"abcde", 100, 0);    \
+    test_strncmp<T>(P##"abcd1", P##"abcd0", 100, 1);    \
+    test_strncmp<T>(P##"abcd0", P##"abcd1", 100, -1);   \
+    test_strncmp<T>(P##"ab1de", P##"abcd0", 100, -1);   \
+                                                        \
+    test_strncmp<T>(P##"abc\0de", P##"abcde", 100, -1); \
+    test_strncmp<T>(P##"abc\0d1", P##"abcd0", 100, -1); \
+    test_strncmp<T>(P##"abc\0d0", P##"abcd1", 100, -1); \
+    test_strncmp<T>(P##"ab1\0de", P##"abcd0", 100, -1); \
+  }
+
+TEST_SPECIALIZATION(char, )
+TEST_SPECIALIZATION(char16_t, u)
+TEST_SPECIALIZATION(char32_t, U)
+
+__host__ __device__ constexpr bool test()
+{
+  test_type<char>();
+  test_type<char16_t>();
+  test_type<char32_t>();
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/string_exam/strncmp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/string_exam/strncmp.pass.cpp
@@ -75,12 +75,18 @@ __host__ __device__ constexpr void test_type();
   }
 
 TEST_SPECIALIZATION(char, )
+#if _LIBCUDACXX_HAS_CHAR8_T()
+TEST_SPECIALIZATION(char8_t, u8)
+#endif // _LIBCUDACXX_HAS_CHAR8_T()
 TEST_SPECIALIZATION(char16_t, u)
 TEST_SPECIALIZATION(char32_t, U)
 
 __host__ __device__ constexpr bool test()
 {
   test_type<char>();
+#if _LIBCUDACXX_HAS_CHAR8_T()
+  test_type<char8_t>();
+#endif // _LIBCUDACXX_HAS_CHAR8_T()
   test_type<char16_t>();
   test_type<char32_t>();
 

--- a/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/string_exam/strrchr.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/string_exam/strrchr.pass.cpp
@@ -14,7 +14,7 @@
 template <class T>
 __host__ __device__ constexpr void test_strrchr(T* str, T c, T* expected_ret)
 {
-  const auto ret = cuda::std::__cccl_constexpr_strrchr(str, c);
+  const auto ret = cuda::std::__cccl_strrchr(str, c);
   assert(ret == expected_ret);
 }
 

--- a/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/string_exam/strrchr.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/string_exam/strrchr.pass.cpp
@@ -1,0 +1,75 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/__string/constexpr_c_functions.h>
+#include <cuda/std/cassert>
+#include <cuda/std/cstddef>
+
+template <class T>
+__host__ __device__ constexpr void test_strrchr(T* str, T c, T* expected_ret)
+{
+  const auto ret = cuda::std::__cccl_constexpr_strrchr(str, c);
+  assert(ret == expected_ret);
+}
+
+template <class T>
+__host__ __device__ constexpr void test_type();
+
+#define TEST_SPECIALIZATION(T, P)                   \
+  template <>                                       \
+  __host__ __device__ constexpr void test_type<T>() \
+  {                                                 \
+    {                                               \
+      T str[]{P##""};                               \
+      test_strrchr<T>(str, P##'\0', str);           \
+      test_strrchr<T>(str, P##'a', nullptr);        \
+    }                                               \
+    {                                               \
+      T str[]{P##"a"};                              \
+      test_strrchr<T>(str, P##'\0', str + 1);       \
+      test_strrchr<T>(str, P##'a', str);            \
+      test_strrchr<T>(str, P##'b', nullptr);        \
+    }                                               \
+    {                                               \
+      T str[]{P##"aaa"};                            \
+      test_strrchr<T>(str, P##'\0', str + 3);       \
+      test_strrchr<T>(str, P##'a', str + 2);        \
+      test_strrchr<T>(str, P##'b', nullptr);        \
+    }                                               \
+    {                                               \
+      T str[]{P##"abcdabcd\0\0"};                   \
+      test_strrchr<T>(str, P##'\0', str + 8);       \
+      test_strrchr<T>(str, P##'a', str + 4);        \
+      test_strrchr<T>(str, P##'b', str + 5);        \
+      test_strrchr<T>(str, P##'c', str + 6);        \
+      test_strrchr<T>(str, P##'d', str + 7);        \
+      test_strrchr<T>(str, P##'e', nullptr);        \
+      test_strrchr<T>(str, P##'f', nullptr);        \
+    }                                               \
+  }
+
+TEST_SPECIALIZATION(char, )
+TEST_SPECIALIZATION(char16_t, u)
+TEST_SPECIALIZATION(char32_t, U)
+
+__host__ __device__ constexpr bool test()
+{
+  test_type<char>();
+  test_type<char16_t>();
+  test_type<char32_t>();
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/string_exam/strrchr.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/string_exam/strrchr.pass.cpp
@@ -55,12 +55,18 @@ __host__ __device__ constexpr void test_type();
   }
 
 TEST_SPECIALIZATION(char, )
+#if _LIBCUDACXX_HAS_CHAR8_T()
+TEST_SPECIALIZATION(char8_t, u8)
+#endif // _LIBCUDACXX_HAS_CHAR8_T()
 TEST_SPECIALIZATION(char16_t, u)
 TEST_SPECIALIZATION(char32_t, U)
 
 __host__ __device__ constexpr bool test()
 {
   test_type<char>();
+#if _LIBCUDACXX_HAS_CHAR8_T()
+  test_type<char8_t>();
+#endif // _LIBCUDACXX_HAS_CHAR8_T()
   test_type<char16_t>();
   test_type<char32_t>();
 

--- a/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/string_manip/strcpy.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/string_manip/strcpy.pass.cpp
@@ -30,7 +30,7 @@ __host__ __device__ constexpr void test_strcpy(const T* str, const T (&ref)[N])
 
 __host__ __device__ constexpr bool test()
 {
-  // char8
+  // char
   test_strcpy<char>("", "\0\0\0");
   test_strcpy<char>("a", "a\0\0");
   test_strcpy<char>("a\0", "a\0\0");
@@ -38,7 +38,17 @@ __host__ __device__ constexpr bool test()
   test_strcpy<char>("hello", "hello\0\0\0\0");
   test_strcpy<char>("hell\0o", "hell\0\0\0");
 
-  // char16
+#if _LIBCUDACXX_HAS_CHAR8_T()
+  // char8_t
+  test_strcpy<char8_t>(u8"", u8"\0\0\0");
+  test_strcpy<char8_t>(u8"a", u8"a\0\0");
+  test_strcpy<char8_t>(u8"a\0", u8"a\0\0");
+  test_strcpy<char8_t>(u8"a\0sdf\0", u8"a\0\0\0\0\0");
+  test_strcpy<char8_t>(u8"hello", u8"hello\0\0\0\0");
+  test_strcpy<char8_t>(u8"hell\0o", u8"hell\0\0\0");
+#endif // _LIBCUDACXX_HAS_CHAR8_T()
+
+  // char16_t
   test_strcpy<char16_t>(u"", u"\0\0\0");
   test_strcpy<char16_t>(u"a", u"a\0\0");
   test_strcpy<char16_t>(u"a\0", u"a\0\0");
@@ -46,7 +56,7 @@ __host__ __device__ constexpr bool test()
   test_strcpy<char16_t>(u"hello", u"hello\0\0\0\0");
   test_strcpy<char16_t>(u"hell\0o", u"hell\0\0\0");
 
-  // char32
+  // char32_t
   test_strcpy<char32_t>(U"", U"\0\0\0");
   test_strcpy<char32_t>(U"a", U"a\0\0");
   test_strcpy<char32_t>(U"a\0", U"a\0\0");

--- a/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/string_manip/strcpy.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/string_manip/strcpy.pass.cpp
@@ -23,7 +23,7 @@ template <class T, cuda::std::size_t N>
 __host__ __device__ constexpr void test_strcpy(const T* str, const T (&ref)[N])
 {
   T buff[N]{};
-  const auto ret = cuda::std::__cccl_constexpr_strcpy(buff, str);
+  const auto ret = cuda::std::__cccl_strcpy(buff, str);
   assert(ret == buff);
   assert(equal_buffers(buff, ref, cuda::std::make_index_sequence<N - 1>{}));
 }

--- a/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/string_manip/strcpy.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/string_manip/strcpy.pass.cpp
@@ -1,0 +1,65 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/__string/constexpr_c_functions.h>
+#include <cuda/std/cassert>
+#include <cuda/std/cstddef>
+#include <cuda/std/type_traits>
+#include <cuda/std/utility>
+
+template <class T, cuda::std::size_t... N>
+__host__ __device__ constexpr bool equal_buffers(const T* lhs, const T* rhs, cuda::std::index_sequence<N...>)
+{
+  return ((lhs[N] == rhs[N]) && ...);
+}
+
+template <class T, cuda::std::size_t N>
+__host__ __device__ constexpr void test_strcpy(const T* str, const T (&ref)[N])
+{
+  T buff[N]{};
+  const auto ret = cuda::std::__cccl_constexpr_strcpy(buff, str);
+  assert(ret == buff);
+  assert(equal_buffers(buff, ref, cuda::std::make_index_sequence<N - 1>{}));
+}
+
+__host__ __device__ constexpr bool test()
+{
+  // char8
+  test_strcpy<char>("", "\0\0\0");
+  test_strcpy<char>("a", "a\0\0");
+  test_strcpy<char>("a\0", "a\0\0");
+  test_strcpy<char>("a\0sdf\0", "a\0\0\0\0\0");
+  test_strcpy<char>("hello", "hello\0\0\0\0");
+  test_strcpy<char>("hell\0o", "hell\0\0\0");
+
+  // char16
+  test_strcpy<char16_t>(u"", u"\0\0\0");
+  test_strcpy<char16_t>(u"a", u"a\0\0");
+  test_strcpy<char16_t>(u"a\0", u"a\0\0");
+  test_strcpy<char16_t>(u"a\0sdf\0", u"a\0\0\0\0\0");
+  test_strcpy<char16_t>(u"hello", u"hello\0\0\0\0");
+  test_strcpy<char16_t>(u"hell\0o", u"hell\0\0\0");
+
+  // char32
+  test_strcpy<char32_t>(U"", U"\0\0\0");
+  test_strcpy<char32_t>(U"a", U"a\0\0");
+  test_strcpy<char32_t>(U"a\0", U"a\0\0");
+  test_strcpy<char32_t>(U"a\0sdf\0", U"a\0\0\0\0\0");
+  test_strcpy<char32_t>(U"hello", U"hello\0\0\0\0");
+  test_strcpy<char32_t>(U"hell\0o", U"hell\0\0\0");
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/string_manip/strncpy.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/string_manip/strncpy.pass.cpp
@@ -28,7 +28,7 @@ __host__ __device__ constexpr void test_strncpy(const T* str, cuda::std::size_t 
     buff[i] = T('x');
   }
 
-  const auto ret = cuda::std::__cccl_constexpr_strncpy(buff, str, count);
+  const auto ret = cuda::std::__cccl_strncpy(buff, str, count);
   assert(ret == buff);
   assert(equal_buffers(buff, ref, cuda::std::make_index_sequence<N - 1>{}));
 }

--- a/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/string_manip/strncpy.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/string_manip/strncpy.pass.cpp
@@ -1,0 +1,112 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/__string/constexpr_c_functions.h>
+#include <cuda/std/cassert>
+#include <cuda/std/cstddef>
+#include <cuda/std/type_traits>
+#include <cuda/std/utility>
+
+template <class T, cuda::std::size_t... N>
+__host__ __device__ constexpr bool equal_buffers(const T* lhs, const T* rhs, cuda::std::index_sequence<N...>)
+{
+  return ((lhs[N] == rhs[N]) && ...);
+}
+
+template <class T, cuda::std::size_t N>
+__host__ __device__ constexpr void test_strncpy(const T* str, cuda::std::size_t count, const T (&ref)[N])
+{
+  T buff[N]{};
+  for (cuda::std::size_t i = 0; i < N; ++i)
+  {
+    buff[i] = T('x');
+  }
+
+  const auto ret = cuda::std::__cccl_constexpr_strncpy(buff, str, count);
+  assert(ret == buff);
+  assert(equal_buffers(buff, ref, cuda::std::make_index_sequence<N - 1>{}));
+}
+
+__host__ __device__ constexpr bool test()
+{
+  // char8
+  test_strncpy<char>("", 0, "xxx");
+  test_strncpy<char>("", 1, "\0xx");
+  test_strncpy<char>("", 2, "\0\0x");
+  test_strncpy<char>("", 3, "\0\0\0");
+  test_strncpy<char>("a", 0, "xxx");
+  test_strncpy<char>("a", 1, "axx");
+  test_strncpy<char>("a", 2, "a\0x");
+  test_strncpy<char>("a", 3, "a\0\0");
+  test_strncpy<char>("\0a", 0, "xxx");
+  test_strncpy<char>("\0a", 1, "\0xx");
+  test_strncpy<char>("\0a", 2, "\0\0x");
+  test_strncpy<char>("\0a", 3, "\0\0\0");
+  test_strncpy<char>("hello", 5, "helloxxx");
+  test_strncpy<char>("hello", 6, "hello\0xx");
+  test_strncpy<char>("hello", 7, "hello\0\0x");
+  test_strncpy<char>("hello", 8, "hello\0\0\0");
+  test_strncpy<char>("hell\0o", 4, "hellxxxx");
+  test_strncpy<char>("hell\0o", 5, "hell\0xx");
+  test_strncpy<char>("hell\0o", 6, "hell\0\0x");
+  test_strncpy<char>("hell\0o", 7, "hell\0\0\0");
+
+  // char16
+  test_strncpy<char16_t>(u"", 0, u"xxx");
+  test_strncpy<char16_t>(u"", 1, u"\0xx");
+  test_strncpy<char16_t>(u"", 2, u"\0\0x");
+  test_strncpy<char16_t>(u"", 3, u"\0\0\0");
+  test_strncpy<char16_t>(u"a", 0, u"xxx");
+  test_strncpy<char16_t>(u"a", 1, u"axx");
+  test_strncpy<char16_t>(u"a", 2, u"a\0x");
+  test_strncpy<char16_t>(u"a", 3, u"a\0\0");
+  test_strncpy<char16_t>(u"\0a", 0, u"xxx");
+  test_strncpy<char16_t>(u"\0a", 1, u"\0xx");
+  test_strncpy<char16_t>(u"\0a", 2, u"\0\0x");
+  test_strncpy<char16_t>(u"\0a", 3, u"\0\0\0");
+  test_strncpy<char16_t>(u"hello", 5, u"helloxxx");
+  test_strncpy<char16_t>(u"hello", 6, u"hello\0xx");
+  test_strncpy<char16_t>(u"hello", 7, u"hello\0\0x");
+  test_strncpy<char16_t>(u"hello", 8, u"hello\0\0\0");
+  test_strncpy<char16_t>(u"hell\0o", 4, u"hellxxxx");
+  test_strncpy<char16_t>(u"hell\0o", 5, u"hell\0xx");
+  test_strncpy<char16_t>(u"hell\0o", 6, u"hell\0\0x");
+  test_strncpy<char16_t>(u"hell\0o", 7, u"hell\0\0\0");
+
+  // char32
+  test_strncpy<char32_t>(U"", 0, U"xxx");
+  test_strncpy<char32_t>(U"", 1, U"\0xx");
+  test_strncpy<char32_t>(U"", 2, U"\0\0x");
+  test_strncpy<char32_t>(U"", 3, U"\0\0\0");
+  test_strncpy<char32_t>(U"a", 0, U"xxx");
+  test_strncpy<char32_t>(U"a", 1, U"axx");
+  test_strncpy<char32_t>(U"a", 2, U"a\0x");
+  test_strncpy<char32_t>(U"a", 3, U"a\0\0");
+  test_strncpy<char32_t>(U"\0a", 0, U"xxx");
+  test_strncpy<char32_t>(U"\0a", 1, U"\0xx");
+  test_strncpy<char32_t>(U"\0a", 2, U"\0\0x");
+  test_strncpy<char32_t>(U"\0a", 3, U"\0\0\0");
+  test_strncpy<char32_t>(U"hello", 5, U"helloxxx");
+  test_strncpy<char32_t>(U"hello", 6, U"hello\0xx");
+  test_strncpy<char32_t>(U"hello", 7, U"hello\0\0x");
+  test_strncpy<char32_t>(U"hello", 8, U"hello\0\0\0");
+  test_strncpy<char32_t>(U"hell\0o", 4, U"hellxxxx");
+  test_strncpy<char32_t>(U"hell\0o", 5, U"hell\0xx");
+  test_strncpy<char32_t>(U"hell\0o", 6, U"hell\0\0x");
+  test_strncpy<char32_t>(U"hell\0o", 7, U"hell\0\0\0");
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/string_manip/strncpy.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/strings/cstring.syn/string_manip/strncpy.pass.cpp
@@ -35,7 +35,7 @@ __host__ __device__ constexpr void test_strncpy(const T* str, cuda::std::size_t 
 
 __host__ __device__ constexpr bool test()
 {
-  // char8
+  // char
   test_strncpy<char>("", 0, "xxx");
   test_strncpy<char>("", 1, "\0xx");
   test_strncpy<char>("", 2, "\0\0x");
@@ -57,7 +57,31 @@ __host__ __device__ constexpr bool test()
   test_strncpy<char>("hell\0o", 6, "hell\0\0x");
   test_strncpy<char>("hell\0o", 7, "hell\0\0\0");
 
-  // char16
+#if _LIBCUDACXX_HAS_CHAR8_T()
+  // char8_t
+  test_strncpy<char8_t>(u8"", 0, u8"xxx");
+  test_strncpy<char8_t>(u8"", 1, u8"\0xx");
+  test_strncpy<char8_t>(u8"", 2, u8"\0\0x");
+  test_strncpy<char8_t>(u8"", 3, u8"\0\0\0");
+  test_strncpy<char8_t>(u8"a", 0, u8"xxx");
+  test_strncpy<char8_t>(u8"a", 1, u8"axx");
+  test_strncpy<char8_t>(u8"a", 2, u8"a\0x");
+  test_strncpy<char8_t>(u8"a", 3, u8"a\0\0");
+  test_strncpy<char8_t>(u8"\0a", 0, u8"xxx");
+  test_strncpy<char8_t>(u8"\0a", 1, u8"\0xx");
+  test_strncpy<char8_t>(u8"\0a", 2, u8"\0\0x");
+  test_strncpy<char8_t>(u8"\0a", 3, u8"\0\0\0");
+  test_strncpy<char8_t>(u8"hello", 5, u8"helloxxx");
+  test_strncpy<char8_t>(u8"hello", 6, u8"hello\0xx");
+  test_strncpy<char8_t>(u8"hello", 7, u8"hello\0\0x");
+  test_strncpy<char8_t>(u8"hello", 8, u8"hello\0\0\0");
+  test_strncpy<char8_t>(u8"hell\0o", 4, u8"hellxxxx");
+  test_strncpy<char8_t>(u8"hell\0o", 5, u8"hell\0xx");
+  test_strncpy<char8_t>(u8"hell\0o", 6, u8"hell\0\0x");
+  test_strncpy<char8_t>(u8"hell\0o", 7, u8"hell\0\0\0");
+#endif // _LIBCUDACXX_HAS_CHAR8_T()
+
+  // char16_t
   test_strncpy<char16_t>(u"", 0, u"xxx");
   test_strncpy<char16_t>(u"", 1, u"\0xx");
   test_strncpy<char16_t>(u"", 2, u"\0\0x");
@@ -79,7 +103,7 @@ __host__ __device__ constexpr bool test()
   test_strncpy<char16_t>(u"hell\0o", 6, u"hell\0\0x");
   test_strncpy<char16_t>(u"hell\0o", 7, u"hell\0\0\0");
 
-  // char32
+  // char32_t
   test_strncpy<char32_t>(U"", 0, U"xxx");
   test_strncpy<char32_t>(U"", 1, U"\0xx");
   test_strncpy<char32_t>(U"", 2, U"\0\0x");


### PR DESCRIPTION
This PR implements constexpr versions of cstring functions, so they can be used in `char_traits`.
