### PR TITLE
Add `-G` when compiling in Debug mode

### DIFF
--- a/cmake/CCCLBuildCompilerTargets.cmake
+++ b/cmake/CCCLBuildCompilerTargets.cmake
@@ -82,6 +82,10 @@ function(cccl_build_compiler_targets)
     list(APPEND cxx_compile_definitions "CCCL_DISABLE_RTTI")
   endif()
 
+  if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+    list(APPEND cuda_compile_options "-G")
+  endif()
+
   if ("MSVC" STREQUAL "${CMAKE_CXX_COMPILER_ID}")
     list(APPEND cuda_compile_options "--use-local-env")
     list(APPEND cxx_compile_options "/bigobj")


### PR DESCRIPTION
## Description

By default, cmake adds `-g` (host debug) when `CMAKE_BUILD_TYPE == Debug`.
This behavior should be extended to CUDA files by also adding `-G` that allow to debug device-side code/kernels.