### PR TITLE
Exclude gcc-11, gcc-10 from `annotated_ptr` constexpr test

### DIFF
--- a/libcudacxx/test/libcudacxx/cuda/annotated_ptr/access_property_constexpr.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/annotated_ptr/access_property_constexpr.pass.cpp
@@ -10,7 +10,7 @@
 // UNSUPPORTED: nvrtc
 
 // error: expression must have a constant value annotated_ptr.h: note #2701-D: attempt to access run-time storage
-// UNSUPPORTED: clang-14, gcc-9, gcc-8, gcc-7, msvc-19.29
+// UNSUPPORTED: clang-14, gcc-11, gcc-10, gcc-9, gcc-8, gcc-7, msvc-19.29
 
 #include <cuda/annotated_ptr>
 

--- a/libcudacxx/test/libcudacxx/cuda/annotated_ptr/annotated_ptr_constexpr.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/annotated_ptr/annotated_ptr_constexpr.pass.cpp
@@ -10,7 +10,7 @@
 // UNSUPPORTED: nvrtc
 
 // error: expression must have a constant value annotated_ptr.h: note #2701-D: attempt to access run-time storage
-// UNSUPPORTED: clang-14, gcc-9, gcc-8, gcc-7, msvc-19.29
+// UNSUPPORTED: clang-14, gcc-11, gcc-10, gcc-9, gcc-8, gcc-7, msvc-19.29
 
 #include <cuda/annotated_ptr>
 


### PR DESCRIPTION
## Description

The PR excludes gcc-11, gcc-10 from `annotated_ptr` constexpr test because they don't support internal storage during constant evaluation.