### PR TITLE
Implement `shuffle_iterator` iterator type

### DIFF
--- a/thrust/testing/shuffle.cu
+++ b/thrust/testing/shuffle.cu
@@ -588,6 +588,37 @@ void TestShuffleIteratorConstructibleFromBijection()
 }
 DECLARE_UNITTEST(TestShuffleIteratorConstructibleFromBijection);
 
+void TestShuffleAndPermutationIterator()
+{
+  thrust::default_random_engine g(0xD5);
+
+  auto it = thrust::make_shuffle_iterator(32, g);
+
+  thrust::device_vector<uint64_t> data(32);
+  thrust::sequence(data.begin(), data.end(), 0);
+
+  auto permute_it = thrust::make_permutation_iterator(data.begin(), it);
+
+  thrust::device_vector<uint64_t> premute_vec(32);
+  thrust::gather(it, it + 32, data.begin(), premute_vec.begin());
+
+  ASSERT_EQUAL(true, thrust::equal(permute_it, permute_it + 32, premute_vec.begin()));
+}
+DECLARE_UNITTEST(TestShuffleAndPermutationIterator);
+
+void TestShuffleIteratorStateless()
+{
+  thrust::default_random_engine g(0xD5);
+
+  auto it = thrust::make_shuffle_iterator(32, g);
+
+  ASSERT_EQUAL(*it, *it);
+  ASSERT_EQUAL(*(it + 1), *(it + 1));
+  ++it;
+  ASSERT_EQUAL(*(it - 1), *(it - 1));
+}
+DECLARE_UNITTEST(TestShuffleIteratorStateless);
+
 // Individual input keys should be permuted to output locations with uniform
 // probability. Perform chi-squared test with confidence 99.9%.
 template <typename ShuffleFunc, typename Vector>

--- a/thrust/testing/shuffle.cu
+++ b/thrust/testing/shuffle.cu
@@ -550,7 +550,7 @@ void TestFunctionIsBijectionIterator(size_t m)
 DECLARE_INTEGRAL_VARIABLE_UNITTEST(TestFunctionIsBijection);
 DECLARE_INTEGRAL_VARIABLE_UNITTEST(TestFunctionIsBijectionIterator);
 
-void TestBijectionLength()
+void TestFeistelBijectionLength()
 {
   thrust::default_random_engine g(0xD5);
 
@@ -566,7 +566,27 @@ void TestBijectionLength()
   f = thrust::detail::feistel_bijection(m, g);
   ASSERT_EQUAL(f.nearest_power_of_two(), uint64_t(16));
 }
-DECLARE_UNITTEST(TestBijectionLength);
+DECLARE_UNITTEST(TestFeistelBijectionLength);
+
+void TestShuffleIteratorConstructibleFromBijection()
+{
+  thrust::default_random_engine g(0xD5);
+
+  thrust::detail::feistel_bijection f(32, g);
+  thrust::shuffle_iterator<uint64_t, decltype(f)> it(f);
+
+  g.seed(0xD5);
+  thrust::detail::random_bijection<uint64_t> f2(32, g);
+  thrust::shuffle_iterator<uint64_t, decltype(f2)> it2(f2);
+
+  g.seed(0xD5);
+  thrust::shuffle_iterator<uint64_t> it3(32, g);
+
+  ASSERT_EQUAL(f.size(), f2.size());
+  ASSERT_EQUAL(true, thrust::equal(thrust::device, it, it + f.size(), it2));
+  ASSERT_EQUAL(true, thrust::equal(thrust::device, it, it + f.size(), it3));
+}
+DECLARE_UNITTEST(TestShuffleIteratorConstructibleFromBijection);
 
 // Individual input keys should be permuted to output locations with uniform
 // probability. Perform chi-squared test with confidence 99.9%.

--- a/thrust/testing/shuffle.cu
+++ b/thrust/testing/shuffle.cu
@@ -1,5 +1,7 @@
 #include <thrust/detail/config.h>
 
+#include <thrust/gather.h>
+#include <thrust/iterator/shuffle_iterator.h>
 #include <thrust/random.h>
 #include <thrust/scatter.h>
 #include <thrust/sequence.h>
@@ -388,35 +390,100 @@ constexpr double CephesFunctions::A[];
 constexpr double CephesFunctions::B[];
 constexpr double CephesFunctions::C[];
 
-template <typename Vector>
-void TestShuffleSimple()
+struct iterator_shuffle_copy
+{
+  template <typename Iterator, typename ResultIterator>
+  void operator()(Iterator first, Iterator last, ResultIterator result, thrust::default_random_engine& g)
+  {
+    auto shuffle_iter = thrust::make_shuffle_iterator(static_cast<uint64_t>(last - first), g);
+    thrust::gather(shuffle_iter, shuffle_iter + (last - first), first, result);
+  }
+};
+
+struct iterator_shuffle
+{
+  template <typename Iterator>
+  void operator()(Iterator first, Iterator last, thrust::default_random_engine& g)
+  {
+    using thrust::system::detail::generic::select_system;
+    using InputType = typename thrust::detail::it_value_t<Iterator>;
+    using System    = typename thrust::iterator_system<Iterator>::type;
+    System system;
+    auto policy = select_system(system);
+    thrust::detail::temporary_array<InputType, System> temp(policy, first, last);
+    iterator_shuffle_copy{}(temp.begin(), temp.end(), first, g);
+  }
+};
+
+struct thrust_shuffle
+{
+  template <typename Iterator>
+  void operator()(Iterator first, Iterator last, thrust::default_random_engine& g)
+  {
+    thrust::shuffle(first, last, g);
+  }
+};
+
+struct thrust_shuffle_copy
+{
+  template <typename Iterator>
+  void operator()(Iterator first, Iterator last, Iterator result, thrust::default_random_engine& g)
+  {
+    thrust::shuffle_copy(first, last, result, g);
+  }
+};
+
+template <class ShuffleFunc, typename Vector>
+void TestShuffleSimpleBase()
 {
   Vector data{0, 1, 2, 3, 4};
   Vector shuffled(data.begin(), data.end());
   thrust::default_random_engine g(2);
-  thrust::shuffle(shuffled.begin(), shuffled.end(), g);
+  ShuffleFunc{}(shuffled.begin(), shuffled.end(), g);
   thrust::sort(shuffled.begin(), shuffled.end());
   // Check all of our data is present
   // This only tests for strange conditions like duplicated elements
   ASSERT_EQUAL(shuffled, data);
 }
