### PR TITLE
[BACKPORT] Missing forward include in iterator facade category (#4512)

### DIFF
--- a/thrust/thrust/iterator/detail/iterator_facade_category.h
+++ b/thrust/thrust/iterator/detail/iterator_facade_category.h
@@ -29,6 +29,7 @@
 #include <thrust/iterator/detail/any_system_tag.h>
 #include <thrust/iterator/detail/device_system_tag.h>
 #include <thrust/iterator/detail/host_system_tag.h>
+#include <thrust/iterator/detail/iterator_category_to_system.h>
 #include <thrust/iterator/detail/iterator_category_to_traversal.h>
 #include <thrust/iterator/detail/iterator_category_with_system_and_traversal.h>
 #include <thrust/iterator/detail/iterator_traversal_tags.h>


### PR DESCRIPTION
Fixes nvbug5213141