### PR TITLE
Extend CUB DeviceSegmentedReduce API with fixed segment size to support all operators

### DIFF
--- a/c2h/include/c2h/custom_type.h
+++ b/c2h/include/c2h/custom_type.h
@@ -69,7 +69,7 @@ class less_comparable_t
 {
   // The CUDA compiler follows the IA64 ABI for class layout, while the
   // Microsoft host compiler does not.
-  char workaround_msvc;
+  char workaround_msvc{};
 
 public:
   friend __host__ __device__ bool operator<(const CustomType& lhs, const CustomType& rhs)
@@ -83,7 +83,7 @@ class greater_comparable_t
 {
   // The CUDA compiler follows the IA64 ABI for class layout, while the
   // Microsoft host compiler does not.
-  char workaround_msvc;
+  char workaround_msvc{};
 
 public:
   friend __host__ __device__ bool operator>(const CustomType& lhs, const CustomType& rhs)
@@ -97,7 +97,7 @@ class lexicographical_less_comparable_t
 {
   // The CUDA compiler follows the IA64 ABI for class layout, while the
   // Microsoft host compiler does not.
-  char workaround_msvc;
+  char workaround_msvc{};
 
 public:
   friend __host__ __device__ bool operator<(const CustomType& lhs, const CustomType& rhs)
@@ -111,7 +111,7 @@ class lexicographical_greater_comparable_t
 {
   // The CUDA compiler follows the IA64 ABI for class layout, while the
   // Microsoft host compiler does not.
-  char workaround_msvc;
+  char workaround_msvc{};
 
 public:
   friend __host__ __device__ bool operator>(const CustomType& lhs, const CustomType& rhs)
@@ -125,7 +125,7 @@ class equal_comparable_t
 {
   // The CUDA compiler follows the IA64 ABI for class layout, while the
   // Microsoft host compiler does not.
-  char workaround_msvc;
+  char workaround_msvc{};
 
 public:
   friend __host__ __device__ bool operator==(const CustomType& lhs, const CustomType& rhs)
@@ -144,7 +144,7 @@ class subtractable_t
 {
   // The CUDA compiler follows the IA64 ABI for class layout, while the
   // Microsoft host compiler does not.
-  char workaround_msvc;
+  char workaround_msvc{};
 
 public:
   friend __host__ __device__ CustomType operator-(const CustomType& lhs, const CustomType& rhs)
@@ -163,7 +163,7 @@ class accumulateable_t
 {
   // The CUDA compiler follows the IA64 ABI for class layout, while the
   // Microsoft host compiler does not.
-  char workaround_msvc;
+  char workaround_msvc{};
 
 public:
   friend __host__ __device__ CustomType operator+(const CustomType& lhs, const CustomType& rhs)

--- a/cub/cub/device/device_segmented_reduce.cuh
+++ b/cub/cub/device/device_segmented_reduce.cuh
@@ -996,7 +996,7 @@ public:
     int segment_size,
     cudaStream_t stream = 0)
   {
-    _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceSegmentedReduce::ArgMax");
+    _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceSegmentedReduce::ArgMin");
 
     // `offset_t` a.k.a `SegmentSizeT` is fixed to `int` type now, but later can be changed to accept
     // integral constant or larger integral types

--- a/cub/cub/device/device_segmented_reduce.cuh
+++ b/cub/cub/device/device_segmented_reduce.cuh
@@ -517,8 +517,8 @@ public:
   //! .. literalinclude:: ../../../cub/test/catch2_test_device_segmented_reduce_api.cu
   //!     :language: c++
   //!     :dedent:
-  //!     :start-after: example-begin segmented-reduce-sum
-  //!     :end-before: example-end segmented-reduce-sum
+  //!     :start-after: example-begin fixed-size-segmented-reduce-sum
+  //!     :end-before: example-end fixed-size-segmented-reduce-sum
   //!
   //! @endrst
   //!
@@ -717,8 +717,8 @@ public:
   //! .. literalinclude:: ../../../cub/test/catch2_test_device_segmented_reduce_api.cu
   //!     :language: c++
   //!     :dedent:
-  //!     :start-after: example-begin segmented-reduce-min
-  //!     :end-before: example-end segmented-reduce-min
+  //!     :start-after: example-begin fixed-size-segmented-reduce-min
+  //!     :end-before: example-end fixed-size-segmented-reduce-min
   //!
   //! @endrst
   //!
@@ -951,8 +951,8 @@ public:
   //! .. literalinclude:: ../../../cub/test/catch2_test_device_segmented_reduce_api.cu
   //!     :language: c++
   //!     :dedent:
-  //!     :start-after: example-begin segmented-reduce-argmin
-  //!     :end-before: example-end segmented-reduce-argmin
+  //!     :start-after: example-begin fixed-size-segmented-reduce-argmin
+  //!     :end-before: example-end fixed-size-segmented-reduce-argmin
   //!
   //! @endrst
   //!
@@ -1167,8 +1167,8 @@ public:
   //! .. literalinclude:: ../../../cub/test/catch2_test_device_segmented_reduce_api.cu
   //!     :language: c++
   //!     :dedent:
-  //!     :start-after: example-begin segmented-reduce-max
-  //!     :end-before: example-end segmented-reduce-max
+  //!     :start-after: example-begin fixed-size-segmented-reduce-max
+  //!     :end-before: example-end fixed-size-segmented-reduce-max
   //!
   //! @endrst
   //!
@@ -1405,8 +1405,8 @@ public:
   //! .. literalinclude:: ../../../cub/test/catch2_test_device_segmented_reduce_api.cu
   //!     :language: c++
   //!     :dedent:
-  //!     :start-after: example-begin segmented-reduce-argmax
-  //!     :end-before: example-end segmented-reduce-argmax
+  //!     :start-after: example-begin fixed-size-segmented-reduce-argmax
+  //!     :end-before: example-end fixed-size-segmented-reduce-argmax
   //!
   //! @endrst
   //!

--- a/cub/cub/device/device_segmented_reduce.cuh
+++ b/cub/cub/device/device_segmented_reduce.cuh
@@ -503,6 +503,54 @@ public:
       stream);
   }
 
+  //! @rst
+  //! Computes a device-wide segmented sum using the addition (``+``) operator.
+  //!
+  //! - Uses ``0`` as the initial value of the reduction for each segment.
+  //! - @devicestorage
+  //!
+  //! Snippet
+  //! +++++++++++++++++++++++++++++++++++++++++++++
+  //!
+  //! The code snippet below illustrates the sum reduction of a device vector of ``int`` data elements.
+  //!
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_segmented_reduce_api.cu
+  //!     :language: c++
+  //!     :dedent:
+  //!     :start-after: example-begin segmented-reduce-sum
+  //!     :end-before: example-end segmented-reduce-sum
+  //!
+  //! @endrst
+  //!
+  //! @tparam InputIteratorT
+  //!   **[inferred]** Random-access input iterator type for reading input items @iterator
+  //!
+  //! @tparam OutputIteratorT
+  //!   **[inferred]** Output iterator type for recording the reduced aggregate @iterator
+  //!
+  //! @param[in] d_temp_storage
+  //!   Device-accessible allocation of temporary storage. When `nullptr`, the
+  //!   required allocation size is written to `temp_storage_bytes` and no work is done.
+  //!
+  //! @param[in,out] temp_storage_bytes
+  //!   Reference to size in bytes of `d_temp_storage` allocation
+  //!
+  //! @param[in] d_in
+  //!   Pointer to the input sequence of data items
+  //!
+  //! @param[out] d_out
+  //!   Pointer to the output aggregate
+  //!
+  //! @param[in] num_segments
+  //!   The number of segments that comprise the segmented reduction data
+  //!
+  //! @param[in] segment_size
+  //!   The fixed segment size of each segment
+  //!
+  //! @param[in] stream
+  //!   @rst
+  //!   **[optional]** CUDA stream to launch kernels within. Default is stream\ :sub:`0`.
+  //!   @endrst
   template <typename InputIteratorT, typename OutputIteratorT>
   CUB_RUNTIME_FUNCTION static cudaError_t
   Sum(void* d_temp_storage,
@@ -650,6 +698,59 @@ public:
       stream);
   }
 
+  //! @rst
+  //! Computes a device-wide segmented minimum using the less-than (``<``) operator.
+  //!
+  //! - Uses ``::cuda::std::numeric_limits<T>::max()`` as the initial value of the reduction for each segment.
+  //!
+  //! Snippet
+  //! +++++++++++++++++++++++++++++++++++++++++++++
+  //!
+  //! The code snippet below illustrates the min-reduction of a device vector of ``int`` data elements.
+  //!
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_segmented_reduce_api.cu
+  //!     :language: c++
+  //!     :dedent:
+  //!     :start-after: example-begin segmented-reduce-custommin
+  //!     :end-before: example-end segmented-reduce-custommin
+  //!
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_segmented_reduce_api.cu
+  //!     :language: c++
+  //!     :dedent:
+  //!     :start-after: example-begin segmented-reduce-min
+  //!     :end-before: example-end segmented-reduce-min
+  //!
+  //! @endrst
+  //!
+  //! @tparam InputIteratorT
+  //!   **[inferred]** Random-access input iterator type for reading input items @iterator
+  //!
+  //! @tparam OutputIteratorT
+  //!   **[inferred]** Output iterator type for recording the reduced aggregate @iterator
+  //!
+  //! @param[in] d_temp_storage
+  //!   Device-accessible allocation of temporary storage. When `nullptr`, the
+  //!   required allocation size is written to `temp_storage_bytes` and no work is done.
+  //!
+  //! @param[in,out] temp_storage_bytes
+  //!   Reference to size in bytes of `d_temp_storage` allocation
+  //!
+  //! @param[in] d_in
+  //!   Pointer to the input sequence of data items
+  //!
+  //! @param[out] d_out
+  //!   Pointer to the output aggregate
+  //!
+  //! @param[in] num_segments
+  //!   The number of segments that comprise the segmented reduction data
+  //!
+  //! @param[in] segment_size
+  //!   The fixed segment size of each segment
+  //!
+  //! @param[in] stream
+  //!   @rst
+  //!   **[optional]** CUDA stream to launch kernels within. Default is stream\ :sub:`0`.
+  //!   @endrst
   template <typename InputIteratorT, typename OutputIteratorT>
   CUB_RUNTIME_FUNCTION static cudaError_t
   Min(void* d_temp_storage,
@@ -1053,6 +1154,53 @@ public:
       stream);
   }
 
+  //! @rst
+  //! Computes a device-wide segmented maximum using the greater-than (``>``) operator.
+  //!
+  //! - Uses ``::cuda::std::numeric_limits<T>::lowest()`` as the initial value of the reduction.
+  //!
+  //! Snippet
+  //! +++++++++++++++++++++++++++++++++++++++++++++
+  //!
+  //! The code snippet below illustrates the max-reduction of a device vector of ``int`` data elements.
+  //!
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_segmented_reduce_api.cu
+  //!     :language: c++
+  //!     :dedent:
+  //!     :start-after: example-begin segmented-reduce-max
+  //!     :end-before: example-end segmented-reduce-max
+  //!
+  //! @endrst
+  //!
+  //! @tparam InputIteratorT
+  //!   **[inferred]** Random-access input iterator type for reading input items @iterator
+  //!
+  //! @tparam OutputIteratorT
+  //!   **[inferred]** Output iterator type for recording the reduced aggregate @iterator
+  //!
+  //! @param[in] d_temp_storage
+  //!   Device-accessible allocation of temporary storage. When `nullptr`, the
+  //!   required allocation size is written to `temp_storage_bytes` and no work is done.
+  //!
+  //! @param[in,out] temp_storage_bytes
+  //!   Reference to size in bytes of `d_temp_storage` allocation
+  //!
+  //! @param[in] d_in
+  //!   Pointer to the input sequence of data items
+  //!
+  //! @param[out] d_out
+  //!   Pointer to the output aggregate
+  //!
+  //! @param[in] num_segments
+  //!   The number of segments that comprise the segmented reduction data
+  //!
+  //! @param[in] segment_size
+  //!   The fixed segment size of each segment
+  //!
+  //! @param[in] stream
+  //!   @rst
+  //!   **[optional]** CUDA stream to launch kernels within. Default is stream\ :sub:`0`.
+  //!   @endrst
   template <typename InputIteratorT, typename OutputIteratorT>
   CUB_RUNTIME_FUNCTION static cudaError_t
   Max(void* d_temp_storage,

--- a/cub/cub/device/device_segmented_reduce.cuh
+++ b/cub/cub/device/device_segmented_reduce.cuh
@@ -439,7 +439,12 @@ public:
   //!   @rst
   //!   **[optional]** CUDA stream to launch kernels within. Default is stream\ :sub:`0`.
   //!   @endrst
-  template <typename InputIteratorT, typename OutputIteratorT, typename BeginOffsetIteratorT, typename EndOffsetIteratorT>
+  template <typename InputIteratorT,
+            typename OutputIteratorT,
+            typename BeginOffsetIteratorT,
+            typename EndOffsetIteratorT,
+            typename = ::cuda::std::void_t<typename ::cuda::std::iterator_traits<BeginOffsetIteratorT>::value_type,
+                                           typename ::cuda::std::iterator_traits<EndOffsetIteratorT>::value_type>>
   CUB_RUNTIME_FUNCTION static cudaError_t
   Sum(void* d_temp_storage,
       size_t& temp_storage_bytes,
@@ -642,7 +647,12 @@ public:
   //!   @rst
   //!   **[optional]** CUDA stream to launch kernels within. Default is stream\ :sub:`0`.
   //!   @endrst
-  template <typename InputIteratorT, typename OutputIteratorT, typename BeginOffsetIteratorT, typename EndOffsetIteratorT>
+  template <typename InputIteratorT,
+            typename OutputIteratorT,
+            typename BeginOffsetIteratorT,
+            typename EndOffsetIteratorT,
+            typename = ::cuda::std::void_t<typename ::cuda::std::iterator_traits<BeginOffsetIteratorT>::value_type,
+                                           typename ::cuda::std::iterator_traits<EndOffsetIteratorT>::value_type>>
   CUB_RUNTIME_FUNCTION static cudaError_t
   Min(void* d_temp_storage,
       size_t& temp_storage_bytes,
@@ -854,7 +864,12 @@ public:
   //!   @rst
   //!   **[optional]** CUDA stream to launch kernels within. Default is stream\ :sub:`0`.
   //!   @endrst
-  template <typename InputIteratorT, typename OutputIteratorT, typename BeginOffsetIteratorT, typename EndOffsetIteratorT>
+  template <typename InputIteratorT,
+            typename OutputIteratorT,
+            typename BeginOffsetIteratorT,
+            typename EndOffsetIteratorT,
+            typename = ::cuda::std::void_t<typename ::cuda::std::iterator_traits<BeginOffsetIteratorT>::value_type,
+                                           typename ::cuda::std::iterator_traits<EndOffsetIteratorT>::value_type>>
   CUB_RUNTIME_FUNCTION static cudaError_t ArgMin(
     void* d_temp_storage,
     size_t& temp_storage_bytes,
@@ -1103,7 +1118,12 @@ public:
   //!   @rst
   //!   **[optional]** CUDA stream to launch kernels within. Default is stream\ :sub:`0`.
   //!   @endrst
-  template <typename InputIteratorT, typename OutputIteratorT, typename BeginOffsetIteratorT, typename EndOffsetIteratorT>
+  template <typename InputIteratorT,
+            typename OutputIteratorT,
+            typename BeginOffsetIteratorT,
+            typename EndOffsetIteratorT,
+            typename = ::cuda::std::void_t<typename ::cuda::std::iterator_traits<BeginOffsetIteratorT>::value_type,
+                                           typename ::cuda::std::iterator_traits<EndOffsetIteratorT>::value_type>>
   CUB_RUNTIME_FUNCTION static cudaError_t
   Max(void* d_temp_storage,
       size_t& temp_storage_bytes,
@@ -1307,7 +1327,12 @@ public:
   //!   @rst
   //!   **[optional]** CUDA stream to launch kernels within. Default is stream\ :sub:`0`.
   //!   @endrst
-  template <typename InputIteratorT, typename OutputIteratorT, typename BeginOffsetIteratorT, typename EndOffsetIteratorT>
+  template <typename InputIteratorT,
+            typename OutputIteratorT,
+            typename BeginOffsetIteratorT,
+            typename EndOffsetIteratorT,
+            typename = ::cuda::std::void_t<typename ::cuda::std::iterator_traits<BeginOffsetIteratorT>::value_type,
+                                           typename ::cuda::std::iterator_traits<EndOffsetIteratorT>::value_type>>
   CUB_RUNTIME_FUNCTION static cudaError_t ArgMax(
     void* d_temp_storage,
     size_t& temp_storage_bytes,

--- a/cub/cub/device/device_segmented_reduce.cuh
+++ b/cub/cub/device/device_segmented_reduce.cuh
@@ -53,6 +53,7 @@
 
 #include <cuda/std/limits>
 #include <cuda/std/type_traits>
+#include <cuda/std/utility>
 
 CUB_NAMESPACE_BEGIN
 

--- a/cub/cub/device/device_segmented_reduce.cuh
+++ b/cub/cub/device/device_segmented_reduce.cuh
@@ -543,7 +543,7 @@ public:
       int segment_size,
       cudaStream_t stream = 0)
   {
-    CUB_DETAIL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceSegmentedReduce::Sum");
+    _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceSegmentedReduce::Sum");
 
     // `offset_t` a.k.a `SegmentSizeT` is fixed to `int` type now, but later can be changed to accept
     // integral constant or larger integral types
@@ -756,7 +756,7 @@ public:
       int segment_size,
       cudaStream_t stream = 0)
   {
-    CUB_DETAIL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceSegmentedReduce::Min");
+    _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceSegmentedReduce::Min");
 
     // `offset_t` a.k.a `SegmentSizeT` is fixed to `int` type now, but later can be changed to accept
     // integral constant or larger integral types
@@ -996,7 +996,7 @@ public:
     int segment_size,
     cudaStream_t stream = 0)
   {
-    CUB_DETAIL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceSegmentedReduce::ArgMax");
+    _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceSegmentedReduce::ArgMax");
 
     // `offset_t` a.k.a `SegmentSizeT` is fixed to `int` type now, but later can be changed to accept
     // integral constant or larger integral types
@@ -1216,7 +1216,7 @@ public:
       int segment_size,
       cudaStream_t stream = 0)
   {
-    CUB_DETAIL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceSegmentedReduce::Max");
+    _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceSegmentedReduce::Max");
 
     // `offset_t` a.k.a `SegmentSizeT` is fixed to `int` type now, but later can be changed to accept
     // integral constant or larger integral types
@@ -1462,7 +1462,7 @@ public:
     int segment_size,
     cudaStream_t stream = 0)
   {
-    CUB_DETAIL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceSegmentedReduce::ArgMax");
+    _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceSegmentedReduce::ArgMax");
 
     // `offset_t` a.k.a `SegmentSizeT` is fixed to `int` type now, but later can be changed to accept
     // integral constant or larger integral types

--- a/cub/cub/device/dispatch/dispatch_reduce.cuh
+++ b/cub/cub/device/dispatch/dispatch_reduce.cuh
@@ -995,6 +995,26 @@ struct DispatchSegmentedReduce
 namespace detail::reduce
 {
 
+// @brief Functor to generate a key-value pair from an index and value
+template <typename Iterator, typename OutputValueT>
+struct generate_idx_value
+{
+private:
+  Iterator it;
+  int segment_size;
+
+public:
+  _CCCL_HOST_DEVICE _CCCL_FORCEINLINE generate_idx_value(Iterator it, int segment_size)
+      : it(it)
+      , segment_size(segment_size)
+  {}
+
+  _CCCL_HOST_DEVICE _CCCL_FORCEINLINE auto operator()(::cuda::std::int64_t idx) const
+  {
+    return ::cuda::std::pair<int, OutputValueT>(static_cast<int>(idx % segment_size), it[idx]);
+  }
+};
+
 template <typename MaxPolicyT,
           typename InputIteratorT,
           typename OutputIteratorT,

--- a/cub/cub/device/dispatch/kernels/segmented_reduce.cuh
+++ b/cub/cub/device/dispatch/kernels/segmented_reduce.cuh
@@ -270,7 +270,7 @@ __launch_bounds__(int(ChainedPolicyT::ActivePolicy::ReducePolicy::BLOCK_THREADS)
     {
       if (lane_id == 0)
       {
-        *(d_out + global_segment_id) = init;
+        *(d_out + global_segment_id) = detail::reduce::unwrap_empty_problem_init(init);
       }
       return;
     }

--- a/cub/cub/device/dispatch/kernels/segmented_reduce.cuh
+++ b/cub/cub/device/dispatch/kernels/segmented_reduce.cuh
@@ -265,18 +265,18 @@ __launch_bounds__(int(ChainedPolicyT::ActivePolicy::ReducePolicy::BLOCK_THREADS)
     const int global_segment_id = bid * segments_per_small_block + sid_within_block;
 
     const auto segment_begin = static_cast<::cuda::std::int64_t>(global_segment_id) * segment_size;
-    // If empty segment, write out the initial value
-    if (segment_size == 0)
-    {
-      if (lane_id == 0)
-      {
-        *(d_out + global_segment_id) = detail::reduce::unwrap_empty_problem_init(init);
-      }
-      return;
-    }
 
     if (global_segment_id < num_segments)
     {
+      // If empty segment, write out the initial value
+      if (segment_size == 0)
+      {
+        if (lane_id == 0)
+        {
+          *(d_out + global_segment_id) = detail::reduce::unwrap_empty_problem_init(init);
+        }
+        return;
+      }
       // Consume input tiles
       AccumT warp_aggregate =
         AgentSmallReduceT(temp_storage.small_storage[sid_within_block], d_in + segment_begin, reduction_op)

--- a/cub/cub/device/dispatch/kernels/segmented_reduce.cuh
+++ b/cub/cub/device/dispatch/kernels/segmented_reduce.cuh
@@ -282,9 +282,6 @@ __launch_bounds__(int(ChainedPolicyT::ActivePolicy::ReducePolicy::BLOCK_THREADS)
         AgentSmallReduceT(temp_storage.small_storage[sid_within_block], d_in + segment_begin, reduction_op)
           .ConsumeRange({}, static_cast<int>(segment_size));
 
-      // Normalize as needed
-      NormalizeReductionOutput(warp_aggregate, segment_begin, d_in);
-
       if (lane_id == 0)
       {
         finalize_and_store_aggregate(d_out + global_segment_id, reduction_op, init, warp_aggregate);
@@ -306,9 +303,6 @@ __launch_bounds__(int(ChainedPolicyT::ActivePolicy::ReducePolicy::BLOCK_THREADS)
         AgentMediumReduceT(temp_storage.medium_storage[sid_within_block], d_in + segment_begin, reduction_op)
           .ConsumeRange({}, static_cast<int>(segment_size));
 
-      // Normalize as needed
-      NormalizeReductionOutput(warp_aggregate, segment_begin, d_in);
-
       if (lane_id == 0)
       {
         finalize_and_store_aggregate(d_out + global_segment_id, reduction_op, init, warp_aggregate);
@@ -322,9 +316,6 @@ __launch_bounds__(int(ChainedPolicyT::ActivePolicy::ReducePolicy::BLOCK_THREADS)
     // Consume input tiles
     AccumT block_aggregate = AgentReduceT(temp_storage.large_storage, d_in + segment_begin, reduction_op)
                                .ConsumeRange({}, static_cast<int>(segment_size));
-
-    // Normalize as needed
-    NormalizeReductionOutput(block_aggregate, segment_begin, d_in);
 
     if (tid == 0)
     {

--- a/cub/cub/thread/thread_operators.cuh
+++ b/cub/cub/thread/thread_operators.cuh
@@ -100,6 +100,28 @@ struct ArgMax
   }
 };
 
+namespace detail
+{
+/// @brief Arg max functor (keeps the value and offset of the first occurrence
+///        of the larger item)
+struct ArgMax
+{
+  /// Boolean max operator, preferring the item having the smaller offset in
+  /// case of ties
+  template <typename T, typename OffsetT>
+  _CCCL_HOST_DEVICE _CCCL_FORCEINLINE ::cuda::std::pair<OffsetT, T>
+  operator()(const ::cuda::std::pair<OffsetT, T>& a, const ::cuda::std::pair<OffsetT, T>& b) const
+  {
+    if ((b.second > a.second) || ((a.second == b.second) && (b.first < a.first)))
+    {
+      return b;
+    }
+
+    return a;
+  }
+};
+} // namespace detail
+
 /// @brief Arg min functor (keeps the value and offset of the first occurrence
 ///        of the smallest item)
 struct ArgMin

--- a/cub/cub/thread/thread_operators.cuh
+++ b/cub/cub/thread/thread_operators.cuh
@@ -120,6 +120,26 @@ struct ArgMax
     return a;
   }
 };
+
+/// @brief Arg min functor (keeps the value and offset of the first occurrence
+///        of the smallest item)
+struct ArgMin
+{
+  /// Boolean min operator, preferring the item having the smaller offset in
+  /// case of ties
+  template <typename T, typename OffsetT>
+  _CCCL_HOST_DEVICE _CCCL_FORCEINLINE ::cuda::std::pair<OffsetT, T>
+  operator()(const ::cuda::std::pair<OffsetT, T>& a, const ::cuda::std::pair<OffsetT, T>& b) const
+  {
+    if ((b.second < a.second) || ((a.second == b.second) && (b.first < a.first)))
+    {
+      return b;
+    }
+
+    return a;
+  }
+};
+
 } // namespace detail
 
 /// @brief Arg min functor (keeps the value and offset of the first occurrence

--- a/cub/cub/thread/thread_operators.cuh
+++ b/cub/cub/thread/thread_operators.cuh
@@ -52,6 +52,7 @@
 #include <cuda/functional> // cuda::maximum, cuda::minimum
 #include <cuda/std/cstdint> // cuda::std::uint32_t
 #include <cuda/std/functional> // cuda::std::plus
+#include <cuda/std/utility> // cuda::std::pair
 
 CUB_NAMESPACE_BEGIN
 

--- a/cub/cub/thread/thread_operators.cuh
+++ b/cub/cub/thread/thread_operators.cuh
@@ -130,7 +130,7 @@ namespace detail
 
 /// @brief Arg max functor (keeps the value and offset of the first occurrence
 ///        of the larger item)
-struct ArgMax
+struct arg_max
 {
   /// Boolean max operator, preferring the item having the smaller offset in
   /// case of ties
@@ -149,7 +149,7 @@ struct ArgMax
 
 /// @brief Arg min functor (keeps the value and offset of the first occurrence
 ///        of the smallest item)
-struct ArgMin
+struct arg_min
 {
   /// Boolean min operator, preferring the item having the smaller offset in
   /// case of ties

--- a/cub/test/catch2_test_device_reduce.cuh
+++ b/cub/test/catch2_test_device_reduce.cuh
@@ -466,7 +466,7 @@ void compute_fixed_size_segmented_argmax_reference(
       auto seg_begin          = h_begin + seg * segment_size;
       auto seg_end            = seg_begin + segment_size;
       auto expected_result_it = std::max_element(seg_begin, seg_end);
-      int result_offset       = static_cast<int>(thrust::distance((seg_begin), expected_result_it));
+      int result_offset       = static_cast<int>(::cuda::std::distance((seg_begin), expected_result_it));
       h_results[seg]          = {result_offset, *expected_result_it};
     }
   }
@@ -494,7 +494,7 @@ void compute_fixed_size_segmented_argmin_reference(
       auto seg_begin          = h_begin + seg * segment_size;
       auto seg_end            = seg_begin + segment_size;
       auto expected_result_it = std::min_element(seg_begin, seg_end);
-      int result_offset       = static_cast<int>(thrust::distance((seg_begin), expected_result_it));
+      int result_offset       = static_cast<int>(::cuda::std::distance((seg_begin), expected_result_it));
       h_results[seg]          = {result_offset, *expected_result_it};
     }
   }

--- a/cub/test/catch2_test_device_reduce.cuh
+++ b/cub/test/catch2_test_device_reduce.cuh
@@ -420,6 +420,58 @@ void compute_segmented_argmax_reference(
 }
 
 /**
+ * @brief Helper function to compute the reference solution for result verification, taking a
+ * c2h::device_vector of input items, num_segments and segment_size.
+ */
+template <typename ItemT, typename ReductionOpT, typename AccumulatorT, typename ResultItT>
+void compute_fixed_size_segmented_problem_reference(
+  const c2h::device_vector<ItemT>& d_in,
+  const int num_segments,
+  const int segment_size,
+  ReductionOpT reduction_op,
+  AccumulatorT init,
+  ResultItT h_results)
+{
+  c2h::host_vector<ItemT> h_items(d_in);
+  auto h_begin = h_items.cbegin();
+
+  for (int segment = 0; segment < num_segments; segment++)
+  {
+    auto seg_begin = h_begin + segment * segment_size;
+    auto seg_end   = seg_begin + segment_size;
+    h_results[segment] =
+      static_cast<cub::detail::it_value_t<ResultItT>>(std::accumulate(seg_begin, seg_end, init, reduction_op));
+  }
+}
+
+/**
+ * @brief Helper function to compute the reference solution for result verification, taking a
+ * c2h::device_vector of input items, num_segments and segment_size.
+ */
+template <typename ItemT, typename ResultItT>
+void compute_fixed_size_segmented_argmax_reference(
+  const c2h::device_vector<ItemT>& d_in, const int num_segments, const int segment_size, ResultItT h_results)
+{
+  c2h::host_vector<ItemT> h_items(d_in);
+  auto h_begin = h_items.begin();
+
+  for (int seg = 0; seg < num_segments; seg++)
+  {
+    if (segment_size == 0)
+    {
+      h_results[seg] = {1, ::cuda::std::numeric_limits<ItemT>::lowest()};
+    }
+    else
+    {
+      auto seg_begin          = h_begin + seg * segment_size;
+      auto seg_end            = seg_begin + segment_size;
+      auto expected_result_it = std::max_element(seg_begin, seg_end);
+      int result_offset       = static_cast<int>(thrust::distance((seg_begin), expected_result_it));
+      h_results[seg]          = {result_offset, *expected_result_it};
+    }
+  }
+}
+/**
  * @brief Helper function to compute the reference solution for unique keys (i.e., collapsing each
  * run of equal keys into a single key).
  */

--- a/cub/test/catch2_test_device_segmented_reduce.cu
+++ b/cub/test/catch2_test_device_segmented_reduce.cu
@@ -31,6 +31,7 @@
 #include <cub/device/device_segmented_reduce.cuh>
 
 #include <cuda/std/limits>
+#include <cuda/std/utility>
 
 #include <numeric>
 

--- a/cub/test/catch2_test_device_segmented_reduce.cu
+++ b/cub/test/catch2_test_device_segmented_reduce.cu
@@ -232,31 +232,6 @@ C2H_TEST("Device reduce works with all device interfaces", "[segmented][reduce][
   }
 }
 
-/**
- * @brief Helper function to compute the reference solution for result verification, taking a
- * c2h::device_vector of input items, num_segments and segment_size.
- */
-template <typename ItemT, typename ReductionOpT, typename AccumulatorT, typename ResultItT>
-void compute_fixed_size_segmented_problem_reference(
-  const c2h::device_vector<ItemT>& d_in,
-  const int num_segments,
-  const int segment_size,
-  ReductionOpT reduction_op,
-  AccumulatorT init,
-  ResultItT h_results)
-{
-  c2h::host_vector<ItemT> h_items(d_in);
-  auto h_begin = h_items.cbegin();
-
-  for (int segment = 0; segment < num_segments; segment++)
-  {
-    auto seg_begin = h_begin + segment * segment_size;
-    auto seg_end   = seg_begin + segment_size;
-    h_results[segment] =
-      static_cast<cub::detail::it_value_t<ResultItT>>(std::accumulate(seg_begin, seg_end, init, reduction_op));
-  }
-}
-
 C2H_TEST("Device fixed size segmented reduce works with all device interfaces",
          "[segmented][reduce][device]",
          full_type_list)
@@ -309,6 +284,91 @@ C2H_TEST("Device fixed size segmented reduce works with all device interfaces",
     using init_t = cub::detail::it_value_t<decltype(unwrap_it(d_out_it))>;
     init_t init  = static_cast<init_t>(*unwrap_it(&default_constant));
     device_segmented_reduce(unwrap_it(d_in_it), unwrap_it(d_out_it), num_segments, segment_size, reduction_op, init);
+    // Verify result
+    REQUIRE(expected_result == out_result);
+  }
+
+// Skip DeviceReduce::Sum tests for extended floating-point types because of unbounded epsilon due
+// to pseudo associativity of the addition operation over floating point numbers
+#if TEST_TYPES != 3
+  SECTION("sum")
+  {
+    using op_t    = ::cuda::std::plus<>;
+    using accum_t = ::cuda::std::__accumulator_t<op_t, input_t, output_t>;
+
+    // Prepare verification data
+    c2h::host_vector<output_t> expected_result(num_segments);
+    compute_fixed_size_segmented_problem_reference(
+      in_items, num_segments, segment_size, op_t{}, accum_t{}, expected_result.begin());
+
+    // Run test
+    c2h::device_vector<output_t> out_result(num_segments);
+    auto d_out_it = unwrap_it(thrust::raw_pointer_cast(out_result.data()));
+    device_segmented_sum(d_in_it, d_out_it, num_segments, segment_size);
+
+    // Verify result
+    REQUIRE(expected_result == out_result);
+  }
+#endif
+
+  SECTION("min")
+  {
+    using op_t = ::cuda::minimum<>;
+
+    // Prepare verification data
+    c2h::host_vector<output_t> expected_result(num_segments);
+    compute_fixed_size_segmented_problem_reference(
+      in_items,
+      num_segments,
+      segment_size,
+      op_t{},
+      ::cuda::std::numeric_limits<input_t>::max(),
+      expected_result.begin());
+
+    // Run test
+    c2h::device_vector<output_t> out_result(num_segments);
+    auto d_out_it = thrust::raw_pointer_cast(out_result.data());
+    device_segmented_min(unwrap_it(d_in_it), unwrap_it(d_out_it), num_segments, segment_size);
+
+    // Verify result
+    REQUIRE(expected_result == out_result);
+  }
+
+  SECTION("max")
+  {
+    using op_t = ::cuda::maximum<>;
+
+    // Prepare verification data
+    c2h::host_vector<output_t> expected_result(num_segments);
+    compute_fixed_size_segmented_problem_reference(
+      in_items,
+      num_segments,
+      segment_size,
+      op_t{},
+      ::cuda::std::numeric_limits<input_t>::lowest(),
+      expected_result.begin());
+
+    // Run test
+    c2h::device_vector<output_t> out_result(num_segments);
+    auto d_out_it = thrust::raw_pointer_cast(out_result.data());
+    device_segmented_max(unwrap_it(d_in_it), unwrap_it(d_out_it), num_segments, segment_size);
+
+    // Verify result
+    REQUIRE(expected_result == out_result);
+  }
+
+  SECTION("argmax")
+  {
+    using result_t = cub::KeyValuePair<int, output_t>;
+
+    // Prepare verification data
+    c2h::host_vector<result_t> expected_result(num_segments);
+    compute_fixed_size_segmented_argmax_reference(in_items, num_segments, segment_size, expected_result.begin());
+
+    // Run test
+    c2h::device_vector<result_t> out_result(num_segments);
+    device_segmented_arg_max(d_in_it, thrust::raw_pointer_cast(out_result.data()), num_segments, segment_size);
+
     // Verify result
     REQUIRE(expected_result == out_result);
   }

--- a/cub/test/catch2_test_device_segmented_reduce.cu
+++ b/cub/test/catch2_test_device_segmented_reduce.cu
@@ -334,6 +334,23 @@ C2H_TEST("Device fixed size segmented reduce works with all device interfaces",
     REQUIRE(expected_result == out_result);
   }
 
+  SECTION("argmin")
+  {
+    using result_t = ::cuda::std::pair<int, output_t>;
+
+    // Prepare verification data
+    c2h::host_vector<result_t> expected_result(num_segments);
+    compute_fixed_size_segmented_argmin_reference(in_items, num_segments, segment_size, expected_result.begin());
+
+    // Run test
+    c2h::device_vector<result_t> out_result(num_segments);
+    device_segmented_arg_min(d_in_it, thrust::raw_pointer_cast(out_result.data()), num_segments, segment_size);
+
+    c2h::host_vector<result_t> host_result(out_result);
+    // Verify result
+    REQUIRE(expected_result == host_result);
+  }
+
   SECTION("max")
   {
     using op_t = ::cuda::maximum<>;

--- a/cub/test/catch2_test_device_segmented_reduce.cu
+++ b/cub/test/catch2_test_device_segmented_reduce.cu
@@ -297,17 +297,18 @@ C2H_TEST("Device fixed size segmented reduce works with all device interfaces",
     using accum_t = ::cuda::std::__accumulator_t<op_t, input_t, output_t>;
 
     // Prepare verification data
-    c2h::host_vector<output_t> expected_result(num_segments);
+    c2h::host_vector<output_t> h_expected_result(num_segments);
     compute_fixed_size_segmented_problem_reference(
-      in_items, num_segments, segment_size, op_t{}, accum_t{}, expected_result.begin());
+      in_items, num_segments, segment_size, op_t{}, accum_t{}, h_expected_result.begin());
 
     // Run test
-    c2h::device_vector<output_t> out_result(num_segments);
-    auto d_out_it = unwrap_it(thrust::raw_pointer_cast(out_result.data()));
+    c2h::device_vector<output_t> d_out_result(num_segments);
+    auto d_out_it = unwrap_it(thrust::raw_pointer_cast(d_out_result.data()));
     device_segmented_sum(d_in_it, d_out_it, num_segments, segment_size);
 
+    c2h::host_vector<output_t> h_out_result(d_out_result);
     // Verify result
-    REQUIRE(expected_result == out_result);
+    REQUIRE(h_expected_result == h_out_result);
   }
 #endif
 
@@ -316,22 +317,23 @@ C2H_TEST("Device fixed size segmented reduce works with all device interfaces",
     using op_t = ::cuda::minimum<>;
 
     // Prepare verification data
-    c2h::host_vector<output_t> expected_result(num_segments);
+    c2h::host_vector<output_t> h_expected_result(num_segments);
     compute_fixed_size_segmented_problem_reference(
       in_items,
       num_segments,
       segment_size,
       op_t{},
       ::cuda::std::numeric_limits<input_t>::max(),
-      expected_result.begin());
+      h_expected_result.begin());
 
     // Run test
-    c2h::device_vector<output_t> out_result(num_segments);
-    auto d_out_it = thrust::raw_pointer_cast(out_result.data());
+    c2h::device_vector<output_t> d_out_result(num_segments);
+    auto d_out_it = thrust::raw_pointer_cast(d_out_result.data());
     device_segmented_min(unwrap_it(d_in_it), unwrap_it(d_out_it), num_segments, segment_size);
 
+    c2h::host_vector<output_t> h_out_result(d_out_result);
     // Verify result
-    REQUIRE(expected_result == out_result);
+    REQUIRE(h_expected_result == h_out_result);
   }
 
   SECTION("argmin")
@@ -339,16 +341,16 @@ C2H_TEST("Device fixed size segmented reduce works with all device interfaces",
     using result_t = ::cuda::std::pair<int, output_t>;
 
     // Prepare verification data
-    c2h::host_vector<result_t> expected_result(num_segments);
-    compute_fixed_size_segmented_argmin_reference(in_items, num_segments, segment_size, expected_result.begin());
+    c2h::host_vector<result_t> h_expected_result(num_segments);
+    compute_fixed_size_segmented_argmin_reference(in_items, num_segments, segment_size, h_expected_result.begin());
 
     // Run test
-    c2h::device_vector<result_t> out_result(num_segments);
-    device_segmented_arg_min(d_in_it, thrust::raw_pointer_cast(out_result.data()), num_segments, segment_size);
+    c2h::device_vector<result_t> d_out_result(num_segments);
+    device_segmented_arg_min(d_in_it, thrust::raw_pointer_cast(d_out_result.data()), num_segments, segment_size);
 
-    c2h::host_vector<result_t> host_result(out_result);
+    c2h::host_vector<result_t> h_out_result(d_out_result);
     // Verify result
-    REQUIRE(expected_result == host_result);
+    REQUIRE(h_expected_result == h_out_result);
   }
 
   SECTION("max")
@@ -356,22 +358,23 @@ C2H_TEST("Device fixed size segmented reduce works with all device interfaces",
     using op_t = ::cuda::maximum<>;
 
     // Prepare verification data
-    c2h::host_vector<output_t> expected_result(num_segments);
+    c2h::host_vector<output_t> h_expected_result(num_segments);
     compute_fixed_size_segmented_problem_reference(
       in_items,
       num_segments,
       segment_size,
       op_t{},
       ::cuda::std::numeric_limits<input_t>::lowest(),
-      expected_result.begin());
+      h_expected_result.begin());
 
     // Run test
-    c2h::device_vector<output_t> out_result(num_segments);
-    auto d_out_it = thrust::raw_pointer_cast(out_result.data());
+    c2h::device_vector<output_t> d_out_result(num_segments);
+    auto d_out_it = thrust::raw_pointer_cast(d_out_result.data());
     device_segmented_max(unwrap_it(d_in_it), unwrap_it(d_out_it), num_segments, segment_size);
 
+    c2h::host_vector<output_t> h_out_result(d_out_result);
     // Verify result
-    REQUIRE(expected_result == out_result);
+    REQUIRE(h_expected_result == h_out_result);
   }
 
   SECTION("argmax")
@@ -379,15 +382,15 @@ C2H_TEST("Device fixed size segmented reduce works with all device interfaces",
     using result_t = ::cuda::std::pair<int, output_t>;
 
     // Prepare verification data
-    c2h::host_vector<result_t> expected_result(num_segments);
-    compute_fixed_size_segmented_argmax_reference(in_items, num_segments, segment_size, expected_result.begin());
+    c2h::host_vector<result_t> h_expected_result(num_segments);
+    compute_fixed_size_segmented_argmax_reference(in_items, num_segments, segment_size, h_expected_result.begin());
 
     // Run test
-    c2h::device_vector<result_t> out_result(num_segments);
-    device_segmented_arg_max(d_in_it, thrust::raw_pointer_cast(out_result.data()), num_segments, segment_size);
+    c2h::device_vector<result_t> d_out_result(num_segments);
+    device_segmented_arg_max(d_in_it, thrust::raw_pointer_cast(d_out_result.data()), num_segments, segment_size);
 
-    c2h::host_vector<result_t> host_result(out_result);
+    c2h::host_vector<result_t> h_out_result(d_out_result);
     // Verify result
-    REQUIRE(expected_result == host_result);
+    REQUIRE(h_expected_result == h_out_result);
   }
 }

--- a/cub/test/catch2_test_device_segmented_reduce.cu
+++ b/cub/test/catch2_test_device_segmented_reduce.cu
@@ -359,7 +359,7 @@ C2H_TEST("Device fixed size segmented reduce works with all device interfaces",
 
   SECTION("argmax")
   {
-    using result_t = cub::KeyValuePair<int, output_t>;
+    using result_t = ::cuda::std::pair<int, output_t>;
 
     // Prepare verification data
     c2h::host_vector<result_t> expected_result(num_segments);
@@ -369,7 +369,8 @@ C2H_TEST("Device fixed size segmented reduce works with all device interfaces",
     c2h::device_vector<result_t> out_result(num_segments);
     device_segmented_arg_max(d_in_it, thrust::raw_pointer_cast(out_result.data()), num_segments, segment_size);
 
+    c2h::host_vector<result_t> host_result(out_result);
     // Verify result
-    REQUIRE(expected_result == out_result);
+    REQUIRE(expected_result == host_result);
   }
 }

--- a/cub/test/catch2_test_device_segmented_reduce_api.cu
+++ b/cub/test/catch2_test_device_segmented_reduce_api.cu
@@ -57,6 +57,11 @@ struct is_equal
   {
     return !(lhs != rhs);
   }
+
+  __device__ bool operator()(::cuda::std::pair<int, int> lhs, ::cuda::std::pair<int, int> rhs)
+  {
+    return !(lhs != rhs);
+  }
 };
 
 C2H_TEST("cub::DeviceSegmentedReduce::Reduce works with int data elements", "[segmented_reduce][device]")
@@ -273,4 +278,148 @@ C2H_TEST("cub::DeviceSegmentedReduce::Reduce Fixed Segment Size works with int d
   // example-end fixed-size-segmented-reduce-reduce
 
   REQUIRE(d_out == expected);
+}
+
+C2H_TEST("cub::DeviceSegmentedReduce::Sum Fixed Segment Size works with int data elements",
+         "[segmented_reduce][device]")
+{
+  // example-begin fixed-size-segmented-reduce-sum
+  int num_segments = 3;
+  int segment_size = 2;
+  c2h::device_vector<int> d_in{6, 8, 7, 5, 3, 0};
+  c2h::device_vector<int> d_out(3);
+
+  // Determine temporary device storage requirements
+  void* d_temp_storage      = nullptr;
+  size_t temp_storage_bytes = 0;
+  cub::DeviceSegmentedReduce::Sum(
+    d_temp_storage, temp_storage_bytes, d_in.begin(), d_out.begin(), num_segments, segment_size);
+
+  c2h::device_vector<std::uint8_t> temp_storage(temp_storage_bytes);
+  d_temp_storage = thrust::raw_pointer_cast(temp_storage.data());
+
+  // Run reduction
+  cub::DeviceSegmentedReduce::Sum(
+    d_temp_storage, temp_storage_bytes, d_in.begin(), d_out.begin(), num_segments, segment_size);
+
+  c2h::device_vector<int> expected{14, 12, 3};
+  // example-end fixed-size-segmented-reduce-sum
+
+  REQUIRE(d_out == expected);
+}
+
+C2H_TEST("cub::DeviceSegmentedReduce::Min Fixed Segment Size works with int data elements",
+         "[segmented_reduce][device]")
+{
+  // example-begin fixed-size-segmented-reduce-min
+  int num_segments = 3;
+  int segment_size = 2;
+  c2h::device_vector<int> d_in{6, 8, 7, 5, 3, 0};
+  c2h::device_vector<int> d_out(3);
+
+  // Determine temporary device storage requirements
+  void* d_temp_storage      = nullptr;
+  size_t temp_storage_bytes = 0;
+  cub::DeviceSegmentedReduce::Min(
+    d_temp_storage, temp_storage_bytes, d_in.begin(), d_out.begin(), num_segments, segment_size);
+
+  c2h::device_vector<std::uint8_t> temp_storage(temp_storage_bytes);
+  d_temp_storage = thrust::raw_pointer_cast(temp_storage.data());
+
+  // Run reduction
+  cub::DeviceSegmentedReduce::Min(
+    d_temp_storage, temp_storage_bytes, d_in.begin(), d_out.begin(), num_segments, segment_size);
+
+  c2h::device_vector<int> expected{6, 5, 0};
+  // example-end fixed-size-segmented-reduce-min
+
+  REQUIRE(d_out == expected);
+}
+
+C2H_TEST("cub::DeviceSegmentedReduce::ArgMin Fixed Segment Size works with int data elements",
+         "[segmented_reduce][device]")
+{
+  // example-begin fixed-size-segmented-reduce-argmin
+  int num_segments = 3;
+  int segment_size = 2;
+  c2h::device_vector<int> d_in{6, 8, 7, 5, 3, 0};
+  c2h::device_vector<::cuda::std::pair<int, int>> d_out(3);
+
+  // Determine temporary device storage requirements
+  void* d_temp_storage      = nullptr;
+  size_t temp_storage_bytes = 0;
+  cub::DeviceSegmentedReduce::ArgMin(
+    d_temp_storage, temp_storage_bytes, d_in.begin(), d_out.begin(), num_segments, segment_size);
+
+  c2h::device_vector<std::uint8_t> temp_storage(temp_storage_bytes);
+  d_temp_storage = thrust::raw_pointer_cast(temp_storage.data());
+
+  // Run reduction
+  cub::DeviceSegmentedReduce::ArgMin(
+    d_temp_storage, temp_storage_bytes, d_in.begin(), d_out.begin(), num_segments, segment_size);
+
+  c2h::host_vector<::cuda::std::pair<int, int>> h_expected{{0, 6}, {1, 5}, {1, 0}};
+  // example-end fixed-size-segmented-reduce-argmin
+
+  c2h::host_vector<::cuda::std::pair<int, int>> h_out(d_out);
+
+  REQUIRE(h_expected == h_out);
+}
+
+C2H_TEST("cub::DeviceSegmentedReduce::Max Fixed Segment Size works with int data elements",
+         "[segmented_reduce][device]")
+{
+  // example-begin fixed-size-segmented-reduce-max
+  int num_segments = 3;
+  int segment_size = 2;
+
+  c2h::device_vector<int> d_in{6, 8, 7, 5, 3, 0};
+  c2h::device_vector<int> d_out(3);
+
+  // Determine temporary device storage requirements
+  void* d_temp_storage      = nullptr;
+  size_t temp_storage_bytes = 0;
+  cub::DeviceSegmentedReduce::Max(
+    d_temp_storage, temp_storage_bytes, d_in.begin(), d_out.begin(), num_segments, segment_size);
+
+  c2h::device_vector<std::uint8_t> temp_storage(temp_storage_bytes);
+  d_temp_storage = thrust::raw_pointer_cast(temp_storage.data());
+
+  // Run reduction
+  cub::DeviceSegmentedReduce::Max(
+    d_temp_storage, temp_storage_bytes, d_in.begin(), d_out.begin(), num_segments, segment_size);
+
+  c2h::device_vector<int> expected{8, 7, 3};
+  // example-end fixed-size-segmented-reduce-max
+
+  REQUIRE(d_out == expected);
+}
+
+C2H_TEST("cub::DeviceSegmentedReduce::ArgMax Fixed Segment Size works with int data elements",
+         "[segmented_reduce][device]")
+{
+  // example-begin fixed-size-segmented-reduce-argmax
+  int num_segments = 3;
+  int segment_size = 2;
+  c2h::device_vector<int> d_in{6, 8, 7, 5, 3, 0};
+  c2h::device_vector<::cuda::std::pair<int, int>> d_out(3);
+
+  // Determine temporary device storage requirements
+  void* d_temp_storage      = nullptr;
+  size_t temp_storage_bytes = 0;
+  cub::DeviceSegmentedReduce::ArgMax(
+    d_temp_storage, temp_storage_bytes, d_in.begin(), d_out.begin(), num_segments, segment_size);
+
+  c2h::device_vector<std::uint8_t> temp_storage(temp_storage_bytes);
+  d_temp_storage = thrust::raw_pointer_cast(temp_storage.data());
+
+  // Run reduction
+  cub::DeviceSegmentedReduce::ArgMax(
+    d_temp_storage, temp_storage_bytes, d_in.begin(), d_out.begin(), num_segments, segment_size);
+
+  c2h::host_vector<::cuda::std::pair<int, int>> h_expected{{1, 8}, {0, 7}, {0, 3}};
+  // example-end fixed-size-segmented-reduce-argmax
+
+  c2h::host_vector<::cuda::std::pair<int, int>> h_out(d_out);
+  REQUIRE(h_expected == h_out);
 }

--- a/cub/test/catch2_test_device_segmented_reduce_api.cu
+++ b/cub/test/catch2_test_device_segmented_reduce_api.cu
@@ -302,10 +302,10 @@ C2H_TEST("cub::DeviceSegmentedReduce::Sum Fixed Segment Size works with int data
   cub::DeviceSegmentedReduce::Sum(
     d_temp_storage, temp_storage_bytes, d_in.begin(), d_out.begin(), num_segments, segment_size);
 
-  c2h::device_vector<int> expected{14, 12, 3};
+  c2h::device_vector<int> d_expected{14, 12, 3};
   // example-end fixed-size-segmented-reduce-sum
 
-  REQUIRE(d_out == expected);
+  REQUIRE(d_expected == d_out);
 }
 
 C2H_TEST("cub::DeviceSegmentedReduce::Min Fixed Segment Size works with int data elements",
@@ -330,10 +330,10 @@ C2H_TEST("cub::DeviceSegmentedReduce::Min Fixed Segment Size works with int data
   cub::DeviceSegmentedReduce::Min(
     d_temp_storage, temp_storage_bytes, d_in.begin(), d_out.begin(), num_segments, segment_size);
 
-  c2h::device_vector<int> expected{6, 5, 0};
+  c2h::device_vector<int> d_expected{6, 5, 0};
   // example-end fixed-size-segmented-reduce-min
 
-  REQUIRE(d_out == expected);
+  REQUIRE(d_expected == d_out);
 }
 
 C2H_TEST("cub::DeviceSegmentedReduce::ArgMin Fixed Segment Size works with int data elements",
@@ -389,10 +389,10 @@ C2H_TEST("cub::DeviceSegmentedReduce::Max Fixed Segment Size works with int data
   cub::DeviceSegmentedReduce::Max(
     d_temp_storage, temp_storage_bytes, d_in.begin(), d_out.begin(), num_segments, segment_size);
 
-  c2h::device_vector<int> expected{8, 7, 3};
+  c2h::device_vector<int> d_expected{8, 7, 3};
   // example-end fixed-size-segmented-reduce-max
 
-  REQUIRE(d_out == expected);
+  REQUIRE(d_expected == d_out);
 }
 
 C2H_TEST("cub::DeviceSegmentedReduce::ArgMax Fixed Segment Size works with int data elements",

--- a/cub/test/catch2_test_device_segmented_reduce_api.cu
+++ b/cub/test/catch2_test_device_segmented_reduce_api.cu
@@ -33,6 +33,8 @@
 #include <thrust/device_vector.h>
 #include <thrust/equal.h>
 
+#include <cuda/std/utility>
+
 #include <climits>
 #include <cstddef>
 

--- a/cub/test/catch2_test_device_segmented_reduce_large_offsets.cu
+++ b/cub/test/catch2_test_device_segmented_reduce_large_offsets.cu
@@ -64,8 +64,13 @@ struct get_max_from_counting_it_range_op
 template <typename IndexT>
 struct get_argmin_from_counting_it_range_op
 {
-  _CCCL_HOST_DEVICE _CCCL_FORCEINLINE ::cuda::std::pair<int, IndexT> operator()(IndexT begin, IndexT)
+  IndexT init_val;
+  _CCCL_HOST_DEVICE _CCCL_FORCEINLINE ::cuda::std::pair<int, IndexT> operator()(IndexT begin, IndexT end)
   {
+    if (begin == end)
+    {
+      return {1, init_val};
+    }
     return {0, begin};
   }
 };
@@ -73,8 +78,13 @@ struct get_argmin_from_counting_it_range_op
 template <typename IndexT>
 struct get_argmax_from_counting_it_range_op
 {
+  IndexT init_val;
   _CCCL_HOST_DEVICE _CCCL_FORCEINLINE ::cuda::std::pair<int, IndexT> operator()(IndexT begin, IndexT end)
   {
+    if (begin == end)
+    {
+      return {1, init_val};
+    }
     return {static_cast<int>(end - begin - 1), end - 1};
   }
 };
@@ -416,7 +426,8 @@ C2H_TEST("Device fixed size segmented reduce works with a very large number of s
     using accum_t = ::cuda::std::pair<int, input_t>;
     using op_t    = cub::detail::arg_min;
 
-    auto compute_expected_op = get_argmin_from_counting_it_range_op<offset_t>{};
+    auto compute_expected_op =
+      get_argmin_from_counting_it_range_op<offset_t>{::cuda::std::numeric_limits<offset_t>::max()};
 
     test_fixed_size_segmented_reduce<false, input_t, accum_t, op_t>(
       num_segments, compute_expected_op, device_segmented_argmin);
@@ -428,7 +439,8 @@ C2H_TEST("Device fixed size segmented reduce works with a very large number of s
     using accum_t = ::cuda::std::pair<int, input_t>;
     using op_t    = cub::detail::arg_max;
 
-    auto compute_expected_op = get_argmax_from_counting_it_range_op<offset_t>{};
+    auto compute_expected_op =
+      get_argmax_from_counting_it_range_op<offset_t>{::cuda::std::numeric_limits<offset_t>::lowest()};
 
     test_fixed_size_segmented_reduce<false, input_t, accum_t, op_t>(
       num_segments, compute_expected_op, device_segmented_argmax);

--- a/cub/test/catch2_test_device_segmented_reduce_large_offsets.cu
+++ b/cub/test/catch2_test_device_segmented_reduce_large_offsets.cu
@@ -62,20 +62,6 @@ struct get_max_from_counting_it_range_op
 };
 
 template <typename IndexT>
-struct get_argmin_from_counting_it_range_op
-{
-  IndexT init_val;
-  _CCCL_HOST_DEVICE _CCCL_FORCEINLINE ::cuda::std::pair<int, IndexT> operator()(IndexT begin, IndexT end)
-  {
-    if (begin == end)
-    {
-      return {1, init_val};
-    }
-    return {0, begin};
-  }
-};
-
-template <typename IndexT>
 struct get_argmax_from_counting_it_range_op
 {
   IndexT init_val;
@@ -394,19 +380,6 @@ C2H_TEST("Device fixed size segmented reduce works with a very large number of s
       num_segments, compute_expected_op, device_segmented_reduce);
   }
 
-  SECTION("segmented min")
-  {
-    using input_t = ::cuda::std::int64_t;
-    using accum_t = input_t;
-    using op_t    = ::cuda::minimum<>;
-
-    auto compute_expected_op =
-      get_min_from_counting_it_range_op<offset_t>{::cuda::std::numeric_limits<offset_t>::max()};
-
-    test_fixed_size_segmented_reduce<false, input_t, accum_t, op_t>(
-      num_segments, compute_expected_op, device_segmented_min);
-  }
-
   SECTION("segmented max")
   {
     using input_t = ::cuda::std::int64_t;
@@ -418,19 +391,6 @@ C2H_TEST("Device fixed size segmented reduce works with a very large number of s
 
     test_fixed_size_segmented_reduce<false, input_t, accum_t, op_t>(
       num_segments, compute_expected_op, device_segmented_max);
-  }
-
-  SECTION("segmented argmin")
-  {
-    using input_t = ::cuda::std::int64_t;
-    using accum_t = ::cuda::std::pair<int, input_t>;
-    using op_t    = cub::detail::arg_min;
-
-    auto compute_expected_op =
-      get_argmin_from_counting_it_range_op<offset_t>{::cuda::std::numeric_limits<offset_t>::max()};
-
-    test_fixed_size_segmented_reduce<false, input_t, accum_t, op_t>(
-      num_segments, compute_expected_op, device_segmented_argmin);
   }
 
   SECTION("segmented argmax")

--- a/cub/test/catch2_test_device_segmented_reduce_large_offsets.cu
+++ b/cub/test/catch2_test_device_segmented_reduce_large_offsets.cu
@@ -23,6 +23,8 @@ DECLARE_LAUNCH_WRAPPER(cub::DeviceSegmentedReduce::Reduce, device_segmented_redu
 DECLARE_LAUNCH_WRAPPER(cub::DeviceSegmentedReduce::Sum, device_segmented_sum);
 DECLARE_LAUNCH_WRAPPER(cub::DeviceSegmentedReduce::Min, device_segmented_min);
 DECLARE_LAUNCH_WRAPPER(cub::DeviceSegmentedReduce::Max, device_segmented_max);
+DECLARE_LAUNCH_WRAPPER(cub::DeviceSegmentedReduce::ArgMin, device_segmented_argmin);
+DECLARE_LAUNCH_WRAPPER(cub::DeviceSegmentedReduce::ArgMax, device_segmented_argmax);
 
 // %PARAM% TEST_LAUNCH lid 0:1:2
 
@@ -56,6 +58,28 @@ struct get_max_from_counting_it_range_op
   _CCCL_HOST_DEVICE _CCCL_FORCEINLINE IndexT operator()(IndexT begin, IndexT end)
   {
     return begin == end ? init_val : end - 1;
+  }
+};
+
+template <typename IndexT>
+struct get_argmin_from_counting_it_range_op
+{
+  IndexT init_val;
+
+  _CCCL_HOST_DEVICE _CCCL_FORCEINLINE ::cuda::std::pair<int, IndexT> operator()(IndexT begin, IndexT)
+  {
+    return {0, begin};
+  }
+};
+
+template <typename IndexT>
+struct get_argmax_from_counting_it_range_op
+{
+  IndexT init_val;
+
+  _CCCL_HOST_DEVICE _CCCL_FORCEINLINE ::cuda::std::pair<int, IndexT> operator()(IndexT begin, IndexT end)
+  {
+    return {static_cast<int>(end - begin - 1), end - 1};
   }
 };
 
@@ -276,71 +300,142 @@ struct dispatch_helper
   }
 };
 
+// generic test for fixed size segmented reduce
+template <bool IS_REDUCE_ALGORITHM,
+          typename InputT,
+          typename AccumT,
+          typename OpT,
+          typename SegmentIdxT,
+          typename ComputeExpectedOp,
+          typename DeviceAlgorithm>
+void test_fixed_size_segmented_reduce(
+  const SegmentIdxT num_segments, ComputeExpectedOp compute_expected_op, const DeviceAlgorithm& device_algorithm)
+{
+  using offset_t       = SegmentIdxT;
+  using segment_size_t = int;
+
+  using policy_hub_t = cub::detail::fixed_size_segmented_reduce::policy_hub<AccumT, offset_t, OpT>;
+
+  // Get small and medium segment size thresholds from dispatch helper
+  const ::cuda::std::tuple<int, int> thresholds = dispatch_helper<policy_hub_t>::get_thresholds();
+  const int small_segment_size                  = ::cuda::std::get<0>(thresholds);
+  const int medium_segment_size                 = ::cuda::std::get<1>(thresholds);
+
+  // Take one random segment size from each of the segment sizes
+  const segment_size_t segment_size = GENERATE_COPY(
+    take(1, random(1, small_segment_size)),
+    take(1, random(small_segment_size, medium_segment_size)),
+    take(1, random(medium_segment_size, medium_segment_size * 2)));
+
+  const ::cuda::std::int64_t num_items = num_segments * segment_size;
+
+  // Input data
+  const auto segment_index_it = thrust::make_counting_iterator(SegmentIdxT{});
+
+  // Segment offsets
+  segment_index_to_offset_op<offset_t, SegmentIdxT> index_to_offset_op{0, num_segments, segment_size, num_items};
+  auto offsets_it = thrust::make_transform_iterator(segment_index_it, index_to_offset_op);
+
+  CAPTURE(c2h::type_name<offset_t>(), c2h::type_name<SegmentIdxT>(), num_segments, segment_size, num_items);
+
+  try
+  {
+    // Prepare helper to check results
+    auto get_offset_pair_op  = thrust::make_zip_function(compute_expected_op);
+    auto offset_pair_it      = thrust::make_zip_iterator(thrust::make_tuple(offsets_it, offsets_it + 1));
+    auto expected_result_it  = thrust::make_transform_iterator(offset_pair_it, get_offset_pair_op);
+    auto check_result_helper = detail::large_problem_test_helper(num_segments);
+    auto check_result_it     = check_result_helper.get_flagging_output_iterator(expected_result_it);
+
+    // Run test
+    const auto input_it = thrust::make_counting_iterator(InputT{});
+    if constexpr (IS_REDUCE_ALGORITHM)
+    {
+      device_algorithm(input_it, check_result_it, num_segments, segment_size, OpT{}, InputT{0});
+    }
+    else
+    {
+      device_algorithm(input_it, check_result_it, num_segments, segment_size);
+    }
+
+    // Verify all results were written as expected
+    check_result_helper.check_all_results_correct();
+  }
+  catch (std::bad_alloc& e)
+  {
+    std::cerr << "Skipping large num_segments fixed size segmented reduce test " << e.what() << "\n";
+  }
+}
+
 C2H_TEST("Device fixed size segmented reduce works with a very large number of segments", "[reduce][device]")
 {
-  using offset_t        = ::cuda::std::int64_t;
   using segment_index_t = ::cuda::std::int64_t;
-  using segment_size_t  = int; // fixed size segmented reduce supports only `int` as segment size
+  using offset_t        = segment_index_t;
 
   // To test atlest 2 invocations of the kernel
   const auto num_segments = static_cast<segment_index_t>(::cuda::std::numeric_limits<std::int32_t>::max()) + 1;
 
   SECTION("segmented reduce")
   {
-    using sum_t = ::cuda::std::int64_t;
+    using input_t = ::cuda::std::int64_t;
+    using accum_t = input_t;
+    using op_t    = custom_sum_op;
 
-    // Use a custom operator to increase test coverage
-    using op_t = custom_sum_op;
+    auto compute_expected_op = get_gaussian_sum_from_offset_op{};
 
-    // Initial value of reduction
-    const auto init_val = sum_t{0};
+    test_fixed_size_segmented_reduce<true, input_t, accum_t, op_t>(
+      num_segments, compute_expected_op, device_segmented_reduce);
+  }
 
-    // Binary reduction operator
-    const auto reduction_op = op_t{};
+  SECTION("segmented min")
+  {
+    using input_t = ::cuda::std::int64_t;
+    using accum_t = input_t;
+    using op_t    = ::cuda::minimum<>;
 
-    using policy_hub_t = cub::detail::fixed_size_segmented_reduce::policy_hub<sum_t, offset_t, op_t>;
+    auto compute_expected_op =
+      get_min_from_counting_it_range_op<offset_t>{::cuda::std::numeric_limits<offset_t>::max()};
 
-    // Get small and medium segment size thresholds from dispatch helper
-    const ::cuda::std::tuple<int, int> thresholds = dispatch_helper<policy_hub_t>::get_thresholds();
-    const int small_segment_size                  = ::cuda::std::get<0>(thresholds);
-    const int medium_segment_size                 = ::cuda::std::get<1>(thresholds);
+    test_fixed_size_segmented_reduce<false, input_t, accum_t, op_t>(
+      num_segments, compute_expected_op, device_segmented_min);
+  }
 
-    // Take one random segment size from each of the segment sizes
-    const segment_size_t segment_size = GENERATE_COPY(
-      take(1, random(1, small_segment_size)),
-      take(1, random(small_segment_size, medium_segment_size)),
-      take(1, random(medium_segment_size, medium_segment_size * 2)));
+  SECTION("segmented max")
+  {
+    using input_t = ::cuda::std::int64_t;
+    using accum_t = input_t;
+    using op_t    = ::cuda::maximum<>;
 
-    const ::cuda::std::int64_t num_items = num_segments * segment_size;
+    auto compute_expected_op =
+      get_max_from_counting_it_range_op<offset_t>{::cuda::std::numeric_limits<offset_t>::lowest()};
 
-    // Input data
-    const auto segment_index_it = thrust::make_counting_iterator(segment_index_t{});
+    test_fixed_size_segmented_reduce<false, input_t, accum_t, op_t>(
+      num_segments, compute_expected_op, device_segmented_max);
+  }
 
-    // Segment offsets
-    segment_index_to_offset_op<offset_t, segment_index_t> index_to_offset_op{0, num_segments, segment_size, num_items};
-    auto offsets_it = thrust::make_transform_iterator(segment_index_it, index_to_offset_op);
+  SECTION("segmented argmin")
+  {
+    using input_t = ::cuda::std::int64_t;
+    using accum_t = ::cuda::std::pair<int, input_t>;
+    using op_t    = cub::detail::arg_min;
 
-    CAPTURE(c2h::type_name<offset_t>(), c2h::type_name<segment_index_t>(), num_segments, segment_size, num_items);
+    auto compute_expected_op =
+      get_argmin_from_counting_it_range_op<offset_t>{::cuda::std::numeric_limits<offset_t>::max()};
 
-    try
-    {
-      // Prepare helper to check results
-      auto get_sum_from_offset_pair_op = thrust::make_zip_function(get_gaussian_sum_from_offset_op{});
-      auto offset_pair_it              = thrust::make_zip_iterator(thrust::make_tuple(offsets_it, offsets_it + 1));
-      auto expected_result_it          = thrust::make_transform_iterator(offset_pair_it, get_sum_from_offset_pair_op);
-      auto check_result_helper         = detail::large_problem_test_helper(num_segments);
-      auto check_result_it             = check_result_helper.get_flagging_output_iterator(expected_result_it);
+    test_fixed_size_segmented_reduce<false, input_t, accum_t, op_t>(
+      num_segments, compute_expected_op, device_segmented_argmin);
+  }
 
-      // Run test
-      const auto input_it = thrust::make_counting_iterator(sum_t{});
-      device_segmented_reduce(input_it, check_result_it, num_segments, segment_size, reduction_op, init_val);
+  SECTION("segmented argmax")
+  {
+    using input_t = ::cuda::std::int64_t;
+    using accum_t = ::cuda::std::pair<int, input_t>;
+    using op_t    = cub::detail::arg_max;
 
-      // Verify all results were written as expected
-      check_result_helper.check_all_results_correct();
-    }
-    catch (std::bad_alloc& e)
-    {
-      std::cerr << "Skipping large num_segments fixed size segmented reduce test " << e.what() << "\n";
-    }
+    auto compute_expected_op =
+      get_argmax_from_counting_it_range_op<offset_t>{::cuda::std::numeric_limits<offset_t>::lowest()};
+
+    test_fixed_size_segmented_reduce<false, input_t, accum_t, op_t>(
+      num_segments, compute_expected_op, device_segmented_argmax);
   }
 }


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes #4474

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
