### PR TITLE
add a visitation interface to the senders of ustdex

### DIFF
--- a/cudax/include/cuda/experimental/__async/sender.cuh
+++ b/cudax/include/cuda/experimental/__async/sender.cuh
@@ -41,6 +41,7 @@
 #include <cuda/experimental/__async/sender/sync_wait.cuh>      // IWYU pragma: export
 #include <cuda/experimental/__async/sender/then.cuh>           // IWYU pragma: export
 #include <cuda/experimental/__async/sender/thread_context.cuh> // IWYU pragma: export
+#include <cuda/experimental/__async/sender/visit.cuh>          // IWYU pragma: export
 #include <cuda/experimental/__async/sender/when_all.cuh>       // IWYU pragma: export
 #include <cuda/experimental/__async/sender/write_env.cuh>      // IWYU pragma: export
 

--- a/cudax/include/cuda/experimental/__async/sender/conditional.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/conditional.cuh
@@ -57,13 +57,14 @@ struct _FUNCTION_MUST_RETURN_A_BOOLEAN_TESTABLE_VALUE;
 struct __cond_t
 {
   template <class _Pred, class _Then, class _Else>
-  struct __data
+  struct params
   {
     _Pred pred;
     _Then on_true;
     _Else on_false;
   };
 
+private:
   template <class... _As>
   _CCCL_HOST_DEVICE _CCCL_FORCEINLINE static auto __mk_complete_fn(_As&&... __as) noexcept
   {
@@ -108,7 +109,7 @@ struct __cond_t
   struct __opstate
   {
     using operation_state_concept = operation_state_t;
-    using __data_t                = __data<_Pred, _Then, _Else>;
+    using __params_t              = params<_Pred, _Then, _Else>;
     using __env_t                 = _FWD_ENV_T<env_of_t<_Rcvr>>;
 
     template <class... _As>
@@ -120,9 +121,9 @@ struct __cond_t
     using __next_ops_variant_t = //
       __value_types<completion_signatures_of_t<_Sndr, __env_t>, __opstate_t, __type_concat_into_quote<__variant>::__call>;
 
-    _CUDAX_API __opstate(_Sndr&& __sndr, _Rcvr&& __rcvr, __data_t&& __data)
+    _CUDAX_API __opstate(_Sndr&& __sndr, _Rcvr&& __rcvr, __params_t&& __params)
         : __rcvr_{static_cast<_Rcvr&&>(__rcvr)}
-        , __data_{static_cast<__data_t&&>(__data)}
+        , __params_{static_cast<__params_t&&>(__params)}
         , __op_{__async::connect(static_cast<_Sndr&&>(__sndr), __rcvr_ref{*this})}
     {}
 
@@ -137,16 +138,16 @@ struct __cond_t
       auto __just = just_from(__cond_t::__mk_complete_fn(static_cast<_As&&>(__as)...));
       _CUDAX_TRY( //
         ({        //
-          if (static_cast<_Pred&&>(__data_.pred)(__as...))
+          if (static_cast<_Pred&&>(__params_.pred)(__as...))
           {
             auto& __op =
-              __ops_.__emplace_from(connect, static_cast<_Then&&>(__data_.on_true)(__just), __rcvr_ref{__rcvr_});
+              __ops_.__emplace_from(connect, static_cast<_Then&&>(__params_.on_true)(__just), __rcvr_ref{__rcvr_});
             __async::start(__op);
           }
           else
           {
             auto& __op =
-              __ops_.__emplace_from(connect, static_cast<_Else&&>(__data_.on_false)(__just), __rcvr_ref{__rcvr_});
+              __ops_.__emplace_from(connect, static_cast<_Else&&>(__params_.on_false)(__just), __rcvr_ref{__rcvr_});
             __async::start(__op);
           }
         }),
@@ -174,37 +175,17 @@ struct __cond_t
     }
 
     _Rcvr __rcvr_;
-    __data_t __data_;
+    __params_t __params_;
     connect_result_t<_Sndr, __rcvr_ref<__opstate, __env_t>> __op_;
     __next_ops_variant_t __ops_;
   };
 
+  template <class _Pred, class _Then, class _Else>
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __closure;
+
+public:
   template <class _Sndr, class _Pred, class _Then, class _Else>
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __sndr_t;
-
-  template <class _Pred, class _Then, class _Else>
-  struct __closure
-  {
-    __cond_t::__data<_Pred, _Then, _Else> __data_;
-
-    template <class _Sndr>
-    _CUDAX_TRIVIAL_API auto __mk_sender(_Sndr&& __sndr) //
-      -> __sndr_t<_Sndr, _Pred, _Then, _Else>;
-
-    template <class _Sndr>
-    _CUDAX_TRIVIAL_API auto operator()(_Sndr __sndr) //
-      -> __sndr_t<_Sndr, _Pred, _Then, _Else>
-    {
-      return __mk_sender(static_cast<_Sndr&&>(__sndr));
-    }
-
-    template <class _Sndr>
-    _CUDAX_TRIVIAL_API friend auto operator|(_Sndr __sndr, __closure&& __self) //
-      -> __sndr_t<_Sndr, _Pred, _Then, _Else>
-    {
-      return __self.__mk_sender(static_cast<_Sndr&&>(__sndr));
-    }
-  };
 
   template <class _Sndr, class _Pred, class _Then, class _Else>
   _CUDAX_TRIVIAL_API auto operator()(_Sndr __sndr, _Pred __pred, _Then __then, _Else __else) const //
@@ -221,9 +202,9 @@ struct __cond_t
 template <class _Sndr, class _Pred, class _Then, class _Else>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __cond_t::__sndr_t
 {
-  using __data_t = __cond_t::__data<_Pred, _Then, _Else>;
+  using __params_t = __cond_t::params<_Pred, _Then, _Else>;
   _CCCL_NO_UNIQUE_ADDRESS __cond_t __tag_;
-  __data_t __data_;
+  __params_t __params_;
   _Sndr __sndr_;
 
   template <class _Self, class... _Env>
@@ -242,13 +223,13 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __cond_t::__sndr_t
   template <class _Rcvr>
   _CUDAX_API auto connect(_Rcvr __rcvr) && -> __opstate<_Sndr, _Rcvr, _Pred, _Then, _Else>
   {
-    return {static_cast<_Sndr&&>(__sndr_), static_cast<_Rcvr&&>(__rcvr), static_cast<__data_t&&>(__data_)};
+    return {static_cast<_Sndr&&>(__sndr_), static_cast<_Rcvr&&>(__rcvr), static_cast<__params_t&&>(__params_)};
   }
 
   template <class _Rcvr>
   _CUDAX_API auto connect(_Rcvr __rcvr) const& -> __opstate<_Sndr const&, _Rcvr, _Pred, _Then, _Else>
   {
-    return {__sndr_, static_cast<_Rcvr&&>(__rcvr), static_cast<__data_t&&>(__data_)};
+    return {__sndr_, static_cast<_Rcvr&&>(__rcvr), static_cast<__params_t&&>(__params_)};
   }
 
   _CUDAX_API env_of_t<_Sndr> get_env() const noexcept
@@ -274,22 +255,41 @@ _CUDAX_TRIVIAL_API auto __cond_t::operator()(_Sndr __sndr, _Pred __pred, _Then _
 }
 
 template <class _Pred, class _Then, class _Else>
-template <class _Sndr>
-_CUDAX_TRIVIAL_API auto __cond_t::__closure<_Pred, _Then, _Else>::__mk_sender(_Sndr&& __sndr) //
-  -> __sndr_t<_Sndr, _Pred, _Then, _Else>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT __cond_t::__closure
 {
-  if constexpr (!dependent_sender<_Sndr>)
+  __cond_t::params<_Pred, _Then, _Else> __params_;
+
+  template <class _Sndr>
+  _CUDAX_TRIVIAL_API auto __mk_sender(_Sndr&& __sndr) //
+    -> __sndr_t<_Sndr, _Pred, _Then, _Else>
   {
-    using __completions = completion_signatures_of_t<__sndr_t<_Sndr, _Pred, _Then, _Else>>;
-    static_assert(__valid_completion_signatures<__completions>);
+    if constexpr (!dependent_sender<_Sndr>)
+    {
+      using __completions = completion_signatures_of_t<__sndr_t<_Sndr, _Pred, _Then, _Else>>;
+      static_assert(__valid_completion_signatures<__completions>);
+    }
+
+    return __sndr_t<_Sndr, _Pred, _Then, _Else>{
+      {}, static_cast<__cond_t::params<_Pred, _Then, _Else>&&>(__params_), static_cast<_Sndr&&>(__sndr)};
   }
 
-  return __sndr_t<_Sndr, _Pred, _Then, _Else>{
-    {}, static_cast<__cond_t::__data<_Pred, _Then, _Else>&&>(__data_), static_cast<_Sndr&&>(__sndr)};
-}
+  template <class _Sndr>
+  _CUDAX_TRIVIAL_API auto operator()(_Sndr __sndr) //
+    -> __sndr_t<_Sndr, _Pred, _Then, _Else>
+  {
+    return __mk_sender(static_cast<_Sndr&&>(__sndr));
+  }
+
+  template <class _Sndr>
+  _CUDAX_TRIVIAL_API friend auto operator|(_Sndr __sndr, __closure&& __self) //
+    -> __sndr_t<_Sndr, _Pred, _Then, _Else>
+  {
+    return __self.__mk_sender(static_cast<_Sndr&&>(__sndr));
+  }
+};
 
 template <class _Sndr, class _Pred, class _Then, class _Else>
-inline constexpr int structured_binding_size<__cond_t::__sndr_t<_Sndr, _Pred, _Then, _Else>> = 3;
+inline constexpr size_t structured_binding_size<__cond_t::__sndr_t<_Sndr, _Pred, _Then, _Else>> = 3;
 
 using conditional_t = __cond_t;
 _CCCL_GLOBAL_CONSTANT conditional_t conditional{};

--- a/cudax/include/cuda/experimental/__async/sender/continue_on.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/continue_on.cuh
@@ -293,7 +293,7 @@ _CUDAX_TRIVIAL_API continue_on_t::__closure_t<_Sch> continue_on_t::operator()(_S
 }
 
 template <class _Sndr, class _Sch>
-inline constexpr int structured_binding_size<continue_on_t::__sndr_t<_Sndr, _Sch>> = 3;
+inline constexpr size_t structured_binding_size<continue_on_t::__sndr_t<_Sndr, _Sch>> = 3;
 
 _CCCL_GLOBAL_CONSTANT continue_on_t continue_on{};
 } // namespace cuda::experimental::__async

--- a/cudax/include/cuda/experimental/__async/sender/continue_on.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/continue_on.cuh
@@ -33,6 +33,7 @@
 #include <cuda/experimental/__async/sender/tuple.cuh>
 #include <cuda/experimental/__async/sender/utility.cuh>
 #include <cuda/experimental/__async/sender/variant.cuh>
+#include <cuda/experimental/__async/sender/visit.cuh>
 
 #include <cuda/experimental/__async/sender/prologue.cuh>
 
@@ -219,23 +220,23 @@ template <class _Sndr, class _Sch>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT continue_on_t::__sndr_t
 {
   using sender_concept = sender_t;
-  _CCCL_NO_UNIQUE_ADDRESS continue_on_t __tag;
-  _Sch __sch;
-  _Sndr __sndr;
+  _CCCL_NO_UNIQUE_ADDRESS continue_on_t __tag_;
+  _Sch __sch_;
+  _Sndr __sndr_;
 
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __attrs_t
   {
     template <class _SetTag>
     _CUDAX_API auto query(get_completion_scheduler_t<_SetTag>) const noexcept
     {
-      return __sndr_->__sch;
+      return __sndr_->__sch_;
     }
 
     template <class _Query>
     _CUDAX_API auto query(_Query) const //
       -> __query_result_t<_Query, env_of_t<_Sndr>>
     {
-      return __async::get_env(__sndr_->__sndr).query(_Query{});
+      return __async::get_env(__sndr_->__sndr_).query(_Query{});
     }
 
     const __sndr_t* __sndr_;
@@ -263,13 +264,13 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT continue_on_t::__sndr_t
   template <class _Rcvr>
   _CUDAX_API __opstate_t<_Rcvr, _Sndr, _Sch> connect(_Rcvr __rcvr) &&
   {
-    return {static_cast<_Sndr&&>(__sndr), __sch, static_cast<_Rcvr&&>(__rcvr)};
+    return {static_cast<_Sndr&&>(__sndr_), __sch_, static_cast<_Rcvr&&>(__rcvr)};
   }
 
   template <class _Rcvr>
   _CUDAX_API __opstate_t<_Rcvr, const _Sndr&, _Sch> connect(_Rcvr __rcvr) const&
   {
-    return {__sndr, __sch, static_cast<_Rcvr&&>(__rcvr)};
+    return {__sndr_, __sch_, static_cast<_Rcvr&&>(__rcvr)};
   }
 
   _CUDAX_API __attrs_t get_env() const noexcept
@@ -290,6 +291,9 @@ _CUDAX_TRIVIAL_API continue_on_t::__closure_t<_Sch> continue_on_t::operator()(_S
 {
   return __closure_t<_Sch>{__sch};
 }
+
+template <class _Sndr, class _Sch>
+inline constexpr int structured_binding_size<continue_on_t::__sndr_t<_Sndr, _Sch>> = 3;
 
 _CCCL_GLOBAL_CONSTANT continue_on_t continue_on{};
 } // namespace cuda::experimental::__async

--- a/cudax/include/cuda/experimental/__async/sender/exception.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/exception.cuh
@@ -23,16 +23,17 @@
 
 #include <cuda/experimental/__detail/config.cuh>
 
-#include <exception> // IWYU pragma: keep export
+#include <exception> // IWYU pragma: export
 
 #if defined(__CUDACC__)
 #  include <nv/target>
 #  define _CUDAX_CATCH(...)
 #  define _CUDAX_TRY(_TRY, _CATCH) \
-    NV_IF_TARGET(NV_IS_HOST, (try { _NV_EVAL _TRY } catch (...){_NV_EVAL _CATCH}), ({_NV_EVAL _TRY}))
+    NV_IF_TARGET(                  \
+      NV_IS_HOST, (try { _CCCL_PP_EXPAND _TRY } catch (...){_CCCL_PP_EXPAND _CATCH}), ({_CCCL_PP_EXPAND _TRY}))
 #else
 #  define _CUDAX_CATCH(...)
-#  define _CUDAX_TRY(_TRY, _CATCH) _NV_EVAL(try { _NV_EVAL _TRY } catch (...){_NV_EVAL _CATCH})
+#  define _CUDAX_TRY(_TRY, _CATCH) _NV_EVAL(try { _CCCL_PP_EXPAND _TRY } catch (...){_CCCL_PP_EXPAND _CATCH})
 #endif
 
 #if defined(__CUDA_ARCH__)

--- a/cudax/include/cuda/experimental/__async/sender/just.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/just.cuh
@@ -157,11 +157,11 @@ _CUDAX_TRIVIAL_API auto __just_t<_Disposition>::operator()(_Ts... __ts) const
 }
 
 template <class _Fn>
-inline constexpr int structured_binding_size<__just_t<__value>::__sndr_t<_Fn>> = 2;
+inline constexpr size_t structured_binding_size<__just_t<__value>::__sndr_t<_Fn>> = 2;
 template <class _Fn>
-inline constexpr int structured_binding_size<__just_t<__error>::__sndr_t<_Fn>> = 2;
+inline constexpr size_t structured_binding_size<__just_t<__error>::__sndr_t<_Fn>> = 2;
 template <class _Fn>
-inline constexpr int structured_binding_size<__just_t<__stopped>::__sndr_t<_Fn>> = 2;
+inline constexpr size_t structured_binding_size<__just_t<__stopped>::__sndr_t<_Fn>> = 2;
 
 _CCCL_GLOBAL_CONSTANT struct just_t : __just_t<__value>
 {

--- a/cudax/include/cuda/experimental/__async/sender/just_from.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/just_from.cuh
@@ -156,11 +156,11 @@ _CUDAX_TRIVIAL_API auto __just_from_t<_Disposition>::operator()(_Fn __fn) const 
 }
 
 template <class _Fn>
-inline constexpr int structured_binding_size<__just_from_t<__value>::__sndr_t<_Fn>> = 2;
+inline constexpr size_t structured_binding_size<__just_from_t<__value>::__sndr_t<_Fn>> = 2;
 template <class _Fn>
-inline constexpr int structured_binding_size<__just_from_t<__error>::__sndr_t<_Fn>> = 2;
+inline constexpr size_t structured_binding_size<__just_from_t<__error>::__sndr_t<_Fn>> = 2;
 template <class _Fn>
-inline constexpr int structured_binding_size<__just_from_t<__stopped>::__sndr_t<_Fn>> = 2;
+inline constexpr size_t structured_binding_size<__just_from_t<__stopped>::__sndr_t<_Fn>> = 2;
 
 _CCCL_GLOBAL_CONSTANT struct just_from_t : __just_from_t<__value>
 {

--- a/cudax/include/cuda/experimental/__async/sender/just_from.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/just_from.cuh
@@ -28,6 +28,7 @@
 #include <cuda/experimental/__async/sender/cpos.cuh>
 #include <cuda/experimental/__async/sender/tuple.cuh>
 #include <cuda/experimental/__async/sender/utility.cuh>
+#include <cuda/experimental/__async/sender/visit.cuh>
 #include <cuda/experimental/__detail/config.cuh>
 
 #include <cuda/experimental/__async/sender/prologue.cuh>
@@ -153,6 +154,13 @@ _CUDAX_TRIVIAL_API auto __just_from_t<_Disposition>::operator()(_Fn __fn) const 
                 "completion_signatures<>.");
   return __sndr_t<_Fn>{{}, static_cast<_Fn&&>(__fn)};
 }
+
+template <class _Fn>
+inline constexpr int structured_binding_size<__just_from_t<__value>::__sndr_t<_Fn>> = 2;
+template <class _Fn>
+inline constexpr int structured_binding_size<__just_from_t<__error>::__sndr_t<_Fn>> = 2;
+template <class _Fn>
+inline constexpr int structured_binding_size<__just_from_t<__stopped>::__sndr_t<_Fn>> = 2;
 
 _CCCL_GLOBAL_CONSTANT struct just_from_t : __just_from_t<__value>
 {

--- a/cudax/include/cuda/experimental/__async/sender/let_value.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/let_value.cuh
@@ -330,11 +330,11 @@ _CUDAX_TRIVIAL_API auto __let_t<_Disposition>::operator()(_Fn __fn) const noexce
 }
 
 template <class _Sndr, class _Fn>
-inline constexpr int structured_binding_size<__let_t<__value>::__sndr_t<_Sndr, _Fn>> = 3;
+inline constexpr size_t structured_binding_size<__let_t<__value>::__sndr_t<_Sndr, _Fn>> = 3;
 template <class _Sndr, class _Fn>
-inline constexpr int structured_binding_size<__let_t<__error>::__sndr_t<_Sndr, _Fn>> = 3;
+inline constexpr size_t structured_binding_size<__let_t<__error>::__sndr_t<_Sndr, _Fn>> = 3;
 template <class _Sndr, class _Fn>
-inline constexpr int structured_binding_size<__let_t<__stopped>::__sndr_t<_Sndr, _Fn>> = 3;
+inline constexpr size_t structured_binding_size<__let_t<__stopped>::__sndr_t<_Sndr, _Fn>> = 3;
 
 _CCCL_GLOBAL_CONSTANT struct let_value_t : __let_t<__value>
 {

--- a/cudax/include/cuda/experimental/__async/sender/let_value.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/let_value.cuh
@@ -33,6 +33,7 @@
 #include <cuda/experimental/__async/sender/tuple.cuh>
 #include <cuda/experimental/__async/sender/type_traits.cuh>
 #include <cuda/experimental/__async/sender/variant.cuh>
+#include <cuda/experimental/__async/sender/visit.cuh>
 #include <cuda/experimental/__detail/config.cuh>
 
 #include <cuda/experimental/__async/sender/prologue.cuh>
@@ -327,6 +328,13 @@ _CUDAX_TRIVIAL_API auto __let_t<_Disposition>::operator()(_Fn __fn) const noexce
 {
   return __closure_t<_Fn>{static_cast<_Fn&&>(__fn)};
 }
+
+template <class _Sndr, class _Fn>
+inline constexpr int structured_binding_size<__let_t<__value>::__sndr_t<_Sndr, _Fn>> = 3;
+template <class _Sndr, class _Fn>
+inline constexpr int structured_binding_size<__let_t<__error>::__sndr_t<_Sndr, _Fn>> = 3;
+template <class _Sndr, class _Fn>
+inline constexpr int structured_binding_size<__let_t<__stopped>::__sndr_t<_Sndr, _Fn>> = 3;
 
 _CCCL_GLOBAL_CONSTANT struct let_value_t : __let_t<__value>
 {

--- a/cudax/include/cuda/experimental/__async/sender/read_env.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/read_env.cuh
@@ -144,7 +144,7 @@ _CUDAX_TRIVIAL_API constexpr read_env_t::__sndr_t<_Query> read_env_t::operator()
 }
 
 template <class _Query>
-inline constexpr int structured_binding_size<read_env_t::__sndr_t<_Query>> = 2;
+inline constexpr size_t structured_binding_size<read_env_t::__sndr_t<_Query>> = 2;
 
 _CCCL_GLOBAL_CONSTANT read_env_t read_env{};
 

--- a/cudax/include/cuda/experimental/__async/sender/read_env.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/read_env.cuh
@@ -31,6 +31,7 @@
 #include <cuda/experimental/__async/sender/exception.cuh>
 #include <cuda/experimental/__async/sender/queries.cuh>
 #include <cuda/experimental/__async/sender/utility.cuh>
+#include <cuda/experimental/__async/sender/visit.cuh>
 #include <cuda/experimental/__detail/config.cuh>
 
 #include <cuda/experimental/__async/sender/prologue.cuh>
@@ -141,6 +142,9 @@ _CUDAX_TRIVIAL_API constexpr read_env_t::__sndr_t<_Query> read_env_t::operator()
 {
   return __sndr_t<_Query>{{}, __query};
 }
+
+template <class _Query>
+inline constexpr int structured_binding_size<read_env_t::__sndr_t<_Query>> = 2;
 
 _CCCL_GLOBAL_CONSTANT read_env_t read_env{};
 

--- a/cudax/include/cuda/experimental/__async/sender/sequence.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/sequence.cuh
@@ -155,7 +155,7 @@ _CUDAX_API auto __seq_t::operator()(_Sndr1 __sndr1, _Sndr2 __sndr2) const -> __s
 }
 
 template <class _Sndr1, class _Sndr2>
-inline constexpr int structured_binding_size<__seq_t::__sndr_t<_Sndr1, _Sndr2>> = 4;
+inline constexpr size_t structured_binding_size<__seq_t::__sndr_t<_Sndr1, _Sndr2>> = 4;
 
 using sequence_t = __seq_t;
 _CCCL_GLOBAL_CONSTANT sequence_t sequence{};

--- a/cudax/include/cuda/experimental/__async/sender/sequence.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/sequence.cuh
@@ -29,12 +29,13 @@
 #include <cuda/experimental/__async/sender/lazy.cuh>
 #include <cuda/experimental/__async/sender/rcvr_ref.cuh>
 #include <cuda/experimental/__async/sender/variant.cuh>
+#include <cuda/experimental/__async/sender/visit.cuh>
 
 #include <cuda/experimental/__async/sender/prologue.cuh>
 
 namespace cuda::experimental::__async
 {
-struct __seq
+struct __seq_t
 {
   template <class _Rcvr, class _Sndr1, class _Sndr2>
   struct __args
@@ -101,7 +102,7 @@ struct __seq
 };
 
 template <class _Sndr1, class _Sndr2>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT __seq::__sndr_t
+struct _CCCL_TYPE_VISIBILITY_DEFAULT __seq_t::__sndr_t
 {
   using sender_concept = sender_t;
   using __sndr1_t      = _Sndr1;
@@ -141,19 +142,22 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __seq::__sndr_t
     return __async::get_env(__sndr2_);
   }
 
-  _CCCL_NO_UNIQUE_ADDRESS __seq __tag_;
+  _CCCL_NO_UNIQUE_ADDRESS __seq_t __tag_;
   _CCCL_NO_UNIQUE_ADDRESS __ignore __ign_;
   __sndr1_t __sndr1_;
   __sndr2_t __sndr2_;
 };
 
 template <class _Sndr1, class _Sndr2>
-_CUDAX_API auto __seq::operator()(_Sndr1 __sndr1, _Sndr2 __sndr2) const -> __sndr_t<_Sndr1, _Sndr2>
+_CUDAX_API auto __seq_t::operator()(_Sndr1 __sndr1, _Sndr2 __sndr2) const -> __sndr_t<_Sndr1, _Sndr2>
 {
   return __sndr_t<_Sndr1, _Sndr2>{{}, {}, static_cast<_Sndr1&&>(__sndr1), static_cast<_Sndr2&&>(__sndr2)};
 }
 
-using sequence_t = __seq;
+template <class _Sndr1, class _Sndr2>
+inline constexpr int structured_binding_size<__seq_t::__sndr_t<_Sndr1, _Sndr2>> = 4;
+
+using sequence_t = __seq_t;
 _CCCL_GLOBAL_CONSTANT sequence_t sequence{};
 } // namespace cuda::experimental::__async
 

