### PR TITLE
Remove unsupported `__cccl_ptx_isa` versions for CCCL 3.x

### DIFF
--- a/libcudacxx/include/cuda/__bit/bitfield.h
+++ b/libcudacxx/include/cuda/__bit/bitfield.h
@@ -31,8 +31,6 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_CUDA
 
-#if __cccl_ptx_isa >= 200
-
 [[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_DEVICE uint32_t
 __bfi(uint32_t __dest, uint32_t __source, int __start, int __width) noexcept
 {
@@ -60,8 +58,6 @@ __bfi(uint64_t __dest, uint64_t __source, int __start, int __width) noexcept
   asm("bfe.u64 %0, %1, %2, %3;" : "=l"(__ret) : "l"(__value), "r"(__start), "r"(__width));
   return __ret;
 }
-
-#endif // __cccl_ptx_isa >= 200
 
 template <typename _Tp>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp

--- a/libcudacxx/include/cuda/discard_memory
+++ b/libcudacxx/include/cuda/discard_memory
@@ -30,7 +30,6 @@ inline _CCCL_HOST_DEVICE void
 discard_memory([[maybe_unused]] volatile void* __ptr, [[maybe_unused]] _CUDA_VSTD::size_t __nbytes) noexcept
 {
   // The discard PTX instruction is only available with PTX ISA 7.4 and later
-#if __cccl_ptx_isa >= 740ULL
   NV_IF_TARGET(
     NV_PROVIDES_SM_80,
     (if (!__isGlobal((void*) __ptr)) return;
@@ -48,7 +47,6 @@ discard_memory([[maybe_unused]] volatile void* __ptr, [[maybe_unused]] _CUDA_VST
        asm volatile("discard.global.L2 [%0], 128;" ::"l"(__start_aligned) :);
        __start_aligned += _LINE_SIZE;
      }))
-#endif
 }
 
 _LIBCUDACXX_END_NAMESPACE_CUDA

--- a/libcudacxx/include/cuda/std/__bit/byteswap.h
+++ b/libcudacxx/include/cuda/std/__bit/byteswap.h
@@ -59,7 +59,6 @@ template <class _Full>
 template <class _Tp>
 [[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_DEVICE _Tp __byteswap_impl_device(_Tp __val) noexcept
 {
-#if __cccl_ptx_isa >= 200
   if constexpr (sizeof(_Tp) == sizeof(uint16_t))
   {
     return static_cast<uint16_t>(_CUDA_VPTX::prmt(static_cast<uint32_t>(__val), uint32_t{0}, uint32_t{0x3201}));
@@ -78,7 +77,6 @@ template <class _Tp>
     return static_cast<uint64_t>(__new_hi) << 32 | static_cast<uint64_t>(__new_lo);
   }
   else
-#endif // __cccl_ptx_isa >= 200
   {
     return _CUDA_VSTD::__byteswap_impl_recursive(__val);
   }

--- a/libcudacxx/include/cuda/std/__cccl/ptx_isa.h
+++ b/libcudacxx/include/cuda/std/__cccl/ptx_isa.h
@@ -59,35 +59,8 @@
 // PTX ISA 8.0 is available from CUDA 12.0, driver r525
 #elif _CCCL_CUDACC_AT_LEAST(12, 0) && !_CCCL_CUDA_COMPILER(CLANG, <, 17)
 #  define __cccl_ptx_isa 800ULL
-// PTX ISA 7.8 is available from CUDA 11.8, driver r520
-#elif _CCCL_CUDACC_AT_LEAST(11, 8) && !_CCCL_CUDA_COMPILER(CLANG, <, 16)
-#  define __cccl_ptx_isa 780ULL
-// PTX ISA 7.7 is available from CUDA 11.7, driver r515
-#elif _CCCL_CUDACC_AT_LEAST(11, 7) && !_CCCL_CUDA_COMPILER(CLANG, <, 16)
-#  define __cccl_ptx_isa 770ULL
-// PTX ISA 7.6 is available from CUDA 11.6, driver r510
-#elif _CCCL_CUDACC_AT_LEAST(11, 6) && !_CCCL_CUDA_COMPILER(CLANG, <, 16)
-#  define __cccl_ptx_isa 760ULL
-// PTX ISA 7.5 is available from CUDA 11.5, driver r495
-#elif _CCCL_CUDACC_AT_LEAST(11, 5) && !_CCCL_CUDA_COMPILER(CLANG, <, 14)
-#  define __cccl_ptx_isa 750ULL
-// PTX ISA 7.4 is available from CUDA 11.4, driver r470
-#elif _CCCL_CUDACC_AT_LEAST(11, 4) && !_CCCL_CUDA_COMPILER(CLANG, <, 14)
-#  define __cccl_ptx_isa 740ULL
-// PTX ISA 7.3 is available from CUDA 11.3, driver r465
-#elif _CCCL_CUDACC_AT_LEAST(11, 3) && !_CCCL_CUDA_COMPILER(CLANG, <, 14)
-#  define __cccl_ptx_isa 730ULL
-// PTX ISA 7.2 is available from CUDA 11.2, driver r460
-#elif _CCCL_CUDACC_AT_LEAST(11, 2) && !_CCCL_CUDA_COMPILER(CLANG, <, 13)
-#  define __cccl_ptx_isa 720ULL
-// PTX ISA 7.1 is available from CUDA 11.1, driver r455
-#elif _CCCL_CUDACC_AT_LEAST(11, 1) && !_CCCL_CUDA_COMPILER(CLANG, <, 13)
-#  define __cccl_ptx_isa 710ULL
-// PTX ISA 7.0 is available from CUDA 11.0, driver r445
-#elif _CCCL_CUDACC_AT_LEAST(11, 0) && !_CCCL_CUDA_COMPILER(CLANG, <, 12)
-#  define __cccl_ptx_isa 700ULL
-// Fallback case. Define the ISA version to be zero. This ensures that the macro is always defined.
 #else
+// Fallback case. Define the ISA version to be zero. This ensures that the macro is always defined.
 #  define __cccl_ptx_isa 0ULL
 #endif
 


### PR DESCRIPTION
## Description

According to the documentation, CCCL 3.x is aligned to CUDA 12.x toolkit and only supports `__cccl_ptx_isa >= 800`