### PR TITLE
Missing include in iterator_facade_category header

### DIFF
--- a/thrust/thrust/iterator/detail/iterator_facade_category.h
+++ b/thrust/thrust/iterator/detail/iterator_facade_category.h
@@ -29,6 +29,7 @@
 #include <thrust/iterator/detail/any_system_tag.h>
 #include <thrust/iterator/detail/device_system_tag.h>
 #include <thrust/iterator/detail/host_system_tag.h>
+#include <thrust/iterator/detail/iterator_category_to_system.h>
 #include <thrust/iterator/detail/iterator_category_to_traversal.h>
 #include <thrust/iterator/detail/iterator_category_with_system_and_traversal.h>
 #include <thrust/iterator/detail/iterator_traversal_tags.h>


### PR DESCRIPTION
The following code doesn't work without this fix:

```
#include <cub/device/device_scan.cuh>

int main()
{
  int num_items        = 1000;
  size_t size          = 0;
  void* d_temp_storage = nullptr;
  int* d_in;
  int* d_out;
  cudaMalloc((void**) &d_in, num_items * sizeof(float));
  cudaMalloc((void**) &d_out, num_items * sizeof(float));
  cub::DeviceScan::ExclusiveSum(d_temp_storage, size, d_in, d_out, num_items);
  printf("size %zu\n", size);
}
```

We have a forward declaration of `iterator_category_to_system<Category>` in 
https://github.com/NVIDIA/cccl/blob/9f254d5d8d071d67c6a6ad107b0bbd578b3d072d/thrust/thrust/iterator/detail/iterator_category_with_system_and_traversal.h#L38

but it's incomplete and being picked up wrongly here:

https://github.com/NVIDIA/cccl/blob/9f254d5d8d071d67c6a6ad107b0bbd578b3d072d/thrust/thrust/iterator/detail/iterator_facade_category.h#L182

Instead this should be picked up:

https://github.com/NVIDIA/cccl/blob/9f254d5d8d071d67c6a6ad107b0bbd578b3d072d/thrust/thrust/iterator/detail/iterator_category_to_system.h#L46

Not sure if this creates a circular dependency with the forward declaration in `iterator_category_with_system_and_traversal.h`. Maybe @jaredhoberock can tell.