### PR TITLE
add a minimally functional execution context for CUDA streams

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -131,6 +131,7 @@ MaxEmptyLinesToKeep: 1
 Macros:
 - _CCCL_TEMPLATE(...)=template<...>
 - _CCCL_REQUIRES(...)=requires (...)
+- _CUDAX_SEMI_PRIVATE=private
 WhitespaceSensitiveMacros:
 - _CCCL_HAS_INCLUDE
 NamespaceIndentation: None

--- a/cudax/examples/CMakeLists.txt
+++ b/cudax/examples/CMakeLists.txt
@@ -27,6 +27,7 @@ function(cudax_add_example target_name_var example_src cudax_target)
   )
   target_compile_options(${example_target} PRIVATE
     "-DLIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE"
+    $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:--expt-relaxed-constexpr --extended-lambda>
   )
 
   cudax_clone_target_properties(${example_target} ${cudax_target})
@@ -67,6 +68,12 @@ foreach(cudax_target IN LISTS cudax_TARGETS)
 
   foreach (example_src IN LISTS example_srcs)
     cudax_add_example(example_target "${example_src}" ${cudax_target})
+    if (${example_src} MATCHES "stdexec")
+      # The stream context needs atomic wait/notify, which is only available on sm70 and above.
+      get_target_property(cuda_arch_list ${example_target} CUDA_ARCHITECTURES)
+      list(REMOVE_ITEM cuda_arch_list "60" "61")
+      set_target_properties(${example_target} PROPERTIES CUDA_ARCHITECTURES "${cuda_arch_list}")
+    endif()
   endforeach()
 endforeach()
 

--- a/cudax/examples/stdexec_stream.cu
+++ b/cudax/examples/stdexec_stream.cu
@@ -1,0 +1,80 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/experimental/execution.cuh>
+
+#include <nv/target>
+
+#include <cstdio>
+
+#include <cuda_runtime_api.h>
+
+namespace cudax = cuda::experimental;
+namespace task  = cudax::execution;
+
+// This example demonstrates how to use the experimental CUDA implementation of
+// C++26's std::execution async tasking framework.
+
+struct say_hello
+{
+  __device__ int operator()() const
+  {
+    printf("Hello from lambda on device!\n");
+    return value;
+  }
+
+  int value;
+};
+
+__host__ void run()
+{
+  try
+  {
+    task::thread_context tctx;
+    task::stream_context sctx;
+    auto sch = sctx.get_scheduler();
+
+    auto start = //
+      task::schedule(sch) // begin work on the GPU
+      | task::then(say_hello{42}) // enqueue a function object on the GPU
+      | task::then([] __device__(int i) noexcept -> int { // enqueue a lambda on the GPU
+          printf("Hello again from lambda on device! i = %d\n", i);
+          return i + 1;
+        })
+      | task::continues_on(tctx.get_scheduler()) // continue work on the CPU
+      | task::then([] __host__ __device__(int i) noexcept -> int { // run a lambda on the CPU
+          NV_IF_TARGET(NV_IS_HOST,
+                       (printf("Hello from lambda on host! i = %d\n", i);),
+                       (printf("OOPS! still on the device! i = %d\n", i);))
+          return i;
+        });
+
+    // run the task, wait for it to finish, and get the result
+    auto [i] = task::sync_wait(std::move(start)).value();
+    printf("All done on the host! result = %d\n", i);
+  }
+  catch (cuda::cuda_error const& e)
+  {
+    std::printf("CUDA error: %s\n", e.what());
+  }
+  catch (std::exception const& e)
+  {
+    std::printf("Exception: %s\n", e.what());
+  }
+  catch (...)
+  {
+    std::printf("Unknown exception\n");
+  }
+}
+
+int main()
+{
+  run();
+}

--- a/cudax/include/cuda/experimental/__execution/conditional.cuh
+++ b/cudax/include/cuda/experimental/__execution/conditional.cuh
@@ -58,7 +58,7 @@ struct _FUNCTION_MUST_RETURN_A_BOOLEAN_TESTABLE_VALUE;
 
 struct _CCCL_TYPE_VISIBILITY_DEFAULT conditional_t
 {
-private:
+  _CUDAX_SEMI_PRIVATE :
   template <class _Pred, class _Then, class _Else>
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __closure;
 

--- a/cudax/include/cuda/experimental/__execution/epilogue.cuh
+++ b/cudax/include/cuda/experimental/__execution/epilogue.cuh
@@ -17,5 +17,9 @@
 #undef _CCCL_IMMOVABLE_OPSTATE
 #undef _CUDAX_ASYNC_PROLOGUE_INCLUDED
 
+#if _CCCL_CUDA_COMPILER(NVHPC)
+_CCCL_NV_DIAG_DEFAULT(cuda_compile)
+#endif // _CCCL_CUDA_COMPILER(NVHPC)
+
 _CCCL_DIAG_POP
 #include <cuda/std/__cccl/epilogue.h>

--- a/cudax/include/cuda/experimental/__execution/let_value.cuh
+++ b/cudax/include/cuda/experimental/__execution/let_value.cuh
@@ -62,7 +62,7 @@ template <__disposition_t _Disposition>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT _CCCL_PREFERRED_NAME(let_value_t) _CCCL_PREFERRED_NAME(let_error_t)
   _CCCL_PREFERRED_NAME(let_stopped_t) __let_t
 {
-private:
+  _CUDAX_SEMI_PRIVATE :
   using _LetTag _CCCL_NODEBUG_ALIAS = decltype(__detail::__let_tag<_Disposition>());
   using _SetTag _CCCL_NODEBUG_ALIAS = decltype(__detail::__set_tag<_Disposition>());
 

--- a/cudax/include/cuda/experimental/__execution/prologue.cuh
+++ b/cudax/include/cuda/experimental/__execution/prologue.cuh
@@ -39,3 +39,16 @@ _CCCL_DIAG_SUPPRESS_MSVC(5246) // missing braces around initializer
 #else // ^^^ _CCCL_COMPILER(GCC) ^^^ / vvv !_CCCL_COMPILER(GCC) vvv
 #  define _CCCL_IMMOVABLE_OPSTATE(_XP) _XP(_XP&&) = delete
 #endif // !_CCCL_COMPILER(GCC)
+
+#if _CCCL_CUDA_COMPILER(NVHPC)
+_CCCL_NV_DIAG_SUPPRESS(cuda_compile)
+#endif // _CCCL_CUDA_COMPILER(NVHPC)
+
+// private and protected nested class types cannot be used as tparams to __global__
+// functions. _CUDAX_SEMI_PRIVATE expands to public when _CCCL_CUDA_COMPILATION() is true,
+// and private otherwise.
+#if _CCCL_CUDA_COMPILATION()
+#  define _CUDAX_SEMI_PRIVATE public
+#else // ^^^ _CCCL_CUDA_COMPILATION() ^^^ / vvv !_CCCL_CUDA_COMPILATION() vvv
+#  define _CUDAX_SEMI_PRIVATE private
+#endif

--- a/cudax/include/cuda/experimental/__execution/queries.cuh
+++ b/cudax/include/cuda/experimental/__execution/queries.cuh
@@ -218,6 +218,29 @@ _CCCL_GLOBAL_CONSTANT struct get_forward_progress_guarantee_t
   }
 } get_forward_progress_guarantee{};
 
