### PR TITLE
do not use detail `_NV_EVAL` macro from `<nv/target>`

### DIFF
--- a/cudax/include/cuda/experimental/__async/sender/exception.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/exception.cuh
@@ -33,7 +33,7 @@
       NV_IS_HOST, (try { _CCCL_PP_EXPAND _TRY } catch (...){_CCCL_PP_EXPAND _CATCH}), ({_CCCL_PP_EXPAND _TRY}))
 #else
 #  define _CUDAX_CATCH(...)
-#  define _CUDAX_TRY(_TRY, _CATCH) _NV_EVAL(try { _CCCL_PP_EXPAND _TRY } catch (...){_CCCL_PP_EXPAND _CATCH})
+#  define _CUDAX_TRY(_TRY, _CATCH) _CCCL_PP_EXPAND(try { _CCCL_PP_EXPAND _TRY } catch (...){_CCCL_PP_EXPAND _CATCH})
 #endif
 
 #if defined(__CUDA_ARCH__)


### PR DESCRIPTION
## Description

`_NV_EVAL` is an implementation detail of the macros in `<nv/target>`. we should not depend on it, especially not in conditional code that doesn't even `#include <nv/target>`. :-P