### PR TITLE
Drop cuSpatial from RAPIDS builds.

### DIFF
--- a/.github/workflows/build-rapids.yml
+++ b/.github/workflows/build-rapids.yml
@@ -63,7 +63,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { cuda: '12.8', libs: 'rmm kvikio cudf cudf_kafka cuspatial' }
+          - { cuda: '12.8', libs: 'rmm kvikio cudf cudf_kafka' }
           - { cuda: '12.8', libs: 'rmm ucxx raft cuvs cumlprims_mg cuml' }
           - { cuda: '12.8', libs: 'rmm ucxx raft cugraph'                }
     permissions:
@@ -96,7 +96,6 @@ jobs:
           # RAPIDS_cugraph_gnn_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-25.04"}'
           # RAPIDS_cuml_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-25.04"}'
           # RAPIDS_cumlprims_mg_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-25.04"}'
-          # RAPIDS_cuspatial_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-25.04"}'
           # RAPIDS_cuvs_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-25.04"}'
           # RAPIDS_kvikio_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-25.04"}'
           # RAPIDS_raft_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-25.04"}'

--- a/README.md
+++ b/README.md
@@ -469,7 +469,6 @@ Does your project use CCCL? [Open a PR to add your project to this list!](https:
 - [cuML](https://github.com/rapidsai/cuml) - Machine learning algorithms and primitives
 - [CuPy](https://cupy.dev) - NumPy & SciPy for GPU
 - [cuSOLVER](https://developer.nvidia.com/cusolver) - Dense and sparse linear solvers
-- [cuSpatial](https://github.com/rapidsai/cuspatial) - Algorithms for geospatial operations
 - [GooFit](https://github.com/GooFit/GooFit) - Library for maximum-likelihood fits
 - [HeavyDB](https://github.com/heavyai/heavydb) - SQL database engine
 - [HOOMD](https://github.com/glotzerlab/hoomd-blue) - Monte Carlo and molecular dynamics simulations

--- a/ci/rapids/cuda12.8-conda/devcontainer.json
+++ b/ci/rapids/cuda12.8-conda/devcontainer.json
@@ -37,10 +37,9 @@
     "RAPIDS_cumlprims_mg_GIT_REPO": "${localEnv:RAPIDS_cumlprims_mg_GIT_REPO}",
     "RAPIDS_cuml_GIT_REPO": "${localEnv:RAPIDS_cuml_GIT_REPO}",
     "RAPIDS_cugraph_GIT_REPO": "${localEnv:RAPIDS_cugraph_GIT_REPO}",
-    "RAPIDS_cugraph_gnn_GIT_REPO": "${localEnv:RAPIDS_cugraph_gnn_GIT_REPO}",
-    "RAPIDS_cuspatial_GIT_REPO": "${localEnv:RAPIDS_cuspatial_GIT_REPO}"
+    "RAPIDS_cugraph_gnn_GIT_REPO": "${localEnv:RAPIDS_cugraph_gnn_GIT_REPO}"
   },
-  "initializeCommand": ["/bin/bash", "-c", "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config} ${localWorkspaceFolder}/ci/rapids/.{conda,log/devcontainer-utils} ${localWorkspaceFolder}/ci/rapids/.repos/{rmm,kvikio,ucxx,cudf,raft,cuvs,cuml,cugraph,cugraph-gnn,cuspatial}"],
+  "initializeCommand": ["/bin/bash", "-c", "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config} ${localWorkspaceFolder}/ci/rapids/.{conda,log/devcontainer-utils} ${localWorkspaceFolder}/ci/rapids/.repos/{rmm,kvikio,ucxx,cudf,raft,cuvs,cuml,cugraph,cugraph-gnn}"],
   "postCreateCommand": ["/bin/bash", "-c", "if [ ${CI:-false} = 'false' ]; then . /home/coder/cccl/ci/rapids/post-create-command.sh; fi"],
   "postAttachCommand": ["/bin/bash", "-c", "if [ ${CODESPACES:-false} = 'true' ]; then . devcontainer-utils-post-attach-command; fi"],
   "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
@@ -58,7 +57,6 @@
     "source=${localWorkspaceFolder}/ci/rapids/.repos/cuml,target=/home/coder/cuml,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/ci/rapids/.repos/cugraph,target=/home/coder/cugraph,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/ci/rapids/.repos/cugraph-gnn,target=/home/coder/cugraph-gnn,type=bind,consistency=consistent",
-    "source=${localWorkspaceFolder}/ci/rapids/.repos/cuspatial,target=/home/coder/cuspatial,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/ci/rapids/.conda,target=/home/coder/.conda,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/ci/rapids/.log/devcontainer-utils,target=/var/log/devcontainer-utils,type=bind,consistency=consistent"
   ],


### PR DESCRIPTION
## Description
This PR drops cuSpatial from the RAPIDS CI build jobs. cuSpatial is no longer being updated, see https://docs.rapids.ai/notices/rsn0045/.

## Checklist
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