+//////////////////////////////////////////////////////////////////////////////////////////
+// get_launch_config: A sender can define this attribute to control the launch configuration
+// of the kernel it will launch when executed on a CUDA stream scheduler.
+_CCCL_GLOBAL_CONSTANT struct get_launch_config_t
+{
+  _CCCL_EXEC_CHECK_DISABLE
+  template <class _Env>
+  [[nodiscard]] _CCCL_API auto operator()(const _Env& __env) const noexcept
+  {
+    if constexpr (__queryable_with<_Env, get_launch_config_t>)
+    {
+      static_assert(noexcept(__env.query(*this)), "The get_launch_config query must be noexcept.");
+      static_assert(__is_specialization_of_v<decltype(__env.query(*this)), kernel_config>,
+                    "The get_launch_config query must return a kernel_config type.");
+      return __env.query(*this);
+    }
+    else
+    {
+      return experimental::make_config(grid_dims<1>, block_dims<1>);
+    }
+  }
+} get_launch_config{};
+
 } // namespace cuda::experimental::execution
 
 #include <cuda/experimental/__execution/epilogue.cuh>

--- a/cudax/include/cuda/experimental/__execution/rcvr_with_env.cuh
+++ b/cudax/include/cuda/experimental/__execution/rcvr_with_env.cuh
@@ -31,6 +31,10 @@ namespace cuda::experimental::execution
 template <class _Rcvr, class _Env>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __rcvr_with_env_t : _Rcvr
 {
+  // If _Env has a value for the `get_scheduler` query, then we must ensure that we report
+  // the domain correctly. Under no circumstances should we forward the `get_domain` query
+  // to the receiver's environment. That environment may have a domain that does not
+  // conform to the scheduler in _Env.
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __env_t
   {
     // Prefer to query _Env
@@ -56,7 +60,8 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __rcvr_with_env_t : _Rcvr
       // forwarding a get_domain query to the parent receiver's environment.
       static_assert(!_CUDA_VSTD::is_same_v<_Query, get_domain_t> || !__queryable_with<_Env, get_scheduler_t>,
                     "_Env specifies a scheduler but not a domain.");
-      return execution::get_env(__rcvr_->__base()).query(_Query{});
+      return __rcvr_->__base().query(_Query{});
+      // return execution::get_env(__rcvr_->__base()).query(_Query{});
     }
 
     __rcvr_with_env_t const* __rcvr_;

--- a/cudax/include/cuda/experimental/__execution/run_loop.cuh
+++ b/cudax/include/cuda/experimental/__execution/run_loop.cuh
@@ -62,7 +62,7 @@ public:
     }
   }
 
