### PR TITLE
Add _CCCL_LOG_CUDA_API, improve cuda_error reporting

### DIFF
--- a/c2h/catch2_runner_helper.inl
+++ b/c2h/catch2_runner_helper.inl
@@ -32,14 +32,15 @@
 //! include all the tests into a single executable, this file is only included into catch2_runner_helper.cu. When CMake
 //! is configured to compile each test as a separate binary, this file is included into each test.
 
+#include <cuda/std/__cuda/api_wrapper.h>
+
 #include <iostream>
 
 int device_guard(int device_id)
 {
   int device_count{};
-  if (cudaGetDeviceCount(&device_count) != cudaSuccess)
+  if (_CCCL_LOG_CUDA_API(cudaGetDeviceCount, "Failed getting number of devices", &device_count) != cudaSuccess)
   {
-    std::cerr << "Can't query devices number." << std::endl;
     std::exit(-1);
   }
 
@@ -54,5 +55,9 @@ int device_guard(int device_id)
 
 void set_device(int device_id)
 {
-  cudaSetDevice(device_guard(device_id));
+  if (_CCCL_LOG_CUDA_API(cudaSetDevice, "Failed to set requested device", device_guard(device_id)) != cudaSuccess)
+  {
+    std::cerr << "Failed to set device ID: " << device_id << std::endl;
+    std::exit(-1);
+  }
 }

--- a/libcudacxx/include/cuda/std/__cuda/api_wrapper.h
+++ b/libcudacxx/include/cuda/std/__cuda/api_wrapper.h
@@ -27,17 +27,17 @@
 
 #include <cuda/std/__exception/cuda_error.h>
 
-#define _CCCL_TRY_CUDA_API(_NAME, _MSG, ...)           \
-  {                                                    \
-    const ::cudaError_t __status = _NAME(__VA_ARGS__); \
-    switch (__status)                                  \
-    {                                                  \
-      case ::cudaSuccess:                              \
-        break;                                         \
-      default:                                         \
-        ::cudaGetLastError();                          \
-        ::cuda::__throw_cuda_error(__status, _MSG);    \
-    }                                                  \
+#define _CCCL_TRY_CUDA_API(_NAME, _MSG, ...)                                    \
+  {                                                                             \
+    const ::cudaError_t __status = _NAME(__VA_ARGS__);                          \
+    switch (__status)                                                           \
+    {                                                                           \
+      case ::cudaSuccess:                                                       \
+        break;                                                                  \
+      default:                                                                  \
+        ::cudaGetLastError();                                                   \
+        ::cuda::__throw_cuda_error(__status, _MSG, #_NAME, __FILE__, __LINE__); \
+    }                                                                           \
   }
 
 #define _CCCL_ASSERT_CUDA_API(_NAME, _MSG, ...)                         \

--- a/libcudacxx/include/cuda/std/__cuda/api_wrapper.h
+++ b/libcudacxx/include/cuda/std/__cuda/api_wrapper.h
@@ -46,4 +46,17 @@
     _CCCL_ASSERT(__status == cudaSuccess, _MSG);                        \
   }
 
+#define _CCCL_LOG_CUDA_API(_NAME, _MSG, ...)                                                           \
+  [&]() {                                                                                              \
+    const ::cudaError_t __status = _NAME(__VA_ARGS__);                                                 \
+    if (__status != ::cudaSuccess)                                                                     \
+    {                                                                                                  \
+      ::cuda::__detail::__msg_storage __msg_buffer;                                                    \
+      ::cuda::__detail::__format_cuda_error(__msg_buffer, __status, _MSG, #_NAME, __FILE__, __LINE__); \
+      ::fprintf(stderr, "%s\n", __msg_buffer.__buffer);                                                \
+      ::fflush(stderr);                                                                                \
+    }                                                                                                  \
+    return __status;                                                                                   \
+  }()
+
 #endif //_CUDA__STD__CUDA_API_WRAPPER_H

--- a/libcudacxx/include/cuda/std/__cuda/api_wrapper.h
+++ b/libcudacxx/include/cuda/std/__cuda/api_wrapper.h
@@ -27,17 +27,17 @@
 
 #include <cuda/std/__exception/cuda_error.h>
 
-#define _CCCL_TRY_CUDA_API(_NAME, _MSG, ...)                                    \
-  {                                                                             \
-    const ::cudaError_t __status = _NAME(__VA_ARGS__);                          \
-    switch (__status)                                                           \
-    {                                                                           \
-      case ::cudaSuccess:                                                       \
-        break;                                                                  \
-      default:                                                                  \
-        ::cudaGetLastError();                                                   \
-        ::cuda::__throw_cuda_error(__status, _MSG, #_NAME, __FILE__, __LINE__); \
-    }                                                                           \
+#define _CCCL_TRY_CUDA_API(_NAME, _MSG, ...)                \
+  {                                                         \
+    const ::cudaError_t __status = _NAME(__VA_ARGS__);      \
+    switch (__status)                                       \
+    {                                                       \
+      case ::cudaSuccess:                                   \
+        break;                                              \
+      default:                                              \
+        ::cudaGetLastError();                               \
+        ::cuda::__throw_cuda_error(__status, _MSG, #_NAME); \
+    }                                                       \
   }
 
 #define _CCCL_ASSERT_CUDA_API(_NAME, _MSG, ...)                         \
@@ -46,17 +46,17 @@
     _CCCL_ASSERT(__status == cudaSuccess, _MSG);                        \
   }
 
-#define _CCCL_LOG_CUDA_API(_NAME, _MSG, ...)                                                           \
-  [&]() {                                                                                              \
-    const ::cudaError_t __status = _NAME(__VA_ARGS__);                                                 \
-    if (__status != ::cudaSuccess)                                                                     \
-    {                                                                                                  \
-      ::cuda::__detail::__msg_storage __msg_buffer;                                                    \
-      ::cuda::__detail::__format_cuda_error(__msg_buffer, __status, _MSG, #_NAME, __FILE__, __LINE__); \
-      ::fprintf(stderr, "%s\n", __msg_buffer.__buffer);                                                \
-      ::fflush(stderr);                                                                                \
-    }                                                                                                  \
-    return __status;                                                                                   \
+#define _CCCL_LOG_CUDA_API(_NAME, _MSG, ...)                                       \
+  [&]() {                                                                          \
+    const ::cudaError_t __status = _NAME(__VA_ARGS__);                             \
+    if (__status != ::cudaSuccess)                                                 \
+    {                                                                              \
+      ::cuda::__detail::__msg_storage __msg_buffer;                                \
+      ::cuda::__detail::__format_cuda_error(__msg_buffer, __status, _MSG, #_NAME); \
+      ::fprintf(stderr, "%s\n", __msg_buffer.__buffer);                            \
+      ::fflush(stderr);                                                            \
+    }                                                                              \
+    return __status;                                                               \
   }()
 
 #endif //_CUDA__STD__CUDA_API_WRAPPER_H

--- a/libcudacxx/include/cuda/std/__exception/cuda_error.h
+++ b/libcudacxx/include/cuda/std/__exception/cuda_error.h
@@ -37,6 +37,8 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_CUDA
 
+#if _CCCL_HAS_EXCEPTIONS()
+
 namespace __detail
 {
 
@@ -70,11 +72,11 @@ static char* __format_cuda_error(
     "%s%s%s(%d): %s",
     __msg_buffer.__location,
     __msg_buffer.__api,
-#if _CCCL_HAS_CUDA_COMPILER()
+#  if _CCCL_HAS_CUDA_COMPILER()
     ::cudaGetErrorString(::cudaError_t(__status)),
-#else
+#  else
     "cudaError",
-#endif
+#  endif
     __status,
     __msg);
   return __msg_buffer.__buffer;
@@ -84,7 +86,6 @@ static char* __format_cuda_error(
 /**
  * @brief Exception thrown when a CUDA error is encountered.
  */
-#if _CCCL_HAS_EXCEPTIONS()
 class cuda_error : public ::std::runtime_error
 {
 public:

--- a/libcudacxx/include/cuda/std/__exception/cuda_error.h
+++ b/libcudacxx/include/cuda/std/__exception/cuda_error.h
@@ -22,7 +22,9 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda_runtime_api.h>
+#if _CCCL_CUDA_COMPILER(CLANG)
+#  include <cuda_runtime_api.h>
+#endif // _CCCL_CUDA_COMPILER(CLANG)
 
 #include <cuda/std/__exception/terminate.h>
 
@@ -68,7 +70,7 @@ static char* __format_cuda_error(
     "%s%s%s(%d): %s",
     __msg_buffer.__location,
     __msg_buffer.__api,
-    cudaGetErrorString(cudaError_t(__status)),
+    ::cudaGetErrorString(::cudaError_t(__status)),
     __status,
     __msg);
   return __msg_buffer.__buffer;

--- a/libcudacxx/include/cuda/std/__exception/cuda_error.h
+++ b/libcudacxx/include/cuda/std/__exception/cuda_error.h
@@ -52,16 +52,17 @@ static char* __format_cuda_error(
   __msg_storage& __msg_buffer,
   const int __status,
   const char* __msg,
-  const char* __api,
+  const char* __api                 = nullptr,
   _CUDA_VSTD::source_location __loc = _CUDA_VSTD::source_location::current()) noexcept
 {
   ::snprintf(
     __msg_buffer.__buffer,
     512,
-    "%s:%d %s %s(%d): %s",
+    "%s:%d %s%s%s(%d): %s",
     __loc.file_name(),
     __loc.line(),
-    __api,
+    __api ? __api : "",
+    __api ? " " : "",
 #  if _CCCL_HAS_CUDA_COMPILER()
     ::cudaGetErrorString(::cudaError_t(__status)),
 #  else
@@ -81,7 +82,7 @@ class cuda_error : public ::std::runtime_error
 public:
   cuda_error(const int __status,
              const char* __msg,
-             const char* __api,
+             const char* __api                    = nullptr,
              _CUDA_VSTD::source_location __loc    = _CUDA_VSTD::source_location::current(),
              __detail::__msg_storage __msg_buffer = {}) noexcept
       : ::std::runtime_error(__detail::__format_cuda_error(__msg_buffer, __status, __msg, __api, __loc))
@@ -91,7 +92,7 @@ public:
 [[noreturn]] _LIBCUDACXX_HIDE_FROM_ABI void __throw_cuda_error(
   [[maybe_unused]] const int __status,
   [[maybe_unused]] const char* __msg,
-  [[maybe_unused]] const char* __api,
+  [[maybe_unused]] const char* __api                 = nullptr,
   [[maybe_unused]] _CUDA_VSTD::source_location __loc = _CUDA_VSTD::source_location::current())
 {
   NV_IF_ELSE_TARGET(NV_IS_HOST,
@@ -103,12 +104,15 @@ class cuda_error
 {
 public:
   _LIBCUDACXX_HIDE_FROM_ABI cuda_error(
-    const int, const char*, const char*, _CUDA_VSTD::source_location = _CUDA_VSTD::source_location::current()) noexcept
+    const int,
+    const char*,
+    const char*                 = nullptr,
+    _CUDA_VSTD::source_location = _CUDA_VSTD::source_location::current()) noexcept
   {}
 };
 
 [[noreturn]] _LIBCUDACXX_HIDE_FROM_ABI void __throw_cuda_error(
-  const int, const char*, const char*, _CUDA_VSTD::source_location = _CUDA_VSTD::source_location::current())
+  const int, const char*, const char* = nullptr, _CUDA_VSTD::source_location = _CUDA_VSTD::source_location::current())
 {
   _CUDA_VSTD_NOVERSION::terminate();
 }

--- a/libcudacxx/include/cuda/std/__exception/cuda_error.h
+++ b/libcudacxx/include/cuda/std/__exception/cuda_error.h
@@ -22,6 +22,8 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda_runtime_api.h>
+
 #include <cuda/std/__exception/terminate.h>
 
 #if !_CCCL_COMPILER(NVRTC)
@@ -33,43 +35,85 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_CUDA
 
+namespace __detail
+{
+
+struct __msg_storage
+{
+  char __location[128]{0};
+  char __api[128]{0};
+  char __buffer[512]{0};
+};
+
+static char* __format_cuda_error(
+  __msg_storage& __msg_buffer,
+  const int __status,
+  const char* __msg,
+  const char* __api  = nullptr,
+  const char* __file = nullptr,
+  const int __line   = 0) noexcept
+{
+  if (__file)
+  {
+    ::snprintf(__msg_buffer.__location, 128, "%s:%d ", __file, __line);
+  }
+  if (__api)
+  {
+    ::snprintf(__msg_buffer.__api, 128, "%s: ", __api);
+  }
+
+  ::snprintf(
+    __msg_buffer.__buffer,
+    512,
+    "%s%s%s(%d): %s",
+    __msg_buffer.__location,
+    __msg_buffer.__api,
+    cudaGetErrorString(cudaError_t(__status)),
+    __status,
+    __msg);
+  return __msg_buffer.__buffer;
+}
+} // namespace __detail
+
 /**
  * @brief Exception thrown when a CUDA error is encountered.
  */
 #if _CCCL_HAS_EXCEPTIONS()
 class cuda_error : public ::std::runtime_error
 {
-private:
-  struct __msg_storage
-  {
-    char __buffer[256];
-  };
-
-  static char* __format_cuda_error(const int __status, const char* __msg, char* __msg_buffer) noexcept
-  {
-    ::snprintf(__msg_buffer, 256, "cudaError %d: %s", __status, __msg);
-    return __msg_buffer;
-  }
-
 public:
-  cuda_error(const int __status, const char* __msg, __msg_storage __msg_buffer = {0}) noexcept
-      : ::std::runtime_error(__format_cuda_error(__status, __msg, __msg_buffer.__buffer))
+  cuda_error(const int __status,
+             const char* __msg,
+             const char* __api                    = nullptr,
+             const char* __file                   = nullptr,
+             const int __line                     = 0,
+             __detail::__msg_storage __msg_buffer = {}) noexcept
+      : ::std::runtime_error(__detail::__format_cuda_error(__msg_buffer, __status, __msg, __api, __file, __line))
   {}
 };
 
-[[noreturn]] _LIBCUDACXX_HIDE_FROM_ABI void
-__throw_cuda_error([[maybe_unused]] const int __status, [[maybe_unused]] const char* __msg)
+[[noreturn]] _LIBCUDACXX_HIDE_FROM_ABI void __throw_cuda_error(
+  [[maybe_unused]] const int __status,
+  [[maybe_unused]] const char* __msg,
+  [[maybe_unused]] const char* __api  = nullptr,
+  [[maybe_unused]] const char* __file = nullptr,
+  [[maybe_unused]] const int __line   = 0)
 {
-  NV_IF_ELSE_TARGET(NV_IS_HOST, (throw ::cuda::cuda_error(__status, __msg);), (_CUDA_VSTD_NOVERSION::terminate();))
+  NV_IF_ELSE_TARGET(NV_IS_HOST,
+                    (throw ::cuda::cuda_error(__status, __msg, __api, __file, __line);),
+                    (_CUDA_VSTD_NOVERSION::terminate();))
 }
 #else // ^^^ _CCCL_HAS_EXCEPTIONS() ^^^ / vvv !_CCCL_HAS_EXCEPTIONS() vvv
 class cuda_error
 {
 public:
-  _LIBCUDACXX_HIDE_FROM_ABI cuda_error(const int, const char*) noexcept {}
+  _LIBCUDACXX_HIDE_FROM_ABI
+  cuda_error(const int, const char*, const char* = nullptr, const char* = nullptr, const int = 0) noexcept
+  {}
 };
 
-[[noreturn]] _LIBCUDACXX_HIDE_FROM_ABI void __throw_cuda_error(const int, const char*)
+[[noreturn]] _LIBCUDACXX_HIDE_FROM_ABI void
+__throw_cuda_error(const int, const char*, const char* = nullptr, const char* = nullptr, const int = 0)
 {
   _CUDA_VSTD_NOVERSION::terminate();
 }

--- a/libcudacxx/include/cuda/std/__exception/cuda_error.h
+++ b/libcudacxx/include/cuda/std/__exception/cuda_error.h
@@ -22,9 +22,9 @@
 #  pragma system_header
 #endif // no system header
 
-#if _CCCL_CUDA_COMPILER(CLANG)
+#if _CCCL_HAS_CUDA_COMPILER()
 #  include <cuda_runtime_api.h>
-#endif // _CCCL_CUDA_COMPILER(CLANG)
+#endif // _CCCL_HAS_CUDA_COMPILER()
 
 #include <cuda/std/__exception/terminate.h>
 
@@ -70,7 +70,11 @@ static char* __format_cuda_error(
     "%s%s%s(%d): %s",
     __msg_buffer.__location,
     __msg_buffer.__api,
+#if _CCCL_HAS_CUDA_COMPILER()
     ::cudaGetErrorString(::cudaError_t(__status)),
+#else
+    "cudaError",
+#endif
     __status,
     __msg);
   return __msg_buffer.__buffer;


### PR DESCRIPTION
Add more information to `cuda_error` messages.
    
- Location (file:line)
- Failing CUDA API
- CUDA error string

--------------

Add new _CCCL_LOG_CUDA_API macro.
    
This behaves similarly to the CubDebug macro, logging the error to stderr and returning the error code to allow the caller to decide how to handle it.

-----------

Use new API macro in c2h.
    
Example:
    
```cpp
  if (_CCCL_LOG_CUDA_API(cudaSetDevice, "Failed to set requested device", device_guard(device_id)) != cudaSuccess)
  {
    std::cerr << "Failed to set device ID: " << device_id << std::endl;
    std::exit(-1);
  }
```
    
```
/home/coder/cccl/c2h/catch2_runner_helper.inl:58 cudaSetDevice: invalid device ordinal(101): Failed to set requested device
Failed to set device ID: 2
```