### PR TITLE
Mark libcu++ algorithms with `_CCCL_EXEC_CHECK_DISABLE`

### DIFF
--- a/libcudacxx/include/cuda/std/__algorithm/adjacent_find.h
+++ b/libcudacxx/include/cuda/std/__algorithm/adjacent_find.h
@@ -24,6 +24,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _ForwardIterator, class _BinaryPredicate>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _ForwardIterator
 adjacent_find(_ForwardIterator __first, _ForwardIterator __last, _BinaryPredicate __pred)

--- a/libcudacxx/include/cuda/std/__algorithm/all_of.h
+++ b/libcudacxx/include/cuda/std/__algorithm/all_of.h
@@ -21,6 +21,7 @@
 #endif // no system header
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _InputIterator, class _Predicate>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr bool
 all_of(_InputIterator __first, _InputIterator __last, _Predicate __pred)

--- a/libcudacxx/include/cuda/std/__algorithm/any_of.h
+++ b/libcudacxx/include/cuda/std/__algorithm/any_of.h
@@ -21,6 +21,7 @@
 #endif // no system header
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _InputIterator, class _Predicate>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr bool
 any_of(_InputIterator __first, _InputIterator __last, _Predicate __pred)

--- a/libcudacxx/include/cuda/std/__algorithm/binary_search.h
+++ b/libcudacxx/include/cuda/std/__algorithm/binary_search.h
@@ -27,6 +27,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _ForwardIterator, class _Tp, class _Compare>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr bool
 binary_search(_ForwardIterator __first, _ForwardIterator __last, const _Tp& __value, _Compare __comp)

--- a/libcudacxx/include/cuda/std/__algorithm/clamp.h
+++ b/libcudacxx/include/cuda/std/__algorithm/clamp.h
@@ -24,6 +24,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _Tp, class _Compare>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr const _Tp&
 clamp(const _Tp& __v, const _Tp& __lo, const _Tp& __hi, _Compare __comp)

