### PR TITLE
Add weekly compute-sanitizer CI jobs for CUB

### DIFF
--- a/.github/workflows/ci-workflow-weekly.yml
+++ b/.github/workflows/ci-workflow-weekly.yml
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: weekly
+
+defaults:
+  run:
+    shell: bash --noprofile --norc -euo pipefail {0}
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * 6" # Saturdays at 12AM UTC, 8PM EST, 5PM PST
+
+concurrency:
+  group: ${{ github.workflow }}-on-${{ github.event_name }}-from-${{ github.ref_name }}
+
+jobs:
+
+  build-workflow:
+    name: Build workflow from matrix
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      workflow: ${{ steps.build-workflow.outputs.workflow }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Build workflow
+        id: build-workflow
+        uses: ./.github/actions/workflow-build
+        with:
+          workflows: weekly
+          slack_token: ${{ secrets.SLACK_NOTIFIER_BOT_TOKEN }}
+          slack_log: ${{ secrets.SLACK_CHANNEL_CI_LOG }}
+          slack_alert: ${{ secrets.SLACK_CHANNEL_CI_ALERT }}
+
+  dispatch-groups-linux-two-stage:
+    name: ${{ matrix.name }}
+    if: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['linux_two_stage']['keys']) != '[]' }}
+    needs: build-workflow
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        name: ${{ fromJSON(needs.build-workflow.outputs.workflow)['linux_two_stage']['keys'] }}
+    uses: ./.github/workflows/workflow-dispatch-two-stage-group-linux.yml
+    with:
+      pc-array: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['linux_two_stage']['jobs'][matrix.name]) }}
+
+  dispatch-groups-windows-two-stage:
+    name: ${{ matrix.name }}
+    if: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['windows_two_stage']['keys']) != '[]' }}
+    needs: build-workflow
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        name: ${{ fromJSON(needs.build-workflow.outputs.workflow)['windows_two_stage']['keys'] }}
+    uses: ./.github/workflows/workflow-dispatch-two-stage-group-windows.yml
+    with:
+      pc-array: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['windows_two_stage']['jobs'][matrix.name]) }}
+
+  dispatch-groups-linux-standalone:
+    name: ${{ matrix.name }}
+    if: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['linux_standalone']['keys']) != '[]' }}
+    needs: build-workflow
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        name: ${{ fromJSON(needs.build-workflow.outputs.workflow)['linux_standalone']['keys'] }}
+    uses: ./.github/workflows/workflow-dispatch-standalone-group-linux.yml
+    with:
+      job-array: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['linux_standalone']['jobs'][matrix.name]) }}
+
+  dispatch-groups-windows-standalone:
+    name: ${{ matrix.name }}
+    if: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['windows_standalone']['keys']) != '[]' }}
+    needs: build-workflow
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        name: ${{ fromJSON(needs.build-workflow.outputs.workflow)['windows_standalone']['keys'] }}
+    uses: ./.github/workflows/workflow-dispatch-standalone-group-windows.yml
+    with:
+      job-array: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['windows_standalone']['jobs'][matrix.name]) }}
+
+  verify-workflow:
+    name: Verify and summarize workflow results
+    if: ${{ always() && !cancelled() }}
+    needs:
+      - build-workflow
+      - dispatch-groups-linux-two-stage
+      - dispatch-groups-windows-two-stage
+      - dispatch-groups-linux-standalone
+      - dispatch-groups-windows-standalone
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Check workflow success
+        id: check-workflow
+        uses: ./.github/actions/workflow-results
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          slack_token: ${{ secrets.SLACK_NOTIFIER_BOT_TOKEN }}
+          slack_log: ${{ secrets.SLACK_CHANNEL_CI_LOG }}
+          slack_alert: ${{ secrets.SLACK_CHANNEL_CI_ALERT }}

--- a/c2h/include/c2h/catch2_test_helper.h
+++ b/c2h/include/c2h/catch2_test_helper.h
@@ -286,7 +286,7 @@ inline std::size_t get_override_seed_count()
 
 inline std::size_t adjust_seed_count(std::size_t requested)
 {
-  static int override_seeds = get_override_seed_count();
+  static std::size_t override_seeds = get_override_seed_count();
   return override_seeds != 0 ? override_seeds : requested;
 }
 } // namespace c2h

--- a/c2h/include/c2h/catch2_test_helper.h
+++ b/c2h/include/c2h/catch2_test_helper.h
@@ -272,22 +272,29 @@ struct Catch::StringMaker<cudaError>
 
 #define C2H_TEST_STR(a) #a
 