--- a/cudax/include/cuda/experimental/__async/sender/start_on.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/start_on.cuh
@@ -147,7 +147,7 @@ _CUDAX_API auto start_on_t::operator()(_Sch __sch, _Sndr __sndr) const noexcept 
 }
 
 template <class _Sch, class _Sndr>
-inline constexpr int structured_binding_size<start_on_t::__sndr_t<_Sch, _Sndr>> = 3;
+inline constexpr size_t structured_binding_size<start_on_t::__sndr_t<_Sch, _Sndr>> = 3;
 
 _CCCL_GLOBAL_CONSTANT start_on_t start_on{};
 } // namespace cuda::experimental::__async

--- a/cudax/include/cuda/experimental/__async/sender/start_on.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/start_on.cuh
@@ -31,6 +31,7 @@
 #include <cuda/experimental/__async/sender/tuple.cuh>
 #include <cuda/experimental/__async/sender/utility.cuh>
 #include <cuda/experimental/__async/sender/variant.cuh>
+#include <cuda/experimental/__async/sender/visit.cuh>
 
 #include <cuda/experimental/__async/sender/prologue.cuh>
 
@@ -47,7 +48,7 @@ struct __sch_env_t
   }
 };
 
-_CCCL_GLOBAL_CONSTANT struct start_on_t
+struct start_on_t
 {
 private:
   template <class _Rcvr, class _Sch, class _CvSndr>
@@ -84,13 +85,13 @@ private:
     connect_result_t<_CvSndr, __rcvr_ref<__rcvr_with_sch_t>> __opstate2_;
   };
 
