### PR TITLE
make `run_loop` lock-free and usable from device code

### DIFF
--- a/cudax/include/cuda/experimental/__async/sender/atomic_intrusive_queue.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/atomic_intrusive_queue.cuh
@@ -1,0 +1,86 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//                         Copyright (c) 2023 Maikel Nadolski
+//===----------------------------------------------------------------------===//
+
+#ifndef __CUDAX_ASYNC_DETAIL_ATOMIC_INTRUSIVE_QUEUE
+#define __CUDAX_ASYNC_DETAIL_ATOMIC_INTRUSIVE_QUEUE
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/atomic>
+
+#include <cuda/experimental/__async/sender/intrusive_queue.cuh>
+#include <cuda/experimental/__detail/config.cuh>
+
+#include <cuda/experimental/__async/sender/prologue.cuh>
+
+namespace cuda::experimental::__async
+{
+template <auto _NextPtr>
+class _CCCL_TYPE_VISIBILITY_DEFAULT __atomic_intrusive_queue;
+
+template <class _Tp, _Tp* _Tp::* _NextPtr>
+class alignas(64) __atomic_intrusive_queue<_NextPtr>
+{
+public:
+  using __node_pointer _CCCL_NODEBUG_ALIAS        = _Tp*;
+  using __atomic_node_pointer _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::atomic<_Tp*>;
+
+  [[nodiscard]]
+  _CUDAX_API auto empty() const noexcept -> bool
+  {
+    return __head_.load(_CUDA_VSTD::memory_order_relaxed) == nullptr;
+  }
+
+  _CUDAX_API auto push(__node_pointer __node) noexcept -> bool
+  {
+    _CCCL_ASSERT(__node != nullptr, "Cannot push a null pointer to the queue");
+    __node_pointer __old_head = __head_.load(_CUDA_VSTD::memory_order_relaxed);
+    do
+    {
+      __node->*_NextPtr = __old_head;
+    } while (!__head_.compare_exchange_weak(__old_head, __node, _CUDA_VSTD::memory_order_acq_rel));
+
+    if (__old_head != nullptr)
+    {
+      return false;
+    }
+
+    __head_.notify_one();
+    return true;
+  }
+
+  _CUDAX_API void wait_for_item() noexcept
+  {
+    // Wait until the queue has an item in it:
+    __head_.wait(nullptr);
+  }
+
+  [[nodiscard]]
+  _CUDAX_API auto pop_all() noexcept -> __intrusive_queue<_NextPtr>
+  {
+    return __intrusive_queue<_NextPtr>::make_reversed(__head_.exchange(nullptr, _CUDA_VSTD::memory_order_acq_rel));
+  }
+
+private:
+  __atomic_node_pointer __head_{nullptr};
+};
+} // namespace cuda::experimental::__async
+
+#include <cuda/experimental/__async/sender/epilogue.cuh>
+
+#endif // __CUDAX_ASYNC_DETAIL_ATOMIC_INTRUSIVE_QUEUE

--- a/cudax/include/cuda/experimental/__async/sender/completion_signatures.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/completion_signatures.cuh
@@ -235,7 +235,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __compile_time_error // : ::std::exception
 };
 
 template <class _Data, class... _What>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT __sender_type_check_failure
