### PR TITLE
Add domain support and make all algorithms customizable with domain-based dispatch

### DIFF
--- a/cudax/include/cuda/experimental/__async/sender.cuh
+++ b/cudax/include/cuda/experimental/__async/sender.cuh
@@ -28,6 +28,7 @@
 #include <cuda/experimental/__async/sender/conditional.cuh>    // IWYU pragma: export
 #include <cuda/experimental/__async/sender/continue_on.cuh>    // IWYU pragma: export
 #include <cuda/experimental/__async/sender/cpos.cuh>           // IWYU pragma: export
+#include <cuda/experimental/__async/sender/domain.cuh>         // IWYU pragma: export
 #include <cuda/experimental/__async/sender/just.cuh>           // IWYU pragma: export
 #include <cuda/experimental/__async/sender/just_from.cuh>      // IWYU pragma: export
 #include <cuda/experimental/__async/sender/let_value.cuh>      // IWYU pragma: export

--- a/cudax/include/cuda/experimental/__async/sender/completion_signatures.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/completion_signatures.cuh
@@ -34,7 +34,9 @@
 #include <cuda/experimental/__async/sender/exception.cuh>
 #include <cuda/experimental/__async/sender/tuple.cuh>
 #include <cuda/experimental/__async/sender/type_traits.cuh>
+#include <cuda/experimental/__async/sender/utility.cuh>
 #include <cuda/experimental/__detail/config.cuh>
+#include <cuda/experimental/__detail/utility.cuh>
 
 #include <nv/target>
 

--- a/cudax/include/cuda/experimental/__async/sender/continue_on.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/continue_on.cuh
@@ -26,6 +26,7 @@
 
 #include <cuda/experimental/__async/sender/completion_signatures.cuh>
 #include <cuda/experimental/__async/sender/cpos.cuh>
+#include <cuda/experimental/__async/sender/env.cuh>
 #include <cuda/experimental/__async/sender/exception.cuh>
 #include <cuda/experimental/__async/sender/meta.cuh>
 #include <cuda/experimental/__async/sender/queries.cuh>
@@ -167,7 +168,18 @@ private:
     connect_result_t<schedule_result_t<_Sch>, __rcvr_ref<__rcvr_t<_Rcvr, __result_t>>> __opstate2_;
   };
 
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __fn
+  {
+    template <class _Sch, class _Sndr>
+    _CUDAX_TRIVIAL_API constexpr auto operator()(_Sch __sch, _Sndr __sndr) const;
+  };
+
 public:
+  _CUDAX_API static constexpr auto __apply() noexcept
+  {
+    return __fn{};
+  }
+
   template <class _Sndr, class _Sch>
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __sndr_t;
 
@@ -175,10 +187,10 @@ public:
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __closure_t;
 
   template <class _Sndr, class _Sch>
-  _CUDAX_TRIVIAL_API constexpr __sndr_t<_Sndr, _Sch> operator()(_Sndr __sndr, _Sch __sch) const noexcept;
+  _CUDAX_TRIVIAL_API constexpr auto operator()(_Sndr __sndr, _Sch __sch) const;
 
   template <class _Sch>
-  _CUDAX_TRIVIAL_API constexpr __closure_t<_Sch> operator()(_Sch __sch) const noexcept;
+  _CUDAX_TRIVIAL_API constexpr auto operator()(_Sch __sch) const noexcept -> __closure_t<_Sch>;
 };
 
 template <class _Sch>
@@ -227,14 +239,13 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT continue_on_t::__sndr_t
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __attrs_t
   {
     template <class _SetTag>
-    _CUDAX_API auto query(get_completion_scheduler_t<_SetTag>) const noexcept
+    _CUDAX_API auto query(get_completion_scheduler_t<_SetTag>) const noexcept -> _Sch
     {
       return __sndr_->__sch_;
     }
 
     template <class _Query>
-    _CUDAX_API auto query(_Query) const //
-      -> __query_result_t<_Query, env_of_t<_Sndr>>
+    _CUDAX_API auto query(_Query) const -> __query_result_t<_Query, env_of_t<_Sndr>>
     {
       return __async::get_env(__sndr_->__sndr_).query(_Query{});
     }
@@ -279,15 +290,21 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT continue_on_t::__sndr_t
   }
 };
 
-template <class _Sndr, class _Sch>
-_CUDAX_TRIVIAL_API constexpr auto continue_on_t::operator()(_Sndr __sndr, _Sch __sch) const noexcept
-  -> continue_on_t::__sndr_t<_Sndr, _Sch>
+template <class _Sch, class _Sndr>
+_CUDAX_TRIVIAL_API constexpr auto continue_on_t::__fn::operator()(_Sch __sch, _Sndr __sndr) const
 {
   return __sndr_t<_Sndr, _Sch>{{}, __sch, static_cast<_Sndr&&>(__sndr)};
 }
 
+template <class _Sndr, class _Sch>
+_CUDAX_TRIVIAL_API constexpr auto continue_on_t::operator()(_Sndr __sndr, _Sch __sch) const
+{
+  using __dom_t _CCCL_NODEBUG_ALIAS = early_domain_of_t<_Sndr>;
+  return __dom_t::__apply(*this)(static_cast<_Sch&&>(__sch), static_cast<_Sndr&&>(__sndr));
+}
+
 template <class _Sch>
-_CUDAX_TRIVIAL_API constexpr continue_on_t::__closure_t<_Sch> continue_on_t::operator()(_Sch __sch) const noexcept
+_CUDAX_TRIVIAL_API constexpr auto continue_on_t::operator()(_Sch __sch) const noexcept -> __closure_t<_Sch>
 {
   return __closure_t<_Sch>{__sch};
 }

--- a/cudax/include/cuda/experimental/__async/sender/cpos.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/cpos.cuh
@@ -22,62 +22,14 @@
 #endif // no system header
 
 #include <cuda/std/__type_traits/is_same.h>
-#include <cuda/std/__type_traits/remove_cvref.h>
 
-#include <cuda/experimental/__async/sender/env.cuh>
-#include <cuda/experimental/__async/sender/meta.cuh>
-#include <cuda/experimental/__async/sender/type_traits.cuh>
-#include <cuda/experimental/__async/sender/utility.cuh>
+#include <cuda/experimental/__async/sender/fwd.cuh>
 #include <cuda/experimental/__detail/config.cuh>
