### PR TITLE
Fix cudax regression on main

### DIFF
--- a/ci/inspect_changes.sh
+++ b/ci/inspect_changes.sh
@@ -33,13 +33,13 @@ subprojects=(
 )
 
 # ...and their dependencies.
-# Mapped as: key project is rebuild if any value project is dirty.
+# Mapped as: key project is rebuilt if any value project is dirty.
 declare -A dependencies=(
   [cccl]=""
   [libcudacxx]="cccl"
   [cub]="cccl libcudacxx thrust c2h"
   [thrust]="cccl libcudacxx cub"
-  [cudax]="cccl libcudacxx c2h"
+  [cudax]="cccl libcudacxx thrust cub c2h"
   [stdpar]="cccl libcudacxx cub thrust"
   [python]="cccl libcudacxx cub thrust cccl_c_parallel"
   [cccl_c_parallel]="cccl libcudacxx cub thrust c2h"

--- a/cudax/examples/async_buffer_add.cu
+++ b/cudax/examples/async_buffer_add.cu
@@ -51,7 +51,7 @@ int main()
   cudax::stream stream{};
 
   // The execution policy we want to use to run all work on the same stream
-  auto policy = thrust::cuda::par_nosync.on(stream);
+  auto policy = thrust::cuda::par_nosync.on(stream.get());
 
   // An environment we use to pass all necessary information to the containers
   cudax::env_t<cuda::mr::device_accessible> env{cudax::device_memory_resource{}, stream};

--- a/cudax/include/cuda/experimental/__container/async_buffer.cuh
+++ b/cudax/include/cuda/experimental/__container/async_buffer.cuh
@@ -240,7 +240,7 @@ private:
     else
     {
       ::cuda::experimental::__ensure_current_device __guard(__buf_.get_stream());
-      thrust::fill_n(thrust::cuda::par_nosync.on(__buf_.get_stream()), __first, __count, _Tp());
+      thrust::fill_n(thrust::cuda::par_nosync.on(__buf_.get_stream().get()), __first, __count, _Tp());
     }
   }
 
@@ -262,7 +262,7 @@ private:
     else
     {
       ::cuda::experimental::__ensure_current_device __guard(__buf_.get_stream());
-      thrust::fill_n(thrust::cuda::par_nosync.on(__buf_.get_stream()), __first, __count, __value);
+      thrust::fill_n(thrust::cuda::par_nosync.on(__buf_.get_stream().get()), __first, __count, __value);
     }
   }
 
@@ -764,7 +764,7 @@ public:
     {
       ::cuda::experimental::__ensure_current_device __guard(__lhs.get_stream().get());
       return (__lhs.size() == __rhs.size())
-          && thrust::equal(thrust::cuda::par_nosync.on(__lhs.get_stream()),
+          && thrust::equal(thrust::cuda::par_nosync.on(__lhs.get_stream().get()),
                            __lhs.__unwrapped_begin(),
                            __lhs.__unwrapped_end(),
                            __rhs.__unwrapped_begin());

--- a/cudax/test/containers/async_buffer/helper.h
+++ b/cudax/test/containers/async_buffer/helper.h
@@ -40,8 +40,10 @@ constexpr bool equal_range(const Buffer& buf)
   else
   {
     return buf.size() == cuda::std::size(device_data)
-        && thrust::equal(
-             thrust::cuda::par.on(buf.get_stream()), buf.begin(), buf.end(), cuda::get_device_address(device_data[0]));
+        && thrust::equal(thrust::cuda::par.on(buf.get_stream().get()),
+                         buf.begin(),
+                         buf.end(),
+                         cuda::get_device_address(device_data[0]));
   }
 }
 
@@ -111,7 +113,7 @@ constexpr bool equal_size_value(const Buffer& buf, const size_t size, const int 
   else
   {
     return buf.size() == size
-        && thrust::equal(thrust::cuda::par.on(buf.get_stream()),
+        && thrust::equal(thrust::cuda::par.on(buf.get_stream().get()),
                          buf.begin(),
                          buf.end(),
                          cuda::std::begin(device_data),
@@ -131,7 +133,7 @@ constexpr bool equal_range(const Range1& range1, const Range2& range2)
   else
   {
     return range1.size() == range2.size()
-        && thrust::equal(thrust::cuda::par.on(range1.get_stream()), range1.begin(), range1.end(), range2.begin());
+        && thrust::equal(thrust::cuda::par.on(range1.get_stream().get()), range1.begin(), range1.end(), range2.begin());
   }
 }
 

--- a/cudax/test/containers/async_buffer/transform.cu
+++ b/cudax/test/containers/async_buffer/transform.cu
@@ -100,8 +100,8 @@ C2H_TEST("DeviceTransform::Transform cudax::async_device_buffer", "[device][devi
 
   cudax::async_device_buffer<type> a{env, num_items, cudax::uninit};
   cudax::async_device_buffer<type> b{env, num_items, cudax::uninit};
-  thrust::sequence(thrust::cuda::par_nosync.on(stream), a.begin(), a.end());
-  thrust::sequence(thrust::cuda::par_nosync.on(stream), b.begin(), b.end());
+  thrust::sequence(thrust::cuda::par_nosync.on(stream.get()), a.begin(), a.end());
+  thrust::sequence(thrust::cuda::par_nosync.on(stream.get()), b.begin(), b.end());
 
   cudax::async_device_buffer<type> result{env, num_items, cudax::uninit};
 


### PR DESCRIPTION
Thrust recently changed it's `par.on(...)` API to fix regressions with custom stream wrappers (#4451). This broke some internal usages of thrust in cudax.

Here, we call `stream_ref::get` to get the `cudaStream_t` to pass into thrust execution policies.

This wasn't caught pre-merge because our CI didn't know that cudax was using thrust internally. `inspect_changes.sh` has been updated to trigger cudax builds in response to thrust/cub changes to close this coverage gap.