### PR TITLE
Cudax cleanups

### DIFF
--- a/cudax/include/cuda/experimental/__async/sender/completion_signatures.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/completion_signatures.cuh
@@ -228,7 +228,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __compile_time_error // : ::std::exception
 {
   _CUDAX_DEFAULTED_API __compile_time_error() = default;
 
-  const char* what() const noexcept // override
+  auto what() const noexcept -> const char* // override
   {
     return _CCCL_TYPEID(_Derived*).name();
   }
@@ -265,13 +265,13 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __dependent_sender_error : dependent_sender
                                "environment before it can know how it will complete."}
   {}
 
-  _CCCL_HOST_DEVICE __dependent_sender_error operator+();
+  _CCCL_HOST_DEVICE auto operator+() -> __dependent_sender_error;
 
   template <class _Ty>
-  _CCCL_HOST_DEVICE __dependent_sender_error& operator,(_Ty&);
+  _CCCL_HOST_DEVICE auto operator,(_Ty&) -> __dependent_sender_error&;
 
   template <class... _What>
-  _CCCL_HOST_DEVICE _ERROR<_What...>&operator,(_ERROR<_What...>&);
+  _CCCL_HOST_DEVICE auto operator,(_ERROR<_What...>&) -> _ERROR<_What...>&;
 };
 
 // Below is the definition of the _CUDAX_LET_COMPLETIONS portability macro. It
@@ -875,7 +875,7 @@ catch (...)
 }
 #else
 template <class _Sndr>
-_CUDAX_API constexpr bool __is_dependent_sender() noexcept
+_CUDAX_API constexpr auto __is_dependent_sender() noexcept -> bool
 {
   using _Completions _CCCL_NODEBUG_ALIAS = decltype(get_completion_signatures<_Sndr>());
   return _CUDA_VSTD::is_base_of_v<dependent_sender_error, _Completions>;

--- a/cudax/include/cuda/experimental/__async/sender/completion_signatures.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/completion_signatures.cuh
@@ -79,7 +79,7 @@ using __partition_completion_signatures_t _CCCL_NODEBUG_ALIAS = //
 struct __concat_completion_signatures_helper;
 
 template <class... _Sigs>
-using __concat_completion_signatures_t =
+using __concat_completion_signatures_t _CCCL_NODEBUG_ALIAS =
   _CUDA_VSTD::__call_result_t<_CUDA_VSTD::__call_result_t<__concat_completion_signatures_helper, const _Sigs&...>>;
 
 struct __concat_completion_signatures_fn
@@ -107,7 +107,7 @@ struct _IN_COMPLETION_SIGNATURES_TRANSFORM_REDUCE;
 struct _FUNCTION_IS_NOT_CALLABLE_WITH_THESE_SIGNATURES;
 
 template <class _Fn, class _Sig>
-using __completion_if =
+using __completion_if _CCCL_NODEBUG_ALIAS =
   _CUDA_VSTD::_If<_CUDA_VSTD::__is_callable_v<_Fn, _Sig*>, completion_signatures<_Sig>, completion_signatures<>>;
 
 template <class _Fn, class _Sig>
@@ -422,7 +422,7 @@ _CUDAX_TRIVIAL_API _CUDAX_CONSTEVAL auto __get_completion_signatures_helper()
   }
   // else if constexpr (__is_awaitable<_Sndr, __env_promise<_Env>...>)
   // {
-  //   using Result = __await_result_t<_Sndr, __env_promise<_Env>...>;
+  //   using Result _CCCL_NODEBUG_ALIAS = __await_result_t<_Sndr, __env_promise<_Env>...>;
   //   return completion_signatures{__set_value_v<Result>, __set_error_v<>, __set_stopped_v};
   // }
   else if constexpr (sizeof...(_Env) == 0)
@@ -449,18 +449,18 @@ _CUDAX_TRIVIAL_API _CUDAX_CONSTEVAL auto get_completion_signatures()
   {
     // BUGBUG TODO:
     // Apply a lazy sender transform if one exists before computing the completion signatures:
-    // using _NewSndr = __transform_sender_result_t<__late_domain_of_t<_Sndr, _Env>, _Sndr, _Env>;
-    using _NewSndr = _Sndr;
+    // using _NewSndr _CCCL_NODEBUG_ALIAS = __transform_sender_result_t<__late_domain_of_t<_Sndr, _Env>, _Sndr, _Env>;
+    using _NewSndr _CCCL_NODEBUG_ALIAS = _Sndr;
     return __get_completion_signatures_helper<_NewSndr, _Env...>();
   }
 }
 
 // BUGBUG TODO
 template <class _Env>
-using _FWD_ENV_T = _Env;
+using _FWD_ENV_T _CCCL_NODEBUG_ALIAS = _Env;
 
 template <class _Parent, class _Child, class... _Env>
-constexpr auto get_child_completion_signatures()
+_CUDAX_TRIVIAL_API _CUDAX_CONSTEVAL auto get_child_completion_signatures()
 {
   return get_completion_signatures<__copy_cvref_t<_Parent, _Child>, _FWD_ENV_T<_Env>...>();
 }
@@ -470,7 +470,7 @@ constexpr auto get_child_completion_signatures()
 _CCCL_DIAG_POP
 
 template <class _Completions>
-using __partitioned_completions_of = typename _Completions::__partitioned;
+using __partitioned_completions_of _CCCL_NODEBUG_ALIAS = typename _Completions::__partitioned;
 
 constexpr int __invalid_disposition = -1;
 
@@ -495,25 +495,28 @@ template <>
 struct __gather_sigs_fn<set_value_t>
 {
   template <class _Sigs, template <class...> class _Tuple, template <class...> class _Variant>
-  using __call = typename __partitioned_completions_of<_Sigs>::template __value_types<_Tuple, _Variant>;
+  using __call _CCCL_NODEBUG_ALIAS =
+    typename __partitioned_completions_of<_Sigs>::template __value_types<_Tuple, _Variant>;
 };
 
 template <>
 struct __gather_sigs_fn<set_error_t>
 {
   template <class _Sigs, template <class...> class _Tuple, template <class...> class _Variant>
-  using __call = typename __partitioned_completions_of<_Sigs>::template __error_types<_Variant, _Tuple>;
+  using __call _CCCL_NODEBUG_ALIAS =
+    typename __partitioned_completions_of<_Sigs>::template __error_types<_Variant, _Tuple>;
 };
 
 template <>
 struct __gather_sigs_fn<set_stopped_t>
 {
   template <class _Sigs, template <class...> class _Tuple, template <class...> class _Variant>
-  using __call = typename __partitioned_completions_of<_Sigs>::template __stopped_types<_Variant, _Tuple<>>;
+  using __call _CCCL_NODEBUG_ALIAS =
+    typename __partitioned_completions_of<_Sigs>::template __stopped_types<_Variant, _Tuple<>>;
 };
 
 template <class _Sigs, class _WantedTag, template <class...> class _TaggedTuple, template <class...> class _Variant>
-using __gather_completion_signatures =
+using __gather_completion_signatures _CCCL_NODEBUG_ALIAS =
   typename __gather_sigs_fn<_WantedTag>::template __call<_Sigs, _TaggedTuple, _Variant>;
 
 // __partitioned_completions is a cache of completion signatures for fast
@@ -524,28 +527,30 @@ template <class... _ValueTuples, class... _Errors, __stop_kind _StopKind>
 struct __partitioned_completions<_CUDA_VSTD::__type_list<_ValueTuples...>, _CUDA_VSTD::__type_list<_Errors...>, _StopKind>
 {
   template <template <class...> class _Tuple, template <class...> class _Variant>
-  using __value_types = _Variant<_CUDA_VSTD::__type_call1<_ValueTuples, _CUDA_VSTD::__type_quote<_Tuple>>...>;
+  using __value_types _CCCL_NODEBUG_ALIAS =
+    _Variant<_CUDA_VSTD::__type_call1<_ValueTuples, _CUDA_VSTD::__type_quote<_Tuple>>...>;
 
   template <template <class...> class _Variant, template <class> class _Transform = _CUDA_VSTD::__type_self_t>
-  using __error_types = _Variant<_Transform<_Errors>...>;
+  using __error_types _CCCL_NODEBUG_ALIAS = _Variant<_Transform<_Errors>...>;
 
   template <template <class...> class _Variant, class _Type = set_stopped_t()>
-  using __stopped_types = _CUDA_VSTD::__type_call1<
+  using __stopped_types _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::__type_call1<
     _CUDA_VSTD::_If<_StopKind == __stop_kind::__stoppable, _CUDA_VSTD::__type_list<_Type>, _CUDA_VSTD::__type_list<>>,
     _CUDA_VSTD::__type_quote<_Variant>>;
 
-  using __count_values  = _CUDA_VSTD::integral_constant<size_t, sizeof...(_ValueTuples)>;
-  using __count_errors  = _CUDA_VSTD::integral_constant<size_t, sizeof...(_Errors)>;
-  using __count_stopped = _CUDA_VSTD::integral_constant<size_t, _StopKind == __stop_kind::__stoppable ? 1 : 0>;
+  using __count_values _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::integral_constant<size_t, sizeof...(_ValueTuples)>;
+  using __count_errors _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::integral_constant<size_t, sizeof...(_Errors)>;
+  using __count_stopped _CCCL_NODEBUG_ALIAS =
+    _CUDA_VSTD::integral_constant<size_t, _StopKind == __stop_kind::__stoppable ? 1 : 0>;
 
   struct __nothrow_decay_copyable
   {
     // These aliases are placed in a separate struct to avoid computing them
     // if they are not needed.
-    using __fn     = _CUDA_VSTD::__type_quote<__nothrow_decay_copyable_t>;
-    using __values = _CUDA_VSTD::_And<_CUDA_VSTD::__type_call1<_ValueTuples, __fn>...>;
-    using __errors = __nothrow_decay_copyable_t<_Errors...>;
-    using __all    = _CUDA_VSTD::_And<__values, __errors>;
+    using __fn _CCCL_NODEBUG_ALIAS     = _CUDA_VSTD::__type_quote<__nothrow_decay_copyable_t>;
+    using __values _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::_And<_CUDA_VSTD::__type_call1<_ValueTuples, __fn>...>;
+    using __errors _CCCL_NODEBUG_ALIAS = __nothrow_decay_copyable_t<_Errors...>;
+    using __all _CCCL_NODEBUG_ALIAS    = _CUDA_VSTD::_And<__values, __errors>;
   };
 };
 
@@ -587,7 +592,7 @@ _CUDAX_API auto __make_unique(_Sigs*...)
   -> _CUDA_VSTD::__type_apply<_CUDA_VSTD::__type_quote<completion_signatures>, _CUDA_VSTD::__make_type_set<_Sigs...>>;
 
 template <class... _Sigs>
-using __make_completion_signatures_t =
+using __make_completion_signatures_t _CCCL_NODEBUG_ALIAS =
   decltype(__async::__make_unique(__async::__normalize(static_cast<_Sigs*>(nullptr))...));
 
 template <class... _ExplicitSigs, class... _DeducedSigs>
@@ -627,8 +632,8 @@ struct __concat_completion_signatures_helper
     const completion_signatures<_Ds...>& = __empty_completion_signatures,
     const _Rest&...) const noexcept
   {
-    using _Tmp       = completion_signatures<_As..., _Bs..., _Cs..., _Ds...>;
-    using _SigsFnPtr = _CUDA_VSTD::__call_result_t<_Self, const _Tmp&, const _Rest&...>;
+    using _Tmp _CCCL_NODEBUG_ALIAS       = completion_signatures<_As..., _Bs..., _Cs..., _Ds...>;
+    using _SigsFnPtr _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::__call_result_t<_Self, const _Tmp&, const _Rest&...>;
     return static_cast<_SigsFnPtr>(nullptr);
   }
 
@@ -657,20 +662,21 @@ struct __concat_completion_signatures_helper
 };
 
 template <class _Sigs, template <class...> class _Tuple, template <class...> class _Variant>
-using __value_types = typename _Sigs::__partitioned::template __value_types<_Tuple, _Variant>;
+using __value_types _CCCL_NODEBUG_ALIAS = typename _Sigs::__partitioned::template __value_types<_Tuple, _Variant>;
 
 template <class _Sndr, class _Env, template <class...> class _Tuple, template <class...> class _Variant>
-using value_types_of_t =
+using value_types_of_t _CCCL_NODEBUG_ALIAS =
   __value_types<completion_signatures_of_t<_Sndr, _Env>, _Tuple, __type_try_quote<_Variant>::template __call>;
 
 template <class _Sigs, template <class...> class _Variant>
-using __error_types = typename _Sigs::__partitioned::template __error_types<_Variant, _CUDA_VSTD::__type_self_t>;
+using __error_types _CCCL_NODEBUG_ALIAS =
+  typename _Sigs::__partitioned::template __error_types<_Variant, _CUDA_VSTD::__type_self_t>;
 
 template <class _Sndr, class _Env, template <class...> class _Variant>
-using error_types_of_t = __error_types<completion_signatures_of_t<_Sndr, _Env>, _Variant>;
+using error_types_of_t _CCCL_NODEBUG_ALIAS = __error_types<completion_signatures_of_t<_Sndr, _Env>, _Variant>;
 
 template <class _Sigs, template <class...> class _Variant, class _Type>
-using __stopped_types = typename _Sigs::__partitioned::template __stopped_types<_Variant, _Type>;
+using __stopped_types _CCCL_NODEBUG_ALIAS = typename _Sigs::__partitioned::template __stopped_types<_Variant, _Type>;
 
 template <class _Sigs>
 inline constexpr bool __sends_stopped = _Sigs::__partitioned::__count_stopped::value != 0;
@@ -709,7 +715,7 @@ struct __decay_transform
 };
 
 template <class _Fn, class... _As>
-using __meta_call_result_t = decltype(declval<_Fn>().template operator()<_As...>());
+using __meta_call_result_t _CCCL_NODEBUG_ALIAS = decltype(declval<_Fn>().template operator()<_As...>());
 
 template <class _Ay, class... _As, class _Fn>
 _CUDAX_TRIVIAL_API constexpr auto __transform_expr(const _Fn& __fn) -> __meta_call_result_t<const _Fn&, _Ay, _As...>
@@ -724,7 +730,7 @@ _CUDAX_TRIVIAL_API constexpr auto __transform_expr(const _Fn& __fn) -> __call_re
 }
 
 template <class _Fn, class... _As>
-using __transform_expr_t = decltype(__async::__transform_expr<_As...>(declval<const _Fn&>()));
+using __transform_expr_t _CCCL_NODEBUG_ALIAS = decltype(__async::__transform_expr<_As...>(declval<const _Fn&>()));
 
 struct _IN_TRANSFORM_COMPLETION_SIGNATURES;
 struct _A_TRANSFORM_FUNCTION_RETURNED_A_TYPE_THAT_IS_NOT_A_COMPLETION_SIGNATURES_SPECIALIZATION;
