### PR TITLE
[c.parallel]: clean-up in test_utils.h

### DIFF
--- a/c/parallel/test/test_reduce.cpp
+++ b/c/parallel/test/test_reduce.cpp
@@ -13,6 +13,7 @@
 #include <cstdint>
 
 #include "test_util.h"
+#include <cccl/c/reduce.h>
 
 void reduce(cccl_iterator_t input, cccl_iterator_t output, uint64_t num_items, cccl_op_t op, cccl_value_t init)
 {

--- a/c/parallel/test/test_scan.cpp
+++ b/c/parallel/test/test_scan.cpp
@@ -13,6 +13,7 @@
 #include <cstdint>
 
 #include "test_util.h"
+#include <cccl/c/scan.h>
 
 void scan(cccl_iterator_t input,
           cccl_iterator_t output,

--- a/c/parallel/test/test_util.h
+++ b/c/parallel/test/test_util.h
@@ -25,8 +25,7 @@
 #include <vector>
 
 #include <c2h/catch2_test_helper.h>
-#include <cccl/c/reduce.h>
-#include <cccl/c/scan.h>
+#include <cccl/c/types.h>
 #include <nvrtc.h>
 
 static std::string inspect_sass(const void* cubin, size_t cubin_size)
@@ -402,7 +401,7 @@ struct pointer_t
   T* ptr{};
   size_t size{};
 
-  pointer_t(int num_items)
+  pointer_t(std::size_t num_items)
   {
     REQUIRE(cudaSuccess == cudaMalloc(&ptr, num_items * sizeof(T)));
     size = num_items;


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes #4543 

<!-- Provide a standalone description of changes in this PR. -->

Replace include of cccl/c/reduce.h/scan.h with types.h

Also changed the pointer_t constructor size argument from int to size_t to allow to testing of large_num_segments.

Add missing include of cccl/c/reduce.h to test_reduce.h Add missing include to cccl/c/scan.h to test_scan.h


<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