--- a/libcudacxx/include/cuda/std/__algorithm/comp.h
+++ b/libcudacxx/include/cuda/std/__algorithm/comp.h
@@ -29,6 +29,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 struct __equal_to
 {
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _T1, class _T2>
   [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr bool operator()(const _T1& __lhs, const _T2& __rhs) const
     noexcept(noexcept(__lhs == __rhs))
@@ -45,6 +46,7 @@ struct __is_trivial_equality_predicate<__equal_to, _Lhs, _Rhs> : true_type
 
 struct __less
 {
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _Tp, class _Up>
   [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr bool operator()(const _Tp& __lhs, const _Up& __rhs) const
     noexcept(noexcept(__lhs < __rhs))

--- a/libcudacxx/include/cuda/std/__algorithm/copy.h
+++ b/libcudacxx/include/cuda/std/__algorithm/copy.h
@@ -33,6 +33,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _AlgPolicy, class _InputIterator, class _OutputIterator>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr pair<_InputIterator, _OutputIterator>
 __copy(_InputIterator __first, _InputIterator __last, _OutputIterator __result)
@@ -62,6 +63,7 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr bool __dispatch_memmove(_Up* __result, _Tp* 
 #endif // ^^^ !_CCCL_BUILTIN_MEMMOVE ^^^
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _Tp, class _Up>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr bool __constexpr_tail_overlap_fallback(_Tp* __first, _Up* __needle, _Tp* __last)
 {
@@ -76,6 +78,7 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr bool __constexpr_tail_overlap_fallback(_Tp* 
   return false;
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _Tp, class _Up>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr bool
 __constexpr_tail_overlap(_Tp* __first, _Up* __needle, [[maybe_unused]] _Tp* __last)
@@ -89,6 +92,7 @@ __constexpr_tail_overlap(_Tp* __first, _Up* __needle, [[maybe_unused]] _Tp* __la
 #endif // !_CCCL_BUILTIN_CONSTANT_P
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _AlgPolicy,
           class _Tp,
           class _Up,

--- a/libcudacxx/include/cuda/std/__algorithm/copy_backward.h
+++ b/libcudacxx/include/cuda/std/__algorithm/copy_backward.h
@@ -29,6 +29,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _BidirectionalIterator, class _OutputIterator>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _OutputIterator
 __copy_backward(_BidirectionalIterator __first, _BidirectionalIterator __last, _OutputIterator __result)
@@ -40,6 +41,7 @@ __copy_backward(_BidirectionalIterator __first, _BidirectionalIterator __last, _
   return __result;
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _Tp,
           class _Up,
           enable_if_t<_CCCL_TRAIT(is_same, remove_const_t<_Tp>, _Up), int> = 0,

--- a/libcudacxx/include/cuda/std/__algorithm/copy_if.h
+++ b/libcudacxx/include/cuda/std/__algorithm/copy_if.h
@@ -22,6 +22,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _InputIterator, class _OutputIterator, class _Predicate>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _OutputIterator
 copy_if(_InputIterator __first, _InputIterator __last, _OutputIterator __result, _Predicate __pred)

--- a/libcudacxx/include/cuda/std/__algorithm/copy_n.h
+++ b/libcudacxx/include/cuda/std/__algorithm/copy_n.h
@@ -27,6 +27,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _InputIterator,
           class _Size,
           class _OutputIterator,
@@ -51,6 +52,7 @@ copy_n(_InputIterator __first, _Size __orig_n, _OutputIterator __result)
   return __result;
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _InputIterator,
           class _Size,
           class _OutputIterator,

--- a/libcudacxx/include/cuda/std/__algorithm/count.h
+++ b/libcudacxx/include/cuda/std/__algorithm/count.h
@@ -24,6 +24,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _InputIterator, class _Tp>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr __iter_diff_t<_InputIterator>
 count(_InputIterator __first, _InputIterator __last, const _Tp& __value_)

--- a/libcudacxx/include/cuda/std/__algorithm/count_if.h
+++ b/libcudacxx/include/cuda/std/__algorithm/count_if.h
@@ -24,6 +24,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _InputIterator, class _Predicate>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr __iter_diff_t<_InputIterator>
 count_if(_InputIterator __first, _InputIterator __last, _Predicate __pred)

--- a/libcudacxx/include/cuda/std/__algorithm/equal_range.h
+++ b/libcudacxx/include/cuda/std/__algorithm/equal_range.h
@@ -39,6 +39,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _AlgPolicy, class _Compare, class _Iter, class _Sent, class _Tp, class _Proj>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr pair<_Iter, _Iter>
 __equal_range(_Iter __first, _Sent __last, const _Tp& __value, _Compare&& __comp, _Proj&& __proj)
@@ -69,6 +70,7 @@ __equal_range(_Iter __first, _Sent __last, const _Tp& __value, _Compare&& __comp
   return pair<_Iter, _Iter>(__first, __first);
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _ForwardIterator, class _Tp, class _Compare>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr pair<_ForwardIterator, _ForwardIterator>
 equal_range(_ForwardIterator __first, _ForwardIterator __last, const _Tp& __value, _Compare __comp)

--- a/libcudacxx/include/cuda/std/__algorithm/fill.h
+++ b/libcudacxx/include/cuda/std/__algorithm/fill.h
@@ -25,6 +25,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _ForwardIterator, class _Tp>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr void
 __fill(_ForwardIterator __first, _ForwardIterator __last, const _Tp& __value_, forward_iterator_tag)

--- a/libcudacxx/include/cuda/std/__algorithm/fill_n.h
+++ b/libcudacxx/include/cuda/std/__algorithm/fill_n.h
@@ -25,6 +25,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _OutputIterator, class _Size, class _Tp>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _OutputIterator __fill_n(_OutputIterator __first, _Size __n, const _Tp& __value_)
 {

--- a/libcudacxx/include/cuda/std/__algorithm/find.h
+++ b/libcudacxx/include/cuda/std/__algorithm/find.h
@@ -24,6 +24,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 // generic implementation
 template <class _Iter, class _Sent, class _Tp, class _Proj>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _Iter
@@ -39,6 +40,7 @@ __find_impl(_Iter __first, _Sent __last, const _Tp& __value, _Proj& __proj)
   return __first;
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _InputIterator, class _Tp>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _InputIterator
 find(_InputIterator __first, _InputIterator __last, const _Tp& __value_)

--- a/libcudacxx/include/cuda/std/__algorithm/find_end.h
+++ b/libcudacxx/include/cuda/std/__algorithm/find_end.h
@@ -26,6 +26,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _BinaryPredicate, class _ForwardIterator1, class _ForwardIterator2>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _ForwardIterator1 __find_end(
   _ForwardIterator1 __first1,
@@ -80,6 +81,7 @@ template <class _BinaryPredicate, class _ForwardIterator1, class _ForwardIterato
   }
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _BinaryPredicate, class _BidirectionalIterator1, class _BidirectionalIterator2>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _BidirectionalIterator1 __find_end(
   _BidirectionalIterator1 __first1,
@@ -133,6 +135,7 @@ template <class _BinaryPredicate, class _BidirectionalIterator1, class _Bidirect
   }
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _BinaryPredicate, class _RandomAccessIterator1, class _RandomAccessIterator2>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _RandomAccessIterator1 __find_end(
   _RandomAccessIterator1 __first1,

--- a/libcudacxx/include/cuda/std/__algorithm/find_first_of.h
+++ b/libcudacxx/include/cuda/std/__algorithm/find_first_of.h
@@ -24,6 +24,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _ForwardIterator1 __find_first_of_ce(
   _ForwardIterator1 __first1,

--- a/libcudacxx/include/cuda/std/__algorithm/find_if.h
+++ b/libcudacxx/include/cuda/std/__algorithm/find_if.h
@@ -21,6 +21,7 @@
 #endif // no system header
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _InputIterator, class _Predicate>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _InputIterator
 find_if(_InputIterator __first, _InputIterator __last, _Predicate __pred)

--- a/libcudacxx/include/cuda/std/__algorithm/find_if_not.h
+++ b/libcudacxx/include/cuda/std/__algorithm/find_if_not.h
@@ -21,6 +21,7 @@
 #endif // no system header
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _InputIterator, class _Predicate>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _InputIterator
 find_if_not(_InputIterator __first, _InputIterator __last, _Predicate __pred)

--- a/libcudacxx/include/cuda/std/__algorithm/for_each.h
+++ b/libcudacxx/include/cuda/std/__algorithm/for_each.h
@@ -21,6 +21,7 @@
 #endif // no system header
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _InputIterator, class _Function>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _Function for_each(_InputIterator __first, _InputIterator __last, _Function __f)
 {

--- a/libcudacxx/include/cuda/std/__algorithm/for_each_n.h
+++ b/libcudacxx/include/cuda/std/__algorithm/for_each_n.h
@@ -24,6 +24,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _InputIterator, class _Size, class _Function>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _InputIterator for_each_n(_InputIterator __first, _Size __orig_n, _Function __f)
 {

--- a/libcudacxx/include/cuda/std/__algorithm/generate.h
+++ b/libcudacxx/include/cuda/std/__algorithm/generate.h
@@ -22,6 +22,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _ForwardIterator, class _Generator>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr void generate(_ForwardIterator __first, _ForwardIterator __last, _Generator __gen)
 {

--- a/libcudacxx/include/cuda/std/__algorithm/generate_n.h
+++ b/libcudacxx/include/cuda/std/__algorithm/generate_n.h
@@ -24,6 +24,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _OutputIterator, class _Size, class _Generator>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _OutputIterator generate_n(_OutputIterator __first, _Size __orig_n, _Generator __gen)
 {

--- a/libcudacxx/include/cuda/std/__algorithm/includes.h
+++ b/libcudacxx/include/cuda/std/__algorithm/includes.h
@@ -30,6 +30,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _Iter1, class _Sent1, class _Iter2, class _Sent2, class _Comp, class _Proj1, class _Proj2>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr bool __includes(
   _Iter1 __first1, _Sent1 __last1, _Iter2 __first2, _Sent2 __last2, _Comp&& __comp, _Proj1&& __proj1, _Proj2&& __proj2)
@@ -51,6 +52,7 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr bool __includes(
   return true;
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _InputIterator1, class _InputIterator2, class _Compare>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr bool includes(
   _InputIterator1 __first1, _InputIterator1 __last1, _InputIterator2 __first2, _InputIterator2 __last2, _Compare __comp)
@@ -68,6 +70,7 @@ template <class _InputIterator1, class _InputIterator2, class _Compare>
     __identity());
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _InputIterator1, class _InputIterator2>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr bool
 includes(_InputIterator1 __first1, _InputIterator1 __last1, _InputIterator2 __first2, _InputIterator2 __last2)

--- a/libcudacxx/include/cuda/std/__algorithm/is_heap.h
+++ b/libcudacxx/include/cuda/std/__algorithm/is_heap.h
@@ -27,6 +27,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _RandomAccessIterator, class _Compare>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr bool
 is_heap(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp)

--- a/libcudacxx/include/cuda/std/__algorithm/is_heap_until.h
+++ b/libcudacxx/include/cuda/std/__algorithm/is_heap_until.h
@@ -26,6 +26,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _Compare, class _RandomAccessIterator>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _RandomAccessIterator
 __is_heap_until(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare&& __comp)

--- a/libcudacxx/include/cuda/std/__algorithm/is_partitioned.h
+++ b/libcudacxx/include/cuda/std/__algorithm/is_partitioned.h
@@ -22,6 +22,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _InputIterator, class _Predicate>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr bool
 is_partitioned(_InputIterator __first, _InputIterator __last, _Predicate __pred)

--- a/libcudacxx/include/cuda/std/__algorithm/is_permutation.h
+++ b/libcudacxx/include/cuda/std/__algorithm/is_permutation.h
@@ -28,6 +28,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr bool is_permutation(
   _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _BinaryPredicate __pred)
@@ -106,6 +107,7 @@ is_permutation(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIt
   return _CUDA_VSTD::is_permutation(__first1, __last1, __first2, __equal_to{});
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _BinaryPredicate, class _ForwardIterator1, class _ForwardIterator2>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr bool __is_permutation(
   _ForwardIterator1 __first1,
@@ -189,6 +191,7 @@ template <class _BinaryPredicate, class _ForwardIterator1, class _ForwardIterato
   return true;
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _BinaryPredicate, class _RandomAccessIterator1, class _RandomAccessIterator2>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr bool __is_permutation(
   _RandomAccessIterator1 __first1,

--- a/libcudacxx/include/cuda/std/__algorithm/is_sorted.h
+++ b/libcudacxx/include/cuda/std/__algorithm/is_sorted.h
@@ -27,6 +27,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _ForwardIterator, class _Compare>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr bool
 is_sorted(_ForwardIterator __first, _ForwardIterator __last, _Compare __comp)

--- a/libcudacxx/include/cuda/std/__algorithm/is_sorted_until.h
+++ b/libcudacxx/include/cuda/std/__algorithm/is_sorted_until.h
@@ -26,6 +26,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _Compare, class _ForwardIterator>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _ForwardIterator
 __is_sorted_until(_ForwardIterator __first, _ForwardIterator __last, _Compare __comp)

--- a/libcudacxx/include/cuda/std/__algorithm/iter_swap.h
+++ b/libcudacxx/include/cuda/std/__algorithm/iter_swap.h
@@ -25,6 +25,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _ForwardIterator1, class _ForwardIterator2>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr void iter_swap(_ForwardIterator1 __a, _ForwardIterator2 __b) noexcept(
   noexcept(swap(*_CUDA_VSTD::declval<_ForwardIterator1>(), *_CUDA_VSTD::declval<_ForwardIterator2>())))

--- a/libcudacxx/include/cuda/std/__algorithm/iterator_operations.h
+++ b/libcudacxx/include/cuda/std/__algorithm/iterator_operations.h
@@ -115,6 +115,7 @@ struct _IterOps<_ClassicAlgPolicy>
   }
 
   // iter_move
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _Iter, enable_if_t<is_reference<__deref_t<_Iter>>::value, int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI constexpr static
     // If the result of dereferencing `_Iter` is a reference type, deduce the result of calling `_CUDA_VSTD::move` on
@@ -127,6 +128,7 @@ struct _IterOps<_ClassicAlgPolicy>
     return _CUDA_VSTD::move(*_CUDA_VSTD::forward<_Iter>(__i));
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _Iter, enable_if_t<!is_reference<__deref_t<_Iter>>::value, int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI constexpr static
     // If the result of dereferencing `_Iter` is a value type, deduce the return value of this function to also be a
@@ -169,6 +171,7 @@ struct _IterOps<_ClassicAlgPolicy>
     return _CUDA_VSTD::prev(_CUDA_VSTD::forward<_Iter>(__iter), __n);
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _Iter>
   _LIBCUDACXX_HIDE_FROM_ABI static constexpr void __advance_to(_Iter& __first, _Iter __last)
   {

--- a/libcudacxx/include/cuda/std/__algorithm/lexicographical_compare.h
+++ b/libcudacxx/include/cuda/std/__algorithm/lexicographical_compare.h
@@ -26,6 +26,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _Compare, class _InputIterator1, class _InputIterator2>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr bool __lexicographical_compare(
   _InputIterator1 __first1, _InputIterator1 __last1, _InputIterator2 __first2, _InputIterator2 __last2, _Compare __comp)

--- a/libcudacxx/include/cuda/std/__algorithm/lower_bound.h
+++ b/libcudacxx/include/cuda/std/__algorithm/lower_bound.h
@@ -33,6 +33,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _AlgPolicy, class _Iter, class _Sent, class _Type, class _Proj, class _Comp>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _Iter
 __lower_bound(_Iter __first, _Sent __last, const _Type& __value, _Comp& __comp, _Proj& __proj)

--- a/libcudacxx/include/cuda/std/__algorithm/make_heap.h
+++ b/libcudacxx/include/cuda/std/__algorithm/make_heap.h
@@ -29,6 +29,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _AlgPolicy, class _Compare, class _RandomAccessIterator>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr void
 __make_heap(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare&& __comp)
@@ -47,6 +48,7 @@ __make_heap(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compar
   }
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _RandomAccessIterator, class _Compare>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr void
 make_heap(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp)
@@ -54,6 +56,7 @@ make_heap(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare 
   _CUDA_VSTD::__make_heap<_ClassicAlgPolicy>(_CUDA_VSTD::move(__first), _CUDA_VSTD::move(__last), __comp);
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _RandomAccessIterator>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr void make_heap(_RandomAccessIterator __first, _RandomAccessIterator __last)
 {

--- a/libcudacxx/include/cuda/std/__algorithm/max.h
+++ b/libcudacxx/include/cuda/std/__algorithm/max.h
@@ -29,12 +29,14 @@ _CCCL_PUSH_MACROS
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _Tp, class _Compare>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr const _Tp& max(const _Tp& __a, const _Tp& __b, _Compare __comp)
 {
   return __comp(__a, __b) ? __b : __a;
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _Tp>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr const _Tp& max(const _Tp& __a, const _Tp& __b)
 {

--- a/libcudacxx/include/cuda/std/__algorithm/max_element.h
+++ b/libcudacxx/include/cuda/std/__algorithm/max_element.h
@@ -26,6 +26,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _Compare, class _ForwardIterator>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _ForwardIterator
 __max_element(_ForwardIterator __first, _ForwardIterator __last, _Compare __comp)

--- a/libcudacxx/include/cuda/std/__algorithm/merge.h
+++ b/libcudacxx/include/cuda/std/__algorithm/merge.h
@@ -27,6 +27,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _Compare, class _InputIterator1, class _InputIterator2, class _OutputIterator>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _OutputIterator __merge(
   _InputIterator1 __first1,

--- a/libcudacxx/include/cuda/std/__algorithm/min.h
+++ b/libcudacxx/include/cuda/std/__algorithm/min.h
@@ -29,12 +29,14 @@ _CCCL_PUSH_MACROS
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _Tp, class _Compare>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr const _Tp& min(const _Tp& __a, const _Tp& __b, _Compare __comp)
 {
   return __comp(__b, __a) ? __b : __a;
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _Tp>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr const _Tp& min(const _Tp& __a, const _Tp& __b)
 {

--- a/libcudacxx/include/cuda/std/__algorithm/min_element.h
+++ b/libcudacxx/include/cuda/std/__algorithm/min_element.h
@@ -32,6 +32,7 @@ _CCCL_PUSH_MACROS
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _Comp, class _Iter, class _Sent, class _Proj>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _Iter __min_element(_Iter __first, _Sent __last, _Comp __comp, _Proj& __proj)
 {
@@ -52,6 +53,7 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr _Iter __min_element(_Iter __first, _Sent __l
   return __first;
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _Comp, class _Iter, class _Sent>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _Iter __min_element(_Iter __first, _Sent __last, _Comp __comp)
 {
@@ -59,6 +61,7 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr _Iter __min_element(_Iter __first, _Sent __l
   return _CUDA_VSTD::__min_element<_Comp>(_CUDA_VSTD::move(__first), _CUDA_VSTD::move(__last), __comp, __proj);
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _ForwardIterator, class _Compare>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _ForwardIterator
 min_element(_ForwardIterator __first, _ForwardIterator __last, _Compare __comp)

--- a/libcudacxx/include/cuda/std/__algorithm/minmax.h
+++ b/libcudacxx/include/cuda/std/__algorithm/minmax.h
@@ -29,6 +29,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _Tp, class _Compare>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr pair<const _Tp&, const _Tp&>
 minmax(const _Tp& __a, const _Tp& __b, _Compare __comp)

--- a/libcudacxx/include/cuda/std/__algorithm/minmax_element.h
+++ b/libcudacxx/include/cuda/std/__algorithm/minmax_element.h
@@ -48,6 +48,7 @@ public:
   }
 };
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _Iter, class _Sent, class _Proj, class _Comp>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr pair<_Iter, _Iter>
 __minmax_element_impl(_Iter __first, _Sent __last, _Comp& __comp, _Proj& __proj)

--- a/libcudacxx/include/cuda/std/__algorithm/mismatch.h
+++ b/libcudacxx/include/cuda/std/__algorithm/mismatch.h
@@ -26,6 +26,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _InputIterator1, class _InputIterator2, class _BinaryPredicate>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr pair<_InputIterator1, _InputIterator2>
 mismatch(_InputIterator1 __first1, _InputIterator1 __last1, _InputIterator2 __first2, _BinaryPredicate __pred)
@@ -47,6 +48,7 @@ mismatch(_InputIterator1 __first1, _InputIterator1 __last1, _InputIterator2 __fi
   return _CUDA_VSTD::mismatch(__first1, __last1, __first2, __equal_to{});
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _InputIterator1, class _InputIterator2, class _BinaryPredicate>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr pair<_InputIterator1, _InputIterator2> mismatch(
   _InputIterator1 __first1,

--- a/libcudacxx/include/cuda/std/__algorithm/move.h
+++ b/libcudacxx/include/cuda/std/__algorithm/move.h
@@ -31,6 +31,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _AlgPolicy, class _InputIterator, class _OutputIterator>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr pair<_InputIterator, _OutputIterator>
 __move(_InputIterator __first, _InputIterator __last, _OutputIterator __result)
@@ -42,6 +43,7 @@ __move(_InputIterator __first, _InputIterator __last, _OutputIterator __result)
   return {__last, __result};
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _AlgPolicy,
           class _Tp,
           class _Up,

--- a/libcudacxx/include/cuda/std/__algorithm/move_backward.h
+++ b/libcudacxx/include/cuda/std/__algorithm/move_backward.h
@@ -30,6 +30,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _AlgPolicy, class _BidirectionalIterator, class _OutputIterator>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr pair<_BidirectionalIterator, _OutputIterator>
 __move_backward(_BidirectionalIterator __first, _BidirectionalIterator __last, _OutputIterator __result)
@@ -41,6 +42,7 @@ __move_backward(_BidirectionalIterator __first, _BidirectionalIterator __last, _
   return {__first, __result};
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _AlgPolicy,
           class _Tp,
           class _Up,

--- a/libcudacxx/include/cuda/std/__algorithm/next_permutation.h
+++ b/libcudacxx/include/cuda/std/__algorithm/next_permutation.h
@@ -30,6 +30,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _AlgPolicy, class _Compare, class _BidirectionalIterator, class _Sentinel>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr pair<_BidirectionalIterator, bool>
 __next_permutation(_BidirectionalIterator __first, _Sentinel __last, _Compare&& __comp)
@@ -63,6 +64,7 @@ __next_permutation(_BidirectionalIterator __first, _Sentinel __last, _Compare&& 
   }
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _BidirectionalIterator, class _Compare>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr bool
 next_permutation(_BidirectionalIterator __first, _BidirectionalIterator __last, _Compare __comp)

--- a/libcudacxx/include/cuda/std/__algorithm/none_of.h
+++ b/libcudacxx/include/cuda/std/__algorithm/none_of.h
@@ -21,6 +21,7 @@
 #endif // no system header
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _InputIterator, class _Predicate>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr bool
 none_of(_InputIterator __first, _InputIterator __last, _Predicate __pred)

--- a/libcudacxx/include/cuda/std/__algorithm/partial_sort.h
+++ b/libcudacxx/include/cuda/std/__algorithm/partial_sort.h
@@ -33,6 +33,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _AlgPolicy, class _Compare, class _RandomAccessIterator, class _Sentinel>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _RandomAccessIterator
 __partial_sort_impl(_RandomAccessIterator __first, _RandomAccessIterator __middle, _Sentinel __last, _Compare&& __comp)
@@ -59,6 +60,7 @@ __partial_sort_impl(_RandomAccessIterator __first, _RandomAccessIterator __middl
   return __i;
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _AlgPolicy, class _Compare, class _RandomAccessIterator, class _Sentinel>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _RandomAccessIterator
 __partial_sort(_RandomAccessIterator __first, _RandomAccessIterator __middle, _Sentinel __last, _Compare& __comp)
@@ -72,6 +74,7 @@ __partial_sort(_RandomAccessIterator __first, _RandomAccessIterator __middle, _S
     __first, __middle, __last, static_cast<__comp_ref_type<_Compare>>(__comp));
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _RandomAccessIterator, class _Compare>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr void partial_sort(
   _RandomAccessIterator __first, _RandomAccessIterator __middle, _RandomAccessIterator __last, _Compare __comp)

--- a/libcudacxx/include/cuda/std/__algorithm/partial_sort_copy.h
+++ b/libcudacxx/include/cuda/std/__algorithm/partial_sort_copy.h
@@ -36,6 +36,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _AlgPolicy,
           class _Compare,
           class _InputIterator,

--- a/libcudacxx/include/cuda/std/__algorithm/partition.h
+++ b/libcudacxx/include/cuda/std/__algorithm/partition.h
@@ -28,6 +28,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _Predicate, class _AlgPolicy, class _ForwardIterator, class _Sentinel>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr pair<_ForwardIterator, _ForwardIterator>
 __partition_impl(_ForwardIterator __first, _Sentinel __last, _Predicate __pred, forward_iterator_tag)
@@ -57,6 +58,7 @@ __partition_impl(_ForwardIterator __first, _Sentinel __last, _Predicate __pred, 
   return _CUDA_VSTD::make_pair(_CUDA_VSTD::move(__first), _CUDA_VSTD::move(__p));
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _Predicate, class _AlgPolicy, class _BidirectionalIterator, class _Sentinel>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr pair<_BidirectionalIterator, _BidirectionalIterator>
 __partition_impl(_BidirectionalIterator __first, _Sentinel __sentinel, _Predicate __pred, bidirectional_iterator_tag)
@@ -90,6 +92,7 @@ __partition_impl(_BidirectionalIterator __first, _Sentinel __sentinel, _Predicat
   }
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _AlgPolicy, class _ForwardIterator, class _Sentinel, class _Predicate, class _IterCategory>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr pair<_ForwardIterator, _ForwardIterator>
 __partition(_ForwardIterator __first, _Sentinel __last, _Predicate&& __pred, _IterCategory __iter_category)
@@ -98,6 +101,7 @@ __partition(_ForwardIterator __first, _Sentinel __last, _Predicate&& __pred, _It
     _CUDA_VSTD::move(__first), _CUDA_VSTD::move(__last), __pred, __iter_category);
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _ForwardIterator, class _Predicate>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _ForwardIterator
 partition(_ForwardIterator __first, _ForwardIterator __last, _Predicate __pred)

--- a/libcudacxx/include/cuda/std/__algorithm/partition_copy.h
+++ b/libcudacxx/include/cuda/std/__algorithm/partition_copy.h
@@ -25,6 +25,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _InputIterator, class _OutputIterator1, class _OutputIterator2, class _Predicate>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr pair<_OutputIterator1, _OutputIterator2> partition_copy(
   _InputIterator __first,

--- a/libcudacxx/include/cuda/std/__algorithm/partition_point.h
+++ b/libcudacxx/include/cuda/std/__algorithm/partition_point.h
@@ -27,6 +27,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _ForwardIterator, class _Predicate>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _ForwardIterator
 partition_point(_ForwardIterator __first, _ForwardIterator __last, _Predicate __pred)

--- a/libcudacxx/include/cuda/std/__algorithm/pop_heap.h
+++ b/libcudacxx/include/cuda/std/__algorithm/pop_heap.h
@@ -32,6 +32,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _AlgPolicy, class _Compare, class _RandomAccessIterator>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr void __pop_heap(
   _RandomAccessIterator __first,
@@ -65,6 +66,7 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr void __pop_heap(
   }
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _RandomAccessIterator, class _Compare>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr void
 pop_heap(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp)
@@ -77,6 +79,7 @@ pop_heap(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare _
   _CUDA_VSTD::__pop_heap<_ClassicAlgPolicy>(_CUDA_VSTD::move(__first), _CUDA_VSTD::move(__last), __comp, __len);
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _RandomAccessIterator>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr void pop_heap(_RandomAccessIterator __first, _RandomAccessIterator __last)
 {

--- a/libcudacxx/include/cuda/std/__algorithm/prev_permutation.h
+++ b/libcudacxx/include/cuda/std/__algorithm/prev_permutation.h
@@ -30,6 +30,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _AlgPolicy, class _Compare, class _BidirectionalIterator, class _Sentinel>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr pair<_BidirectionalIterator, bool>
 __prev_permutation(_BidirectionalIterator __first, _Sentinel __last, _Compare&& __comp)
@@ -63,6 +64,7 @@ __prev_permutation(_BidirectionalIterator __first, _Sentinel __last, _Compare&& 
   }
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _BidirectionalIterator, class _Compare>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr bool
 prev_permutation(_BidirectionalIterator __first, _BidirectionalIterator __last, _Compare __comp)

--- a/libcudacxx/include/cuda/std/__algorithm/push_heap.h
+++ b/libcudacxx/include/cuda/std/__algorithm/push_heap.h
@@ -30,6 +30,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _AlgPolicy, class _Compare, class _RandomAccessIterator>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr void
 __sift_up(_RandomAccessIterator __first,
@@ -64,6 +65,7 @@ __sift_up(_RandomAccessIterator __first,
   }
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _AlgPolicy, class _RandomAccessIterator, class _Compare>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr void
 __push_heap(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare& __comp)
@@ -73,6 +75,7 @@ __push_heap(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compar
     _CUDA_VSTD::move(__first), _CUDA_VSTD::move(__last), __comp, __len);
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _RandomAccessIterator, class _Compare>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr void
 push_heap(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp)
@@ -84,6 +87,7 @@ push_heap(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare 
   _CUDA_VSTD::__push_heap<_ClassicAlgPolicy>(_CUDA_VSTD::move(__first), _CUDA_VSTD::move(__last), __comp);
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _RandomAccessIterator>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr void push_heap(_RandomAccessIterator __first, _RandomAccessIterator __last)
 {

--- a/libcudacxx/include/cuda/std/__algorithm/remove.h
+++ b/libcudacxx/include/cuda/std/__algorithm/remove.h
@@ -25,6 +25,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _ForwardIterator, class _Tp>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _ForwardIterator
 remove(_ForwardIterator __first, _ForwardIterator __last, const _Tp& __value_)

--- a/libcudacxx/include/cuda/std/__algorithm/remove_copy.h
+++ b/libcudacxx/include/cuda/std/__algorithm/remove_copy.h
@@ -22,6 +22,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _InputIterator, class _OutputIterator, class _Tp>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _OutputIterator
 remove_copy(_InputIterator __first, _InputIterator __last, _OutputIterator __result, const _Tp& __value_)

--- a/libcudacxx/include/cuda/std/__algorithm/remove_copy_if.h
+++ b/libcudacxx/include/cuda/std/__algorithm/remove_copy_if.h
@@ -22,6 +22,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _InputIterator, class _OutputIterator, class _Predicate>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _OutputIterator
 remove_copy_if(_InputIterator __first, _InputIterator __last, _OutputIterator __result, _Predicate __pred)

--- a/libcudacxx/include/cuda/std/__algorithm/remove_if.h
+++ b/libcudacxx/include/cuda/std/__algorithm/remove_if.h
@@ -26,6 +26,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _ForwardIterator, class _Predicate>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _ForwardIterator
 remove_if(_ForwardIterator __first, _ForwardIterator __last, _Predicate __pred)

--- a/libcudacxx/include/cuda/std/__algorithm/replace.h
+++ b/libcudacxx/include/cuda/std/__algorithm/replace.h
@@ -22,6 +22,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _ForwardIterator, class _Tp>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr void
 replace(_ForwardIterator __first, _ForwardIterator __last, const _Tp& __old_value, const _Tp& __new_value)

--- a/libcudacxx/include/cuda/std/__algorithm/replace_copy.h
+++ b/libcudacxx/include/cuda/std/__algorithm/replace_copy.h
@@ -22,6 +22,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _InputIterator, class _OutputIterator, class _Tp>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _OutputIterator replace_copy(
   _InputIterator __first,

--- a/libcudacxx/include/cuda/std/__algorithm/replace_copy_if.h
+++ b/libcudacxx/include/cuda/std/__algorithm/replace_copy_if.h
@@ -22,6 +22,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _InputIterator, class _OutputIterator, class _Predicate, class _Tp>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _OutputIterator replace_copy_if(
   _InputIterator __first, _InputIterator __last, _OutputIterator __result, _Predicate __pred, const _Tp& __new_value)

--- a/libcudacxx/include/cuda/std/__algorithm/replace_if.h
+++ b/libcudacxx/include/cuda/std/__algorithm/replace_if.h
@@ -22,6 +22,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _ForwardIterator, class _Predicate, class _Tp>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr void
 replace_if(_ForwardIterator __first, _ForwardIterator __last, _Predicate __pred, const _Tp& __new_value)

--- a/libcudacxx/include/cuda/std/__algorithm/reverse.h
+++ b/libcudacxx/include/cuda/std/__algorithm/reverse.h
@@ -27,6 +27,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _AlgPolicy, class _BidirectionalIterator>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr void
 __reverse_impl(_BidirectionalIterator __first, _BidirectionalIterator __last, bidirectional_iterator_tag)
@@ -42,6 +43,7 @@ __reverse_impl(_BidirectionalIterator __first, _BidirectionalIterator __last, bi
   }
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _AlgPolicy, class _RandomAccessIterator>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr void
 __reverse_impl(_RandomAccessIterator __first, _RandomAccessIterator __last, random_access_iterator_tag)
@@ -55,6 +57,7 @@ __reverse_impl(_RandomAccessIterator __first, _RandomAccessIterator __last, rand
   }
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _AlgPolicy, class _BidirectionalIterator, class _Sentinel>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr void __reverse(_BidirectionalIterator __first, _Sentinel __last)
 {
@@ -62,6 +65,7 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr void __reverse(_BidirectionalIterator __firs
   _CUDA_VSTD::__reverse_impl<_AlgPolicy>(_CUDA_VSTD::move(__first), _CUDA_VSTD::move(__last), _IterCategory());
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _BidirectionalIterator>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr void reverse(_BidirectionalIterator __first, _BidirectionalIterator __last)
 {

--- a/libcudacxx/include/cuda/std/__algorithm/reverse_copy.h
+++ b/libcudacxx/include/cuda/std/__algorithm/reverse_copy.h
@@ -22,6 +22,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _BidirectionalIterator, class _OutputIterator>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _OutputIterator
 reverse_copy(_BidirectionalIterator __first, _BidirectionalIterator __last, _OutputIterator __result)

--- a/libcudacxx/include/cuda/std/__algorithm/rotate.h
+++ b/libcudacxx/include/cuda/std/__algorithm/rotate.h
@@ -31,6 +31,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _AlgPolicy, class _ForwardIterator>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _ForwardIterator __rotate_left(_ForwardIterator __first, _ForwardIterator __last)
 {
@@ -43,6 +44,7 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr _ForwardIterator __rotate_left(_ForwardItera
   return __lm1;
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _AlgPolicy, class _BidirectionalIterator>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _BidirectionalIterator
 __rotate_right(_BidirectionalIterator __first, _BidirectionalIterator __last)
@@ -58,6 +60,7 @@ __rotate_right(_BidirectionalIterator __first, _BidirectionalIterator __last)
   return __fp1;
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _AlgPolicy, class _ForwardIterator>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _ForwardIterator
 __rotate_forward(_ForwardIterator __first, _ForwardIterator __middle, _ForwardIterator __last)
@@ -101,6 +104,7 @@ __rotate_forward(_ForwardIterator __first, _ForwardIterator __middle, _ForwardIt
   return __r;
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <typename _Integral>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _Integral __algo_gcd(_Integral __x, _Integral __y)
 {
@@ -113,6 +117,7 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr _Integral __algo_gcd(_Integral __x, _Integra
   return __x;
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _AlgPolicy, typename _RandomAccessIterator>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _RandomAccessIterator
 __rotate_gcd(_RandomAccessIterator __first, _RandomAccessIterator __middle, _RandomAccessIterator __last)
@@ -153,6 +158,7 @@ __rotate_gcd(_RandomAccessIterator __first, _RandomAccessIterator __middle, _Ran
   return __first + __m2;
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _AlgPolicy, class _ForwardIterator>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _ForwardIterator __rotate_impl(
   _ForwardIterator __first, _ForwardIterator __middle, _ForwardIterator __last, _CUDA_VSTD::forward_iterator_tag)
@@ -168,6 +174,7 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr _ForwardIterator __rotate_impl(
   return _CUDA_VSTD::__rotate_forward<_AlgPolicy>(__first, __middle, __last);
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _AlgPolicy, class _BidirectionalIterator>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _BidirectionalIterator __rotate_impl(
   _BidirectionalIterator __first,
@@ -190,6 +197,7 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr _BidirectionalIterator __rotate_impl(
   return _CUDA_VSTD::__rotate_forward<_AlgPolicy>(__first, __middle, __last);
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _AlgPolicy, class _RandomAccessIterator>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _RandomAccessIterator __rotate_impl(
   _RandomAccessIterator __first,
@@ -213,6 +221,7 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr _RandomAccessIterator __rotate_impl(
   return _CUDA_VSTD::__rotate_forward<_AlgPolicy>(__first, __middle, __last);
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _AlgPolicy, class _Iterator, class _Sentinel>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr pair<_Iterator, _Iterator>
 __rotate(_Iterator __first, _Iterator __middle, _Sentinel __last)
@@ -236,6 +245,7 @@ __rotate(_Iterator __first, _Iterator __middle, _Sentinel __last)
   return _Ret(_CUDA_VSTD::move(__result), _CUDA_VSTD::move(__last_iter));
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _ForwardIterator>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _ForwardIterator
 rotate(_ForwardIterator __first, _ForwardIterator __middle, _ForwardIterator __last)

--- a/libcudacxx/include/cuda/std/__algorithm/search.h
+++ b/libcudacxx/include/cuda/std/__algorithm/search.h
@@ -32,6 +32,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _BinaryPredicate, class _ForwardIterator1, class _ForwardIterator2>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr pair<_ForwardIterator1, _ForwardIterator1> __search(
   _ForwardIterator1 __first1,
@@ -83,6 +84,7 @@ template <class _BinaryPredicate, class _ForwardIterator1, class _ForwardIterato
   }
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _BinaryPredicate, class _RandomAccessIterator1, class _RandomAccessIterator2>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr pair<_RandomAccessIterator1, _RandomAccessIterator1> __search(
   _RandomAccessIterator1 __first1,

--- a/libcudacxx/include/cuda/std/__algorithm/search_n.h
+++ b/libcudacxx/include/cuda/std/__algorithm/search_n.h
@@ -27,6 +27,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _BinaryPredicate, class _ForwardIterator, class _Size, class _Tp>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _ForwardIterator __search_n(
   _ForwardIterator __first,
@@ -78,6 +79,7 @@ template <class _BinaryPredicate, class _ForwardIterator, class _Size, class _Tp
   }
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _BinaryPredicate, class _RandomAccessIterator, class _Size, class _Tp>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _RandomAccessIterator __search_n(
   _RandomAccessIterator __first,

--- a/libcudacxx/include/cuda/std/__algorithm/set_difference.h
+++ b/libcudacxx/include/cuda/std/__algorithm/set_difference.h
@@ -33,6 +33,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _AlgPolicy, class _Comp, class _InIter1, class _Sent1, class _InIter2, class _Sent2, class _OutIter>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr pair<remove_cvref_t<_InIter1>, remove_cvref_t<_OutIter>> __set_difference(
   _InIter1&& __first1, _Sent1&& __last1, _InIter2&& __first2, _Sent2&& __last2, _OutIter&& __result, _Comp&& __comp)

--- a/libcudacxx/include/cuda/std/__algorithm/set_intersection.h
+++ b/libcudacxx/include/cuda/std/__algorithm/set_intersection.h
@@ -29,6 +29,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _InIter1, class _InIter2, class _OutIter>
 struct __set_intersection_result
 {
@@ -45,6 +46,7 @@ struct __set_intersection_result
   {}
 };
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _AlgPolicy, class _Compare, class _InIter1, class _Sent1, class _InIter2, class _Sent2, class _OutIter>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr __set_intersection_result<_InIter1, _InIter2, _OutIter> __set_intersection(
   _InIter1 __first1, _Sent1 __last1, _InIter2 __first2, _Sent2 __last2, _OutIter __result, _Compare&& __comp)
@@ -73,6 +75,7 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr __set_intersection_result<_InIter1, _InIter2
     _CUDA_VSTD::move(__result));
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _InputIterator1, class _InputIterator2, class _OutputIterator, class _Compare>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _OutputIterator set_intersection(
   _InputIterator1 __first1,
@@ -92,6 +95,7 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr _OutputIterator set_intersection(
     .__out_;
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _InputIterator1, class _InputIterator2, class _OutputIterator>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _OutputIterator set_intersection(
   _InputIterator1 __first1,

--- a/libcudacxx/include/cuda/std/__algorithm/set_symmetric_difference.h
+++ b/libcudacxx/include/cuda/std/__algorithm/set_symmetric_difference.h
@@ -30,6 +30,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _InIter1, class _InIter2, class _OutIter>
 struct __set_symmetric_difference_result
 {
@@ -46,6 +47,7 @@ struct __set_symmetric_difference_result
   {}
 };
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _AlgPolicy, class _Compare, class _InIter1, class _Sent1, class _InIter2, class _Sent2, class _OutIter>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr __set_symmetric_difference_result<_InIter1, _InIter2, _OutIter>
 __set_symmetric_difference(
@@ -86,6 +88,7 @@ __set_symmetric_difference(
     _CUDA_VSTD::move(__first1), _CUDA_VSTD::move(__ret2.first), _CUDA_VSTD::move((__ret2.second)));
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _InputIterator1, class _InputIterator2, class _OutputIterator, class _Compare>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _OutputIterator set_symmetric_difference(
   _InputIterator1 __first1,
@@ -105,6 +108,7 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr _OutputIterator set_symmetric_difference(
     .__out_;
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _InputIterator1, class _InputIterator2, class _OutputIterator>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _OutputIterator set_symmetric_difference(
   _InputIterator1 __first1,

--- a/libcudacxx/include/cuda/std/__algorithm/set_union.h
+++ b/libcudacxx/include/cuda/std/__algorithm/set_union.h
@@ -30,6 +30,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _InIter1, class _InIter2, class _OutIter>
 struct __set_union_result
 {
@@ -46,6 +47,7 @@ struct __set_union_result
   {}
 };
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _AlgPolicy, class _Compare, class _InIter1, class _Sent1, class _InIter2, class _Sent2, class _OutIter>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr __set_union_result<_InIter1, _InIter2, _OutIter>
 __set_union(_InIter1 __first1, _Sent1 __last1, _InIter2 __first2, _Sent2 __last2, _OutIter __result, _Compare&& __comp)
@@ -80,6 +82,7 @@ __set_union(_InIter1 __first1, _Sent1 __last1, _InIter2 __first2, _Sent2 __last2
     _CUDA_VSTD::move(__first1), _CUDA_VSTD::move(__ret2.first), _CUDA_VSTD::move((__ret2.second)));
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _InputIterator1, class _InputIterator2, class _OutputIterator, class _Compare>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _OutputIterator set_union(
   _InputIterator1 __first1,
@@ -99,6 +102,7 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr _OutputIterator set_union(
     .__out_;
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _InputIterator1, class _InputIterator2, class _OutputIterator>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _OutputIterator set_union(
   _InputIterator1 __first1,

--- a/libcudacxx/include/cuda/std/__algorithm/shift_left.h
+++ b/libcudacxx/include/cuda/std/__algorithm/shift_left.h
@@ -25,6 +25,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _ForwardIterator>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _ForwardIterator __shift_left(
   _ForwardIterator __first,
@@ -41,6 +42,7 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr _ForwardIterator __shift_left(
   return _CUDA_VSTD::move(__m, __last, __first);
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _ForwardIterator>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _ForwardIterator __shift_left(
   _ForwardIterator __first,

--- a/libcudacxx/include/cuda/std/__algorithm/shift_right.h
+++ b/libcudacxx/include/cuda/std/__algorithm/shift_right.h
@@ -28,6 +28,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _ForwardIterator>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _ForwardIterator __shift_right(
   _ForwardIterator __first,
@@ -44,6 +45,7 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr _ForwardIterator __shift_right(
   return _CUDA_VSTD::move_backward(__first, __m, __last);
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _ForwardIterator>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _ForwardIterator __shift_right(
   _ForwardIterator __first,
@@ -63,6 +65,7 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr _ForwardIterator __shift_right(
   return _CUDA_VSTD::move_backward(__first, __m, __last);
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _ForwardIterator>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _ForwardIterator __shift_right(
   _ForwardIterator __first,

--- a/libcudacxx/include/cuda/std/__algorithm/sift_down.h
+++ b/libcudacxx/include/cuda/std/__algorithm/sift_down.h
@@ -26,6 +26,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _AlgPolicy, class _Compare, class _RandomAccessIterator>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr void __sift_down(
   _RandomAccessIterator __first,
@@ -91,6 +92,7 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr void __sift_down(
   *__start = _CUDA_VSTD::move(__top);
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _AlgPolicy, class _Compare, class _RandomAccessIterator>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _RandomAccessIterator __floyd_sift_down(
   _RandomAccessIterator __first,

--- a/libcudacxx/include/cuda/std/__algorithm/sort_heap.h
+++ b/libcudacxx/include/cuda/std/__algorithm/sort_heap.h
@@ -31,6 +31,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _AlgPolicy, class _Compare, class _RandomAccessIterator>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr void
 __sort_heap(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare&& __comp)
@@ -44,6 +45,7 @@ __sort_heap(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compar
   }
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _RandomAccessIterator, class _Compare>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr void
 sort_heap(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp)
@@ -54,6 +56,7 @@ sort_heap(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare 
   _CUDA_VSTD::__sort_heap<_ClassicAlgPolicy>(_CUDA_VSTD::move(__first), _CUDA_VSTD::move(__last), __comp);
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _RandomAccessIterator>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr void sort_heap(_RandomAccessIterator __first, _RandomAccessIterator __last)
 {

--- a/libcudacxx/include/cuda/std/__algorithm/swap_ranges.h
+++ b/libcudacxx/include/cuda/std/__algorithm/swap_ranges.h
@@ -28,6 +28,7 @@
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 // 2+2 iterators: the shorter size will be used.
+_CCCL_EXEC_CHECK_DISABLE
 template <class _AlgPolicy, class _ForwardIterator1, class _Sentinel1, class _ForwardIterator2, class _Sentinel2>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr pair<_ForwardIterator1, _ForwardIterator2>
 __swap_ranges(_ForwardIterator1 __first1, _Sentinel1 __last1, _ForwardIterator2 __first2, _Sentinel2 __last2)
@@ -43,6 +44,7 @@ __swap_ranges(_ForwardIterator1 __first1, _Sentinel1 __last1, _ForwardIterator2 
 }
 
 // 2+1 iterators: size2 >= size1.
+_CCCL_EXEC_CHECK_DISABLE
 template <class _AlgPolicy, class _ForwardIterator1, class _Sentinel1, class _ForwardIterator2>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr pair<_ForwardIterator1, _ForwardIterator2>
 __swap_ranges(_ForwardIterator1 __first1, _Sentinel1 __last1, _ForwardIterator2 __first2)
@@ -57,6 +59,7 @@ __swap_ranges(_ForwardIterator1 __first1, _Sentinel1 __last1, _ForwardIterator2 
   return pair<_ForwardIterator1, _ForwardIterator2>(_CUDA_VSTD::move(__first1), _CUDA_VSTD::move(__first2));
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _ForwardIterator1, class _ForwardIterator2>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _ForwardIterator2
 swap_ranges(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2)

--- a/libcudacxx/include/cuda/std/__algorithm/transform.h
+++ b/libcudacxx/include/cuda/std/__algorithm/transform.h
@@ -22,6 +22,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _InputIterator, class _OutputIterator, class _UnaryOperation>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _OutputIterator
 transform(_InputIterator __first, _InputIterator __last, _OutputIterator __result, _UnaryOperation __op)
@@ -33,6 +34,7 @@ transform(_InputIterator __first, _InputIterator __last, _OutputIterator __resul
   return __result;
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _InputIterator1, class _InputIterator2, class _OutputIterator, class _BinaryOperation>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _OutputIterator transform(
   _InputIterator1 __first1,

--- a/libcudacxx/include/cuda/std/__algorithm/unique.h
+++ b/libcudacxx/include/cuda/std/__algorithm/unique.h
@@ -29,6 +29,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _AlgPolicy, class _Iter, class _Sent, class _BinaryPredicate>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _CUDA_VSTD::pair<_Iter, _Iter>
 __unique(_Iter __first, _Sent __last, _BinaryPredicate&& __pred)
@@ -52,6 +53,7 @@ __unique(_Iter __first, _Sent __last, _BinaryPredicate&& __pred)
   return _CUDA_VSTD::pair<_Iter, _Iter>(__first, __first);
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _ForwardIterator, class _BinaryPredicate>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _ForwardIterator
 unique(_ForwardIterator __first, _ForwardIterator __last, _BinaryPredicate __pred)

--- a/libcudacxx/include/cuda/std/__algorithm/unique_copy.h
+++ b/libcudacxx/include/cuda/std/__algorithm/unique_copy.h
@@ -43,6 +43,7 @@ struct __read_from_tmp_value_tag
 
 } // namespace __unique_copy_tags
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _AlgPolicy, class _BinaryPredicate, class _InputIterator, class _Sent, class _OutputIterator>
 constexpr _LIBCUDACXX_HIDE_FROM_ABI pair<_InputIterator, _OutputIterator> __unique_copy(
   _InputIterator __first,
@@ -69,6 +70,7 @@ constexpr _LIBCUDACXX_HIDE_FROM_ABI pair<_InputIterator, _OutputIterator> __uniq
   return pair<_InputIterator, _OutputIterator>(_CUDA_VSTD::move(__first), _CUDA_VSTD::move(__result));
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _AlgPolicy, class _BinaryPredicate, class _ForwardIterator, class _Sent, class _OutputIterator>
 constexpr _LIBCUDACXX_HIDE_FROM_ABI pair<_ForwardIterator, _OutputIterator> __unique_copy(
   _ForwardIterator __first,
@@ -95,6 +97,7 @@ constexpr _LIBCUDACXX_HIDE_FROM_ABI pair<_ForwardIterator, _OutputIterator> __un
   return pair<_ForwardIterator, _OutputIterator>(_CUDA_VSTD::move(__first), _CUDA_VSTD::move(__result));
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _AlgPolicy, class _BinaryPredicate, class _InputIterator, class _Sent, class _InputAndOutputIterator>
 constexpr _LIBCUDACXX_HIDE_FROM_ABI pair<_InputIterator, _InputAndOutputIterator> __unique_copy(
   _InputIterator __first,
@@ -118,6 +121,7 @@ constexpr _LIBCUDACXX_HIDE_FROM_ABI pair<_InputIterator, _InputAndOutputIterator
   return pair<_InputIterator, _InputAndOutputIterator>(_CUDA_VSTD::move(__first), _CUDA_VSTD::move(__result));
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _InputIterator, class _OutputIterator, class _BinaryPredicate>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _OutputIterator
 unique_copy(_InputIterator __first, _InputIterator __last, _OutputIterator __result, _BinaryPredicate __pred)
@@ -134,6 +138,7 @@ unique_copy(_InputIterator __first, _InputIterator __last, _OutputIterator __res
     .second;
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _InputIterator, class _OutputIterator>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _OutputIterator
 unique_copy(_InputIterator __first, _InputIterator __last, _OutputIterator __result)

--- a/libcudacxx/include/cuda/std/__algorithm/unwrap_iter.h
+++ b/libcudacxx/include/cuda/std/__algorithm/unwrap_iter.h
@@ -42,10 +42,12 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 template <class _Iter, bool = __is_cpp17_contiguous_iterator<_Iter>::value>
 struct __unwrap_iter_impl
 {
+  _CCCL_EXEC_CHECK_DISABLE
   static _LIBCUDACXX_HIDE_FROM_ABI constexpr _Iter __rewrap(_Iter, _Iter __iter)
   {
     return __iter;
   }
+  _CCCL_EXEC_CHECK_DISABLE
   static _LIBCUDACXX_HIDE_FROM_ABI constexpr _Iter __unwrap(_Iter __i) noexcept
   {
     return __i;
@@ -58,11 +60,13 @@ struct __unwrap_iter_impl<_Iter, true>
 {
   using _ToAddressT = decltype(_CUDA_VSTD::__to_address(_CUDA_VSTD::declval<_Iter>()));
 
+  _CCCL_EXEC_CHECK_DISABLE
   static _LIBCUDACXX_HIDE_FROM_ABI constexpr _Iter __rewrap(_Iter __orig_iter, _ToAddressT __unwrapped_iter)
   {
     return __orig_iter + (__unwrapped_iter - _CUDA_VSTD::__to_address(__orig_iter));
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   static _LIBCUDACXX_HIDE_FROM_ABI constexpr _ToAddressT __unwrap(_Iter __i) noexcept
   {
     return _CUDA_VSTD::__to_address(__i);
@@ -76,6 +80,7 @@ __unwrap_iter(_Iter __i) noexcept
   return _Impl::__unwrap(__i);
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _OrigIter, class _Iter, class _Impl = __unwrap_iter_impl<_OrigIter>>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _OrigIter __rewrap_iter(_OrigIter __orig_iter, _Iter __iter) noexcept
 {

--- a/libcudacxx/include/cuda/std/__algorithm/unwrap_range.h
+++ b/libcudacxx/include/cuda/std/__algorithm/unwrap_range.h
@@ -39,6 +39,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 template <class _Iter, class _Sent>
 struct __unwrap_range_impl
 {
+  _CCCL_EXEC_CHECK_DISABLE
   _LIBCUDACXX_HIDE_FROM_ABI static constexpr auto __unwrap(_Iter __first, _Sent __sent)
     requires random_access_iterator<_Iter> && sized_sentinel_for<_Sent, _Iter>
   {
@@ -47,11 +48,13 @@ struct __unwrap_range_impl
                 _CUDA_VSTD::__unwrap_iter(_CUDA_VSTD::move(__last))};
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   _LIBCUDACXX_HIDE_FROM_ABI static constexpr auto __unwrap(_Iter __first, _Sent __last)
   {
     return pair{_CUDA_VSTD::move(__first), _CUDA_VSTD::move(__last)};
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   _LIBCUDACXX_HIDE_FROM_ABI static constexpr auto
   __rewrap(_Iter __orig_iter, decltype(_CUDA_VSTD::__unwrap_iter(_CUDA_VSTD::move(__orig_iter))) __iter)
     requires random_access_iterator<_Iter> && sized_sentinel_for<_Sent, _Iter>
@@ -59,6 +62,7 @@ struct __unwrap_range_impl
     return _CUDA_VSTD::__rewrap_iter(_CUDA_VSTD::move(__orig_iter), _CUDA_VSTD::move(__iter));
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   _LIBCUDACXX_HIDE_FROM_ABI static constexpr auto __rewrap(const _Iter&, _Iter __iter)
     requires(!(random_access_iterator<_Iter> && sized_sentinel_for<_Sent, _Iter>) )
   {
@@ -69,12 +73,14 @@ struct __unwrap_range_impl
 template <class _Iter>
 struct __unwrap_range_impl<_Iter, _Iter>
 {
+  _CCCL_EXEC_CHECK_DISABLE
   _LIBCUDACXX_HIDE_FROM_ABI static constexpr auto __unwrap(_Iter __first, _Iter __last)
   {
     return pair{_CUDA_VSTD::__unwrap_iter(_CUDA_VSTD::move(__first)),
                 _CUDA_VSTD::__unwrap_iter(_CUDA_VSTD::move(__last))};
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   _LIBCUDACXX_HIDE_FROM_ABI static constexpr auto
   __rewrap(_Iter __orig_iter, decltype(_CUDA_VSTD::__unwrap_iter(__orig_iter)) __iter)
   {
@@ -82,18 +88,21 @@ struct __unwrap_range_impl<_Iter, _Iter>
   }
 };
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _Iter, class _Sent>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr auto __unwrap_range(_Iter __first, _Sent __last)
 {
   return __unwrap_range_impl<_Iter, _Sent>::__unwrap(_CUDA_VSTD::move(__first), _CUDA_VSTD::move(__last));
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _Sent, class _Iter, class _Unwrapped>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _Iter __rewrap_range(_Iter __orig_iter, _Unwrapped __iter)
 {
   return __unwrap_range_impl<_Iter, _Sent>::__rewrap(_CUDA_VSTD::move(__orig_iter), _CUDA_VSTD::move(__iter));
 }
 #else // ^^^ C++20 ^^^ / vvv C++17 vvv
+_CCCL_EXEC_CHECK_DISABLE
 template <class _Iter, class _Unwrapped = decltype(_CUDA_VSTD::__unwrap_iter(_CUDA_VSTD::declval<_Iter>()))>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr pair<_Unwrapped, _Unwrapped> __unwrap_range(_Iter __first, _Iter __last)
 {
@@ -101,6 +110,7 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr pair<_Unwrapped, _Unwrapped> __unwrap_range(
     _CUDA_VSTD::__unwrap_iter(_CUDA_VSTD::move(__first)), _CUDA_VSTD::__unwrap_iter(_CUDA_VSTD::move(__last)));
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _Iter, class _Unwrapped>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _Iter __rewrap_range(_Iter __orig_iter, _Unwrapped __iter)
 {

--- a/libcudacxx/include/cuda/std/__algorithm/upper_bound.h
+++ b/libcudacxx/include/cuda/std/__algorithm/upper_bound.h
@@ -33,6 +33,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _AlgPolicy, class _Compare, class _Iter, class _Sent, class _Tp, class _Proj>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _Iter
 __upper_bound(_Iter __first, _Sent __last, const _Tp& __value, _Compare&& __comp, _Proj&& __proj)
@@ -55,6 +56,7 @@ __upper_bound(_Iter __first, _Sent __last, const _Tp& __value, _Compare&& __comp
   return __first;
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _ForwardIterator, class _Tp, class _Compare>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _ForwardIterator
 upper_bound(_ForwardIterator __first, _ForwardIterator __last, const _Tp& __value, _Compare __comp)
@@ -64,6 +66,7 @@ upper_bound(_ForwardIterator __first, _ForwardIterator __last, const _Tp& __valu
     _CUDA_VSTD::move(__first), _CUDA_VSTD::move(__last), __value, _CUDA_VSTD::move(__comp), _CUDA_VSTD::__identity());
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _ForwardIterator, class _Tp>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _ForwardIterator
 upper_bound(_ForwardIterator __first, _ForwardIterator __last, const _Tp& __value)


### PR DESCRIPTION
We cannot control the predicate used nor the iterator. For example rapids uses device only predicates a lot