@@ -736,7 +742,7 @@ _CUDAX_API constexpr auto __apply_transform(const _Fn& __fn)
 {
   if constexpr (__type_valid_v<__transform_expr_t, _Fn, _As...>)
   {
-    using __completions = __transform_expr_t<_Fn, _As...>;
+    using __completions _CCCL_NODEBUG_ALIAS = __transform_expr_t<_Fn, _As...>;
     if constexpr (__valid_completion_signatures<__completions> || __type_is_error<__completions>
                   || _CUDA_VSTD::is_base_of_v<dependent_sender_error, __completions>)
     {
@@ -871,7 +877,7 @@ catch (...)
 template <class _Sndr>
 _CUDAX_API constexpr bool __is_dependent_sender() noexcept
 {
-  using _Completions = decltype(get_completion_signatures<_Sndr>());
+  using _Completions _CCCL_NODEBUG_ALIAS = decltype(get_completion_signatures<_Sndr>());
   return _CUDA_VSTD::is_base_of_v<dependent_sender_error, _Completions>;
 }
 #endif

--- a/cudax/include/cuda/experimental/__async/sender/concepts.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/concepts.cuh
@@ -40,7 +40,7 @@ namespace cuda::experimental::__async
 {
 // Utilities:
 template <class _Ty>
-_CUDAX_API constexpr bool __is_constexpr_helper(_Ty)
+_CUDAX_API constexpr auto __is_constexpr_helper(_Ty) -> bool
 {
   return true;
 }
@@ -87,7 +87,7 @@ _CCCL_CONCEPT __is_awaitable = false; // TODO: Implement this concept.
 
 // Sender traits:
 template <class _Sndr>
-_CUDAX_API constexpr bool __enable_sender()
+_CUDAX_API constexpr auto __enable_sender() -> bool
 {
   if constexpr (__is_sender<_Sndr>)
   {

--- a/cudax/include/cuda/experimental/__async/sender/conditional.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/conditional.cuh
@@ -54,10 +54,10 @@ namespace cuda::experimental::__async
 {
 struct _FUNCTION_MUST_RETURN_A_BOOLEAN_TESTABLE_VALUE;
 
-struct __cond_t
+struct _CCCL_TYPE_VISIBILITY_DEFAULT __cond_t
 {
   template <class _Pred, class _Then, class _Else>
-  struct params
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT params
   {
     _Pred pred;
     _Then on_true;
@@ -74,7 +74,7 @@ private:
   }
 
   template <class... _As>
-  using __just_from_t = decltype(just_from(__cond_t::__mk_complete_fn(declval<_As>()...)));
+  using __just_from_t _CCCL_NODEBUG_ALIAS = decltype(just_from(__cond_t::__mk_complete_fn(declval<_As>()...)));
 
   template <class _Pred, class _Then, class _Else, class... _Env>
   struct __either_sig_fn
@@ -106,19 +106,19 @@ private:
   };
 
   template <class _Sndr, class _Rcvr, class _Pred, class _Then, class _Else>
-  struct __opstate
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __opstate : private __immovable
   {
-    using operation_state_concept = operation_state_t;
-    using __params_t              = params<_Pred, _Then, _Else>;
-    using __env_t                 = _FWD_ENV_T<env_of_t<_Rcvr>>;
+    using operation_state_concept _CCCL_NODEBUG_ALIAS = operation_state_t;
+    using __params_t _CCCL_NODEBUG_ALIAS              = params<_Pred, _Then, _Else>;
+    using __env_t _CCCL_NODEBUG_ALIAS                 = _FWD_ENV_T<env_of_t<_Rcvr>>;
 
     template <class... _As>
-    using __opstate_t =        //
-      _CUDA_VSTD::__type_list< //
+    using __opstate_t _CCCL_NODEBUG_ALIAS = //
+      _CUDA_VSTD::__type_list<              //
         connect_result_t<__call_result_t<_Then, __just_from_t<_As...>>, __rcvr_ref<_Rcvr>>,
         connect_result_t<__call_result_t<_Else, __just_from_t<_As...>>, __rcvr_ref<_Rcvr>>>;
 
-    using __next_ops_variant_t = //
+    using __next_ops_variant_t _CCCL_NODEBUG_ALIAS = //
       __value_types<completion_signatures_of_t<_Sndr, __env_t>, __opstate_t, __type_concat_into_quote<__variant>::__call>;
 
     _CUDAX_API __opstate(_Sndr&& __sndr, _Rcvr&& __rcvr, __params_t&& __params)
@@ -188,11 +188,11 @@ public:
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __sndr_t;
 
   template <class _Sndr, class _Pred, class _Then, class _Else>
-  _CUDAX_TRIVIAL_API auto operator()(_Sndr __sndr, _Pred __pred, _Then __then, _Else __else) const //
+  _CUDAX_TRIVIAL_API constexpr auto operator()(_Sndr __sndr, _Pred __pred, _Then __then, _Else __else) const //
     -> __sndr_t<_Sndr, _Pred, _Then, _Else>;
 
   template <class _Pred, class _Then, class _Else>
-  _CUDAX_TRIVIAL_API auto operator()(_Pred __pred, _Then __then, _Else __else) const
+  _CUDAX_TRIVIAL_API constexpr auto operator()(_Pred __pred, _Then __then, _Else __else) const
   {
     return __closure<_Pred, _Then, _Else>{
       {static_cast<_Pred&&>(__pred), static_cast<_Then&&>(__then), static_cast<_Else&&>(__else)}};
@@ -202,7 +202,7 @@ public:
 template <class _Sndr, class _Pred, class _Then, class _Else>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __cond_t::__sndr_t
 {
-  using __params_t = __cond_t::params<_Pred, _Then, _Else>;
+  using __params_t _CCCL_NODEBUG_ALIAS = __cond_t::params<_Pred, _Then, _Else>;
   _CCCL_NO_UNIQUE_ADDRESS __cond_t __tag_;
   __params_t __params_;
   _Sndr __sndr_;
@@ -239,12 +239,12 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __cond_t::__sndr_t
 };
 
 template <class _Sndr, class _Pred, class _Then, class _Else>
-_CUDAX_TRIVIAL_API auto __cond_t::operator()(_Sndr __sndr, _Pred __pred, _Then __then, _Else __else) const //
+_CUDAX_TRIVIAL_API constexpr auto __cond_t::operator()(_Sndr __sndr, _Pred __pred, _Then __then, _Else __else) const //
   -> __sndr_t<_Sndr, _Pred, _Then, _Else>
 {
   if constexpr (!dependent_sender<_Sndr>)
   {
-    using __completions = completion_signatures_of_t<__sndr_t<_Sndr, _Pred, _Then, _Else>>;
+    using __completions _CCCL_NODEBUG_ALIAS = completion_signatures_of_t<__sndr_t<_Sndr, _Pred, _Then, _Else>>;
     static_assert(__valid_completion_signatures<__completions>);
   }
 
@@ -265,7 +265,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __cond_t::__closure
   {
     if constexpr (!dependent_sender<_Sndr>)
     {
-      using __completions = completion_signatures_of_t<__sndr_t<_Sndr, _Pred, _Then, _Else>>;
+      using __completions _CCCL_NODEBUG_ALIAS = completion_signatures_of_t<__sndr_t<_Sndr, _Pred, _Then, _Else>>;
       static_assert(__valid_completion_signatures<__completions>);
     }
 
@@ -291,7 +291,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __cond_t::__closure
 template <class _Sndr, class _Pred, class _Then, class _Else>
 inline constexpr size_t structured_binding_size<__cond_t::__sndr_t<_Sndr, _Pred, _Then, _Else>> = 3;
 
-using conditional_t = __cond_t;
+using conditional_t _CCCL_NODEBUG_ALIAS = __cond_t;
 _CCCL_GLOBAL_CONSTANT conditional_t conditional{};
 } // namespace cuda::experimental::__async
 

--- a/cudax/include/cuda/experimental/__async/sender/conditional.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/conditional.cuh
@@ -232,7 +232,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __cond_t::__sndr_t
     return {__sndr_, static_cast<_Rcvr&&>(__rcvr), static_cast<__params_t&&>(__params_)};
   }
 
-  _CUDAX_API env_of_t<_Sndr> get_env() const noexcept
+  _CUDAX_API auto get_env() const noexcept -> env_of_t<_Sndr>
   {
     return __async::get_env(__sndr_);
   }

--- a/cudax/include/cuda/experimental/__async/sender/continue_on.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/continue_on.cuh
@@ -109,7 +109,7 @@ private:
       __async::set_stopped(static_cast<_Rcvr&&>(__rcvr_));
     }
 
-    _CUDAX_API env_of_t<_Rcvr> get_env() const noexcept
+    _CUDAX_API auto get_env() const noexcept -> env_of_t<_Rcvr>
     {
       return __async::get_env(__rcvr_);
     }
@@ -262,18 +262,18 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT continue_on_t::__sndr_t
   }
 
   template <class _Rcvr>
-  _CUDAX_API __opstate_t<_Rcvr, _Sndr, _Sch> connect(_Rcvr __rcvr) &&
+  _CUDAX_API auto connect(_Rcvr __rcvr) && -> __opstate_t<_Rcvr, _Sndr, _Sch>
   {
     return {static_cast<_Sndr&&>(__sndr_), __sch_, static_cast<_Rcvr&&>(__rcvr)};
   }
 
   template <class _Rcvr>
-  _CUDAX_API __opstate_t<_Rcvr, const _Sndr&, _Sch> connect(_Rcvr __rcvr) const&
+  _CUDAX_API auto connect(_Rcvr __rcvr) const& -> __opstate_t<_Rcvr, const _Sndr&, _Sch>
   {
     return {__sndr_, __sch_, static_cast<_Rcvr&&>(__rcvr)};
   }
 
-  _CUDAX_API __attrs_t get_env() const noexcept
+  _CUDAX_API auto get_env() const noexcept -> __attrs_t
   {
     return __attrs_t{this};
   }

--- a/cudax/include/cuda/experimental/__async/sender/continue_on.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/continue_on.cuh
@@ -39,23 +39,23 @@
 
 namespace cuda::experimental::__async
 {
-struct continue_on_t
+struct _CCCL_TYPE_VISIBILITY_DEFAULT continue_on_t
 {
 private:
   template <class... _As>
-  using __set_value_tuple_t = __tuple<set_value_t, __decay_t<_As>...>;
+  using __set_value_tuple_t _CCCL_NODEBUG_ALIAS = __tuple<set_value_t, __decay_t<_As>...>;
 
   template <class _Error>
-  using __set_error_tuple_t = __tuple<set_error_t, __decay_t<_Error>>;
+  using __set_error_tuple_t _CCCL_NODEBUG_ALIAS = __tuple<set_error_t, __decay_t<_Error>>;
 
-  using __set_stopped_tuple_t = __tuple<set_stopped_t>;
+  using __set_stopped_tuple_t _CCCL_NODEBUG_ALIAS = __tuple<set_stopped_t>;
 
-  using __complete_fn = void (*)(void*) noexcept;
+  using __complete_fn _CCCL_NODEBUG_ALIAS = void (*)(void*) noexcept;
 
   template <class _Rcvr, class _Result>
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __rcvr_t
   {
-    using receiver_concept = receiver_t;
+    using receiver_concept _CCCL_NODEBUG_ALIAS = receiver_t;
     _Rcvr __rcvr_;
     _Result __result_;
     __complete_fn __complete_;
@@ -69,7 +69,7 @@ private:
     template <class _Tag, class... _As>
     _CUDAX_API void __set_result(_Tag, _As&&... __as) noexcept
     {
-      using __tupl_t = __tuple<_Tag, __decay_t<_As>...>;
+      using __tupl_t _CCCL_NODEBUG_ALIAS = __tuple<_Tag, __decay_t<_As>...>;
       if constexpr (__nothrow_decay_copyable<_As...>)
       {
         __result_.template __emplace<__tupl_t>(_Tag(), static_cast<_As&&>(__as)...);
@@ -116,12 +116,12 @@ private:
   };
 
   template <class _Rcvr, class _CvSndr, class _Sch>
-  struct _CCCL_TYPE_VISIBILITY_DEFAULT __opstate_t
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __opstate_t : private __immovable
   {
-    using operation_state_concept = operation_state_t;
-    using __env_t                 = _FWD_ENV_T<env_of_t<_Rcvr>>;
+    using operation_state_concept _CCCL_NODEBUG_ALIAS = operation_state_t;
+    using __env_t _CCCL_NODEBUG_ALIAS                 = _FWD_ENV_T<env_of_t<_Rcvr>>;
 
-    using __result_t =
+    using __result_t _CCCL_NODEBUG_ALIAS =
       typename completion_signatures_of_t<_CvSndr, __env_t>::template __transform_q<__decayed_tuple, __variant>;
 
     _CUDAX_API __opstate_t(_CvSndr&& __sndr, _Sch __sch, _Rcvr __rcvr)
@@ -172,13 +172,13 @@ public:
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __sndr_t;
 
   template <class _Sch>
-  struct __closure_t;
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __closure_t;
 
   template <class _Sndr, class _Sch>
-  _CUDAX_API __sndr_t<_Sndr, _Sch> operator()(_Sndr __sndr, _Sch __sch) const noexcept;
+  _CUDAX_TRIVIAL_API constexpr __sndr_t<_Sndr, _Sch> operator()(_Sndr __sndr, _Sch __sch) const noexcept;
 
   template <class _Sch>
-  _CUDAX_TRIVIAL_API __closure_t<_Sch> operator()(_Sch __sch) const noexcept;
+  _CUDAX_TRIVIAL_API constexpr __closure_t<_Sch> operator()(_Sch __sch) const noexcept;
 };
 
 template <class _Sch>
@@ -187,7 +187,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT continue_on_t::__closure_t
   _Sch __sch;
 
   template <class _Sndr>
-  _CUDAX_TRIVIAL_API friend auto operator|(_Sndr __sndr, __closure_t&& __self)
+  _CUDAX_TRIVIAL_API friend constexpr auto operator|(_Sndr __sndr, __closure_t __self)
   {
     return continue_on_t()(static_cast<_Sndr&&>(__sndr), static_cast<_Sch&&>(__self.__sch));
   }
@@ -219,7 +219,7 @@ struct __decay_args
 template <class _Sndr, class _Sch>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT continue_on_t::__sndr_t
 {
-  using sender_concept = sender_t;
+  using sender_concept _CCCL_NODEBUG_ALIAS = sender_t;
   _CCCL_NO_UNIQUE_ADDRESS continue_on_t __tag_;
   _Sch __sch_;
   _Sndr __sndr_;
@@ -280,14 +280,14 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT continue_on_t::__sndr_t
 };
 
 template <class _Sndr, class _Sch>
-_CUDAX_API auto continue_on_t::operator()(_Sndr __sndr, _Sch __sch) const noexcept
+_CUDAX_TRIVIAL_API constexpr auto continue_on_t::operator()(_Sndr __sndr, _Sch __sch) const noexcept
   -> continue_on_t::__sndr_t<_Sndr, _Sch>
 {
   return __sndr_t<_Sndr, _Sch>{{}, __sch, static_cast<_Sndr&&>(__sndr)};
 }
 
 template <class _Sch>
-_CUDAX_TRIVIAL_API continue_on_t::__closure_t<_Sch> continue_on_t::operator()(_Sch __sch) const noexcept
+_CUDAX_TRIVIAL_API constexpr continue_on_t::__closure_t<_Sch> continue_on_t::operator()(_Sch __sch) const noexcept
 {
   return __closure_t<_Sch>{__sch};
 }

--- a/cudax/include/cuda/experimental/__async/sender/cpos.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/cpos.cuh
@@ -53,13 +53,13 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT scheduler_t
 {};
 
 template <class _Ty>
-using __sender_concept_t = typename _CUDA_VSTD::remove_reference_t<_Ty>::sender_concept;
+using __sender_concept_t _CCCL_NODEBUG_ALIAS = typename _CUDA_VSTD::remove_reference_t<_Ty>::sender_concept;
 
 template <class _Ty>
-using __receiver_concept_t = typename _CUDA_VSTD::remove_reference_t<_Ty>::receiver_concept;
+using __receiver_concept_t _CCCL_NODEBUG_ALIAS = typename _CUDA_VSTD::remove_reference_t<_Ty>::receiver_concept;
 
 template <class _Ty>
-using __scheduler_concept_t = typename _CUDA_VSTD::remove_reference_t<_Ty>::scheduler_concept;
+using __scheduler_concept_t _CCCL_NODEBUG_ALIAS = typename _CUDA_VSTD::remove_reference_t<_Ty>::scheduler_concept;
 
 template <class _Ty>
 inline constexpr bool __is_sender = __type_valid_v<__sender_concept_t, _Ty>;
@@ -174,13 +174,13 @@ _CCCL_GLOBAL_CONSTANT struct schedule_t
 } schedule{};
 
 template <class _Sndr, class _Rcvr>
-using connect_result_t = decltype(connect(declval<_Sndr>(), declval<_Rcvr>()));
+using connect_result_t _CCCL_NODEBUG_ALIAS = decltype(connect(declval<_Sndr>(), declval<_Rcvr>()));
 
 template <class _Sndr, class... _Env>
-using completion_signatures_of_t = decltype(get_completion_signatures<_Sndr, _Env...>());
+using completion_signatures_of_t _CCCL_NODEBUG_ALIAS = decltype(get_completion_signatures<_Sndr, _Env...>());
 
 template <class _Sch>
-using schedule_result_t = decltype(schedule(declval<_Sch>()));
+using schedule_result_t _CCCL_NODEBUG_ALIAS = decltype(schedule(declval<_Sch>()));
 
 template <class _Sndr, class _Rcvr>
 inline constexpr bool __nothrow_connectable = noexcept(connect(declval<_Sndr>(), declval<_Rcvr>()));

--- a/cudax/include/cuda/experimental/__async/sender/env.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/env.cuh
@@ -73,7 +73,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT prop
     return __value;
   }
 
-  prop& operator=(const prop&) = delete;
+  auto operator=(const prop&) -> prop& = delete;
 };
 
 template <class _Query, class _Value>
@@ -107,7 +107,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT env
     return env::__get_1st<_Query>(*this).query(__query);
   }
 
-  env& operator=(const env&) = delete;
+  auto operator=(const env&) -> env& = delete;
 };
 
 // partial specialization for two environments
@@ -141,7 +141,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT env<_Env0, _Env1>
     return env::__get_1st<_Query>(*this).query(__query);
   }
 
-  env& operator=(const env&) = delete;
+  auto operator=(const env&) -> env& = delete;
 };
 
 template <class... _Envs>

--- a/cudax/include/cuda/experimental/__async/sender/env.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/env.cuh
@@ -60,7 +60,7 @@ template <class _Ty>
 extern _Ty& __unwrap_ref<_CUDA_VSTD::reference_wrapper<_Ty>>;
 
 template <class _Ty>
-using __unwrap_reference_t = decltype(__unwrap_ref<_Ty>);
+using __unwrap_reference_t _CCCL_NODEBUG_ALIAS = decltype(__unwrap_ref<_Ty>);
 
 template <class _Query, class _Value>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT prop
@@ -97,7 +97,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT env
   }
 
   template <class _Query>
-  using __1st_env_t = decltype(env::__get_1st<_Query>(declval<const env&>()));
+  using __1st_env_t _CCCL_NODEBUG_ALIAS = decltype(env::__get_1st<_Query>(declval<const env&>()));
 
   _CCCL_TEMPLATE(class _Query)
   _CCCL_REQUIRES(__queryable_with<__1st_env_t<_Query>, _Query>)
@@ -130,8 +130,8 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT env<_Env0, _Env1>
     }
   }
 
-  template <class _Query, class _Env = env>
-  using __1st_env_t = decltype(env::__get_1st<_Query>(declval<const _Env&>()));
+  template <class _Query>
+  using __1st_env_t _CCCL_NODEBUG_ALIAS = decltype(env::__get_1st<_Query>(declval<const env&>()));
 
   _CCCL_TEMPLATE(class _Query)
   _CCCL_REQUIRES(__queryable_with<__1st_env_t<_Query>, _Query>)
@@ -152,7 +152,7 @@ using empty_env CCCL_DEPRECATED_BECAUSE("please use env<> instead of empty_env")
 struct get_env_t
 {
   template <class _Ty>
-  using __env_of = decltype(declval<_Ty>().get_env());
+  using __env_of _CCCL_NODEBUG_ALIAS = decltype(declval<_Ty>().get_env());
 
   template <class _Ty>
   _CUDAX_TRIVIAL_API auto operator()(_Ty&& __ty) const noexcept -> __env_of<_Ty&>
@@ -175,7 +175,7 @@ _CCCL_GLOBAL_CONSTANT get_env_t get_env{};
 using namespace __region;
 
 template <class _Ty>
-using env_of_t = decltype(__async::get_env(declval<_Ty>()));
+using env_of_t _CCCL_NODEBUG_ALIAS = decltype(__async::get_env(declval<_Ty>()));
 } // namespace cuda::experimental::__async
 
 _CCCL_NV_DIAG_DEFAULT(20012)

--- a/cudax/include/cuda/experimental/__async/sender/just.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/just.cuh
@@ -134,15 +134,15 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __just_t<_Disposition>::__sndr_t
   }
 
   template <class _Rcvr>