-#include <cuda/experimental/__detail/utility.cuh>
 
 #include <cuda/experimental/__async/sender/prologue.cuh>
 
 namespace cuda::experimental::__async
 {
-struct _CCCL_TYPE_VISIBILITY_DEFAULT dependent_sender_error;
-
-template <class... _Sigs>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT completion_signatures;
-
-struct _CCCL_TYPE_VISIBILITY_DEFAULT receiver_t
-{};
-
-struct _CCCL_TYPE_VISIBILITY_DEFAULT operation_state_t
-{};
-
-struct _CCCL_TYPE_VISIBILITY_DEFAULT sender_t
-{};
-
-struct _CCCL_TYPE_VISIBILITY_DEFAULT scheduler_t
-{};
-
-template <class _Ty>
-using __sender_concept_t _CCCL_NODEBUG_ALIAS = typename _CUDA_VSTD::remove_reference_t<_Ty>::sender_concept;
-
-template <class _Ty>
-using __receiver_concept_t _CCCL_NODEBUG_ALIAS = typename _CUDA_VSTD::remove_reference_t<_Ty>::receiver_concept;
-
-template <class _Ty>
-using __scheduler_concept_t _CCCL_NODEBUG_ALIAS = typename _CUDA_VSTD::remove_reference_t<_Ty>::scheduler_concept;
-
-template <class _Ty>
-inline constexpr bool __is_sender = __type_valid_v<__sender_concept_t, _Ty>;
-
-template <class _Ty>
-inline constexpr bool __is_receiver = __type_valid_v<__receiver_concept_t, _Ty>;
-
-template <class _Ty>
-inline constexpr bool __is_scheduler = __type_valid_v<__scheduler_concept_t, _Ty>;
-
-// handy enumerations for keeping type names readable
-enum __disposition_t
-{
-  __value,
-  __error,
-  __stopped
-};
-
 // make the completion tags equality comparable
 template <__disposition_t _Disposition>
 struct __completion_tag
@@ -97,7 +49,7 @@ struct __completion_tag
   static constexpr __disposition_t __disposition = _Disposition;
 };
 
-_CCCL_GLOBAL_CONSTANT struct set_value_t : __completion_tag<__value>
+struct set_value_t : __completion_tag<__value>
 {
   template <class _Rcvr, class... _Ts>
   _CUDAX_TRIVIAL_API auto operator()(_Rcvr&& __rcvr, _Ts&&... __ts) const noexcept
@@ -108,9 +60,9 @@ _CCCL_GLOBAL_CONSTANT struct set_value_t : __completion_tag<__value>
     static_assert(noexcept(static_cast<_Rcvr&&>(__rcvr).set_value(static_cast<_Ts&&>(__ts)...)));
     static_cast<_Rcvr&&>(__rcvr).set_value(static_cast<_Ts&&>(__ts)...);
   }
-} set_value{};
+};
 
-_CCCL_GLOBAL_CONSTANT struct set_error_t : __completion_tag<__error>
+struct set_error_t : __completion_tag<__error>
 {
   template <class _Rcvr, class _Ey>
   _CUDAX_TRIVIAL_API auto operator()(_Rcvr&& __rcvr, _Ey&& __e) const noexcept
@@ -121,9 +73,9 @@ _CCCL_GLOBAL_CONSTANT struct set_error_t : __completion_tag<__error>
     static_assert(noexcept(static_cast<_Rcvr&&>(__rcvr).set_error(static_cast<_Ey&&>(__e))));
     static_cast<_Rcvr&&>(__rcvr).set_error(static_cast<_Ey&&>(__e));
   }
-} set_error{};
+};
 
-_CCCL_GLOBAL_CONSTANT struct set_stopped_t : __completion_tag<__stopped>
+struct set_stopped_t : __completion_tag<__stopped>
 {
   template <class _Rcvr>
   _CUDAX_TRIVIAL_API auto operator()(_Rcvr&& __rcvr) const noexcept
@@ -133,26 +85,21 @@ _CCCL_GLOBAL_CONSTANT struct set_stopped_t : __completion_tag<__stopped>
     static_assert(noexcept(static_cast<_Rcvr&&>(__rcvr).set_stopped()));
     static_cast<_Rcvr&&>(__rcvr).set_stopped();
   }
-} set_stopped{};
+};
 
-_CCCL_GLOBAL_CONSTANT struct start_t
+struct start_t
 {
   template <class _OpState>
   _CUDAX_TRIVIAL_API auto operator()(_OpState& __opstate) const noexcept -> decltype(__opstate.start())
   {
-    // static_assert(!__type_is_error<typename _OpState::completion_signatures>);
     static_assert(_CUDA_VSTD::is_same_v<decltype(__opstate.start()), void>);
     static_assert(noexcept(__opstate.start()));
     __opstate.start();
   }
-} start{};
-
-// get_completion_signatures
-template <class _Sndr, class... _Env>
-_CUDAX_TRIVIAL_API _CUDAX_CONSTEVAL auto get_completion_signatures();
+};
 
 // connect
-_CCCL_GLOBAL_CONSTANT struct connect_t
+struct connect_t
 {
   template <class _Sndr, class _Rcvr>
   _CUDAX_TRIVIAL_API auto operator()(_Sndr&& __sndr, _Rcvr&& __rcvr) const
@@ -161,9 +108,9 @@ _CCCL_GLOBAL_CONSTANT struct connect_t
   {
     return static_cast<_Sndr&&>(__sndr).connect(static_cast<_Rcvr&&>(__rcvr));
   }
-} connect{};
+};
 
-_CCCL_GLOBAL_CONSTANT struct schedule_t
+struct schedule_t
 {
   template <class _Sch>
   _CUDAX_TRIVIAL_API auto operator()(_Sch&& __sch) const noexcept -> decltype(static_cast<_Sch&&>(__sch).schedule())
@@ -171,31 +118,23 @@ _CCCL_GLOBAL_CONSTANT struct schedule_t
     static_assert(noexcept(static_cast<_Sch&&>(__sch).schedule()));
     return static_cast<_Sch&&>(__sch).schedule();
   }
-} schedule{};
+};
+
+_CCCL_GLOBAL_CONSTANT set_value_t set_value{};
+_CCCL_GLOBAL_CONSTANT set_error_t set_error{};
+_CCCL_GLOBAL_CONSTANT set_stopped_t set_stopped{};
+_CCCL_GLOBAL_CONSTANT start_t start{};
+_CCCL_GLOBAL_CONSTANT connect_t connect{};
+_CCCL_GLOBAL_CONSTANT schedule_t schedule{};
 
 template <class _Sndr, class _Rcvr>
 using connect_result_t _CCCL_NODEBUG_ALIAS = decltype(connect(declval<_Sndr>(), declval<_Rcvr>()));
-
-template <class _Sndr, class... _Env>
-using completion_signatures_of_t _CCCL_NODEBUG_ALIAS = decltype(get_completion_signatures<_Sndr, _Env...>());
 
 template <class _Sch>
 using schedule_result_t _CCCL_NODEBUG_ALIAS = decltype(schedule(declval<_Sch>()));
 
 template <class _Sndr, class _Rcvr>
 inline constexpr bool __nothrow_connectable = noexcept(connect(declval<_Sndr>(), declval<_Rcvr>()));
-
-namespace __detail
-{
-template <__disposition_t, class _Void = void>
-extern __undefined<_Void> __set_tag;
-template <class _Void>
-extern __fn_t<set_value_t>* __set_tag<__value, _Void>;
-template <class _Void>
-extern __fn_t<set_error_t>* __set_tag<__error, _Void>;
-template <class _Void>
-extern __fn_t<set_stopped_t>* __set_tag<__stopped, _Void>;
-} // namespace __detail
 } // namespace cuda::experimental::__async
 
 #include <cuda/experimental/__async/sender/epilogue.cuh>

