### PR TITLE
Add CMake configuration for Thrust backend selection (CPP, OMP, CUDA)

### DIFF
--- a/docs/cccl/cmake_device_systems.md
+++ b/docs/cccl/cmake_device_systems.md
@@ -1,0 +1,28 @@
+# Using Thrust with CMake: Selecting Device Backends
+
+This guide shows how to compile a Thrust-based project using different device backends (`CPP`, `OMP`, `CUDA`) using CMake.
+
+## Example Project
+
+See: [`examples/device_system_selector`](../examples/device_system_selector)
+
+### Build Instructions
+
+**CPP Backend**
+
+```bash
+cmake -B build-cpp -DTHRUST_BACKEND=CPP
+cmake --build build-cpp
+```
+
+**OMP Backend**
+```bash
+cmake -B build-omp -DTHRUST_BACKEND=OMP
+cmake --build build-omp
+```
+
+**CUDA Backend**
+```bash
+cmake -B build-cuda -DTHRUST_BACKEND=CUDA
+cmake --build build-cuda
+```

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -14,6 +14,13 @@
 # limitations under the License.
 
 string(REPLACE ";" "\\\;" arches_escaped "${CMAKE_CUDA_ARCHITECTURES}")
+# Set the THRUST_BACKEND variable for selecting the Thrust device backend
+if(NOT DEFINED THRUST_BACKEND)
+    set(THRUST_BACKEND CPP CACHE STRING "Select the Thrust backend (CPP, OMP, CUDA)")
+endif()
+
+message(STATUS "Using Thrust Backend: ${THRUST_BACKEND}")
+
 
 set(cmake_opts
   -D "CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
@@ -37,10 +44,9 @@ cccl_add_compile_test(test_name
   basic
   "default"
   ${cmake_opts}
+  -D "THRUST_BACKEND=${THRUST_BACKEND}"
   ${cmake_cpm_opts}
 )
-
-find_package(CUDAToolkit REQUIRED)
 
 if (CUDAToolkit_VERSION_MAJOR VERSION_GREATER_EQUAL 12)
   cccl_add_compile_test(test_name
@@ -48,6 +54,8 @@ if (CUDAToolkit_VERSION_MAJOR VERSION_GREATER_EQUAL 12)
     cudax
     "default"
     ${cmake_opts}
+    -D "THRUST_BACKEND=${THRUST_BACKEND}"
     ${cmake_cpm_opts}
   )
 endif()
+

--- a/examples/device_system_selector/main.cpp
+++ b/examples/device_system_selector/main.cpp
@@ -1,0 +1,10 @@
+#include <iostream>
+#include <thrust/device_vector.h>
+
+int main()
+{
+    thrust::device_vector<double> v(100, 7);
+    v[3] = 8;
+    std::cout << "Element is " << v[3] << "\n";
+    return 0;
+}

--- a/examples/device_system_selector/main.cu
+++ b/examples/device_system_selector/main.cu
@@ -1,0 +1,10 @@
+#include <iostream>
+#include <thrust/device_vector.h>
+
+int main()
+{
+    thrust::device_vector<double> v(100, 7);
+    v[3] = 8;
+    std::cout << "Element is " << v[3] << "\n";
+    return 0;
+}


### PR DESCRIPTION
## Description

- Added functionality to select the Thrust backend (CPP, OMP, CUDA) during CMake configuration via the THRUST_BACKEND variable.
- Updated examples/CMakeLists.txt to handle backend selection dynamically.
- Created and updated documentation in cmake_device_systems.md for clear instructions on how to set the THRUST_BACKEND variable.


## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
