### PR TITLE
fix spelling of clang's `-Wno-unknown-cuda-version` switch

### DIFF
--- a/cudax/cmake/cudaxBuildCompilerTargets.cmake
+++ b/cudax/cmake/cudaxBuildCompilerTargets.cmake
@@ -60,7 +60,7 @@ function(cudax_build_compiler_targets)
   # Clang-cuda only:
   target_compile_options(cudax.compiler_interface INTERFACE
     $<$<COMPILE_LANG_AND_ID:CUDA,Clang>:-Xclang=-fcuda-allow-variadic-functions>
-    $<$<COMPILE_LANG_AND_ID:CUDA,Clang>:-Wno_unknown-cuda-version>
+    $<$<COMPILE_LANG_AND_ID:CUDA,Clang>:-Wno-unknown-cuda-version>
   )
 
   # Ensure that we test with assertions enabled


### PR DESCRIPTION
## Description

switch should be `-Wno-unknown-cuda-version`, not `-Wno_unknown-cuda-version`.