-  _CUDAX_API __opstate_t<_Rcvr, _Values> connect(_Rcvr __rcvr) && //
-    noexcept(__nothrow_decay_copyable<_Rcvr, _Values>)
+  _CUDAX_API auto connect(_Rcvr __rcvr) && //
+    noexcept(__nothrow_decay_copyable<_Rcvr, _Values>) -> __opstate_t<_Rcvr, _Values>
   {
     return __opstate_t<_Rcvr, _Values>{{}, static_cast<_Rcvr&&>(__rcvr), static_cast<_Values&&>(__values_)};
   }
 
   template <class _Rcvr>
-  _CUDAX_API __opstate_t<_Rcvr, _Values> connect(_Rcvr __rcvr) const& //
-    noexcept(__nothrow_decay_copyable<_Rcvr, _Values const&>)
+  _CUDAX_API auto connect(_Rcvr __rcvr) const& //
+    noexcept(__nothrow_decay_copyable<_Rcvr, _Values const&>) -> __opstate_t<_Rcvr, _Values>
   {
     return __opstate_t<_Rcvr, _Values>{{}, static_cast<_Rcvr&&>(__rcvr), __values_};
   }

--- a/cudax/include/cuda/experimental/__async/sender/just.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/just.cuh
@@ -51,11 +51,11 @@ extern __fn_t<just_stopped_t>* __just_tag<__stopped, _Void>;
 } // namespace __detail
 
 template <__disposition_t _Disposition>