+public:
   template <class _Sch, class _Sndr>
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __sndr_t;
 
-public:
   template <class _Sch, class _Sndr>
   _CUDAX_API auto operator()(_Sch __sch, _Sndr __sndr) const noexcept -> __sndr_t<_Sch, _Sndr>;
-} start_on{};
+};
 
 template <class _Sch, class _Sndr>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT start_on_t::__sndr_t
@@ -144,6 +145,11 @@ _CUDAX_API auto start_on_t::operator()(_Sch __sch, _Sndr __sndr) const noexcept 
 {
   return __sndr_t<_Sch, _Sndr>{{}, __sch, __sndr};
 }
+
+template <class _Sch, class _Sndr>
+inline constexpr int structured_binding_size<start_on_t::__sndr_t<_Sch, _Sndr>> = 3;
+
+_CCCL_GLOBAL_CONSTANT start_on_t start_on{};
 } // namespace cuda::experimental::__async
 
 #include <cuda/experimental/__async/sender/epilogue.cuh>

--- a/cudax/include/cuda/experimental/__async/sender/then.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/then.cuh
@@ -325,11 +325,11 @@ _CUDAX_TRIVIAL_API auto __upon_t<_Disposition>::operator()(_Fn __fn) const noexc
 }
 
 template <class _Sndr, class _Fn>