-namespace detail
+namespace c2h
 {
-inline std::size_t adjust_seed_count(std::size_t requested)
+
+inline std::size_t get_override_seed_count()
 {
   // Setting this environment variable forces a fixed number of seeds to be generated, regardless of the requested
   // count. Set to 1 to reduce redundant, expensive testing when using sanitizers, etc.
-  static const char* override_str = std::getenv("CCCL_SEED_COUNT_OVERRIDE");
-  static int override             = override_str ? std::atoi(override_str) : 0;
-  return override_str ? override : requested;
+  static const char* override_str = std::getenv("C2H_SEED_COUNT_OVERRIDE");
+  static const int override_seeds = override_str ? std::atoi(override_str) : 0;
+  return override_seeds;
 }
-} // namespace detail
+
+inline std::size_t adjust_seed_count(std::size_t requested)
+{
+  static int override_seeds = get_override_seed_count();
+  return override_seeds != 0 ? override_seeds : requested;
+}
+} // namespace c2h
 
 #define C2H_SEED(N)                                                                         \
   c2h::seed_t                                                                               \
   {                                                                                         \
-    GENERATE_COPY(take(detail::adjust_seed_count(N),                                        \
+    GENERATE_COPY(take(c2h::adjust_seed_count(N),                                           \
                        random(::cuda::std::numeric_limits<unsigned long long int>::min(),   \
                               ::cuda::std::numeric_limits<unsigned long long int>::max()))) \
   }

--- a/c2h/include/c2h/checked_allocator.cuh
+++ b/c2h/include/c2h/checked_allocator.cuh
@@ -51,18 +51,18 @@ struct memory_info
   bool override{false};
 };
 
-// If the environment variable CCCL_DEVICE_MEMORY_LIMIT is set, the total device memory
+// If the environment variable C2H_DEVICE_MEMORY_LIMIT is set, the total device memory
 // will be limited to this number of bytes.
 inline std::size_t get_device_memory_limit()
 {
-  static const char* override_str = std::getenv("CCCL_DEVICE_MEMORY_LIMIT");
+  static const char* override_str = std::getenv("C2H_DEVICE_MEMORY_LIMIT");
   static std::size_t result       = override_str ? static_cast<std::size_t>(std::atoll(override_str)) : 0;
   return result;
 }
 
 inline bool get_debug_checked_allocs()
 {
-  static const char* debug_checked_allocs = std::getenv("CCCL_DEBUG_CHECKED_ALLOC_FAILURES");
+  static const char* debug_checked_allocs = std::getenv("C2H_DEBUG_CHECKED_ALLOC_FAILURES");
   static bool result                      = debug_checked_allocs && (std::atoi(debug_checked_allocs) != 0);
   return result;
 }
@@ -112,7 +112,7 @@ inline cudaError_t check_free_device_memory(std::size_t bytes)
       if (info.override)
       {
         std::cerr
-          << "Available device memory has been limited (env var CCCL_DEVICE_MEMORY_LIMIT=" << get_device_memory_limit()
+          << "Available device memory has been limited (env var C2H_DEVICE_MEMORY_LIMIT=" << get_device_memory_limit()
           << ").\n";
       }
 

--- a/ci/compute-sanitizer-suppressions.xml
+++ b/ci/compute-sanitizer-suppressions.xml
@@ -1,0 +1,453 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ComputeSanitizerOutput>
+  <!--
+  thrust::equal reduces using an accumulator type tuple<bool, OffsetT>.
+  The padding bytes inside the tuple are not initialized.
+  This causes issues during `cub::ThreadLoad`, which loads the memory as aliased
+  machine words that are cast to the tuple type.
+  -->
+  <record>
+    <kind>Initcheck</kind>
+    <what>
+      <text>Uninitialized __global__ memory read of size 2 bytes</text>
+      <size>2</size>
+    </what>
+    <where>
+      <func>ThreadLoad</func>
+    </where>
+    <deviceStack>
+      <frame>
+        <func>UnrolledThreadLoadImpl</func>
+      </frame>
+      <frame>
+        <func>UnrolledThreadLoad</func>
+      </frame>
+      <frame>
+        <func>ThreadLoad</func>
+      </frame>
+      <frame>
+        <func>ThreadLoad</func>
+      </frame>
+    </deviceStack>
+    <hostStack>
+      <frame>
+        <module>.*libcuda.so.*</module>
+      </frame>
+      <frame>
+        <func>libcudart_static.*</func>
+      </frame>
+      <frame>
+        <func>cudaLaunchKernel</func>
+      </frame>
+      <frame>
+        <func>.*cub::.*::DeviceReduce.*.*thrust::.*find_if.*</func>
+      </frame>
+    </hostStack>
+  </record>
+  <!--
+  Similar to the above, thrust::equal copies a tuple<bool, OffsetT> from host -> device
+  with the result of the comparison. The padding bytes trigger host API initialization
+  errors during the cudaMemcpy.
+  Sadly, this is a very generic suppression that may hide real issues, but it's the best
+  we can do given the current tooling.
+  -->
+  <record>
+    <kind>InitcheckApiError</kind>
+    <level>Error</level>
+    <what>
+      <text>Host API uninitialized memory access</text>
+      <accessSize>16</accessSize>
+    </what>
+    <hostStack>
+      <saveLocation>error</saveLocation>
+      <frame>
+        <module>.*/libcuda.so.*</module>
+      </frame>
+      <frame>
+        <func>libcudart_static_.*</func>
+      </frame>
+      <frame>
+        <func>libcudart_static_.*</func>
+      </frame>
+      <frame>
+        <func>cudaMemcpyAsync</func>
+      </frame>
+      <frame>
+        <func>void C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_F_U_N_C_.*</func>
+      </frame>
+    </hostStack>
+  </record>
+  <!-- Another variant of the above with a different catch2 dispatcher -->
+  <record>
+    <kind>InitcheckApiError</kind>
+    <level>Error</level>
+    <what>
+      <text>Host API uninitialized memory access</text>
+      <accessSize>16</accessSize>
+    </what>
+    <hostStack>
+      <saveLocation>error</saveLocation>
+      <frame>
+        <module>.*/libcuda.so.*</module>
+      </frame>
+      <frame>
+        <func>libcudart_static_.*</func>
+      </frame>
+      <frame>
+        <func>libcudart_static_.*</func>
+      </frame>
+      <frame>
+        <func>cudaMemcpyAsync</func>
+      </frame>
+      <frame>
+        <func>void CATCH2_INTERNAL_TEMPLATE_TEST.*</func>
+      </frame>
+    </hostStack>
+  </record>
+  <!-- Yet another instance of that tuple<Offset, bool> padding -->
+  <record>
+    <kind>InitcheckApiError</kind>
+    <level>Error</level>
+    <what>
+      <text>Host API uninitialized memory access</text>
+      <accessSize>16</accessSize>
+    </what>
+    <hostStack>
+      <saveLocation>error</saveLocation>
+      <frame>
+        <module>.*libcuda.so.*</module>
+      </frame>
+      <frame>
+        <func>libcudart_static.*</func>
+      </frame>
+      <frame>
+        <func>libcudart_static.*</func>
+      </frame>
+      <frame>
+        <func>cudaMemcpyAsync</func>
+      </frame>
+      <frame>
+        <func>.*thrust::.*(equal|operator==|mismatch|find_if).*</func>
+      </frame>
+    </hostStack>
+  </record>
+  <!-- Yet another instance of that tuple<Offset, bool> padding -->
+  <record>
+    <kind>InitcheckApiError</kind>
+    <level>Error</level>
+    <what>
+      <text>Host API uninitialized memory access</text>
+      <accessSize>16</accessSize>
+    </what>
+    <hostStack>
+      <saveLocation>error</saveLocation>
+      <frame>
+        <module>.*libcuda.so.*</module>
+      </frame>
+      <frame>
+        <func>libcudart_static.*</func>
+      </frame>
+      <frame>
+        <func>libcudart_static.*</func>
+      </frame>
+      <frame>
+        <func>cudaMemcpyAsync</func>
+      </frame>
+      <frame>
+        <func>bool binary_equal.*</func> <!-- Implementation detail of CUB's block radix sort tests, calls thrust::equal -->
+      </frame>
+    </hostStack>
+  </record>
+  <!-- Yet another instance of that tuple<Offset, bool> padding -->
+  <record>
+    <kind>InitcheckApiError</kind>
+    <level>Error</level>
+    <what>
+      <text>Host API uninitialized memory access</text>
+      <accessSize>16</accessSize>
+    </what>
+    <hostStack>
+      <saveLocation>error</saveLocation>
+      <frame>
+        <module>.*libcuda.so.*</module>
+      </frame>
+      <frame>
+        <func>libcudart_static.*</func>
+      </frame>
+      <frame>
+        <func>libcudart_static.*</func>
+      </frame>
+      <frame>
+        <func>cudaMemcpyAsync</func>
+      </frame>
+      <frame>
+        <!-- CUB's namespace_wrapped test has this issue inlined into main: -->
+        <func>main</func>
+        <module>.*cub.*test.namespace_wrapped</module>
+      </frame>
+    </hostStack>
+  </record>
+  <!-- Yet another instance of that tuple<Offset, bool> padding -->
+  <record>
+    <kind>InitcheckApiError</kind>
+    <what>
+      <text>Host API uninitialized memory access</text>
+      <accessSize>16</accessSize>
+    </what>
+    <hostStack>
+      <saveLocation>error</saveLocation>
+      <frame>
+        <module>.*libcuda.so.*</module>
+      </frame>
+      <frame>
+        <func>libcudart_static.*</func>
+      </frame>
+      <frame>
+        <func>libcudart_static.*</func>
+      </frame>
+      <frame>
+        <func>cudaMemcpyAsync</func>
+      </frame>
+      <frame>
+        <!-- The segmented sort test have several stacks that have padding bit issues. -->
+        <module>.*cub.*device_segmented_sort.*</module>
+      </frame>
+    </hostStack>
+  </record>
+  <!-- Yet another instance of that tuple<Offset, bool> padding -->
+  <record>
+    <kind>InitcheckApiError</kind>
+    <what>
+      <text>Host API uninitialized memory access</text>
+      <accessSize>16</accessSize>
+    </what>
+    <hostStack>
+      <saveLocation>error</saveLocation>
+      <frame>
+        <module>.*libcuda.so.*</module>
+      </frame>
+      <frame>
+        <func>libcudart_static.*</func>
+      </frame>
+      <frame>
+        <func>libcudart_static.*</func>
+      </frame>
+      <frame>
+        <func>cudaMemcpyAsync</func>
+      </frame>
+      <frame>
+        <!-- The RLE tests have several stacks that have padding bit issues. -->
+        <module>.*cub.*device_run_length_encode.*</module>
+      </frame>
+    </hostStack>
+  </record>
+  <!--
+  DeviceRunLengthEncode performs a WarpExchange::ScatterToStriped that 'discards'
+  elements by scattering them to the same (ignored) destination address. This
+  triggers a WAW race that we can safely ignore.
+  -->
+  <record>
+    <kind>Analysis</kind>
+    <level>Error</level>
+    <what>
+      <text>Race condition</text>
+      <source>
+        <direction>Write</direction>
+        <where>
+          <func>ScatterToStriped</func>
+        </where>
+      </source>
+      <destination>
+        <direction>Write</direction>
+        <where>
+          <func>ScatterToStriped</func>
+        </where>
+      </destination>
+      <destination>
+        <direction>Write</direction>
+        <where>
+          <func>ScatterToStriped</func>
+        </where>
+      </destination>
+      <destination>
+        <direction>Write</direction>
+        <where>
+          <func>ScatterToStriped</func>
+        </where>
+      </destination>
+    </what>
+  </record>
+  <!-- Another variation of the above -->
+  <record>
+    <kind>Analysis</kind>
+    <level>Error</level>
+    <what>
+      <text>Race condition</text>
+      <source>
+        <direction>Write</direction>
+        <where>
+          <func>ScatterToStriped</func>
+        </where>
+      </source>
+      <destination>
+        <direction>Write</direction>
+        <where>
+          <func>ScatterToStriped</func>
+        </where>
+      </destination>
+    </what>
+  </record>
+  <!-- Another variation of the above -->
+  <record>
+    <kind>Analysis</kind>
+    <level>Error</level>
+    <what>
+      <text>Race condition</text>
+      <source>
+        <direction>Write</direction>
+        <where>
+          <func>ScatterToStriped</func>
+        </where>
+      </source>
+      <destination>
+        <direction>Write</direction>
+        <where>
+          <func>ScatterToStriped</func>
+        </where>
+      </destination>
+      <destination>
+        <direction>Write</direction>
+        <where>
+          <func>ScatterToStriped</func>
+        </where>
+      </destination>
+    </what>
+  </record>
+  <!--
+  There are uninitialized padding bits inside cub::ConstantInputIterator,
+  which is basically a struct{ T value; ptrdiff_t offset; }.
+  -->
+  <record>
+    <kind>InitcheckApiError</kind>
+    <level>Error</level>
+    <what>
+      <text>Host API uninitialized memory access</text>
+      <accessSize>32</accessSize>
+    </what>
+    <hostStack>
+      <saveLocation>error</saveLocation>
+      <frame>
+        <module>.*libcuda.so.*</module>
+      </frame>
+      <frame>
+        <func>libcudart_static_.*</func>
+      </frame>
+      <frame>
+        <func>libcudart_static_.*</func>
+      </frame>
+      <frame>
+        <func>cudaMemcpyAsync</func>
+      </frame>
+      <frame>
+        <func>thrust.*vector_base.*ConstantInputIterator.*</func>
+      </frame>
+      <frame>
+        <func>void test_iterator.*ConstantInputIterator.*</func>
+      </frame>
+    </hostStack>
+  </record>
+  <!--
+  Similar to the above; cub::TransformInputIterator is a struct{TransformOp op; InputIterT iter;}.
+  In this case TransformOp is 1 byte, and InputIterT is an 8-byte pointer.
+  Padding bits strike again.
+  -->
+    <record>
+    <kind>InitcheckApiError</kind>
+    <level>Error</level>
+    <what>
+      <text>Host API uninitialized memory access</text>
+      <accessSize>32</accessSize>
+    </what>
+    <hostStack>
+      <saveLocation>error</saveLocation>
+      <frame>
+        <module>.*/libcuda.so.*</module>
+      </frame>
+      <frame>
+        <func>libcudart_static_.*</func>
+      </frame>
+      <frame>
+        <func>libcudart_static_.*</func>
+      </frame>
+      <frame>
+        <func>cudaMemcpyAsync</func>
+      </frame>
+      <frame>
+        <func>thrust.*vector_base.*TransformInputIterator.*</func>
+      </frame>
+      <frame>
+        <func>void test_iterator.*TransformInputIterator.*</func>
+      </frame>
+    </hostStack>
+  </record>
+  <!--
+  Same as above; this time InputIterT is a cub::TexObjInputIterator.
+  -->
+  <record>
+    <kind>InitcheckApiError</kind>
+    <level>Error</level>
+    <what>
+      <text>Host API uninitialized memory access</text>
+      <accessSize>64</accessSize>
+    </what>
+    <hostStack>
+      <saveLocation>error</saveLocation>
+      <frame>
+        <module>.*/libcuda.so.*</module>
+      </frame>
+      <frame>
+        <func>libcudart_static_.*</func>
+      </frame>
+      <frame>
+        <func>libcudart_static_.*</func>
+      </frame>
+      <frame>
+        <func>cudaMemcpyAsync</func>
+      </frame>
+      <frame>
+        <func>thrust.*vector_base.*TransformInputIterator.*</func>
+      </frame>
+      <frame>
+        <func>void test_iterator.*TransformInputIterator.*</func>
+      </frame>
+    </hostStack>
+  </record>
+  <!--
+  cub.test.device_reduce transfers cub::KeyValuePair<int, unwrap_value_t<...>> from
+  device -> host. This suppresses warnings about transferring padding bits inside
+  of the KeyValuePair.
+  -->
+  <record>
+    <kind>InitcheckApiError</kind>
+    <level>Error</level>
+    <what>
+      <text>Host API uninitialized memory access</text>
+    </what>
+    <hostStack>
+      <saveLocation>error</saveLocation>
+      <frame>
+        <module>.*libcuda.so.*</module>
+      </frame>
+      <frame>
+        <func>libcudart_static.*</func>
+      </frame>
+      <frame>
+        <func>libcudart_static.*</func>
+      </frame>
+      <frame>
+        <func>cudaMemcpyAsync</func>
+        <module>.*cub.*device_(segmented_|)reduce.*</module>
+      </frame>
+    </hostStack>
+  </record>
+</ComputeSanitizerOutput>

--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -110,6 +110,9 @@ workflows:
     # NVHPC stdpar smoke tests
     - {jobs: ['build'], project: 'stdpar', std: 'all', ctk: '12.8', cxx: 'nvhpc', cpu: ['amd64', 'arm64']}
 
+  weekly:
+    - {jobs: ['compute_sanitizer'], project: 'cub', std: 'max', gpu: 'rtxa6000', sm: 'gpu', cmake_options: '-DCMAKE_CUDA_FLAGS=-lineinfo'}
+
   # Any generated jobs that match the entries in `exclude` will be removed from the final matrix for all workflows.
   exclude:
     # GPU runners are not available on Windows.

--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -196,7 +196,10 @@ jobs:
   # General:
   build:        { gpu: false }
   test:         { gpu: true, needs: 'build' }
+
   test_nobuild: { gpu: true, name: 'Test', invoke: { prefix: 'test' } }
+
+  compute_sanitizer: { gpu: true, name: 'ComputeSanitizer', needs: 'build', invoke: { prefix: 'test', args: '-compute-sanitizer' } }
 
   # CCCL:
   infra: { gpu: true } # example project launches a kernel
@@ -218,6 +221,15 @@ jobs:
   # Limited build reduces the number of runtime test cases, available device memory, etc, and may be used
   # to reduce test runtime in limited environments.
   limited:    { name: "SmallGMem",   gpu: true, needs: 'build', invoke: { prefix: 'test', args: '-limited'} }
+  # Compute sanitizer jobs:
+  compute_mem_nolid:  { name: 'CSMem-TestGPU',       gpu: true, needs: 'build', invoke: { prefix: 'test', args: '-compute-sanitizer-memcheck  -no-lid'} }
+  compute_mem_lid0:   { name: 'CSMem-HostLaunch',    gpu: true, needs: 'build', invoke: { prefix: 'test', args: '-compute-sanitizer-memcheck  -lid0'} }
+  compute_race_nolid: { name: 'CSRace-TestGPU',      gpu: true, needs: 'build', invoke: { prefix: 'test', args: '-compute-sanitizer-racecheck -no-lid'} }
+  compute_race_lid0:  { name: 'CSRace-HostLaunch',   gpu: true, needs: 'build', invoke: { prefix: 'test', args: '-compute-sanitizer-racecheck -lid0'} }
+  compute_init_nolid: { name: 'CSInit-TestGPU',      gpu: true, needs: 'build', invoke: { prefix: 'test', args: '-compute-sanitizer-initcheck -no-lid'} }
+  compute_init_lid0:  { name: 'CSInit-HostLaunch',   gpu: true, needs: 'build', invoke: { prefix: 'test', args: '-compute-sanitizer-initcheck -lid0'} }
+  compute_sync_nolid: { name: 'CSSync-TestGPU',      gpu: true, needs: 'build', invoke: { prefix: 'test', args: '-compute-sanitizer-synccheck -no-lid'} }
+  compute_sync_lid0:  { name: 'CSSync-HostLaunch',   gpu: true, needs: 'build', invoke: { prefix: 'test', args: '-compute-sanitizer-synccheck -lid0'} }
 
   # Thrust:
   test_cpu: { name: 'TestCPU', gpu: false, needs: 'build', invoke: { prefix: 'test', args: '-cpu-only'} }
@@ -228,7 +240,7 @@ jobs:
   test_cuda_cooperative: { name: "cuda.cooperative", gpu: true }
   test_cuda_parallel:    { name: "cuda.parallel",    gpu: true }
 
-# Project have the following properties:
+# Projects have the following properties:
 #
 # Keys are project subdirectories names. These will also be used in script names.
 #
@@ -248,7 +260,17 @@ projects:
   cub:
     name: 'CUB'
     stds: [17, 20]
-    job_map: { test: ['test_nolid', 'test_lid0', 'test_lid1', 'test_lid2'] }
+    job_map:
+      test: ['test_nolid', 'test_lid0', 'test_lid1', 'test_lid2']
+      compute_sanitizer:
+        - compute_mem_nolid
+        - compute_mem_lid0
+        - compute_race_nolid
+        - compute_race_lid0
+        - compute_init_nolid
+        - compute_init_lid0
+        - compute_sync_nolid
+        - compute_sync_lid0
   thrust:
     name: 'Thrust'
     stds: [17, 20]

--- a/ci/test_cub.sh
+++ b/ci/test_cub.sh
@@ -7,10 +7,22 @@ LID0=false
 LID1=false
 LID2=false
 LIMITED=false
+COMPUTE_SANITIZER=false
 
 ci_dir=$(dirname "$0")
 
-new_args=$("${ci_dir}/util/extract_switches.sh" -no-lid -lid0 -lid1 -lid2 -limited -- "$@")
+new_args=$("${ci_dir}/util/extract_switches.sh" \
+  -no-lid \
+  -lid0 \
+  -lid1 \
+  -lid2 \
+  -limited \
+  -compute-sanitizer-memcheck \
+  -compute-sanitizer-racecheck \
+  -compute-sanitizer-initcheck \
+  -compute-sanitizer-synccheck \
+  -- "$@")
+
 eval set -- ${new_args}
 while true; do
   case "$1" in
@@ -34,6 +46,26 @@ while true; do
     LIMITED=true
     shift
     ;;
+  -compute-sanitizer-memcheck)
+    COMPUTE_SANITIZER=true
+    TOOL=memcheck
+    shift
+    ;;
+  -compute-sanitizer-racecheck)
+    COMPUTE_SANITIZER=true
+    TOOL=racecheck
+    shift
+    ;;
+  -compute-sanitizer-initcheck)
+    COMPUTE_SANITIZER=true
+    TOOL=initcheck
+    shift
+    ;;
+  -compute-sanitizer-synccheck)
+    COMPUTE_SANITIZER=true
+    TOOL=synccheck
+    shift
+    ;;
   --)
     shift
     break