--- a/cudax/include/cuda/experimental/__async/sender/domain.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/domain.cuh
@@ -1,0 +1,42 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __CUDAX_ASYNC_DETAIL_DOMAIN
+#define __CUDAX_ASYNC_DETAIL_DOMAIN
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/experimental/__detail/config.cuh>
+
+#include <cuda/experimental/__async/sender/prologue.cuh>
+
+namespace cuda::experimental::__async
+{
+struct _CCCL_TYPE_VISIBILITY_DEFAULT default_domain
+{
+  template <class _Tag>
+  _CUDAX_API static constexpr auto __apply(_Tag) noexcept
+  {
+    return _Tag::__apply();
+  }
+};
+} // namespace cuda::experimental::__async
+
+#include <cuda/experimental/__async/sender/epilogue.cuh>
+
+#endif // __CUDAX_ASYNC_DETAIL_DOMAIN

--- a/cudax/include/cuda/experimental/__async/sender/fwd.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/fwd.cuh
@@ -1,0 +1,109 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __CUDAX_ASYNC_DETAIL_FWD
+#define __CUDAX_ASYNC_DETAIL_FWD
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__type_traits/remove_reference.h>
+#include <cuda/std/__type_traits/type_list.h>
+
+#include <cuda/experimental/__async/sender/meta.cuh>
+#include <cuda/experimental/__detail/config.cuh>
+
+#include <cuda/experimental/__async/sender/prologue.cuh>
+
+namespace cuda::experimental::__async
+{
+struct _CCCL_TYPE_VISIBILITY_DEFAULT receiver_t
+{};
+
+struct _CCCL_TYPE_VISIBILITY_DEFAULT operation_state_t
+{};
+
+struct _CCCL_TYPE_VISIBILITY_DEFAULT sender_t
+{};
+
+struct _CCCL_TYPE_VISIBILITY_DEFAULT scheduler_t
+{};
+
+template <class _Ty>
+using __sender_concept_t _CCCL_NODEBUG_ALIAS = typename _CUDA_VSTD::remove_reference_t<_Ty>::sender_concept;
+
+template <class _Ty>
+using __receiver_concept_t _CCCL_NODEBUG_ALIAS = typename _CUDA_VSTD::remove_reference_t<_Ty>::receiver_concept;
+
+template <class _Ty>
+using __scheduler_concept_t _CCCL_NODEBUG_ALIAS = typename _CUDA_VSTD::remove_reference_t<_Ty>::scheduler_concept;
+
+template <class _Ty>
+inline constexpr bool __is_sender = __type_valid_v<__sender_concept_t, _Ty>;
+
+template <class _Ty>
+inline constexpr bool __is_receiver = __type_valid_v<__receiver_concept_t, _Ty>;
+
+template <class _Ty>
+inline constexpr bool __is_scheduler = __type_valid_v<__scheduler_concept_t, _Ty>;
+
+struct default_domain;
+struct stream_domain;
+struct dependent_sender_error;
+
+template <class... _Sigs>
+struct completion_signatures;
+
+template <class _Sndr, class... _Env>
+_CUDAX_TRIVIAL_API _CUDAX_CONSTEVAL auto get_completion_signatures();
+
+template <class _Sndr, class... _Env>
+using completion_signatures_of_t _CCCL_NODEBUG_ALIAS = decltype(get_completion_signatures<_Sndr, _Env...>());
+
+// handy enumerations for keeping type names readable
+enum __disposition_t
+{
+  __value,
+  __error,
+  __stopped
+};
+
+struct set_value_t;
+struct set_error_t;
+struct set_stopped_t;
+struct start_t;
+struct connect_t;
+struct schedule_t;
+struct get_env_t;
+struct sync_wait_t;
+
+namespace __detail
+{
+template <__disposition_t, class _Void = void>
+extern _CUDA_VSTD::__undefined<_Void> __set_tag;
+template <class _Void>
+extern __fn_t<set_value_t>* __set_tag<__value, _Void>;
+template <class _Void>
+extern __fn_t<set_error_t>* __set_tag<__error, _Void>;
+template <class _Void>
+extern __fn_t<set_stopped_t>* __set_tag<__stopped, _Void>;
+} // namespace __detail
+} // namespace cuda::experimental::__async
+
+#include <cuda/experimental/__async/sender/epilogue.cuh>
+
+#endif

--- a/cudax/include/cuda/experimental/__async/sender/just.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/just.cuh
@@ -114,7 +114,7 @@ public:
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __sndr_t;
 
   template <class... _Ts>
-  _CUDAX_TRIVIAL_API auto operator()(_Ts... __ts) const;
+  _CUDAX_TRIVIAL_API constexpr auto operator()(_Ts... __ts) const;
 };
 
 template <__disposition_t _Disposition>
@@ -150,7 +150,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __just_t<_Disposition>::__sndr_t
 
 template <__disposition_t _Disposition>
 template <class... _Ts>
-_CUDAX_TRIVIAL_API auto __just_t<_Disposition>::operator()(_Ts... __ts) const
+_CUDAX_TRIVIAL_API constexpr auto __just_t<_Disposition>::operator()(_Ts... __ts) const
 {
   using _Values _CCCL_NODEBUG_ALIAS = decltype(__mk_values(__ts...));
   return __sndr_t<_Values>{{}, __mk_values(__ts...)};

--- a/cudax/include/cuda/experimental/__async/sender/just_from.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/just_from.cuh
@@ -112,7 +112,7 @@ public:
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __sndr_t;
 
   template <class _Fn>
-  _CUDAX_TRIVIAL_API auto operator()(_Fn __fn) const noexcept -> __sndr_t<_Fn>;
+  _CUDAX_TRIVIAL_API constexpr auto operator()(_Fn __fn) const noexcept -> __sndr_t<_Fn>;
 };
 
 template <__disposition_t _Disposition>
@@ -147,7 +147,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __just_from_t<_Disposition>::__sndr_t
 
 template <__disposition_t _Disposition>
 template <class _Fn>
-_CUDAX_TRIVIAL_API auto __just_from_t<_Disposition>::operator()(_Fn __fn) const noexcept -> __sndr_t<_Fn>
+_CUDAX_TRIVIAL_API constexpr auto __just_from_t<_Disposition>::operator()(_Fn __fn) const noexcept -> __sndr_t<_Fn>
 {
   using __completions _CCCL_NODEBUG_ALIAS = __call_result_t<_Fn, __probe_fn>;
   static_assert(__valid_completion_signatures<__completions>,

--- a/cudax/include/cuda/experimental/__async/sender/let_value.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/let_value.cuh
@@ -28,6 +28,7 @@
 #include <cuda/experimental/__async/sender/completion_signatures.cuh>
 #include <cuda/experimental/__async/sender/concepts.cuh>
 #include <cuda/experimental/__async/sender/cpos.cuh>
+#include <cuda/experimental/__async/sender/env.cuh>
 #include <cuda/experimental/__async/sender/exception.cuh>
 #include <cuda/experimental/__async/sender/rcvr_ref.cuh>
 #include <cuda/experimental/__async/sender/tuple.cuh>
@@ -216,7 +217,18 @@ private:
     }
   };
 
