### PR TITLE
C2H fixes

### DIFF
--- a/c2h/catch2_runner.cpp
+++ b/c2h/catch2_runner.cpp
@@ -29,6 +29,6 @@
 //! This file includes a custom Catch2 main function when CMake is configured to build all tests into a single
 //! executable.
 
-#define CUB_CONFIG_MAIN
-#define CUB_EXCLUDE_CATCH2_HELPER_IMPL
+#define C2H_CONFIG_MAIN
+#define C2H_EXCLUDE_CATCH2_HELPER_IMPL
 #include <c2h/catch2_main.h>

--- a/c2h/include/c2h/catch2_main.h
+++ b/c2h/include/c2h/catch2_main.h
@@ -67,6 +67,6 @@ int main(int argc, char* argv[])
 
   set_device(device_id);
 #  endif // THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
-  return session.run(argc, argv);
+  return session.run();
 }
 #endif // CUB_CONFIG_MAIN

--- a/c2h/include/c2h/catch2_main.h
+++ b/c2h/include/c2h/catch2_main.h
@@ -38,13 +38,13 @@
 
 #include <catch2/catch_session.hpp>
 
-#ifdef CUB_CONFIG_MAIN
+#ifdef C2H_CONFIG_MAIN
 #  if THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
 #    include <c2h/catch2_runner_helper.h>
 
-#    ifndef CUB_EXCLUDE_CATCH2_HELPER_IMPL
+#    ifndef C2H_EXCLUDE_CATCH2_HELPER_IMPL
 #      include "catch2_runner_helper.inl"
-#    endif // !CUB_EXCLUDE_CATCH2_HELPER_IMPL
+#    endif // !C2H_EXCLUDE_CATCH2_HELPER_IMPL
 #  endif // THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
 
 int main(int argc, char* argv[])
@@ -69,4 +69,4 @@ int main(int argc, char* argv[])
 #  endif // THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
   return session.run();
 }
-#endif // CUB_CONFIG_MAIN
+#endif // C2H_CONFIG_MAIN


### PR DESCRIPTION
- Fixes bug where CLI args were duplicated in Catch2 internal data structures.
- Rename some c2h macros from `CUB_` to `C2H_`.