### PR TITLE
Maintenance/c parallel tests build caching

### DIFF
--- a/c/parallel/test/algorithm_execution.h
+++ b/c/parallel/test/algorithm_execution.h
@@ -1,0 +1,174 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <cuda.h>
+
+#include <iostream>
+#include <optional>
+#include <string>
+
+#include "test_util.h"
+#include <c2h/catch2_test_helper.h>
+#include <cccl/c/types.h>
+
+template <int device_id_ = 0>
+class BuildInformation
+{
+  int cc_major;
+  int cc_minor;
+  const char* cub_path;
+  const char* thrust_path;
+  const char* libcudacxx_path;
+  const char* ctk_path;
+
+  BuildInformation() = default;
+  BuildInformation(int major, int minor, const char* cub, const char* thrust, const char* libcudacxx, const char* ctk)
+      : cc_major(major)
+      , cc_minor(minor)
+      , cub_path(cub)
+      , thrust_path(thrust)
+      , libcudacxx_path(libcudacxx)
+      , ctk_path(ctk)
+  {}
+
+public:
+  static constexpr int device_id = device_id_;
+
+  static const auto& init()
+  {
+    cudaDeviceProp deviceProp;
+    cudaGetDeviceProperties(&deviceProp, device_id);
+
+    static BuildInformation singleton{
+      deviceProp.major, deviceProp.minor, TEST_CUB_PATH, TEST_THRUST_PATH, TEST_LIBCUDACXX_PATH, TEST_CTK_PATH};
+    return singleton;
+  }
+
+  int get_cc_major() const
+  {
+    return cc_major;
+  }
+  int get_cc_minor() const
+  {
+    return cc_minor;
+  }
+  const char* get_cub_path() const
+  {
+    return cub_path;
+  }
+  const char* get_thrust_path() const
+  {
+    return thrust_path;
+  }
+  const char* get_libcudacxx_path() const
+  {
+    return libcudacxx_path;
+  }
+  const char* get_ctk_path() const
+  {
+    return ctk_path;
+  }
+};
+
+template <typename BuildResultT,
+          typename Build,
+          typename Cleanup,
+          typename Run,
+          typename BuildCache,
+          typename KeyT,
+          typename... Tx>
+void AlgorithmExecute(std::optional<BuildCache>& cache, const std::optional<KeyT>& lookup_key, Tx&&... args)
+{
+  constexpr int device_id = 0;
+  const auto& build_info  = BuildInformation<device_id>::init();
+
+  BuildResultT build;
+
+  bool found               = false;
+  const bool cache_and_key = bool(cache) && bool(lookup_key);
+
+  if (cache_and_key)
+  {
+    auto& cache_v     = cache.value();
+    const auto& key_v = lookup_key.value();
+    if (cache_v.contains(key_v))
+    {
+      build = cache_v.get(key_v).get();
+      found = true;
+    }
+  }
+
+  if (!found)
+  {
+    REQUIRE(
+      CUDA_SUCCESS
+      == Build{}(&build,
+                 args...,
+                 build_info.get_cc_major(),
+                 build_info.get_cc_minor(),
+                 build_info.get_cub_path(),
+                 build_info.get_thrust_path(),
+                 build_info.get_libcudacxx_path(),
+                 build_info.get_ctk_path()));
+
+    if (cache_and_key)
+    {
+      auto& cache_v     = cache.value();
+      const auto& key_v = lookup_key.value();
+      cache_v.insert(key_v, build);
+    }
+  }
+
+  const std::string& sass = inspect_sass(build.cubin, build.cubin_size);
+
+  REQUIRE(sass.find("LDL") == std::string::npos);
+  REQUIRE(sass.find("STL") == std::string::npos);
+
+  CUstream null_stream = 0;
+
+  size_t temp_storage_bytes = 0;
+  REQUIRE(CUDA_SUCCESS == Run{}(build, nullptr, &temp_storage_bytes, args..., null_stream));
+
+  pointer_t<uint8_t> temp_storage(temp_storage_bytes);
+
+  REQUIRE(CUDA_SUCCESS == Run{}(build, temp_storage.ptr, &temp_storage_bytes, args..., null_stream));
+
+  if (cache_and_key)
+  {
+    // if cache and lookup_key were provided, the ownership of resources
+    // allocated for build is transferred to the cache, hence do nothing
+  }
+  else
+  {
+    // release build data resources
+    REQUIRE(CUDA_SUCCESS == Cleanup{}(&build));
+  }
+}
+
+template <typename BuildResultT, typename Cleanup>
+struct BuildResultDeleter
+{
+  static constexpr Cleanup cleanup_{};
+  void operator()(BuildResultT* build_data) const noexcept
+  {
+    check_success(cleanup_(build_data));
+  }
+
+private:
+  void check_success(CUresult status) const noexcept
+  {
+    if (status != CUDA_SUCCESS)
+    {
+      std::cerr << "Clean-up call returned status " << status << std::endl;
+    }
+  }
+};

--- a/c/parallel/test/algorithm_execution.h
+++ b/c/parallel/test/algorithm_execution.h
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -160,11 +160,11 @@ struct BuildResultDeleter
   static constexpr Cleanup cleanup_{};
   void operator()(BuildResultT* build_data) const noexcept
   {
-    check_success(cleanup_(build_data));
+    BuildResultDeleter::check_success(cleanup_(build_data));
   }
 
 private:
-  void check_success(CUresult status) const noexcept
+  static void check_success(CUresult status) noexcept
   {
     if (status != CUDA_SUCCESS)
     {

--- a/c/parallel/test/build_result_caching.h
+++ b/c/parallel/test/build_result_caching.h
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -93,8 +93,7 @@ template <typename T, typename Tag>
 class fixture
 {
 public:
-  using OptionalT  = typename std::optional<T>;
-  using FixtureTag = Tag;
+  using OptionalT = typename std::optional<T>;
 
 private:
   OptionalT v;
@@ -104,8 +103,6 @@ private:
   {}
 
 public:
-  ~fixture() = default;
-
   OptionalT& get_value()
   {
     return v;

--- a/c/parallel/test/build_result_caching.h
+++ b/c/parallel/test/build_result_caching.h
@@ -14,6 +14,7 @@
 #include <memory>
 #include <optional>
 #include <sstream>
+#include <tuple>
 #include <typeinfo>
 #include <unordered_map>
 
@@ -148,3 +149,29 @@ struct KeyBuilder
     return ss.str();
   }
 };
+
+template <typename TupleLike, std::size_t I = 0>
+void adder_helper(std::stringstream& ss)
+{
+  constexpr std::size_t S = std::tuple_size_v<TupleLike>;
+  if constexpr (I < S)
+  {
+    using SelectedType       = std::tuple_element_t<I, TupleLike>;
+    constexpr std::size_t In = I + 1;
+
+    ss << KeyBuilder::type_as_key<SelectedType>();
+    if constexpr (In < S)
+    {
+      ss << "-";
+    }
+    adder_helper<TupleLike, In>(ss);
+  }
+}
+
+template <typename... Ts>
+std::optional<std::string> make_key()
+{
+  std::stringstream ss{};
+  adder_helper<std::tuple<Ts...>, 0>(ss);
+  return std::make_optional(ss.str());
+}

--- a/c/parallel/test/build_result_caching.h
+++ b/c/parallel/test/build_result_caching.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include <cassert>
 #include <iostream>
 #include <memory>
 #include <optional>
@@ -85,6 +86,7 @@ public:
 
   ValueT& get(const KeyT& key)
   {
+    assert(m_map.contains(key));
     return m_map[key];
   }
 };

--- a/c/parallel/test/build_result_caching.h
+++ b/c/parallel/test/build_result_caching.h
@@ -1,0 +1,150 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <sstream>
+#include <typeinfo>
+#include <unordered_map>
+
+template <typename ResultT, typename CleanupCallable>
+class result_wrapper_t
+{
+  std::shared_ptr<ResultT> m_owner;
+
+public:
+  result_wrapper_t()
+      : m_owner{}
+  {}
+  result_wrapper_t(ResultT v)
+      : m_owner{std::make_shared<ResultT>(v)}
+  {}
+
+  result_wrapper_t(const result_wrapper_t&) = default;
+  result_wrapper_t(result_wrapper_t&&)      = default;
+
+  result_wrapper_t& operator=(const result_wrapper_t&) = default;
+  result_wrapper_t& operator=(result_wrapper_t&&)      = default;
+
+  ~result_wrapper_t() noexcept
+  {
+    if (!m_owner)
+    {
+      return;
+    }
+    try
+    {
+      if (m_owner.use_count() <= 1)
+      {
+        // release resources
+        CleanupCallable{}(m_owner.get());
+      }
+    }
+    catch (const std::exception& e)
+    {
+      std::cerr << "~result_wrapper_t ignores exception: " << e.what() << std::endl;
+    }
+  }
+
+  ResultT& get()
+  {
+    return *m_owner.get();
+  }
+};
+
+template <typename KeyT, typename ValueT>
+class build_cache_t
+{
+  std::unordered_map<KeyT, ValueT> m_map;
+
+public:
+  build_cache_t()
+      : m_map{} {};
+
+  bool contains(const KeyT& key) const
+  {
+    // unorder_map::contains is C++20 feature
+    return m_map.contains(key);
+  }
+
+  void insert(const KeyT& key, ValueT&& new_value)
+  {
+    m_map[key] = std::move(new_value);
+  }
+
+  ValueT& get(const KeyT& key)
+  {
+    return m_map[key];
+  }
+};
+
+template <typename T, typename Tag>
+class fixture
+{
+public:
+  using OptionalT  = typename std::optional<T>;
+  using FixtureTag = Tag;
+
+private:
+  OptionalT v;
+
+  fixture()
+      : v{T{}}
+  {}
+
+public:
+  ~fixture() = default;
+
+  OptionalT& get_value()
+  {
+    return v;
+  }
+
+  static auto& get_or_create()
+  {
+    static fixture singleton{};
+    return singleton;
+  }
+};
+
+struct KeyBuilder
+{
+  static std::string bool_as_key(bool v)
+  {
+    return (v) ? std::string("T") : std::string("F");
+  }
+
+  template <typename T>
+  static std::string type_as_key()
+  {
+    return typeid(T).name();
+  }
+
+  template <std::size_t N>
+  static std::string join(const std::string (&collection)[N])
+  {
+    constexpr std::string_view delimiter = "-";
+    std::stringstream ss;
+
+    for (std::size_t i = 0; i < N; ++i)
+    {
+      ss << collection[i];
+      if (i + 1 < N)
+      {
+        ss << delimiter;
+      }
+    }
+
+    return ss.str();
+  }
+};

--- a/c/parallel/test/test_for.cpp
+++ b/c/parallel/test/test_for.cpp
@@ -11,12 +11,42 @@
 #include <cuda_runtime.h>
 
 #include <algorithm>
+#include <iostream> // std::cerr
+#include <optional> // std::optional
+#include <string>
 
+#include "build_result_caching.h"
 #include "test_util.h"
 #include <cccl/c/for.h>
 #include <stdint.h>
 
-void for_each(cccl_iterator_t input, uint64_t num_items, cccl_op_t op)
+struct for_build_cleaner
+{
+  void operator()(cccl_device_for_build_result_t* build_data) noexcept
+  {
+    auto command_status = cccl_device_for_cleanup(build_data);
+    if (CUDA_SUCCESS != command_status)
+    {
+      std::cerr << "  Clean-up call returned status " << command_status << ". The pointer was "
+                << static_cast<void*>(build_data) << std::endl;
+      if (build_data)
+      {
+        std::cerr << "build->cc: " << build_data->cc << ", build->cubin: " << build_data->cubin
+                  << ", build->cubin_size: " << build_data->cubin_size << std::endl;
+      }
+    };
+  }
+};
+
+using for_build_cache_t =
+  build_cache_t<std::string, result_wrapper_t<cccl_device_for_build_result_t, for_build_cleaner>>;
+
+template <typename BuildCache = for_build_cache_t, typename KeyT = std::string>
+void for_each(cccl_iterator_t input,
+              uint64_t num_items,
+              cccl_op_t op,
+              std::optional<BuildCache>& cache,
+              const std::optional<KeyT>& lookup_key)
 {
   cudaDeviceProp deviceProp;
   cudaGetDeviceProperties(&deviceProp, 0);
@@ -30,18 +60,62 @@ void for_each(cccl_iterator_t input, uint64_t num_items, cccl_op_t op)
   const char* ctk_path        = TEST_CTK_PATH;
 
   cccl_device_for_build_result_t build;
-  REQUIRE(
-    CUDA_SUCCESS
-    == cccl_device_for_build(&build, input, op, cc_major, cc_minor, cub_path, thrust_path, libcudacxx_path, ctk_path));
+  bool found = false;
+
+  const bool cache_and_key = bool(cache) && bool(lookup_key);
+
+  if (cache_and_key)
+  {
+    auto& cache_v     = cache.value();
+    const auto& key_v = lookup_key.value();
+    if (cache_v.contains(key_v))
+    {
+      build = cache_v.get(key_v).get();
+      found = true;
+    }
+  }
+
+  if (!found)
+  {
+    REQUIRE(CUDA_SUCCESS
+            == cccl_device_for_build(
+              &build, input, op, cc_major, cc_minor, cub_path, thrust_path, libcudacxx_path, ctk_path));
+
+    if (cache_and_key)
+    {
+      auto& cache_v     = cache.value();
+      const auto& key_v = lookup_key.value();
+      cache_v.insert(key_v, build);
+    }
+  }
+
   const std::string sass = inspect_sass(build.cubin, build.cubin_size);
   REQUIRE(sass.find("LDL") == std::string::npos);
   REQUIRE(sass.find("STL") == std::string::npos);
 
   REQUIRE(CUDA_SUCCESS == cccl_device_for(build, input, num_items, op, 0));
-  REQUIRE(CUDA_SUCCESS == cccl_device_for_cleanup(&build));
+  if (cache_and_key)
+  {
+    // if cache and lookup_key were provided, the ownership of resources
+    // allocated for build is transferred to the cache
+  }
+  else
+  {
+    // release build data resources
+    REQUIRE(CUDA_SUCCESS == cccl_device_for_cleanup(&build));
+  }
+}
+
+void for_each(cccl_iterator_t input, uint64_t num_items, cccl_op_t op)
+{
+  std::optional<for_build_cache_t> no_build_cache = std::nullopt;
+  std::optional<std::string> no_test_key          = std::nullopt;
+
+  return for_each(input, num_items, op, no_build_cache, no_test_key);
 }
 
 using integral_types = c2h::type_list<int32_t, uint32_t, int64_t, uint64_t>;
+struct DeviceFor_Pointer_Fixture_Tag;
 C2H_TEST("for works with integral types", "[for]", integral_types)
 {
   using T = c2h::get<0, TestType>;
@@ -52,7 +126,12 @@ C2H_TEST("for works with integral types", "[for]", integral_types)
   std::vector<T> input(num_items, T(1));
   pointer_t<T> input_ptr(input);
 
-  for_each(input_ptr, num_items, op);
+  auto& build_cache = fixture<for_build_cache_t, DeviceFor_Pointer_Fixture_Tag>::get_or_create().get_value();
+
+  std::string key_string = KeyBuilder::type_as_key<T>();
+  std::optional<std::string> test_key{key_string};
+
+  for_each(input_ptr, num_items, op, build_cache, test_key);
 
   // Copy back input array
   input          = input_ptr;
@@ -90,7 +169,12 @@ extern "C" __device__ void op(void* a_ptr) {
   std::vector<pair> input(num_items, pair{short(1), size_t(1)});
   pointer_t<pair> input_ptr(input);
 
-  for_each(input_ptr, num_items, op);
+  auto& build_cache = fixture<for_build_cache_t, DeviceFor_Pointer_Fixture_Tag>::get_or_create().get_value();
+
+  std::string key_string = KeyBuilder::type_as_key<pair>();
+  std::optional<std::string> test_key{key_string};
+
+  for_each(input_ptr, num_items, op, build_cache, test_key);
 
   // Copy back input array
   input          = input_ptr;
@@ -129,6 +213,7 @@ extern "C" __device__ void op(void* state_ptr, void* a_ptr) {
   std::vector<int> input(num_items, 1);
   pointer_t<int> input_ptr(input);
 
+  // no build caching
   for_each(input_ptr, num_items, op);
 
   const int invocation_count = counter[0];
@@ -166,6 +251,7 @@ extern "C" __device__ void op(void* state_ptr, void* a_ptr) {
   std::vector<int> input(num_items, 1);
   pointer_t<int> input_ptr(input);
 
+  // no build caching
   for_each(input_ptr, num_items, op);
 
   const int invocation_count = counter[0];

--- a/c/parallel/test/test_for.cpp
+++ b/c/parallel/test/test_for.cpp
@@ -72,7 +72,7 @@ template <typename T>
 void for_each_pointer_input(pointer_t<T>& input_ptr, uint64_t num_items, cccl_op_t op)
 {
   auto& build_cache    = fixture<for_each_build_cache_t, DeviceFor_Pointer_Fixture_Tag>::get_or_create().get_value();
-  const auto& test_key = std::make_optional(KeyBuilder::type_as_key<T>());
+  const auto& test_key = make_key<T>();
 
   for_each(static_cast<cccl_iterator_t>(input_ptr), num_items, op, build_cache, test_key);
 }

--- a/c/parallel/test/test_for.cpp
+++ b/c/parallel/test/test_for.cpp
@@ -99,17 +99,12 @@ C2H_TEST("for works with integral types", "[for]", integral_types)
 
   for_each_pointer_input(input_ptr, num_items, op);
 
-  // Copy back input arrayw
+  // Copy input array back to host
   input = input_ptr;
 
-  bool all_match = true;
-  const T expected{2};
-
-  std::for_each(input.begin(), input.end(), [&all_match, expected](auto v) {
-    all_match = all_match && (v == expected);
-  });
-
-  REQUIRE(all_match);
+  REQUIRE(std::all_of(input.begin(), input.end(), [](auto&& v) {
+    return v == T{2};
+  }));
 }
 
 struct pair
@@ -138,14 +133,11 @@ extern "C" __device__ void op(void* a_ptr) {
   for_each_pointer_input(input_ptr, num_items, op);
 
   // Copy back input array
-  input          = input_ptr;
-  bool all_match = true;
-  const pair expected{2, 2};
-  std::for_each(input.begin(), input.end(), [&all_match, expected](auto v) {
-    all_match = all_match && (v.a == expected.a) && (v.b == expected.b);
-  });
+  input = input_ptr;
 
-  REQUIRE(all_match);
+  REQUIRE(std::all_of(input.begin(), input.end(), [](auto v) {
+    return (v.a == short(2)) && (v.b == size_t(2));
+  }));
 }
 
 struct invocation_counter_state_t

--- a/c/parallel/test/test_for.cpp
+++ b/c/parallel/test/test_for.cpp
@@ -71,10 +71,8 @@ struct DeviceFor_Pointer_Fixture_Tag;
 template <typename T>
 void for_each_pointer_input(pointer_t<T>& input_ptr, uint64_t num_items, cccl_op_t op)
 {
-  auto& build_cache = fixture<for_each_build_cache_t, DeviceFor_Pointer_Fixture_Tag>::get_or_create().get_value();
-
-  const std::string& key_string = KeyBuilder::type_as_key<T>();
-  const std::optional<std::string>& test_key{key_string};
+  auto& build_cache    = fixture<for_each_build_cache_t, DeviceFor_Pointer_Fixture_Tag>::get_or_create().get_value();
+  const auto& test_key = std::make_optional(KeyBuilder::type_as_key<T>());
 
   for_each(static_cast<cccl_iterator_t>(input_ptr), num_items, op, build_cache, test_key);
 }

--- a/c/parallel/test/test_merge_sort.cpp
+++ b/c/parallel/test/test_merge_sort.cpp
@@ -101,10 +101,8 @@ C2H_TEST("DeviceMergeSort::SortKeys works", "[merge_sort]", key_types)
   pointer_t<key_t> input_keys_it(input_keys);
   pointer_t<key_t> input_items_it;
 
-  auto& build_cache = get_cache<DeviceMergeSort_SortKeys_Fixture_Tag>();
-
-  std::string key_string = KeyBuilder::type_as_key<key_t>();
-  std::optional<std::string> test_key{key_string};
+  auto& build_cache    = get_cache<DeviceMergeSort_SortKeys_Fixture_Tag>();
+  const auto& test_key = std::make_optional(KeyBuilder::type_as_key<key_t>());
 
   merge_sort(input_keys_it, input_items_it, input_keys_it, input_items_it, num_items, op, build_cache, test_key);
 
@@ -128,10 +126,8 @@ C2H_TEST("DeviceMergeSort::SortKeysCopy works", "[merge_sort]", key_types)
   pointer_t<key_t> input_items_it;
   pointer_t<key_t> output_keys_it(output_keys);
 
-  auto& build_cache = get_cache<DeviceMergeSort_SortKeysCopy_Fixture_Tag>();
-
-  std::string key_string = KeyBuilder::type_as_key<key_t>();
-  std::optional<std::string> test_key{key_string};
+  auto& build_cache    = get_cache<DeviceMergeSort_SortKeysCopy_Fixture_Tag>();
+  const auto& test_key = std::make_optional(KeyBuilder::type_as_key<key_t>());
 
   merge_sort(input_keys_it, input_items_it, output_keys_it, input_items_it, num_items, op, build_cache, test_key);
 
@@ -159,9 +155,8 @@ C2H_TEST("DeviceMergeSort::SortPairs works", "[merge_sort]", key_types)
   pointer_t<item_t> input_items_it(input_items);
 
   auto& build_cache = get_cache<DeviceMergeSort_SortPairs_Fixture_Tag>();
-
-  std::string key_string = KeyBuilder::join({KeyBuilder::type_as_key<key_t>(), KeyBuilder::type_as_key<item_t>()});
-  std::optional<std::string> test_key{key_string};
+  const auto& test_key =
+    std::make_optional(KeyBuilder::join({KeyBuilder::type_as_key<key_t>(), KeyBuilder::type_as_key<item_t>()}));
 
   merge_sort(input_keys_it, input_items_it, input_keys_it, input_items_it, num_items, op, build_cache, test_key);
 
@@ -195,9 +190,8 @@ C2H_TEST("DeviceMergeSort::SortPairsCopy works ", "[merge_sort]", key_types)
   pointer_t<item_t> output_items_it(output_items);
 
   auto& build_cache = get_cache<DeviceMergeSort_SortPairs_Fixture_Tag>();
-
-  std::string key_string = KeyBuilder::join({KeyBuilder::type_as_key<key_t>(), KeyBuilder::type_as_key<item_t>()});
-  std::optional<std::string> test_key{key_string};
+  const auto& test_key =
+    std::make_optional(KeyBuilder::join({KeyBuilder::type_as_key<key_t>(), KeyBuilder::type_as_key<item_t>()}));
 
   merge_sort(input_keys_it, input_items_it, output_keys_it, output_items_it, num_items, op, build_cache, test_key);
 
@@ -250,10 +244,8 @@ C2H_TEST("DeviceMergeSort:SortPairsCopy works with custom types", "[merge_sort]"
   pointer_t<item_pair> output_items_it(input_items);
 
   auto& build_cache = get_cache<DeviceMergeSort_SortPairsCopy_CustomType_Fixture_Tag>();
-
-  std::string key_string =
-    KeyBuilder::join({KeyBuilder::type_as_key<key_pair>(), KeyBuilder::type_as_key<item_pair>()});
-  std::optional<std::string> test_key{key_string};
+  const auto& test_key =
+    std::make_optional(KeyBuilder::join({KeyBuilder::type_as_key<key_pair>(), KeyBuilder::type_as_key<item_pair>()}));
 
   merge_sort(input_keys_it, input_items_it, output_keys_it, output_items_it, num_items, op, build_cache, test_key);
 
@@ -295,10 +287,8 @@ C2H_TEST("DeviceMergeSort::SortKeys works with input iterators", "[merge_sort]")
   input_keys_it.state.data = input_keys_ptr.ptr;
   pointer_t<T> input_items_it;
 
-  auto& build_cache = get_cache<DeviceMergeSort_SortKeys_Iterators_Fixture_Tag>();
-
-  std::string key_string = KeyBuilder::type_as_key<T>();
-  std::optional<std::string> test_key{key_string};
+  auto& build_cache    = get_cache<DeviceMergeSort_SortKeys_Iterators_Fixture_Tag>();
+  const auto& test_key = std::make_optional(KeyBuilder::type_as_key<T>());
 
   merge_sort(input_keys_it, input_items_it, input_keys_ptr, input_items_it, num_items, op, build_cache, test_key);
 
@@ -334,9 +324,8 @@ C2H_TEST("DeviceMergeSort::SortPairs works with input iterators", "[merge_sort]"
   input_items_it.state.data = input_items_ptr.ptr;
 
   auto& build_cache = get_cache<DeviceMergeSort_SortPairs_Iterators_Fixture_Tag>();
-
-  std::string key_string = KeyBuilder::join({KeyBuilder::type_as_key<key_t>(), KeyBuilder::type_as_key<item_t>()});
-  std::optional<std::string> test_key{key_string};
+  const auto& test_key =
+    std::make_optional(KeyBuilder::join({KeyBuilder::type_as_key<key_t>(), KeyBuilder::type_as_key<item_t>()}));
 
   merge_sort(input_keys_it, input_items_it, input_keys_ptr, input_items_ptr, num_items, op, build_cache, test_key);
 

--- a/c/parallel/test/test_merge_sort.cpp
+++ b/c/parallel/test/test_merge_sort.cpp
@@ -102,7 +102,7 @@ C2H_TEST("DeviceMergeSort::SortKeys works", "[merge_sort]", key_types)
   pointer_t<key_t> input_items_it;
 
   auto& build_cache    = get_cache<DeviceMergeSort_SortKeys_Fixture_Tag>();
-  const auto& test_key = std::make_optional(KeyBuilder::type_as_key<key_t>());
+  const auto& test_key = make_key<key_t>();
 
   merge_sort(input_keys_it, input_items_it, input_keys_it, input_items_it, num_items, op, build_cache, test_key);
 
@@ -127,7 +127,7 @@ C2H_TEST("DeviceMergeSort::SortKeysCopy works", "[merge_sort]", key_types)
   pointer_t<key_t> output_keys_it(output_keys);
 
   auto& build_cache    = get_cache<DeviceMergeSort_SortKeysCopy_Fixture_Tag>();
-  const auto& test_key = std::make_optional(KeyBuilder::type_as_key<key_t>());
+  const auto& test_key = make_key<key_t>();
 
   merge_sort(input_keys_it, input_items_it, output_keys_it, input_items_it, num_items, op, build_cache, test_key);
 
@@ -154,9 +154,8 @@ C2H_TEST("DeviceMergeSort::SortPairs works", "[merge_sort]", key_types)
   pointer_t<key_t> input_keys_it(input_keys);
   pointer_t<item_t> input_items_it(input_items);
 
-  auto& build_cache = get_cache<DeviceMergeSort_SortPairs_Fixture_Tag>();
-  const auto& test_key =
-    std::make_optional(KeyBuilder::join({KeyBuilder::type_as_key<key_t>(), KeyBuilder::type_as_key<item_t>()}));
+  auto& build_cache    = get_cache<DeviceMergeSort_SortPairs_Fixture_Tag>();
+  const auto& test_key = make_key<key_t, item_t>();
 
   merge_sort(input_keys_it, input_items_it, input_keys_it, input_items_it, num_items, op, build_cache, test_key);
 
@@ -189,9 +188,8 @@ C2H_TEST("DeviceMergeSort::SortPairsCopy works ", "[merge_sort]", key_types)
   pointer_t<key_t> output_keys_it(output_keys);
   pointer_t<item_t> output_items_it(output_items);
 
-  auto& build_cache = get_cache<DeviceMergeSort_SortPairs_Fixture_Tag>();
-  const auto& test_key =
-    std::make_optional(KeyBuilder::join({KeyBuilder::type_as_key<key_t>(), KeyBuilder::type_as_key<item_t>()}));
+  auto& build_cache    = get_cache<DeviceMergeSort_SortPairs_Fixture_Tag>();
+  const auto& test_key = make_key<key_t, item_t>();
 
   merge_sort(input_keys_it, input_items_it, output_keys_it, output_items_it, num_items, op, build_cache, test_key);
 
@@ -243,9 +241,8 @@ C2H_TEST("DeviceMergeSort:SortPairsCopy works with custom types", "[merge_sort]"
   pointer_t<key_pair> output_keys_it(input_keys);
   pointer_t<item_pair> output_items_it(input_items);
 
-  auto& build_cache = get_cache<DeviceMergeSort_SortPairsCopy_CustomType_Fixture_Tag>();
-  const auto& test_key =
-    std::make_optional(KeyBuilder::join({KeyBuilder::type_as_key<key_pair>(), KeyBuilder::type_as_key<item_pair>()}));
+  auto& build_cache    = get_cache<DeviceMergeSort_SortPairsCopy_CustomType_Fixture_Tag>();
+  const auto& test_key = make_key<key_pair, item_pair>();
 
   merge_sort(input_keys_it, input_items_it, output_keys_it, output_items_it, num_items, op, build_cache, test_key);
 
@@ -288,7 +285,7 @@ C2H_TEST("DeviceMergeSort::SortKeys works with input iterators", "[merge_sort]")
   pointer_t<T> input_items_it;
 
   auto& build_cache    = get_cache<DeviceMergeSort_SortKeys_Iterators_Fixture_Tag>();
-  const auto& test_key = std::make_optional(KeyBuilder::type_as_key<T>());
+  const auto& test_key = make_key<T>();
 
   merge_sort(input_keys_it, input_items_it, input_keys_ptr, input_items_it, num_items, op, build_cache, test_key);
 
@@ -323,9 +320,8 @@ C2H_TEST("DeviceMergeSort::SortPairs works with input iterators", "[merge_sort]"
   pointer_t<key_t> input_items_ptr(input_items);
   input_items_it.state.data = input_items_ptr.ptr;
 
-  auto& build_cache = get_cache<DeviceMergeSort_SortPairs_Iterators_Fixture_Tag>();
-  const auto& test_key =
-    std::make_optional(KeyBuilder::join({KeyBuilder::type_as_key<key_t>(), KeyBuilder::type_as_key<item_t>()}));
+  auto& build_cache    = get_cache<DeviceMergeSort_SortPairs_Iterators_Fixture_Tag>();
+  const auto& test_key = make_key<key_t, item_t>();
 
   merge_sort(input_keys_it, input_items_it, input_keys_ptr, input_items_ptr, num_items, op, build_cache, test_key);
 

--- a/c/parallel/test/test_radix_sort.cpp
+++ b/c/parallel/test/test_radix_sort.cpp
@@ -165,12 +165,12 @@ TEMPLATE_LIST_TEST_CASE("DeviceRadixSort::SortKeys works", "[radix_sort]", key_t
 
   auto& build_cache = get_cache<DeviceRadixSort_SortKeys_Fixture_Tag>();
 
-  std::string key_string = KeyBuilder::join(
+  const std::string& key_string = KeyBuilder::join(
     {KeyBuilder::bool_as_key(is_descending),
      KeyBuilder::type_as_key<TestType>(),
      KeyBuilder::type_as_key<item_t>(),
      KeyBuilder::bool_as_key(is_overwrite_okay)});
-  std::optional<std::string> test_key{key_string};
+  const auto& test_key = std::make_optional(key_string);
 
   radix_sort(
     order,
@@ -237,13 +237,12 @@ TEMPLATE_LIST_TEST_CASE("DeviceRadixSort::SortPairs works", "[radix_sort]", key_
 
   auto& build_cache = get_cache<DeviceRadixSort_SortPairs_Fixture_Tag>();
 
-  std::string key_string = KeyBuilder::join(
+  const std::string& key_string = KeyBuilder::join(
     {KeyBuilder::bool_as_key(is_descending),
      KeyBuilder::type_as_key<TestType>(),
      KeyBuilder::type_as_key<item_t>(),
      KeyBuilder::bool_as_key(is_overwrite_okay)});
-
-  std::optional<std::string> test_key{key_string};
+  const auto& test_key = std::make_optional(key_string);
 
   radix_sort(
     order,

--- a/c/parallel/test/test_reduce.cpp
+++ b/c/parallel/test/test_reduce.cpp
@@ -100,7 +100,7 @@ C2H_TEST("Reduce works with integral types", "[reduce]", integral_types)
   value_t<T> init{T{42}};
 
   auto& build_cache    = get_cache<Reduce_IntegralTypes_Fixture_Tag>();
-  const auto& test_key = std::make_optional(KeyBuilder::type_as_key<T>());
+  const auto& test_key = make_key<T>();
 
   reduce(input_ptr, output_ptr, num_items, op, init, build_cache, test_key);
 
@@ -141,7 +141,7 @@ C2H_TEST("Reduce works with custom types", "[reduce]")
   value_t<pair> init{pair{4, 2}};
 
   auto& build_cache    = get_cache<Reduce_CustomTypes_Fixture_Tag>();
-  const auto& test_key = std::make_optional(KeyBuilder::type_as_key<pair>());
+  const auto& test_key = make_key<pair>();
 
   reduce(input_ptr, output_ptr, num_items, op, init, build_cache, test_key);
 
@@ -164,7 +164,7 @@ C2H_TEST("Reduce works with input iterators", "[reduce]")
   value_t<int> init{42};
 
   auto& build_cache    = get_cache<Reduce_CustomTypes_Fixture_Tag>();
-  const auto& test_key = std::make_optional(KeyBuilder::type_as_key<int>());
+  const auto& test_key = make_key<int>();
 
   reduce(input_it, output_it, num_items, op, init, build_cache, test_key);
 
@@ -187,7 +187,7 @@ C2H_TEST("Reduce works with output iterators", "[reduce]")
   value_t<int> init{42};
 
   auto& build_cache    = get_cache<Reduce_OutputIterators_Fixture_Tag>();
-  const auto& test_key = std::make_optional(KeyBuilder::type_as_key<int>());
+  const auto& test_key = make_key<int>();
 
   reduce(input_it, output_it, num_items, op, init, build_cache, test_key);
 
@@ -210,7 +210,7 @@ C2H_TEST("Reduce works with input and output iterators", "[reduce]")
   value_t<int> init{42};
 
   auto& build_cache    = get_cache<Reduce_InputOutputIterators_Fixture_Tag>();
-  const auto& test_key = std::make_optional(KeyBuilder::type_as_key<int>());
+  const auto& test_key = make_key<int>();
 
   reduce(input_it, output_it, num_items, op, init, build_cache, test_key);
 
@@ -230,9 +230,8 @@ C2H_TEST("Reduce accumulator type is influenced by initial value", "[reduce]")
   pointer_t<size_t> output_it(1);
   value_t<size_t> init{42};
 
-  auto& build_cache = get_cache<Reduce_AccumulatorType_Fixture_Tag>();
-  const auto& test_key =
-    std::make_optional(KeyBuilder::join({KeyBuilder::type_as_key<char>(), KeyBuilder::type_as_key<size_t>()}));
+  auto& build_cache    = get_cache<Reduce_AccumulatorType_Fixture_Tag>();
+  const auto& test_key = make_key<char, size_t>();
 
   reduce(input_it, output_it, num_items, op, init, build_cache, test_key);
 
@@ -251,9 +250,8 @@ C2H_TEST("Reduce works with large inputs", "[reduce]")
   value_t<size_t> init{42};
 
   // reuse fixture cache from previous example, as it runs identical example on larger input
-  auto& build_cache = get_cache<Reduce_AccumulatorType_Fixture_Tag>();
-  const auto& test_key =
-    std::make_optional(KeyBuilder::join({KeyBuilder::type_as_key<char>(), KeyBuilder::type_as_key<size_t>()}));
+  auto& build_cache    = get_cache<Reduce_AccumulatorType_Fixture_Tag>();
+  const auto& test_key = make_key<char, size_t>();
 
   reduce(input_it, output_it, num_items, op, init, build_cache, test_key);
 

--- a/c/parallel/test/test_reduce.cpp
+++ b/c/parallel/test/test_reduce.cpp
@@ -11,11 +11,43 @@
 #include <cuda_runtime.h>
 
 #include <cstdint>
+#include <iostream> // std::cerr
+#include <optional> // std::optional
+#include <string>
 
+#include "build_result_caching.h"
 #include "test_util.h"
 #include <cccl/c/reduce.h>
 
-void reduce(cccl_iterator_t input, cccl_iterator_t output, uint64_t num_items, cccl_op_t op, cccl_value_t init)
+struct reduce_build_cleaner
+{
+  void operator()(cccl_device_reduce_build_result_t* build_data) noexcept
+  {
+    auto command_status = cccl_device_reduce_cleanup(build_data);
+    if (CUDA_SUCCESS != command_status)
+    {
+      std::cerr << "  Clean-up call returned status " << command_status << ". The pointer was "
+                << static_cast<void*>(build_data) << std::endl;
+      if (build_data)
+      {
+        std::cerr << "build->cc: " << build_data->cc << ", build->cubin: " << build_data->cubin
+                  << ", build->cubin_size: " << build_data->cubin_size << std::endl;
+      }
+    };
+  }
+};
+
+using reduce_build_cache_t =
+  build_cache_t<std::string, result_wrapper_t<cccl_device_reduce_build_result_t, reduce_build_cleaner>>;
+
+template <typename BuildCache = reduce_build_cache_t, typename KeyT = std::string>
+void reduce(cccl_iterator_t input,
+            cccl_iterator_t output,
+            uint64_t num_items,
+            cccl_op_t op,
+            cccl_value_t init,
+            std::optional<BuildCache>& cache,
+            const std::optional<KeyT>& lookup_key)
 {
   cudaDeviceProp deviceProp;
   cudaGetDeviceProperties(&deviceProp, 0);
@@ -29,9 +61,33 @@ void reduce(cccl_iterator_t input, cccl_iterator_t output, uint64_t num_items, c
   const char* ctk_path        = TEST_CTK_PATH;
 
   cccl_device_reduce_build_result_t build;
-  REQUIRE(CUDA_SUCCESS
-          == cccl_device_reduce_build(
-            &build, input, output, op, init, cc_major, cc_minor, cub_path, thrust_path, libcudacxx_path, ctk_path));
+  const bool cache_and_key = bool(cache) && bool(lookup_key);
+  bool found               = false;
+
+  if (cache_and_key)
+  {
+    auto& cache_v     = cache.value();
+    const auto& key_v = lookup_key.value();
+    if (cache_v.contains(key_v))
+    {
+      build = cache_v.get(key_v).get();
+      found = true;
+    }
+  }
+
+  if (!found)
+  {
+    REQUIRE(CUDA_SUCCESS
+            == cccl_device_reduce_build(
+              &build, input, output, op, init, cc_major, cc_minor, cub_path, thrust_path, libcudacxx_path, ctk_path));
+
+    if (cache_and_key)
+    {
+      auto& cache_v     = cache.value();
+      const auto& key_v = lookup_key.value();
+      cache_v.insert(key_v, build);
+    }
+  }
 
   const std::string sass = inspect_sass(build.cubin, build.cubin_size);
   REQUIRE(sass.find("LDL") == std::string::npos);
@@ -45,10 +101,21 @@ void reduce(cccl_iterator_t input, cccl_iterator_t output, uint64_t num_items, c
 
   REQUIRE(CUDA_SUCCESS
           == cccl_device_reduce(build, temp_storage.ptr, &temp_storage_bytes, input, output, num_items, op, init, 0));
-  REQUIRE(CUDA_SUCCESS == cccl_device_reduce_cleanup(&build));
+
+  if (cache_and_key)
+  {
+    // if cache and lookup_key were provided, the ownership of resources
+    // allocated for build is transferred to the cache
+  }
+  else
+  {
+    // release build data resources
+    REQUIRE(CUDA_SUCCESS == cccl_device_reduce_cleanup(&build));
+  }
 }
 
 using integral_types = c2h::type_list<int32_t, uint32_t, int64_t, uint64_t>;
+struct Reduce_IntegralTypes_Fixture_Tag;
 C2H_TEST("Reduce works with integral types", "[reduce]", integral_types)
 {
   using T = c2h::get<0, TestType>;
@@ -60,7 +127,12 @@ C2H_TEST("Reduce works with integral types", "[reduce]", integral_types)
   pointer_t<T> output_ptr(1);
   value_t<T> init{T{42}};
 
-  reduce(input_ptr, output_ptr, num_items, op, init);
+  auto& build_cache = fixture<reduce_build_cache_t, Reduce_IntegralTypes_Fixture_Tag>::get_or_create().get_value();
+
+  std::string key_string = KeyBuilder::type_as_key<T>();
+  std::optional<std::string> test_key{key_string};
+
+  reduce(input_ptr, output_ptr, num_items, op, init, build_cache, test_key);
 
   const T output   = output_ptr[0];
   const T expected = std::accumulate(input.begin(), input.end(), init.value);
@@ -73,6 +145,7 @@ struct pair
   size_t b;
 };
 
+struct Reduce_CustomTypes_Fixture_Tag;
 C2H_TEST("Reduce works with custom types", "[reduce]")
 {
   const std::size_t num_items = GENERATE(0, 42, take(4, random(1 << 12, 1 << 24)));
@@ -97,7 +170,12 @@ C2H_TEST("Reduce works with custom types", "[reduce]")
   pointer_t<pair> output_ptr(1);
   value_t<pair> init{pair{4, 2}};
 
-  reduce(input_ptr, output_ptr, num_items, op, init);
+  auto& build_cache = fixture<reduce_build_cache_t, Reduce_CustomTypes_Fixture_Tag>::get_or_create().get_value();
+
+  std::string key_string = KeyBuilder::type_as_key<pair>();
+  std::optional<std::string> test_key{key_string};
+
+  reduce(input_ptr, output_ptr, num_items, op, init, build_cache, test_key);
 
   const pair output   = output_ptr[0];
   const pair expected = std::accumulate(input.begin(), input.end(), init.value, [](const pair& lhs, const pair& rhs) {
@@ -107,6 +185,7 @@ C2H_TEST("Reduce works with custom types", "[reduce]")
   REQUIRE(output.b == expected.b);
 }
 
+struct Reduce_InputIterators_Fixture_Tag;
 C2H_TEST("Reduce works with input iterators", "[reduce]")
 {
   const std::size_t num_items = GENERATE(1, 42, take(4, random(1 << 12, 1 << 16)));
@@ -116,13 +195,19 @@ C2H_TEST("Reduce works with input iterators", "[reduce]")
   pointer_t<int> output_it(1);
   value_t<int> init{42};
 
-  reduce(input_it, output_it, num_items, op, init);
+  auto& build_cache = fixture<reduce_build_cache_t, Reduce_CustomTypes_Fixture_Tag>::get_or_create().get_value();
+
+  std::string key_string = KeyBuilder::type_as_key<int>();
+  std::optional<std::string> test_key{key_string};
+
+  reduce(input_it, output_it, num_items, op, init, build_cache, test_key);
 
   const int output   = output_it[0];
   const int expected = init.value + num_items * (num_items - 1) / 2;
   REQUIRE(output == expected);
 }
 
+struct Reduce_OutputIterators_Fixture_Tag;
 C2H_TEST("Reduce works with output iterators", "[reduce]")
 {
   const int num_items = GENERATE(1, 42, take(4, random(1 << 12, 1 << 16)));
@@ -135,13 +220,19 @@ C2H_TEST("Reduce works with output iterators", "[reduce]")
   output_it.state.data = inner_output_it.ptr;
   value_t<int> init{42};
 
-  reduce(input_it, output_it, num_items, op, init);
+  auto& build_cache = fixture<reduce_build_cache_t, Reduce_OutputIterators_Fixture_Tag>::get_or_create().get_value();
+
+  std::string key_string = KeyBuilder::type_as_key<int>();
+  std::optional<std::string> test_key{key_string};
+
+  reduce(input_it, output_it, num_items, op, init, build_cache, test_key);
 
   const int output   = inner_output_it[0];
   const int expected = std::accumulate(input.begin(), input.end(), init.value);
   REQUIRE(output == expected * 2);
 }
 
+struct Reduce_InputOutputIterators_Fixture_Tag;
 C2H_TEST("Reduce works with input and output iterators", "[reduce]")
 {
   const int num_items = GENERATE(1, 42, take(4, random(1 << 12, 1 << 16)));
@@ -154,13 +245,20 @@ C2H_TEST("Reduce works with input and output iterators", "[reduce]")
   output_it.state.data = inner_output_it.ptr;
   value_t<int> init{42};
 
-  reduce(input_it, output_it, num_items, op, init);
+  auto& build_cache =
+    fixture<reduce_build_cache_t, Reduce_InputOutputIterators_Fixture_Tag>::get_or_create().get_value();
+
+  std::string key_string = KeyBuilder::type_as_key<int>();
+  std::optional<std::string> test_key{key_string};
+
+  reduce(input_it, output_it, num_items, op, init, build_cache, test_key);
 
   const int output   = inner_output_it[0];
   const int expected = 2 * (init.value + num_items);
   REQUIRE(output == expected);
 }
 
+struct Reduce_AccumulatorType_Fixture_Tag;
 C2H_TEST("Reduce accumulator type is influenced by initial value", "[reduce]")
 {
   const std::size_t num_items = 1 << 14; // 16384 > 128
@@ -171,7 +269,12 @@ C2H_TEST("Reduce accumulator type is influenced by initial value", "[reduce]")
   pointer_t<size_t> output_it(1);
   value_t<size_t> init{42};
 
-  reduce(input_it, output_it, num_items, op, init);
+  auto& build_cache = fixture<reduce_build_cache_t, Reduce_AccumulatorType_Fixture_Tag>::get_or_create().get_value();
+
+  std::string key_string = KeyBuilder::join({KeyBuilder::type_as_key<char>(), KeyBuilder::type_as_key<size_t>()});
+  std::optional<std::string> test_key{key_string};
+
+  reduce(input_it, output_it, num_items, op, init, build_cache, test_key);
 
   const size_t output   = output_it[0];
   const size_t expected = init.value + num_items;
@@ -187,7 +290,13 @@ C2H_TEST("Reduce works with large inputs", "[reduce]")
   pointer_t<size_t> output_it(1);
   value_t<size_t> init{42};
 
-  reduce(input_it, output_it, num_items, op, init);
+  // reuse fixture cache from previous example, as it runs identical example on larger input
+  auto& build_cache = fixture<reduce_build_cache_t, Reduce_AccumulatorType_Fixture_Tag>::get_or_create().get_value();
+
+  std::string key_string = KeyBuilder::join({KeyBuilder::type_as_key<char>(), KeyBuilder::type_as_key<size_t>()});
+  std::optional<std::string> test_key{key_string};
+
+  reduce(input_it, output_it, num_items, op, init, build_cache, test_key);
 
   const size_t output   = output_it[0];
   const size_t expected = init.value + num_items;
@@ -220,7 +329,11 @@ C2H_TEST("Reduce works with stateful operators", "[reduce]")
   pointer_t<int> output_ptr(1);
   value_t<int> init{42};
 
-  reduce(input_ptr, output_ptr, num_items, op, init);
+  // turn off caching, since the example is only compiled once
+  std::optional<reduce_build_cache_t> build_cache = std::nullopt;
+  std::optional<std::string> test_key             = std::nullopt;
+
+  reduce(input_ptr, output_ptr, num_items, op, init, build_cache, test_key);
 
   const int invocation_count          = counter[0];
   const int expected_invocation_count = num_items - 1;

--- a/c/parallel/test/test_reduce.cpp
+++ b/c/parallel/test/test_reduce.cpp
@@ -99,10 +99,8 @@ C2H_TEST("Reduce works with integral types", "[reduce]", integral_types)
   pointer_t<T> output_ptr(1);
   value_t<T> init{T{42}};
 
-  auto& build_cache = get_cache<Reduce_IntegralTypes_Fixture_Tag>();
-
-  std::string key_string = KeyBuilder::type_as_key<T>();
-  std::optional<std::string> test_key{key_string};
+  auto& build_cache    = get_cache<Reduce_IntegralTypes_Fixture_Tag>();
+  const auto& test_key = std::make_optional(KeyBuilder::type_as_key<T>());
 
   reduce(input_ptr, output_ptr, num_items, op, init, build_cache, test_key);
 
@@ -142,10 +140,8 @@ C2H_TEST("Reduce works with custom types", "[reduce]")
   pointer_t<pair> output_ptr(1);
   value_t<pair> init{pair{4, 2}};
 
-  auto& build_cache = get_cache<Reduce_CustomTypes_Fixture_Tag>();
-
-  std::string key_string = KeyBuilder::type_as_key<pair>();
-  std::optional<std::string> test_key{key_string};
+  auto& build_cache    = get_cache<Reduce_CustomTypes_Fixture_Tag>();
+  const auto& test_key = std::make_optional(KeyBuilder::type_as_key<pair>());
 
   reduce(input_ptr, output_ptr, num_items, op, init, build_cache, test_key);
 
@@ -167,10 +163,8 @@ C2H_TEST("Reduce works with input iterators", "[reduce]")
   pointer_t<int> output_it(1);
   value_t<int> init{42};
 
-  auto& build_cache = get_cache<Reduce_CustomTypes_Fixture_Tag>();
-
-  std::string key_string = KeyBuilder::type_as_key<int>();
-  std::optional<std::string> test_key{key_string};
+  auto& build_cache    = get_cache<Reduce_CustomTypes_Fixture_Tag>();
+  const auto& test_key = std::make_optional(KeyBuilder::type_as_key<int>());
 
   reduce(input_it, output_it, num_items, op, init, build_cache, test_key);
 
@@ -192,10 +186,8 @@ C2H_TEST("Reduce works with output iterators", "[reduce]")
   output_it.state.data = inner_output_it.ptr;
   value_t<int> init{42};
 
-  auto& build_cache = get_cache<Reduce_OutputIterators_Fixture_Tag>();
-
-  std::string key_string = KeyBuilder::type_as_key<int>();
-  std::optional<std::string> test_key{key_string};
+  auto& build_cache    = get_cache<Reduce_OutputIterators_Fixture_Tag>();
+  const auto& test_key = std::make_optional(KeyBuilder::type_as_key<int>());
 
   reduce(input_it, output_it, num_items, op, init, build_cache, test_key);
 
@@ -217,10 +209,8 @@ C2H_TEST("Reduce works with input and output iterators", "[reduce]")
   output_it.state.data = inner_output_it.ptr;
   value_t<int> init{42};
 
-  auto& build_cache = get_cache<Reduce_InputOutputIterators_Fixture_Tag>();
-
-  std::string key_string = KeyBuilder::type_as_key<int>();
-  std::optional<std::string> test_key{key_string};
+  auto& build_cache    = get_cache<Reduce_InputOutputIterators_Fixture_Tag>();
+  const auto& test_key = std::make_optional(KeyBuilder::type_as_key<int>());
 
   reduce(input_it, output_it, num_items, op, init, build_cache, test_key);
 
@@ -241,9 +231,8 @@ C2H_TEST("Reduce accumulator type is influenced by initial value", "[reduce]")
   value_t<size_t> init{42};
 
   auto& build_cache = get_cache<Reduce_AccumulatorType_Fixture_Tag>();
-
-  std::string key_string = KeyBuilder::join({KeyBuilder::type_as_key<char>(), KeyBuilder::type_as_key<size_t>()});
-  std::optional<std::string> test_key{key_string};
+  const auto& test_key =
+    std::make_optional(KeyBuilder::join({KeyBuilder::type_as_key<char>(), KeyBuilder::type_as_key<size_t>()}));
 
   reduce(input_it, output_it, num_items, op, init, build_cache, test_key);
 
@@ -263,9 +252,8 @@ C2H_TEST("Reduce works with large inputs", "[reduce]")
 
   // reuse fixture cache from previous example, as it runs identical example on larger input
   auto& build_cache = get_cache<Reduce_AccumulatorType_Fixture_Tag>();
-
-  std::string key_string = KeyBuilder::join({KeyBuilder::type_as_key<char>(), KeyBuilder::type_as_key<size_t>()});
-  std::optional<std::string> test_key{key_string};
+  const auto& test_key =
+    std::make_optional(KeyBuilder::join({KeyBuilder::type_as_key<char>(), KeyBuilder::type_as_key<size_t>()}));
 
   reduce(input_it, output_it, num_items, op, init, build_cache, test_key);
 

--- a/c/parallel/test/test_scan.cpp
+++ b/c/parallel/test/test_scan.cpp
@@ -122,7 +122,7 @@ C2H_TEST("Scan works with integral types", "[scan]", integral_types)
   value_t<T> init{T{42}};
 
   auto& build_cache    = get_cache<Scan_IntegralTypes_Fixture_Tag>();
-  const auto& test_key = std::make_optional(KeyBuilder::type_as_key<T>());
+  const auto& test_key = make_key<T>();
 
   scan(input_ptr, output_ptr, num_items, op, init, false, build_cache, test_key);
 
@@ -148,7 +148,7 @@ C2H_TEST("Inclusive Scan works with integral types", "[scan]", integral_types)
   value_t<T> init{T{42}};
 
   auto& build_cache    = get_cache<InclusiveScan_IntegralTypes_Fixture_Tag>();
-  const auto& test_key = std::make_optional(KeyBuilder::type_as_key<T>());
+  const auto& test_key = make_key<T>();
 
   scan(input_ptr, output_ptr, num_items, op, init, true, build_cache, test_key);
 
@@ -198,7 +198,7 @@ C2H_TEST("Scan works with custom types", "[scan]")
   value_t<pair> init{pair{4, 2}};
 
   auto& build_cache    = get_cache<Scan_CustomTypes_Fixture_Tag>();
-  const auto& test_key = std::make_optional(KeyBuilder::type_as_key<pair>());
+  const auto& test_key = make_key<pair>();
 
   scan(input_ptr, output_ptr, num_items, op, init, false, build_cache, test_key);
 
@@ -223,7 +223,7 @@ C2H_TEST("Scan works with input iterators", "[scan]")
   value_t<int> init{42};
 
   auto& build_cache    = get_cache<Scan_InputIterators_Fixture_Tag>();
-  const auto& test_key = std::make_optional(KeyBuilder::type_as_key<int>());
+  const auto& test_key = make_key<int>();
 
   scan(input_it, output_it, num_items, op, init, false, build_cache, test_key);
 
@@ -253,7 +253,7 @@ C2H_TEST("Scan works with output iterators", "[scan]")
   value_t<int> init{42};
 
   auto& build_cache    = get_cache<Scan_OutputIterators_Fixture_Tag>();
-  const auto& test_key = std::make_optional(KeyBuilder::type_as_key<int>());
+  const auto& test_key = make_key<int>();
 
   scan(input_it, output_it, num_items, op, init, false, build_cache, test_key);
 
@@ -283,7 +283,7 @@ C2H_TEST("Scan works with reverse input iterators", "[scan]")
   value_t<int> init{42};
 
   auto& build_cache    = get_cache<Scan_ReverseInputIterators_Fixture_Tag>();
-  const auto& test_key = std::make_optional(KeyBuilder::type_as_key<int>());
+  const auto& test_key = make_key<int>();
 
   scan(input_it, output_it, num_items, op, init, false, build_cache, test_key);
 
@@ -309,7 +309,7 @@ C2H_TEST("Scan works with reverse output iterators", "[scan]")
   value_t<int> init{42};
 
   auto& build_cache    = get_cache<Scan_ReverseOutputIterators_Fixture_Tag>();
-  const auto& test_key = std::make_optional(KeyBuilder::type_as_key<int>());
+  const auto& test_key = make_key<int>();
 
   scan(input_it, output_it, num_items, op, init, false, build_cache, test_key);
 
@@ -336,7 +336,7 @@ C2H_TEST("Scan works with input and output iterators", "[scan]")
   value_t<int> init{42};
 
   auto& build_cache    = get_cache<Scan_InputOutputIterators_Fixture_Tag>();
-  const auto& test_key = std::make_optional(KeyBuilder::type_as_key<int>());
+  const auto& test_key = make_key<int>();
 
   scan(input_it, output_it, num_items, op, init, false, build_cache, test_key);
 

--- a/c/parallel/test/test_segmented_reduce.cpp
+++ b/c/parallel/test/test_segmented_reduce.cpp
@@ -179,7 +179,7 @@ extern "C" __device__ unsigned long long {0}(
   value_t<TestType> init{0};
 
   auto& build_cache    = get_cache<SegmentedReduce_SumOverRows_Fixture_Tag>();
-  const auto& test_key = std::make_optional(KeyBuilder::type_as_key<TestType>());
+  const auto& test_key = make_key<TestType>();
 
   segmented_reduce(input_ptr, output_ptr, n_rows, start_offset_it, end_offset_it, op, init, build_cache, test_key);
 
@@ -255,7 +255,7 @@ extern "C" __device__ void {0}(void* lhs_ptr, void* rhs_ptr, void* out_ptr) {{
   value_t<pair> init{v0};
 
   auto& build_cache    = get_cache<SegmentedReduce_CustomTypes_Fixture_Tag>();
-  const auto& test_key = std::make_optional(KeyBuilder::type_as_key<pair>());
+  const auto& test_key = make_key<pair>();
 
   segmented_reduce(input_ptr, output_ptr, n_segments, start_offset_it, end_offset_it, op, init, build_cache, test_key);
 
@@ -398,7 +398,7 @@ extern "C" __device__ {1} {0}({2} *state) {{
   value_t<ValueT> init{0};
 
   auto& build_cache    = get_cache<SegmentedReduce_InputIterators_Fixture_Tag>();
-  const auto& test_key = std::make_optional(KeyBuilder::type_as_key<ValueT>());
+  const auto& test_key = make_key<ValueT>();
 
   segmented_reduce(
     input_transposed_iterator_it, output_ptr, n_cols, start_offset_it, end_offset_it, op, init, build_cache, test_key);

--- a/c/parallel/test/test_segmented_reduce.cpp
+++ b/c/parallel/test/test_segmented_reduce.cpp
@@ -93,6 +93,10 @@ void segmented_reduce(
     cache, lookup_key, input, output, num_segments, start_offsets, end_offsets, op, init);
 }
 
+// ==============
+//   Test section
+// ==============
+
 using SizeT = unsigned long long;
 
 struct row_offset_iterator_state_t
@@ -174,10 +178,8 @@ extern "C" __device__ unsigned long long {0}(
   operation_t op = make_operation("op", get_reduce_op(get_type_info<TestType>().type));
   value_t<TestType> init{0};
 
-  auto& build_cache = get_cache<SegmentedReduce_SumOverRows_Fixture_Tag>();
-
-  std::string key_string = KeyBuilder::type_as_key<TestType>();
-  std::optional<std::string> test_key{key_string};
+  auto& build_cache    = get_cache<SegmentedReduce_SumOverRows_Fixture_Tag>();
+  const auto& test_key = std::make_optional(KeyBuilder::type_as_key<TestType>());
 
   segmented_reduce(input_ptr, output_ptr, n_rows, start_offset_it, end_offset_it, op, init, build_cache, test_key);
 
@@ -252,10 +254,8 @@ extern "C" __device__ void {0}(void* lhs_ptr, void* rhs_ptr, void* out_ptr) {{
   pair v0        = pair{4, 2};
   value_t<pair> init{v0};
 
-  auto& build_cache = get_cache<SegmentedReduce_CustomTypes_Fixture_Tag>();
-
-  std::string key_string = KeyBuilder::type_as_key<pair>();
-  std::optional<std::string> test_key{key_string};
+  auto& build_cache    = get_cache<SegmentedReduce_CustomTypes_Fixture_Tag>();
+  const auto& test_key = std::make_optional(KeyBuilder::type_as_key<pair>());
 
   segmented_reduce(input_ptr, output_ptr, n_segments, start_offset_it, end_offset_it, op, init, build_cache, test_key);
 
@@ -397,10 +397,8 @@ extern "C" __device__ {1} {0}({2} *state) {{
   operation_t op = make_operation("op", get_reduce_op(get_type_info<ValueT>().type));
   value_t<ValueT> init{0};
 
-  auto& build_cache = get_cache<SegmentedReduce_InputIterators_Fixture_Tag>();
-
-  std::string key_string = KeyBuilder::type_as_key<ValueT>();
-  std::optional<std::string> test_key{key_string};
+  auto& build_cache    = get_cache<SegmentedReduce_InputIterators_Fixture_Tag>();
+  const auto& test_key = std::make_optional(KeyBuilder::type_as_key<ValueT>());
 
   segmented_reduce(
     input_transposed_iterator_it, output_ptr, n_cols, start_offset_it, end_offset_it, op, init, build_cache, test_key);

--- a/c/parallel/test/test_transform.cpp
+++ b/c/parallel/test/test_transform.cpp
@@ -112,7 +112,7 @@ C2H_TEST("Transform works with integral types", "[transform]", integral_types)
   pointer_t<T> output_ptr(output);
 
   auto& build_cache    = get_cache<Transform_IntegralTypes_Fixture_Tag>();
-  const auto& test_key = std::make_optional(KeyBuilder::type_as_key<T>());
+  const auto& test_key = make_key<T>();
 
   unary_transform(input_ptr, output_ptr, num_items, op, build_cache, test_key);
 
@@ -161,9 +161,8 @@ C2H_TEST("Transform works with output of different type", "[transform]")
   pointer_t<int> input_ptr(input);
   pointer_t<pair> output_ptr(output);
 
-  auto& build_cache = get_cache<Transform_DifferentOutputTypes_Fixture_Tag>();
-  const auto& test_key =
-    std::make_optional(KeyBuilder::join({KeyBuilder::type_as_key<int>(), KeyBuilder::type_as_key<pair>()}));
+  auto& build_cache    = get_cache<Transform_DifferentOutputTypes_Fixture_Tag>();
+  const auto& test_key = make_key<int, pair>();
 
   unary_transform(input_ptr, output_ptr, num_items, op, build_cache, test_key);
 
@@ -197,9 +196,8 @@ C2H_TEST("Transform works with custom types", "[transform]")
   pointer_t<pair> input_ptr(input);
   pointer_t<pair> output_ptr(output);
 
-  auto& build_cache = get_cache<Transform_CustomTypes_FIxture_Tag>();
-  const auto& test_key =
-    std::make_optional(KeyBuilder::join({KeyBuilder::type_as_key<pair>(), KeyBuilder::type_as_key<pair>()}));
+  auto& build_cache    = get_cache<Transform_CustomTypes_FIxture_Tag>();
+  const auto& test_key = make_key<pair, pair>();
 
   unary_transform(input_ptr, output_ptr, num_items, op, build_cache, test_key);
 
@@ -223,7 +221,7 @@ C2H_TEST("Transform works with input iterators", "[transform]")
   pointer_t<int> output_it(num_items);
 
   auto& build_cache    = get_cache<Transform_InputIterators_Fixture_Tag>();
-  const auto& test_key = std::make_optional(KeyBuilder::type_as_key<int>());
+  const auto& test_key = make_key<int>();
 
   unary_transform(input_it, output_it, num_items, op, build_cache, test_key);
 
@@ -254,7 +252,7 @@ C2H_TEST("Transform works with output iterators", "[transform]")
   output_it.state.data = inner_output_it.ptr;
 
   auto& build_cache    = get_cache<Transform_OutputIterators_Fixture_Tag>();
-  const auto& test_key = std::make_optional(KeyBuilder::type_as_key<int>());
+  const auto& test_key = make_key<int>();
 
   unary_transform(input_it, output_it, num_items, op, build_cache, test_key);
 
@@ -289,7 +287,7 @@ C2H_TEST("Transform with binary operator", "[transform]")
     "}");
 
   auto& build_cache    = get_cache<Transform_BinaryOp_Fixture_Tag>();
-  const auto& test_key = std::make_optional(KeyBuilder::type_as_key<int>());
+  const auto& test_key = make_key<int>();
 
   binary_transform(input1_ptr, input2_ptr, output_ptr, num_items, op, build_cache, test_key);
 
@@ -327,7 +325,7 @@ C2H_TEST("Binary transform with one iterator", "[transform]")
     "}");
 
   auto& build_cache    = get_cache<Transform_BinaryOp_Iterator_Fixture_Tag>();
-  const auto& test_key = std::make_optional(KeyBuilder::type_as_key<int>());
+  const auto& test_key = make_key<int>();
 
   binary_transform(input1_ptr, input2_it, output_ptr, num_items, op, build_cache, test_key);
 

--- a/c/parallel/test/test_transform.cpp
+++ b/c/parallel/test/test_transform.cpp
@@ -111,10 +111,8 @@ C2H_TEST("Transform works with integral types", "[transform]", integral_types)
   pointer_t<T> input_ptr(input);
   pointer_t<T> output_ptr(output);
 
-  auto& build_cache = get_cache<Transform_IntegralTypes_Fixture_Tag>();
-
-  std::string key_string = KeyBuilder::type_as_key<T>();
-  std::optional<std::string> test_key{key_string};
+  auto& build_cache    = get_cache<Transform_IntegralTypes_Fixture_Tag>();
+  const auto& test_key = std::make_optional(KeyBuilder::type_as_key<T>());
 
   unary_transform(input_ptr, output_ptr, num_items, op, build_cache, test_key);
 
@@ -164,9 +162,8 @@ C2H_TEST("Transform works with output of different type", "[transform]")
   pointer_t<pair> output_ptr(output);
 
   auto& build_cache = get_cache<Transform_DifferentOutputTypes_Fixture_Tag>();
-
-  std::string key_string = KeyBuilder::join({KeyBuilder::type_as_key<int>(), KeyBuilder::type_as_key<pair>()});
-  std::optional<std::string> test_key{key_string};
+  const auto& test_key =
+    std::make_optional(KeyBuilder::join({KeyBuilder::type_as_key<int>(), KeyBuilder::type_as_key<pair>()}));
 
   unary_transform(input_ptr, output_ptr, num_items, op, build_cache, test_key);
 
@@ -201,9 +198,8 @@ C2H_TEST("Transform works with custom types", "[transform]")
   pointer_t<pair> output_ptr(output);
 
   auto& build_cache = get_cache<Transform_CustomTypes_FIxture_Tag>();
-
-  std::string key_string = KeyBuilder::join({KeyBuilder::type_as_key<pair>(), KeyBuilder::type_as_key<pair>()});
-  std::optional<std::string> test_key{key_string};
+  const auto& test_key =
+    std::make_optional(KeyBuilder::join({KeyBuilder::type_as_key<pair>(), KeyBuilder::type_as_key<pair>()}));
 
   unary_transform(input_ptr, output_ptr, num_items, op, build_cache, test_key);
 
@@ -226,10 +222,8 @@ C2H_TEST("Transform works with input iterators", "[transform]")
   input_it.state.value                                     = 0;
   pointer_t<int> output_it(num_items);
 
-  auto& build_cache = get_cache<Transform_InputIterators_Fixture_Tag>();
-
-  std::string key_string = KeyBuilder::type_as_key<int>();
-  std::optional<std::string> test_key{key_string};
+  auto& build_cache    = get_cache<Transform_InputIterators_Fixture_Tag>();
+  const auto& test_key = std::make_optional(KeyBuilder::type_as_key<int>());
 
   unary_transform(input_it, output_it, num_items, op, build_cache, test_key);
 
@@ -259,10 +253,8 @@ C2H_TEST("Transform works with output iterators", "[transform]")
   pointer_t<int> inner_output_it(num_items);
   output_it.state.data = inner_output_it.ptr;
 
-  auto& build_cache = get_cache<Transform_OutputIterators_Fixture_Tag>();
-
-  std::string key_string = KeyBuilder::type_as_key<int>();
-  std::optional<std::string> test_key{key_string};
+  auto& build_cache    = get_cache<Transform_OutputIterators_Fixture_Tag>();
+  const auto& test_key = std::make_optional(KeyBuilder::type_as_key<int>());
 
   unary_transform(input_it, output_it, num_items, op, build_cache, test_key);
 
@@ -296,10 +288,8 @@ C2H_TEST("Transform with binary operator", "[transform]")
     "  *out = (*x > *y) ? *x : *y;\n"
     "}");
 
-  auto& build_cache = get_cache<Transform_BinaryOp_Fixture_Tag>();
-
-  std::string key_string = KeyBuilder::type_as_key<int>();
-  std::optional<std::string> test_key{key_string};
+  auto& build_cache    = get_cache<Transform_BinaryOp_Fixture_Tag>();
+  const auto& test_key = std::make_optional(KeyBuilder::type_as_key<int>());
 
   binary_transform(input1_ptr, input2_ptr, output_ptr, num_items, op, build_cache, test_key);
 
@@ -336,10 +326,8 @@ C2H_TEST("Binary transform with one iterator", "[transform]")
     "  *out = (*x > *y) ? *x : *y;\n"
     "}");
 
-  auto& build_cache = get_cache<Transform_BinaryOp_Iterator_Fixture_Tag>();
-
-  std::string key_string = KeyBuilder::type_as_key<int>();
-  std::optional<std::string> test_key{key_string};
+  auto& build_cache    = get_cache<Transform_BinaryOp_Iterator_Fixture_Tag>();
+  const auto& test_key = std::make_optional(KeyBuilder::type_as_key<int>());
 
   binary_transform(input1_ptr, input2_it, output_ptr, num_items, op, build_cache, test_key);
 

--- a/c/parallel/test/test_unique_by_key.cpp
+++ b/c/parallel/test/test_unique_by_key.cpp
@@ -124,11 +124,8 @@ C2H_TEST("DeviceSelect::UniqueByKey can run with empty input", "[unique_by_key]"
   auto& output_items_it = input_keys_it;
 
   auto& build_cache = get_cache<UniqueByKey_AllPointerInputs_Fixture_Tag>();
-
   // key: (input_type, output_type, num_selected_type)
-  std::string key_string = KeyBuilder::join(
-    {KeyBuilder::type_as_key<key_t>(), KeyBuilder::type_as_key<key_t>(), KeyBuilder::type_as_key<int>()});
-  std::optional<std::string> test_key{key_string};
+  const auto& test_key = make_key<key_t, key_t, int>();
 
   unique_by_key(
     input_keys_it,
@@ -161,11 +158,8 @@ C2H_TEST("DeviceSelect::UniqueByKey works", "[unique_by_key]", key_types)
   pointer_t<int> output_num_selected_it(1);
 
   auto& build_cache = get_cache<UniqueByKey_AllPointerInputs_Fixture_Tag>();
-
   // key: (input_type, output_type, num_selected_type)
-  std::string key_string = KeyBuilder::join(
-    {KeyBuilder::type_as_key<key_t>(), KeyBuilder::type_as_key<item_t>(), KeyBuilder::type_as_key<int>()});
-  std::optional<std::string> test_key{key_string};
+  const auto& test_key = make_key<key_t, item_t, int>();
 
   unique_by_key(
     input_keys_it,
@@ -221,11 +215,8 @@ C2H_TEST("DeviceSelect::UniqueByKey handles none equal", "[device][select_unique
   pointer_t<int> output_num_selected_it(1);
 
   auto& build_cache = get_cache<UniqueByKey_AllPointerInputs_Fixture_Tag>();
-
   // key: (input_type, output_type, num_selected_type)
-  std::string key_string = KeyBuilder::join(
-    {KeyBuilder::type_as_key<key_t>(), KeyBuilder::type_as_key<item_t>(), KeyBuilder::type_as_key<int>()});
-  std::optional<std::string> test_key{key_string};
+  const auto& test_key = make_key<key_t, item_t, int>();
 
   unique_by_key(
     input_keys_it,
@@ -260,11 +251,8 @@ C2H_TEST("DeviceSelect::UniqueByKey handles all equal", "[device][select_unique_
   pointer_t<int> output_num_selected_it(1);
 
   auto& build_cache = get_cache<UniqueByKey_AllPointerInputs_Fixture_Tag>();
-
   // key: (input_type, output_type, num_selected_type)
-  std::string key_string = KeyBuilder::join(
-    {KeyBuilder::type_as_key<key_t>(), KeyBuilder::type_as_key<item_t>(), KeyBuilder::type_as_key<int>()});
-  std::optional<std::string> test_key{key_string};
+  const auto& test_key = make_key<key_t, item_t, int>();
 
   unique_by_key(
     input_keys_it,
@@ -322,11 +310,8 @@ C2H_TEST("DeviceSelect::UniqueByKey works with custom types", "[device][select_u
   pointer_t<int> output_num_selected_it(1);
 
   auto& build_cache = get_cache<UniqueByKey_AllPointerInputs_Fixture_Tag>();
-
   // key: (input_type, output_type, num_selected_type)
-  std::string key_string = KeyBuilder::join(
-    {KeyBuilder::type_as_key<key_pair>(), KeyBuilder::type_as_key<item_t>(), KeyBuilder::type_as_key<int>()});
-  std::optional<std::string> test_key{key_string};
+  const auto& test_key = make_key<key_pair, item_t, int>();
 
   unique_by_key(
     input_keys_it,
@@ -402,11 +387,8 @@ C2H_TEST("DeviceMergeSort::SortPairs works with input and output iterators", "[m
   output_num_selected_it.state.data = output_num_selected_ptr.ptr;
 
   auto& build_cache = get_cache<UniqueByKey_Iterators_Fixture_Tag>();
-
   // key: (input_type, output_type, num_selected_type)
-  std::string key_string =
-    KeyBuilder::join({KeyBuilder::type_as_key<T>(), KeyBuilder::type_as_key<T>(), KeyBuilder::type_as_key<int>()});
-  std::optional<std::string> test_key{key_string};
+  const auto& test_key = make_key<T, T, int>();
 
   unique_by_key(
     input_keys_it,

--- a/c/parallel/test/test_util.h
+++ b/c/parallel/test/test_util.h
@@ -18,7 +18,6 @@
 #include <filesystem>
 #include <format>
 #include <fstream>
-#include <iostream>
 #include <random>
 #include <string>
 #include <type_traits>


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes #4608 

<!-- Provide a standalone description of changes in this PR. -->

Add classes to enable build caching in c.parallel test suite.

1. `result_wrapper_t` is owning reference to CCCL build result based
on shared pointer. It must be copy/move assignable/constructable
to enable use as value type in std::unordered_map.

The class is templated on CCCL build result struct type, and
callable to clean-up resources allocated for build result.

2. `build_cache_t` in simple cache based on std::unordered_map.

The class is templated on key type (std::string) and value type,
an instance of result_wrapper_t.

3. `fixture` is a singleton to lazily create build cache at
  its first use. Fixture wraps the cache in std::optional
  to match use pattern in algorithms.

fixture allows for Tag template parameter to be able to create
multiple instances of singleton classes. We usually want cache
for a test family where algorithm compile the same problem and
execute it for different problem sizes. Caching then allows to
reuse the build artifact.

4. KeyBuilder is a struct with static methods to facilitate
   creation of test-variant identifier to use as cache key.

Cache keys are crafted per test.

5. Deployed caching in each test file, resulting in 3X reduction of test suite run-time.

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
