### PR TITLE
Avoid deprecated CUDART usage.

### DIFF
--- a/cub/test/test_util.h
+++ b/cub/test/test_util.h
@@ -328,7 +328,21 @@ struct CommandLineArgs
         exit(1);
       }
 
-      device_giga_bandwidth = float(deviceProp.memoryBusWidth) * deviceProp.memoryClockRate * 2 / 8 / 1000 / 1000;
+      int memoryClockRate{};
+      error = CubDebug(cudaDeviceGetAttribute(&memoryClockRate, cudaDevAttrMemoryClockRate, dev));
+      if (error)
+      {
+        break;
+      }
+
+      int memoryBusWidth{};
+      error = CubDebug(cudaDeviceGetAttribute(&memoryBusWidth, cudaDevAttrGlobalMemoryBusWidth, dev));
+      if (error)
+      {
+        break;
+      }
+
+      device_giga_bandwidth = float(memoryBusWidth) * memoryClockRate * 2 / 8 / 1000 / 1000;
 
       if (!CheckCmdLineFlag("quiet"))
       {
@@ -344,7 +358,7 @@ struct CommandLineArgs
           (unsigned long long) device_free_physmem / 1024 / 1024,
           (unsigned long long) device_total_physmem / 1024 / 1024,
           device_giga_bandwidth,
-          deviceProp.memoryClockRate,
+          memoryClockRate,
           (deviceProp.ECCEnabled) ? "on" : "off");
         fflush(stdout);
       }

--- a/cudax/include/cuda/experimental/__device/attributes.cuh
+++ b/cudax/include/cuda/experimental/__device/attributes.cuh
@@ -159,10 +159,6 @@ struct __dev_attr<::cudaDevAttrCooperativeLaunch> //
     : __dev_attr_impl<::cudaDevAttrCooperativeLaunch, bool>
 {};
 template <>
-struct __dev_attr<::cudaDevAttrCooperativeMultiDeviceLaunch> //
-    : __dev_attr_impl<::cudaDevAttrCooperativeMultiDeviceLaunch, bool>
-{};
-template <>
 struct __dev_attr<::cudaDevAttrCanFlushRemoteWrites> //
     : __dev_attr_impl<::cudaDevAttrCanFlushRemoteWrites, bool>
 {};
@@ -606,11 +602,6 @@ struct __device_attrs
   // cudaLaunchCooperativeKernel, and false otherwise
   using cooperative_launch_t = detail::__dev_attr<::cudaDevAttrCooperativeLaunch>;
   static constexpr cooperative_launch_t cooperative_launch{};
-
-  // true if the device supports launching cooperative kernels via
-  // cudaLaunchCooperativeKernelMultiDevice, and false otherwise
-  using cooperative_multi_device_launch_t = detail::__dev_attr<::cudaDevAttrCooperativeMultiDeviceLaunch>;
-  static constexpr cooperative_multi_device_launch_t cooperative_multi_device_launch{};
 
   // true if the device supports flushing of outstanding remote writes, and
   // false otherwise

--- a/cudax/test/device/device_smoke.cu
+++ b/cudax/test/device/device_smoke.cu
@@ -154,9 +154,6 @@ C2H_TEST("Smoke", "[device]")
                             ::cudaDevAttrCanUseHostPointerForRegisteredMem,
                             bool>();
     ::test_device_attribute<device::attrs::cooperative_launch, ::cudaDevAttrCooperativeLaunch, bool>();
-    ::test_device_attribute<device::attrs::cooperative_multi_device_launch,
-                            ::cudaDevAttrCooperativeMultiDeviceLaunch,
-                            bool>();
     ::test_device_attribute<device::attrs::can_flush_remote_writes, ::cudaDevAttrCanFlushRemoteWrites, bool>();
     ::test_device_attribute<device::attrs::host_register_supported, ::cudaDevAttrHostRegisterSupported, bool>();
     ::test_device_attribute<device::attrs::pageable_memory_access_uses_host_page_tables,


### PR DESCRIPTION
These fields and attributes have been deprecated.