@@ -47,16 +79,15 @@ done
 
 if $LIMITED; then
 
-  export CCCL_SEED_COUNT_OVERRIDE=1
+  export C2H_SEED_COUNT_OVERRIDE=1
   readonly device_mem_GiB=8
-  export CCCL_DEVICE_MEMORY_LIMIT=$((${device_mem_GiB} * 1024 * 1024 * 1024))
-  export CCCL_DEBUG_CHECKED_ALLOC_FAILURES=1
-
+  export C2H_DEVICE_MEMORY_LIMIT=$((${device_mem_GiB} * 1024 * 1024 * 1024))
+  export C2H_DEBUG_CHECKED_ALLOC_FAILURES=1
 
   echo "Configuring limited environment:"
-  echo "  CCCL_SEED_COUNT_OVERRIDE=${CCCL_SEED_COUNT_OVERRIDE}"
-  echo "  CCCL_DEVICE_MEMORY_LIMIT=${CCCL_DEVICE_MEMORY_LIMIT} (${device_mem_GiB} GiB)"
-  echo "  CCCL_DEBUG_CHECKED_ALLOC_FAILURES=${CCCL_DEBUG_CHECKED_ALLOC_FAILURES}"
+  echo "  C2H_SEED_COUNT_OVERRIDE=${C2H_SEED_COUNT_OVERRIDE}"
+  echo "  C2H_DEVICE_MEMORY_LIMIT=${C2H_DEVICE_MEMORY_LIMIT} (${device_mem_GiB} GiB)"
+  echo "  C2H_DEBUG_CHECKED_ALLOC_FAILURES=${C2H_DEBUG_CHECKED_ALLOC_FAILURES}"
   echo
 fi
 
@@ -76,6 +107,13 @@ elif $LID2; then
   PRESETS=("cub-lid2-cpp$CXX_STANDARD")
 else
   PRESETS=("cub-cpp$CXX_STANDARD")
+fi
+
+if $COMPUTE_SANITIZER; then
+  echo "Setting CCCL_TEST_MODE=compute-sanitizer-${TOOL}"
+  export CCCL_TEST_MODE=compute-sanitizer-${TOOL}
+  echo "Setting C2H_SEED_COUNT_OVERRIDE=1"
+  export C2H_SEED_COUNT_OVERRIDE=1
 fi
 
 for PRESET in ${PRESETS[@]}; do

--- a/cub/test/CMakeLists.txt
+++ b/cub/test/CMakeLists.txt
@@ -180,7 +180,14 @@ function(cub_add_test target_name_var test_name test_src cub_target launcher_id)
     target_link_libraries(${test_target} PRIVATE cccl.c2h.main)
     add_dependencies(${config_meta_target} ${test_target})
 
-    add_test(NAME ${test_target} COMMAND "$<TARGET_FILE:${test_target}>")
+    add_test(NAME ${test_target} COMMAND
+      "${CMAKE_COMMAND}"
+      "-DCCCL_SOURCE_DIR=${CCCL_SOURCE_DIR}"
+      "-DTEST=$<TARGET_FILE:${test_target}>"
+      "-DTYPE=Catch2"
+      -P "${CUB_SOURCE_DIR}/test/run_test.cmake"
+    )
+    set_tests_properties(${test_target} PROPERTIES SKIP_REGULAR_EXPRESSION "CCCL_SKIP_TEST")
 
     if ("${test_target}" MATCHES "nvrtc")
       configure_file("cmake/nvrtc_args.h.in" ${CMAKE_CURRENT_BINARY_DIR}/nvrtc_args.h)
@@ -259,7 +266,13 @@ function(cub_add_test target_name_var test_name test_src cub_target launcher_id)
       endif()
       add_dependencies(${test_meta_target} ${test_target})
 
-      add_test(NAME ${test_target} COMMAND "$<TARGET_FILE:${test_target}>")
+      add_test(NAME ${test_target} COMMAND
+        "${CMAKE_COMMAND}"
+        "-DCCCL_SOURCE_DIR=${CCCL_SOURCE_DIR}"
+        "-DTEST=$<TARGET_FILE:${test_target}>"
+        -P "${CUB_SOURCE_DIR}/test/run_test.cmake"
+      )
+      set_tests_properties(${test_target} PROPERTIES SKIP_REGULAR_EXPRESSION "CCCL_SKIP_TEST")
     endif()
   endif() # Not catch2 test
 

--- a/cub/test/catch2_test_device_adjacent_difference_substract_left.cu
+++ b/cub/test/catch2_test_device_adjacent_difference_substract_left.cu
@@ -270,7 +270,8 @@ struct check_difference
   }
 };
 
-C2H_TEST("DeviceAdjacentDifference::SubtractLeftCopy works with large indexes", "[device][adjacent_difference]")
+C2H_TEST("DeviceAdjacentDifference::SubtractLeftCopy works with large indexes",
+         "[device][adjacent_difference][skip-cs-racecheck][skip-cs-initcheck][skip-cs-synccheck]")
 {
   constexpr cuda::std::size_t num_items = 1ll << 33;
   c2h::device_vector<int> error(1);

--- a/cub/test/catch2_test_device_adjacent_difference_substract_right.cu
+++ b/cub/test/catch2_test_device_adjacent_difference_substract_right.cu
@@ -319,7 +319,8 @@ struct check_difference
   }
 };
 
-C2H_TEST("DeviceAdjacentDifference::SubtractRightCopy works with large indexes", "[device][adjacent_difference]")
+C2H_TEST("DeviceAdjacentDifference::SubtractRightCopy works with large indexes",
+         "[device][adjacent_difference][skip-cs-racecheck][skip-cs-initcheck][skip-cs-synccheck]")
 {
   constexpr cuda::std::size_t num_items = 1ll << 33;
   c2h::device_vector<int> error(1);

--- a/cub/test/catch2_test_device_copy_batched.cu
+++ b/cub/test/catch2_test_device_copy_batched.cu
@@ -118,7 +118,8 @@ try
        {1, 32 * 1024},
        {128 * 1024, 256 * 1024},
        {target_copy_size, target_copy_size}}),
