### PR TITLE
Fix race in decoupled lookback test harness.

### DIFF
--- a/cub/test/catch2_test_device_decoupled_look_back.cu
+++ b/cub/test/catch2_test_device_decoupled_look_back.cu
@@ -63,6 +63,8 @@ __global__ void decoupled_look_back_kernel(cub::ScanTileState<MessageT> tile_sta
   // "Compute" tile aggregate
   MessageT tile_aggregate = tile_data[tile_idx];
 
+  __syncthreads();
+
   if (tile_idx == 0)
   {
     // There are no blocks to look back to, immediately set the inclusive state


### PR DESCRIPTION
Fixes a race where `tile_data[tile_idx]` was overwritten with the inclusive prefix by tid 0 (line 91) before later warps read the block aggregate (line 64).

Synchronizing after the read ensures that all threads in the block have a consistent view of the input data before the output is written.

Fixes #1887.