+  struct __fn
+  {
+    template <class _Fn, class _Sndr>
+    _CUDAX_TRIVIAL_API constexpr auto operator()(_Fn __fn, _Sndr __sndr) const;
+  };
+
 public:
+  _CUDAX_API static constexpr auto __apply() noexcept
+  {
+    return __fn{};
+  }
+
   /// @brief The `let_(value|error|stopped)` sender.
   /// @tparam _Sndr The predecessor sender.
   /// @tparam _Fn The function to be called when the predecessor sender
@@ -228,10 +240,10 @@ public:
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __closure_t;
 
   template <class _Sndr, class _Fn>
-  _CUDAX_API auto operator()(_Sndr __sndr, _Fn __fn) const -> __sndr_t<_Sndr, _Fn>;
+  _CUDAX_TRIVIAL_API constexpr auto operator()(_Sndr __sndr, _Fn __fn) const;
 
   template <class _Fn>
-  _CUDAX_TRIVIAL_API auto operator()(_Fn __fn) const noexcept -> __closure_t<_Fn>;
+  _CUDAX_TRIVIAL_API constexpr auto operator()(_Fn __fn) const noexcept -> __closure_t<_Fn>;
 };
 
 template <__disposition_t _Disposition>
@@ -310,8 +322,8 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __let_t<_Disposition>::__closure_t
 };
 
 template <__disposition_t _Disposition>
-template <class _Sndr, class _Fn>
-_CUDAX_API auto __let_t<_Disposition>::operator()(_Sndr __sndr, _Fn __fn) const -> __sndr_t<_Sndr, _Fn>
+template <class _Fn, class _Sndr>
+_CUDAX_TRIVIAL_API constexpr auto __let_t<_Disposition>::__fn::operator()(_Fn __fn, _Sndr __sndr) const
 {
   // If the incoming sender is non-dependent, we can check the completion
   // signatures of the composed sender immediately.
@@ -324,8 +336,16 @@ _CUDAX_API auto __let_t<_Disposition>::operator()(_Sndr __sndr, _Fn __fn) const 
 }
 
 template <__disposition_t _Disposition>
+template <class _Sndr, class _Fn>
+_CUDAX_TRIVIAL_API constexpr auto __let_t<_Disposition>::operator()(_Sndr __sndr, _Fn __fn) const
+{
+  using __dom_t _CCCL_NODEBUG_ALIAS = early_domain_of_t<_Sndr>;
+  return __dom_t::__apply(*this)(static_cast<_Fn&&>(__fn), static_cast<_Sndr&&>(__sndr));
+}
+
+template <__disposition_t _Disposition>
 template <class _Fn>
-_CUDAX_TRIVIAL_API auto __let_t<_Disposition>::operator()(_Fn __fn) const noexcept -> __closure_t<_Fn>
+_CUDAX_TRIVIAL_API constexpr auto __let_t<_Disposition>::operator()(_Fn __fn) const noexcept -> __closure_t<_Fn>
 {
   return __closure_t<_Fn>{static_cast<_Fn&&>(__fn)};
 }

--- a/cudax/include/cuda/experimental/__async/sender/queries.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/queries.cuh
@@ -27,6 +27,8 @@ _CCCL_SUPPRESS_DEPRECATED_PUSH
 #include <cuda/std/__memory/allocator.h>
 _CCCL_SUPPRESS_DEPRECATED_POP
 
+#include <cuda/experimental/__async/sender/domain.cuh>
+#include <cuda/experimental/__async/sender/fwd.cuh>
 #include <cuda/experimental/__async/sender/meta.cuh>
 #include <cuda/experimental/__async/sender/stop_token.cuh>
 #include <cuda/experimental/__async/sender/type_traits.cuh>
@@ -56,49 +58,58 @@ template <class _Ty, class _Query>
 inline constexpr bool __nothrow_queryable_with = __type_valid_v<__nothrow_queryable_with_, _Ty, _Query>;
 #endif
 
+//////////////////////////////////////////////////////////////////////////////////////////
+// get_allocator
 _CCCL_GLOBAL_CONSTANT struct get_allocator_t
 {
   template <class _Env>
-  _CUDAX_API auto operator()(const _Env& __env) const noexcept //
-    -> decltype(__env.query(*this))
+  _CUDAX_API auto operator()(const _Env& __env) const noexcept
   {
-    static_assert(noexcept(__env.query(*this)));
-    return __env.query(*this);
-  }
-
-  _CUDAX_API auto operator()(__ignore) const noexcept -> _CUDA_VSTD::allocator<void>
-  {
-    return {};
+    if constexpr (__queryable_with<_Env, get_allocator_t>)
+    {
+      static_assert(noexcept(__env.query(*this)));
+      return __env.query(*this);
+    }
+    else
+    {
+      return _CUDA_VSTD::allocator<void>{};
+    }
   }
 } get_allocator{};
 
+//////////////////////////////////////////////////////////////////////////////////////////
+// get_stop_token
 _CCCL_GLOBAL_CONSTANT struct get_stop_token_t
 {
   template <class _Env>
-  _CUDAX_API auto operator()(const _Env& __env) const noexcept //
-    -> decltype(__env.query(*this))
+  _CUDAX_API auto operator()(const _Env& __env) const noexcept
   {
-    static_assert(noexcept(__env.query(*this)));
-    return __env.query(*this);
-  }
-
-  _CUDAX_API auto operator()(__ignore) const noexcept -> never_stop_token
-  {
-    return {};
+    if constexpr (__queryable_with<_Env, get_stop_token_t>)
+    {
+      static_assert(noexcept(__env.query(*this)));
+      return __env.query(*this);
+    }
+    else
+    {
+      return never_stop_token{};
+    }
   }
 } get_stop_token{};
 
 template <class _Ty>
 using stop_token_of_t _CCCL_NODEBUG_ALIAS = __decay_t<__call_result_t<get_stop_token_t, _Ty>>;
 
+//////////////////////////////////////////////////////////////////////////////////////////
+// get_completion_scheduler
 template <class _Tag>
 struct get_completion_scheduler_t
 {
-  template <class _Env>
-  _CUDAX_API auto operator()(const _Env& __env) const noexcept //
-    -> decltype(__env.query(*this))
+  _CCCL_TEMPLATE(class _Env)
+  _CCCL_REQUIRES(__queryable_with<_Env, get_completion_scheduler_t>)
+  _CUDAX_API auto operator()(const _Env& __env) const noexcept
   {
     static_assert(noexcept(__env.query(*this)));
+    static_assert(__is_scheduler<decltype(__env.query(*this))>);
     return __env.query(*this);
   }
 };