-DECLARE_VECTOR_UNITTEST(TestShuffleSimple);
-
 template <typename Vector>
-void TestShuffleCopySimple()
+void TestShuffleSimple()
+{
+  TestShuffleSimpleBase<thrust_shuffle, Vector>();
+}
+template <typename Vector>
+void TestShuffleSimpleIterator()
+{
+  TestShuffleSimpleBase<iterator_shuffle, Vector>();
+}
+DECLARE_VECTOR_UNITTEST(TestShuffleSimple);
+DECLARE_VECTOR_UNITTEST(TestShuffleSimpleIterator);
+
+template <typename ShuffleFunc, typename ShuffleCopyFunc, typename Vector>
+void TestShuffleCopySimpleBase()
 {
   Vector data{0, 1, 2, 3, 4};
   Vector shuffled(5);
   thrust::default_random_engine g(2);
-  thrust::shuffle_copy(data.begin(), data.end(), shuffled.begin(), g);
+  ShuffleCopyFunc{}(data.begin(), data.end(), shuffled.begin(), g);
   g.seed(2);
-  thrust::shuffle(data.begin(), data.end(), g);
+  ShuffleFunc{}(data.begin(), data.end(), g);
   ASSERT_EQUAL(shuffled, data);
 }
+template <typename Vector>
+void TestShuffleCopySimple()
+{
+  TestShuffleCopySimpleBase<thrust_shuffle, thrust_shuffle_copy, Vector>();
+}
+template <typename Vector>
+void TestShuffleCopySimpleIterator()
+{
+  TestShuffleCopySimpleBase<iterator_shuffle, iterator_shuffle_copy, Vector>();
+}
 DECLARE_VECTOR_UNITTEST(TestShuffleCopySimple);
+DECLARE_VECTOR_UNITTEST(TestShuffleCopySimpleIterator);
 
-template <typename T>
-void TestHostDeviceIdentical(size_t m)
+template <typename ShuffleFunc, typename T>
+void TestHostDeviceIdenticalBase(size_t m)
 {
   thrust::host_vector<T> host_result(m);
   thrust::device_vector<T> device_result(m);
@@ -426,20 +493,31 @@ void TestHostDeviceIdentical(size_t m)
   thrust::default_random_engine host_g(183);
   thrust::default_random_engine device_g(183);
 
-  thrust::shuffle(host_result.begin(), host_result.end(), host_g);
-  thrust::shuffle(device_result.begin(), device_result.end(), device_g);
+  ShuffleFunc{}(host_result.begin(), host_result.end(), host_g);
+  ShuffleFunc{}(device_result.begin(), device_result.end(), device_g);
 
   ASSERT_EQUAL(device_result, host_result);
 }
-DECLARE_VARIABLE_UNITTEST(TestHostDeviceIdentical);
-
 template <typename T>