-struct __just_t
+struct _CCCL_TYPE_VISIBILITY_DEFAULT __just_t
 {
 private:
-  using _JustTag = decltype(__detail::__just_tag<_Disposition>());
-  using _SetTag  = decltype(__detail::__set_tag<_Disposition>());
+  using _JustTag _CCCL_NODEBUG_ALIAS = decltype(__detail::__just_tag<_Disposition>());
+  using _SetTag _CCCL_NODEBUG_ALIAS  = decltype(__detail::__set_tag<_Disposition>());
 
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __signatures_fn
   {
@@ -76,9 +76,9 @@ private:
   };
 
   template <class _Rcvr, class _Values>
-  struct _CCCL_TYPE_VISIBILITY_DEFAULT __opstate_t
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __opstate_t : __immovable
   {
-    using operation_state_concept = operation_state_t;
+    using operation_state_concept _CCCL_NODEBUG_ALIAS = operation_state_t;
 
     _CUDAX_API void start() & noexcept
     {
@@ -95,14 +95,14 @@ private:
 #if _CCCL_STD_VER >= 2020 && _CCCL_COMPILER(CLANG)
     // In C++20 we can directly move-capture a variadic pack of arguments:
     return [... __ts = static_cast<_Ts&&>(__ts)](auto fn) mutable noexcept {
-      using _Fn = decltype(fn);
+      using _Fn _CCCL_NODEBUG_ALIAS = decltype(fn);
       static_assert(__nothrow_callable<_Fn, _Ts...>);
       return static_cast<_Fn&&>(fn)(static_cast<_Ts&&>(__ts)...);
     };
 #else
     // In C++17 we need to use a tuple to move-capture a variadic pack of arguments:
     return [__ts = __tupl{static_cast<_Ts&&>(__ts)...}](auto fn) mutable noexcept {
-      using _Fn = decltype(fn);
+      using _Fn _CCCL_NODEBUG_ALIAS = decltype(fn);
       static_assert(__nothrow_callable<_Fn, _Ts...>);
       return __ts.__apply(static_cast<_Fn&&>(fn), static_cast<__tuple<_Ts...>&&>(__ts));
     };
@@ -121,7 +121,7 @@ template <__disposition_t _Disposition>
 template <class _Values>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __just_t<_Disposition>::__sndr_t
 {
-  using sender_concept = sender_t;
+  using sender_concept _CCCL_NODEBUG_ALIAS = sender_t;
 
   _CCCL_NO_UNIQUE_ADDRESS _JustTag __tag_;
   _Values __values_;
@@ -129,7 +129,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __just_t<_Disposition>::__sndr_t
   template <class _Self, class... _Env>
   _CUDAX_API static constexpr auto get_completion_signatures() noexcept
   {
-    using __signatures_t = __call_result_t<_Values&, __signatures_fn>;
+    using __signatures_t _CCCL_NODEBUG_ALIAS = __call_result_t<_Values&, __signatures_fn>;
     return __signatures_t();
   }
 
@@ -137,14 +137,14 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __just_t<_Disposition>::__sndr_t
   _CUDAX_API __opstate_t<_Rcvr, _Values> connect(_Rcvr __rcvr) && //
     noexcept(__nothrow_decay_copyable<_Rcvr, _Values>)
   {
-    return __opstate_t<_Rcvr, _Values>{static_cast<_Rcvr&&>(__rcvr), static_cast<_Values&&>(__values_)};
+    return __opstate_t<_Rcvr, _Values>{{}, static_cast<_Rcvr&&>(__rcvr), static_cast<_Values&&>(__values_)};
   }
 
   template <class _Rcvr>
   _CUDAX_API __opstate_t<_Rcvr, _Values> connect(_Rcvr __rcvr) const& //
     noexcept(__nothrow_decay_copyable<_Rcvr, _Values const&>)
   {
-    return __opstate_t<_Rcvr, _Values>{static_cast<_Rcvr&&>(__rcvr), __values_};
+    return __opstate_t<_Rcvr, _Values>{{}, static_cast<_Rcvr&&>(__rcvr), __values_};
   }
 };
 
@@ -152,7 +152,7 @@ template <__disposition_t _Disposition>
 template <class... _Ts>
 _CUDAX_TRIVIAL_API auto __just_t<_Disposition>::operator()(_Ts... __ts) const
 {
-  using _Values = decltype(__mk_values(__ts...));
+  using _Values _CCCL_NODEBUG_ALIAS = decltype(__mk_values(__ts...));
   return __sndr_t<_Values>{{}, __mk_values(__ts...)};
 }
 

--- a/cudax/include/cuda/experimental/__async/sender/just_from.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/just_from.cuh
@@ -131,15 +131,15 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __just_from_t<_Disposition>::__sndr_t
   }
 
   template <class _Rcvr>
-  _CUDAX_API __opstate<_Rcvr, _Fn> connect(_Rcvr __rcvr) && //
-    noexcept(__nothrow_decay_copyable<_Rcvr, _Fn>)
+  _CUDAX_API auto connect(_Rcvr __rcvr) && //
+    noexcept(__nothrow_decay_copyable<_Rcvr, _Fn>) -> __opstate<_Rcvr, _Fn>
   {
     return __opstate<_Rcvr, _Fn>{{}, static_cast<_Rcvr&&>(__rcvr), static_cast<_Fn&&>(__fn_)};
   }
 
   template <class _Rcvr>
-  _CUDAX_API __opstate<_Rcvr, _Fn> connect(_Rcvr __rcvr) const& //
-    noexcept(__nothrow_decay_copyable<_Rcvr, _Fn const&>)
+  _CUDAX_API auto connect(_Rcvr __rcvr) const& //
+    noexcept(__nothrow_decay_copyable<_Rcvr, _Fn const&>) -> __opstate<_Rcvr, _Fn>
   {
     return __opstate<_Rcvr, _Fn>{{}, static_cast<_Rcvr&&>(__rcvr), __fn_};
   }

--- a/cudax/include/cuda/experimental/__async/sender/just_from.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/just_from.cuh
@@ -60,18 +60,19 @@ template <__disposition_t _Disposition>
 struct __just_from_t
 {
 private:
-  using _JustTag = decltype(__detail::__just_from_tag<_Disposition>());
-  using _SetTag  = decltype(__detail::__set_tag<_Disposition>());
+  using _JustTag _CCCL_NODEBUG_ALIAS = decltype(__detail::__just_from_tag<_Disposition>());
+  using _SetTag _CCCL_NODEBUG_ALIAS  = decltype(__detail::__set_tag<_Disposition>());
 
-  using __diag_t = _CUDA_VSTD::conditional_t<_SetTag() == set_error,
-                                             _AN_ERROR_COMPLETION_MUST_HAVE_EXACTLY_ONE_ERROR_ARGUMENT,
-                                             _A_STOPPED_COMPLETION_MUST_HAVE_NO_ARGUMENTS>;
+  using __diag_t _CCCL_NODEBUG_ALIAS =
+    _CUDA_VSTD::conditional_t<_SetTag() == set_error,
+                              _AN_ERROR_COMPLETION_MUST_HAVE_EXACTLY_ONE_ERROR_ARGUMENT,
+                              _A_STOPPED_COMPLETION_MUST_HAVE_NO_ARGUMENTS>;
 
   template <class... _Ts>
-  using __error_t =
+  using __error_t _CCCL_NODEBUG_ALIAS =
     _ERROR<_WHERE(_IN_ALGORITHM, _JustTag), _WHAT(__diag_t), _WITH_COMPLETION_SIGNATURE<_SetTag(_Ts...)>>;
 
-  struct __probe_fn
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __probe_fn
   {
     template <class... _Ts>
     auto operator()(_Ts&&... __ts) const noexcept
@@ -81,7 +82,7 @@ private:
   };
 
   template <class _Rcvr>
-  struct __complete_fn
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __complete_fn
   {
     _Rcvr& __rcvr_;
 
@@ -93,17 +94,17 @@ private:
   };
 
   template <class _Rcvr, class _Fn>
-  struct __opstate
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __opstate : __immovable
   {
-    using operation_state_concept = operation_state_t;
-
-    _Rcvr __rcvr_;
-    _Fn __fn_;
+    using operation_state_concept _CCCL_NODEBUG_ALIAS = operation_state_t;
 
     _CUDAX_API void start() & noexcept
     {
       static_cast<_Fn&&>(__fn_)(__complete_fn<_Rcvr>{__rcvr_});
     }
+
+    _Rcvr __rcvr_;
+    _Fn __fn_;
   };
 
 public:
@@ -118,7 +119,7 @@ template <__disposition_t _Disposition>
 template <class _Fn>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __just_from_t<_Disposition>::__sndr_t
 {
-  using sender_concept = sender_t;
+  using sender_concept _CCCL_NODEBUG_ALIAS = sender_t;
 
   _CCCL_NO_UNIQUE_ADDRESS _JustTag __tag_;
   _Fn __fn_;
@@ -133,14 +134,14 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __just_from_t<_Disposition>::__sndr_t
   _CUDAX_API __opstate<_Rcvr, _Fn> connect(_Rcvr __rcvr) && //
     noexcept(__nothrow_decay_copyable<_Rcvr, _Fn>)
   {
-    return __opstate<_Rcvr, _Fn>{static_cast<_Rcvr&&>(__rcvr), static_cast<_Fn&&>(__fn_)};
+    return __opstate<_Rcvr, _Fn>{{}, static_cast<_Rcvr&&>(__rcvr), static_cast<_Fn&&>(__fn_)};
   }
 
   template <class _Rcvr>
   _CUDAX_API __opstate<_Rcvr, _Fn> connect(_Rcvr __rcvr) const& //
     noexcept(__nothrow_decay_copyable<_Rcvr, _Fn const&>)
   {
-    return __opstate<_Rcvr, _Fn>{static_cast<_Rcvr&&>(__rcvr), __fn_};
+    return __opstate<_Rcvr, _Fn>{{}, static_cast<_Rcvr&&>(__rcvr), __fn_};
   }
 };
 
@@ -148,7 +149,7 @@ template <__disposition_t _Disposition>
 template <class _Fn>
 _CUDAX_TRIVIAL_API auto __just_from_t<_Disposition>::operator()(_Fn __fn) const noexcept -> __sndr_t<_Fn>
 {
-  using __completions = __call_result_t<_Fn, __probe_fn>;
+  using __completions _CCCL_NODEBUG_ALIAS = __call_result_t<_Fn, __probe_fn>;
   static_assert(__valid_completion_signatures<__completions>,
                 "The function passed to just_from must return an instance of a specialization of "
                 "completion_signatures<>.");

--- a/cudax/include/cuda/experimental/__async/sender/lazy.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/lazy.cuh
@@ -78,7 +78,7 @@ struct __lazy_box_
 };
 
 template <size_t _Idx, class _Ty>
-using __lazy_box = __lazy_box_<_Idx, sizeof(_Ty), alignof(_Ty)>;
+using __lazy_box _CCCL_NODEBUG_ALIAS = __lazy_box_<_Idx, sizeof(_Ty), alignof(_Ty)>;
 } // namespace __detail
 
 template <class _Idx, class... _Ts>
@@ -99,7 +99,7 @@ template <size_t... _Idx, class... _Ts>
 struct __lazy_tupl<_CUDA_VSTD::index_sequence<_Idx...>, _Ts...> : __detail::__lazy_box<_Idx, _Ts>...
 {
   template <size_t _Ny>
-  using __at = _CUDA_VSTD::__type_index_c<_Ny, _Ts...>;
+  using __at _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::__type_index_c<_Ny, _Ts...>;
 
   _CUDAX_TRIVIAL_API __lazy_tupl() noexcept {}
 
@@ -118,9 +118,9 @@ struct __lazy_tupl<_CUDA_VSTD::index_sequence<_Idx...>, _Ts...> : __detail::__la
   _CUDAX_TRIVIAL_API __at<_Ny>& __emplace(_Us&&... __us) //
     noexcept(__nothrow_constructible<__at<_Ny>, _Us...>)
   {
-    using _Ty       = __at<_Ny>;
-    _Ty* __value_   = ::new (static_cast<void*>(__get<_Ny, _Ty>())) _Ty{static_cast<_Us&&>(__us)...};
-    __engaged_[_Ny] = true;
+    using _Ty _CCCL_NODEBUG_ALIAS = __at<_Ny>;
+    _Ty* __value_                 = ::new (static_cast<void*>(__get<_Ny, _Ty>())) _Ty{static_cast<_Us&&>(__us)...};
+    __engaged_[_Ny]               = true;
     return *_CUDA_VSTD::launder(__value_);
   }
 
@@ -140,19 +140,19 @@ struct __lazy_tupl<_CUDA_VSTD::index_sequence<_Idx...>, _Ts...> : __detail::__la
 template <class... _Ts>
 struct __mk_lazy_tuple_
 {
-  using __indices_t = _CUDA_VSTD::make_index_sequence<sizeof...(_Ts)>;
-  using type        = __lazy_tupl<__indices_t, _Ts...>;
+  using __indices_t _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::make_index_sequence<sizeof...(_Ts)>;
+  using type _CCCL_NODEBUG_ALIAS        = __lazy_tupl<__indices_t, _Ts...>;
 };
 
 template <class... _Ts>
-using __lazy_tuple = typename __mk_lazy_tuple_<_Ts...>::type;
+using __lazy_tuple _CCCL_NODEBUG_ALIAS = typename __mk_lazy_tuple_<_Ts...>::type;
 #else
 template <class... _Ts>
-using __lazy_tuple = __lazy_tupl<_CUDA_VSTD::make_index_sequence<sizeof...(_Ts)>, _Ts...>;
+using __lazy_tuple _CCCL_NODEBUG_ALIAS = __lazy_tupl<_CUDA_VSTD::make_index_sequence<sizeof...(_Ts)>, _Ts...>;
 #endif
 
 template <class... _Ts>
-using __decayed_lazy_tuple = __lazy_tuple<__decay_t<_Ts>...>;
+using __decayed_lazy_tuple _CCCL_NODEBUG_ALIAS = __lazy_tuple<__decay_t<_Ts>...>;
 
 } // namespace cuda::experimental::__async
 

--- a/cudax/include/cuda/experimental/__async/sender/lazy.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/lazy.cuh
@@ -43,14 +43,14 @@ struct __lazy
   _CUDAX_API ~__lazy() {}
 
   template <class... _Ts>
-  _CUDAX_API _Ty& construct(_Ts&&... __ts) noexcept(__nothrow_constructible<_Ty, _Ts...>)
+  _CUDAX_API auto construct(_Ts&&... __ts) noexcept(__nothrow_constructible<_Ty, _Ts...>) -> _Ty&
   {
     _Ty* __value_ = ::new (static_cast<void*>(_CUDA_VSTD::addressof(__value_))) _Ty{static_cast<_Ts&&>(__ts)...};
     return *_CUDA_VSTD::launder(__value_);
   }
 
   template <class _Fn, class... _Ts>
-  _CUDAX_API _Ty& construct_from(_Fn&& __fn, _Ts&&... __ts) noexcept(__nothrow_callable<_Fn, _Ts...>)
+  _CUDAX_API auto construct_from(_Fn&& __fn, _Ts&&... __ts) noexcept(__nothrow_callable<_Fn, _Ts...>) -> _Ty&
   {
     _Ty* __value_ = ::new (static_cast<void*>(_CUDA_VSTD::addressof(__value_)))
       _Ty{static_cast<_Fn&&>(__fn)(static_cast<_Ts&&>(__ts)...)};

--- a/cudax/include/cuda/experimental/__async/sender/let_value.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/let_value.cuh
@@ -282,7 +282,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __let_t<_Disposition>::__sndr_t
     return __opstate_t<_Rcvr, const _Sndr&, _Fn>(__sndr_, __fn_, static_cast<_Rcvr&&>(__rcvr));
   }
 
-  _CUDAX_API env_of_t<_Sndr> get_env() const noexcept
+  _CUDAX_API auto get_env() const noexcept -> env_of_t<_Sndr>
   {
     return __async::get_env(__sndr_);
   }

--- a/cudax/include/cuda/experimental/__async/sender/let_value.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/let_value.cuh
@@ -32,6 +32,7 @@
 #include <cuda/experimental/__async/sender/rcvr_ref.cuh>
 #include <cuda/experimental/__async/sender/tuple.cuh>
 #include <cuda/experimental/__async/sender/type_traits.cuh>
+#include <cuda/experimental/__async/sender/utility.cuh>
 #include <cuda/experimental/__async/sender/variant.cuh>
 #include <cuda/experimental/__async/sender/visit.cuh>
 #include <cuda/experimental/__detail/config.cuh>
@@ -62,32 +63,32 @@ extern __fn_t<let_stopped_t>* __let_tag<__stopped, _Void>;
 } // namespace __detail
 
 template <__disposition_t _Disposition>
-struct __let_t
+struct _CCCL_TYPE_VISIBILITY_DEFAULT __let_t
 {
 private:
-  using _LetTag = decltype(__detail::__let_tag<_Disposition>());
-  using _SetTag = decltype(__detail::__set_tag<_Disposition>());
+  using _LetTag _CCCL_NODEBUG_ALIAS = decltype(__detail::__let_tag<_Disposition>());
+  using _SetTag _CCCL_NODEBUG_ALIAS = decltype(__detail::__set_tag<_Disposition>());
 
   template <class...>
-  using __empty_tuple = __tuple<>;
+  using __empty_tuple _CCCL_NODEBUG_ALIAS = __tuple<>;
 
   /// @brief Computes the type of a variant of tuples to hold the results of
   /// the predecessor sender.
   template <class _CvSndr, class _Env>
-  using __results =
+  using __results _CCCL_NODEBUG_ALIAS =
     __gather_completion_signatures<completion_signatures_of_t<_CvSndr, _Env>, _SetTag, __decayed_tuple, __variant>;
 
   template <class _Fn, class _Rcvr>
   struct __opstate_fn
   {
     template <class... _As>
-    using __call = connect_result_t<__call_result_t<_Fn, __decay_t<_As>&...>, __rcvr_ref<_Rcvr>>;
+    using __call _CCCL_NODEBUG_ALIAS = connect_result_t<__call_result_t<_Fn, __decay_t<_As>&...>, __rcvr_ref<_Rcvr>>;
   };
 
   /// @brief Computes the type of a variant of operation states to hold
   /// the second operation state.
   template <class _CvSndr, class _Fn, class _Rcvr>
-  using __opstate2_t =
+  using __opstate2_t _CCCL_NODEBUG_ALIAS =
     __gather_completion_signatures<completion_signatures_of_t<_CvSndr, _FWD_ENV_T<env_of_t<_Rcvr>>>,
                                    _SetTag,
                                    __opstate_fn<_Fn, _Rcvr>::template __call,
@@ -100,13 +101,13 @@ private:
   /// @tparam _Rcvr The receiver connected to the `let_(value|error|stopped)`
   /// sender.
   template <class _Rcvr, class _CvSndr, class _Fn>
-  struct _CCCL_TYPE_VISIBILITY_DEFAULT __opstate_t
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __opstate_t : private __immovable
   {
-    using operation_state_concept = operation_state_t;
-    using __env_t                 = _FWD_ENV_T<env_of_t<_Rcvr>>;
+    using operation_state_concept _CCCL_NODEBUG_ALIAS = operation_state_t;
+    using __env_t _CCCL_NODEBUG_ALIAS                 = _FWD_ENV_T<env_of_t<_Rcvr>>;
 
     // Compute the type of the variant of operation states
-    using __opstate_variant_t = __opstate2_t<_CvSndr, _Fn, _Rcvr>;
+    using __opstate_variant_t _CCCL_NODEBUG_ALIAS = __opstate2_t<_CvSndr, _Fn, _Rcvr>;
 
     _CUDAX_API __opstate_t(_CvSndr&& __sndr, _Fn __fn, _Rcvr __rcvr) noexcept(
       __nothrow_decay_copyable<_Fn, _Rcvr> && __nothrow_connectable<_CvSndr, __opstate_t*>)
@@ -207,7 +208,7 @@ private:
       else
       {
         // TODO: test that _Sndr satisfies sender_in<_Sndr, _Env...>
-        using _Sndr = _CUDA_VSTD::__call_result_t<_Fn, _CUDA_VSTD::decay_t<_Ts>&...>;
+        using _Sndr _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::__call_result_t<_Fn, _CUDA_VSTD::decay_t<_Ts>&...>;
         // The function is callable with the arguments and returns a sender, but we
         // do not know whether connect will throw.
         return concat_completion_signatures(get_completion_signatures<_Sndr, _Env...>(), __eptr_completion());
@@ -237,7 +238,7 @@ template <__disposition_t _Disposition>
 template <class _Sndr, class _Fn>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __let_t<_Disposition>::__sndr_t
 {
-  using sender_concept = sender_t;
+  using sender_concept _CCCL_NODEBUG_ALIAS = sender_t;
   _CCCL_NO_UNIQUE_ADDRESS _LetTag __tag_;
   _Fn __fn_;
   _Sndr __sndr_;
@@ -291,7 +292,7 @@ template <__disposition_t _Disposition>
 template <class _Fn>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __let_t<_Disposition>::__closure_t
 {
-  using _LetTag = decltype(__detail::__let_tag<_Disposition>());
+  using _LetTag _CCCL_NODEBUG_ALIAS = decltype(__detail::__let_tag<_Disposition>());
   _Fn __fn_;
 
   template <class _Sndr>
@@ -316,7 +317,7 @@ _CUDAX_API auto __let_t<_Disposition>::operator()(_Sndr __sndr, _Fn __fn) const 
   // signatures of the composed sender immediately.
   if constexpr (!dependent_sender<_Sndr>)
   {
-    using __completions = completion_signatures_of_t<__sndr_t<_Sndr, _Fn>>;
+    using __completions _CCCL_NODEBUG_ALIAS = completion_signatures_of_t<__sndr_t<_Sndr, _Fn>>;
     static_assert(__valid_completion_signatures<__completions>);
   }
   return __sndr_t<_Sndr, _Fn>{{}, static_cast<_Fn&&>(__fn), static_cast<_Sndr&&>(__sndr)};

--- a/cudax/include/cuda/experimental/__async/sender/meta.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/meta.cuh
@@ -41,7 +41,7 @@ _CCCL_DIAG_SUPPRESS_GCC("-Wnon-template-friend")
 namespace cuda::experimental::__async
 {
 template <class _Ret, class... _Args>
-using __fn_t = _Ret(_Args...);
+using __fn_t _CCCL_NODEBUG_ALIAS = _Ret(_Args...);
 
 template <class _Ty>
 _Ty&& declval() noexcept;
@@ -150,7 +150,7 @@ inline constexpr bool __type_contains_error =
 #endif
 
 template <class... _Ts>
-using __type_find_error = decltype(+(declval<_Ts&>(), ..., declval<_ERROR<_UNKNOWN>&>()));
+using __type_find_error _CCCL_NODEBUG_ALIAS = decltype(+(declval<_Ts&>(), ..., declval<_ERROR<_UNKNOWN>&>()));
 
 template <template <class...> class _Fn, class... _Ts>
 inline constexpr bool __type_valid_v = _CUDA_VSTD::_IsValidExpansion<_Fn, _Ts...>::value;
@@ -170,7 +170,7 @@ struct __type_self_or_error_with_<true>
 };
 
 template <class _Ty, class... _With>
-using __type_self_or_error_with =
+using __type_self_or_error_with _CCCL_NODEBUG_ALIAS =
   _CUDA_VSTD::__type_call<__type_self_or_error_with_<__type_is_error<_Ty>>, _Ty, _With...>;
 
 template <bool>
@@ -180,7 +180,7 @@ template <>
 struct __type_try__<false>
 {
   template <template <class...> class _Fn, class... _Ts>
-  using __call_q = _Fn<_Ts...>;
+  using __call_q _CCCL_NODEBUG_ALIAS = _Fn<_Ts...>;
 
   template <class _Fn, class... _Ts>
   using __call _CCCL_NODEBUG_ALIAS = typename _Fn::template __call<_Ts...>;
@@ -190,17 +190,19 @@ template <>
 struct __type_try__<true>
 {
   template <template <class...> class _Fn, class... _Ts>
-  using __call_q = __type_find_error<_Ts...>;
+  using __call_q _CCCL_NODEBUG_ALIAS = __type_find_error<_Ts...>;
 
   template <class _Fn, class... _Ts>
   using __call _CCCL_NODEBUG_ALIAS = __type_find_error<_Fn, _Ts...>;
 };
 
 template <class _Fn, class... _Ts>
-using __type_try_call = typename __type_try__<__type_contains_error<_Fn, _Ts...>>::template __call<_Fn, _Ts...>;
+using __type_try_call _CCCL_NODEBUG_ALIAS =
+  typename __type_try__<__type_contains_error<_Fn, _Ts...>>::template __call<_Fn, _Ts...>;
 
 template <template <class...> class _Fn, class... _Ts>
-using __type_try_call_quote = typename __type_try__<__type_contains_error<_Ts...>>::template __call_q<_Fn, _Ts...>;
+using __type_try_call_quote _CCCL_NODEBUG_ALIAS =
+  typename __type_try__<__type_contains_error<_Ts...>>::template __call_q<_Fn, _Ts...>;
 
 // wraps a meta-callable such that if any of the arguments are errors, the
 // result is an error.
@@ -244,15 +246,15 @@ struct __type_function
 template <class _First, class _Second>
 struct __type_pair
 {
-  using first  = _First;
-  using second = _Second;
+  using first _CCCL_NODEBUG_ALIAS  = _First;
+  using second _CCCL_NODEBUG_ALIAS = _Second;
 };
 
 template <class _Pair>
-using __type_first = typename _Pair::first;
+using __type_first _CCCL_NODEBUG_ALIAS = typename _Pair::first;
 
 template <class _Pair>
-using __type_second = typename _Pair::second;
+using __type_second _CCCL_NODEBUG_ALIAS = typename _Pair::second;
 
 template <template <class...> class _Second, template <class...> class _First>
 struct __type_compose_quote

--- a/cudax/include/cuda/experimental/__async/sender/meta.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/meta.cuh
@@ -44,7 +44,7 @@ template <class _Ret, class... _Args>
 using __fn_t _CCCL_NODEBUG_ALIAS = _Ret(_Args...);
 
 template <class _Ty>
-_Ty&& declval() noexcept;
+auto declval() noexcept -> _Ty&&;
 
 template <size_t... _Vals>
 struct __moffsets;
@@ -92,7 +92,7 @@ struct __merror_base
 {
   // _CUDAX_DEFAULTED_API virtual ~__merror_base() = default;
 
-  _CCCL_HOST_DEVICE constexpr friend bool __ustdex_unhandled_error(void*) noexcept
+  _CCCL_HOST_DEVICE constexpr friend auto __ustdex_unhandled_error(void*) noexcept -> bool
   {
     return true;
   }
@@ -117,16 +117,16 @@ struct _ERROR : __merror_base
   using __sends_stopped _CCCL_NODEBUG_ALIAS = _ERROR;
 
   // The following operator overloads also simplify error propagation.
-  _CCCL_HOST_DEVICE _ERROR operator+();
+  _CCCL_HOST_DEVICE auto operator+() -> _ERROR;
 
   template <class _Ty>
-  _CCCL_HOST_DEVICE _ERROR& operator,(_Ty&);
+  _CCCL_HOST_DEVICE auto operator,(_Ty&) -> _ERROR&;
 
   template <class... _With>
-  _CCCL_HOST_DEVICE _ERROR<_What..., _With...>& with(_ERROR<_With...>&);
+  _CCCL_HOST_DEVICE auto with(_ERROR<_With...>&) -> _ERROR<_What..., _With...>&;
 };
 
-_CCCL_HOST_DEVICE constexpr bool __ustdex_unhandled_error(...) noexcept
+_CCCL_HOST_DEVICE constexpr auto __ustdex_unhandled_error(...) noexcept -> bool
 {
   return false;
 }

--- a/cudax/include/cuda/experimental/__async/sender/queries.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/queries.cuh
@@ -40,7 +40,7 @@ template <class _Ty, class _Query>
 auto __query_result_() -> decltype(declval<_Ty>().query(_Query()));
 
 template <class _Ty, class _Query>
-using __query_result_t = decltype(__async::__query_result_<_Ty, _Query>());
+using __query_result_t _CCCL_NODEBUG_ALIAS = decltype(__async::__query_result_<_Ty, _Query>());
 
 template <class _Ty, class _Query>
 inline constexpr bool __queryable_with = __type_valid_v<__query_result_t, _Ty, _Query>;
@@ -50,7 +50,7 @@ template <class _Ty, class _Query>
 inline constexpr bool __nothrow_queryable_with = true;
 #else
 template <class _Ty, class _Query>
-using __nothrow_queryable_with_ = _CUDA_VSTD::enable_if_t<noexcept(declval<_Ty>().query(_Query{}))>;
+using __nothrow_queryable_with_ _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::enable_if_t<noexcept(declval<_Ty>().query(_Query{}))>;
 
 template <class _Ty, class _Query>
 inline constexpr bool __nothrow_queryable_with = __type_valid_v<__nothrow_queryable_with_, _Ty, _Query>;
@@ -89,7 +89,7 @@ _CCCL_GLOBAL_CONSTANT struct get_stop_token_t
 } get_stop_token{};
 
 template <class _Ty>
-using stop_token_of_t = __decay_t<__call_result_t<get_stop_token_t, _Ty>>;
+using stop_token_of_t _CCCL_NODEBUG_ALIAS = __decay_t<__call_result_t<get_stop_token_t, _Ty>>;
 
 template <class _Tag>
 struct get_completion_scheduler_t
@@ -162,7 +162,7 @@ _CCCL_GLOBAL_CONSTANT struct get_domain_t
 } get_domain{};
 
 template <class _Sch>
-using domain_of_t = __call_result_t<get_domain_t, _Sch>;
+using domain_of_t _CCCL_NODEBUG_ALIAS = __call_result_t<get_domain_t, _Sch>;
 
 } // namespace cuda::experimental::__async
 

--- a/cudax/include/cuda/experimental/__async/sender/rcvr_ref.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/rcvr_ref.cuh
@@ -30,9 +30,9 @@
 namespace cuda::experimental::__async
 {
 template <class _Rcvr, class _Env = env_of_t<_Rcvr>>
-struct __rcvr_ref
+struct _CCCL_TYPE_VISIBILITY_DEFAULT __rcvr_ref
 {
-  using receiver_concept = receiver_t;
+  using receiver_concept _CCCL_NODEBUG_ALIAS = receiver_t;
   _Rcvr& __rcvr_;
 
   template <class... _As>

--- a/cudax/include/cuda/experimental/__async/sender/rcvr_with_env.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/rcvr_with_env.cuh
@@ -29,9 +29,9 @@
 namespace cuda::experimental::__async
 {
 template <class _Rcvr, class _Env>
-struct __rcvr_with_env_t : _Rcvr
+struct _CCCL_TYPE_VISIBILITY_DEFAULT __rcvr_with_env_t : _Rcvr
 {
-  struct __env_t
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __env_t
   {
     template <class _Query>
     _CUDAX_TRIVIAL_API static constexpr decltype(auto) __get_1st(const __env_t& __self) noexcept
@@ -47,7 +47,7 @@ struct __rcvr_with_env_t : _Rcvr
     }
 
     template <class _Query>
-    using __1st_env_t = decltype(__env_t::__get_1st<_Query>(declval<const __env_t&>()));
+    using __1st_env_t _CCCL_NODEBUG_ALIAS = decltype(__env_t::__get_1st<_Query>(declval<const __env_t&>()));
 
     template <class _Query>
     _CUDAX_TRIVIAL_API constexpr auto query(_Query) const

--- a/cudax/include/cuda/experimental/__async/sender/read_env.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/read_env.cuh
@@ -41,21 +41,19 @@ namespace cuda::experimental::__async
 struct _THE_CURRENT_ENVIRONMENT_LACKS_THIS_QUERY;
 struct _THE_CURRENT_ENVIRONMENT_RETURNED_VOID_FOR_THIS_QUERY;
 
-struct read_env_t
+struct _CCCL_TYPE_VISIBILITY_DEFAULT read_env_t
 {
 private:
   template <class _Rcvr, class _Query>
-  struct _CCCL_TYPE_VISIBILITY_DEFAULT __opstate_t
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __opstate_t : private __immovable
   {
-    using operation_state_concept = operation_state_t;
+    using operation_state_concept _CCCL_NODEBUG_ALIAS = operation_state_t;
 
     _Rcvr __rcvr_;
 
     _CUDAX_API explicit __opstate_t(_Rcvr __rcvr)
         : __rcvr_(static_cast<_Rcvr&&>(__rcvr))
     {}
-
-    _CUDAX_IMMOVABLE(__opstate_t);
 
     _CUDAX_API void start() noexcept
     {
@@ -97,7 +95,7 @@ public:
 template <class _Query>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT read_env_t::__sndr_t
 {
-  using sender_concept = sender_t;
+  using sender_concept _CCCL_NODEBUG_ALIAS = sender_t;
   _CCCL_NO_UNIQUE_ADDRESS read_env_t __tag;
   _CCCL_NO_UNIQUE_ADDRESS _Query __query;
 

--- a/cudax/include/cuda/experimental/__async/sender/run_loop.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/run_loop.cuh
@@ -39,11 +39,11 @@
 
 namespace cuda::experimental::__async
 {
-class run_loop;
+class _CCCL_TYPE_VISIBILITY_DEFAULT run_loop;
 
-struct __task : __immovable
+struct __task : private __immovable
 {
-  using __execute_fn_t = void(__task*) noexcept;
+  using __execute_fn_t _CCCL_NODEBUG_ALIAS = void(__task*) noexcept;
 
   _CUDAX_DEFAULTED_API __task() = default;
 
@@ -72,7 +72,7 @@ struct __task : __immovable
 };
 
 template <class _Rcvr>
-struct __operation : __task
+struct _CCCL_TYPE_VISIBILITY_DEFAULT __operation : __task
 {
   run_loop* __loop_;
   _CCCL_NO_UNIQUE_ADDRESS _Rcvr __rcvr_;
@@ -111,10 +111,10 @@ struct __operation : __task
   _CUDAX_API void start() & noexcept;
 };
 
-class run_loop
+class _CCCL_TYPE_VISIBILITY_DEFAULT run_loop
 {
   template <class... _Ts>
-  using __completion_signatures = completion_signatures<_Ts...>;
+  using __completion_signatures _CCCL_NODEBUG_ALIAS = completion_signatures<_Ts...>;
 
   template <class>
   friend struct __operation;
@@ -125,13 +125,11 @@ public:
     __head.__next_ = __head.__tail_ = &__head;
   }
 
-  class __scheduler
+  class _CCCL_TYPE_VISIBILITY_DEFAULT __scheduler
   {
-    struct __schedule_task
+    struct _CCCL_TYPE_VISIBILITY_DEFAULT __schedule_task
     {
-      using __t            = __schedule_task;
-      using __id           = __schedule_task;
-      using sender_concept = sender_t;
+      using sender_concept _CCCL_NODEBUG_ALIAS = sender_t;
 
       template <class _Rcvr>
       _CUDAX_API auto connect(_Rcvr __rcvr) const noexcept -> __operation<_Rcvr>
@@ -142,13 +140,17 @@ public:
       template <class _Self>
       _CUDAX_API static constexpr auto get_completion_signatures() noexcept
       {
+#  if _CCCL_HAS_EXCEPTIONS()
         return completion_signatures<set_value_t(), set_error_t(::std::exception_ptr), set_stopped_t()>();
+#  else  // ^^^ _CCCL_HAS_EXCEPTIONS() ^^^ / vvv !_CCCL_HAS_EXCEPTIONS() vvv
+        return completion_signatures<set_value_t(), set_stopped_t()>();
+#  endif // !_CCCL_HAS_EXCEPTIONS()
       }
 
     private:
       friend __scheduler;
 
-      struct __env
+      struct _CCCL_TYPE_VISIBILITY_DEFAULT __env
       {
         run_loop* __loop_;
 
@@ -185,7 +187,7 @@ public:
     run_loop* __loop_;
 
   public:
-    using scheduler_concept = scheduler_t;
+    using scheduler_concept _CCCL_NODEBUG_ALIAS = scheduler_t;
 
     [[nodiscard]] _CUDAX_API auto schedule() const noexcept -> __schedule_task
     {

--- a/cudax/include/cuda/experimental/__async/sender/run_loop.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/run_loop.cuh
@@ -194,12 +194,12 @@ public:
       return __schedule_task{__loop_};
     }
 
-    _CUDAX_API friend bool operator==(const __scheduler& __a, const __scheduler& __b) noexcept
+    _CUDAX_API friend auto operator==(const __scheduler& __a, const __scheduler& __b) noexcept -> bool
     {
       return __a.__loop_ == __b.__loop_;
     }
 
-    _CUDAX_API friend bool operator!=(const __scheduler& __a, const __scheduler& __b) noexcept
+    _CUDAX_API friend auto operator!=(const __scheduler& __a, const __scheduler& __b) noexcept -> bool
     {
       return __a.__loop_ != __b.__loop_;
     }

--- a/cudax/include/cuda/experimental/__async/sender/sequence.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/sequence.cuh
@@ -28,6 +28,7 @@
 #include <cuda/experimental/__async/sender/exception.cuh>
 #include <cuda/experimental/__async/sender/lazy.cuh>
 #include <cuda/experimental/__async/sender/rcvr_ref.cuh>
+#include <cuda/experimental/__async/sender/utility.cuh>
 #include <cuda/experimental/__async/sender/variant.cuh>
 #include <cuda/experimental/__async/sender/visit.cuh>
 
@@ -35,26 +36,26 @@
 
 namespace cuda::experimental::__async
 {
-struct __seq_t
+struct _CCCL_TYPE_VISIBILITY_DEFAULT __seq_t
 {
   template <class _Rcvr, class _Sndr1, class _Sndr2>
   struct __args
   {
-    using __rcvr_t  = _Rcvr;
-    using __sndr1_t = _Sndr1;
-    using __sndr2_t = _Sndr2;
+    using __rcvr_t _CCCL_NODEBUG_ALIAS  = _Rcvr;
+    using __sndr1_t _CCCL_NODEBUG_ALIAS = _Sndr1;
+    using __sndr2_t _CCCL_NODEBUG_ALIAS = _Sndr2;
   };
 
   template <class _Zip>
-  struct _CCCL_TYPE_VISIBILITY_DEFAULT __opstate
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __opstate : private __immovable
   {
-    using operation_state_concept = operation_state_t;
+    using operation_state_concept _CCCL_NODEBUG_ALIAS = operation_state_t;
 
-    using __args_t  = __unzip<_Zip>; // __unzip<_Zip> is __args<_Rcvr, _Sndr1, _Sndr2>
-    using __rcvr_t  = typename __args_t::__rcvr_t;
-    using __sndr1_t = typename __args_t::__sndr1_t;
-    using __sndr2_t = typename __args_t::__sndr2_t;
-    using __env_t   = env_of_t<__rcvr_t>;
+    using __args_t _CCCL_NODEBUG_ALIAS  = __unzip<_Zip>; // __unzip<_Zip> is __args<_Rcvr, _Sndr1, _Sndr2>
+    using __rcvr_t _CCCL_NODEBUG_ALIAS  = typename __args_t::__rcvr_t;
+    using __sndr1_t _CCCL_NODEBUG_ALIAS = typename __args_t::__sndr1_t;
+    using __sndr2_t _CCCL_NODEBUG_ALIAS = typename __args_t::__sndr2_t;
+    using __env_t _CCCL_NODEBUG_ALIAS   = env_of_t<__rcvr_t>;
 
     _CUDAX_API __opstate(__sndr1_t&& __sndr1, __sndr2_t&& __sndr2, __rcvr_t&& __rcvr)
         : __rcvr_(static_cast<__rcvr_t&&>(__rcvr))
@@ -98,15 +99,15 @@ struct __seq_t
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __sndr_t;
 
   template <class _Sndr1, class _Sndr2>
-  _CUDAX_API auto operator()(_Sndr1 __sndr1, _Sndr2 __sndr2) const -> __sndr_t<_Sndr1, _Sndr2>;
+  _CUDAX_TRIVIAL_API constexpr auto operator()(_Sndr1 __sndr1, _Sndr2 __sndr2) const -> __sndr_t<_Sndr1, _Sndr2>;
 };
 
 template <class _Sndr1, class _Sndr2>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __seq_t::__sndr_t
 {
-  using sender_concept = sender_t;
-  using __sndr1_t      = _Sndr1;
-  using __sndr2_t      = _Sndr2;
+  using sender_concept _CCCL_NODEBUG_ALIAS = sender_t;
+  using __sndr1_t _CCCL_NODEBUG_ALIAS      = _Sndr1;
+  using __sndr2_t _CCCL_NODEBUG_ALIAS      = _Sndr2;
 
   template <class _Self, class... _Env>
   _CUDAX_API static constexpr auto get_completion_signatures()
@@ -126,14 +127,14 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __seq_t::__sndr_t
   template <class _Rcvr>
   _CUDAX_API auto connect(_Rcvr __rcvr) &&
   {
-    using __opstate_t = __opstate<__zip<__args<_Rcvr, _Sndr1, _Sndr2>>>;
+    using __opstate_t _CCCL_NODEBUG_ALIAS = __opstate<__zip<__args<_Rcvr, _Sndr1, _Sndr2>>>;
     return __opstate_t{static_cast<_Sndr1&&>(__sndr1_), static_cast<_Sndr2>(__sndr2_), static_cast<_Rcvr&&>(__rcvr)};
   }
 
   template <class _Rcvr>
   _CUDAX_API auto connect(_Rcvr __rcvr) const&
   {
-    using __opstate_t = __opstate<__zip<__args<_Rcvr, const _Sndr1&, const _Sndr2&>>>;
+    using __opstate_t _CCCL_NODEBUG_ALIAS = __opstate<__zip<__args<_Rcvr, const _Sndr1&, const _Sndr2&>>>;
     return __opstate_t{__sndr1_, __sndr2_, static_cast<_Rcvr&&>(__rcvr)};
   }
 
@@ -149,7 +150,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __seq_t::__sndr_t
 };
 
 template <class _Sndr1, class _Sndr2>
-_CUDAX_API auto __seq_t::operator()(_Sndr1 __sndr1, _Sndr2 __sndr2) const -> __sndr_t<_Sndr1, _Sndr2>
+_CUDAX_TRIVIAL_API constexpr auto __seq_t::operator()(_Sndr1 __sndr1, _Sndr2 __sndr2) const -> __sndr_t<_Sndr1, _Sndr2>
 {
   return __sndr_t<_Sndr1, _Sndr2>{{}, {}, static_cast<_Sndr1&&>(__sndr1), static_cast<_Sndr2&&>(__sndr2)};
 }
@@ -157,7 +158,7 @@ _CUDAX_API auto __seq_t::operator()(_Sndr1 __sndr1, _Sndr2 __sndr2) const -> __s
 template <class _Sndr1, class _Sndr2>
 inline constexpr size_t structured_binding_size<__seq_t::__sndr_t<_Sndr1, _Sndr2>> = 4;
 
-using sequence_t = __seq_t;
+using sequence_t _CCCL_NODEBUG_ALIAS = __seq_t;
 _CCCL_GLOBAL_CONSTANT sequence_t sequence{};
 } // namespace cuda::experimental::__async
 

--- a/cudax/include/cuda/experimental/__async/sender/sequence.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/sequence.cuh
@@ -138,7 +138,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __seq_t::__sndr_t
     return __opstate_t{__sndr1_, __sndr2_, static_cast<_Rcvr&&>(__rcvr)};
   }
 
-  _CUDAX_API env_of_t<_Sndr2> get_env() const noexcept
+  _CUDAX_API auto get_env() const noexcept -> env_of_t<_Sndr2>
   {
     return __async::get_env(__sndr2_);
   }

--- a/cudax/include/cuda/experimental/__async/sender/start_detached.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/start_detached.cuh
@@ -25,6 +25,7 @@
 
 #include <cuda/experimental/__async/sender/cpos.cuh>
 #include <cuda/experimental/__detail/config.cuh>
+#include <cuda/experimental/__detail/utility.cuh>
 
 #include <cuda/experimental/__async/sender/prologue.cuh>
 
@@ -33,12 +34,12 @@ namespace cuda::experimental::__async
 struct start_detached_t
 {
 private:
-  struct __opstate_base_t : __immovable
+  struct __opstate_base_t : private __immovable
   {};
 
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __rcvr_t
   {
-    using receiver_concept = receiver_t;
+    using receiver_concept _CCCL_NODEBUG_ALIAS = receiver_t;
 
     __opstate_base_t* __opstate_;
     void (*__destroy)(__opstate_base_t*) noexcept;
@@ -64,7 +65,7 @@ private:
   template <class _Sndr>
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __opstate_t : __opstate_base_t
   {
-    using operation_state_concept = operation_state_t;
+    using operation_state_concept _CCCL_NODEBUG_ALIAS = operation_state_t;
     connect_result_t<_Sndr, __rcvr_t> __opstate_;
 
     static void __destroy(__opstate_base_t* __ptr) noexcept

--- a/cudax/include/cuda/experimental/__async/sender/start_on.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/start_on.cuh
@@ -42,7 +42,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __sch_env_t
 {
   _Sch __sch_;
 
-  _Sch query(get_scheduler_t) const noexcept
+  auto query(get_scheduler_t) const noexcept -> _Sch
   {
     return __sch_;
   }
@@ -134,7 +134,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT start_on_t::__sndr_t
     return __opstate_t<_Rcvr, _Sch, const _Sndr&>{__sch_, static_cast<_Rcvr&&>(__rcvr), __sndr_};
   }
 
-  _CUDAX_API env_of_t<_Sndr> get_env() const noexcept
+  _CUDAX_API auto get_env() const noexcept -> env_of_t<_Sndr>
   {
     return __async::get_env(__sndr_);
   }

--- a/cudax/include/cuda/experimental/__async/sender/start_on.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/start_on.cuh
@@ -38,7 +38,7 @@
 namespace cuda::experimental::__async
 {
 template <class _Sch>
-struct __sch_env_t
+struct _CCCL_TYPE_VISIBILITY_DEFAULT __sch_env_t
 {
   _Sch __sch_;
 
@@ -54,9 +54,9 @@ private:
   template <class _Rcvr, class _Sch, class _CvSndr>
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __opstate_t : __rcvr_with_env_t<_Rcvr, __sch_env_t<_Sch>>
   {
-    using operation_state_concept = operation_state_t;
-    using __env_t                 = env_of_t<_Rcvr>;
-    using __rcvr_with_sch_t       = __rcvr_with_env_t<_Rcvr, __sch_env_t<_Sch>>;
+    using operation_state_concept _CCCL_NODEBUG_ALIAS = operation_state_t;
+    using __env_t _CCCL_NODEBUG_ALIAS                 = env_of_t<_Rcvr>;
+    using __rcvr_with_sch_t _CCCL_NODEBUG_ALIAS       = __rcvr_with_env_t<_Rcvr, __sch_env_t<_Sch>>;
 
     _CUDAX_API __opstate_t(_Sch __sch, _Rcvr __rcvr, _CvSndr&& __sndr)
         : __rcvr_with_sch_t{static_cast<_Rcvr&&>(__rcvr), {__sch}}
@@ -90,25 +90,25 @@ public:
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __sndr_t;
 
   template <class _Sch, class _Sndr>
-  _CUDAX_API auto operator()(_Sch __sch, _Sndr __sndr) const noexcept -> __sndr_t<_Sch, _Sndr>;
+  _CUDAX_TRIVIAL_API constexpr auto operator()(_Sch __sch, _Sndr __sndr) const noexcept -> __sndr_t<_Sch, _Sndr>;
 };
 
 template <class _Sch, class _Sndr>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT start_on_t::__sndr_t
 {
-  using sender_concept = sender_t;
+  using sender_concept _CCCL_NODEBUG_ALIAS = sender_t;
   _CCCL_NO_UNIQUE_ADDRESS start_on_t __tag_;
   _Sch __sch_;
   _Sndr __sndr_;
 
   template <class _Env>
-  using __env_t = env<__sch_env_t<_Sch>, _FWD_ENV_T<_Env>>;
+  using __env_t _CCCL_NODEBUG_ALIAS = env<__sch_env_t<_Sch>, _FWD_ENV_T<_Env>>;
 
   template <class _Self, class... _Env>
   _CUDAX_API static constexpr auto get_completion_signatures()
   {
-    using __sch_sndr   = schedule_result_t<_Sch>;
-    using __child_sndr = __copy_cvref_t<_Self, _Sndr>;
+    using __sch_sndr _CCCL_NODEBUG_ALIAS   = schedule_result_t<_Sch>;
+    using __child_sndr _CCCL_NODEBUG_ALIAS = __copy_cvref_t<_Self, _Sndr>;
     _CUDAX_LET_COMPLETIONS(
       auto(__sndr_completions) = __async::get_completion_signatures<__child_sndr, __env_t<_Env>...>())
     {
@@ -141,7 +141,8 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT start_on_t::__sndr_t
 };
 
 template <class _Sch, class _Sndr>
-_CUDAX_API auto start_on_t::operator()(_Sch __sch, _Sndr __sndr) const noexcept -> __sndr_t<_Sch, _Sndr>
+_CUDAX_TRIVIAL_API constexpr auto start_on_t::operator()(_Sch __sch, _Sndr __sndr) const noexcept
+  -> __sndr_t<_Sch, _Sndr>
 {
   return __sndr_t<_Sch, _Sndr>{{}, __sch, __sndr};
 }

--- a/cudax/include/cuda/experimental/__async/sender/stop_token.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/stop_token.cuh
@@ -127,12 +127,12 @@ public:
     return false;
   }
 
-  _CUDAX_API friend constexpr bool operator==(const never_stop_token&, const never_stop_token&) noexcept
+  _CUDAX_API friend constexpr auto operator==(const never_stop_token&, const never_stop_token&) noexcept -> bool
   {
     return true;
   }
 
-  _CUDAX_API friend constexpr bool operator!=(const never_stop_token&, const never_stop_token&) noexcept
+  _CUDAX_API friend constexpr auto operator!=(const never_stop_token&, const never_stop_token&) noexcept -> bool
   {
     return false;
   }
@@ -221,12 +221,12 @@ public:
     __async::__swap(__source_, __other.__source_);
   }
 
-  _CUDAX_API friend bool operator==(const inplace_stop_token& __a, const inplace_stop_token& __b) noexcept
+  _CUDAX_API friend auto operator==(const inplace_stop_token& __a, const inplace_stop_token& __b) noexcept -> bool
   {
     return __a.__source_ == __b.__source_;
   }
 
-  _CUDAX_API friend bool operator!=(const inplace_stop_token& __a, const inplace_stop_token& __b) noexcept
+  _CUDAX_API friend auto operator!=(const inplace_stop_token& __a, const inplace_stop_token& __b) noexcept -> bool
   {
     return __a.__source_ != __b.__source_;
   }

--- a/cudax/include/cuda/experimental/__async/sender/stop_token.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/stop_token.cuh
@@ -35,18 +35,13 @@
 
 #include <cuda/experimental/__async/sender/prologue.cuh>
 
-// warning #20012-D: __device__ annotation is ignored on a
-// function("inplace_stop_source") that is explicitly defaulted on its first
-// declaration
-_CCCL_NV_DIAG_SUPPRESS(20012)
-
 namespace cuda::experimental::__async
 {
 // [stoptoken.inplace], class inplace_stop_token
-class inplace_stop_token;
+class _CCCL_TYPE_VISIBILITY_DEFAULT inplace_stop_token;
 
 // [stopsource.inplace], class inplace_stop_source
-class inplace_stop_source;
+class _CCCL_TYPE_VISIBILITY_DEFAULT inplace_stop_source;
 
 // [stopcallback.inplace], class template inplace_stop_callback
 template <class _Callback>
@@ -62,7 +57,7 @@ struct __inplace_stop_callback_base
   }
 
 protected:
-  using __execute_fn_t = void(__inplace_stop_callback_base*) noexcept;
+  using __execute_fn_t _CCCL_NODEBUG_ALIAS = void(__inplace_stop_callback_base*) noexcept;
 
   _CUDAX_API explicit __inplace_stop_callback_base( //
     const inplace_stop_source* __source,            //
@@ -110,7 +105,7 @@ struct __check_type_alias_exists;
 } // namespace __stok
 
 // [stoptoken.never], class never_stop_token
-struct never_stop_token
+struct _CCCL_TYPE_VISIBILITY_DEFAULT never_stop_token
 {
 private:
   struct __callback_type
@@ -120,7 +115,7 @@ private:
 
 public:
   template <class>
-  using callback_type = __callback_type;
+  using callback_type _CCCL_NODEBUG_ALIAS = __callback_type;
 
   _CUDAX_API static constexpr auto stop_requested() noexcept -> bool
   {
@@ -144,10 +139,10 @@ public:
 };
 
 template <class _Callback>
-class inplace_stop_callback;
+class _CCCL_TYPE_VISIBILITY_DEFAULT inplace_stop_callback;
 
 // [stopsource.inplace], class inplace_stop_source
-class inplace_stop_source
+class _CCCL_TYPE_VISIBILITY_DEFAULT inplace_stop_source
 {
 public:
   _CUDAX_DEFAULTED_API inplace_stop_source() noexcept = default;
@@ -187,11 +182,11 @@ private:
 };
 
 // [stoptoken.inplace], class inplace_stop_token
-class inplace_stop_token
+class _CCCL_TYPE_VISIBILITY_DEFAULT inplace_stop_token
 {
 public:
   template <class _Fun>
-  using callback_type = inplace_stop_callback<_Fun>;
+  using callback_type _CCCL_NODEBUG_ALIAS = inplace_stop_callback<_Fun>;
 
   _CUDAX_API inplace_stop_token() noexcept
       : __source_(nullptr)
@@ -255,7 +250,7 @@ _CUDAX_API inline auto inplace_stop_source::get_token() const noexcept -> inplac
 
 // [stopcallback.inplace], class template inplace_stop_callback
 template <class _Fun>
-class inplace_stop_callback : __stok::__inplace_stop_callback_base
+class _CCCL_TYPE_VISIBILITY_DEFAULT inplace_stop_callback : __stok::__inplace_stop_callback_base
 {
 public:
   template <class _Fun2>
@@ -478,10 +473,8 @@ struct __on_stop_request
 };
 
 template <class _Token, class _Callback>
-using stop_callback_for_t = typename _Token::template callback_type<_Callback>;
+using stop_callback_for_t _CCCL_NODEBUG_ALIAS = typename _Token::template callback_type<_Callback>;
 } // namespace cuda::experimental::__async
-
-_CCCL_NV_DIAG_DEFAULT(20012)
 
 #include <cuda/experimental/__async/sender/epilogue.cuh>
 

--- a/cudax/include/cuda/experimental/__async/sender/sync_wait.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/sync_wait.cuh
@@ -47,7 +47,7 @@ namespace cuda::experimental::__async
 struct sync_wait_t
 {
 private:
-  struct __env_t
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __env_t
   {
     run_loop* __loop_;
 
@@ -63,11 +63,11 @@ private:
   };
 
   template <class _Values>
-  struct __state_t
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __state_t
   {
     struct _CCCL_TYPE_VISIBILITY_DEFAULT __rcvr_t
     {
-      using receiver_concept = receiver_t;
+      using receiver_concept _CCCL_NODEBUG_ALIAS = receiver_t;
       __state_t* __state_;
 
       template <class... _As>
@@ -161,7 +161,7 @@ public:
   template <class _Sndr>
   auto operator()(_Sndr&& __sndr) const
   {
-    using __completions = completion_signatures_of_t<_Sndr, __env_t>;
+    using __completions _CCCL_NODEBUG_ALIAS = completion_signatures_of_t<_Sndr, __env_t>;
 
     if constexpr (!__valid_completion_signatures<__completions>)
     {
@@ -169,13 +169,13 @@ public:
     }
     else
     {
-      using __values = __value_types<__completions, _CUDA_VSTD::tuple, _CUDA_VSTD::__type_self_t>;
+      using __values _CCCL_NODEBUG_ALIAS = __value_types<__completions, _CUDA_VSTD::tuple, _CUDA_VSTD::__type_self_t>;
       _CUDA_VSTD::optional<__values> __result{};
       __state_t<__values> __state{&__result, {}, {}};
 
       // Launch the sender with a continuation that will fill in a variant
-      using __rcvr   = typename __state_t<__values>::__rcvr_t;
-      auto __opstate = __async::connect(static_cast<_Sndr&&>(__sndr), __rcvr{&__state});
+      using __rcvr _CCCL_NODEBUG_ALIAS = typename __state_t<__values>::__rcvr_t;
+      auto __opstate                   = __async::connect(static_cast<_Sndr&&>(__sndr), __rcvr{&__state});
       __async::start(__opstate);
 
       // Wait for the variant to be filled in, and process any work that

--- a/cudax/include/cuda/experimental/__async/sender/sync_wait.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/sync_wait.cuh
@@ -108,7 +108,7 @@ private:
         __state_->__loop_.finish();
       }
 
-      __env_t get_env() const noexcept
+      auto get_env() const noexcept -> __env_t
       {
         return __env_t{&__state_->__loop_};
       }
@@ -124,10 +124,10 @@ private:
   {
     static_assert(_CUDA_VSTD::__always_false_v<_Diagnostic>(),
                   "sync_wait cannot compute the completions of the sender passed to it.");
-    static __bad_sync_wait __result();
+    static auto __result() -> __bad_sync_wait;
 
-    const __bad_sync_wait& value() const;
-    const __bad_sync_wait& operator*() const;
+    auto value() const -> const __bad_sync_wait&;
+    auto operator*() const -> const __bad_sync_wait&;
 
     int i{}; // so that structured bindings kinda work
   };

--- a/cudax/include/cuda/experimental/__async/sender/then.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/then.cuh
@@ -274,7 +274,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __upon_t<_Disposition>::__sndr_t
     return __opstate_t<_Rcvr, const _Sndr&, _Fn>{__sndr_, static_cast<_Rcvr&&>(__rcvr), __fn_};
   }
 
-  _CUDAX_API env_of_t<_Sndr> get_env() const noexcept
+  _CUDAX_API auto get_env() const noexcept -> env_of_t<_Sndr>
   {
     return __async::get_env(__sndr_);
   }

--- a/cudax/include/cuda/experimental/__async/sender/then.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/then.cuh
@@ -64,58 +64,56 @@ template <bool IsVoid, bool _Nothrow>
 struct __completion_fn
 { // non-void, potentially throwing case
   template <class _Result>
-  using __call = completion_signatures<set_value_t(_Result), set_error_t(::std::exception_ptr)>;
+  using __call _CCCL_NODEBUG_ALIAS = completion_signatures<set_value_t(_Result), set_error_t(::std::exception_ptr)>;
 };
 
 template <>
 struct __completion_fn<true, false>
 { // void, potentially throwing case
   template <class>
-  using __call = completion_signatures<set_value_t(), set_error_t(::std::exception_ptr)>;
+  using __call _CCCL_NODEBUG_ALIAS = completion_signatures<set_value_t(), set_error_t(::std::exception_ptr)>;
 };
 
 template <>
 struct __completion_fn<false, true>
 { // non-void, non-throwing case
   template <class _Result>
-  using __call = completion_signatures<set_value_t(_Result)>;
+  using __call _CCCL_NODEBUG_ALIAS = completion_signatures<set_value_t(_Result)>;
 };
 
 template <>
 struct __completion_fn<true, true>
 { // void, non-throwing case
   template <class>
-  using __call = completion_signatures<set_value_t()>;
+  using __call _CCCL_NODEBUG_ALIAS = completion_signatures<set_value_t()>;
 };
 
 template <class _Result, bool _Nothrow>
-using __completion_ =
+using __completion_ _CCCL_NODEBUG_ALIAS =
   _CUDA_VSTD::__type_call1<__completion_fn<_CUDA_VSTD::is_same_v<_Result, void>, _Nothrow>, _Result>;
 
 template <class _Fn, class... _Ts>
-using __completion = __completion_<__call_result_t<_Fn, _Ts...>, __nothrow_callable<_Fn, _Ts...>>;
+using __completion _CCCL_NODEBUG_ALIAS = __completion_<__call_result_t<_Fn, _Ts...>, __nothrow_callable<_Fn, _Ts...>>;
 } // namespace __upon
 
 template <__disposition_t _Disposition>
-struct __upon_t
+struct _CCCL_TYPE_VISIBILITY_DEFAULT __upon_t
 {
 private:
-  using _UponTag = decltype(__detail::__upon_tag<_Disposition>());
-  using _SetTag  = decltype(__detail::__set_tag<_Disposition>());
+  using _UponTag _CCCL_NODEBUG_ALIAS = decltype(__detail::__upon_tag<_Disposition>());
+  using _SetTag _CCCL_NODEBUG_ALIAS  = decltype(__detail::__set_tag<_Disposition>());
 
   template <class _Rcvr, class _CvSndr, class _Fn>
-  struct _CCCL_TYPE_VISIBILITY_DEFAULT __opstate_t
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __opstate_t : private __immovable
   {
-    using operation_state_concept = operation_state_t;
-    using __env_t                 = env_of_t<_Rcvr>;
+    using operation_state_concept _CCCL_NODEBUG_ALIAS = operation_state_t;
+    using __env_t _CCCL_NODEBUG_ALIAS                 = env_of_t<_Rcvr>;
 
     _CUDAX_API __opstate_t(_CvSndr&& __sndr, _Rcvr __rcvr, _Fn __fn)
         : __rcvr_{static_cast<_Rcvr&&>(__rcvr)}
         , __fn_{static_cast<_Fn&&>(__fn)}
         , __opstate_{__async::connect(static_cast<_CvSndr&&>(__sndr), __rcvr_ref{*this})}
     {}
-
-    _CUDAX_IMMOVABLE(__opstate_t);
 
     _CUDAX_API void start() & noexcept
     {
@@ -229,7 +227,7 @@ template <__disposition_t _Disposition>
 template <class _Fn, class _Sndr>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __upon_t<_Disposition>::__sndr_t
 {
-  using sender_concept = sender_t;
+  using sender_concept _CCCL_NODEBUG_ALIAS = sender_t;
   _CCCL_NO_UNIQUE_ADDRESS _UponTag __tag_;
   _Fn __fn_;
   _Sndr __sndr_;
@@ -286,7 +284,7 @@ template <__disposition_t _Disposition>
 template <class _Fn>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __upon_t<_Disposition>::__closure_t
 {
-  using _UponTag = decltype(__detail::__upon_tag<_Disposition>());
+  using _UponTag _CCCL_NODEBUG_ALIAS = decltype(__detail::__upon_tag<_Disposition>());
   _Fn __fn_;
 
   template <class _Sndr>
@@ -311,7 +309,7 @@ _CUDAX_TRIVIAL_API auto __upon_t<_Disposition>::operator()(_Sndr __sndr, _Fn __f
   // signatures of the composed sender immediately.
   if constexpr (!dependent_sender<_Sndr>)
   {
-    using __completions = completion_signatures_of_t<__sndr_t<_Fn, _Sndr>>;
+    using __completions _CCCL_NODEBUG_ALIAS = completion_signatures_of_t<__sndr_t<_Fn, _Sndr>>;
     static_assert(__valid_completion_signatures<__completions>);
   }
   return __sndr_t<_Fn, _Sndr>{{}, static_cast<_Fn&&>(__fn), static_cast<_Sndr&&>(__sndr)};

--- a/cudax/include/cuda/experimental/__async/sender/thread.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/thread.cuh
@@ -70,7 +70,7 @@ struct __thread_id
 using __thread_id _CCCL_NODEBUG_ALIAS = ::std::thread::id;
 #endif
 
-inline _CUDAX_API __thread_id __this_thread_id() noexcept
+inline _CUDAX_API auto __this_thread_id() noexcept -> __thread_id
 {
   _CUDAX_FOR_HOST_OR_DEVICE((return ::std::this_thread::get_id();),
                             (return static_cast<int>(threadIdx.x + blockIdx.x * blockDim.x);))

--- a/cudax/include/cuda/experimental/__async/sender/thread.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/thread.cuh
@@ -35,7 +35,7 @@
 namespace cuda::experimental::__async
 {
 #if defined(__CUDA_ARCH__)
-using __thread_id = int;
+using __thread_id _CCCL_NODEBUG_ALIAS = int;
 #elif _CCCL_COMPILER(NVHPC)
 struct __thread_id
 {
@@ -67,7 +67,7 @@ struct __thread_id
   }
 };
 #else
-using __thread_id = ::std::thread::id;
+using __thread_id _CCCL_NODEBUG_ALIAS = ::std::thread::id;
 #endif
 
 inline _CUDAX_API __thread_id __this_thread_id() noexcept

--- a/cudax/include/cuda/experimental/__async/sender/tuple.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/tuple.cuh
@@ -67,7 +67,7 @@ struct __tupl<_CUDA_VSTD::index_sequence<_Idx...>, _Ts...> : __box<_Idx, _Ts>...
 };
 
 template <auto _Value>
-using __v = _CUDA_VSTD::integral_constant<decltype(_Value), _Value>;
+using __v _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::integral_constant<decltype(_Value), _Value>;
 
 // Unroll tuples up to some size
 #define _CCCL_TUPLE_DEFINE_TPARAM(_Idx)  , class _CCCL_PP_CAT(_T, _Idx)
@@ -100,7 +100,7 @@ using __v = _CUDA_VSTD::integral_constant<decltype(_Value), _Value>;
     template <size_t _Idx>                                                                                            \
     _CUDAX_API static constexpr auto __get_mbr_ptr() noexcept                                                         \
     {                                                                                                                 \
-      using __result_t =                                                                                              \
+      using __result_t _CCCL_NODEBUG_ALIAS =                                                                          \
         _CUDA_VSTD::__type_index_c<_Idx, __v<&__tupl::__t0> _CCCL_PP_REPEAT(_SizeSub1, _CCCL_TUPLE_MBR_PTR, 1)>;      \
       return __result_t::value;                                                                                       \
     }                                                                                                                 \
@@ -134,25 +134,26 @@ __tupl(_Ts...) //
   ->__tupl<_CUDA_VSTD::make_index_sequence<sizeof...(_Ts)>, _Ts...>;
 
 template <class _Fn, class _Tupl, class... _Us>
-using __apply_result_t = decltype(declval<_Tupl>().__apply(declval<_Fn>(), declval<_Tupl>(), declval<_Us>()...));
+using __apply_result_t _CCCL_NODEBUG_ALIAS =
+  decltype(declval<_Tupl>().__apply(declval<_Fn>(), declval<_Tupl>(), declval<_Us>()...));
 
 #if _CCCL_COMPILER(MSVC)
 template <class... _Ts>
 struct __mk_tuple_
 {
-  using __indices_t = _CUDA_VSTD::make_index_sequence<sizeof...(_Ts)>;
-  using type        = __tupl<__indices_t, _Ts...>;
+  using __indices_t _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::make_index_sequence<sizeof...(_Ts)>;
+  using type _CCCL_NODEBUG_ALIAS        = __tupl<__indices_t, _Ts...>;
 };
 
 template <class... _Ts>
-using __tuple = typename __mk_tuple_<_Ts...>::type;
+using __tuple _CCCL_NODEBUG_ALIAS = typename __mk_tuple_<_Ts...>::type;
 #else
 template <class... _Ts>
-using __tuple = __tupl<_CUDA_VSTD::make_index_sequence<sizeof...(_Ts)>, _Ts...>;
+using __tuple _CCCL_NODEBUG_ALIAS = __tupl<_CUDA_VSTD::make_index_sequence<sizeof...(_Ts)>, _Ts...>;
 #endif
 
 template <class... _Ts>
-using __decayed_tuple = __tuple<__decay_t<_Ts>...>;
+using __decayed_tuple _CCCL_NODEBUG_ALIAS = __tuple<__decay_t<_Ts>...>;
 
 // A very simple pair type
 template <class _First, class _Second>

--- a/cudax/include/cuda/experimental/__async/sender/type_traits.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/type_traits.cuh
@@ -40,12 +40,12 @@ namespace cuda::experimental::__async
 #if defined(_CCCL_BUILTIN_DECAY)
 
 template <class _Ty>
-using __decay_t = _CCCL_BUILTIN_DECAY(_Ty);
+using __decay_t _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_DECAY(_Ty);
 
 #else // ^^^ _CCCL_BUILTIN_DECAY ^^^ / vvv !_CCCL_BUILTIN_DECAY vvv
 
 template <class _Ty>
-using __decay_t = _CUDA_VSTD::decay_t<_Ty>;
+using __decay_t _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::decay_t<_Ty>;
 
 #endif // _CCCL_BUILTIN_DECAY
 
@@ -54,22 +54,22 @@ using __decay_t = _CUDA_VSTD::decay_t<_Ty>;
 // TODO: This is a temporary implementation. We should merge this file and meta.cuh
 // with the facilities in <cuda/std/__type_traits/type_list.h>.
 template <class _Ty>
-using __cref_t = _Ty const&;
+using __cref_t _CCCL_NODEBUG_ALIAS = _Ty const&;
 
-using __cp    = _CUDA_VSTD::__type_self;
-using __cpclr = _CUDA_VSTD::__type_quote1<__cref_t>;
+using __cp _CCCL_NODEBUG_ALIAS    = _CUDA_VSTD::__type_self;
+using __cpclr _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::__type_quote1<__cref_t>;
 
 template <class _From, class _To>
-using __copy_cvref_t = _CUDA_VSTD::__copy_cvref_t<_From, _To>;
+using __copy_cvref_t _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::__copy_cvref_t<_From, _To>;
 
 template <class _Fn, class... _As>
-using __call_result_t = decltype(declval<_Fn>()(declval<_As>()...));
+using __call_result_t _CCCL_NODEBUG_ALIAS = decltype(declval<_Fn>()(declval<_As>()...));
 
 template <class _Fn, class... _As>
 inline constexpr bool __callable = __type_valid_v<__call_result_t, _Fn, _As...>;
 
 template <class _Ty>
-using __decay_copyable_ = decltype(__decay_t<_Ty>(declval<_Ty>()));
+using __decay_copyable_ _CCCL_NODEBUG_ALIAS = decltype(__decay_t<_Ty>(declval<_Ty>()));
 
 template <class... _As>
 inline constexpr bool __decay_copyable = (__type_valid_v<__decay_copyable_, _As> && ...);
@@ -91,38 +91,38 @@ template <class... _As>
 inline constexpr bool __nothrow_copyable = true;
 #else
 template <class _Fn, class... _As>
-using __nothrow_callable_ = _CUDA_VSTD::enable_if_t<noexcept(declval<_Fn>()(declval<_As>()...))>;
+using __nothrow_callable_ _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::enable_if_t<noexcept(declval<_Fn>()(declval<_As>()...))>;
 
 template <class _Fn, class... _As>
 inline constexpr bool __nothrow_callable = __type_valid_v<__nothrow_callable_, _Fn, _As...>;
 
 template <class _Ty, class... _As>
-using __nothrow_constructible_ = _CUDA_VSTD::enable_if_t<noexcept(_Ty{declval<_As>()...})>;
+using __nothrow_constructible_ _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::enable_if_t<noexcept(_Ty{declval<_As>()...})>;
 
 template <class _Ty, class... _As>
 inline constexpr bool __nothrow_constructible = __type_valid_v<__nothrow_constructible_, _Ty, _As...>;
 
 template <class _Ty>
-using __nothrow_decay_copyable_ = _CUDA_VSTD::enable_if_t<noexcept(__decay_t<_Ty>(declval<_Ty>()))>;
+using __nothrow_decay_copyable_ _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::enable_if_t<noexcept(__decay_t<_Ty>(declval<_Ty>()))>;
 
 template <class... _As>
 inline constexpr bool __nothrow_decay_copyable = (__type_valid_v<__nothrow_decay_copyable_, _As> && ...);
 
 template <class _Ty>
-using __nothrow_movable_ = _CUDA_VSTD::enable_if_t<noexcept(_Ty(declval<_Ty>()))>;
+using __nothrow_movable_ _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::enable_if_t<noexcept(_Ty(declval<_Ty>()))>;
 
 template <class... _As>
 inline constexpr bool __nothrow_movable = (__type_valid_v<__nothrow_movable_, _As> && ...);
 
 template <class _Ty>
-using __nothrow_copyable_ = _CUDA_VSTD::enable_if_t<noexcept(_Ty(declval<const _Ty&>()))>;
+using __nothrow_copyable_ _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::enable_if_t<noexcept(_Ty(declval<const _Ty&>()))>;
 
 template <class... _As>
 inline constexpr bool __nothrow_copyable = (__type_valid_v<__nothrow_copyable_, _As> && ...);
 #endif
 
 template <class... _As>
-using __nothrow_decay_copyable_t = _CUDA_VSTD::bool_constant<__nothrow_decay_copyable<_As...>>;
+using __nothrow_decay_copyable_t _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::bool_constant<__nothrow_decay_copyable<_As...>>;
 } // namespace cuda::experimental::__async
 
 #include <cuda/experimental/__async/sender/epilogue.cuh>

--- a/cudax/include/cuda/experimental/__async/sender/utility.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/utility.cuh
@@ -29,6 +29,7 @@
 #include <cuda/experimental/__async/sender/meta.cuh>
 #include <cuda/experimental/__async/sender/type_traits.cuh>
 #include <cuda/experimental/__detail/config.cuh>
+#include <cuda/experimental/__detail/utility.cuh>
 
 #include <cuda/experimental/__async/sender/prologue.cuh>
 
@@ -37,8 +38,8 @@ namespace cuda::experimental::__async
 _CCCL_GLOBAL_CONSTANT size_t __npos = static_cast<size_t>(-1);
 
 using __ignore _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::__ignore_t; // NOLINT: misc-unused-using-decls
-
-using _CUDA_VSTD::__undefined; // NOLINT: misc-unused-using-decls
+using __cudax::detail::__immovable;                          // NOLINT: misc-unused-using-decls
+using _CUDA_VSTD::__undefined;                               // NOLINT: misc-unused-using-decls
 
 struct __empty
 {};
@@ -48,12 +49,6 @@ struct [[deprecated]] __deprecated
 
 struct __nil
 {};
-
-struct __immovable
-{
-  _CUDAX_DEFAULTED_API __immovable() = default;
-  _CUDAX_IMMOVABLE(__immovable);
-};
 
 _CUDAX_API constexpr size_t __maximum(_CUDA_VSTD::initializer_list<size_t> __il) noexcept
 {
@@ -177,18 +172,18 @@ constexpr size_t __next(long)
 #if _CCCL_COMPILER(CLANG, <, 12)
 
 template <class _Type>
-using __zip = _Type;
+using __zip _CCCL_NODEBUG_ALIAS = _Type;
 
 template <class _Id>
-using __unzip = _Id;
+using __unzip _CCCL_NODEBUG_ALIAS = _Id;
 
 #else
 
 template <class _Type, size_t _Val = __async::__next<_Type>(0)>
-using __zip = __slot<_Val>;
+using __zip _CCCL_NODEBUG_ALIAS = __slot<_Val>;
 
 template <class _Id>
-using __unzip = decltype(__slot_allocated(_Id())());
+using __unzip _CCCL_NODEBUG_ALIAS = decltype(__slot_allocated(_Id())());
 
 #endif
 

--- a/cudax/include/cuda/experimental/__async/sender/utility.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/utility.cuh
@@ -50,7 +50,7 @@ struct [[deprecated]] __deprecated
 struct __nil
 {};
 
-_CUDAX_API constexpr size_t __maximum(_CUDA_VSTD::initializer_list<size_t> __il) noexcept
+_CUDAX_API constexpr auto __maximum(_CUDA_VSTD::initializer_list<size_t> __il) noexcept -> size_t
 {
   size_t __max = 0;
   for (auto i : __il)
@@ -63,7 +63,7 @@ _CUDAX_API constexpr size_t __maximum(_CUDA_VSTD::initializer_list<size_t> __il)
   return __max;
 }
 
-_CUDAX_API constexpr size_t __find_pos(bool const* const __begin, bool const* const __end) noexcept
+_CUDAX_API constexpr auto __find_pos(bool const* const __begin, bool const* const __end) noexcept -> size_t
 {
   for (bool const* __where = __begin; __where != __end; ++__where)
   {
@@ -76,14 +76,14 @@ _CUDAX_API constexpr size_t __find_pos(bool const* const __begin, bool const* co
 }
 
 template <class _Ty, class... _Ts>
-_CUDAX_API constexpr size_t __index_of() noexcept
+_CUDAX_API constexpr auto __index_of() noexcept -> size_t
 {
   constexpr bool __same[] = {_CUDA_VSTD::is_same_v<_Ty, _Ts>...};
   return __async::__find_pos(__same, __same + sizeof...(_Ts));
 }
 
 template <class _Ty, class _Uy = _Ty>
-_CUDAX_API constexpr _Ty __exchange(_Ty& __obj, _Uy&& __new_value) noexcept
+_CUDAX_API constexpr auto __exchange(_Ty& __obj, _Uy&& __new_value) noexcept -> _Ty
 {
   constexpr bool __is_nothrow =                        //
     noexcept(_Ty(static_cast<_Ty&&>(__obj))) &&        //
@@ -109,7 +109,7 @@ _CUDAX_API constexpr void __swap(_Ty& __left, _Ty& __right) noexcept
 }
 
 template <class _Ty>
-_CUDAX_API constexpr _CUDA_VSTD::decay_t<_Ty> __decay_copy(_Ty&& __ty) noexcept(__nothrow_decay_copyable<_Ty>)
+_CUDAX_API constexpr auto __decay_copy(_Ty&& __ty) noexcept(__nothrow_decay_copyable<_Ty>) -> _CUDA_VSTD::decay_t<_Ty>
 {
   return static_cast<_Ty&&>(__ty);
 }
@@ -141,7 +141,7 @@ struct __allocate_slot
 };
 
 template <class _Type, size_t _Id = 0, size_t _Pow2 = 0>
-constexpr size_t __next(long);
+constexpr auto __next(long) -> size_t;
 
 // If __slot_allocated(__slot<_Id>) has NOT been defined, then SFINAE will keep
 // this function out of the overload set...
@@ -149,13 +149,13 @@ template <class _Type, //
           size_t _Id   = 0,
           size_t _Pow2 = 0,
           bool         = !__slot_allocated(__slot<_Id + (1 << _Pow2) - 1>())>
-constexpr size_t __next(int)
+constexpr auto __next(int) -> size_t
 {
   return __async::__next<_Type, _Id, _Pow2 + 1>(0);
 }
 
 template <class _Type, size_t _Id, size_t _Pow2>
-constexpr size_t __next(long)
+constexpr auto __next(long) -> size_t
 {
   if constexpr (_Pow2 == 0)
   {

--- a/cudax/include/cuda/experimental/__async/sender/variant.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/variant.cuh
@@ -96,8 +96,8 @@ public:
   }
 
   template <class _Ty, class... _As>
-  _CUDAX_API _Ty& __emplace(_As&&... __as) //
-    noexcept(__nothrow_constructible<_Ty, _As...>)
+  _CUDAX_API auto __emplace(_As&&... __as) //
+    noexcept(__nothrow_constructible<_Ty, _As...>) -> _Ty&
   {
     constexpr size_t __new_index = __async::__index_of<_Ty, _Ts...>();
     static_assert(__new_index != __npos, "Type not in variant");
@@ -109,8 +109,8 @@ public:
   }
 
   template <size_t _Ny, class... _As>
-  _CUDAX_API __at<_Ny>& __emplace_at(_As&&... __as) //
-    noexcept(__nothrow_constructible<__at<_Ny>, _As...>)
+  _CUDAX_API auto __emplace_at(_As&&... __as) //
+    noexcept(__nothrow_constructible<__at<_Ny>, _As...>) -> __at<_Ny>&
   {
     static_assert(_Ny < sizeof...(_Ts), "variant index is too large");
 
@@ -148,21 +148,21 @@ public:
   }
 
   template <size_t _Ny>
-  _CUDAX_API __at<_Ny>&& __get() && noexcept
+  _CUDAX_API auto __get() && noexcept -> __at<_Ny>&&
   {
     _CCCL_ASSERT(_Ny == __index_, "");
     return static_cast<__at<_Ny>&&>(*static_cast<__at<_Ny>*>(__ptr()));
   }
 
   template <size_t _Ny>
-  _CUDAX_API __at<_Ny>& __get() & noexcept
+  _CUDAX_API auto __get() & noexcept -> __at<_Ny>&
   {
     _CCCL_ASSERT(_Ny == __index_, "");
     return *static_cast<__at<_Ny>*>(__ptr());
   }
 
   template <size_t _Ny>
-  _CUDAX_API const __at<_Ny>& __get() const& noexcept
+  _CUDAX_API auto __get() const& noexcept -> const __at<_Ny>&
   {
     _CCCL_ASSERT(_Ny == __index_, "");
     return *static_cast<const __at<_Ny>*>(__ptr());

--- a/cudax/include/cuda/experimental/__async/sender/variant.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/variant.cuh
@@ -63,7 +63,7 @@ class __variant_impl<_CUDA_VSTD::index_sequence<_Idx...>, _Ts...>
   alignas(_Ts...) unsigned char __storage_[__max_size];
 
   template <size_t _Ny>
-  using __at = _CUDA_VSTD::__type_index_c<_Ny, _Ts...>;
+  using __at _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::__type_index_c<_Ny, _Ts...>;
 
   _CUDAX_API void __destroy() noexcept
   {
@@ -124,8 +124,8 @@ public:
   _CUDAX_API auto __emplace_from(_Fn&& __fn, _As&&... __as) //
     noexcept(__nothrow_callable<_Fn, _As...>) -> __call_result_t<_Fn, _As...>&
   {
-    using __result_t             = __call_result_t<_Fn, _As...>;
-    constexpr size_t __new_index = __async::__index_of<__result_t, _Ts...>();
+    using __result_t _CCCL_NODEBUG_ALIAS = __call_result_t<_Fn, _As...>;
+    constexpr size_t __new_index         = __async::__index_of<__result_t, _Ts...>();
     static_assert(__new_index != __npos, "_Type not in variant");
 
     __destroy();
@@ -173,19 +173,19 @@ public:
 template <class... _Ts>
 struct __mk_variant_
 {
-  using __indices_t = _CUDA_VSTD::make_index_sequence<sizeof...(_Ts)>;
-  using type        = __variant_impl<__indices_t, _Ts...>;
+  using __indices_t _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::make_index_sequence<sizeof...(_Ts)>;
+  using type _CCCL_NODEBUG_ALIAS        = __variant_impl<__indices_t, _Ts...>;
 };
 
 template <class... _Ts>
-using __variant = typename __mk_variant_<_Ts...>::type;
+using __variant _CCCL_NODEBUG_ALIAS = typename __mk_variant_<_Ts...>::type;
 #else
 template <class... _Ts>
-using __variant = __variant_impl<_CUDA_VSTD::make_index_sequence<sizeof...(_Ts)>, _Ts...>;
+using __variant _CCCL_NODEBUG_ALIAS = __variant_impl<_CUDA_VSTD::make_index_sequence<sizeof...(_Ts)>, _Ts...>;
 #endif
 
 template <class... _Ts>
-using __decayed_variant = __variant<__decay_t<_Ts>...>;
+using __decayed_variant _CCCL_NODEBUG_ALIAS = __variant<__decay_t<_Ts>...>;
 } // namespace cuda::experimental::__async
 
 #include <cuda/experimental/__async/sender/epilogue.cuh>

--- a/cudax/include/cuda/experimental/__async/sender/visit.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/visit.cuh
@@ -50,7 +50,7 @@ extern __sender_type_cannot_be_used_to_initialize_a_structured_binding<_Arity> _
   [[maybe_unused]]                                                                                              \
   _CCCL_GLOBAL_CONSTANT auto __unpack<2 + _Arity> =                                                             \
     [](auto& __visitor, auto&& __sndr, auto& __context) -> decltype(auto) {                                     \
-    using _Sndr                                                      = decltype(__sndr);                        \
+    using _Sndr _CCCL_NODEBUG_ALIAS                                  = decltype(__sndr);                        \
     auto&& [__tag, __data _CCCL_PP_REPEAT(_Arity, _CCCL_BIND_CHILD)] = static_cast<_Sndr&&>(__sndr);            \
     return __visitor(__context, __tag, _CCCL_FWD_LIKE(_Sndr, __data) _CCCL_PP_REPEAT(_Arity, _CCCL_FWD_CHILD)); \
   }
@@ -70,7 +70,7 @@ _CCCL_UNPACK_SENDER(7);
 
 [[maybe_unused]]
 _CCCL_GLOBAL_CONSTANT auto visit = [](auto& __visitor, auto&& sndr, auto& __context) -> decltype(auto) {
-  using _Sndr = __decay_t<decltype(sndr)>;
+  using _Sndr _CCCL_NODEBUG_ALIAS = __decay_t<decltype(sndr)>;
   return __unpack<structured_binding_size<_Sndr>>(__visitor, static_cast<decltype(sndr)&&>(sndr), __context);
 };
 

--- a/cudax/include/cuda/experimental/__async/sender/when_all.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/when_all.cuh
@@ -59,7 +59,8 @@ private:
   // Extract the first template parameter of the __state_t specialization.
   // The first template parameter is the receiver type.
   template <class _State>
-  using __rcvr_from_state_t = _CUDA_VSTD::__type_apply<_CUDA_VSTD::__detail::__type_at_fn<0>, _State>;
+  using __rcvr_from_state_t _CCCL_NODEBUG_ALIAS =
+    _CUDA_VSTD::__type_apply<_CUDA_VSTD::__detail::__type_at_fn<0>, _State>;
 
   // Returns the completion signatures of a child sender. Throws an exception if
   // the child sender has more than one set_value completion signature.
@@ -78,8 +79,8 @@ private:
   template <class _StateZip>
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __env_t
   {
-    using __state_t = __unzip<_StateZip>;
-    using __rcvr_t  = __rcvr_from_state_t<__state_t>;
+    using __state_t _CCCL_NODEBUG_ALIAS = __unzip<_StateZip>;
+    using __rcvr_t _CCCL_NODEBUG_ALIAS  = __rcvr_from_state_t<__state_t>;
 
     __state_t& __state_;
 
@@ -99,8 +100,8 @@ private:
   template <class _StateZip, size_t _Index>
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __rcvr_t
   {
-    using receiver_concept = receiver_t;
-    using __state_t        = __unzip<_StateZip>;
+    using receiver_concept _CCCL_NODEBUG_ALIAS = receiver_t;
+    using __state_t _CCCL_NODEBUG_ALIAS        = __unzip<_StateZip>;
 
     __state_t& __state_;
 
@@ -149,18 +150,18 @@ private:
   template <class _Rcvr, class _CvFn, class _Idx, class _Ign0, class _Ign1, class... _Sndrs>
   struct __state_t<_Rcvr, _CvFn, __tupl<_Idx, _Ign0, _Ign1, _Sndrs...>>
   {
-    using __env_t     = when_all_t::__env_t<__zip<__state_t>>;
-    using __sndr_t    = when_all_t::__sndr_t<_Sndrs...>;
-    using __cv_sndr_t = _CUDA_VSTD::__type_call1<_CvFn, __sndr_t>;
+    using __env_t _CCCL_NODEBUG_ALIAS     = when_all_t::__env_t<__zip<__state_t>>;
+    using __sndr_t _CCCL_NODEBUG_ALIAS    = when_all_t::__sndr_t<_Sndrs...>;
+    using __cv_sndr_t _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::__type_call1<_CvFn, __sndr_t>;
 
     static constexpr auto __completions_and_offsets =
       __sndr_t::template __get_completions_and_offsets<__cv_sndr_t, __env_t>();
 
-    using __completions_t   = decltype(__completions_and_offsets.first);
-    using __values_t        = __value_types<__completions_t, __lazy_tuple, __type_self_or<__nil>::__call>;
-    using __errors_t        = __error_types<__completions_t, __variant>;
-    using __stop_tok_t      = stop_token_of_t<env_of_t<_Rcvr>>;
-    using __stop_callback_t = stop_callback_for_t<__stop_tok_t, __on_stop_request>;
+    using __completions_t _CCCL_NODEBUG_ALIAS = decltype(__completions_and_offsets.first);
+    using __values_t _CCCL_NODEBUG_ALIAS = __value_types<__completions_t, __lazy_tuple, __type_self_or<__nil>::__call>;
+    using __errors_t _CCCL_NODEBUG_ALIAS = __error_types<__completions_t, __variant>;
+    using __stop_tok_t _CCCL_NODEBUG_ALIAS      = stop_token_of_t<env_of_t<_Rcvr>>;
+    using __stop_callback_t _CCCL_NODEBUG_ALIAS = stop_callback_for_t<__stop_tok_t, __on_stop_request>;
 
     _CUDAX_API explicit __state_t(_Rcvr __rcvr, size_t __count)
         : __rcvr_{static_cast<_Rcvr&&>(__rcvr)}
@@ -299,10 +300,11 @@ private:
   template <class _Rcvr, class _CvFn, size_t... _Idx, class _Ign0, class _Ign1, class... _Sndrs>
   struct _CCCL_TYPE_VISIBILITY_DEFAULT
   __opstate_t<_Rcvr, _CvFn, __tupl<_CUDA_VSTD::index_sequence<0, 1, _Idx...>, _Ign0, _Ign1, _Sndrs...>>
+      : private __immovable
   {
-    using operation_state_concept = operation_state_t;
-    using __sndrs_t               = _CUDA_VSTD::__type_call<_CvFn, __tuple<_Ign0, _Ign1, _Sndrs...>>;
-    using __state_t               = when_all_t::__state_t<_Rcvr, _CvFn, __tuple<_Ign0, _Ign1, _Sndrs...>>;
+    using operation_state_concept _CCCL_NODEBUG_ALIAS = operation_state_t;
+    using __sndrs_t _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::__type_call<_CvFn, __tuple<_Ign0, _Ign1, _Sndrs...>>;
+    using __state_t _CCCL_NODEBUG_ALIAS = when_all_t::__state_t<_Rcvr, _CvFn, __tuple<_Ign0, _Ign1, _Sndrs...>>;
 
     // This function object is used to connect all the sub-operations with
     // receivers, each of which knows which elements in the values tuple it
@@ -312,7 +314,7 @@ private:
       template <class... _CvSndrs>
       _CUDAX_API auto operator()(__state_t& __state, __ignore, __ignore, _CvSndrs&&... __sndrs_) const
       {
-        using __state_ref_t = __zip<__state_t>;
+        using __state_ref_t _CCCL_NODEBUG_ALIAS = __zip<__state_t>;
         // When there are no offsets, the when_all sender has no value
         // completions. All child senders can be connected to receivers
         // of the same type, saving template instantiations.
@@ -326,7 +328,7 @@ private:
     };
 
     // This is a tuple of operation states for the sub-operations.
-    using __sub_opstates_t = __apply_result_t<__connect_subs_fn, __sndrs_t, __state_t&>;
+    using __sub_opstates_t _CCCL_NODEBUG_ALIAS = __apply_result_t<__connect_subs_fn, __sndrs_t, __state_t&>;
 
     __state_t __state_;
     __sub_opstates_t __sub_ops_;
@@ -337,8 +339,6 @@ private:
         : __state_{static_cast<_Rcvr&&>(__rcvr), sizeof...(_Sndrs)}
         , __sub_ops_{__sndrs_.__apply(__connect_subs_fn(), static_cast<__sndrs_t&&>(__sndrs_), __state_)}
     {}
-
-    _CUDAX_IMMOVABLE(__opstate_t);
 
     /// Start all the sub-operations.
     _CUDAX_API void start() & noexcept
@@ -372,17 +372,17 @@ private:
   };
 
   template <class... _Ts>
-  using __decay_all = _CUDA_VSTD::__type_list<_CUDA_VSTD::decay_t<_Ts>...>;
+  using __decay_all _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::__type_list<_CUDA_VSTD::decay_t<_Ts>...>;
 
 public:
   template <class... _Sndrs>
-  _CUDAX_API auto operator()(_Sndrs... __sndrs) const -> __sndr_t<_Sndrs...>;
+  _CUDAX_TRIVIAL_API constexpr auto operator()(_Sndrs... __sndrs) const -> __sndr_t<_Sndrs...>;
 };
 
 template <class _Child, class... _Env>
 _CUDAX_API constexpr auto when_all_t::__child_completions()
 {
-  using __env_t = prop<get_stop_token_t, inplace_stop_token>;
+  using __env_t _CCCL_NODEBUG_ALIAS = prop<get_stop_token_t, inplace_stop_token>;
   _CUDAX_LET_COMPLETIONS(auto(__completions) = get_completion_signatures<_Child, env<__env_t, _FWD_ENV_T<_Env>>...>())
   {
     if constexpr (__completions.count(set_value) > 1)
@@ -428,8 +428,8 @@ _CUDAX_API constexpr auto when_all_t::__merge_completions(_Completions... __cs)
       // All child senders have exactly one value completion signature, each of
       // which may have multiple arguments. Concatenate all the arguments into a
       // single set_value_t completion signature.
-      using __values_t = _CUDA_VSTD::__type_call<         //
-        __type_concat_into<__type_function<set_value_t>>, //
+      using __values_t _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::__type_call< //
+        __type_concat_into<__type_function<set_value_t>>,             //
         __value_types<_Completions, __decay_all, _CUDA_VSTD::__type_self_t>...>;
       // Add the value completion to the error and stopped completions.
       auto __local = __non_value_completions + completion_signatures<__values_t>();
@@ -449,8 +449,8 @@ _CCCL_DIAG_POP
 template <class... _Sndrs>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT when_all_t::__sndr_t : __tuple<when_all_t, __ignore, _Sndrs...>
 {
-  using sender_concept = sender_t;
-  using __sndrs_t      = __tuple<when_all_t, __ignore, _Sndrs...>;
+  using sender_concept _CCCL_NODEBUG_ALIAS = sender_t;
+  using __sndrs_t _CCCL_NODEBUG_ALIAS      = __tuple<when_all_t, __ignore, _Sndrs...>;
 
   template <class _Self, class... _Env>
   _CUDAX_API static constexpr auto __get_completions_and_offsets()
@@ -478,13 +478,13 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT when_all_t::__sndr_t : __tuple<when_all_t, 
 };
 
 template <class... _Sndrs>
-_CUDAX_API auto when_all_t::operator()(_Sndrs... __sndrs) const -> __sndr_t<_Sndrs...>
+_CUDAX_TRIVIAL_API constexpr auto when_all_t::operator()(_Sndrs... __sndrs) const -> __sndr_t<_Sndrs...>
 {
   // If the incoming senders are non-dependent, we can check the completion
   // signatures of the composed sender immediately.
   if constexpr (((!dependent_sender<_Sndrs>) && ...))
   {
-    using __completions = completion_signatures_of_t<__sndr_t<_Sndrs...>>;
+    using __completions _CCCL_NODEBUG_ALIAS = completion_signatures_of_t<__sndr_t<_Sndrs...>>;
     static_assert(__valid_completion_signatures<__completions>);
   }
   return __sndr_t<_Sndrs...>{{{}, {}, static_cast<_Sndrs&&>(__sndrs)...}};

--- a/cudax/include/cuda/experimental/__async/sender/when_all.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/when_all.cuh
@@ -84,7 +84,7 @@ private:
 
     __state_t& __state_;
 
-    _CUDAX_API inplace_stop_token query(get_stop_token_t) const noexcept
+    _CUDAX_API auto query(get_stop_token_t) const noexcept -> inplace_stop_token
     {
       return __state_.__stop_token_;
     }

--- a/cudax/include/cuda/experimental/__async/sender/write_env.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/write_env.cuh
@@ -36,28 +36,26 @@
 
 namespace cuda::experimental::__async
 {
-struct write_env_t
+struct _CCCL_TYPE_VISIBILITY_DEFAULT write_env_t
 {
 private:
   template <class _Rcvr, class _Sndr, class _Env>
-  struct _CCCL_TYPE_VISIBILITY_DEFAULT __opstate_t
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __opstate_t : private __immovable
   {
-    using operation_state_concept = operation_state_t;
-
-    __rcvr_with_env_t<_Rcvr, _Env> __env_rcvr_;
-    connect_result_t<_Sndr, __rcvr_ref<__rcvr_with_env_t<_Rcvr, _Env>>> __opstate_;
+    using operation_state_concept _CCCL_NODEBUG_ALIAS = operation_state_t;
 
     _CUDAX_API explicit __opstate_t(_Sndr&& __sndr, _Env __env, _Rcvr __rcvr)
         : __env_rcvr_{static_cast<_Rcvr&&>(__rcvr), static_cast<_Env&&>(__env)}
         , __opstate_(__async::connect(static_cast<_Sndr&&>(__sndr), __rcvr_ref{__env_rcvr_}))
     {}
 
-    _CUDAX_IMMOVABLE(__opstate_t);
-
     _CUDAX_API void start() noexcept
     {
       __async::start(__opstate_);
     }
+
+    __rcvr_with_env_t<_Rcvr, _Env> __env_rcvr_;
+    connect_result_t<_Sndr, __rcvr_ref<__rcvr_with_env_t<_Rcvr, _Env>>> __opstate_;
   };
 
 public:
@@ -73,15 +71,12 @@ public:
 template <class _Sndr, class _Env>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT write_env_t::__sndr_t
 {
-  using sender_concept = sender_t;
-  _CCCL_NO_UNIQUE_ADDRESS write_env_t __tag_;
-  _Env __env_;
-  _Sndr __sndr_;
+  using sender_concept _CCCL_NODEBUG_ALIAS = sender_t;
 
   template <class _Self, class... _Env2>
   _CUDAX_API static constexpr auto get_completion_signatures()
   {
-    using _Child = __copy_cvref_t<_Self, _Sndr>;
+    using _Child _CCCL_NODEBUG_ALIAS = __copy_cvref_t<_Self, _Sndr>;
     return __async::get_completion_signatures<_Child, env<const _Env&, _FWD_ENV_T<_Env2>>...>();
   }
 
@@ -102,6 +97,10 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT write_env_t::__sndr_t
   {
     return __async::get_env(__sndr_);
   }
+
+  _CCCL_NO_UNIQUE_ADDRESS write_env_t __tag_;
+  _Env __env_;
+  _Sndr __sndr_;
 };
 
 template <class _Sndr, class _Env>


### PR DESCRIPTION
## Description

while working on other changes in the cudax async code, i found some minor inconsistencies. the changes in this PR include:

* consistent use of `_CCCL_TYPE_VISIBILITY_DEFAULT` for types that may appear in template parameters
* consistent use of `_CCCL_NODEBUG_ALIAS` for type aliases
* functions that do nothing but construct senders from arguments are made "trivial" and `constexpr`. ("trivial" == force inline & erase from ABI and debug info)
* remove duplicate definition of `__immovable`
* make all operation states immovable
* move data members lexically to the bottom of their enclosing class (which is where i and most programmers (?) typically look for them)
* remove the `set_error_t(std::exception_ptr)` completion from `run_loop`'s schedule sender when `_CCCL_HAS_EXCEPTIONS()` is `0`.
* switch to trailing return type.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