-    take(4,
+    // Use c2h::adjust_seed_count to reduce runtime on sanitizers:
+    take(c2h::adjust_seed_count(4),
          map(
            [](const std::vector<range_size_t>& chunk) {
              range_size_t lhs = chunk[0];
@@ -180,7 +181,8 @@ catch (std::bad_alloc& e)
   std::cerr << "Caught bad_alloc: " << e.what() << std::endl;
 }
 
-C2H_TEST("DeviceCopy::Batched works for a very large range", "[copy]")
+C2H_TEST("DeviceCopy::Batched works for a very large range",
+         "[copy][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]")
 try
 {
   using data_t        = uint64_t;
@@ -230,7 +232,8 @@ C2H_TEST("DeviceCopy::Batched works for non-trivial ctors", "[copy]")
   REQUIRE(in == out);
 }
 
-C2H_TEST("DeviceMemcpy::Batched works for a very large number of ranges", "[copy]")
+C2H_TEST("DeviceMemcpy::Batched works for a very large number of ranges",
+         "[copy][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]")
 try
 {
   using item_t         = uint8_t;

--- a/cub/test/catch2_test_device_decoupled_look_back.cu
+++ b/cub/test/catch2_test_device_decoupled_look_back.cu
@@ -127,7 +127,8 @@ C2H_TEST("Decoupled look-back works with various message types", "[decoupled loo
   using scan_tile_state_t = cub::ScanTileState<message_t>;
 
   constexpr int max_tiles = 1024 * 1024;
-  const int num_tiles     = GENERATE_COPY(take(10, random(1, max_tiles)));
+  // Use c2h::adjust_seed_count to reduce the number of runs when using sanitizers:
+  const int num_tiles = GENERATE_COPY(take(c2h::adjust_seed_count(10), random(1, max_tiles)));
 
   c2h::device_vector<message_t> tile_data(num_tiles);
   message_t* d_tile_data = thrust::raw_pointer_cast(tile_data.data());

--- a/cub/test/catch2_test_device_memcpy_batched.cu
+++ b/cub/test/catch2_test_device_memcpy_batched.cu
@@ -48,7 +48,8 @@ try
        {1, 32 * 1024},
        {128 * 1024, 256 * 1024},
        {target_copy_size, target_copy_size}}),
-    take(4,
+    // Use c2h::adjust_seed_count to reduce runtime on sanitizers.
+    take(c2h::adjust_seed_count(4),
          map(
            [](const std::vector<buffer_size_t>& chunk) {
              buffer_size_t lhs = chunk[0];
@@ -112,7 +113,8 @@ catch (std::bad_alloc& e)
   std::cerr << "Caught bad_alloc: " << e.what() << std::endl;
 }
 
-C2H_TEST("DeviceMemcpy::Batched works for a very large buffer", "[memcpy]")
+C2H_TEST("DeviceMemcpy::Batched works for a very large buffer",
+         "[memcpy][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]")
 try
 {
   using data_t        = uint64_t;
@@ -143,7 +145,8 @@ catch (std::bad_alloc& e)
   std::cerr << "Caught bad_alloc: " << e.what() << std::endl;
 }
 
-C2H_TEST("DeviceMemcpy::Batched works for a very large number of buffer", "[memcpy]")
+C2H_TEST("DeviceMemcpy::Batched works for a very large number of buffer",
+         "[memcpy][skip-cs-racecheck][skip-cs-initcheck][skip-cs-synccheck]")
 try
 {
   using src_ptr_t       = const cuda::std::uint8_t*;

--- a/cub/test/catch2_test_device_merge.cu
+++ b/cub/test/catch2_test_device_merge.cu
@@ -64,7 +64,8 @@ C2H_TEST("DeviceMerge::MergeKeys key types", "[merge][device]", types)
   test_keys<key_t, offset_t>();
 }
 
-C2H_TEST("DeviceMerge::MergeKeys works for large number of items", "[merge][device]")
+C2H_TEST("DeviceMerge::MergeKeys works for large number of items",
+         "[merge][device][skip-cs-racecheck][skip-cs-initcheck][skip-cs-synccheck]")
 try
 {
   using key_t    = char;
@@ -252,7 +253,8 @@ C2H_TEST("DeviceMerge::MergePairs input sizes", "[merge][device]")
 }
 
 // this test exceeds 4GiB of memory and the range of 32-bit integers
-C2H_TEST("DeviceMerge::MergePairs really large input", "[merge][device]")
+C2H_TEST("DeviceMerge::MergePairs really large input",
+         "[merge][device][skip-cs-racecheck][skip-cs-initcheck][skip-cs-synccheck]")
 try
 {
   using key_t     = char;

--- a/cub/test/catch2_test_device_merge_sort.cu
+++ b/cub/test/catch2_test_device_merge_sort.cu
@@ -219,14 +219,18 @@ c2h::device_vector<OffsetT> make_shuffled_key_ranks_vector(OffsetT num_items, c2
   return key_ranks;
 }
 
-C2H_TEST("DeviceMergeSort::SortKeysCopy works", "[merge][sort][device]", wide_key_types)
+C2H_TEST("DeviceMergeSort::SortKeysCopy works",
+         "[merge][sort][device][skip-cs-racecheck][skip-cs-memcheck]",
+         wide_key_types)
 {
   using key_t    = typename c2h::get<0, TestType>;
   using offset_t = std::int32_t;
 
   // Prepare input
-  const offset_t num_items = GENERATE_COPY(take(2, random(1, 1000000)), values({500, 1000000, 2000000}));
-  auto key_ranks           = make_shuffled_key_ranks_vector(num_items, C2H_SEED(2));
+  // Use c2h::adjust_seed_count to reduce runtime on sanitizers.
+  const offset_t num_items =
+    GENERATE_COPY(take(c2h::adjust_seed_count(2), random(1, 1000000)), values({500, 1000000, 2000000}));
+  auto key_ranks = make_shuffled_key_ranks_vector(num_items, C2H_SEED(2));
   c2h::device_vector<key_t> keys_in(num_items);
   thrust::transform(
     c2h::device_policy, key_ranks.begin(), key_ranks.end(), keys_in.begin(), rank_to_key_op_t<offset_t, key_t>{});
@@ -249,8 +253,10 @@ C2H_TEST("DeviceMergeSort::SortKeys works", "[merge][sort][device]", wide_key_ty
   using offset_t = std::int32_t;
 
   // Prepare input
-  const offset_t num_items = GENERATE_COPY(take(2, random(1, 1000000)), values({500, 1000000, 2000000}));
-  auto key_ranks           = make_shuffled_key_ranks_vector(num_items, C2H_SEED(2));
+  // Use c2h::adjust_seed_count to reduce runtime on sanitizers.
+  const offset_t num_items =
+    GENERATE_COPY(take(c2h::adjust_seed_count(2), random(1, 1000000)), values({500, 1000000, 2000000}));
+  auto key_ranks = make_shuffled_key_ranks_vector(num_items, C2H_SEED(2));
   c2h::device_vector<key_t> keys_in_out(num_items);
   thrust::transform(
     c2h::device_policy, key_ranks.begin(), key_ranks.end(), keys_in_out.begin(), rank_to_key_op_t<offset_t, key_t>{});
@@ -267,13 +273,15 @@ C2H_TEST("DeviceMergeSort::SortKeys works", "[merge][sort][device]", wide_key_ty
 
 C2H_TEST("DeviceMergeSort::StableSortKeysCopy works and performs a stable sort when there are a lot sort-keys that "
          "compare equal",
-         "[merge][sort][device]")
+         "[merge][sort][device][skip-cs-racecheck][skip-cs-memcheck]")
 {
   using key_t    = c2h::custom_type_t<c2h::equal_comparable_t, c2h::less_comparable_t>;
   using offset_t = std::size_t;
 
   // Prepare input (generate a items that compare equally to check for stability of sort)
-  const offset_t num_items = GENERATE_COPY(take(2, random(1, 1000000)), values({500, 1000000, 2000000}));
+  // Use c2h::adjust_seed_count to reduce runtime on sanitizers.
+  const offset_t num_items =
+    GENERATE_COPY(take(c2h::adjust_seed_count(2), random(1, 1000000)), values({500, 1000000, 2000000}));
   c2h::device_vector<offset_t> key_ranks(num_items);
   c2h::gen(C2H_SEED(2), key_ranks, offset_t{}, static_cast<offset_t>(128));
   c2h::device_vector<key_t> keys_in(num_items);
@@ -300,7 +308,9 @@ C2H_TEST("DeviceMergeSort::StableSortKeys works", "[merge][sort][device]")
   using offset_t = std::int32_t;
 
   // Prepare input
-  const offset_t num_items = GENERATE_COPY(take(2, random(1, 1000000)), values({500, 1000000, 2000000}));
+  // Use c2h::adjust_seed_count to reduce runtime on sanitizers.
+  const offset_t num_items =
+    GENERATE_COPY(take(c2h::adjust_seed_count(2), random(1, 1000000)), values({500, 1000000, 2000000}));
   c2h::device_vector<key_t> keys_in_out(num_items);
   c2h::gen(C2H_SEED(2), keys_in_out);
 
@@ -314,14 +324,18 @@ C2H_TEST("DeviceMergeSort::StableSortKeys works", "[merge][sort][device]")
   REQUIRE(keys_expected == keys_in_out);
 }
 
-C2H_TEST("DeviceMergeSort::SortPairsCopy works", "[merge][sort][device]", wide_key_types)
+C2H_TEST("DeviceMergeSort::SortPairsCopy works",
+         "[merge][sort][device][skip-cs-racecheck][skip-cs-memcheck]",
+         wide_key_types)
 {
   using key_t    = typename c2h::get<0, TestType>;
   using offset_t = std::int32_t;
 
   // Prepare input
-  const offset_t num_items = GENERATE_COPY(take(2, random(1, 1000000)), values({500, 1000000, 2000000}));
-  auto key_ranks           = make_shuffled_key_ranks_vector(num_items, C2H_SEED(2));
+  // Use c2h::adjust_seed_count to reduce runtime on sanitizers.
+  const offset_t num_items =
+    GENERATE_COPY(take(c2h::adjust_seed_count(2), random(1, 1000000)), values({500, 1000000, 2000000}));
+  auto key_ranks = make_shuffled_key_ranks_vector(num_items, C2H_SEED(2));
   c2h::device_vector<key_t> keys_in(num_items);
   thrust::transform(
     c2h::device_policy, key_ranks.begin(), key_ranks.end(), keys_in.begin(), rank_to_key_op_t<offset_t, key_t>{});
@@ -353,8 +367,10 @@ C2H_TEST("DeviceMergeSort::SortPairs works", "[merge][sort][device]", wide_key_t
   using offset_t = std::int32_t;
 
   // Prepare input
-  const offset_t num_items = GENERATE_COPY(take(2, random(1, 1000000)), values({500, 1000000, 2000000}));
-  auto key_ranks           = make_shuffled_key_ranks_vector(num_items, C2H_SEED(2));
+  // Use c2h::adjust_seed_count to reduce runtime on sanitizers.
+  const offset_t num_items =
+    GENERATE_COPY(take(c2h::adjust_seed_count(2), random(1, 1000000)), values({500, 1000000, 2000000}));
+  auto key_ranks = make_shuffled_key_ranks_vector(num_items, C2H_SEED(2));
   c2h::device_vector<key_t> keys_in_out(num_items);
   thrust::transform(
     c2h::device_policy, key_ranks.begin(), key_ranks.end(), keys_in_out.begin(), rank_to_key_op_t<offset_t, key_t>{});
@@ -383,7 +399,9 @@ C2H_TEST(
   using offset_t = std::int32_t;
 
   // Prepare input
-  const offset_t num_items = GENERATE_COPY(take(2, random(1, 1000000)), values({500, 1000000, 2000000}));
+  // Use c2h::adjust_seed_count to reduce runtime on sanitizers.
+  const offset_t num_items =
+    GENERATE_COPY(take(c2h::adjust_seed_count(2), random(1, 1000000)), values({500, 1000000, 2000000}));
   c2h::device_vector<key_t> keys_in_out(num_items);
   c2h::device_vector<data_t> values_in_out(num_items);
   c2h::gen(C2H_SEED(2), keys_in_out);
@@ -405,7 +423,9 @@ C2H_TEST(
   REQUIRE(values_expected == values_in_out);
 }
 
-C2H_TEST("DeviceMergeSort::StableSortPairs works for large inputs", "[merge][sort][device]", offset_types)
+C2H_TEST("DeviceMergeSort::StableSortPairs works for large inputs",
+         "[merge][sort][device][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]",
+         offset_types)
 {
   using testing_types_tuple = c2h::get<0, TestType>;
   using key_t               = typename testing_types_tuple::key_t;

--- a/cub/test/catch2_test_device_partition_flagged.cu
+++ b/cub/test/catch2_test_device_partition_flagged.cu
@@ -402,7 +402,9 @@ C2H_TEST("DevicePartition::Flagged works with different output type", "[device][
   REQUIRE(reference == out);
 }
 
-C2H_TEST("DevicePartition::Flagged works for very large number of items", "[device][partition_flagged]", offset_types)
+C2H_TEST("DevicePartition::Flagged works for very large number of items",
+         "[device][partition_flagged][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]",
+         offset_types)
 try
 {
   using type     = std::int64_t;

--- a/cub/test/catch2_test_device_partition_if.cu
+++ b/cub/test/catch2_test_device_partition_if.cu
@@ -315,7 +315,9 @@ C2H_TEST("DevicePartition::If works with a different output type", "[device][par
   REQUIRE(reference == out);
 }
 
-C2H_TEST("DevicePartition::If works for very large number of items", "[device][partition_if]", offset_types)
+C2H_TEST("DevicePartition::If works for very large number of items",
+         "[device][partition_if][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]",
+         offset_types)
 try
 {
   using type     = std::int64_t;

--- a/cub/test/catch2_test_device_radix_sort_custom.cu
+++ b/cub/test/catch2_test_device_radix_sort_custom.cu
@@ -175,7 +175,8 @@ static std::pair<c2h::device_vector<key>, c2h::device_vector<value>> reference_s
 C2H_TEST("Device radix sort works with parts of custom i128_t", "[radix][sort][device]")
 {
   constexpr int max_items = 1 << 18;
-  const int num_items     = GENERATE_COPY(take(4, random(max_items / 2, max_items)));
+  // Use c2h::adjust_seed_count to reduce runtime on sanitizers.
+  const int num_items = GENERATE_COPY(take(c2h::adjust_seed_count(4), random(max_items / 2, max_items)));
 
   c2h::device_vector<key> in_keys(num_items);
   c2h::device_vector<key> out_keys(num_items);
@@ -191,7 +192,8 @@ C2H_TEST("Device radix sort works with parts of custom i128_t", "[radix][sort][d
 C2H_TEST("Device radix descending sort works with custom i128_t", "[radix][sort][device]")
 {
   constexpr int max_items = 1 << 18;
-  const int num_items     = GENERATE_COPY(take(4, random(max_items / 2, max_items)));
+  // Use c2h::adjust_seed_count to reduce runtime on sanitizers.
+  const int num_items = GENERATE_COPY(take(c2h::adjust_seed_count(4), random(max_items / 2, max_items)));
 
   c2h::device_vector<key> in_keys(num_items);
   c2h::device_vector<key> out_keys(num_items);
@@ -222,7 +224,8 @@ C2H_TEST("Device radix descending sort works with custom i128_t", "[radix][sort]
 C2H_TEST("Device radix sort can sort pairs with custom i128_t keys", "[radix][sort][device]")
 {
   constexpr int max_items = 1 << 18;
-  const int num_items     = GENERATE_COPY(take(4, random(max_items / 2, max_items)));
+  // Use c2h::adjust_seed_count to reduce runtime on sanitizers.
+  const int num_items = GENERATE_COPY(take(c2h::adjust_seed_count(4), random(max_items / 2, max_items)));
 
   c2h::device_vector<key> in_keys(num_items);
   c2h::device_vector<key> out_keys(num_items);
@@ -262,7 +265,8 @@ C2H_TEST("Device radix sort can sort pairs with custom i128_t keys", "[radix][so
 C2H_TEST("Device radix sort works with custom i128_t (db)", "[radix][sort][device]")
 {
   constexpr int max_items = 1 << 18;
-  const int num_items     = GENERATE_COPY(take(4, random(max_items / 2, max_items)));
+  // Use c2h::adjust_seed_count to reduce runtime on sanitizers.
+  const int num_items = GENERATE_COPY(take(c2h::adjust_seed_count(4), random(max_items / 2, max_items)));
 
   c2h::device_vector<key> keys_1(num_items);
   c2h::device_vector<key> keys_2(num_items);
@@ -291,7 +295,8 @@ C2H_TEST("Device radix sort works with custom i128_t (db)", "[radix][sort][devic
 C2H_TEST("Device radix sort works with custom i128_t keys (db)", "[radix][sort][device]")
 {
   constexpr int max_items = 1 << 18;
-  const int num_items     = GENERATE_COPY(take(4, random(max_items / 2, max_items)));
+  // Use c2h::adjust_seed_count to reduce runtime on sanitizers.
+  const int num_items = GENERATE_COPY(take(c2h::adjust_seed_count(4), random(max_items / 2, max_items)));
 
   c2h::device_vector<key> keys_1(num_items);
   c2h::device_vector<key> keys_2(num_items);
@@ -332,15 +337,16 @@ C2H_TEST("Device radix sort works with custom i128_t keys (db)", "[radix][sort][
 C2H_TEST("Device radix descending sort works with bits of custom i128_t", "[radix][sort][device]")
 {
   constexpr int max_items = 1 << 18;
-  const int num_items     = GENERATE_COPY(take(1, random(max_items / 2, max_items)));
+
+  // Use c2h::adjust_seed_count to reduce runtime on sanitizers.
+  const int num_items      = GENERATE_COPY(take(c2h::adjust_seed_count(1), random(max_items / 2, max_items)));
+  const int begin_bit      = GENERATE_COPY(take(c2h::adjust_seed_count(4), random(0, 120)));
+  const int end_bit        = GENERATE_COPY(take(c2h::adjust_seed_count(4), random(begin_bit, 128)));
+  const bool is_descending = GENERATE(false, true);
 
   c2h::device_vector<key> in_keys(num_items);
   c2h::device_vector<key> out_keys(num_items);
   c2h::gen(C2H_SEED(2), in_keys);
-
-  const int begin_bit      = GENERATE_COPY(take(4, random(0, 120)));
-  const int end_bit        = GENERATE_COPY(take(4, random(begin_bit, 128)));
-  const bool is_descending = GENERATE(false, true);
 
   auto reference_keys = reference_sort_keys(in_keys, is_descending, begin_bit, end_bit);
 
@@ -370,7 +376,12 @@ C2H_TEST("Device radix descending sort works with bits of custom i128_t", "[radi
 C2H_TEST("Device radix sort can sort pairs with bits of custom i128_t keys", "[radix][sort][device]")
 {
   constexpr int max_items = 1 << 18;
-  const int num_items     = GENERATE_COPY(take(1, random(max_items / 2, max_items)));
+
+  // Use c2h::adjust_seed_count to reduce runtime on sanitizers.
+  const int num_items      = GENERATE_COPY(take(c2h::adjust_seed_count(1), random(max_items / 2, max_items)));
+  const int begin_bit      = GENERATE_COPY(take(c2h::adjust_seed_count(4), random(0, 120)));
+  const int end_bit        = GENERATE_COPY(take(c2h::adjust_seed_count(4), random(begin_bit, 128)));
+  const bool is_descending = GENERATE(false, true);
 
   c2h::device_vector<key> in_keys(num_items);
   c2h::device_vector<key> out_keys(num_items);
@@ -379,10 +390,6 @@ C2H_TEST("Device radix sort can sort pairs with bits of custom i128_t keys", "[r
   c2h::device_vector<value> out_values(num_items);
   c2h::gen(C2H_SEED(2), in_keys);
   c2h::gen(C2H_SEED(1), in_values);
-
-  const int begin_bit      = GENERATE_COPY(take(4, random(0, 120)));
-  const int end_bit        = GENERATE_COPY(take(4, random(begin_bit, 128)));
-  const bool is_descending = GENERATE(false, true);
 
   auto reference = reference_sort_pairs(in_keys, in_values, is_descending, begin_bit, end_bit);
 
@@ -418,7 +425,10 @@ C2H_TEST("Device radix sort can sort pairs with bits of custom i128_t keys", "[r
 C2H_TEST("Device radix sort works with bits of custom i128_t (db)", "[radix][sort][device]")
 {
   constexpr int max_items = 1 << 18;
-  const int num_items     = GENERATE_COPY(take(4, random(max_items / 2, max_items)));
+  // Use c2h::adjust_seed_count to reduce runtime on sanitizers.
+  const int num_items = GENERATE_COPY(take(c2h::adjust_seed_count(1), random(max_items / 2, max_items)));
+  const int begin_bit = GENERATE_COPY(take(c2h::adjust_seed_count(4), random(0, 120)));
+  const int end_bit   = GENERATE_COPY(take(c2h::adjust_seed_count(4), random(begin_bit, 128)));
 
   c2h::device_vector<key> keys_1(num_items);
   c2h::device_vector<key> keys_2(num_items);
@@ -429,8 +439,6 @@ C2H_TEST("Device radix sort works with bits of custom i128_t (db)", "[radix][sor
 
   cub::DoubleBuffer<key> keys(d_keys_1, d_keys_2);
 
-  const int begin_bit      = GENERATE_COPY(take(4, random(0, 120)));
-  const int end_bit        = GENERATE_COPY(take(4, random(begin_bit, 128)));
   const bool is_descending = GENERATE(false, true);
 
   auto reference_keys = reference_sort_keys(keys_1, is_descending, begin_bit, end_bit);
@@ -450,7 +458,11 @@ C2H_TEST("Device radix sort works with bits of custom i128_t (db)", "[radix][sor
 C2H_TEST("Device radix sort works with bits of custom i128_t keys (db)", "[radix][sort][device]")
 {
   constexpr int max_items = 1 << 18;
-  const int num_items     = GENERATE_COPY(take(4, random(max_items / 2, max_items)));
+  // Use c2h::adjust_seed_count to reduce runtime on sanitizers.
+  const int num_items      = GENERATE_COPY(take(c2h::adjust_seed_count(1), random(max_items / 2, max_items)));
+  const int begin_bit      = GENERATE_COPY(take(c2h::adjust_seed_count(4), random(0, 120)));
+  const int end_bit        = GENERATE_COPY(take(c2h::adjust_seed_count(4), random(begin_bit, 128)));
+  const bool is_descending = GENERATE(false, true);
 
   c2h::device_vector<key> keys_1(num_items);
   c2h::device_vector<key> keys_2(num_items);
@@ -468,10 +480,6 @@ C2H_TEST("Device radix sort works with bits of custom i128_t keys (db)", "[radix
 
   cub::DoubleBuffer<key> keys(d_keys_1, d_keys_2);
   cub::DoubleBuffer<value> values(d_values_1, d_values_2);
-
-  const int begin_bit      = GENERATE_COPY(take(4, random(0, 120)));
-  const int end_bit        = GENERATE_COPY(take(4, random(begin_bit, 128)));
-  const bool is_descending = GENERATE(false, true);
 
   auto reference_keys = reference_sort_pairs(keys_1, values_1, is_descending, begin_bit, end_bit);
 

--- a/cub/test/catch2_test_device_radix_sort_keys.cu
+++ b/cub/test/catch2_test_device_radix_sort_keys.cu
@@ -508,7 +508,9 @@ void do_large_offset_test(std::size_t num_items)
   }
 }
 
-C2H_TEST("DeviceRadixSort::SortKeys: 32-bit overflow check", "[large][keys][radix][sort][device]", single_key_type)
+C2H_TEST("DeviceRadixSort::SortKeys: 32-bit overflow check",
+         "[large][keys][radix][sort][device][skip-cs-synccheck][skip-cs-initcheck][skip-cs-racecheck]",
+         single_key_type)
 {
   using key_t       = c2h::get<0, TestType>;
   using num_items_t = std::uint32_t;
@@ -523,7 +525,9 @@ C2H_TEST("DeviceRadixSort::SortKeys: 32-bit overflow check", "[large][keys][radi
   do_large_offset_test<key_t, num_items_t>(num_items);
 }
 
-C2H_TEST("DeviceRadixSort::SortKeys: Large Offsets", "[large][keys][radix][sort][device]", single_key_type)
+C2H_TEST("DeviceRadixSort::SortKeys: Large Offsets",
+         "[large][keys][radix][sort][device][skip-cs-synccheck][skip-cs-initcheck][skip-cs-racecheck]",
+         single_key_type)
 {
   using key_t       = c2h::get<0, TestType>;
   using num_items_t = std::uint64_t;

--- a/cub/test/catch2_test_device_radix_sort_pairs.cu
+++ b/cub/test/catch2_test_device_radix_sort_pairs.cu
@@ -195,7 +195,8 @@ void do_large_offset_test(std::size_t num_items)
   }
 }
 
-C2H_TEST("DeviceRadixSort::SortPairs: 32-bit overflow check", "[large][pairs][radix][sort][device]")
+C2H_TEST("DeviceRadixSort::SortPairs: 32-bit overflow check",
+         "[large][pairs][radix][sort][device][skip-cs-initcheck][skip-cs-racecheck]")
 {
   using key_t       = std::uint8_t;
   using value_t     = std::uint8_t;
@@ -207,7 +208,8 @@ C2H_TEST("DeviceRadixSort::SortPairs: 32-bit overflow check", "[large][pairs][ra
   do_large_offset_test<key_t, value_t, num_items_t>(num_items);
 }
 
-C2H_TEST("DeviceRadixSort::SortPairs: Large Offsets", "[large][pairs][radix][sort][device]")
+C2H_TEST("DeviceRadixSort::SortPairs: Large Offsets",
+         "[large][pairs][radix][sort][device][skip-cs-initcheck][skip-cs-racecheck]")
 {
   using key_t       = std::uint8_t;
   using value_t     = std::uint8_t;

--- a/cub/test/catch2_test_device_run_length_encode.cu
+++ b/cub/test/catch2_test_device_run_length_encode.cu
@@ -290,7 +290,9 @@ C2H_TEST("DeviceRunLengthEncode::Encode can handle leading NaN", "[device][run_l
   REQUIRE(out_num_runs == reference_num_runs);
 }
 
-C2H_TEST("DeviceRunLengthEncode::Encode works for a large number of items", "[device][run_length_encode]", offset_types)
+C2H_TEST("DeviceRunLengthEncode::Encode works for a large number of items",
+         "[device][run_length_encode][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]",
+         offset_types)
 try
 {
   using offset_type     = typename c2h::get<0, TestType>;
@@ -348,7 +350,7 @@ catch (std::bad_alloc& e)
 }
 
 C2H_TEST("DeviceRunLengthEncode::Encode works for large runs of equal items",
-         "[device][run_length_encode]",
+         "[device][run_length_encode][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]",
          offset_types)
 try
 {

--- a/cub/test/catch2_test_device_scan_by_key.cu
+++ b/cub/test/catch2_test_device_scan_by_key.cu
@@ -92,8 +92,9 @@ C2H_TEST("Device scan works with all device interfaces", "[by_key][scan][device]
   constexpr offset_t max_items = 1000000;
 
   // Generate the input sizes to test for
+  // Use c2h::adjust_seed_count to reduce runtime on sanitizers.
   const offset_t num_items = GENERATE_COPY(
-    take(2, random(min_items, max_items)),
+    take(c2h::adjust_seed_count(2), random(min_items, max_items)),
     values({
       min_items,
       max_items,
@@ -278,8 +279,9 @@ C2H_TEST("Device scan works when memory for keys and results alias one another",
   constexpr offset_t max_items = 1000000;
 
   // Generate the input sizes to test for
+  // Use c2h::adjust_seed_count to reduce runtime on sanitizers.
   const offset_t num_items = GENERATE_COPY(
-    take(2, random(min_items, max_items)),
+    take(c2h::adjust_seed_count(2), random(min_items, max_items)),
     values({
       min_items,
       max_items,

--- a/cub/test/catch2_test_device_segmented_radix_sort_keys.cu
+++ b/cub/test/catch2_test_device_segmented_radix_sort_keys.cu
@@ -101,8 +101,11 @@ C2H_TEST("DeviceSegmentedRadixSort::SortKeys: basic testing",
 
   constexpr std::size_t min_num_items = 1 << 5;
   constexpr std::size_t max_num_items = 1 << 20;
-  const std::size_t num_items         = GENERATE_COPY(take(3, random(min_num_items, max_num_items)));
-  const std::size_t num_segments      = GENERATE_COPY(take(2, random(std::size_t{2}, num_items / 2)));
+
+  // Use c2h::adjust_seed_count() to reduce cost when running sanitizers:
+  const std::size_t num_items = GENERATE_COPY(take(c2h::adjust_seed_count(3), random(min_num_items, max_num_items)));
+  const std::size_t num_segments =
+    GENERATE_COPY(take(c2h::adjust_seed_count(2), random(std::size_t{2}, num_items / 2)));
 
   c2h::device_vector<key_t> in_keys(num_items);
   const int num_key_seeds = 1;
@@ -218,8 +221,9 @@ C2H_TEST("DeviceSegmentedRadixSort::SortKeys: bit windows",
 
   constexpr std::size_t min_num_items = 1 << 5;
   constexpr std::size_t max_num_items = 1 << 20;
-  const std::size_t num_items         = GENERATE_COPY(take(2, random(min_num_items, max_num_items)));
-  const std::size_t num_segments      = GENERATE_COPY(take(1, random(std::size_t{2}, num_items / 2)));
+
+  const std::size_t num_items    = GENERATE_COPY(take(c2h::adjust_seed_count(2), random(min_num_items, max_num_items)));
+  const std::size_t num_segments = GENERATE_COPY(take(1, random(std::size_t{2}, num_items / 2)));
 
   c2h::device_vector<key_t> in_keys(num_items);
   const int num_key_seeds = 1;
@@ -287,8 +291,10 @@ C2H_TEST("DeviceSegmentedRadixSort::SortKeys: large segments", "[keys][segmented
 
   constexpr std::size_t min_num_items = 1 << 19;
   constexpr std::size_t max_num_items = 1 << 20;
-  const std::size_t num_items         = GENERATE_COPY(take(2, random(min_num_items, max_num_items)));
-  const std::size_t num_segments      = 2;
+
+  // Use c2h::adjust_seed_count to reduce cost when running sanitizers:
+  const std::size_t num_items    = GENERATE_COPY(take(c2h::adjust_seed_count(2), random(min_num_items, max_num_items)));
+  const std::size_t num_segments = 2;
 
   c2h::device_vector<key_t> in_keys(num_items);
   c2h::device_vector<key_t> out_keys(num_items);
@@ -463,7 +469,7 @@ C2H_TEST("DeviceSegmentedRadixSort::SortKeys: unspecified ranges",
 }
 
 C2H_TEST("DeviceSegmentedRadixSort::SortKeys: very large num. items and num. segments",
-         "[keys][segmented][radix][sort][device]",
+         "[keys][segmented][radix][sort][device][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]",
          all_offset_types)
 try
 {
@@ -512,7 +518,7 @@ catch (std::bad_alloc& e)
 // Currently, size of a single segment in DeviceRadixSort is limited to INT_MAX
 #  if defined(CCCL_TEST_ENABLE_LARGE_SEGMENTED_SORT)
 C2H_TEST("DeviceSegmentedRadixSort::SortKeys: very large segments",
-         "[keys][segmented][radix][sort][device]",
+         "[keys][segmented][radix][sort][device][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]",
          all_offset_types)
 try
 {

--- a/cub/test/catch2_test_device_segmented_radix_sort_pairs.cu
+++ b/cub/test/catch2_test_device_segmented_radix_sort_pairs.cu
@@ -63,8 +63,11 @@ C2H_TEST("DeviceSegmentedRadixSort::SortPairs: Basic testing",
 
   constexpr std::size_t min_num_items = 1 << 5;
   constexpr std::size_t max_num_items = 1 << 20;
-  const std::size_t num_items         = GENERATE_COPY(take(3, random(min_num_items, max_num_items)));
-  const std::size_t num_segments      = GENERATE_COPY(take(2, random(std::size_t{2}, num_items / 2)));
+
+  // Use c2h::adjust_seed_count to reduce runtime with sanitizers:
+  const std::size_t num_items = GENERATE_COPY(take(c2h::adjust_seed_count(3), random(min_num_items, max_num_items)));
+  const std::size_t num_segments =
+    GENERATE_COPY(take(c2h::adjust_seed_count(2), random(std::size_t{2}, num_items / 2)));
 
   c2h::device_vector<key_t> in_keys(num_items);
   const int num_key_seeds = 1;
@@ -278,7 +281,7 @@ C2H_TEST("DeviceSegmentedRadixSort::SortPairs: unspecified ranges",
 }
 
 C2H_TEST("DeviceSegmentedSortPairs: very large num. items and num. segments",
-         "[pairs][segmented][sort][device]",
+         "[pairs][segmented][sort][device][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]",
          all_offset_types)
 try
 {
@@ -337,7 +340,9 @@ catch (std::bad_alloc& e)
 
 // Currently, size of a single segment in DeviceRadixSort is limited to INT_MAX
 #if defined(CCCL_TEST_ENABLE_LARGE_SEGMENTED_SORT)
-C2H_TEST("DeviceSegmentedSort::SortPairs: very large segments", "[pairs][segmented][sort][device]", all_offset_types)
+C2H_TEST("DeviceSegmentedSort::SortPairs: very large segments",
+         "[pairs][segmented][sort][device][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]",
+         all_offset_types)
 try
 {
   using key_t                      = cuda::std::uint8_t; // minimize memory footprint to support a wider range of GPUs

--- a/cub/test/catch2_test_device_segmented_reduce.cu
+++ b/cub/test/catch2_test_device_segmented_reduce.cu
@@ -90,8 +90,9 @@ C2H_TEST("Device reduce works with all device interfaces", "[segmented][reduce][
   constexpr int max_items = 1000000;
 
   // Number of items
+  // Use c2h::adjust_seed_count to reduce runtime on sanitizers.
   const int num_items = GENERATE_COPY(
-    take(2, random(min_items, max_items)),
+    take(c2h::adjust_seed_count(2), random(min_items, max_items)),
     values({
       min_items,
       max_items,
@@ -267,11 +268,12 @@ C2H_TEST("Device fixed size segmented reduce works with all device interfaces",
 
   const int max_items = 1 << 22;
 
+  // Use c2h::adjust_seed_count to reduce runtime on sanitizers.
   const segment_size_t segment_size = GENERATE_COPY(
-    take(2, random(1 << 0, 1 << 5)),
-    take(2, random(1 << 5, 1 << 10)),
-    take(2, random(1 << 10, 1 << 15)),
-    take(2, random(1 << 15, 1 << 20)));
+    take(c2h::adjust_seed_count(2), random(1 << 0, 1 << 5)),
+    take(c2h::adjust_seed_count(2), random(1 << 5, 1 << 10)),
+    take(c2h::adjust_seed_count(2), random(1 << 10, 1 << 15)),
+    take(c2h::adjust_seed_count(2), random(1 << 15, 1 << 20)));
 
   const int num_segments = max_items / segment_size;
   const int num_items    = num_segments * segment_size;

--- a/cub/test/catch2_test_device_segmented_sort_keys.cu
+++ b/cub/test/catch2_test_device_segmented_sort_keys.cu
@@ -126,45 +126,55 @@ C2H_TEST("DeviceSegmentedSortKeys: Empty segments", "[keys][segmented][sort][dev
   REQUIRE(values_buffer.selector == 1);
 }
 
-C2H_TEST("DeviceSegmentedSortKeys: Same size segments, derived keys", "[keys][segmented][sort][device]", key_types)
+C2H_TEST("DeviceSegmentedSortKeys: Same size segments, derived keys",
+         "[keys][segmented][sort][device][skip-cs-racecheck]",
+         key_types)
 {
   using KeyT = c2h::get<0, TestType>;
 
+  // Use adjust_seed_count to limit the number of passes run during sanitizer tests.
   const int segment_size = GENERATE_COPY(
-    take(2, random(1 << 0, 1 << 5)), //
-    take(2, random(1 << 5, 1 << 10)),
-    take(2, random(1 << 10, 1 << 15)));
+    take(c2h::adjust_seed_count(2), random(1 << 0, 1 << 5)), //
+    take(c2h::adjust_seed_count(2), random(1 << 5, 1 << 10)),
+    take(c2h::adjust_seed_count(2), random(1 << 10, 1 << 15)));
 
-  const int segments = GENERATE_COPY(take(2, random(1 << 0, 1 << 5)), //
-                                     take(2, random(1 << 5, 1 << 10)));
+  const int segments = GENERATE_COPY( //
+    take(c2h::adjust_seed_count(2), random(1 << 0, 1 << 5)), //
+    take(c2h::adjust_seed_count(2), random(1 << 5, 1 << 10)));
 
   test_same_size_segments_derived<KeyT>(segment_size, segments);
 }
 
-C2H_TEST("DeviceSegmentedSortKeys: Randomly sized segments, derived keys", "[keys][segmented][sort][device]", key_types)
+C2H_TEST("DeviceSegmentedSortKeys: Randomly sized segments, derived keys",
+         "[keys][segmented][sort][device][skip-cs-racecheck]",
+         key_types)
 {
   using KeyT = c2h::get<0, TestType>;
 
   const int max_items   = 1 << 22;
   const int max_segment = 6000;
 
+  // Use adjust_seed_count to limit the number of passes run during sanitizer tests.
   const int segments = GENERATE_COPY(
-    take(2, random(1 << 0, 1 << 5)), //
-    take(2, random(1 << 5, 1 << 10)),
-    take(2, random(1 << 10, 1 << 15)),
-    take(2, random(1 << 15, 1 << 20)));
+    take(c2h::adjust_seed_count(2), random(1 << 0, 1 << 5)), //
+    take(c2h::adjust_seed_count(2), random(1 << 5, 1 << 10)),
+    take(c2h::adjust_seed_count(2), random(1 << 10, 1 << 15)),
+    take(c2h::adjust_seed_count(2), random(1 << 15, 1 << 20)));
 
   test_random_size_segments_derived<KeyT>(C2H_SEED(1), max_items, max_segment, segments);
 }
 
-C2H_TEST("DeviceSegmentedSortKeys: Randomly sized segments, random keys", "[keys][segmented][sort][device]", key_types)
+C2H_TEST("DeviceSegmentedSortKeys: Randomly sized segments, random keys",
+         "[keys][segmented][sort][device][skip-cs-initcheck][skip-cs-racecheck]",
+         key_types)
 {
   using KeyT = c2h::get<0, TestType>;
 
   const int max_items   = 1 << 22;
   const int max_segment = 6000;
 
-  const int segments = GENERATE_COPY(take(2, random(1 << 15, 1 << 20)));
+  // Use adjust_seed_count to limit the number of passes run during sanitizer tests.
+  const int segments = GENERATE_COPY(take(c2h::adjust_seed_count(2), random(1 << 15, 1 << 20)));
 
   test_random_size_segments_random<KeyT>(C2H_SEED(1), max_items, max_segment, segments);
 }
@@ -181,7 +191,9 @@ C2H_TEST("DeviceSegmentedSortKeys: Unspecified segments, random keys", "[keys][s
   test_unspecified_segments_random<KeyT>(C2H_SEED(4));
 }
 
-C2H_TEST("DeviceSegmentedSortKeys: very large number of segments", "[keys][segmented][sort][device]", all_offset_types)
+C2H_TEST("DeviceSegmentedSortKeys: very large number of segments",
+         "[keys][segmented][sort][device][skip-cs-memcheck][skip-cs-racecheck][skip-cs-initcheck]",
+         all_offset_types)
 try
 {
   using key_t                        = cuda::std::uint8_t; // minimize memory footprint to support a wider range of GPUs
@@ -224,7 +236,9 @@ catch (std::bad_alloc& e)
   std::cerr << "Skipping segmented sort test, insufficient GPU memory. " << e.what() << "\n";
 }
 
-C2H_TEST("DeviceSegmentedSort::SortKeys: very large segments", "[keys][segmented][sort][device]", all_offset_types)
+C2H_TEST("DeviceSegmentedSort::SortKeys: very large segments",
+         "[keys][segmented][sort][device][skip-cs-memcheck][skip-cs-racecheck][skip-cs-initcheck]",
+         all_offset_types)
 try
 {
   using key_t                      = cuda::std::uint8_t; // minimize memory footprint to support a wider range of GPUs

--- a/cub/test/catch2_test_device_segmented_sort_pairs.cu
+++ b/cub/test/catch2_test_device_segmented_sort_pairs.cu
@@ -123,26 +123,28 @@ C2H_TEST("DeviceSegmentedSortPairs: Empty segments", "[pairs][segmented][sort][d
 }
 
 C2H_TEST("DeviceSegmentedSortPairs: Same size segments, derived keys/values",
-         "[pairs][segmented][sort][device]",
+         "[pairs][segmented][sort][device][skip-cs-racecheck]",
          pair_types)
 {
   using PairT  = c2h::get<0, TestType>;
   using KeyT   = c2h::get<0, PairT>;
   using ValueT = c2h::get<1, PairT>;
 
+  // Use c2h::adjust_seed_count to reduce the number of runs when using sanitizers:
   const int segment_size = GENERATE_COPY(
-    take(2, random(1 << 0, 1 << 5)), //
-    take(2, random(1 << 5, 1 << 10)),
-    take(2, random(1 << 10, 1 << 15)));
+    take(c2h::adjust_seed_count(2), random(1 << 0, 1 << 5)), //
+    take(c2h::adjust_seed_count(2), random(1 << 5, 1 << 10)),
+    take(c2h::adjust_seed_count(2), random(1 << 10, 1 << 15)));
 
-  const int segments = GENERATE_COPY(take(2, random(1 << 0, 1 << 5)), //
-                                     take(2, random(1 << 5, 1 << 10)));
+  const int segments = GENERATE_COPY( //
+    take(c2h::adjust_seed_count(2), random(1 << 0, 1 << 5)), //
+    take(c2h::adjust_seed_count(2), random(1 << 5, 1 << 10)));
 
   test_same_size_segments_derived<KeyT, ValueT>(segment_size, segments);
 }
 
 C2H_TEST("DeviceSegmentedSortPairs: Randomly sized segments, derived keys/values",
-         "[pairs][segmented][sort][device]",
+         "[pairs][segmented][sort][device][skip-cs-racecheck]",
          pair_types)
 {
   using PairT  = c2h::get<0, TestType>;
@@ -152,17 +154,18 @@ C2H_TEST("DeviceSegmentedSortPairs: Randomly sized segments, derived keys/values
   const int max_items   = 1 << 22;
   const int max_segment = 6000;
 
+  // Use c2h::adjust_seed_count to reduce the number of runs when using sanitizers:
   const int segments = GENERATE_COPY(
-    take(2, random(1 << 0, 1 << 5)), //
-    take(2, random(1 << 5, 1 << 10)),
-    take(2, random(1 << 10, 1 << 15)),
-    take(2, random(1 << 15, 1 << 20)));
+    take(c2h::adjust_seed_count(2), random(1 << 0, 1 << 5)), //
+    take(c2h::adjust_seed_count(2), random(1 << 5, 1 << 10)),
+    take(c2h::adjust_seed_count(2), random(1 << 10, 1 << 15)),
+    take(c2h::adjust_seed_count(2), random(1 << 15, 1 << 20)));
 
   test_random_size_segments_derived<KeyT, ValueT>(C2H_SEED(1), max_items, max_segment, segments);
 }
 
 C2H_TEST("DeviceSegmentedSortPairs: Randomly sized segments, random keys/values",
-         "[pairs][segmented][sort][device]",
+         "[pairs][segmented][sort][device][skip-cs-racecheck]",
          pair_types)
 {
   using PairT  = c2h::get<0, TestType>;
@@ -172,7 +175,8 @@ C2H_TEST("DeviceSegmentedSortPairs: Randomly sized segments, random keys/values"
   const int max_items   = 1 << 22;
   const int max_segment = 6000;
 
-  const int segments = GENERATE_COPY(take(2, random(1 << 15, 1 << 20)));
+  // Use c2h::adjust_seed_count to reduce the number of runs when using sanitizers:
+  const int segments = GENERATE_COPY(take(c2h::adjust_seed_count(2), random(1 << 15, 1 << 20)));
 
   test_random_size_segments_random<KeyT, ValueT>(C2H_SEED(1), max_items, max_segment, segments);
 }
@@ -200,7 +204,7 @@ C2H_TEST("DeviceSegmentedSortPairs: Unspecified segments, random key/values",
 }
 
 C2H_TEST("DeviceSegmentedSortPairs: very large num. items and num. segments",
-         "[pairs][segmented][sort][device]",
+         "[pairs][segmented][sort][device][skip-cs-racecheck][skip-cs-initcheck][skip-cs-synccheck]",
          all_offset_types)
 try
 {
@@ -255,7 +259,9 @@ catch (std::bad_alloc& e)
   std::cerr << "Skipping segmented sort test, insufficient GPU memory. " << e.what() << "\n";
 }
 
-C2H_TEST("DeviceSegmentedSort::SortPairs: very large segments", "[pairs][segmented][sort][device]", all_offset_types)
+C2H_TEST("DeviceSegmentedSort::SortPairs: very large segments",
+         "[pairs][segmented][sort][device][skip-cs-racecheck][skip-cs-initcheck][skip-cs-synccheck]",
+         all_offset_types)
 try
 {
   using key_t                      = cuda::std::uint8_t; // minimize memory footprint to support a wider range of GPUs

--- a/cub/test/catch2_test_device_select_flagged.cu
+++ b/cub/test/catch2_test_device_select_flagged.cu
@@ -428,7 +428,8 @@ C2H_TEST("DeviceSelect::Flagged works with a different output type", "[device][s
   REQUIRE(reference == out);
 }
 
-C2H_TEST("DeviceSelect::Flagged works for very large number of items", "[device][select_flagged]")
+C2H_TEST("DeviceSelect::Flagged works for very large number of items",
+         "[device][select_flagged][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]")
 try
 {
   using type     = std::int64_t;

--- a/cub/test/catch2_test_device_select_if.cu
+++ b/cub/test/catch2_test_device_select_if.cu
@@ -327,7 +327,8 @@ C2H_TEST("DeviceSelect::If works with a different output type", "[device][select
   REQUIRE(thrust::all_of(c2h::device_policy, boundary, out.end(), equal_to_default_t{}));
 }
 
-C2H_TEST("DeviceSelect::If works for very large number of items", "[device][select_if]")
+C2H_TEST("DeviceSelect::If works for very large number of items",
+         "[device][select_if][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]")
 try
 {
   using type     = std::int64_t;
@@ -372,7 +373,8 @@ catch (std::bad_alloc&)
   // Exceeding memory is not a failure.
 }
 
-C2H_TEST("DeviceSelect::If works for very large number of output items", "[device][select_if]")
+C2H_TEST("DeviceSelect::If works for very large number of output items",
+         "[device][select_if][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]")
 try
 {
   using type     = std::uint8_t;

--- a/cub/test/catch2_test_device_select_unique.cu
+++ b/cub/test/catch2_test_device_select_unique.cu
@@ -271,7 +271,8 @@ C2H_TEST("DeviceSelect::Unique works with a different output type", "[device][se
   REQUIRE(reference == out);
 }
 
-C2H_TEST("DeviceSelect::Unique works for very large number of items", "[device][select_unique]")
+C2H_TEST("DeviceSelect::Unique works for very large number of items",
+         "[device][select_unique][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]")
 try
 {
   using type     = std::int64_t;

--- a/cub/test/catch2_test_device_three_way_partition.cu
+++ b/cub/test/catch2_test_device_three_way_partition.cu
@@ -462,7 +462,9 @@ C2H_TEST("Device three-way partition handles single output", "[partition][device
   REQUIRE(actual_num_items_in_second_part == num_items_in_second_part);
 }
 
-C2H_TEST("Device three-way partition works for very large number of items", "[device][partition]", offset_types)
+C2H_TEST("Device three-way partition works for very large number of items",
+         "[device][partition][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]",
+         offset_types)
 try
 {
   using offset_t = typename c2h::get<0, TestType>;

--- a/cub/test/catch2_test_device_transform.cu
+++ b/cub/test/catch2_test_device_transform.cu
@@ -188,7 +188,9 @@ using overaligned_types =
 #endif // !_CCCL_COMPILER(MSVC)
                  >;
 
-C2H_TEST("DeviceTransform::Transform works for large number of items", "[device][device_transform]", offset_types)
+C2H_TEST("DeviceTransform::Transform works for large number of items",
+         "[device][device_transform][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]",
+         offset_types)
 {
   using offset_t = c2h::get<0, TestType>;
   CAPTURE(c2h::type_name<offset_t>());
@@ -213,7 +215,7 @@ C2H_TEST("DeviceTransform::Transform works for large number of items", "[device]
 }
 
 C2H_TEST("DeviceTransform::Transform with multiple inputs works for large number of items",
-         "[device][device_transform]",
+         "[device][device_transform][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]",
          offset_types)
 {
   using offset_t = c2h::get<0, TestType>;
@@ -290,7 +292,9 @@ struct times_seven
   }
 };
 
-C2H_TEST("DeviceTransform::Transform with large input", "[device][device_transform]", algorithms)
+C2H_TEST("DeviceTransform::Transform with large input",
+         "[device][device_transform][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]",
+         algorithms)
 try
 {
   using type         = unsigned char;

--- a/cub/test/run_test.cmake
+++ b/cub/test/run_test.cmake
@@ -1,0 +1,144 @@
+#
+# Launch a test, optionally enabling runtime sanitizers, etc.
+#
+
+function(usage)
+  message("Usage:")
+  message("  cmake -D CCCL_SOURCE_DIR=/path/to/cccl \\")
+  message("        -D TEST=bin/test.exe \\")
+  message("        -D ARGS=\"arg1;arg2;arg3\" \\")
+  message("        -D TYPE=Catch2 \\")
+  message("        -D MODE=compute-sanitizer-memcheck \\")
+  message("        -P cccl/cub/test/run_test.cmake")
+  message("")
+  message("  - CCCL_SOURCE_DIR: Required.  Path to the CCCL source directory.")
+  message("  - TEST: Required.  Path to the test executable.")
+  message("  - ARGS: Optional.  Arguments to pass to the test executable.")
+  message("  - TYPE: Optional.")
+  message("    - The test framework used by the test executable.")
+  message("    - Must be one of the following:")
+  message("    -  \"none\" (default)")
+  message("    -  \"Catch2\"")
+  message("  - MODE: Optional.")
+  message("    - May be set through CCCL_TEST_MODE env var.")
+  message("    - Must be one of the following:")
+  message("    -  \"none\" (default)")
+  message("    -  \"compute-sanitizer-memcheck\"")
+  message("    -  \"compute-sanitizer-racecheck\"")
+  message("    -  \"compute-sanitizer-initcheck\"")
+  message("    -  \"compute-sanitizer-synccheck\"")
+endfunction()
+
+# Usage:
+#   run_command(COMMAND [ARGS...])
+#
+# The command is printed before it is executed.
+# The new process's stdout, sterr are redirected to the current process.
+# The current process will exit with an error if the new process exits with a non-zero status.
+function(run_command command)
+  set(command_str "${command}")
+  list(APPEND command_str ${ARGN})
+  list(JOIN command_str " " command_str)
+  message(STATUS ">> Running:\n\t${command_str}")
+  execute_process(COMMAND ${command} ${ARGN} RESULT_VARIABLE result)
+  if (NOT result EQUAL 0)
+    message(FATAL_ERROR ">> Exit Status: ${result}")
+  else()
+    message(STATUS ">> Exit Status: ${result}")
+  endif()
+endfunction()
+
+######################################################################
+
+# Parse arguments
+if(NOT DEFINED TEST)
+  usage()
+  message(FATAL_ERROR "TEST must be defined")
+endif()
+
+if(NOT DEFINED ARGS)
+  set(ARGS)
+endif()
+
+if(NOT DEFINED TYPE)
+  set(TYPE "none")
+endif()
+
+if(NOT DEFINED MODE)
+  if(DEFINED ENV{CCCL_TEST_MODE})
+    message(STATUS "Using CCCL_TEST_MODE from env: $ENV{CCCL_TEST_MODE}")
+    set(MODE $ENV{CCCL_TEST_MODE})
+  else()
+    set(MODE "none")
+  endif()
+elseif(NOT MODE)
+  set(MODE "none")
+endif()
+
+if (MODE STREQUAL "none")
+  run_command(${TEST} ${ARGS})
+elseif (MODE MATCHES "^compute-sanitizer-(.*)$")
+  set(tool ${CMAKE_MATCH_1})
+
+  # All test cases in these tests take an excessive amount of time to execute with the compute-sanitizer tools.
+  # Just skip the whole test.
+  if (("${TEST}" MATCHES "/cub.+test.*large_offsets.*" AND
+       (tool STREQUAL "initcheck" OR tool STREQUAL "racecheck" OR tool STREQUAL "synccheck")) OR
+      # These take >2000s on racecheck to complete, even with reduced seeds, skipping large offsets, etc.
+      ("${TEST}" MATCHES "/cub.+test.device_segmented_(radix_sort|reduce).*" AND
+       (tool STREQUAL "racecheck")))
+    message(FATAL_ERROR "CCCL_SKIP_TEST:\n${TEST} takes an excessive amount of time to execute with ${tool}.")
+  endif()
+
+  # These tests intentionally don't launch any kernels or make any CUDA API calls:
+  if ("${TEST}" MATCHES "/cub.*.test.cdp_variant_state.*")
+    message(FATAL_ERROR "CCCL_SKIP_TEST:\n${TEST} intentionally doesn't use CUDA APIs. Skipping.")
+  endif()
+
+  # The CUB debug test intentionally throws CUDA errors to test error handling:
+  if ("${TEST}" MATCHES "/cub.*test.debug$")
+    message(FATAL_ERROR "CCCL_SKIP_TEST:\n${TEST} intentionally throws CUDA errors. Skipping.")
+  endif()
+
+
+  if (TYPE STREQUAL "Catch2")
+    list(APPEND ARGS
+      "--durations" "yes"
+      "~[skip-cs-${tool}]"
+    )
+  endif()
+
+  # Compile the compute-sanitizer args:
+  set(cs_general_args
+    "--tool" "${tool}"
+    "--suppressions" "${CCCL_SOURCE_DIR}/ci/compute-sanitizer-suppressions.xml"
+    "--check-device-heap" "yes"
+    "--check-bulk-copy" "yes"
+    "--check-exit-code" "yes"
+    "--check-warpgroup-mma" "yes"
+    "--error-exitcode" "1"
+    "--nvtx" "true"
+  )
+  if (tool STREQUAL "memcheck")
+    set(cs_tool_args
+      "--leak-check" "full"
+      "--padding" "512"
+      "--track-stream-ordered-races" "all"
+    )
+  elseif (tool STREQUAL "racecheck")
+    set(cs_tool_args)
+  elseif (tool STREQUAL "initcheck")
+    set(cs_tool_args)
+  elseif(tool STREQUAL "synccheck")
+    set(cs_tool_args)
+  endif()
+
+  run_command(compute-sanitizer
+    ${cs_general_args}
+    ${cs_tool_args}
+    ${TEST} ${ARGS}
+  )
+else()
+  usage()
+  message(FATAL_ERROR "Invalid MODE: ${MODE}")
+endif()


### PR DESCRIPTION
This adds the first round of compute-sanitizer testing to a new weekly CI job. Currently CUB tests are covered.

Results from the most recent test run of these jobs is here: https://github.com/NVIDIA/cccl/actions/runs/14719940501?pr=1879

Fixes #1911.