-private:
+  _CUDAX_SEMI_PRIVATE :
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __task : __immovable
   {
     using __execute_fn_t _CCCL_NODEBUG_ALIAS = void(__task*) noexcept;

--- a/cudax/include/cuda/experimental/__execution/schedule_from.cuh
+++ b/cudax/include/cuda/experimental/__execution/schedule_from.cuh
@@ -154,7 +154,7 @@ struct __transfer_sndr_t
 
 struct _CCCL_TYPE_VISIBILITY_DEFAULT schedule_from_t
 {
-private:
+  _CUDAX_SEMI_PRIVATE :
   template <class... _As>
   using __set_value_tuple_t _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::__tuple<set_value_t, _CUDA_VSTD::decay_t<_As>...>;
 

--- a/cudax/include/cuda/experimental/__execution/sequence.cuh
+++ b/cudax/include/cuda/experimental/__execution/sequence.cuh
@@ -41,7 +41,7 @@ namespace cuda::experimental::execution
 {
 struct _CCCL_TYPE_VISIBILITY_DEFAULT sequence_t
 {
-private:
+  _CUDAX_SEMI_PRIVATE :
   template <class _Rcvr, class _Sndr1, class _Sndr2>
   struct __args
   {

--- a/cudax/include/cuda/experimental/__execution/starts_on.cuh
+++ b/cudax/include/cuda/experimental/__execution/starts_on.cuh
@@ -55,7 +55,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __sch_env_t
 
 struct starts_on_t
 {
-private:
+  _CUDAX_SEMI_PRIVATE :
   template <class _Rcvr, class _Sch, class _CvSndr>
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __opstate_t : __rcvr_with_env_t<_Rcvr, __sch_env_t<_Sch>>
   {

--- a/cudax/include/cuda/experimental/__execution/stream/adaptor.cuh
+++ b/cudax/include/cuda/experimental/__execution/stream/adaptor.cuh
@@ -1,0 +1,352 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __CUDAX_EXECUTION_STREAM_ADAPTOR
+#define __CUDAX_EXECUTION_STREAM_ADAPTOR
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/atomic>
+#include <cuda/std/__exception/cuda_error.h>
+#include <cuda/std/__memory/addressof.h>
+#include <cuda/std/__memory/unique_ptr.h>
+#include <cuda/std/__tuple_dir/ignore.h>
+#include <cuda/std/__type_traits/is_same.h>
+#include <cuda/std/__type_traits/remove_cvref.h>
+#include <cuda/std/__type_traits/remove_reference.h>
+#include <cuda/std/__type_traits/type_list.h>
+#include <cuda/std/__utility/pod_tuple.h>
+
+#include <cuda/experimental/__detail/utility.cuh>
+#include <cuda/experimental/__execution/completion_signatures.cuh>
+#include <cuda/experimental/__execution/domain.cuh>
+#include <cuda/experimental/__execution/stream/domain.cuh>
+#include <cuda/experimental/__execution/variant.cuh>
+#include <cuda/experimental/__launch/configuration.cuh>
+#include <cuda/experimental/__launch/launch.cuh>
+#include <cuda/experimental/__stream/stream_ref.cuh>
+
+#include <nv/target>
+
+#include <cuda_runtime_api.h>
+
+#include <cuda/experimental/__execution/prologue.cuh>
+
+_CCCL_DIAG_PUSH
+_CCCL_DIAG_SUPPRESS_GCC("-Wattributes")
+
+namespace cuda::experimental::execution::__stream
+{
+template <class _Rcvr>
+struct __completion_fn
+{
+  template <class _Tag, class... _Args>
+  _CCCL_API void operator()(_Tag, _Args&&... __args) const noexcept
+  {
+    _Tag{}(static_cast<_Rcvr&&>(__rcvr_), static_cast<_Args&&>(__args)...);
+  }
+
+  _Rcvr& __rcvr_;
+};
+
+template <class _Rcvr>
+struct __results_visitor
+{
+  template <class _Tuple>
+  _CCCL_API void operator()(_Tuple&& __tuple) const noexcept
+  {
+    _CUDA_VSTD::__apply(__completion_fn<_Rcvr>{__rcvr_}, static_cast<_Tuple&&>(__tuple));
+  }
+
+  _Rcvr& __rcvr_;
+};
+
+template <class _Rcvr, class _Variant>
+struct __state_t
+{
+  _Rcvr __rcvr_;
+  _Variant __results_;
+  stream_ref __stream_;
+  bool __complete_inline_;
+};
+
+template <class _Completions>
+_CCCL_API static constexpr auto __with_cuda_error(_Completions __completions) noexcept
+{
+  return __completions - __eptr_completion() + completion_signatures<set_error_t(cudaError_t)>{};
+}
+
+template <class _Rcvr, class _Variant>
+__launch_bounds__(1) __global__ void __host_complete_fn(__state_t<_Rcvr, _Variant>* __state)
+{
+  _Variant::__visit(__results_visitor<_Rcvr>{__state->__rcvr_}, __state->__results_);
+}
+
+template <class _Env>
+struct __env_t
+{
+  template <class _Query>
+  [[nodiscard]] _CCCL_API constexpr auto query(_Query) const noexcept(__nothrow_queryable_with<_Env, _Query>)
+    -> __query_result_t<_Env, _Query>
+  {
+    return __env_.query(_Query{});
+  }
+
+  [[nodiscard]] _CCCL_API static constexpr auto query(get_domain_t) noexcept -> default_domain
+  {
+    return default_domain{};
+  }
+
+  _Env __env_;
+};
+
+template <class _Rcvr, class _Variant>
+struct __rcvr_t
+{
+  template <class _Tag, class... _Args>
+  _CCCL_API void __complete(_Tag, _Args&&... __args) noexcept
+  {
+    if (__state_->__complete_inline_)
+    {
+      _Tag{}(static_cast<_Rcvr&&>(__state_->__rcvr_), static_cast<_Args&&>(__args)...);
+    }
+    else
+    {
+      using __tuple_t = _CUDA_VSTD::__decayed_tuple<_Tag, _Args...>;
+      __state_->__results_.template __emplace<__tuple_t>(_Tag{}, static_cast<_Args&&>(__args)...);
+    }
+  }
+
+  template <class... _Args>
+  _CCCL_TRIVIAL_API void set_value(_Args&&... __args) noexcept
+  {
+    __complete(execution::set_value, static_cast<_Args&&>(__args)...);
+  }
+
+  template <class _Error>
+  _CCCL_TRIVIAL_API void set_error(_Error&& __err) noexcept
+  {
+    if constexpr (_CUDA_VSTD::is_same_v<_CUDA_VSTD::remove_cvref_t<_Error>, ::std::exception_ptr>)
+    {
+      __complete(execution::set_error, cudaErrorUnknown);
+    }
+    else
+    {
+      __complete(execution::set_error, static_cast<_Error&&>(__err));
+    }
+  }
+
+  _CCCL_TRIVIAL_API void set_stopped() noexcept
+  {
+    __complete(execution::set_stopped);
+  }
+
+  _CCCL_API auto get_env() const noexcept -> __env_t<env_of_t<_Rcvr>>
+  {
+    return {execution::get_env(__state_->__rcvr_)};
+  }
+
+  __state_t<_Rcvr, _Variant>* __state_;
+};
+
+template <class _Sndr>
+_CCCL_HOST_API auto __bulk_launch_config(const _Sndr& __sndr) noexcept
+{
+  constexpr int __block             = 256;
+  auto&& [__tag, __params, __child] = __sndr;
+  auto&& [__shape, __fn]            = __params;
+  const int __grid                  = (static_cast<int>(__shape) + __block - 1) / __block;
+  return experimental::make_config(block_dims<__block>, grid_dims(__grid));
+}
+
+template <class _CvSndr, class _Rcvr>
+struct __opstate_t
+{
+  using operation_state_concept = operation_state_t;
+
+  _CCCL_API explicit __opstate_t(_CvSndr&& __sndr, _Rcvr __rcvr, stream_ref __stream)
+      : __launch_config_{get_launch_config(get_env(__sndr))}
+  {
+    NV_IF_TARGET(NV_IS_HOST,
+                 (__host_make_state(static_cast<_CvSndr&&>(__sndr), static_cast<_Rcvr&&>(__rcvr), __stream);),
+                 (__device_make_state(static_cast<_CvSndr&&>(__sndr), static_cast<_Rcvr&&>(__rcvr), __stream);));
+  }
+
+  _CCCL_IMMOVABLE_OPSTATE(__opstate_t);
+
+  _CCCL_API void start() noexcept
+  {
+    NV_IF_TARGET(NV_IS_HOST, (__host_start();), (__device_start();));
+  }
+
+private:
+  using __child_completions_t = completion_signatures_of_t<_CvSndr, __env_t<env_of_t<_Rcvr>>>;
+  using __completions_t       = decltype(__stream::__with_cuda_error(__child_completions_t{}));
+  using __results_t = typename __completions_t::template __transform_q<_CUDA_VSTD::__decayed_tuple, __variant>;
+
+  _CCCL_HOST_API void __host_make_state(_CvSndr&& __sndr, _Rcvr __rcvr, stream_ref __stream)
+  {
+    // If *this is already in device or managed memory, then we can avoid a separate
+    // allocation.
+    if (auto const __attrs = execution::__get_pointer_attributes(this); __attrs.type == ::cudaMemoryTypeManaged)
+    {
+      __state_.template __emplace<__state_t>(static_cast<_CvSndr&&>(__sndr), static_cast<_Rcvr&&>(__rcvr), __stream);
+    }
+    else
+    {
+      __state_.__emplace(__managed_box<__state_t>::__make_unique(
+        static_cast<_CvSndr&&>(__sndr), static_cast<_Rcvr&&>(__rcvr), __stream));
+    }
+  }
+
+  _CCCL_DEVICE_API void __device_make_state(_CvSndr&& __sndr, _Rcvr __rcvr, stream_ref __stream)
+  {
+    __state_.template __emplace<__state_t>(static_cast<_CvSndr&&>(__sndr), static_cast<_Rcvr&&>(__rcvr), __stream);
+  }
+
+  _CCCL_HOST_API void __host_start() noexcept
+  {
+    auto& __state       = __get_state();
+    auto const __stream = __state.__state_.__stream_.get();
+
+    _CCCL_ASSERT(execution::__get_pointer_attributes(&__state.__state_).type == ::cudaMemoryTypeManaged,
+                 "stream scheduler's operation state must be allocated in managed memory");
+    // start the child operation state on the host and launch a kernel to pass the results
+    // to the receiver.
+    execution::start(__state.__opstate_);
+    auto __status =
+      __detail::launch_impl(__stream, __launch_config_, &__host_complete_fn<_Rcvr, __results_t>, &__state.__state_);
+    if (__status != cudaSuccess)
+    {
+      execution::set_error(static_cast<_Rcvr&&>(__state.__state_.__rcvr_), __status);
+    }
+  }
+
+  _CCCL_DEVICE_API void __device_start() noexcept
+  {
+    [[maybe_unused]] auto* const __complete_fn = &__host_complete_fn<_Rcvr, __results_t>;
+    auto& __state                              = __get_state();
+    __state.__state_.__complete_inline_        = true;
+    execution::start(__state.__opstate_);
+  }
+
+  struct __state_t
+  {
+    _CCCL_HOST_API explicit __state_t(_CvSndr&& __sndr, _Rcvr __rcvr, stream_ref __stream)
+        : __state_{static_cast<_Rcvr&&>(__rcvr), {}, __stream, false}
+        , __opstate_(connect(static_cast<_CvSndr&&>(__sndr), __rcvr_t<_Rcvr, __results_t>{&__state_}))
+    {}
+
+    __stream::__state_t<_Rcvr, __results_t> __state_;
+    connect_result_t<_CvSndr, __rcvr_t<_Rcvr, __results_t>> __opstate_;
+  };
+
+  // Return a reference to the state for this operation, whether it is stored in-situ or
+  // in dyncamically-allocated managed memory.
+  _CCCL_API auto __get_state() noexcept -> __state_t&
+  {
+    return __state_.__index() == 0 ? __state_.template __get<0>() : __state_.template __get<1>()->__value;
+  }
+
+  using __launch_config_t _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::__call_result_t<get_launch_config_t, env_of_t<_CvSndr>>;
+  __launch_config_t __launch_config_{};
+  __variant<__state_t, _CUDA_VSTD::unique_ptr<__managed_box<__state_t>>> __state_{};
+};
+
+template <class _Sndr>
+struct __attrs_t
+{
+  [[nodiscard]] _CCCL_TRIVIAL_API static constexpr auto query(get_domain_late_t) noexcept -> stream_domain
+  {
+    return {};
+  }
+
+  _CCCL_TEMPLATE(class _Query)
+  _CCCL_REQUIRES(__queryable_with<env_of_t<_Sndr>, _Query>)
+  [[nodiscard]] _CCCL_API constexpr auto query(_Query) const noexcept(__nothrow_queryable_with<env_of_t<_Sndr>, _Query>)
+    -> __query_result_t<env_of_t<_Sndr>, _Query>
+  {
+    return execution::get_env(*__sndr_).query(_Query{});
+  }
+
+  const _Sndr* __sndr_;
+};
+
+template <class _Sndr>
+struct __sndr_t
+{
+  using sender_concept = sender_t;
+
+  template <class _Self, class _Env>
+  [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL auto get_completion_signatures() noexcept
+  {
+    using __cv_sndr_t _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::__copy_cvref_t<_Self, _Sndr>;
+    _CUDAX_LET_COMPLETIONS(auto(__completions) = execution::get_completion_signatures<__cv_sndr_t, __env_t<_Env>>())
+    {
+      return __with_cuda_error(__completions);
+    }
+  }
+
+  template <class _Rcvr>
+  [[nodiscard]] _CCCL_API auto connect(_Rcvr __rcvr) && -> __opstate_t<_Sndr, _Rcvr>
+  {
+    return __opstate_t<_Sndr, _Rcvr>(
+      static_cast<_Sndr&&>(__state_.__sndr_), static_cast<_Rcvr&&>(__rcvr), __state_.__stream_);
+  }
+
+  template <class _Rcvr>
+  [[nodiscard]] _CCCL_API auto connect(_Rcvr __rcvr) const& -> __opstate_t<const _Sndr&, _Rcvr>
+  {
+    return __opstate_t<const _Sndr&, _Rcvr>(__state_.__sndr_, static_cast<_Rcvr&&>(__rcvr), __state_.__stream_);
+  }
+
+  [[nodiscard]] _CCCL_API auto get_env() const noexcept -> __attrs_t<_Sndr>
+  {
+    return __attrs_t<_Sndr>{&__state_.__sndr_};
+  }
+
+  // By having just one data member, this sender does not look like one that can be
+  // introspected, transformed, or visited.
+  struct __state_t
+  {
+    stream_ref __stream_;
+    _Sndr __sndr_;
+  } __state_;
+};
+
+template <class _Sndr>
+_CCCL_API constexpr auto __adapt(_Sndr __sndr, stream_ref __stream) -> decltype(auto)
+{
+  return __sndr_t<_Sndr>{{__stream, static_cast<_Sndr&&>(__sndr)}};
+}
+
+template <class _Sndr>
+_CCCL_API constexpr auto __adapt(_Sndr __sndr) -> decltype(auto)
+{
+  return __stream::__adapt(static_cast<_Sndr&&>(__sndr), get_stream(get_env(__sndr)));
+}
+
+template <class _Sndr>
+_CCCL_API void __adapt(__sndr_t<_Sndr>, stream_ref) = delete;
+} // namespace cuda::experimental::execution::__stream
+
+_CCCL_DIAG_POP
+
+#include <cuda/experimental/__execution/epilogue.cuh>
+
+#endif // __CUDAX_EXECUTION_STREAM_ADAPTOR

--- a/cudax/include/cuda/experimental/__execution/stream/context.cuh
+++ b/cudax/include/cuda/experimental/__execution/stream/context.cuh
@@ -1,0 +1,219 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __CUDAX_EXECUTION_STREAM_CONTEXT_IMPL
+#define __CUDAX_EXECUTION_STREAM_CONTEXT_IMPL
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__memory/unique_ptr.h>
+#include <cuda/std/__type_traits/is_callable.h>
+
+#include <cuda/experimental/__execution/completion_signatures.cuh>
+#include <cuda/experimental/__execution/cpos.cuh>
+#include <cuda/experimental/__execution/domain.cuh>
+#include <cuda/experimental/__execution/fwd.cuh>
+#include <cuda/experimental/__execution/queries.cuh>
+#include <cuda/experimental/__execution/rcvr_ref.cuh>
+#include <cuda/experimental/__execution/stream/domain.cuh>
+#include <cuda/experimental/__execution/utility.cuh>
+#include <cuda/experimental/stream.cuh>
+
+#include <new> // IWYU pragma: keep for placement new
+
+#include <cuda_runtime_api.h>
+
+#include <cuda/experimental/__execution/prologue.cuh>
+
+namespace cuda::experimental::execution
+{
+template <class _Tag, class _Rcvr, class... _Args>
+__launch_bounds__(1) __global__ static void __stream_complete(_Tag, _Rcvr* __rcvr, _Args... __args)
+{
+  _Tag{}(static_cast<_Rcvr&&>(*__rcvr), static_cast<_Args&&>(__args)...);
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// stream_context
+struct _CCCL_TYPE_VISIBILITY_DEFAULT stream_context : private __immovable
+{
+  stream_context() noexcept = default;
+
+  _CCCL_HOST_API void sync() noexcept
+  {
+    __stream_.sync();
+  }
+
+  ////////////////////////////////////////////////////////////////////////////////////////
+  // stream scheduler
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT scheduler
+  {
+    using scheduler_concept = scheduler_t;
+
+    [[nodiscard]] _CCCL_API constexpr auto query(get_stream_t) const noexcept -> stream_ref
+    {
+      return __stream_;
+    }
+
+    [[nodiscard]] _CCCL_API static constexpr auto query(get_domain_t) noexcept -> stream_domain
+    {
+      return {};
+    }
+
+    [[nodiscard]] _CCCL_API static constexpr auto query(get_forward_progress_guarantee_t) noexcept
+      -> forward_progress_guarantee
+    {
+      return forward_progress_guarantee::weakly_parallel;
+    }
+
+    [[nodiscard]] _CCCL_API auto schedule() const noexcept
+    {
+      return __sndr_t{{}, {__stream_}};
+    }
+
+    [[nodiscard]] _CCCL_API friend bool operator==(const scheduler& __lhs, const scheduler& __rhs) noexcept
+    {
+      return __lhs.__stream_ == __rhs.__stream_;
+    }
+
+    [[nodiscard]] _CCCL_API friend bool operator!=(const scheduler& __lhs, const scheduler& __rhs) noexcept
+    {
+      return __lhs.__stream_ != __rhs.__stream_;
+    }
+
+    stream_ref __stream_;
+  };
+
+  [[nodiscard]] _CCCL_TRIVIAL_HOST_API auto get_scheduler() noexcept -> scheduler
+  {
+    return scheduler{__stream_};
+  }
+
+  _CUDAX_SEMI_PRIVATE :
+  ////////////////////////////////////////////////////////////////////////////////////////
+  // attributes of the stream scheduler's sender
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __attrs_t
+  {
+    [[nodiscard]] _CCCL_API constexpr auto query(get_stream_t) const noexcept -> stream_ref
+    {
+      return __stream_;
+    }
+
+    [[nodiscard]] _CCCL_API constexpr auto query(get_completion_scheduler_t<set_value_t>) const noexcept -> scheduler
+    {
+      return scheduler{__stream_};
+    }
+
+    [[nodiscard]] _CCCL_TRIVIAL_API static constexpr auto query(get_domain_t) noexcept -> stream_domain
+    {
+      return {};
+    }
+
+    [[nodiscard]] _CCCL_TRIVIAL_API static constexpr auto query(get_domain_late_t) noexcept -> stream_domain
+    {
+      return {};
+    }
+
+    stream_ref __stream_;
+  };
+
+  ////////////////////////////////////////////////////////////////////////////////////////
+  // stream scheduler's operation state
+  template <class _Rcvr>
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __opstate_t
+  {
+    using operation_state_concept = operation_state_t;
+
+    _CCCL_EXEC_CHECK_DISABLE
+    _CCCL_API explicit __opstate_t(_Rcvr __rcvr, stream_ref __stream_ref) noexcept(__nothrow_movable<_Rcvr>)
+        : __rcvr_{static_cast<_Rcvr&&>(__rcvr)}
+        , __stream_{__stream_ref}
+    {
+      _CCCL_ASSERT(execution::__get_pointer_attributes(this).type == ::cudaMemoryTypeManaged,
+                   "stream scheduler's operation state must be allocated in managed memory");
+    }
+
+    _CCCL_IMMOVABLE_OPSTATE(__opstate_t);
+
+    _CCCL_API void start() noexcept
+    {
+      NV_IF_TARGET(NV_IS_HOST, (__host_start();), (__device_start();));
+    }
+
+  private:
+    _CCCL_HOST_API void __host_start() noexcept
+    {
+      __stream_complete<<<1, 1, 0, __stream_.get()>>>(set_value, &__rcvr_);
+      if (auto __status = cudaGetLastError(); __status != cudaSuccess)
+      {
+        execution::set_error(static_cast<_Rcvr&&>(__rcvr_), cudaError_t(__status));
+      }
+    }
+
+    _CCCL_DEVICE_API void __device_start() noexcept
+    {
+      // without the following, the kernel in __host_start will fail to launch with
+      // cudaErrorInvalidDeviceFunction.
+      [[maybe_unused]] auto __ignore = &__stream_complete<set_value_t, _Rcvr>;
+      execution::set_value(static_cast<_Rcvr&&>(__rcvr_));
+    }
+
+    _Rcvr __rcvr_;
+    stream_ref __stream_;
+  };
+
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __tag_t
+  {};
+
+  ////////////////////////////////////////////////////////////////////////////////////////
+  // stream scheduler's sender
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __sndr_t
+  {
+    using sender_concept = sender_t;
+
+    template <class _Self>
+    _CCCL_API static _CCCL_CONSTEVAL auto get_completion_signatures() noexcept
+    {
+      return completion_signatures<set_value_t(), set_error_t(cudaError_t)>{};
+    }
+
+    [[nodiscard]] _CCCL_API constexpr auto get_env() const noexcept -> const __attrs_t&
+    {
+      return __env_;
+    }
+
+    template <class _Rcvr>
+    [[nodiscard]] _CCCL_API auto connect(_Rcvr __rcvr) const noexcept -> __opstate_t<_Rcvr>
+    {
+      return __opstate_t<_Rcvr>{static_cast<_Rcvr&&>(__rcvr), __env_.__stream_};
+    }
+
+    _CCCL_NO_UNIQUE_ADDRESS __tag_t __tag_;
+    __attrs_t __env_;
+  };
+
+  stream __stream_{};
+};
+
+using stream_scheduler = stream_context::scheduler;
+
+} // namespace cuda::experimental::execution
+
+#include <cuda/experimental/__execution/epilogue.cuh>
+
+#endif // __CUDAX_EXECUTION_STREAM_CONTEXT_IMPL

--- a/cudax/include/cuda/experimental/__execution/stream/continues_on.cuh
+++ b/cudax/include/cuda/experimental/__execution/stream/continues_on.cuh
@@ -1,0 +1,129 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __CUDAX_EXECUTION_STREAM_CONTINUES_ON
+#define __CUDAX_EXECUTION_STREAM_CONTINUES_ON
+
+#include <cuda/std/detail/__config>
+
+#include "cuda/experimental/__execution/visit.cuh"
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/__stream/get_stream.h>
+#include <cuda/std/__utility/forward_like.h>
+
+#include <cuda/experimental/__execution/completion_signatures.cuh>
+#include <cuda/experimental/__execution/continues_on.cuh>
+#include <cuda/experimental/__execution/cpos.cuh>
+#include <cuda/experimental/__execution/rcvr_ref.cuh>
+#include <cuda/experimental/__execution/stream/adaptor.cuh>
+#include <cuda/experimental/__execution/stream/domain.cuh>
+#include <cuda/experimental/__launch/launch.cuh>
+#include <cuda/experimental/__stream/stream_ref.cuh>
+
+#include <cuda_runtime_api.h>
+
+#include <cuda/experimental/__execution/prologue.cuh>
+
+namespace cuda::experimental::execution
+{
+// Transition from the GPU to the CPU domain
+template <>
+struct stream_domain::__apply_t<continues_on_t>
+{
+  template <class _CvSndr, class _Rcvr>
+  struct __opstate_t
+  {
+    _CCCL_API explicit __opstate_t(_CvSndr&& __sndr, _Rcvr __rcvr, stream_ref __stream)
+        : __stream_(__stream)
+        , __rcvr_(static_cast<_Rcvr&&>(__rcvr))
+        , __opstate_(execution::connect(static_cast<_CvSndr&&>(__sndr), __ref_rcvr(__rcvr_)))
+    {}
+
+    _CCCL_HOST_API void start() noexcept
+    {
+      execution::start(__opstate_);
+      if (auto __status = ::cudaStreamSynchronize(__stream_.get()); __status != ::cudaSuccess)
+      {
+        printf("stream continues_on failed to synchronize stream: (%d)\n", __status);
+        execution::set_error(static_cast<_Rcvr&&>(__rcvr_), cudaError_t(__status));
+      }
+    }
+
+    stream_ref __stream_;
+    _Rcvr __rcvr_;
+    connect_result_t<_CvSndr, __rcvr_ref_t<_Rcvr>> __opstate_;
+  };
+
+  struct __tag_t
+  {};
+
+  template <class _Sndr>
+  struct __sndr_t
+  {
+    using sender_concept = sender_t;
+
+    [[nodiscard]] _CCCL_API auto get_env() const noexcept -> env_of_t<_Sndr>
+    {
+      return execution::get_env(__sndr_);
+    }
+
+    template <class _Self, class... _Env>
+    _CCCL_API static _CCCL_CONSTEVAL auto get_completion_signatures()
+    {
+      return execution::get_child_completion_signatures<_Self, _Sndr, _Env...>();
+    }
+
+    template <class _Rcvr>
+    [[nodiscard]] _CCCL_API auto connect(_Rcvr __rcvr) &&
+    {
+      return __opstate_t<_Sndr, _Rcvr>{static_cast<_Sndr&&>(__sndr_), static_cast<_Rcvr&&>(__rcvr), __stream_};
+    }
+
+    template <class _Rcvr>
+    [[nodiscard]] _CCCL_API auto connect(_Rcvr __rcvr) const&
+    {
+      return __opstate_t<const _Sndr&, _Rcvr>{__sndr_, static_cast<_Rcvr&&>(__rcvr), __stream_};
+    }
+
+    _CCCL_NO_UNIQUE_ADDRESS __tag_t __tag_;
+    stream_ref __stream_;
+    _Sndr __sndr_;
+  };
+
+  template <class _Sndr, class _Env>
+  [[nodiscard]] _CCCL_API auto operator()(_Sndr&& __sndr, const _Env& __env) const -> decltype(auto)
+  {
+    auto&& [__tag, __sched, __child] = static_cast<_Sndr&&>(__sndr);
+    auto __thunk_sched               = get_delegation_scheduler(__env);
+    auto __stream                    = get_stream(get_env(__child));
+
+    // Insert an extra hop through the delegation scheduler (a run_loop being driven by sync_wait).
+    auto __thunk    = execution::schedule_from(__thunk_sched, _CUDA_VSTD::forward_like<_Sndr>(__child));
+    using __thunk_t = decltype(__thunk);
+
+    return execution::schedule_from(__sched, __sndr_t<__thunk_t>{{}, __stream, static_cast<__thunk_t&&>(__thunk)});
+  }
+};
+
+template <class _Sndr>
+inline constexpr size_t structured_binding_size<stream_domain::__apply_t<continues_on_t>::__sndr_t<_Sndr>> = 3;
+} // namespace cuda::experimental::execution
+
+#include <cuda/experimental/__execution/epilogue.cuh>
+
+#endif // __CUDAX_EXECUTION_STREAM_CONTINUES_ON

--- a/cudax/include/cuda/experimental/__execution/stream/domain.cuh
+++ b/cudax/include/cuda/experimental/__execution/stream/domain.cuh
@@ -1,0 +1,85 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __CUDAX_EXECUTION_STREAM_DOMAIN
+#define __CUDAX_EXECUTION_STREAM_DOMAIN
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__concepts/concept_macros.h>
+#include <cuda/std/__type_traits/is_callable.h>
+
+#include <cuda/experimental/__execution/domain.cuh>
+#include <cuda/experimental/__stream/stream_ref.cuh>
+
+#include <cuda/experimental/__execution/prologue.cuh>
+
+namespace cuda::experimental::execution
+{
+namespace __stream
+{
+// Forward declaration of the __adapt function
+template <class _Sndr>
+_CCCL_API constexpr auto __adapt(_Sndr, stream_ref) -> decltype(auto);
+
+template <class _Sndr>
+_CCCL_API constexpr auto __adapt(_Sndr) -> decltype(auto);
+} // namespace __stream
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// stream domain
+struct stream_domain : default_domain
+{
+  _CUDAX_SEMI_PRIVATE :
+  struct __default_apply_t
+  {
+    template <class _Sndr>
+    _CCCL_API constexpr auto operator()(_Sndr&& __sndr) const
+    {
+      return __stream::__adapt(static_cast<_Sndr&&>(__sndr));
+    }
+  };
+
+  template <class _Tag>
+  struct __apply_t : __default_apply_t
+  {};
+
+public:
+  _CCCL_TEMPLATE(class _Tag, class _Sndr, class... _Args)
+  _CCCL_REQUIRES(_CUDA_VSTD::__is_callable_v<__apply_t<_Tag>, _Sndr, _Args...>)
+  _CCCL_TRIVIAL_HOST_API static constexpr auto apply_sender(_Tag, _Sndr&& __sndr, _Args&&... __args) noexcept(
+    _CUDA_VSTD::__is_nothrow_callable_v<__apply_t<_Tag>, _Sndr, _Args...>)
+    -> _CUDA_VSTD::__call_result_t<__apply_t<_Tag>, _Sndr, _Args...>
+  {
+    return __apply_t<_Tag>{}(static_cast<_Sndr&&>(__sndr), static_cast<_Args&&>(__args)...);
+  }
+
+  _CCCL_TEMPLATE(class _Sndr, class... _Env)
+  _CCCL_REQUIRES(_CUDA_VSTD::__is_callable_v<__apply_t<tag_of_t<_Sndr>>, _Sndr, const _Env&...>)
+  _CCCL_TRIVIAL_API static constexpr auto transform_sender(_Sndr&& __sndr, const _Env&... __env) noexcept(
+    _CUDA_VSTD::__is_nothrow_callable_v<__apply_t<tag_of_t<_Sndr>>, _Sndr, const _Env&...>) -> decltype(auto)
+  {
+    return __apply_t<tag_of_t<_Sndr>>{}(static_cast<_Sndr&&>(__sndr), __env...);
+  }
+};
+
+} // namespace cuda::experimental::execution
+
+#include <cuda/experimental/__execution/epilogue.cuh>
+
+#endif // __CUDAX_EXECUTION_STREAM_DOMAIN

--- a/cudax/include/cuda/experimental/__execution/stream/launch.cuh
+++ b/cudax/include/cuda/experimental/__execution/stream/launch.cuh
@@ -1,0 +1,46 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __CUDAX_EXECUTION_STREAM_LAUNCH
+#define __CUDAX_EXECUTION_STREAM_LAUNCH
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/experimental/__execution/stream/domain.cuh>
+#include <cuda/experimental/__launch/launch.cuh>
+
+#include <cuda/experimental/__execution/prologue.cuh>
+
+namespace cuda::experimental::execution
+{
+// TODO: not implemented yet
+template <>
+struct stream_domain::__apply_t<__kernel_t>
+{
+  template <class _Sndr, class _Env>
+  _CCCL_API auto operator()(_Sndr __sndr, const _Env& __env) const
+  {
+    static_assert(_CUDA_VSTD::__always_false_v<_Sndr>,
+                  "The CUDA stream scheduler does not yet support the `launch` algorithm.");
+  }
+};
+} // namespace cuda::experimental::execution
+
+#include <cuda/experimental/__execution/epilogue.cuh>
+
+#endif // __CUDAX_EXECUTION_STREAM_LAUNCH

--- a/cudax/include/cuda/experimental/__execution/stream/let_value.cuh
+++ b/cudax/include/cuda/experimental/__execution/stream/let_value.cuh
@@ -1,0 +1,50 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __CUDAX_EXECUTION_STREAM_LET_VALUE
+#define __CUDAX_EXECUTION_STREAM_LET_VALUE
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/experimental/__execution/fwd.cuh>
+#include <cuda/experimental/__execution/let_value.cuh>
+#include <cuda/experimental/__execution/stream/domain.cuh>
+
+#include <cuda/experimental/__execution/prologue.cuh>
+
+namespace cuda::experimental::execution
+{
+/////////////////////////////////////////////////////////////////////////////////
+// let_value, let_error, let_stopped: customization for the stream scheduler
+template <__disposition_t _Disposition>
+struct stream_domain::__apply_t<__let_t<_Disposition>>
+{
+  template <class _Sndr, class _Env>
+  _CCCL_API auto operator()(_Sndr __sndr, const _Env& __env) const
+  {
+    static_assert(_CUDA_VSTD::__always_false_v<_Sndr>,
+                  "The CUDA stream scheduler does not yet support the `let_value`, `let_error`, and `let_stopped` "
+                  "algorithms.");
+  }
+};
+
+} // namespace cuda::experimental::execution
+
+#include <cuda/experimental/__execution/epilogue.cuh>
+
+#endif // __CUDAX_EXECUTION_STREAM_LET_VALUE

--- a/cudax/include/cuda/experimental/__execution/stream/sequence.cuh
+++ b/cudax/include/cuda/experimental/__execution/stream/sequence.cuh
@@ -1,0 +1,49 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __CUDAX_EXECUTION_STREAM_SEQUENCE
+#define __CUDAX_EXECUTION_STREAM_SEQUENCE
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/experimental/__execution/fwd.cuh>
+#include <cuda/experimental/__execution/sequence.cuh>
+#include <cuda/experimental/__execution/stream/domain.cuh>
+
+#include <cuda/experimental/__execution/prologue.cuh>
+
+namespace cuda::experimental::execution
+{
+/////////////////////////////////////////////////////////////////////////////////
+// sequence: customization for the stream scheduler
+template <>
+struct stream_domain::__apply_t<sequence_t>
+{
+  template <class _Sndr, class _Env>
+  _CCCL_API auto operator()(_Sndr __sndr, const _Env& __env) const
+  {
+    static_assert(_CUDA_VSTD::__always_false_v<_Sndr>,
+                  "The CUDA stream scheduler does not yet support the `sequence` algorithm.");
+  }
+};
+
+} // namespace cuda::experimental::execution
+
+#include <cuda/experimental/__execution/epilogue.cuh>
+
+#endif // __CUDAX_EXECUTION_STREAM_SEQUENCE

--- a/cudax/include/cuda/experimental/__execution/stream/sync_wait.cuh
+++ b/cudax/include/cuda/experimental/__execution/stream/sync_wait.cuh
@@ -1,0 +1,126 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __CUDAX_EXECUTION_STREAM_SYNC_WAIT
+#define __CUDAX_EXECUTION_STREAM_SYNC_WAIT
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/experimental/__execution/stream/domain.cuh>
+#include <cuda/experimental/__execution/sync_wait.cuh>
+#include <cuda/experimental/__execution/utility.cuh>
+
+#include <cuda/experimental/__execution/prologue.cuh>
+
+namespace cuda::experimental::execution
+{
+template <class _Sndr, class _Rcvr>
+struct __connect_emplace
+{
+  using type = connect_result_t<_Sndr, _Rcvr>;
+
+  _CCCL_API operator type() && noexcept(__nothrow_connectable<_Sndr, _Rcvr>)
+  {
+    return execution::connect(static_cast<_Sndr&&>(__sndr_), static_cast<_Rcvr&&>(__rcvr_));
+  }
+
+  _Sndr&& __sndr_;
+  _Rcvr&& __rcvr_;
+};
+
+template <class _Sndr, class _Rcvr>
+_CCCL_HOST_DEVICE __connect_emplace(_Sndr&& __sndr, _Rcvr&& __rcvr) -> __connect_emplace<_Sndr, _Rcvr>;
+
+/////////////////////////////////////////////////////////////////////////////////
+// sync_wait: customization for the stream scheduler
+template <>
+struct stream_domain::__apply_t<sync_wait_t>
+{
+  // TODO: calling sync_wait from device code is not supported yet.
+  template <class _Sndr, class _Env>
+  _CCCL_API auto operator()(_Sndr&& __sndr, _Env&& __env) const
+  {
+    NV_IF_TARGET(NV_IS_HOST,
+                 (return __host_apply(static_cast<_Sndr&&>(__sndr), static_cast<_Env&&>(__env));),
+                 (return __device_apply(static_cast<_Sndr&&>(__sndr), static_cast<_Env&&>(__env));))
+    _CCCL_UNREACHABLE();
+  }
+
+  template <class _Sndr>
+  _CCCL_API auto operator()(_Sndr&& __sndr) const
+  {
+    return (*this)(static_cast<_Sndr&&>(__sndr), env{});
+  }
+
+private:
+  template <class _Sndr, class _Env>
+  struct __state_t
+  {
+    using __values_t = typename sync_wait_t::__state_t<_Sndr, _Env>::__values_t;
+    using __errors_t = typename sync_wait_t::__state_t<_Sndr, _Env>::__errors_t;
+    using __rcvr_t   = sync_wait_t::__rcvr_t<_Sndr, _Env>;
+
+    _CCCL_HOST_API explicit __state_t(_Sndr&& __sndr, _Env&& __env)
+        : __result_{}
+        , __state_{{{}, static_cast<_Env&&>(__env)}, &__result_, {}}
+        , __opstate_{execution::connect(static_cast<_Sndr&&>(__sndr), __rcvr_t{&__state_})}
+    {}
+
+    _CUDA_VSTD::optional<__values_t> __result_;
+    sync_wait_t::__state_t<_Sndr, _Env> __state_;
+    connect_result_t<_Sndr, __rcvr_t> __opstate_;
+  };
+
+  template <class _Sndr, class _Env>
+  _CCCL_DEVICE_API static auto __device_apply(_Sndr&& __sndr, _Env&& __env)
+  {
+    return sync_wait.apply_sender(static_cast<_Sndr&&>(__sndr), static_cast<_Env&&>(__env));
+  }
+
+  template <class _Sndr, class _Env>
+  _CCCL_HOST_API static auto __host_apply(_Sndr&& __sndr, _Env&& __env)
+  {
+    stream_ref __stream = get_stream(get_env(__sndr));
+
+    // Launch the sender with a continuation that will fill in a variant
+    using __box_t = __managed_box<__state_t<_Sndr, _Env>>;
+    auto __box    = __box_t::__make_unique(static_cast<_Sndr&&>(__sndr), static_cast<_Env&&>(__env));
+    execution::start(__box->__value.__opstate_);
+
+    // The kernels have been launched, now we sync the stream to guarantee forward progress.
+    __stream.sync();
+
+    // While waiting for the variant to be filled in, process any work that may be
+    // delegated to this thread.
+    auto& __state = __box->__value.__state_;
+    __state.__loop_.run();
+
+    if (__state.__errors_.__index() != __npos)
+    {
+      __state.__errors_.__visit(sync_wait_t::__throw_error_fn{}, _CUDA_VSTD::move(__state.__errors_));
+    }
+
+    return _CUDA_VSTD::move(__box->__value.__result_);
+  }
+};
+
+} // namespace cuda::experimental::execution
+
+#include <cuda/experimental/__execution/epilogue.cuh>
+
+#endif // __CUDAX_EXECUTION_STREAM_SYNC_WAIT

--- a/cudax/include/cuda/experimental/__execution/stream_context.cuh
+++ b/cudax/include/cuda/experimental/__execution/stream_context.cuh
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __CUDAX_EXECUTION_STREAM_CONTEXT
+#define __CUDAX_EXECUTION_STREAM_CONTEXT
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+// IWYU pragma: begin_exports
+#include <cuda/experimental/__execution/stream/adaptor.cuh>
+#include <cuda/experimental/__execution/stream/context.cuh>
+#include <cuda/experimental/__execution/stream/continues_on.cuh>
+#include <cuda/experimental/__execution/stream/domain.cuh>
+#include <cuda/experimental/__execution/stream/launch.cuh>
+#include <cuda/experimental/__execution/stream/let_value.cuh>
+#include <cuda/experimental/__execution/stream/sequence.cuh>
+#include <cuda/experimental/__execution/stream/sync_wait.cuh>
+// IWYU pragma: end_exports
+
+#endif //__CUDAX_EXECUTION_STREAM_CONTEXT

--- a/cudax/include/cuda/experimental/__execution/sync_wait.cuh
+++ b/cudax/include/cuda/experimental/__execution/sync_wait.cuh
@@ -47,7 +47,7 @@ namespace cuda::experimental::execution
 /// sender.
 struct sync_wait_t
 {
-private:
+  _CUDAX_SEMI_PRIVATE :
   template <class _Env>
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __state_base_t
   {

--- a/cudax/include/cuda/experimental/__execution/then.cuh
+++ b/cudax/include/cuda/experimental/__execution/then.cuh
@@ -98,7 +98,7 @@ template <__disposition_t _Disposition>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT _CCCL_PREFERRED_NAME(then_t) _CCCL_PREFERRED_NAME(upon_error_t)
   _CCCL_PREFERRED_NAME(upon_stopped_t) __upon_t
 {
-private:
+  _CUDAX_SEMI_PRIVATE :
   using _UponTag _CCCL_NODEBUG_ALIAS = decltype(__detail::__upon_tag<_Disposition>());
   using _SetTag _CCCL_NODEBUG_ALIAS  = decltype(__detail::__set_tag<_Disposition>());
 

--- a/cudax/include/cuda/experimental/__execution/variant.cuh
+++ b/cudax/include/cuda/experimental/__execution/variant.cuh
@@ -69,6 +69,9 @@ public:
 template <size_t... _Idx, class... _Ts>
 class __variant_impl<_CUDA_VSTD::index_sequence<_Idx...>, _Ts...>
 {
+  // static_assert(!_CUDA_VSTD::__is_included_in_v<::std::exception_ptr, _Ts...>,
+  //               "std::exception_ptr is not allowed in variant alternatives");
+
   static constexpr size_t __max_size = __maximum({sizeof(_Ts)...});
   static_assert(__max_size != 0);
   size_t __index_{__npos};

--- a/cudax/include/cuda/experimental/__execution/when_all.cuh
+++ b/cudax/include/cuda/experimental/__execution/when_all.cuh
@@ -57,7 +57,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT when_all_t
   template <class... _Sndrs>
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __sndr_t;
 
-private:
+  _CUDAX_SEMI_PRIVATE :
   // Extract the first template parameter of the __state_t specialization.
   // The first template parameter is the receiver type.
   template <class _State>

--- a/cudax/include/cuda/experimental/__execution/write_env.cuh
+++ b/cudax/include/cuda/experimental/__execution/write_env.cuh
@@ -38,7 +38,7 @@ namespace cuda::experimental::execution
 {
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __write_env_t
 {
-private:
+  _CUDAX_SEMI_PRIVATE :
   template <class _Rcvr, class _Sndr, class _Env>
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __opstate_t
   {

--- a/cudax/include/cuda/experimental/__hierarchy/hierarchy_dimensions.cuh
+++ b/cudax/include/cuda/experimental/__hierarchy/hierarchy_dimensions.cuh
@@ -178,6 +178,7 @@ struct __make_hierarchy
       static_assert(__can_stack<UnitOrDefault, Levels...>,
                     "Provided levels can't create a valid hierarchy when stacked in the provided order or reversed");
     }
+    _CCCL_UNREACHABLE();
   }
 };
 

--- a/cudax/include/cuda/experimental/execution.cuh
+++ b/cudax/include/cuda/experimental/execution.cuh
@@ -30,6 +30,7 @@
 #include <cuda/experimental/__execution/start_detached.cuh>
 #include <cuda/experimental/__execution/starts_on.cuh>
 #include <cuda/experimental/__execution/stop_token.cuh>
+#include <cuda/experimental/__execution/stream_context.cuh>
 #include <cuda/experimental/__execution/sync_wait.cuh>
 #include <cuda/experimental/__execution/then.cuh>
 #include <cuda/experimental/__execution/thread_context.cuh>

--- a/cudax/test/CMakeLists.txt
+++ b/cudax/test/CMakeLists.txt
@@ -85,13 +85,20 @@ foreach(cn_target IN LISTS cudax_TARGETS)
     execution/test_conditional.cu
     execution/test_continues_on.cu
     execution/test_just.cu
-    execution/test_sequence.cu
     execution/test_let_value.cu
+    execution/test_sequence.cu
+    execution/test_stream_context.cu
     execution/test_visit.cu
     execution/test_when_all.cu
   )
   target_compile_options(${test_target} PRIVATE $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:--extended-lambda>)
   target_compile_options(${test_target} PRIVATE $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:--expt-relaxed-constexpr>)
+
+  # The stream context needs atomic wait/notify, which is only available on sm70 and
+  # above.
+  get_target_property(cuda_arch_list ${test_target} CUDA_ARCHITECTURES)
+  list(REMOVE_ITEM cuda_arch_list "60" "61")
+  set_target_properties(${test_target} PROPERTIES CUDA_ARCHITECTURES "${cuda_arch_list}")
 
   cudax_add_catch2_test(test_target graph ${cn_target}
     graph/graph_smoke.cu

--- a/cudax/test/execution/common/inline_scheduler.cuh
+++ b/cudax/test/execution/common/inline_scheduler.cuh
@@ -21,7 +21,7 @@ namespace
 struct inline_scheduler
 {
 private:
-  struct env_t
+  struct _env_t
   {
     _CCCL_HOST_DEVICE auto query(cudax_async::get_completion_scheduler_t<cudax_async::set_value_t>) const noexcept
     {
@@ -30,7 +30,7 @@ private:
   };
 
   template <class Rcvr>
-  struct opstate_t : cudax::__immovable
+  struct _opstate_t : cudax::__immovable
   {
     using operation_state_concept = cudax_async::operation_state_t;
 
@@ -42,7 +42,10 @@ private:
     }
   };
 
-  struct sndr_t
+public:
+  using scheduler_concept = cudax_async::scheduler_t;
+
+  struct _sndr_t
   {
     using sender_concept = cudax_async::sender_t;
 
@@ -53,16 +56,23 @@ private:
     }
 
     template <class Rcvr>
-    _CCCL_HOST_DEVICE opstate_t<Rcvr> connect(Rcvr rcvr) const
+    _CCCL_HOST_DEVICE _opstate_t<Rcvr> connect(Rcvr rcvr) const
     {
       return {{}, static_cast<Rcvr&&>(rcvr)};
     }
 
-    _CCCL_HOST_DEVICE env_t get_env() const noexcept
+    _CCCL_HOST_DEVICE _env_t get_env() const noexcept
     {
       return {};
     }
   };
+
+  inline_scheduler() = default;
+
+  _CCCL_HOST_DEVICE _sndr_t schedule() const noexcept
+  {
+    return {};
+  }
 
   _CCCL_HOST_DEVICE friend bool operator==(inline_scheduler, inline_scheduler) noexcept
   {
@@ -72,16 +82,6 @@ private:
   _CCCL_HOST_DEVICE friend bool operator!=(inline_scheduler, inline_scheduler) noexcept
   {
     return false;
-  }
-
-public:
-  using scheduler_concept = cudax_async::scheduler_t;
-
-  inline_scheduler() = default;
-
-  _CCCL_HOST_DEVICE sndr_t schedule() const noexcept
-  {
-    return {};
   }
 };
 } // namespace

--- a/cudax/test/execution/test_stream_context.cu
+++ b/cudax/test/execution/test_stream_context.cu
@@ -1,0 +1,98 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// Include this first
+#include <cuda/experimental/execution.cuh>
+
+// Then include the test helpers
+#include <nv/target>
+
+#include "testing.cuh" // IWYU pragma: keep
+
+_CCCL_NV_DIAG_SUPPRESS(177) // function "_is_on_device" was declared but never referenced
+
+namespace
+{
+__host__ __device__ bool _is_on_device() noexcept
+{
+  NV_IF_ELSE_TARGET(NV_IS_HOST, //
+                    ({ return false; }),
+                    ({ return true; }));
+}
+
+struct _say_hello
+{
+  __device__ int operator()() const
+  {
+    CUDAX_CHECK(_is_on_device());
+    printf("Hello from lambda on device!\n");
+    return value;
+  }
+
+  int value;
+};
+
+void stream_context_test1()
+{
+  cudax_async::stream_context ctx;
+  auto sched = ctx.get_scheduler();
+
+  auto sndr = cudax_async::schedule(sched) //
+            | cudax_async::then([] __device__() noexcept -> bool {
+                return _is_on_device();
+              });
+
+  auto [on_device] = cudax_async::sync_wait(std::move(sndr)).value();
+  CHECK(on_device);
+}
+
+void stream_context_test2()
+{
+  cudax_async::thread_context tctx;
+  cudax_async::stream_context sctx;
+  auto sch = sctx.get_scheduler();
+
+  auto start = //
+    cudax_async::schedule(sch) // begin work on the GPU
+    | cudax_async::then(_say_hello{42}) // enqueue a function object on the GPU
+    | cudax_async::then([] __device__(int i) noexcept -> int { // enqueue a lambda on the GPU
+        CUDAX_CHECK(_is_on_device());
+        printf("Hello again from lambda on device! i = %d\n", i);
+        return i + 1;
+      })
+    | cudax_async::continues_on(tctx.get_scheduler()) // continue work on the CPU
+    | cudax_async::then([] __host__ __device__(int i) noexcept -> int { // run a lambda on the CPU
+        CUDAX_CHECK(!_is_on_device());
+        NV_IF_TARGET(NV_IS_HOST,
+                     (printf("Hello from lambda on host! i = %d\n", i);),
+                     (printf("OOPS! still on the device! i = %d\n", i);))
+        return i;
+      });
+
+  // run the cudax_async, wait for it to finish, and get the result
+  auto [i] = cudax_async::sync_wait(std::move(start)).value();
+  CHECK(i == 43);
+  printf("All done on the host! result = %d\n", i);
+}
+
+// Test code is placed in separate functions to avoid an nvc++ issue with
+// extended lambdas in functions with internal linkage (as is the case
+// with C2H tests).
+
+C2H_TEST("a simple use of the stream context", "[context][stream]")
+{
+  REQUIRE_NOTHROW(stream_context_test1());
+}
+
+C2H_TEST("a simple use of the stream context", "[context][stream]")
+{
+  REQUIRE_NOTHROW(stream_context_test2());
+}
+} // namespace


### PR DESCRIPTION
## Description

this PR gives ustdex a minimally functional CUDA stream scheduler and customizes the sync_wait algorithm for stream execution.

this pr recreates #4540 which was closed automatically.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