@@ -106,28 +117,43 @@ struct get_completion_scheduler_t
 template <class _Tag>
 _CCCL_GLOBAL_CONSTANT get_completion_scheduler_t<_Tag> get_completion_scheduler{};
 
+template <class _Env, class _Tag = set_value_t>
+using __completion_scheduler_of_t _CCCL_NODEBUG_ALIAS =
+  __decay_t<__call_result_t<get_completion_scheduler_t<_Tag>, _Env>>;
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// get_scheduler
 _CCCL_GLOBAL_CONSTANT struct get_scheduler_t
 {
-  template <class _Env>
-  _CUDAX_API auto operator()(const _Env& __env) const noexcept //
-    -> decltype(__env.query(*this))
+  _CCCL_TEMPLATE(class _Env)
+  _CCCL_REQUIRES(__queryable_with<_Env, get_scheduler_t>)
+  _CUDAX_API auto operator()(const _Env& __env) const noexcept
   {
     static_assert(noexcept(__env.query(*this)));
+    static_assert(__is_scheduler<decltype(__env.query(*this))>);
     return __env.query(*this);
   }
 } get_scheduler{};
 
+template <class _Env>
+using __scheduler_of_t _CCCL_NODEBUG_ALIAS = __decay_t<__call_result_t<get_scheduler_t, _Env>>;
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// get_delegation_scheduler
 _CCCL_GLOBAL_CONSTANT struct get_delegation_scheduler_t
 {
-  template <class _Env>
-  _CUDAX_API auto operator()(const _Env& __env) const noexcept //
-    -> decltype(__env.query(*this))
+  _CCCL_TEMPLATE(class _Env)
+  _CCCL_REQUIRES(__queryable_with<_Env, get_delegation_scheduler_t>)
+  _CUDAX_API auto operator()(const _Env& __env) const noexcept
   {
     static_assert(noexcept(__env.query(*this)));
+    static_assert(__is_scheduler<decltype(__env.query(*this))>);
     return __env.query(*this);
   }
 } get_delegation_scheduler{};
 
+//////////////////////////////////////////////////////////////////////////////////////////
+// get_forward_progress_guarantee
 enum class forward_progress_guarantee
 {
   concurrent,
@@ -138,31 +164,41 @@ enum class forward_progress_guarantee
 _CCCL_GLOBAL_CONSTANT struct get_forward_progress_guarantee_t
 {
   template <class _Sch>
-  _CUDAX_API auto operator()(const _Sch& __sch) const noexcept //
-    -> decltype(__async::__decay_copy(__sch.query(*this)))
+  _CUDAX_API auto operator()(const _Sch& __sch) const noexcept
   {
-    static_assert(noexcept(__sch.query(*this)));
-    return __sch.query(*this);
-  }
-
-  _CUDAX_API auto operator()(__ignore) const noexcept -> forward_progress_guarantee
-  {
-    return forward_progress_guarantee::weakly_parallel;
+    if constexpr (__queryable_with<_Sch, get_forward_progress_guarantee_t>)
+    {
+      static_assert(noexcept(__sch.query(*this)));
+      return __sch.query(*this);
+    }
+    else
+    {
+      return forward_progress_guarantee::weakly_parallel;
+    }
   }
 } get_forward_progress_guarantee{};
 
+//////////////////////////////////////////////////////////////////////////////////////////
+// get_domain
 _CCCL_GLOBAL_CONSTANT struct get_domain_t
 {
-  template <class _Sch>
-  _CUDAX_API constexpr auto operator()(const _Sch& __sch) const noexcept //
-    -> decltype(__async::__decay_copy(__sch.query(*this)))
+  template <class _Env>
+  _CUDAX_API constexpr auto operator()(const _Env& __env) const noexcept
   {
-    return {};
+    if constexpr (__queryable_with<_Env, get_domain_t>)
+    {
+      static_assert(noexcept(__env.query(*this)));
+      return __env.query(*this);
+    }
+    else
+    {
+      return default_domain{};
+    }
   }
 } get_domain{};
 
-template <class _Sch>
-using domain_of_t _CCCL_NODEBUG_ALIAS = __call_result_t<get_domain_t, _Sch>;
+template <class _Env>
+using __domain_of_t _CCCL_NODEBUG_ALIAS = __call_result_t<get_domain_t, _Env>;
 
 } // namespace cuda::experimental::__async
 

--- a/cudax/include/cuda/experimental/__async/sender/sequence.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/sequence.cuh
@@ -25,6 +25,7 @@
 
 #include <cuda/experimental/__async/sender/completion_signatures.cuh>
 #include <cuda/experimental/__async/sender/cpos.cuh>
+#include <cuda/experimental/__async/sender/env.cuh>
 #include <cuda/experimental/__async/sender/exception.cuh>
 #include <cuda/experimental/__async/sender/lazy.cuh>
 #include <cuda/experimental/__async/sender/rcvr_ref.cuh>
@@ -38,6 +39,7 @@ namespace cuda::experimental::__async
 {
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __seq_t
 {
+private:
   template <class _Rcvr, class _Sndr1, class _Sndr2>
   struct __args
   {
@@ -95,11 +97,23 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __seq_t
     connect_result_t<__sndr2_t, __rcvr_ref<__rcvr_t>> __opstate2_;
   };
 
+  struct __fn
+  {
+    template <class _Sndr1, class _Sndr2>
+    _CUDAX_TRIVIAL_API constexpr auto operator()(__ignore, _Sndr1 __sndr1, _Sndr2 __sndr2) const;
+  };
+
+public:
+  _CUDAX_API static constexpr auto __apply() noexcept
+  {
+    return __fn{};
+  }
+
   template <class _Sndr1, class _Sndr2>
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __sndr_t;
 
   template <class _Sndr1, class _Sndr2>
-  _CUDAX_TRIVIAL_API constexpr auto operator()(_Sndr1 __sndr1, _Sndr2 __sndr2) const -> __sndr_t<_Sndr1, _Sndr2>;
+  _CUDAX_TRIVIAL_API constexpr auto operator()(_Sndr1 __sndr1, _Sndr2 __sndr2) const;
 };
 
 template <class _Sndr1, class _Sndr2>
@@ -150,9 +164,17 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __seq_t::__sndr_t
 };
 
 template <class _Sndr1, class _Sndr2>
