### PR TITLE
Fix `__nv_pure__` compatibility

### DIFF
--- a/libcudacxx/include/cuda/std/__cccl/attributes.h
+++ b/libcudacxx/include/cuda/std/__cccl/attributes.h
@@ -101,13 +101,8 @@
 #  define _CCCL_ASSUME(...) _CCCL_BUILTIN_ASSUME(__VA_ARGS__)
 #endif
 
-#if _CCCL_CUDA_COMPILER(NVCC)
-#  if _CCCL_CUDA_COMPILER(NVCC, ==, 12) \
-    && (_CCCL_COMPILER(CLANG, <=, 14) || _CCCL_COMPILER(MSVC, <=, 19, 29) || _CCCL_COMPILER(GCC, <=, 9))
-#    define _CCCL_PURE
-#  else
-#    define _CCCL_PURE __nv_pure__
-#  endif
+#if _CCCL_CUDA_COMPILER(NVCC, >=, 12, 5)
+#  define _CCCL_PURE __nv_pure__
 #elif _CCCL_HAS_CPP_ATTRIBUTE(pure) || _CCCL_COMPILER(CLANG)
 #  define _CCCL_PURE [[gnu::pure]]
 #elif _CCCL_COMPILER(MSVC)


### PR DESCRIPTION
## Description

`__nv_pure__` has been introduced in CUDA 12.5. This PR fixes the compatibility with nvcc.