### PR TITLE
CUB merge algorithms: avoid OOB access and improve compile time.

### DIFF
--- a/cub/cub/block/block_merge_sort.cuh
+++ b/cub/cub/block/block_merge_sort.cuh
@@ -94,8 +94,10 @@ _CCCL_DEVICE _CCCL_FORCEINLINE void SerialMerge(
   const int keys1_end = keys1_beg + keys1_count;
   const int keys2_end = keys2_beg + keys2_count;
 
-  KeyT key1 = keys_shared[keys1_beg];
-  KeyT key2 = keys_shared[keys2_beg];
+  // Either range may be empty. If so, load a valid key from the other range
+  // to avoid out-of-bounds access:
+  KeyT key1 = keys1_count ? keys_shared[keys1_beg] : keys_shared[keys2_beg];
+  KeyT key2 = keys2_count ? keys_shared[keys2_beg] : keys_shared[keys1_beg];
 
   _CCCL_SORT_MAYBE_UNROLL()
   for (int item = 0; item < ITEMS_PER_THREAD; ++item)

--- a/cub/cub/block/block_merge_sort.cuh
+++ b/cub/cub/block/block_merge_sort.cuh
@@ -94,10 +94,13 @@ _CCCL_DEVICE _CCCL_FORCEINLINE void SerialMerge(
   const int keys1_end = keys1_beg + keys1_count;
   const int keys2_end = keys2_beg + keys2_count;
 
-  // Either range may be empty. If so, load a valid key from the other range
+  // Either range may be empty. If it is, load a valid key from the other range
   // to avoid out-of-bounds access:
-  KeyT key1 = keys1_count ? keys_shared[keys1_beg] : keys_shared[keys2_beg];
-  KeyT key2 = keys2_count ? keys_shared[keys2_beg] : keys_shared[keys1_beg];
+  const int key1_initial_load_offset = (keys1_count != 0) ? keys1_beg : keys2_beg;
+  const int key2_initial_load_offset = (keys2_count != 0) ? keys2_beg : keys1_beg;
+
+  KeyT key1 = keys_shared[key1_initial_load_offset];
+  KeyT key2 = keys_shared[key2_initial_load_offset];
 
   _CCCL_SORT_MAYBE_UNROLL()
   for (int item = 0; item < ITEMS_PER_THREAD; ++item)

--- a/cub/cub/block/block_merge_sort.cuh
+++ b/cub/cub/block/block_merge_sort.cuh
@@ -89,18 +89,14 @@ _CCCL_DEVICE _CCCL_FORCEINLINE void SerialMerge(
   int keys2_count,
   KeyT (&output)[ITEMS_PER_THREAD],
   int (&indices)[ITEMS_PER_THREAD],
-  CompareOp compare_op)
+  CompareOp compare_op,
+  KeyT oob_default)
 {
   const int keys1_end = keys1_beg + keys1_count;
   const int keys2_end = keys2_beg + keys2_count;
 
-  // Either range may be empty. If it is, load a valid key from the other range
-  // to avoid out-of-bounds access:
-  const int key1_initial_load_offset = (keys1_count != 0) ? keys1_beg : keys2_beg;
-  const int key2_initial_load_offset = (keys2_count != 0) ? keys2_beg : keys1_beg;
-
-  KeyT key1 = keys_shared[key1_initial_load_offset];
-  KeyT key2 = keys_shared[key2_initial_load_offset];
+  KeyT key1 = keys1_count != 0 ? keys_shared[keys1_beg] : oob_default;
+  KeyT key2 = keys2_count != 0 ? keys_shared[keys2_beg] : oob_default;
 
   _CCCL_SORT_MAYBE_UNROLL()
   for (int item = 0; item < ITEMS_PER_THREAD; ++item)
@@ -117,6 +113,20 @@ _CCCL_DEVICE _CCCL_FORCEINLINE void SerialMerge(
       key1 = keys_shared[keys1_beg];
     }
   }
+}
+
+template <typename KeyIt, typename KeyT, typename CompareOp, int ITEMS_PER_THREAD>
+_CCCL_DEVICE _CCCL_FORCEINLINE void SerialMerge(
+  KeyIt keys_shared,
+  int keys1_beg,
+  int keys2_beg,
+  int keys1_count,
+  int keys2_count,
+  KeyT (&output)[ITEMS_PER_THREAD],
+  int (&indices)[ITEMS_PER_THREAD],
+  CompareOp compare_op)
+{
+  SerialMerge(keys_shared, keys1_beg, keys2_beg, keys1_count, keys2_count, output, indices, compare_op, output[0]);
 }
 
 /**
@@ -464,7 +474,8 @@ public:
         keys2_count_loc,
         keys,
         indices,
-        compare_op);
+        compare_op,
+        oob_default);
 
       if (!KEYS_ONLY)
       {

--- a/cub/test/catch2_test_device_merge.cu
+++ b/cub/test/catch2_test_device_merge.cu
@@ -64,69 +64,6 @@ C2H_TEST("DeviceMerge::MergeKeys key types", "[merge][device]", types)
   test_keys<key_t, offset_t>();
 }
 
-using large_type_fallb = c2h::custom_type_t<c2h::equal_comparable_t, c2h::less_comparable_t, c2h::huge_data<56>::type>;
-using large_type_vsmem = c2h::custom_type_t<c2h::equal_comparable_t, c2h::less_comparable_t, c2h::huge_data<774>::type>;
-
-struct fallback_test_policy_hub
-{
-  struct max_policy : cub::ChainedPolicy<100, max_policy, max_policy>
-  {
-    using merge_policy = cub::detail::merge::
-      agent_policy_t<128, 7, cub::BLOCK_LOAD_WARP_TRANSPOSE, cub::LOAD_DEFAULT, cub::BLOCK_STORE_WARP_TRANSPOSE>;
-  };
-};
-
-// TODO(bgruber): This test alone increases compile time from 1m16s to 8m43s. What's going on?
-C2H_TEST("DeviceMerge::MergeKeys large key types", "[merge][device]", c2h::type_list<large_type_vsmem, large_type_fallb>)
-{
-  using key_t    = c2h::get<0, TestType>;
-  using offset_t = int;
-
-  constexpr auto agent_sm = sizeof(key_t) * 128 * 7;
-  constexpr auto fallback_sm =
-    sizeof(key_t) * cub::detail::merge::fallback_BLOCK_THREADS * cub::detail::merge::fallback_ITEMS_PER_THREAD;
-  static_assert(agent_sm > cub::detail::max_smem_per_block,
-                "key_t is not big enough to exceed SM and trigger fallback policy");
-  static_assert(::cuda::std::is_same_v<key_t, large_type_fallb> == (fallback_sm <= cub::detail::max_smem_per_block),
-                "SM consumption by fallback policy should fit into max_smem_per_block");
-
-  test_keys<key_t, offset_t>(
-    3623,
-    6346,
-    ::cuda::std::less<key_t>{},
-    [](const key_t* k1, offset_t s1, const key_t* k2, offset_t s2, key_t* r, ::cuda::std::less<key_t> co) {
-      using dispatch_t = cub::detail::merge::dispatch_t<
-        const key_t*,
-        const cub::NullType*,
-        const key_t*,
-        const cub::NullType*,
-        key_t*,
-        cub::NullType*,
-        offset_t,
-        ::cuda::std::less<key_t>,
-        fallback_test_policy_hub>; // use a fixed policy for this test so the needed shared memory is deterministic
-
-      std::size_t temp_storage_bytes = 0;
-      dispatch_t::dispatch(
-        nullptr, temp_storage_bytes, k1, nullptr, s1, k2, nullptr, s2, r, nullptr, co, cudaStream_t{0});
-
-      c2h::device_vector<char> temp_storage(temp_storage_bytes);
-      dispatch_t::dispatch(
-        thrust::raw_pointer_cast(temp_storage.data()),
-        temp_storage_bytes,
-        k1,
-        nullptr,
-        s1,
-        k2,
-        nullptr,
-        s2,
-        r,
-        nullptr,
-        co,
-        cudaStream_t{0});
-    });
-}
-
 C2H_TEST("DeviceMerge::MergeKeys works for large number of items", "[merge][device]")
 try
 {

--- a/cub/test/catch2_test_device_merge.cu
+++ b/cub/test/catch2_test_device_merge.cu
@@ -128,7 +128,6 @@ C2H_TEST("DeviceMerge::MergeKeys large key types", "[merge][device]", c2h::type_
 }
 
 C2H_TEST("DeviceMerge::MergeKeys works for large number of items", "[merge][device]")
-
 try
 {
   using key_t    = char;

--- a/cub/test/catch2_test_device_merge_no_unroll.cu
+++ b/cub/test/catch2_test_device_merge_no_unroll.cu
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Define this to enable compile-time optimizations that avoid unrolling
+// some loops in the merge kernels. This reduces the compile time for this
+// test from ~8 minutes to >2.
+#define CCCL_AVOID_SORT_UNROLL
+
+#include "insert_nested_NVTX_range_guard.h"
+// above header needs to be included first
+
+#include <cub/device/device_merge.cuh>
+
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/sort.h>
+
+#include <algorithm>
+
+#include "catch2_test_launch_helper.h"
+#include <c2h/catch2_test_helper.h>
+#include <test_util.h>
+
+// %PARAM% TEST_LAUNCH lid 0:1:2
+
+DECLARE_LAUNCH_WRAPPER(cub::DeviceMerge::MergePairs, merge_pairs);
+DECLARE_LAUNCH_WRAPPER(cub::DeviceMerge::MergeKeys, merge_keys);
+
+template <typename Key,
+          typename Offset,
+          typename CompareOp = ::cuda::std::less<Key>,
+          typename MergeKeys = decltype(::merge_keys)>
+void test_keys(Offset size1 = 3623, Offset size2 = 6346, CompareOp compare_op = {}, MergeKeys merge_keys = ::merge_keys)
+{
+  CAPTURE(c2h::type_name<Key>(), c2h::type_name<Offset>(), size1, size2);
+
+  c2h::device_vector<Key> keys1_d(size1);
+  c2h::device_vector<Key> keys2_d(size2);
+
+  c2h::gen(C2H_SEED(1), keys1_d);
+  c2h::gen(C2H_SEED(1), keys2_d);
+
+  thrust::sort(c2h::device_policy, keys1_d.begin(), keys1_d.end(), compare_op);
+  thrust::sort(c2h::device_policy, keys2_d.begin(), keys2_d.end(), compare_op);
+  // CAPTURE(keys1_d, keys2_d);
+
+  c2h::device_vector<Key> result_d(size1 + size2);
+  merge_keys(thrust::raw_pointer_cast(keys1_d.data()),
+             static_cast<Offset>(keys1_d.size()),
+             thrust::raw_pointer_cast(keys2_d.data()),
+             static_cast<Offset>(keys2_d.size()),
+             thrust::raw_pointer_cast(result_d.data()),
+             compare_op);
+
+  c2h::host_vector<Key> keys1_h = keys1_d;
+  c2h::host_vector<Key> keys2_h = keys2_d;
+  c2h::host_vector<Key> reference_h(size1 + size2);
+  std::merge(keys1_h.begin(), keys1_h.end(), keys2_h.begin(), keys2_h.end(), reference_h.begin(), compare_op);
+
+  // FIXME(bgruber): comparing std::vectors (slower than thrust vectors) but compiles a lot faster
+  CHECK((detail::to_vec(reference_h) == detail::to_vec(c2h::host_vector<Key>(result_d))));
+}
+
+using large_type_fallb = c2h::custom_type_t<c2h::equal_comparable_t, c2h::less_comparable_t, c2h::huge_data<56>::type>;
+using large_type_vsmem = c2h::custom_type_t<c2h::equal_comparable_t, c2h::less_comparable_t, c2h::huge_data<774>::type>;
+
+struct fallback_test_policy_hub
+{
+  struct max_policy : cub::ChainedPolicy<100, max_policy, max_policy>
+  {
+    using merge_policy = cub::detail::merge::
+      agent_policy_t<128, 7, cub::BLOCK_LOAD_WARP_TRANSPOSE, cub::LOAD_DEFAULT, cub::BLOCK_STORE_WARP_TRANSPOSE>;
+  };
+};
+
+C2H_TEST("DeviceMerge::MergeKeys large key types", "[merge][device]", c2h::type_list<large_type_vsmem, large_type_fallb>)
+{
+  using key_t    = c2h::get<0, TestType>;
+  using offset_t = int;
+
+  constexpr auto agent_sm = sizeof(key_t) * 128 * 7;
+  constexpr auto fallback_sm =
+    sizeof(key_t) * cub::detail::merge::fallback_BLOCK_THREADS * cub::detail::merge::fallback_ITEMS_PER_THREAD;
+  static_assert(agent_sm > cub::detail::max_smem_per_block,
+                "key_t is not big enough to exceed SM and trigger fallback policy");
+  static_assert(::cuda::std::is_same_v<key_t, large_type_fallb> == (fallback_sm <= cub::detail::max_smem_per_block),
+                "SM consumption by fallback policy should fit into max_smem_per_block");
+
+  test_keys<key_t, offset_t>(
+    3623,
+    6346,
+    ::cuda::std::less<key_t>{},
+    [](const key_t* k1, offset_t s1, const key_t* k2, offset_t s2, key_t* r, ::cuda::std::less<key_t> co) {
+      using dispatch_t = cub::detail::merge::dispatch_t<
+        const key_t*,
+        const cub::NullType*,
+        const key_t*,
+        const cub::NullType*,
+        key_t*,
+        cub::NullType*,
+        offset_t,
+        ::cuda::std::less<key_t>,
+        fallback_test_policy_hub>; // use a fixed policy for this test so the needed shared memory is deterministic
+
+      std::size_t temp_storage_bytes = 0;
+      dispatch_t::dispatch(
+        nullptr, temp_storage_bytes, k1, nullptr, s1, k2, nullptr, s2, r, nullptr, co, cudaStream_t{0});
+
+      c2h::device_vector<char> temp_storage(temp_storage_bytes);
+      dispatch_t::dispatch(
+        thrust::raw_pointer_cast(temp_storage.data()),
+        temp_storage_bytes,
+        k1,
+        nullptr,
+        s1,
+        k2,
+        nullptr,
+        s2,
+        r,
+        nullptr,
+        co,
+        cudaStream_t{0});
+    });
+}


### PR DESCRIPTION
- Add bounds checks to fix OOB accesses caught by compute-sanitizer.
- Define CCCL_AVOID_SORT_UNROLL for the `huge_data` tests, reducing compile time from ~8m to <2m.
