### PR TITLE
Exclude cudastf stress tests from CI.

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -682,7 +682,12 @@
     {
       "name": "cudax-base",
       "hidden": true,
-      "inherits": "base"
+      "inherits": "base",
+      "filter": {
+        "exclude": {
+          "name": "^cudax\\.cpp[0-9][0-9]\\.test\\.stf\\.stress.*$"
+        }
+      }
     },
     {
       "name": "cudax-cpp17",


### PR DESCRIPTION
These are meant to measure performance and are causing timeouts on some CI configs.