-_CUDAX_TRIVIAL_API constexpr auto __seq_t::operator()(_Sndr1 __sndr1, _Sndr2 __sndr2) const -> __sndr_t<_Sndr1, _Sndr2>
+_CUDAX_TRIVIAL_API constexpr auto __seq_t::__fn::operator()(__ignore, _Sndr1 __sndr1, _Sndr2 __sndr2) const
 {
-  return __sndr_t<_Sndr1, _Sndr2>{{}, {}, static_cast<_Sndr1&&>(__sndr1), static_cast<_Sndr2&&>(__sndr2)};
+  using __sndr_t _CCCL_NODEBUG_ALIAS = __seq_t::__sndr_t<_Sndr1, _Sndr2>;
+  return __sndr_t{{}, {}, static_cast<_Sndr1&&>(__sndr1), static_cast<_Sndr2&&>(__sndr2)};
+}
+
+template <class _Sndr1, class _Sndr2>
+_CUDAX_TRIVIAL_API constexpr auto __seq_t::operator()(_Sndr1 __sndr1, _Sndr2 __sndr2) const
+{
+  using __dom_t _CCCL_NODEBUG_ALIAS = early_domain_of_t<_Sndr1>;
+  return __dom_t::__apply(*this)(__ignore{}, static_cast<_Sndr1&&>(__sndr1), static_cast<_Sndr2&&>(__sndr2));
 }
 
 template <class _Sndr1, class _Sndr2>

--- a/cudax/include/cuda/experimental/__async/sender/start_detached.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/start_detached.cuh
@@ -24,6 +24,8 @@
 #include <cuda/std/__exception/terminate.h>
 
 #include <cuda/experimental/__async/sender/cpos.cuh>
+#include <cuda/experimental/__async/sender/env.cuh>
+#include <cuda/experimental/__async/sender/utility.cuh>
 #include <cuda/experimental/__detail/config.cuh>
 #include <cuda/experimental/__detail/utility.cuh>
 
@@ -77,19 +79,33 @@ private:
         : __opstate_(__async::connect(static_cast<_Sndr&&>(__sndr), __rcvr_t{this, &__destroy}))
     {}
 
-    _CUDAX_API void start() & noexcept
+    _CUDAX_API void start() noexcept
     {
       __async::start(__opstate_);
     }
   };
 
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __fn
+  {
+    template <class _Sndr>
+    _CUDAX_API auto operator()(_Sndr __sndr) const
+    {
+      __async::start(*new __opstate_t<_Sndr>{static_cast<_Sndr&&>(__sndr)});
+    }
+  };
+
 public:
-  /// @brief Eagerly connects and starts a sender and lets it
+  _CUDAX_API static constexpr auto __apply() noexcept
+  {
+    return __fn{};
+  }
+
   /// run detached.
   template <class _Sndr>
   _CUDAX_TRIVIAL_API void operator()(_Sndr __sndr) const
   {
-    __async::start(*new __opstate_t<_Sndr>{static_cast<_Sndr&&>(__sndr)});
+    using __dom_t _CCCL_NODEBUG_ALIAS = early_domain_of_t<_Sndr>;
+    __dom_t::__apply (*this)(static_cast<_Sndr&&>(__sndr));
   }
 };
 

--- a/cudax/include/cuda/experimental/__async/sender/start_on.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/start_on.cuh
@@ -85,12 +85,23 @@ private:
     connect_result_t<_CvSndr, __rcvr_ref<__rcvr_with_sch_t>> __opstate2_;
   };
 
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __fn
+  {
+    template <class _Sch, class _Sndr>
+    _CUDAX_TRIVIAL_API constexpr auto operator()(_Sch __sch, _Sndr __sndr) const;
+  };
+
 public:
+  _CUDAX_API static constexpr auto __apply() noexcept
+  {
+    return __fn{};
+  }
+
   template <class _Sch, class _Sndr>
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __sndr_t;
 
   template <class _Sch, class _Sndr>
-  _CUDAX_TRIVIAL_API constexpr auto operator()(_Sch __sch, _Sndr __sndr) const noexcept -> __sndr_t<_Sch, _Sndr>;
+  _CUDAX_TRIVIAL_API constexpr auto operator()(_Sch __sch, _Sndr __sndr) const;
 };
 
 template <class _Sch, class _Sndr>
@@ -141,10 +152,16 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT start_on_t::__sndr_t
 };
 
 template <class _Sch, class _Sndr>
-_CUDAX_TRIVIAL_API constexpr auto start_on_t::operator()(_Sch __sch, _Sndr __sndr) const noexcept
-  -> __sndr_t<_Sch, _Sndr>
+_CUDAX_TRIVIAL_API constexpr auto start_on_t::__fn::operator()(_Sch __sch, _Sndr __sndr) const
 {
   return __sndr_t<_Sch, _Sndr>{{}, __sch, __sndr};
+}
+
+template <class _Sch, class _Sndr>
+_CUDAX_TRIVIAL_API constexpr auto start_on_t::operator()(_Sch __sch, _Sndr __sndr) const
+{
+  using __dom_t _CCCL_NODEBUG_ALIAS = __domain_of_t<_Sch>; // see [exec.starts.on]
+  return __dom_t::__apply(*this)(static_cast<_Sch&&>(__sch), static_cast<_Sndr&&>(__sndr));
 }
 
 template <class _Sch, class _Sndr>

--- a/cudax/include/cuda/experimental/__async/sender/sync_wait.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/sync_wait.cuh
@@ -21,24 +21,22 @@
 #  pragma system_header
 #endif // no system header
 
-// run_loop isn't supported on-device yet, so neither can sync_wait be.
-#if !defined(__CUDA_ARCH__)
+#include <cuda/std/__type_traits/always_false.h>
+#include <cuda/std/__type_traits/is_same.h>
+#include <cuda/std/__type_traits/type_identity.h>
+#include <cuda/std/optional>
+#include <cuda/std/tuple>
 
-#  include <cuda/std/__type_traits/always_false.h>
-#  include <cuda/std/__type_traits/is_same.h>
-#  include <cuda/std/__type_traits/type_identity.h>
-#  include <cuda/std/optional>
-#  include <cuda/std/tuple>
+#include <cuda/experimental/__async/sender/env.cuh>
+#include <cuda/experimental/__async/sender/exception.cuh>
+#include <cuda/experimental/__async/sender/meta.cuh>
+#include <cuda/experimental/__async/sender/run_loop.cuh>
+#include <cuda/experimental/__async/sender/utility.cuh>
+#include <cuda/experimental/__async/sender/write_env.cuh>
 
-#  include <cuda/experimental/__async/sender/exception.cuh>
-#  include <cuda/experimental/__async/sender/meta.cuh>
-#  include <cuda/experimental/__async/sender/run_loop.cuh>
-#  include <cuda/experimental/__async/sender/utility.cuh>
-#  include <cuda/experimental/__async/sender/write_env.cuh>
+#include <system_error>
 