-void TestFunctionIsBijection(size_t m)
+void TestHostDeviceIdentical(size_t m)
+{
+  TestHostDeviceIdenticalBase<thrust_shuffle, T>(m);
+}
+template <typename T>
+void TestHostDeviceIdenticalIterator(size_t m)
+{
+  TestHostDeviceIdenticalBase<iterator_shuffle, T>(m);
+}
+DECLARE_VARIABLE_UNITTEST(TestHostDeviceIdentical);
+DECLARE_VARIABLE_UNITTEST(TestHostDeviceIdenticalIterator);
+
+template <typename BijectionFunc, typename T>
+void TestFunctionIsBijectionBase(size_t m)
 {
   thrust::default_random_engine device_g(0xD5);
-  thrust::system::detail::generic::feistel_bijection device_f(m, device_g);
+  BijectionFunc device_f(m, device_g);
 
-  const size_t total_length = device_f.nearest_power_of_two();
+  const size_t total_length = device_f.size();
   if (static_cast<double>(total_length) >= static_cast<double>(std::numeric_limits<T>::max()) || m == 0)
   {
     return;
@@ -459,30 +537,41 @@ void TestFunctionIsBijection(size_t m)
   // Check every index is in the result, if any are missing then the function was not a bijection over [0,m)
   ASSERT_EQUAL(true, thrust::equal(unpermuted.begin(), unpermuted.end(), thrust::make_counting_iterator(T(0))));
 }
+template <typename T>
+void TestFunctionIsBijection(size_t m)
+{
+  TestFunctionIsBijectionBase<thrust::detail::feistel_bijection, T>(m);
+}
+template <typename T>
+void TestFunctionIsBijectionIterator(size_t m)
+{
+  TestFunctionIsBijectionBase<thrust::detail::random_bijection<uint64_t>, T>(m);
+}
 DECLARE_INTEGRAL_VARIABLE_UNITTEST(TestFunctionIsBijection);
+DECLARE_INTEGRAL_VARIABLE_UNITTEST(TestFunctionIsBijectionIterator);
 
 void TestBijectionLength()
 {
   thrust::default_random_engine g(0xD5);
 
   uint64_t m = 31;
-  thrust::system::detail::generic::feistel_bijection f(m, g);
+  thrust::detail::feistel_bijection f(m, g);
   ASSERT_EQUAL(f.nearest_power_of_two(), uint64_t(32));
 
   m = 32;
-  f = thrust::system::detail::generic::feistel_bijection(m, g);
+  f = thrust::detail::feistel_bijection(m, g);
   ASSERT_EQUAL(f.nearest_power_of_two(), uint64_t(32));
 
   m = 1;
-  f = thrust::system::detail::generic::feistel_bijection(m, g);
+  f = thrust::detail::feistel_bijection(m, g);
   ASSERT_EQUAL(f.nearest_power_of_two(), uint64_t(16));
 }
 DECLARE_UNITTEST(TestBijectionLength);
 
 // Individual input keys should be permuted to output locations with uniform
 // probability. Perform chi-squared test with confidence 99.9%.
-template <typename Vector>
-void TestShuffleKeyPosition()
+template <typename ShuffleFunc, typename Vector>
+void TestShuffleKeyPositionBase()
 {
   using T            = typename Vector::value_type;
   size_t m           = 20;
@@ -495,7 +584,7 @@ void TestShuffleKeyPosition()
   for (size_t i = 0; i < num_samples; i++)
   {
     Vector shuffled(sequence.begin(), sequence.end());
-    thrust::shuffle(shuffled.begin(), shuffled.end(), g);
+    ShuffleFunc{}(shuffled.begin(), shuffled.end(), g);
     thrust::host_vector<T> tmp(shuffled.begin(), shuffled.end());
 
     for (auto j = 0ull; j < m; j++)
@@ -516,7 +605,18 @@ void TestShuffleKeyPosition()
   double confidence_threshold = 43.82;
   ASSERT_LESS(chi_squared, confidence_threshold);
 }
+template <typename Vector>
+void TestShuffleKeyPosition()
+{
+  TestShuffleKeyPositionBase<thrust_shuffle, Vector>();
+}
+template <typename Vector>
+void TestShuffleKeyPositionIterator()
+{
+  TestShuffleKeyPositionBase<iterator_shuffle, Vector>();
+}
 DECLARE_INTEGRAL_VECTOR_UNITTEST(TestShuffleKeyPosition);
+DECLARE_INTEGRAL_VECTOR_UNITTEST(TestShuffleKeyPositionIterator);
 
 struct vector_compare
 {
@@ -541,8 +641,8 @@ struct vector_compare
 // Brute force check permutations are uniformly distributed on small input
 // Uses a chi-squared test indicating 99% confidence the output is uniformly
 // random
-template <typename Vector>
-void TestShuffleUniformPermutation()
+template <typename ShuffleFunc, typename Vector>
+void TestShuffleUniformPermutationBase()
 {
   using T = typename Vector::value_type;
 
@@ -555,7 +655,7 @@ void TestShuffleUniformPermutation()
   thrust::default_random_engine g(0xD5);
   for (auto i = 0ull; i < num_samples; i++)
   {
-    thrust::shuffle(sequence.begin(), sequence.end(), g);
+    ShuffleFunc{}(sequence.begin(), sequence.end(), g);
     thrust::host_vector<T> tmp(sequence.begin(), sequence.end());
     permutation_counts[tmp]++;
   }
@@ -571,10 +671,21 @@ void TestShuffleUniformPermutation()
   double p_score = CephesFunctions::cephes_igamc((double) (total_permutations - 1) / 2.0, chi_squared / 2.0);
   ASSERT_GREATER(p_score, 0.01);
 }
-DECLARE_VECTOR_UNITTEST(TestShuffleUniformPermutation);
-
 template <typename Vector>
-void TestShuffleEvenSpacingBetweenOccurances()
+void TestShuffleUniformPermutation()
+{
+  TestShuffleUniformPermutationBase<thrust_shuffle, Vector>();
+}
+template <typename Vector>
+void TestShuffleUniformPermutationIterator()
+{
+  TestShuffleUniformPermutationBase<iterator_shuffle, Vector>();
+}
+DECLARE_VECTOR_UNITTEST(TestShuffleUniformPermutation);
+DECLARE_VECTOR_UNITTEST(TestShuffleUniformPermutationIterator);
+
+template <typename ShuffleFunc, typename Vector>
+void TestShuffleEvenSpacingBetweenOccurancesBase()
 {
   using T                     = typename Vector::value_type;
   const uint64_t shuffle_size = 10;
@@ -586,7 +697,7 @@ void TestShuffleEvenSpacingBetweenOccurances()
   thrust::default_random_engine g(0xD6);
   for (auto i = 0ull; i < num_samples; i++)
   {
-    thrust::shuffle(sequence.begin(), sequence.end(), g);
+    ShuffleFunc{}(sequence.begin(), sequence.end(), g);
     thrust::host_vector<T> tmp(sequence.begin(), sequence.end());
     h_results.insert(h_results.end(), sequence.begin(), sequence.end());
   }
@@ -625,10 +736,21 @@ void TestShuffleEvenSpacingBetweenOccurances()
     }
   }
 }
-DECLARE_INTEGRAL_VECTOR_UNITTEST(TestShuffleEvenSpacingBetweenOccurances);
-
 template <typename Vector>
-void TestShuffleEvenDistribution()
+void TestShuffleEvenSpacingBetweenOccurances()
+{
+  TestShuffleEvenSpacingBetweenOccurancesBase<thrust_shuffle, Vector>();
+}
+template <typename Vector>
+void TestShuffleEvenSpacingBetweenOccurancesIterator()
+{
+  TestShuffleEvenSpacingBetweenOccurancesBase<iterator_shuffle, Vector>();
+}
+DECLARE_INTEGRAL_VECTOR_UNITTEST(TestShuffleEvenSpacingBetweenOccurances);
+DECLARE_INTEGRAL_VECTOR_UNITTEST(TestShuffleEvenSpacingBetweenOccurancesIterator);
+
+template <typename ShuffleFunc, typename Vector>
+void TestShuffleEvenDistributionBase()
 {
   using T                        = typename Vector::value_type;
   const uint64_t shuffle_sizes[] = {10, 100, 500};
@@ -646,7 +768,7 @@ void TestShuffleEvenDistribution()
     for (auto i = 0ull; i < num_samples; i++)
     {
       thrust::sequence(sequence.begin(), sequence.end(), 0);
-      thrust::shuffle(sequence.begin(), sequence.end(), g);
+      ShuffleFunc{}(sequence.begin(), sequence.end(), g);
       thrust::host_vector<T> tmp(sequence.begin(), sequence.end());
       for (uint64_t j = 0; j < shuffle_size; j++)
       {
@@ -676,4 +798,15 @@ void TestShuffleEvenDistribution()
     }
   }
 }
+template <typename Vector>
+void TestShuffleEvenDistribution()
+{
+  TestShuffleEvenDistributionBase<thrust_shuffle, Vector>();
+}
+template <typename Vector>
+void TestShuffleEvenDistributionIterator()
+{
+  TestShuffleEvenDistributionBase<iterator_shuffle, Vector>();
+}
+
 DECLARE_INTEGRAL_VECTOR_UNITTEST(TestShuffleEvenDistribution);

--- a/thrust/thrust/detail/random_bijection.h
+++ b/thrust/thrust/detail/random_bijection.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2008-20120 NVIDIA Corporation
+ *  Copyright 2008-2025 NVIDIA Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -13,6 +13,10 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
+
+//! \file random_bijection.h
+//! \brief An implementation of a bijective function for use in shuffling
+
 #pragma once
 
 #include <thrust/detail/config.h>
@@ -32,7 +36,7 @@ THRUST_NAMESPACE_BEGIN
 namespace detail
 {
 
-// An implementation of a Feistel cipher for operating on 64 bit keys
+//! \brief A Feistel cipher for operating on power of two sized problems
 class feistel_bijection
 {
   struct round_state
@@ -123,6 +127,9 @@ private:
   std::uint32_t key[num_rounds];
 };
 
+//! \brief Adaptor for a bijection to work with any size problem
+//! \tparam IndexType The type of the index to shuffle
+//! \tparam Bijection The bijection to use
 template <class IndexType, class Bijection = feistel_bijection>
 class random_bijection
 {
@@ -135,6 +142,8 @@ private:
   IndexType n;
 
 public:
+  using index_type = IndexType;
+
   template <class URBG>
   _CCCL_HOST_DEVICE random_bijection(IndexType n, URBG&& g)
       : bijection(n, ::cuda::std::forward<URBG>(g))

--- a/thrust/thrust/detail/random_bijection.h
+++ b/thrust/thrust/detail/random_bijection.h
@@ -21,13 +21,7 @@
 
 #include <thrust/detail/config.h>
 
-#include <thrust/detail/temporary_array.h>
-#include <thrust/iterator/discard_iterator.h>
-#include <thrust/iterator/transform_iterator.h>
-#include <thrust/iterator/transform_output_iterator.h>
 #include <thrust/random.h>
-#include <thrust/scan.h>
-#include <thrust/system/detail/generic/shuffle.h>
 
 #include <cuda/std/cstdint>
 #include <cuda/std/type_traits>
@@ -153,12 +147,13 @@ public:
   _CCCL_HOST_DEVICE IndexType operator()(IndexType i) const
   {
     auto upcast_i = static_cast<typename Bijection::index_type>(i);
-    assert(upcast_i < static_cast<typename Bijection::index_type>(n) && "IndexType out of range");
+    auto upcast_n = static_cast<typename Bijection::index_type>(n);
+    assert(upcast_i < upcast_n && "IndexType out of range");
 
     do
     {
       upcast_i = bijection(upcast_i);
-    } while (upcast_i >= n);
+    } while (upcast_i >= upcast_n);
     return static_cast<IndexType>(upcast_i);
   }
 

--- a/thrust/thrust/detail/random_bijection.h
+++ b/thrust/thrust/detail/random_bijection.h
@@ -121,9 +121,12 @@ private:
   std::uint32_t key[num_rounds];
 };
 
-//! \brief Adaptor for a bijection to work with any size problem
-//! \tparam IndexType The type of the index to shuffle
-//! \tparam Bijection The bijection to use
+//! \brief Adaptor for a bijection to work with any size problem. It achieves this by iterating the bijection until
+//! the result is less than n. For feistel_bijection, the worst case number of iterations required for one call to
+//! operator() is O(n) with low probability. It has amortised O(1) complexity.
+//! \tparam IndexType The type of the index to shuffle.
+//! \tparam Bijection The bijection to use. A low quality random bijection may lead to poor work balancing between calls
+//! to the operator().
 template <class IndexType, class Bijection = feistel_bijection>
 class random_bijection
 {
@@ -148,8 +151,11 @@ public:
   {
     auto upcast_i = static_cast<typename Bijection::index_type>(i);
     auto upcast_n = static_cast<typename Bijection::index_type>(n);
-    assert(upcast_i < upcast_n && "IndexType out of range");
 
+    // If i < n Iterating a bijection like this will always terminate.
+    // If i >= n, then this may loop forever.
+    // TODO Do we need a runtime check apart from this assert?
+    assert(upcast_i < upcast_n && "IndexType out of range");
     do
     {
       upcast_i = bijection(upcast_i);

--- a/thrust/thrust/detail/random_bijection.h
+++ b/thrust/thrust/detail/random_bijection.h
@@ -1,0 +1,163 @@
+/*
+ *  Copyright 2008-20120 NVIDIA Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+#pragma once
+
+#include <thrust/detail/config.h>
+
+#include <thrust/detail/temporary_array.h>
+#include <thrust/iterator/discard_iterator.h>
+#include <thrust/iterator/transform_iterator.h>
+#include <thrust/iterator/transform_output_iterator.h>
+#include <thrust/random.h>
+#include <thrust/scan.h>
+#include <thrust/system/detail/generic/shuffle.h>
+
+#include <cuda/std/cstdint>
+#include <cuda/std/type_traits>
+
+THRUST_NAMESPACE_BEGIN
+namespace detail
+{
+
+// An implementation of a Feistel cipher for operating on 64 bit keys
+class feistel_bijection
+{
+  struct round_state
+  {
+    std::uint32_t left;
+    std::uint32_t right;
+  };
+
+public:
+  using index_type = std::uint64_t;
+
+  template <class URBG>
+  _CCCL_HOST_DEVICE feistel_bijection(std::uint64_t m, URBG&& g)
+  {
+    std::uint64_t total_bits = get_cipher_bits(m);
+    // Half bits rounded down
+    left_side_bits = total_bits / 2;
+    left_side_mask = (1ull << left_side_bits) - 1;
+    // Half the bits rounded up
+    right_side_bits = total_bits - left_side_bits;
+    right_side_mask = (1ull << right_side_bits) - 1;
+
+    thrust::uniform_int_distribution<std::uint32_t> dist;
+    for (std::uint32_t i = 0; i < num_rounds; i++)
+    {
+      key[i] = dist(g);
+    }
+  }
+
+  _CCCL_HOST_DEVICE std::uint64_t nearest_power_of_two() const
+  {
+    return 1ull << (left_side_bits + right_side_bits);
+  }
+
+  _CCCL_HOST_DEVICE std::uint64_t size() const
+  {
+    return nearest_power_of_two();
+  }
+
+  _CCCL_HOST_DEVICE std::uint64_t operator()(const std::uint64_t val) const
+  {
+    std::uint32_t state[2] = {static_cast<std::uint32_t>(val >> right_side_bits),
+                              static_cast<std::uint32_t>(val & right_side_mask)};
+    for (std::uint32_t i = 0; i < num_rounds; i++)
+    {
+      std::uint32_t hi, lo;
+      constexpr std::uint64_t M0 = UINT64_C(0xD2B74407B1CE6E93);
+      mulhilo(M0, state[0], hi, lo);
+      lo       = (lo << (right_side_bits - left_side_bits)) | state[1] >> left_side_bits;
+      state[0] = ((hi ^ key[i]) ^ state[1]) & left_side_mask;
+      state[1] = lo & right_side_mask;
+    }
+    // Combine the left and right sides together to get result
+    return (static_cast<std::uint64_t>(state[0]) << right_side_bits) | static_cast<std::uint64_t>(state[1]);
+  }
+
+private:
+  // Perform 64 bit multiplication and save result in two 32 bit int
+  static _CCCL_HOST_DEVICE void mulhilo(std::uint64_t a, std::uint64_t b, std::uint32_t& hi, std::uint32_t& lo)
+  {
+    std::uint64_t product = a * b;
+    hi                    = static_cast<std::uint32_t>(product >> 32);
+    lo                    = static_cast<std::uint32_t>(product);
+  }
+
+  // Find the nearest power of two
+  static _CCCL_HOST_DEVICE std::uint64_t get_cipher_bits(std::uint64_t m)
+  {
+    if (m <= 16)
+    {
+      return 4;
+    }
+    std::uint64_t i = 0;
+    m--;
+    while (m != 0)
+    {
+      i++;
+      m >>= 1;
+    }
+    return i;
+  }
+
+  static constexpr std::uint32_t num_rounds = 24;
+  std::uint64_t right_side_bits;
+  std::uint64_t left_side_bits;
+  std::uint64_t right_side_mask;
+  std::uint64_t left_side_mask;
+  std::uint32_t key[num_rounds];
+};
+
+template <class IndexType, class Bijection = feistel_bijection>
+class random_bijection
+{
+private:
+  static_assert(::cuda::std::is_integral_v<IndexType>, "IndexType must be an integral type");
+  static_assert(::cuda::std::is_convertible_v<IndexType, typename Bijection::index_type>,
+                "IndexType must be convertible to Bijection::index_type");
+
+  Bijection bijection;
+  IndexType n;
+
+public:
+  template <class URBG>
+  _CCCL_HOST_DEVICE random_bijection(IndexType n, URBG&& g)
+      : bijection(n, ::cuda::std::forward<URBG>(g))
+      , n(n)
+  {}
+
+  _CCCL_HOST_DEVICE IndexType operator()(IndexType i) const
+  {
+    auto upcast_i = static_cast<typename Bijection::index_type>(i);
+    assert(upcast_i < static_cast<typename Bijection::index_type>(n) && "IndexType out of range");
+
+    do
+    {
+      upcast_i = bijection(upcast_i);
+    } while (upcast_i >= n);
+    return static_cast<IndexType>(upcast_i);
+  }
+
+  _CCCL_HOST_DEVICE IndexType size() const
+  {
+    return n;
+  }
+};
+
+} // namespace detail
+THRUST_NAMESPACE_END

--- a/thrust/thrust/detail/random_bijection.h
+++ b/thrust/thrust/detail/random_bijection.h
@@ -154,8 +154,12 @@ public:
 
     // If i < n Iterating a bijection like this will always terminate.
     // If i >= n, then this may loop forever.
-    // TODO Do we need a runtime check apart from this assert?
-    assert(upcast_i < upcast_n && "IndexType out of range");
+    if (upcast_i >= upcast_n)
+    { // Avoid infinite loop.
+      _CCCL_ASSERT(false, "index out of range");
+      return upcast_i;
+    }
+
     do
     {
       upcast_i = bijection(upcast_i);

--- a/thrust/thrust/iterator/shuffle_iterator.h
+++ b/thrust/thrust/iterator/shuffle_iterator.h
@@ -65,8 +65,7 @@ struct make_shuffle_iterator_base
 //! \p shuffle_iterator is an iterator which generates a sequence of values representing a random permutation.
 //! \tparam IndexType The type of the index to shuffle.
 //! \tparam BijectionFunc The bijection to use. This should be a bijective function that maps [0..n) -> [0..n). It must
-//! be deterministic and stateless. The function will be constructed with parameters (n, g) where n is the number of
-//! elements in the permutation and g is a \c URBG that can be used to seed the bijection.
+//! be deterministic and stateless.
 //!
 //! \addtogroup iterators
 //! \{
@@ -76,7 +75,7 @@ struct make_shuffle_iterator_base
 //! \{
 
 //! \p shuffle_iterator is an iterator which generates a sequence of values representing a random permutation. This
-//! iterator is useful for working with random permutations of a range without explicitly storing it in memory. The
+//! iterator is useful for working with random permutations of a range without explicitly storing them in memory. The
 //! shuffle iterator is also useful for sampling from a range by selecting only a subset of the elements in the
 //! permutation.
 //!
@@ -88,15 +87,15 @@ struct make_shuffle_iterator_base
 //! ...
 //! // create a shuffle iterator
 //! thrust::shuffle_iterator<int> iterator(4, thrust::default_random_engine(0xDEADBEEF));
-//! iterator[0] // returns 1
-//! iterator[1] // returns 3
-//! iterator[2] // returns 2
-//! iterator[3] // returns 0
+//! // iterator[0] returns 1
+//! // iterator[1] returns 3
+//! // iterator[2] returns 2
+//! // iterator[3] returns 0
 //!
 //! thrust::device_vector<int> vec = {0, 10, 20, 30};
 //! thrust::device_vector<int> shuffled(4);
 //! thrust::gather(iterator, iterator + 4, vec.begin(), shuffled.begin());
-//! shuffled // returns {10, 30, 20, 0}
+//! // shuffled returns {10, 30, 20, 0}
 //! \endcode
 //!
 //! This next example demonstrates how to use a \p shuffle_iterator to randomly sample from a vector.
@@ -107,10 +106,10 @@ struct make_shuffle_iterator_base
 //! // create a shuffle iterator
 //! thrust::shuffle_iterator<int> iterator(100, thrust::default_random_engine(0xDEADBEEF));
 //!
-//! iterator[0] // returns 38
-//! iterator[1] // returns 50
-//! iterator[2] // returns 18
-//! iterator[3] // returns 12
+//! // iterator[0] returns 38
+//! // iterator[1] returns 50
+//! // iterator[2] returns 18
+//! // iterator[3] returns 12
 //!
 //! // create a vector of size 100
 //! thrust::device_vector<int> vec(100);
@@ -121,7 +120,7 @@ struct make_shuffle_iterator_base
 //!
 //! // sample 4 random values from vec
 //! thrust::gather(iterator, iterator + 4, vec.begin(), sample.begin());
-//! sample // returns {138, 150, 118, 112}
+//! // sample returns {138, 150, 118, 112}
 //! \endcode
 //!
 //! \see make_shuffle_iterator
@@ -134,7 +133,8 @@ class shuffle_iterator : public detail::make_shuffle_iterator_base<IndexType, Bi
   //! \endcond
 
 public:
-  //! \brief Constructs a \p shuffle_iterator with a given number of elements and a \c URBG.
+  //! \brief Constructs a \p shuffle_iterator with a given number of elements and a \c URBG. The parameters will be
+  //! forwarded to the bijection constructor.
   //! \param n The number of elements in the permutation.
   //! \param g The \c URBG used to generate the random permutation. This is only invoked during construction of the \p
   //! shuffle_iterator.
@@ -145,7 +145,7 @@ public:
       , bijection(n, ::cuda::std::forward<URBG>(g))
   {}
 
-  //! \brief Constructs a \p shuffle_iterator with a given number of elements and a \c URBG.
+  //! \brief Constructs a \p shuffle_iterator with a given bijection.
   //! \param bijection The bijection to use.
   _CCCL_HOST_DEVICE shuffle_iterator(BijectionFunc bijection)
       : super_t(IndexType{0})

--- a/thrust/thrust/iterator/shuffle_iterator.h
+++ b/thrust/thrust/iterator/shuffle_iterator.h
@@ -83,16 +83,16 @@ struct make_shuffle_iterator_base
 //! #include <thrust/iterator/shuffle_iterator.h>
 //! ...
 //! // create a shuffle iterator
-//! thrust::shuffle_iterator<int> iterator(4, thrust::default_random_engine());
+//! thrust::shuffle_iterator<int> iterator(4, thrust::default_random_engine(0xDEADBEEF));
 //! iterator[0] // returns 1
-//! iterator[1] // returns 0
-//! iterator[2] // returns 3
-//! iterator[3] // returns 2
+//! iterator[1] // returns 3
+//! iterator[2] // returns 2
+//! iterator[3] // returns 0
 //!
 //! thrust::device_vector<int> vec = {0, 10, 20, 30};
 //! thrust::device_vector<int> shuffled(4);
 //! thrust::gather(iterator, iterator + 4, vec.begin(), shuffled.begin());
-//! shuffled // returns {10, 0, 30, 20}
+//! shuffled // returns {10, 30, 20, 0}
 //! \endcode
 //!
 //! This next example demonstrates how to use a \p shuffle_iterator to randomly sample from a vector.
@@ -101,12 +101,12 @@ struct make_shuffle_iterator_base
 //! #include <thrust/iterator/shuffle_iterator.h>
 //! ...
 //! // create a shuffle iterator
-//! thrust::shuffle_iterator<int> iterator(100, thrust::default_random_engine());
+//! thrust::shuffle_iterator<int> iterator(100, thrust::default_random_engine(0xDEADBEEF));
 //!
-//! iterator[0] // returns 93
-//! iterator[1] // returns 12
-//! iterator[2] // returns 77
-//! iterator[3] // returns 49
+//! iterator[0] // returns 38
+//! iterator[1] // returns 50
+//! iterator[2] // returns 18
+//! iterator[3] // returns 12
 //!
 //! // create a vector of size 100
 //! thrust::device_vector<int> vec(100);
@@ -117,7 +117,7 @@ struct make_shuffle_iterator_base
 //!
 //! // sample 4 random values from vec
 //! thrust::gather(iterator, iterator + 4, vec.begin(), sample.begin());
-//! sample // returns {193, 112, 177, 149}
+//! sample // returns {138, 150, 118, 112}
 //! \endcode
 //!
 //! \see make_shuffle_iterator

--- a/thrust/thrust/iterator/shuffle_iterator.h
+++ b/thrust/thrust/iterator/shuffle_iterator.h
@@ -1,0 +1,171 @@
+/*
+ *  Copyright 2025 NVIDIA Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+//! \file thrust/iterator/shuffle_iterator.h
+//! \brief An output iterator which generates a sequence of values representing a random permutation
+#pragma once
+
+#include <thrust/detail/config.h>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <thrust/detail/random_bijection.h>
+#include <thrust/detail/type_traits.h>
+#include <thrust/iterator/iterator_adaptor.h>
+#include <thrust/iterator/iterator_traits.h>
+
+#include <cuda/std/type_traits>
+
+THRUST_NAMESPACE_BEGIN
+
+template <class IndexType, class BijectionFunc>
+class shuffle_iterator;
+
+namespace detail
+{
+template <class IndexType, class BijectionFunc>
+struct make_shuffle_iterator_base
+{
+  static_assert(::cuda::std::is_integral_v<IndexType>, "IndexType must be an integral type");
+
+  using system     = any_system_tag;
+  using traversal  = random_access_traversal_tag;
+  using difference = ::cuda::std::_If<sizeof(IndexType) < sizeof(int), int, ::cuda::std::ptrdiff_t>;
+
+  using type =
+    iterator_adaptor<shuffle_iterator<IndexType, BijectionFunc>,
+                     IndexType,
+                     IndexType,
+                     system,
+                     traversal,
+                     IndexType,
+                     difference>;
+};
+} // namespace detail
+
+//! \p shuffle_iterator is an iterator which generates a sequence of values representing a random permutation.
+//!
+//! \addtogroup iterators
+//! \{
+
+//! \addtogroup fancyiterator Fancy Iterators
+//! \ingroup iterators
+//! \{
+
+//! \p shuffle_iterator is an iterator which generates a sequence of values representing a random permutation. This
+//! iterator is useful for working with random permutations of a range without explicitly storing it in memory. The
+//! shuffle iterator is also useful for sampling from a range by selecting only a subset of the elements in the
+//! permutation.
+//!
+//! The following code snippet demonstrates how to create a \p shuffle_iterator which generates a random permutation of
+//! a vector.
+//!
+//! \code
+//! #include <thrust/iterator/shuffle_iterator.h>
+//! ...
+//! // create a shuffle iterator
+//! thrust::shuffle_iterator<int> iterator(4, thrust::default_random_engine());
+//! iterator[0] // returns 1
+//! iterator[1] // returns 0
+//! iterator[2] // returns 3
+//! iterator[3] // returns 2
+//!
+//! thrust::device_vector<int> vec = {0, 10, 20, 30};
+//! thrust::device_vector<int> shuffled(4);
+//! thrust::gather(iterator, iterator + 4, vec.begin(), shuffled.begin());
+//! shuffled // returns {10, 0, 30, 20}
+//! \endcode
+//!
+//! This next example demonstrates how to use a \p shuffle_iterator to randomly sample from a vector.
+//!
+//! \code
+//! #include <thrust/iterator/shuffle_iterator.h>
+//! ...
+//! // create a shuffle iterator
+//! thrust::shuffle_iterator<int> iterator(100, thrust::default_random_engine());
+//!
+//! iterator[0] // returns 93
+//! iterator[1] // returns 12
+//! iterator[2] // returns 77
+//! iterator[3] // returns 49
+//!
+//! // create a vector of size 100
+//! thrust::device_vector<int> vec(100);
+//! thrust::device_vector<int> sample(4);
+//!
+//! // fill vec with random values
+//! thrust::sequence(vec.begin(), vec.end(), 100);
+//!
+//! // sample 4 random values from vec
+//! thrust::gather(iterator, iterator + 4, vec.begin(), sample.begin());
+//! sample // returns {193, 112, 177, 149}
+//! \endcode
+//!
+//! \see make_shuffle_iterator
+template <class IndexType, class BijectionFunc = thrust::detail::random_bijection<IndexType>>
+class shuffle_iterator : public detail::make_shuffle_iterator_base<IndexType, BijectionFunc>::type
+{
+  //! \cond
+  using super_t = typename detail::make_shuffle_iterator_base<IndexType, BijectionFunc>::type;
+  friend class iterator_core_access;
+  //! \endcond
+
+public:
+  //! \brief Constructs a \p shuffle_iterator with a given number of elements and a \c URBG.
+  //! \param n The number of elements in the permutation.
+  //! \param g The \c URBG used to generate the random permutation. This is only invoked during construction of the \p
+  //! shuffle_iterator.
+  template <class URBG>
+  _CCCL_HOST_DEVICE shuffle_iterator(IndexType n, URBG&& g)
+      : super_t(IndexType{0})
+      , bijection(n, ::cuda::std::forward<URBG>(g))
+  {}
+
+  //! \cond
+
+private:
+  _CCCL_HOST_DEVICE IndexType dereference() const
+  {
+    return bijection(this->base());
+  }
+
+  BijectionFunc bijection;
+
+  //! \endcond
+};
+
+//! \p make_shuffle_iterator creates a \p shuffle_iterator from an \c IndexType and \c URBG.
+//!
+//! \param n The number of elements in the permutation.
+//! \param g The \c URBG used to generate the random permutation.
+//! \return A new \p shuffle_iterator which generates a random permutation of the input range.
+//! \see shuffle_iterator
+template <class IndexType, class URBG>
+_CCCL_HOST_DEVICE shuffle_iterator<IndexType> make_shuffle_iterator(IndexType n, URBG&& g)
+{
+  return shuffle_iterator<IndexType>(n, ::cuda::std::forward<URBG>(g));
+} // end make_shuffle_iterator
+
+//! \} // end fancyiterators
+//! \} // end iterators
+
+THRUST_NAMESPACE_END

--- a/thrust/thrust/system/detail/generic/shuffle.inl
+++ b/thrust/thrust/system/detail/generic/shuffle.inl
@@ -16,6 +16,7 @@
 
 #include <thrust/detail/config.h>
 
+#include <thrust/detail/random_bijection.h>
 #include <thrust/detail/temporary_array.h>
 #include <thrust/iterator/discard_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
@@ -33,89 +34,6 @@ namespace detail
 {
 namespace generic
 {
-
-// An implementation of a Feistel cipher for operating on 64 bit keys
-class feistel_bijection
-{
-  struct round_state
-  {
-    std::uint32_t left;
-    std::uint32_t right;
-  };
-
-public:
-  template <class URBG>
-  _CCCL_HOST_DEVICE feistel_bijection(std::uint64_t m, URBG&& g)
-  {
-    std::uint64_t total_bits = get_cipher_bits(m);
-    // Half bits rounded down
-    left_side_bits = total_bits / 2;
-    left_side_mask = (1ull << left_side_bits) - 1;
-    // Half the bits rounded up
-    right_side_bits = total_bits - left_side_bits;
-    right_side_mask = (1ull << right_side_bits) - 1;
-
-    for (std::uint32_t i = 0; i < num_rounds; i++)
-    {
-      key[i] = g();
-    }
-  }
-
-  _CCCL_HOST_DEVICE std::uint64_t nearest_power_of_two() const
-  {
-    return 1ull << (left_side_bits + right_side_bits);
-  }
-
-  _CCCL_HOST_DEVICE std::uint64_t operator()(const std::uint64_t val) const
-  {
-    std::uint32_t state[2] = {static_cast<std::uint32_t>(val >> right_side_bits),
-                              static_cast<std::uint32_t>(val & right_side_mask)};
-    for (std::uint32_t i = 0; i < num_rounds; i++)
-    {
-      std::uint32_t hi, lo;
-      constexpr std::uint64_t M0 = UINT64_C(0xD2B74407B1CE6E93);
-      mulhilo(M0, state[0], hi, lo);
-      lo       = (lo << (right_side_bits - left_side_bits)) | state[1] >> left_side_bits;
-      state[0] = ((hi ^ key[i]) ^ state[1]) & left_side_mask;
-      state[1] = lo & right_side_mask;
-    }
-    // Combine the left and right sides together to get result
-    return (static_cast<std::uint64_t>(state[0]) << right_side_bits) | static_cast<std::uint64_t>(state[1]);
-  }
-
-private:
-  // Perform 64 bit multiplication and save result in two 32 bit int
-  static _CCCL_HOST_DEVICE void mulhilo(std::uint64_t a, std::uint64_t b, std::uint32_t& hi, std::uint32_t& lo)
-  {
-    std::uint64_t product = a * b;
-    hi                    = static_cast<std::uint32_t>(product >> 32);
-    lo                    = static_cast<std::uint32_t>(product);
-  }
-
-  // Find the nearest power of two
-  static _CCCL_HOST_DEVICE std::uint64_t get_cipher_bits(std::uint64_t m)
-  {
-    if (m <= 16)
-    {
-      return 4;
-    }
-    std::uint64_t i = 0;
-    m--;
-    while (m != 0)
-    {
-      i++;
-      m >>= 1;
-    }
-    return i;
-  }
-
-  static constexpr std::uint32_t num_rounds = 24;
-  std::uint64_t right_side_bits;
-  std::uint64_t left_side_bits;
-  std::uint64_t right_side_mask;
-  std::uint64_t left_side_mask;
-  std::uint32_t key[num_rounds];
-};
 
 struct key_flag_tuple
 {
@@ -135,8 +53,8 @@ struct key_flag_scan_op
 struct construct_key_flag_op
 {
   std::uint64_t m;
-  feistel_bijection bijection;
-  _CCCL_HOST_DEVICE construct_key_flag_op(std::uint64_t m, feistel_bijection bijection)
+  thrust::detail::feistel_bijection bijection;
+  _CCCL_HOST_DEVICE construct_key_flag_op(std::uint64_t m, thrust::detail::feistel_bijection bijection)
       : m(m)
       , bijection(bijection)
   {}
@@ -189,7 +107,7 @@ _CCCL_HOST_DEVICE void shuffle_copy(
   // m is the length of the input
   // we have an available bijection of length n via a feistel cipher
   std::size_t m = last - first;
-  feistel_bijection bijection(m, g);
+  thrust::detail::feistel_bijection bijection(m, g);
   std::uint64_t n = bijection.nearest_power_of_two();
 
   // perform stream compaction over length n bijection to get length m


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes https://github.com/NVIDIA/cccl/issues/4524 <!-- Link issue here -->

<!-- Provide a standalone description of changes in this PR. -->

This PR implements a shuffle_iterator type that allows users consume random permutations as an iterator without having to allocate memory.

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
