### PR TITLE
[CUDAX] Fix uninitialized context pointers in streamGetCtx_v2

### DIFF
--- a/cudax/include/cuda/experimental/__utility/driver_api.cuh
+++ b/cudax/include/cuda/experimental/__utility/driver_api.cuh
@@ -163,8 +163,8 @@ struct __ctx_from_stream
 inline __ctx_from_stream streamGetCtx_v2(CUstream stream)
 {
   static auto driver_fn = CUDAX_GET_DRIVER_FUNCTION_VERSIONED(cuStreamGetCtx, cuStreamGetCtx_v2, 12050);
-  CUcontext ctx;
-  CUgreenCtx gctx;
+  CUcontext ctx = nullptr;
+  CUgreenCtx gctx = nullptr;
   __ctx_from_stream __result;
   call_driver_fn(driver_fn, "Failed to get context from a stream", stream, &ctx, &gctx);
   if (gctx)

--- a/cudax/include/cuda/experimental/__utility/driver_api.cuh
+++ b/cudax/include/cuda/experimental/__utility/driver_api.cuh
@@ -163,8 +163,8 @@ struct __ctx_from_stream
 inline __ctx_from_stream streamGetCtx_v2(CUstream stream)
 {
   static auto driver_fn = CUDAX_GET_DRIVER_FUNCTION_VERSIONED(cuStreamGetCtx, cuStreamGetCtx_v2, 12050);
-  CUcontext ctx = nullptr;
-  CUgreenCtx gctx = nullptr;
+  CUcontext ctx         = nullptr;
+  CUgreenCtx gctx       = nullptr;
   __ctx_from_stream __result;
   call_driver_fn(driver_fn, "Failed to get context from a stream", stream, &ctx, &gctx);
   if (gctx)


### PR DESCRIPTION
To query context/green ctx from a stream we call into cuStreamGetCtx_v2. It will return either a device ctx or device ctx + green ctx pair and based on if green ctx was returned, we label the return value as device or green ctx.
The problem is that the variables we want the driver to write into were not initialized, so if the driver didn't write to the green ctx variable, we would sometimes find some random values there and return that as a green ctx. This PR adds the needed initialization.