-inline constexpr int structured_binding_size<__upon_t<__value>::__sndr_t<_Sndr, _Fn>> = 3;
+inline constexpr size_t structured_binding_size<__upon_t<__value>::__sndr_t<_Sndr, _Fn>> = 3;
 template <class _Sndr, class _Fn>
-inline constexpr int structured_binding_size<__upon_t<__error>::__sndr_t<_Sndr, _Fn>> = 3;
+inline constexpr size_t structured_binding_size<__upon_t<__error>::__sndr_t<_Sndr, _Fn>> = 3;
 template <class _Sndr, class _Fn>
-inline constexpr int structured_binding_size<__upon_t<__stopped>::__sndr_t<_Sndr, _Fn>> = 3;
+inline constexpr size_t structured_binding_size<__upon_t<__stopped>::__sndr_t<_Sndr, _Fn>> = 3;
 
 _CCCL_GLOBAL_CONSTANT struct then_t : __upon_t<__value>
 {

--- a/cudax/include/cuda/experimental/__async/sender/then.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/then.cuh
@@ -34,6 +34,7 @@
 #include <cuda/experimental/__async/sender/rcvr_ref.cuh>
 #include <cuda/experimental/__async/sender/tuple.cuh>
 #include <cuda/experimental/__async/sender/utility.cuh>
+#include <cuda/experimental/__async/sender/visit.cuh>
 
 #include <cuda/experimental/__async/sender/prologue.cuh>
 
@@ -322,6 +323,14 @@ _CUDAX_TRIVIAL_API auto __upon_t<_Disposition>::operator()(_Fn __fn) const noexc
 {
   return __closure_t<_Fn>{static_cast<_Fn&&>(__fn)};
 }
+
+template <class _Sndr, class _Fn>
+inline constexpr int structured_binding_size<__upon_t<__value>::__sndr_t<_Sndr, _Fn>> = 3;
+template <class _Sndr, class _Fn>
+inline constexpr int structured_binding_size<__upon_t<__error>::__sndr_t<_Sndr, _Fn>> = 3;
+template <class _Sndr, class _Fn>
+inline constexpr int structured_binding_size<__upon_t<__stopped>::__sndr_t<_Sndr, _Fn>> = 3;
+
 _CCCL_GLOBAL_CONSTANT struct then_t : __upon_t<__value>
 {
 } then{};

--- a/cudax/include/cuda/experimental/__async/sender/tuple.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/tuple.cuh
@@ -22,6 +22,7 @@
 #endif // no system header
 
 #include <cuda/std/__type_traits/enable_if.h>
+#include <cuda/std/__type_traits/type_list.h>
 #include <cuda/std/__utility/integer_sequence.h>
 
 #include <cuda/experimental/__async/sender/meta.cuh>
@@ -62,17 +63,69 @@ struct __tupl<_CUDA_VSTD::index_sequence<_Idx...>, _Ts...> : __box<_Idx, _Ts>...
       static_cast<_Us&&>(__us)...,
       static_cast<_Self&&>(__self).__box<_Idx, _Ts>::__value_...);
   }
