### PR TITLE
Switch cuCtxCreate to cuDevicePrimaryCtxRetain  in cub and libcu++ tests

### DIFF
--- a/cub/test/catch2_test_nvrtc.cu
+++ b/cub/test/catch2_test_nvrtc.cu
@@ -322,7 +322,7 @@ TEST_CASE("Test nvrtc", "[test][nvrtc]")
 
   REQUIRE(CUDA_SUCCESS == cuInit(0));
   REQUIRE(CUDA_SUCCESS == cuDeviceGet(&device, 0));
-  REQUIRE(CUDA_SUCCESS == cuCtxCreate(&context, 0, device));
+  REQUIRE(CUDA_SUCCESS == cuDevicePrimaryCtxRetain(&context, device));
   REQUIRE(CUDA_SUCCESS == cuModuleLoadDataEx(&module, code.get(), 0, 0, 0));
   REQUIRE(CUDA_SUCCESS == cuModuleGetFunction(&kernel, module, "kernel"));
 
@@ -365,5 +365,5 @@ TEST_CASE("Test nvrtc", "[test][nvrtc]")
   REQUIRE(CUDA_SUCCESS == cuMemFree(d_ptr));
   REQUIRE(CUDA_SUCCESS == cuMemFree(d_err));
   REQUIRE(CUDA_SUCCESS == cuModuleUnload(module));
-  REQUIRE(CUDA_SUCCESS == cuCtxDestroy(context));
+  REQUIRE(CUDA_SUCCESS == cuDevicePrimaryCtxRelease(context));
 }

--- a/cub/test/catch2_test_nvrtc.cu
+++ b/cub/test/catch2_test_nvrtc.cu
@@ -365,5 +365,5 @@ TEST_CASE("Test nvrtc", "[test][nvrtc]")
   REQUIRE(CUDA_SUCCESS == cuMemFree(d_ptr));
   REQUIRE(CUDA_SUCCESS == cuMemFree(d_err));
   REQUIRE(CUDA_SUCCESS == cuModuleUnload(module));
-  REQUIRE(CUDA_SUCCESS == cuDevicePrimaryCtxRelease(context));
+  REQUIRE(CUDA_SUCCESS == cuDevicePrimaryCtxRelease(device));
 }

--- a/cub/test/catch2_test_nvrtc.cu
+++ b/cub/test/catch2_test_nvrtc.cu
@@ -323,6 +323,7 @@ TEST_CASE("Test nvrtc", "[test][nvrtc]")
   REQUIRE(CUDA_SUCCESS == cuInit(0));
   REQUIRE(CUDA_SUCCESS == cuDeviceGet(&device, 0));
   REQUIRE(CUDA_SUCCESS == cuDevicePrimaryCtxRetain(&context, device));
+  REQUIRE(CUDA_SUCCESS == cuCtxSetCurrent(context));
   REQUIRE(CUDA_SUCCESS == cuModuleLoadDataEx(&module, code.get(), 0, 0, 0));
   REQUIRE(CUDA_SUCCESS == cuModuleGetFunction(&kernel, module, "kernel"));
 

--- a/libcudacxx/test/utils/nvidia/nvrtc/nvrtcc_run.h
+++ b/libcudacxx/test/utils/nvidia/nvrtc/nvrtcc_run.h
@@ -66,6 +66,7 @@ static void load_and_run_gpu_code(const std::string inputFile, const RunConfig& 
   CUDA_SAFE_CALL(cuInit(0));
   CUDA_SAFE_CALL(cuDeviceGet(&cuDevice, 0));
   CUDA_SAFE_CALL(cuDevicePrimaryCtxRetain(&context, cuDevice));
+  CUDA_SAFE_CALL(cuCtxSetCurrent(context));
   CUDA_SAFE_CALL(cuModuleLoadDataEx(&module, code.data(), 0, 0, 0));
   CUDA_SAFE_CALL(cuModuleGetFunction(&kernel, module, "main_kernel"));
   CUDA_SAFE_CALL(cuLaunchKernel(kernel, 1, 1, 1, rc.threadCount, 1, 1, rc.shmemSize, nullptr, nullptr, 0));

--- a/libcudacxx/test/utils/nvidia/nvrtc/nvrtcc_run.h
+++ b/libcudacxx/test/utils/nvidia/nvrtc/nvrtcc_run.h
@@ -65,7 +65,7 @@ static void load_and_run_gpu_code(const std::string inputFile, const RunConfig& 
 
   CUDA_SAFE_CALL(cuInit(0));
   CUDA_SAFE_CALL(cuDeviceGet(&cuDevice, 0));
-  CUDA_SAFE_CALL(cuCtxCreate(&context, 0, cuDevice));
+  CUDA_SAFE_CALL(cuDevicePrimaryCtxRetain(&context, cuDevice));
   CUDA_SAFE_CALL(cuModuleLoadDataEx(&module, code.data(), 0, 0, 0));
   CUDA_SAFE_CALL(cuModuleGetFunction(&kernel, module, "main_kernel"));
   CUDA_SAFE_CALL(cuLaunchKernel(kernel, 1, 1, 1, rc.threadCount, 1, 1, rc.shmemSize, nullptr, nullptr, 0));


### PR DESCRIPTION
Unless separate context is needed, its usually better to just use the primary context, especially if the application ends up using both driver and runtime APIs.
In our testing we don't use any features of a separate context, so we should use the primary context.
This will also avoid issues when next CUDA major version comes and `cuCtxCreate` is updated to have an extra argument.