+struct _CCCL_TYPE_VISIBILITY_DEFAULT __sender_type_check_failure //
     : __compile_time_error<__sender_type_check_failure<_Data, _What...>>
 {
   _CUDAX_DEFAULTED_API __sender_type_check_failure() = default;

--- a/cudax/include/cuda/experimental/__async/sender/intrusive_queue.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/intrusive_queue.cuh
@@ -1,0 +1,298 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//                         Copyright (c) 2021-2022 Facebook, Inc & AFFILIATES.
+//===----------------------------------------------------------------------===//
+
+#ifndef __CUDAX_ASYNC_DETAIL_INTRUSIVE_QUEUE
+#define __CUDAX_ASYNC_DETAIL_INTRUSIVE_QUEUE
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__iterator/iterator_traits.h>
+#include <cuda/std/__utility/exchange.h>
+
+#include <cuda/experimental/__detail/config.cuh>
+
+#include <cuda/experimental/__async/sender/prologue.cuh>
+
+namespace cuda::experimental::__async
+{
+template <auto _Next>
+class _CCCL_TYPE_VISIBILITY_DEFAULT __intrusive_queue;
+
+template <class _Item, _Item* _Item::* _Next>
+class _CCCL_TYPE_VISIBILITY_DEFAULT __intrusive_queue<_Next>
+{
+public:
+  _CUDAX_DEFAULTED_API __intrusive_queue() noexcept = default;
+
+  _CUDAX_API __intrusive_queue(__intrusive_queue&& __other) noexcept
+      : __head_(_CUDA_VSTD::exchange(__other.__head_, nullptr))
+      , __tail_(_CUDA_VSTD::exchange(__other.__tail_, nullptr))
+  {}
+
+  _CUDAX_API auto operator=(__intrusive_queue&& __other) noexcept -> __intrusive_queue&
+  {
+    __head_ = _CUDA_VSTD::exchange(__other.__head_, nullptr);
+    __tail_ = _CUDA_VSTD::exchange(__other.__tail_, nullptr);
+    return *this;
+  }
+
+  _CUDAX_API ~__intrusive_queue()
+  {
+    _CCCL_ASSERT(empty(), "");
+  }
+
+  [[nodiscard]]
+  _CUDAX_API static auto make_reversed(_Item* __list) noexcept -> __intrusive_queue
+  {
+    _Item* __new_head = nullptr;
+    _Item* __new_tail = __list;
+
+    while (__list != nullptr)
+    {
+      _Item* __next  = __list->*_Next;
+      __list->*_Next = __new_head;
+      __new_head     = __list;
+      __list         = __next;
+    }
+
+    __intrusive_queue __result;
+    __result.__head_ = __new_head;
+    __result.__tail_ = __new_tail;
+    return __result;
+  }
+
+  [[nodiscard]]
+  _CUDAX_API static auto make(_Item* __list) noexcept -> __intrusive_queue
+  {
+    __intrusive_queue __result{};
+    __result.__head_ = __list;
+    __result.__tail_ = __list;
+    if (__list == nullptr)
+    {
+      return __result;
+    }
+    while (__result.__tail_->*_Next != nullptr)
+    {
+      __result.__tail_ = __result.__tail_->*_Next;
+    }
+    return __result;
+  }
+
+  [[nodiscard]]
+  _CUDAX_API auto empty() const noexcept -> bool
+  {
+    return __head_ == nullptr;
+  }
+
+  _CUDAX_API void clear() noexcept
+  {
+    __head_ = nullptr;
+    __tail_ = nullptr;
+  }
+
+  [[nodiscard]]
+  _CUDAX_API auto pop_front() noexcept -> _Item*
+  {
+    _CCCL_ASSERT(!empty(), "");
+    _Item* __item = _CUDA_VSTD::exchange(__head_, __head_->*_Next);
+    // This should test if __head_ == nullptr, but due to a bug in
+    // nvc++'s optimization, `__head_` isn't assigned until later.
+    // Filed as NVBug#3952534.
+    if (__item->*_Next == nullptr)
+    {
+      __tail_ = nullptr;
+    }
+    return __item;
+  }
+
+  _CUDAX_API void push_front(_Item* __item) noexcept
+  {
+    _CCCL_ASSERT(__item != nullptr, "");
+    __item->*_Next = __head_;
+    __head_        = __item;
+    if (__tail_ == nullptr)
+    {
+      __tail_ = __item;
+    }
+  }
+
+  _CUDAX_API void push_back(_Item* __item) noexcept
+  {
+    _CCCL_ASSERT(__item != nullptr, "");
+    __item->*_Next                        = nullptr;
+    (empty() ? __head_ : __tail_->*_Next) = __item;
+    __tail_                               = __item;
+  }
+
+  _CUDAX_API void append(__intrusive_queue __other) noexcept
+  {
+    if (!__other.empty())
+    {
+      (empty() ? __head_ : __tail_->*_Next) = _CUDA_VSTD::exchange(__other.__head_, nullptr);
+      __tail_                               = _CUDA_VSTD::exchange(__other.__tail_, nullptr);
+    }
+  }
+
+  _CUDAX_API void prepend(__intrusive_queue __other) noexcept
+  {
+    if (!__other.empty())
+    {
+      __other.__tail_->*_Next = __head_;
+      __head_                 = __other.__head_;
+      if (__tail_ == nullptr)
+      {
+        __tail_ = __other.__tail_;
+      }
+
+      __other.clear();
+    }
+  }
+
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT iterator
+  {
+    using value_type _CCCL_NODEBUG_ALIAS        = _Item*;
+    using difference_type _CCCL_NODEBUG_ALIAS   = _CUDA_VSTD::ptrdiff_t;
+    using pointer _CCCL_NODEBUG_ALIAS           = _Item* const*;
+    using reference _CCCL_NODEBUG_ALIAS         = _Item* const&;
+    using iterator_category _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::forward_iterator_tag;
+
+    _CUDAX_DEFAULTED_API iterator() noexcept = default;
+
+    _CUDAX_API explicit iterator(_Item* __pred, _Item* __item) noexcept
+        : __predecessor_(__pred)
+        , __item_(__item)
+    {}
+
+    [[nodiscard]]
+    _CUDAX_API auto operator*() const noexcept -> _Item* const&
+    {
+      _CCCL_ASSERT(__item_ != nullptr, "");
+      return __item_;
+    }
+
+    [[nodiscard]]
+    _CUDAX_API auto operator->() const noexcept -> _Item* const*
+    {
+      _CCCL_ASSERT(__item_ != nullptr, "");
+      return &__item_;
+    }
+
+    _CUDAX_API auto operator++() noexcept -> iterator&
+    {
+      _CCCL_ASSERT(__item_ != nullptr, "");
+      __predecessor_ = _CUDA_VSTD::exchange(__item_, __item_->*_Next);
+      return *this;
+    }
+
+    _CUDAX_API auto operator++(int) noexcept -> iterator
+    {
+      iterator __result = *this;
+      ++*this;
+      return __result;
+    }
+
+    [[nodiscard]]
+    _CUDAX_API friend auto operator==(const iterator& __lhs, const iterator& __rhs) noexcept -> bool
+    {
+      return __lhs.__item_ == __rhs.__item_;
+    }
+
+    [[nodiscard]]
+    _CUDAX_API friend auto operator!=(const iterator& __lhs, const iterator& __rhs) noexcept -> bool
+    {
+      return __lhs.__item_ != __rhs.__item_;
+    }
+
+    _Item* __predecessor_ = nullptr;
+    _Item* __item_        = nullptr;
+  };
+
+  [[nodiscard]]
+  _CUDAX_API auto begin() const noexcept -> iterator
+  {
+    return iterator(nullptr, __head_);
+  }
+
+  [[nodiscard]]
+  _CUDAX_API auto end() const noexcept -> iterator
+  {
+    return iterator(__tail_, nullptr);
+  }
+
+  _CUDAX_API void splice(iterator pos, __intrusive_queue& other, iterator first, iterator last) noexcept
+  {
+    if (first == last)
+    {
+      return;
+    }
+    _CCCL_ASSERT(first.__item_ != nullptr, "");
+    _CCCL_ASSERT(last.__predecessor_ != nullptr, "");
+    if (other.__head_ == first.__item_)
+    {
+      other.__head_ = last.__item_;
+      if (other.__head_ == nullptr)
+      {
+        other.__tail_ = nullptr;
+      }
+    }
+    else
+    {
+      _CCCL_ASSERT(first.__predecessor_ != nullptr, "");
+      first.__predecessor_->*_Next = last.__item_;
+      last.__predecessor_->*_Next  = pos.__item_;
+    }
+    if (empty())
+    {
+      __head_ = first.__item_;
+      __tail_ = last.__predecessor_;
+    }
+    else
+    {
+      pos.__predecessor_->*_Next = first.__item_;
+      if (pos.__item_ == nullptr)
+      {
+        __tail_ = last.__predecessor_;
+      }
+    }
+  }
+
+  _CUDAX_API auto front() const noexcept -> _Item* const&
+  {
+    return __head_;
+  }
+
+  _CUDAX_API auto back() const noexcept -> _Item* const&
+  {
+    return __tail_;
+  }
+
+private:
+  _CUDAX_API explicit __intrusive_queue(_Item* __head, _Item* __tail) noexcept
+      : __head_(__head)
+      , __tail_(__tail)
+  {}
+
+  _Item* __head_ = nullptr;
+  _Item* __tail_ = nullptr;
+};
+
+} // namespace cuda::experimental::__async
+
+#include <cuda/experimental/__async/sender/epilogue.cuh>
+
+#endif // __CUDAX_ASYNC_DETAIL_INTRUSIVE_QUEUE

--- a/cudax/include/cuda/experimental/__async/sender/run_loop.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/run_loop.cuh
@@ -21,152 +21,153 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/experimental/__async/sender/atomic_intrusive_queue.cuh>
+#include <cuda/experimental/__async/sender/completion_signatures.cuh>
+#include <cuda/experimental/__async/sender/env.cuh>
+#include <cuda/experimental/__async/sender/exception.cuh>
+#include <cuda/experimental/__async/sender/queries.cuh>
+#include <cuda/experimental/__async/sender/utility.cuh>
 #include <cuda/experimental/__detail/config.cuh>
 
-// libcu++ does not have <cuda/std/mutex> or <cuda/std/condition_variable>
-#if !defined(__CUDA_ARCH__)
-
-#  include <cuda/experimental/__async/sender/completion_signatures.cuh>
-#  include <cuda/experimental/__async/sender/env.cuh>
-#  include <cuda/experimental/__async/sender/exception.cuh>
-#  include <cuda/experimental/__async/sender/queries.cuh>
-#  include <cuda/experimental/__async/sender/utility.cuh>
-
-#  include <condition_variable>
-#  include <mutex>
-
-#  include <cuda/experimental/__async/sender/prologue.cuh>
+#include <cuda/experimental/__async/sender/prologue.cuh>
 
 namespace cuda::experimental::__async
 {
-class _CCCL_TYPE_VISIBILITY_DEFAULT run_loop;
-
-struct __task : private __immovable
+class _CCCL_TYPE_VISIBILITY_DEFAULT run_loop : __immovable
 {
-  using __execute_fn_t _CCCL_NODEBUG_ALIAS = void(__task*) noexcept;
+public:
+  _CUDAX_DEFAULTED_API run_loop() = default;
 
-  _CUDAX_DEFAULTED_API __task() = default;
-
-  _CUDAX_API explicit __task(__task* __next, __task* __tail) noexcept
-      : __next_{__next}
-      , __tail_{__tail}
-  {}
-
-  _CUDAX_API explicit __task(__task* __next, __execute_fn_t* __execute) noexcept
-      : __next_{__next}
-      , __execute_fn_{__execute}
-  {}
-
-  __task* __next_ = this;
-
-  union
+  _CUDAX_API void run() noexcept
   {
-    __task* __tail_ = nullptr;
-    __execute_fn_t* __execute_fn_;
+    // execute work items until the __finishing_ flag is set:
+    while (!__finishing_.load(_CUDA_VSTD::memory_order_acquire))
+    {
+      __queue_.wait_for_item();
+      __execute_all();
+    }
+    // drain the queue, taking care to execute any tasks that get added while
+    // executing the remaining tasks:
+    while (__execute_all())
+      ;
+  }
+
+  _CUDAX_API void finish() noexcept
+  {
+    if (!__finishing_.exchange(true, _CUDA_VSTD::memory_order_acq_rel))
+    {
+      // push an empty work item to the queue to wake up any waiting threads
+      __queue_.push(&__finish_task);
+    }
+  }
+
+private:
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __task : __immovable
+  {
+    using __execute_fn_t _CCCL_NODEBUG_ALIAS = void(__task*) noexcept;
+
+    _CUDAX_DEFAULTED_API __task() = default;
+    _CUDAX_TRIVIAL_API explicit __task(__execute_fn_t* __execute_fn) noexcept
+        : __execute_fn_(__execute_fn)
+    {}
+
+    _CUDAX_API void __execute() noexcept
+    {
+      (*__execute_fn_)(this);
+    }
+
+    __execute_fn_t* __execute_fn_ = nullptr;
+    __task* __next_               = nullptr;
   };
 
-  _CUDAX_API void __execute() noexcept
+  template <class _Rcvr>
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __opstate_t : __task
   {
-    (*__execute_fn_)(this);
-  }
-};
+    __atomic_intrusive_queue<&__task::__next_>* __queue_;
+    _CCCL_NO_UNIQUE_ADDRESS _Rcvr __rcvr_;
 
-template <class _Rcvr>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT __operation : __task
-{
-  run_loop* __loop_;
-  _CCCL_NO_UNIQUE_ADDRESS _Rcvr __rcvr_;
+    _CUDAX_API static void __execute_impl(__task* __p) noexcept
+    {
+      auto& __rcvr = static_cast<__opstate_t*>(__p)->__rcvr_;
+      _CUDAX_TRY( //
+        ({        //
+          if (get_stop_token(get_env(__rcvr)).stop_requested())
+          {
+            set_stopped(static_cast<_Rcvr&&>(__rcvr));
+          }
+          else
+          {
+            set_value(static_cast<_Rcvr&&>(__rcvr));
+          }
+        }),
+        _CUDAX_CATCH(...) //
+        ({                //
+          set_error(static_cast<_Rcvr&&>(__rcvr), ::std::current_exception());
+        }) //
+      )
+    }
 
-  _CUDAX_API static void __execute_impl(__task* __p) noexcept
-  {
-    auto& __rcvr = static_cast<__operation*>(__p)->__rcvr_;
-    _CUDAX_TRY( //
-      ({        //
-        if (get_stop_token(get_env(__rcvr)).stop_requested())
-        {
-          set_stopped(static_cast<_Rcvr&&>(__rcvr));
-        }
-        else
-        {
-          set_value(static_cast<_Rcvr&&>(__rcvr));
-        }
-      }),
-      _CUDAX_CATCH(...) //
-      ({                //
-        set_error(static_cast<_Rcvr&&>(__rcvr), ::std::current_exception());
-      }) //
-    )
-  }
+    _CUDAX_API __opstate_t(__atomic_intrusive_queue<&__task::__next_>* __queue, _Rcvr __rcvr)
+        : __task{&__execute_impl}
+        , __queue_{__queue}
+        , __rcvr_{static_cast<_Rcvr&&>(__rcvr)}
+    {}
 
-  _CUDAX_API explicit __operation(__task* __tail_) noexcept
-      : __task{this, __tail_}
-  {}
-
-  _CUDAX_API __operation(__task* __next_, run_loop* __loop, _Rcvr __rcvr)
-      : __task{__next_, &__execute_impl}
-      , __loop_{__loop}
-      , __rcvr_{static_cast<_Rcvr&&>(__rcvr)}
-  {}
-
-  _CUDAX_API void start() & noexcept;
-};
-
-class _CCCL_TYPE_VISIBILITY_DEFAULT run_loop
-{
-  template <class... _Ts>
-  using __completion_signatures _CCCL_NODEBUG_ALIAS = completion_signatures<_Ts...>;
-
-  template <class>
-  friend struct __operation;
+    _CUDAX_API void start() & noexcept
+    {
+      __queue_->push(this);
+    }
+  };
 
 public:
-  run_loop() noexcept
+  class _CCCL_TYPE_VISIBILITY_DEFAULT scheduler
   {
-    __head.__next_ = __head.__tail_ = &__head;
-  }
-
-  class _CCCL_TYPE_VISIBILITY_DEFAULT __scheduler
-  {
-    struct _CCCL_TYPE_VISIBILITY_DEFAULT __schedule_task
+    struct _CCCL_TYPE_VISIBILITY_DEFAULT __sndr_t
     {
       using sender_concept _CCCL_NODEBUG_ALIAS = sender_t;
 
       template <class _Rcvr>
-      _CUDAX_API auto connect(_Rcvr __rcvr) const noexcept -> __operation<_Rcvr>
+      _CUDAX_API auto connect(_Rcvr __rcvr) const noexcept -> __opstate_t<_Rcvr>
       {
-        return {&__loop_->__head, __loop_, static_cast<_Rcvr&&>(__rcvr)};
+        return {&__loop_->__queue_, static_cast<_Rcvr&&>(__rcvr)};
       }
 
       template <class _Self>
       _CUDAX_API static constexpr auto get_completion_signatures() noexcept
       {
-#  if _CCCL_HAS_EXCEPTIONS()
+#if _CCCL_HAS_EXCEPTIONS()
         return completion_signatures<set_value_t(), set_error_t(::std::exception_ptr), set_stopped_t()>();
-#  else  // ^^^ _CCCL_HAS_EXCEPTIONS() ^^^ / vvv !_CCCL_HAS_EXCEPTIONS() vvv
+#else  // ^^^ _CCCL_HAS_EXCEPTIONS() ^^^ / vvv !_CCCL_HAS_EXCEPTIONS() vvv
         return completion_signatures<set_value_t(), set_stopped_t()>();
-#  endif // !_CCCL_HAS_EXCEPTIONS()
+#endif // !_CCCL_HAS_EXCEPTIONS()
       }
 
     private:
-      friend __scheduler;
+      friend scheduler;
 
-      struct _CCCL_TYPE_VISIBILITY_DEFAULT __env
+      struct _CCCL_TYPE_VISIBILITY_DEFAULT __env_t
       {
         run_loop* __loop_;
 
-        template <class _Tag>
-        _CUDAX_API auto query(get_completion_scheduler_t<_Tag>) const noexcept -> __scheduler
+        _CUDAX_API auto query(get_completion_scheduler_t<set_value_t>) const noexcept -> scheduler
+        {
+          return __loop_->get_scheduler();
+        }
+
+        _CUDAX_API auto query(get_completion_scheduler_t<set_stopped_t>) const noexcept -> scheduler
         {
           return __loop_->get_scheduler();
         }
       };
 
-      _CUDAX_API auto get_env() const noexcept -> __env
+      _CUDAX_API auto get_env() const noexcept -> __env_t
       {
-        return __env{__loop_};
+        return __env_t{__loop_};
       }
 
-      _CUDAX_API explicit __schedule_task(run_loop* __loop) noexcept
+    private:
+      friend class scheduler;
+      _CUDAX_API explicit __sndr_t(run_loop* __loop) noexcept
           : __loop_(__loop)
       {}
 
@@ -175,7 +176,7 @@ public:
 
     friend run_loop;
 
-    _CUDAX_API explicit __scheduler(run_loop* __loop) noexcept
+    _CUDAX_API explicit scheduler(run_loop* __loop) noexcept
         : __loop_(__loop)
     {}
 
@@ -189,93 +190,55 @@ public:
   public:
     using scheduler_concept _CCCL_NODEBUG_ALIAS = scheduler_t;
 
-    [[nodiscard]] _CUDAX_API auto schedule() const noexcept -> __schedule_task
+    [[nodiscard]] _CUDAX_API auto schedule() const noexcept -> __sndr_t
     {
-      return __schedule_task{__loop_};
+      return __sndr_t{__loop_};
     }
 
-    _CUDAX_API friend auto operator==(const __scheduler& __a, const __scheduler& __b) noexcept -> bool
+    [[nodiscard]] _CUDAX_API friend bool operator==(const scheduler& __a, const scheduler& __b) noexcept
     {
       return __a.__loop_ == __b.__loop_;
     }
 
-    _CUDAX_API friend auto operator!=(const __scheduler& __a, const __scheduler& __b) noexcept -> bool
+    [[nodiscard]] _CUDAX_API friend bool operator!=(const scheduler& __a, const scheduler& __b) noexcept
     {
       return __a.__loop_ != __b.__loop_;
     }
   };
 
-  _CUDAX_API auto get_scheduler() noexcept -> __scheduler
+  [[nodiscard]] _CUDAX_API auto get_scheduler() noexcept -> scheduler
   {
-    return __scheduler{this};
+    return scheduler{this};
   }
-
-  _CUDAX_API void run();
-
-  _CUDAX_API void finish();
 
 private:
-  _CUDAX_API void __push_back(__task* __tsk);
-  _CUDAX_API auto __pop_front() -> __task*;
+  // Returns true if any tasks were executed.
+  _CUDAX_API bool __execute_all() noexcept
+  {
+    // Wait until the queue has tasks to execute and then dequeue all of them.
+    auto __queue = __queue_.pop_all();
+    if (__queue.empty())
+    {
+      return false;
+    }
+    // Execute all the tasks in the queue.
+    for (auto __task : __queue)
+    {
+      __task->__execute();
+    }
+    __queue.clear();
+    return true;
+  }
 
-  ::std::mutex __mutex{};
-  ::std::condition_variable __cv{};
-  __task __head{};
-  bool __stop = false;
+  _CUDAX_API static void __noop_(__task*) noexcept {}
+
+  _CUDA_VSTD::atomic<bool> __finishing_{false};
+  __atomic_intrusive_queue<&__task::__next_> __queue_{};
+  __task __finish_task{&__noop_};
 };
 
-template <class _Rcvr>
-_CUDAX_API inline void __operation<_Rcvr>::start() & noexcept {
-  _CUDAX_TRY(                                                               //
-    ({                                                                      //
-      __loop_->__push_back(this);                                           //
-    }),                                                                     //
-    _CUDAX_CATCH(...)                                                       //
-    ({                                                                      //
-      set_error(static_cast<_Rcvr&&>(__rcvr_), ::std::current_exception()); //
-    })                                                                      //
-    )                                                                       //
-}
-
-_CUDAX_API inline void run_loop::run()
-{
-  for (__task* __tsk = __pop_front(); __tsk != &__head; __tsk = __pop_front())
-  {
-    __tsk->__execute();
-  }
-}
-
-_CUDAX_API inline void run_loop::finish()
-{
-  ::std::unique_lock __lock{__mutex};
-  __stop = true;
-  __cv.notify_all();
-}
-
-_CUDAX_API inline void run_loop::__push_back(__task* __tsk)
-{
-  ::std::unique_lock __lock{__mutex};
-  __tsk->__next_ = &__head;
-  __head.__tail_ = __head.__tail_->__next_ = __tsk;
-  __cv.notify_one();
-}
-
-_CUDAX_API inline auto run_loop::__pop_front() -> __task*
-{
-  ::std::unique_lock __lock{__mutex};
-  __cv.wait(__lock, [this] {
-    return __head.__next_ != &__head || __stop;
-  });
-  if (__head.__tail_ == __head.__next_)
-  {
-    __head.__tail_ = &__head;
-  }
-  return __async::__exchange(__head.__next_, __head.__next_->__next_);
-}
 } // namespace cuda::experimental::__async
 
-#  include <cuda/experimental/__async/sender/epilogue.cuh>
+#include <cuda/experimental/__async/sender/epilogue.cuh>
 
-#endif // !defined(__CUDA_ARCH__)
-
-#endif
+#endif // __CUDAX_ASYNC_DETAIL_RUN_LOOP


### PR DESCRIPTION
## Description

the current implementation of `run_loop` uses `std::mutex` and `std::condition_variable`. these types have no analogue in `cuda::std::`. as a result, `run_loop` has been limited to host-only, and hence so has the `sync_wait` algorithm.

in a future PR i want to add a stream-aware `sync_wait` that drives a `run_loop` from a host thread, and call `run_loop::finish()` from a SIMT thread. for that, i need a host/device `run_loop`, and it must still be thread-safe.

stdexec has an `__atomic_intrusive_queue` type that has seen heavy use. this PR slurps in that queue type and implements `run_loop` on top of it, delegating the atomic operations to `cuda::std::atomic`. it uses `atomic::wait` and `atomic::notify_all` to coordinate between threads.

the end result is a `run_loop` that can be used both from device and from host.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