-
-  template <class _Fn, class _Self, class... _Us>
-  _CUDAX_TRIVIAL_API static auto __for_each(_Fn&& __fn, _Self&& __self, _Us&&... __us) //
-    noexcept((__nothrow_callable<_Fn, _Us..., __copy_cvref_t<_Self, _Ts>> && ...))
-      -> _CUDA_VSTD::enable_if_t<(__callable<_Fn, _Us..., __copy_cvref_t<_Self, _Ts>> && ...)>
-  {
-    return (
-      static_cast<_Fn&&>(__fn)(static_cast<_Us&&>(__us)..., static_cast<_Self&&>(__self).__box<_Idx, _Ts>::__value_),
-      ...);
-  }
 };
+
+template <auto _Value>
+struct __v
+{
+  static constexpr auto value = _Value;
+};
+
+// Unroll tuples up to some size
+#define _CCCL_TUPLE_DEFINE_TPARAM(_Idx)  , class _CCCL_PP_CAT(_T, _Idx)
+#define _CCCL_TUPLE_INDEX_SEQUENCE(_Idx) , _Idx
+#define _CCCL_TUPLE_TPARAM(_Idx)         , _CCCL_PP_CAT(_T, _Idx)
+#define _CCCL_TUPLE_DEFINE_ELEMENT(_Idx) _CCCL_PP_CAT(_T, _Idx) _CCCL_PP_CAT(__t, _Idx);
+#define _CCCL_TUPLE_CVREF_TPARAM(_Idx)   , __copy_cvref_t<_Self, _CCCL_PP_CAT(_T, _Idx)>
+#define _CCCL_TUPLE_ELEMENT(_Idx)        , static_cast<_Self&&>(__self)._CCCL_PP_CAT(__t, _Idx)
+#define _CCCL_TUPLE_MBR_PTR(_Idx)        , __v<&__tupl::_CCCL_PP_CAT(__t, _Idx)>
+
+#define _CCCL_DEFINE_TUPLE(_SizeSub1)                                                                                 \
+  template <class _T0 _CCCL_PP_REPEAT(_SizeSub1, _CCCL_TUPLE_DEFINE_TPARAM, 1)>                                       \
+  struct __tupl<_CUDA_VSTD::index_sequence<0 _CCCL_PP_REPEAT(_SizeSub1, _CCCL_TUPLE_INDEX_SEQUENCE, 1)>,              \
+                _T0 _CCCL_PP_REPEAT(_SizeSub1, _CCCL_TUPLE_TPARAM, 1)>                                                \
+  {                                                                                                                   \
+    _T0 __t0;                                                                                                         \
+    _CCCL_PP_REPEAT(_SizeSub1, _CCCL_TUPLE_DEFINE_ELEMENT, 1)                                                         \
+                                                                                                                      \
+    template <class _Fn, class _Self, class... _Us>                                                                   \
+    _CUDAX_TRIVIAL_API static auto __apply(_Fn&& __fn, _Self&& __self, _Us&&... __us) noexcept(                       \
+      __nothrow_callable<_Fn,                                                                                         \
+                         _Us... _CCCL_TUPLE_CVREF_TPARAM(0) _CCCL_PP_REPEAT(_SizeSub1, _CCCL_TUPLE_CVREF_TPARAM, 1)>) \
+      -> __call_result_t<_Fn,                                                                                         \
+                         _Us... _CCCL_TUPLE_CVREF_TPARAM(0) _CCCL_PP_REPEAT(_SizeSub1, _CCCL_TUPLE_CVREF_TPARAM, 1)>  \
+    {                                                                                                                 \
+      return static_cast<_Fn&&>(__fn)(                                                                                \
+        static_cast<_Us&&>(__us)... _CCCL_TUPLE_ELEMENT(0) _CCCL_PP_REPEAT(_SizeSub1, _CCCL_TUPLE_ELEMENT, 1));       \
+    }                                                                                                                 \
+                                                                                                                      \
+    template <class _Idx>                                                                                             \
+    using __tupl_mbr_ptr_t _CCCL_NODEBUG_ALIAS =                                                                      \
+      _CUDA_VSTD::__type_index<_Idx, __v<&__tupl::__t0> _CCCL_PP_REPEAT(_SizeSub1, _CCCL_TUPLE_MBR_PTR, 1)>;          \
+  }
+
+_CCCL_DEFINE_TUPLE(0);
+_CCCL_DEFINE_TUPLE(1);
+_CCCL_DEFINE_TUPLE(2);
+_CCCL_DEFINE_TUPLE(3);
+_CCCL_DEFINE_TUPLE(4);
+_CCCL_DEFINE_TUPLE(5);
+_CCCL_DEFINE_TUPLE(6);
+_CCCL_DEFINE_TUPLE(7);
+
+#undef _CCCL_TUPLE_DEFINE_TPARAM
+#undef _CCCL_TUPLE_INDEX_SEQUENCE
+#undef _CCCL_TUPLE_TPARAM
+#undef _CCCL_TUPLE_DEFINE_ELEMENT
+#undef _CCCL_TUPLE_CVREF_TPARAM
+#undef _CCCL_TUPLE_ELEMENT
+#undef _CCCL_TUPLE_MBR_PTR
+
+template <size_t _Idx, class _Tupl, auto _MbrPtr = _Tupl::template __tupl_mbr_ptr_t<_Idx>::value>
+_CUDAX_TRIVIAL_API constexpr auto __cget(_Tupl const& __tupl) noexcept -> decltype(auto)
+{
+  return __tupl.*_MbrPtr;
+}
 
 template <class... _Ts>
 __tupl(_Ts...) //