-#  include <system_error>
-
-#  include <cuda/experimental/__async/sender/prologue.cuh>
+#include <cuda/experimental/__async/sender/prologue.cuh>
 
 namespace cuda::experimental::__async
 {
@@ -71,7 +69,7 @@ private:
       __state_t* __state_;
 
       template <class... _As>
-      _CUDAX_API void set_value(_As&&... __as) noexcept
+      _CUDAX_API void set_value(_As&&... __as) && noexcept
       {
         _CUDAX_TRY( //
           ({        //
@@ -86,7 +84,7 @@ private:
       }
 
       template <class _Error>
-      _CUDAX_API void set_error(_Error __err) noexcept
+      _CUDAX_API void set_error(_Error __err) && noexcept
       {
         if constexpr (_CUDA_VSTD::is_same_v<_Error, ::std::exception_ptr>)
         {
@@ -103,7 +101,7 @@ private:
         __state_->__loop_.finish();
       }
 
-      _CUDAX_API void set_stopped() noexcept
+      _CUDAX_API void set_stopped() && noexcept
       {
         __state_->__loop_.finish();
       }
@@ -132,77 +130,100 @@ private:
     int i{}; // so that structured bindings kinda work
   };
 
+  // This is the actual default sync_wait implementation.
+  struct __fn
+  {
+    template <class _Sndr>
+    _CUDAX_HOST_API auto operator()(_Sndr&& __sndr) const
+    {
+      using __completions _CCCL_NODEBUG_ALIAS = completion_signatures_of_t<_Sndr, __env_t>;
+
+      if constexpr (!__valid_completion_signatures<__completions>)
+      {
+        return __bad_sync_wait<__completions>::__result();
+      }
+      else
+      {
+        using __values _CCCL_NODEBUG_ALIAS = __value_types<__completions, _CUDA_VSTD::tuple, _CUDA_VSTD::__type_self_t>;
+        _CUDA_VSTD::optional<__values> __result{};
+        __state_t<__values> __state{&__result, {}, {}};
+
+        // Launch the sender with a continuation that will fill in a variant
+        using __rcvr   = typename __state_t<__values>::__rcvr_t;
+        auto __opstate = __async::connect(static_cast<_Sndr&&>(__sndr), __rcvr{&__state});
+        __async::start(__opstate);
+
+        // Wait for the variant to be filled in, and process any work that
+        // may be delegated to this thread.
+        __state.__loop_.run();
+
+        if (__state.__eptr_)
+        {
+          ::std::rethrow_exception(__state.__eptr_);
+        }
+
+        return __result; // uses NRVO to "return" the result
+      }
+    }
+
+    template <class _Sndr, class _Env>
+    _CUDAX_HOST_API auto operator()(_Sndr&& __sndr, _Env&& __env) const
+    {
+      return (*this)(__async::write_env(static_cast<_Sndr&&>(__sndr), static_cast<_Env&&>(__env)));
+    }
+  };
+
 public:
+  _CUDAX_HOST_API static constexpr auto __apply() noexcept
+  {
+    return __fn{};
+  }
+
   // clang-format off
-    /// @brief Synchronously wait for the result of a sender, blocking the
-    ///         current thread.
-    ///
-    /// `sync_wait` connects and starts the given sender, and then drives a
-    ///         `run_loop` instance until the sender completes. Additional work
-    ///         can be delegated to the `run_loop` by scheduling work on the
-    ///         scheduler returned by calling `get_delegation_scheduler` on the
-    ///         receiver's environment.
-    ///
-    /// @pre The sender must have a exactly one value completion signature. That
-    ///         is, it can only complete successfully in one way, with a single
-    ///         set of values.
-    ///
-    /// @retval success Returns an engaged `::std::optional` containing the result
-    ///         values in a `::std::tuple`.
-    /// @retval canceled Returns an empty `::std::optional`.
-    /// @retval error Throws the error.
-    ///
-    /// @throws ::std::rethrow_exception(error) if the error has type
-    ///         `::std::exception_ptr`.
-    /// @throws ::std::system_error(error) if the error has type
-    ///         `::std::error_code`.
-    /// @throws error otherwise
+  /// @brief Synchronously wait for the result of a sender, blocking the
+  ///         current thread.
+  ///
+  /// `sync_wait` connects and starts the given sender, and then drives a
+  ///         `run_loop` instance until the sender completes. Additional work
+  ///         can be delegated to the `run_loop` by scheduling work on the
+  ///         scheduler returned by calling `get_delegation_scheduler` on the
+  ///         receiver's environment.
+  ///
+  /// @pre The sender must have a exactly one value completion signature. That
+  ///         is, it can only complete successfully in one way, with a single
+  ///         set of values.
+  ///
+  /// @retval success Returns an engaged `cuda::std::optional` containing the result
+  ///         values in a `cuda::std::tuple`.
+  /// @retval canceled Returns an empty `cuda::std::optional`.
+  /// @retval error Throws the error.
+  ///
+  /// @throws ::std::rethrow_exception(error) if the error has type
+  ///         `::std::exception_ptr`.
+  /// @throws ::std::system_error(error) if the error has type
+  ///         `::std::error_code`.
+  /// @throws ::cuda::cuda_error(error, "...") if the error has type
+  ///         `cudaError_t`.
+  /// @throws error otherwise
   // clang-format on
   template <class _Sndr>
-  auto operator()(_Sndr&& __sndr) const
+  _CUDAX_HOST_API auto operator()(_Sndr&& __sndr) const
   {
-    using __completions _CCCL_NODEBUG_ALIAS = completion_signatures_of_t<_Sndr, __env_t>;
-
-    if constexpr (!__valid_completion_signatures<__completions>)
-    {
-      return __bad_sync_wait<__completions>::__result();
-    }
-    else
-    {
-      using __values _CCCL_NODEBUG_ALIAS = __value_types<__completions, _CUDA_VSTD::tuple, _CUDA_VSTD::__type_self_t>;
-      _CUDA_VSTD::optional<__values> __result{};
-      __state_t<__values> __state{&__result, {}, {}};
-
-      // Launch the sender with a continuation that will fill in a variant
-      using __rcvr _CCCL_NODEBUG_ALIAS = typename __state_t<__values>::__rcvr_t;
-      auto __opstate                   = __async::connect(static_cast<_Sndr&&>(__sndr), __rcvr{&__state});
-      __async::start(__opstate);
-
-      // Wait for the variant to be filled in, and process any work that
-      // may be delegated to this thread.
-      __state.__loop_.run();
-
-      if (__state.__eptr_)
-      {
-        ::std::rethrow_exception(__state.__eptr_);
-      }
-
-      return __result; // uses NRVO to "return" the result
-    }
+    using __dom_t _CCCL_NODEBUG_ALIAS = early_domain_of_t<_Sndr>;
+    return __dom_t::__apply(*this)(static_cast<_Sndr&&>(__sndr));
   }
 
   template <class _Sndr, class _Env>
-  auto operator()(_Sndr&& __sndr, _Env&& __env) const
+  _CUDAX_HOST_API auto operator()(_Sndr&& __sndr, _Env&& __env) const
   {
-    return (*this)(__async::write_env(static_cast<_Sndr&&>(__sndr), static_cast<_Env&&>(__env)));
+    using __dom_t _CCCL_NODEBUG_ALIAS = late_domain_of_t<_Sndr, _Env>;
+    return __dom_t::__apply(*this)(static_cast<_Sndr&&>(__sndr), static_cast<_Env&&>(__env));
   }
 };
 
 _CCCL_GLOBAL_CONSTANT sync_wait_t sync_wait{};
 } // namespace cuda::experimental::__async
 
-#  include <cuda/experimental/__async/sender/epilogue.cuh>
+#include <cuda/experimental/__async/sender/epilogue.cuh>
 
-#endif // !defined(__CUDA_ARCH__)
-
-#endif
+#endif // __CUDAX_ASYNC_DETAIL_SYNC_WAIT

--- a/cudax/include/cuda/experimental/__async/sender/then.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/then.cuh
@@ -29,6 +29,7 @@
 #include <cuda/experimental/__async/sender/completion_signatures.cuh>
 #include <cuda/experimental/__async/sender/concepts.cuh>
 #include <cuda/experimental/__async/sender/cpos.cuh>
+#include <cuda/experimental/__async/sender/env.cuh>
 #include <cuda/experimental/__async/sender/exception.cuh>
 #include <cuda/experimental/__async/sender/meta.cuh>
 #include <cuda/experimental/__async/sender/rcvr_ref.cuh>
@@ -209,7 +210,18 @@ private:
     }
   };
 
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __fn
+  {
+    template <class _Fn, class _Sndr>
+    _CUDAX_TRIVIAL_API constexpr auto operator()(_Fn __fn, _Sndr __sndr) const;
+  };
+
 public:
