### PR TITLE
Ensure that we are actually calling the cuda APIs ...

### DIFF
--- a/libcudacxx/include/cuda/std/__cuda/api_wrapper.h
+++ b/libcudacxx/include/cuda/std/__cuda/api_wrapper.h
@@ -27,28 +27,23 @@
 
 #include <cuda/std/__exception/cuda_error.h>
 
-#if _CCCL_HAS_CUDA_COMPILER()
-#  define _CCCL_TRY_CUDA_API(_NAME, _MSG, ...)           \
-    {                                                    \
-      const ::cudaError_t __status = _NAME(__VA_ARGS__); \
-      switch (__status)                                  \
-      {                                                  \
-        case ::cudaSuccess:                              \
-          break;                                         \
-        default:                                         \
-          ::cudaGetLastError();                          \
-          ::cuda::__throw_cuda_error(__status, _MSG);    \
-      }                                                  \
-    }
+#define _CCCL_TRY_CUDA_API(_NAME, _MSG, ...)           \
+  {                                                    \
+    const ::cudaError_t __status = _NAME(__VA_ARGS__); \
+    switch (__status)                                  \
+    {                                                  \
+      case ::cudaSuccess:                              \
+        break;                                         \
+      default:                                         \
+        ::cudaGetLastError();                          \
+        ::cuda::__throw_cuda_error(__status, _MSG);    \
+    }                                                  \
+  }
 
-#  define _CCCL_ASSERT_CUDA_API(_NAME, _MSG, ...)                         \
-    {                                                                     \
-      [[maybe_unused]] const ::cudaError_t __status = _NAME(__VA_ARGS__); \
-      _CCCL_ASSERT(__status == cudaSuccess, _MSG);                        \
-    }
-#else // ^^^ _CCCL_HAS_CUDA_COMPILER() ^^^ / vvv !_CCCL_HAS_CUDA_COMPILER() vvv
-#  define _CCCL_TRY_CUDA_API(_NAME, _MSG, ...)
-#  define _CCCL_ASSERT_CUDA_API(_NAME, _MSG, ...)
-#endif // !_CCCL_HAS_CUDA_COMPILER()
+#define _CCCL_ASSERT_CUDA_API(_NAME, _MSG, ...)                         \
+  {                                                                     \
+    [[maybe_unused]] const ::cudaError_t __status = _NAME(__VA_ARGS__); \
+    _CCCL_ASSERT(__status == cudaSuccess, _MSG);                        \
+  }
 
 #endif //_CUDA__STD__CUDA_API_WRAPPER_H


### PR DESCRIPTION
We were dropping them on the floor, which is definitely not the right thing

The original issue was that `cuda_error` was not defined, but we worked around this by using an integer rather than an enum value in the API and just terminate if there are no exceptions