--- a/cudax/include/cuda/experimental/__async/sender/visit.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/visit.cuh
@@ -1,0 +1,81 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __CUDAX_ASYNC_DETAIL_VISIT
+#define __CUDAX_ASYNC_DETAIL_VISIT
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__type_traits/copy_cvref.h>
+
+#include <cuda/experimental/__async/sender/type_traits.cuh>
+#include <cuda/experimental/__detail/config.cuh>
+
+#include <cuda/experimental/__async/sender/prologue.cuh>
+
+namespace cuda::experimental::__async
+{
+
+// Specialize this for each sender type that can be used to initialize a structured binding.
+template <class _Sndr>
+inline constexpr int structured_binding_size = -1;
+
+template <int _Arity>
+struct __sender_type_cannot_be_used_to_initialize_a_structured_binding;
+
+template <int _Arity>
+extern __sender_type_cannot_be_used_to_initialize_a_structured_binding<_Arity> __unpack;
+
+#define _CCCL_BIND_CHILD(_Ord) , _CCCL_PP_CAT(__child, _Ord)
+#define _CCCL_FWD_CHILD(_Ord)  , _CCCL_FWD_LIKE(_Sndr, _CCCL_PP_CAT(__child, _Ord))
+#define _CCCL_FWD_LIKE(_X, _Y) static_cast<_CUDA_VSTD::__copy_cvref_t<_X&&, decltype(_Y)>>(_Y)
+
+#define _CCCL_UNPACK_SENDER(_Arity)                                                                             \
+  template <>                                                                                                   \
+  [[maybe_unused]]                                                                                              \
+  _CCCL_GLOBAL_CONSTANT auto __unpack<2 + _Arity> =                                                             \
+    [](auto& __visitor, auto&& __sndr, auto& __context) -> decltype(auto) {                                     \
+    using _Sndr                                                      = decltype(__sndr);                        \
+    auto&& [__tag, __data _CCCL_PP_REPEAT(_Arity, _CCCL_BIND_CHILD)] = static_cast<_Sndr&&>(__sndr);            \
+    return __visitor(__context, __tag, _CCCL_FWD_LIKE(_Sndr, __data) _CCCL_PP_REPEAT(_Arity, _CCCL_FWD_CHILD)); \
+  }
+
+_CCCL_UNPACK_SENDER(0);
+_CCCL_UNPACK_SENDER(1);
+_CCCL_UNPACK_SENDER(2);
+_CCCL_UNPACK_SENDER(3);
+_CCCL_UNPACK_SENDER(4);
+_CCCL_UNPACK_SENDER(5);
+_CCCL_UNPACK_SENDER(6);
+_CCCL_UNPACK_SENDER(7);
+
+#undef _CCCL_FWD_LIKE
+#undef _CCCL_FWD_CHILD
+#undef _CCCL_BIND_CHILD
+
+[[maybe_unused]]
+_CCCL_GLOBAL_CONSTANT auto visit = [](auto& __visitor, auto&& sndr, auto& __context) -> decltype(auto) {
+  using _Sndr = __decay_t<decltype(sndr)>;
+  return __unpack<structured_binding_size<_Sndr>>(__visitor, static_cast<decltype(sndr)&&>(sndr), __context);
+};
+
+} // namespace cuda::experimental::__async
+
+#include <cuda/experimental/__async/sender/epilogue.cuh>
+
+#endif // __CUDAX_ASYNC_DETAIL_VISIT

--- a/cudax/include/cuda/experimental/__async/sender/visit.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/visit.cuh
@@ -33,12 +33,12 @@ namespace cuda::experimental::__async
 
 // Specialize this for each sender type that can be used to initialize a structured binding.
 template <class _Sndr>
-inline constexpr int structured_binding_size = -1;
+inline constexpr size_t structured_binding_size = static_cast<size_t>(-1);
 
-template <int _Arity>
+template <size_t _Arity>
 struct __sender_type_cannot_be_used_to_initialize_a_structured_binding;
 
-template <int _Arity>
+template <size_t _Arity>
 extern __sender_type_cannot_be_used_to_initialize_a_structured_binding<_Arity> __unpack;
 
 #define _CCCL_BIND_CHILD(_Ord) , _CCCL_PP_CAT(__child, _Ord)

--- a/cudax/include/cuda/experimental/__async/sender/when_all.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/when_all.cuh
@@ -491,7 +491,7 @@ _CUDAX_API auto when_all_t::operator()(_Sndrs... __sndrs) const -> __sndr_t<_Snd
 }
 
 template <class... _Sndrs>
