### PR TITLE
fix some portability issues with the cudax async tests

### DIFF
--- a/cudax/test/async/common/utility.cuh
+++ b/cudax/test/async/common/utility.cuh
@@ -86,7 +86,7 @@ struct string
     while (c[len++])
       ;
     char* tmp = str = new char[len];
-    while (*tmp++ = *c++)
+    while ((*tmp++ = *c++))
       ;
   }
 

--- a/cudax/test/async/test_conditional.cu
+++ b/cudax/test/async/test_conditional.cu
@@ -55,8 +55,8 @@ C2H_TEST("simple use of conditional runs exactly one of the two closures", "[ada
     auto op = cudax_async::connect(std::move(sndr1), checked_value_receiver<>{});
     cudax_async::start(op);
 
-    CUDAX_CHECK(even == (i % 2 == 0));
-    CUDAX_CHECK(odd == (i % 2 == 1));
+    CHECK(even == (i % 2 == 0));
+    CHECK(odd == (i % 2 == 1));
   }
 }
 

--- a/cudax/test/async/test_just.cu
+++ b/cudax/test/async/test_just.cu
@@ -14,5 +14,5 @@
 
 C2H_TEST("this is a dummy test", "[just]")
 {
-  CUDAX_REQUIRE(1 == 1);
+  REQUIRE(1 == 1);
 }

--- a/cudax/test/async/test_sequence.cu
+++ b/cudax/test/async/test_sequence.cu
@@ -47,8 +47,8 @@ C2H_TEST("simple use of sequence executes both child operations", "[adaptors][se
   auto op = cudax_async::connect(std::move(sndr1), checked_value_receiver<>{});
   cudax_async::start(op);
 
-  CUDAX_CHECK(flag1);
-  CUDAX_CHECK(flag2);
+  CHECK(flag1);
+  CHECK(flag2);
 }
 
 } // namespace


### PR DESCRIPTION
## Description

while working on a different set of changes, i found i had to tweak the tests of ustdex for clang-cuda to accept them. these are those minor changes.

NB: i've based this PR on branch NVIDIA:pull-request/4523 so that only the relevant commit shows in the diff. i will rebase on main after #4523 is merged.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
