### PR TITLE
Make `cuda::get_device_address` work with C++ compilers

### DIFF
--- a/libcudacxx/include/cuda/__functional/get_device_address.h
+++ b/libcudacxx/include/cuda/__functional/get_device_address.h
@@ -21,14 +21,16 @@
 #  pragma system_header
 #endif // no system header
 
-#if _CCCL_CUDA_COMPILER(CLANG)
-#  include <cuda_runtime_api.h>
-#endif // _CCCL_CUDA_COMPILER(CLANG)
+#if _CCCL_HAS_CTK()
 
-#include <cuda/std/__cuda/api_wrapper.h>
-#include <cuda/std/__memory/addressof.h>
+#  if !_CCCL_HAS_CUDA_COMPILER() || _CCCL_CUDA_COMPILER(CLANG)
+#    include <cuda_runtime_api.h>
+#  endif // !_CCCL_HAS_CUDA_COMPILER() || _CCCL_CUDA_COMPILER(CLANG)
 
-#include <nv/target>
+#  include <cuda/std/__cuda/api_wrapper.h>
+#  include <cuda/std/__memory/addressof.h>
+
+#  include <nv/target>
 
 _LIBCUDACXX_BEGIN_NAMESPACE_CUDA
 
@@ -38,7 +40,6 @@ _LIBCUDACXX_BEGIN_NAMESPACE_CUDA
 template <class _Tp>
 [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI _Tp* get_device_address(_Tp& __device_object)
 {
-#if _CCCL_HAS_CUDA_COMPILER()
   NV_IF_ELSE_TARGET(
     NV_IS_DEVICE,
     (return _CUDA_VSTD::addressof(__device_object);),
@@ -48,11 +49,10 @@ template <class _Tp>
        &__device_ptr,
        __device_object);
      return static_cast<_Tp*>(__device_ptr);))
-#else // ^^^ _CCCL_HAS_CUDA_COMPILER() ^^^ / vvv !_CCCL_HAS_CUDA_COMPILER() vvv
-  return _CUDA_VSTD::addressof(__device_object);
-#endif // !_CCCL_HAS_CUDA_COMPILER()
 }
 
 _LIBCUDACXX_END_NAMESPACE_CUDA
+
+#endif // _CCCL_HAS_CTK()
 
 #endif // _CUDA___GET_DEVICE_ADDRESS_H


### PR DESCRIPTION
`cuda::get_device_address` uses CUDA runtime API and should be available even when compiling without a CUDA compiler.