### PR TITLE
Replace calls to CUDA runtime occupancy with launcher_factory.MaxSmOccupancy()

### DIFF
--- a/cub/cub/device/dispatch/dispatch_radix_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_radix_sort.cuh
@@ -644,8 +644,7 @@ struct DispatchRadixSort
       int histo_blocks_per_sm       = 1;
       auto histogram_kernel         = kernel_source.RadixSortHistogramKernel();
 
-      error = CubDebug(
-        cudaOccupancyMaxActiveBlocksPerMultiprocessor(&histo_blocks_per_sm, histogram_kernel, HISTO_BLOCK_THREADS, 0));
+      error = CubDebug(launcher_factory.MaxSmOccupancy(histo_blocks_per_sm, histogram_kernel, HISTO_BLOCK_THREADS, 0));
       if (cudaSuccess != error)
       {
         break;

--- a/cub/cub/device/dispatch/dispatch_transform.cuh
+++ b/cub/cub/device/dispatch/dispatch_transform.cuh
@@ -216,8 +216,8 @@ struct dispatch_t<StableAddress,
         }
 
         int max_occupancy = 0;
-        const auto error =
-          CubDebug(MaxSmOccupancy(max_occupancy, kernel_source.TransformKernel(), block_dim, smem_size));
+        const auto error  = CubDebug(
+          launcher_factory.MaxSmOccupancy(max_occupancy, kernel_source.TransformKernel(), block_dim, smem_size));
         if (error != cudaSuccess)
         {
           return ::cuda::std::unexpected<cudaError_t /* nvcc 12.0 with GCC 7 fails CTAD here */>(error);

--- a/cub/cub/device/dispatch/dispatch_unique_by_key.cuh
+++ b/cub/cub/device/dispatch/dispatch_unique_by_key.cuh
@@ -385,9 +385,10 @@ struct DispatchUniqueByKey
       {
         // Get SM occupancy for unique_by_key_kernel
         int sweep_sm_occupancy;
-        error = CubDebug(MaxSmOccupancy(sweep_sm_occupancy, // out
-                                        sweep_kernel,
-                                        block_threads));
+        error = CubDebug(launcher_factory.MaxSmOccupancy(
+          sweep_sm_occupancy, // out
+          sweep_kernel,
+          block_threads));
         if (cudaSuccess != error)
         {
           break;


### PR DESCRIPTION
## Description

closes #4593 

## Checklist
- [X] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