-inline constexpr int structured_binding_size<when_all_t::__sndr_t<_Sndrs...>> = sizeof...(_Sndrs) + 2;
+inline constexpr size_t structured_binding_size<when_all_t::__sndr_t<_Sndrs...>> = sizeof...(_Sndrs) + 2;
 
 _CCCL_GLOBAL_CONSTANT when_all_t when_all{};
 } // namespace cuda::experimental::__async

--- a/cudax/include/cuda/experimental/__async/sender/when_all.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/when_all.cuh
@@ -43,6 +43,7 @@
 #include <cuda/experimental/__async/sender/type_traits.cuh>
 #include <cuda/experimental/__async/sender/utility.cuh>
 #include <cuda/experimental/__async/sender/variant.cuh>
+#include <cuda/experimental/__async/sender/visit.cuh>
 #include <cuda/experimental/__detail/config.cuh>
 
 #include <cuda/experimental/__async/sender/prologue.cuh>
@@ -51,10 +52,10 @@ namespace cuda::experimental::__async
 {
 struct _CCCL_TYPE_VISIBILITY_DEFAULT when_all_t
 {
-private:
   template <class... _Sndrs>
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __sndr_t;
 
+private:
   // Extract the first template parameter of the __state_t specialization.
   // The first template parameter is the receiver type.
   template <class _State>
@@ -145,8 +146,8 @@ private:
   template <class _Rcvr, class _CvFn, class _Sndrs>
   struct __state_t;
 
-  template <class _Rcvr, class _CvFn, class _Idx, class... _Sndrs>
-  struct __state_t<_Rcvr, _CvFn, __tupl<_Idx, _Sndrs...>>
+  template <class _Rcvr, class _CvFn, class _Idx, class _Ign0, class _Ign1, class... _Sndrs>
+  struct __state_t<_Rcvr, _CvFn, __tupl<_Idx, _Ign0, _Ign1, _Sndrs...>>
   {
     using __env_t     = when_all_t::__env_t<__zip<__state_t>>;
     using __sndr_t    = when_all_t::__sndr_t<_Sndrs...>;
@@ -282,16 +283,26 @@ private:
     __lazy<__stop_callback_t> __on_stop_;
   };
 
+  struct __start_all
+  {
+    template <class... _Ops>
+    _CUDAX_TRIVIAL_API void operator()(_Ops&... __ops) const noexcept
+    {
+      (__async::start(__ops), ...);
+    }
+  };
+
   /// The operation state for when_all
   template <class, class, class>
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __opstate_t;
 
-  template <class _Rcvr, class _CvFn, size_t... _Idx, class... _Sndrs>
-  struct _CCCL_TYPE_VISIBILITY_DEFAULT __opstate_t<_Rcvr, _CvFn, __tupl<_CUDA_VSTD::index_sequence<_Idx...>, _Sndrs...>>
+  template <class _Rcvr, class _CvFn, size_t... _Idx, class _Ign0, class _Ign1, class... _Sndrs>
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT
+  __opstate_t<_Rcvr, _CvFn, __tupl<_CUDA_VSTD::index_sequence<0, 1, _Idx...>, _Ign0, _Ign1, _Sndrs...>>
   {
     using operation_state_concept = operation_state_t;
-    using __sndrs_t               = _CUDA_VSTD::__type_call<_CvFn, __tuple<_Sndrs...>>;
-    using __state_t               = when_all_t::__state_t<_Rcvr, _CvFn, __tuple<_Sndrs...>>;
+    using __sndrs_t               = _CUDA_VSTD::__type_call<_CvFn, __tuple<_Ign0, _Ign1, _Sndrs...>>;
+    using __state_t               = when_all_t::__state_t<_Rcvr, _CvFn, __tuple<_Ign0, _Ign1, _Sndrs...>>;
 
     // This function object is used to connect all the sub-operations with
     // receivers, each of which knows which elements in the values tuple it
@@ -299,7 +310,7 @@ private:
     struct __connect_subs_fn
     {
       template <class... _CvSndrs>
-      _CUDAX_API auto operator()(__state_t& __state, _CvSndrs&&... __sndrs_) const
+      _CUDAX_API auto operator()(__state_t& __state, __ignore, __ignore, _CvSndrs&&... __sndrs_) const
       {
         using __state_ref_t = __zip<__state_t>;
         // When there are no offsets, the when_all sender has no value
@@ -310,7 +321,7 @@ private:
         // The offsets are used to determine which elements in the values
         // tuple each receiver is responsible for setting.
         return __tupl{__async::connect(
-          static_cast<_CvSndrs&&>(__sndrs_), __rcvr_t<__state_ref_t, __no_values ? 0 : _Idx>{__state})...};
+          static_cast<_CvSndrs&&>(__sndrs_), __rcvr_t<__state_ref_t, __no_values ? 0 : _Idx - 2>{__state})...};
       }
     };
 
@@ -349,7 +360,7 @@ private:
       else
       {
         // Start all the sub-operations.
-        __sub_ops_.__for_each(__async::start, __sub_ops_);
+        __sub_ops_.__apply(__start_all{}, __sub_ops_);
 
         // If there are no sub-operations, we're done.
         if constexpr (sizeof...(_Sndrs) == 0)
@@ -436,14 +447,10 @@ _CCCL_DIAG_POP
 
 // The sender for when_all
 template <class... _Sndrs>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT when_all_t::__sndr_t
+struct _CCCL_TYPE_VISIBILITY_DEFAULT when_all_t::__sndr_t : __tuple<when_all_t, __ignore, _Sndrs...>
 {
   using sender_concept = sender_t;
-  using __sndrs_t      = __tuple<_Sndrs...>;
-
-  _CCCL_NO_UNIQUE_ADDRESS when_all_t __tag_;
-  _CCCL_NO_UNIQUE_ADDRESS __ignore __ignore1_;
-  __sndrs_t __sndrs_;
+  using __sndrs_t      = __tuple<when_all_t, __ignore, _Sndrs...>;
 
   template <class _Self, class... _Env>
   _CUDAX_API static constexpr auto __get_completions_and_offsets()
@@ -460,13 +467,13 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT when_all_t::__sndr_t
   template <class _Rcvr>
   _CUDAX_API auto connect(_Rcvr __rcvr) && -> __opstate_t<_Rcvr, __cp, __sndrs_t>
   {
-    return __opstate_t<_Rcvr, __cp, __sndrs_t>(static_cast<__sndrs_t&&>(__sndrs_), static_cast<_Rcvr&&>(__rcvr));
+    return __opstate_t<_Rcvr, __cp, __sndrs_t>(static_cast<__sndrs_t&&>(*this), static_cast<_Rcvr&&>(__rcvr));
   }
 
   template <class _Rcvr>
   _CUDAX_API auto connect(_Rcvr __rcvr) const& -> __opstate_t<_Rcvr, __cpclr, __sndrs_t>
   {
-    return __opstate_t<_Rcvr, __cpclr, __sndrs_t>(__sndrs_, static_cast<_Rcvr&&>(__rcvr));
+    return __opstate_t<_Rcvr, __cpclr, __sndrs_t>(static_cast<__sndrs_t const&>(*this), static_cast<_Rcvr&&>(__rcvr));
   }
 };
 
@@ -480,11 +487,13 @@ _CUDAX_API auto when_all_t::operator()(_Sndrs... __sndrs) const -> __sndr_t<_Snd
     using __completions = completion_signatures_of_t<__sndr_t<_Sndrs...>>;
     static_assert(__valid_completion_signatures<__completions>);
   }
-  return __sndr_t<_Sndrs...>{{}, {}, {static_cast<_Sndrs&&>(__sndrs)...}};
+  return __sndr_t<_Sndrs...>{{{}, {}, static_cast<_Sndrs&&>(__sndrs)...}};
 }
 
