### PR TITLE
`cuda::bitmask` should have a default type

### DIFF
--- a/docs/libcudacxx/extended_api/bit/bitmask.rst
+++ b/docs/libcudacxx/extended_api/bit/bitmask.rst
@@ -5,7 +5,7 @@
 
 .. code:: cpp
 
-   template <typename T>
+   template <typename T = uint32_t>
    [[nodiscard]] constexpr T
    bitmask(int start, int width) noexcept;
 
@@ -55,7 +55,7 @@ Example
     #include <cuda/std/cstdint>
 
     __global__ void bitmask_kernel() {
-        assert(cuda::bitmask<uint32_t>(2, 4) == 0b111100u);
+        assert(cuda::bitmask(2, 4) == 0b111100u);
         assert(cuda::bitmask<uint64_t>(1, 3) == uint64_t{0b1110});
     }
 

--- a/libcudacxx/include/cuda/__bit/bitmask.h
+++ b/libcudacxx/include/cuda/__bit/bitmask.h
@@ -61,7 +61,7 @@ template <typename _Tp>
   return (__shift >= _CUDA_VSTD::numeric_limits<_Tp>::digits) ? _Tp{0} : __value >> __shift;
 }
 
-template <typename _Tp>
+template <typename _Tp = uint32_t>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp bitmask(int __start, int __width) noexcept
 {
   static_assert(_CUDA_VSTD::__cccl_is_unsigned_integer_v<_Tp>, "bitmask() requires unsigned integer types");


### PR DESCRIPTION
## Description

Very small PR to add a default type to `cuda::bitmask`