### PR TITLE
Use `_CCCL_ASSUME` if we do not use assertions

### DIFF
--- a/libcudacxx/include/cuda/__cmath/ilog.h
+++ b/libcudacxx/include/cuda/__cmath/ilog.h
@@ -153,7 +153,8 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr int ilog10(_Tp __t) noexcept
   auto __log10_approx                 = static_cast<int>(__log2);
   if constexpr (sizeof(_Tp) <= sizeof(uint32_t))
   {
-    _CCCL_ASSERT(__log10_approx < int{_CUDA_VSTD::size(__power_of_10_32bit())}, "out of bounds");
+    _CCCL_ASSERT(__log10_approx < static_cast<int>(_CUDA_VSTD::tuple_size_v<decltype(__power_of_10_32bit())>),
+                 "out of bounds");
     if constexpr (_CUDA_VSTD::is_same_v<_Tp, uint32_t>)
     {
       // don't replace +1 with >= because wraparound behavior is needed here
@@ -166,14 +167,16 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr int ilog10(_Tp __t) noexcept
   }
   else if constexpr (sizeof(_Tp) == sizeof(uint64_t))
   {
-    _CCCL_ASSERT(__log10_approx < int{_CUDA_VSTD::size(__power_of_10_64bit())}, "out of bounds");
+    _CCCL_ASSERT(__log10_approx < static_cast<int>(_CUDA_VSTD::tuple_size_v<decltype(__power_of_10_64bit())>),
+                 "out of bounds");
     // +1 is not needed here
     __log10_approx += static_cast<uint64_t>(__t) >= __power_of_10_64bit()[__log10_approx];
   }
 #if _CCCL_HAS_INT128()
   else
   {
-    _CCCL_ASSERT(__log10_approx < int{_CUDA_VSTD::size(__power_of_10_128bit())}, "out of bounds");
+    _CCCL_ASSERT(__log10_approx < static_cast<int>(_CUDA_VSTD::tuple_size_v<decltype(__power_of_10_128bit())>),
+                 "out of bounds");
     if constexpr (_CUDA_VSTD::is_same_v<_Tp, __uint128_t>)
     {
       // don't replace +1 with >= because wraparound behavior is needed here

--- a/libcudacxx/include/cuda/std/__cstdlib/aligned_alloc.h
+++ b/libcudacxx/include/cuda/std/__cstdlib/aligned_alloc.h
@@ -44,7 +44,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 __aligned_alloc_host([[maybe_unused]] size_t __nbytes, [[maybe_unused]] size_t __align) noexcept
 {
 #  if _CCCL_OS(WINDOWS)
-  _CCCL_ASSERT(false, "Use of aligned_alloc in host code is not supported on WIndows");
+  _CCCL_VERIFY(false, "Use of aligned_alloc in host code is not supported on Windows");
   return nullptr;
 #  else // ^^^ _CCCL_COMPILER(MSVC) ^^^ / vvv !_CCCL_COMPILER(MSVC) vvv
   return ::aligned_alloc(__align, __nbytes);

--- a/libcudacxx/test/libcudacxx/libcxx/asserts/assert_device.runfail.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/asserts/assert_device.runfail.cpp
@@ -16,6 +16,8 @@
 #endif // !CCCL_ENABLE_ASSERTIONS
 #include <cuda/std/cassert>
 
+#include "test_macros.h"
+
 __host__ __device__ inline bool failed_on_device()
 {
   NV_IF_ELSE_TARGET(NV_IS_DEVICE, return false;, return true;)

--- a/libcudacxx/test/libcudacxx/libcxx/asserts/assert_device_disabled.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/asserts/assert_device_disabled.pass.cpp
@@ -13,6 +13,10 @@
 
 #include <cuda/std/cassert>
 
+#include "test_macros.h"
+
+TEST_DIAG_SUPPRESS_MSVC(4702) // unreachable code
+
 __host__ __device__ inline bool failed_on_device()
 {
   NV_IF_ELSE_TARGET(NV_IS_DEVICE, return false;, return true;)

--- a/libcudacxx/test/libcudacxx/libcxx/asserts/assert_device_enable_device.runfail.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/asserts/assert_device_enable_device.runfail.cpp
@@ -16,6 +16,8 @@
 
 #include <cuda/std/cassert>
 
+#include "test_macros.h"
+
 __host__ __device__ inline bool failed_on_device()
 {
   NV_IF_ELSE_TARGET(NV_IS_DEVICE, return false;, return true;)

--- a/libcudacxx/test/libcudacxx/libcxx/asserts/assert_host.runfail.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/asserts/assert_host.runfail.cpp
@@ -18,6 +18,8 @@
 
 #include <cuda/std/cassert>
 
+#include "test_macros.h"
+
 __host__ __device__ inline bool failed_on_host()
 {
   NV_IF_ELSE_TARGET(NV_IS_DEVICE, return true;, return false;)

--- a/libcudacxx/test/libcudacxx/libcxx/asserts/assert_host_disable.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/asserts/assert_host_disable.pass.cpp
@@ -15,6 +15,10 @@
 
 #include <cuda/std/cassert>
 
+#include "test_macros.h"
+
+TEST_DIAG_SUPPRESS_MSVC(4702)
+
 __host__ __device__ inline bool failed_on_host()
 {
   NV_IF_ELSE_TARGET(NV_IS_DEVICE, return true;, return false;)

--- a/libcudacxx/test/libcudacxx/libcxx/asserts/assert_host_enable_device.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/asserts/assert_host_enable_device.pass.cpp
@@ -16,6 +16,10 @@
 
 #include <cuda/std/cassert>
 
+#include "test_macros.h"
+
+TEST_DIAG_SUPPRESS_MSVC(4702) // unreachable code
+
 int main(int, char**)
 {
   NV_IF_ELSE_TARGET(


### PR DESCRIPTION
We can give the compiler a hint what to expect even if we do not assert