### PR TITLE
move `[[nodiscard]]` before `__device__` to make clang happy

### DIFF
--- a/cudax/include/cuda/experimental/__launch/configuration.cuh
+++ b/cudax/include/cuda/experimental/__launch/configuration.cuh
@@ -607,7 +607,7 @@ template <typename Dimensions, typename... Options>
 
 // Needs to be a char casted to the appropriate type, if it would be a template
 //  different instantiations would clash the extern symbol
-_CCCL_DEVICE [[nodiscard]] static char* get_smem_ptr() noexcept
+[[nodiscard]] _CCCL_DEVICE static char* get_smem_ptr() noexcept
 {
   extern __shared__ char dynamic_smem[];
 


### PR DESCRIPTION
building cudax with clang's CUDA support is currently broken because clang is picky about where C++ [[attributes]] go in relation to GNU \_\_attributes__. the C++ attributes must come first.