+  _CUDAX_API static constexpr auto __apply() noexcept
+  {
+    return __fn{};
+  }
+
   template <class _Fn, class _Sndr>
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __sndr_t;
 
@@ -217,10 +229,10 @@ public:
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __closure_t;
 
   template <class _Sndr, class _Fn>
-  _CUDAX_TRIVIAL_API auto operator()(_Sndr __sndr, _Fn __fn) const -> __sndr_t<_Fn, _Sndr>;
+  _CUDAX_TRIVIAL_API constexpr auto operator()(_Sndr __sndr, _Fn __fn) const;
 
   template <class _Fn>
-  _CUDAX_TRIVIAL_API auto operator()(_Fn __fn) const noexcept;
+  _CUDAX_TRIVIAL_API constexpr auto operator()(_Fn __fn) const;
 };
 
 template <__disposition_t _Disposition>
@@ -302,8 +314,8 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __upon_t<_Disposition>::__closure_t
 };
 
 template <__disposition_t _Disposition>
-template <class _Sndr, class _Fn>
-_CUDAX_TRIVIAL_API auto __upon_t<_Disposition>::operator()(_Sndr __sndr, _Fn __fn) const -> __sndr_t<_Fn, _Sndr>
+template <class _Fn, class _Sndr>
+_CUDAX_TRIVIAL_API constexpr auto __upon_t<_Disposition>::__fn::operator()(_Fn __fn, _Sndr __sndr) const
 {
   // If the incoming sender is non-dependent, we can check the completion
   // signatures of the composed sender immediately.
@@ -316,8 +328,16 @@ _CUDAX_TRIVIAL_API auto __upon_t<_Disposition>::operator()(_Sndr __sndr, _Fn __f
 }
 
 template <__disposition_t _Disposition>
+template <class _Sndr, class _Fn>
+_CUDAX_TRIVIAL_API constexpr auto __upon_t<_Disposition>::operator()(_Sndr __sndr, _Fn __fn) const
+{
+  using __dom_t _CCCL_NODEBUG_ALIAS = early_domain_of_t<_Sndr>;
+  return __dom_t::__apply(*this)(static_cast<_Fn&&>(__fn), static_cast<_Sndr&&>(__sndr));
+}
+
+template <__disposition_t _Disposition>
 template <class _Fn>
-_CUDAX_TRIVIAL_API auto __upon_t<_Disposition>::operator()(_Fn __fn) const noexcept
+_CUDAX_TRIVIAL_API constexpr auto __upon_t<_Disposition>::operator()(_Fn __fn) const
 {
   return __closure_t<_Fn>{static_cast<_Fn&&>(__fn)};
 }

--- a/cudax/include/cuda/experimental/__async/sender/write_env.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/write_env.cuh
@@ -58,14 +58,25 @@ private:
     connect_result_t<_Sndr, __rcvr_ref<__rcvr_with_env_t<_Rcvr, _Env>>> __opstate_;
   };
 
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __fn
+  {
+    template <class _Env, class _Sndr>
+    _CUDAX_TRIVIAL_API constexpr auto operator()(_Env __env, _Sndr __sndr) const;
+  };
+
 public:
+  _CUDAX_TRIVIAL_API static constexpr auto __apply() noexcept
+  {
+    return __fn{};
+  }
+
   template <class _Sndr, class _Env>
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __sndr_t;
 
   /// @brief Wraps one sender in another that modifies the execution
   /// environment by merging in the environment specified.
   template <class _Sndr, class _Env>
-  _CUDAX_TRIVIAL_API constexpr auto operator()(_Sndr, _Env) const -> __sndr_t<_Sndr, _Env>;
+  _CUDAX_TRIVIAL_API constexpr auto operator()(_Sndr, _Env) const;
 };
 
 template <class _Sndr, class _Env>
@@ -103,10 +114,17 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT write_env_t::__sndr_t
   _Sndr __sndr_;
 };
 
-template <class _Sndr, class _Env>
-_CUDAX_TRIVIAL_API constexpr auto write_env_t::operator()(_Sndr __sndr, _Env __env) const -> __sndr_t<_Sndr, _Env>
+template <class _Env, class _Sndr>
+_CUDAX_TRIVIAL_API constexpr auto write_env_t::__fn::operator()(_Env __env, _Sndr __sndr) const
 {
   return __sndr_t<_Sndr, _Env>{{}, static_cast<_Env&&>(__env), static_cast<_Sndr&&>(__sndr)};
+}
+
+template <class _Sndr, class _Env>
+_CUDAX_TRIVIAL_API constexpr auto write_env_t::operator()(_Sndr __sndr, _Env __env) const
+{
+  using __dom_t _CCCL_NODEBUG_ALIAS = __domain_of_t<_Env>;
+  return __dom_t::__apply(*this)(static_cast<_Env&&>(__env), static_cast<_Sndr&&>(__sndr));
 }
 
 template <class _Sndr, class _Env>

--- a/cudax/include/cuda/experimental/__stream/get_stream.cuh
+++ b/cudax/include/cuda/experimental/__stream/get_stream.cuh
@@ -29,7 +29,6 @@
 #include <cuda/std/__type_traits/is_convertible.h>
 #include <cuda/stream_ref>
 
-#include <cuda/experimental/__async/sender/queries.cuh>
 #include <cuda/experimental/__stream/stream.cuh>
 
 namespace cuda::experimental


### PR DESCRIPTION
## Description

this PR makes the sender algorithms of ustdex eagerly customizable based on the domain of sender argument(s).

NB: i've based this PR on branch NVIDIA:pull-request/4538 so that only the relevant commit shows in the diff. i will rebase on main after #4538 is merged.