-_CCCL_GLOBAL_CONSTANT when_all_t when_all{};
+template <class... _Sndrs>
+inline constexpr int structured_binding_size<when_all_t::__sndr_t<_Sndrs...>> = sizeof...(_Sndrs) + 2;
 
+_CCCL_GLOBAL_CONSTANT when_all_t when_all{};
 } // namespace cuda::experimental::__async
 
 #include <cuda/experimental/__async/sender/epilogue.cuh>

--- a/cudax/include/cuda/experimental/__async/sender/write_env.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/write_env.cuh
@@ -111,7 +111,7 @@ _CUDAX_TRIVIAL_API constexpr auto write_env_t::operator()(_Sndr __sndr, _Env __e
 }
 
 template <class _Sndr, class _Env>
-inline constexpr int structured_binding_size<write_env_t::__sndr_t<_Sndr, _Env>> = 3;
+inline constexpr size_t structured_binding_size<write_env_t::__sndr_t<_Sndr, _Env>> = 3;
 
 _CCCL_GLOBAL_CONSTANT write_env_t write_env{};
 } // namespace cuda::experimental::__async

--- a/cudax/include/cuda/experimental/__async/sender/write_env.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/write_env.cuh
@@ -29,6 +29,7 @@
 #include <cuda/experimental/__async/sender/rcvr_ref.cuh>
 #include <cuda/experimental/__async/sender/rcvr_with_env.cuh>
 #include <cuda/experimental/__async/sender/utility.cuh>
+#include <cuda/experimental/__async/sender/visit.cuh>
 #include <cuda/experimental/__detail/config.cuh>
 
 #include <cuda/experimental/__async/sender/prologue.cuh>
@@ -109,8 +110,10 @@ _CUDAX_TRIVIAL_API constexpr auto write_env_t::operator()(_Sndr __sndr, _Env __e
   return __sndr_t<_Sndr, _Env>{{}, static_cast<_Env&&>(__env), static_cast<_Sndr&&>(__sndr)};
 }
 
-_CCCL_GLOBAL_CONSTANT write_env_t write_env{};
+template <class _Sndr, class _Env>
+inline constexpr int structured_binding_size<write_env_t::__sndr_t<_Sndr, _Env>> = 3;
 
+_CCCL_GLOBAL_CONSTANT write_env_t write_env{};
 } // namespace cuda::experimental::__async
 
 #include <cuda/experimental/__async/sender/epilogue.cuh>

--- a/cudax/test/CMakeLists.txt
+++ b/cudax/test/CMakeLists.txt
@@ -126,6 +126,7 @@ foreach(cn_target IN LISTS cudax_TARGETS)
     async/test_continue_on.cu
     async/test_just.cu
     async/test_sequence.cu
+    async/test_visit.cu
     async/test_when_all.cu
   )
   target_compile_options(${test_target} PRIVATE $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:--extended-lambda>)

--- a/cudax/test/async/common/checked_receiver.cuh
+++ b/cudax/test/async/common/checked_receiver.cuh
@@ -22,7 +22,7 @@ struct checked_value_receiver
   using receiver_concept = cudax_async::receiver_t;
 
   checked_value_receiver(Values... values)
-      : _values{{values}...}
+      : _values{values...}
   {}
 
   // This overload is needed to avoid an nvcc compiler bug where a variadic

--- a/cudax/test/async/test_visit.cu
+++ b/cudax/test/async/test_visit.cu
@@ -1,0 +1,67 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/__algorithm/max.h>
+
+#include <cuda/experimental/__async/sender.cuh>
+
+#include "testing.cuh" // IWYU pragma: keep
+
+namespace
+{
+template <class Fn>
+struct recursive_lambda
+{
+  Fn fn;
+
+  template <class... Args>
+  __host__ __device__ auto operator()(Args&&... args)
+  {
+    return fn(*this, cuda::std::forward<Args>(args)...);
+  }
+};
+
+template <class Fn>
+recursive_lambda(Fn) -> recursive_lambda<Fn>;
+
+C2H_TEST("sender visitation API works", "[visit]")
+{
+  int leaves = 0;
+  int depth  = 0;
+
+  auto snd = cudax_async::when_all(
+    cudax_async::just(3), //
+    cudax_async::just(0.1415),
+    cudax_async::then(cudax_async::just(0.1415), [](double f) {
+      return f;
+    }));
+  auto snd1 = std::move(snd) | cudax_async::then([](int x, double y, double z) {
+                return x + y + z;
+              });
+
+  auto count_leaves = recursive_lambda{[](auto& self, int& leaves, auto, auto&, auto&... child) {
+    leaves += (sizeof...(child) == 0);
+    ((cudax_async::visit(self, child, leaves)), ...);
+  }};
+
+  cudax_async::visit(count_leaves, snd1, leaves);
+  CHECK(leaves == 3);
+
+  auto max_depth = recursive_lambda{[i = 0](auto& self, int& depth, auto, auto&, auto&... child) mutable {
+    ++i;
+    depth = cuda::std::max(depth, i);
+    ((cudax_async::visit(self, child, depth)), ...);
+    --i;
+  }};
+
+  cudax_async::visit(max_depth, snd1, depth);
+  CHECK(depth == 4);
+}
+} // namespace


### PR DESCRIPTION
this commit adds a `visit` free function to ustdex. it is callable with a visitor, a sender, and an extra blob of user data. it expands one level of the sender tree. the visitor is responsible for recursing.

`visit` uses the fact that senders from the standard algorithms can be used to initialize a structured binding. this commit adds a trait `structured_binding_size` that is specialized for all the sender types. that trait is used to dispatch to a visitation function of the correct arity. for now the arity is capped at 8 (tag+data+6 children) but that can be increased. eventually the limit will go away with C++26's variadic structured binding support.

this commit also uses the preprocessor to unroll tuples of up to 8 elements, thereby instantiating O(1) class templates instead of O(N)+1. the `when_all` sender uses an unrolled tuple to store its child senders so that it satisfies the requirements for structured bindings without going through the `std::tuple` interface (which is expensive at compile time).
