### PR TITLE
Make per-PR RAPIDS builds opt-in

### DIFF
--- a/.github/workflows/ci-workflow-pull-request.yml
+++ b/.github/workflows/ci-workflow-pull-request.yml
@@ -192,7 +192,7 @@ jobs:
 
   build-rapids:
     name: Build RAPIDS (optional)
-    if: ${{ !contains(github.event.head_commit.message, '[skip-rapids]') }}
+    if: ${{ contains(github.event.head_commit.message, '[test-rapids]') }}
     secrets: inherit
     permissions:
       actions: read


### PR DESCRIPTION
Turning these off while we discuss ways to improve stability.
Nightly testing will continue and is now monitored by both RAPIDS and CCCL teams.

RAPIDS jobs may be re-enabled per-PR by including `[test-rapids]` in the most recent commit of a PR's branch.