### PR TITLE
[CUDAX] Add default properties for resources and add properties deduction to make_async_buffer

### DIFF
--- a/cudax/include/cuda/experimental/__container/async_buffer.cuh
+++ b/cudax/include/cuda/experimental/__container/async_buffer.cuh
@@ -49,6 +49,7 @@
 #include <cuda/std/__type_traits/is_nothrow_move_assignable.h>
 #include <cuda/std/__type_traits/is_swappable.h>
 #include <cuda/std/__type_traits/is_trivially_copyable.h>
+#include <cuda/std/__type_traits/type_list.h>
 #include <cuda/std/__utility/forward.h>
 #include <cuda/std/__utility/move.h>
 #include <cuda/std/cstdint>
@@ -68,7 +69,6 @@
 #include <cuda/experimental/__stream/get_stream.cuh>
 #include <cuda/experimental/__utility/ensure_current_device.cuh>
 #include <cuda/experimental/__utility/select_execution_space.cuh>
-
 _CCCL_PUSH_MACROS
 
 //! @file The \c async_buffer class provides a container of contiguous memory
@@ -731,6 +731,32 @@ using async_device_buffer = async_buffer<_Tp, _CUDA_VMR::device_accessible>;
 template <class _Tp>
 using async_host_buffer = async_buffer<_Tp, _CUDA_VMR::host_accessible>;
 
+template <class _Tp, class _PropsList>
+struct __buffer_type_for_props_t;
+
+template <class _Tp, class... _Props>
+struct __buffer_type_for_props_t<_Tp, _CUDA_VSTD::__type_list<_Props...>>
+{
+  using type = async_buffer<_Tp, _Props...>;
+};
+
+template <class _Tp, class _PropsList>
+using __buffer_type_for_props = __buffer_type_for_props_t<_Tp, _PropsList>::type;
+
+template <typename _BufferTo, typename _BufferFrom>
+void __copy_cross_buffers(stream_ref __stream, _BufferTo& __to, const _BufferFrom& __from)
+{
+  __stream.wait(__from.get_stream());
+  _CCCL_TRY_CUDA_API(
+    ::cudaMemcpyAsync,
+    "make_async_buffer: failed to copy data",
+    __to.__unwrapped_begin(),
+    __from.__unwrapped_begin(),
+    sizeof(typename _BufferTo::value_type) * __from.size(),
+    cudaMemcpyKind::cudaMemcpyDefault,
+    __stream.get());
+}
+
 template <class _Tp, class... _TargetProperties, class... _SourceProperties>
 async_buffer<_Tp, _TargetProperties...> make_async_buffer(
   stream_ref __stream,
@@ -740,17 +766,21 @@ async_buffer<_Tp, _TargetProperties...> make_async_buffer(
   env_t<_TargetProperties...> __env{__mr, __stream};
   async_buffer<_Tp, _TargetProperties...> __res{__env, __source.size(), uninit};
 
-  // We need some opt-out for the wait here, but I don't know how yet
-  __stream.wait(__source.get_stream());
+  __copy_cross_buffers(__stream, __res, __source);
 
-  _CCCL_TRY_CUDA_API(
-    ::cudaMemcpyAsync,
-    "cudax::async_buffer::__copy_cross: failed to copy data",
-    __res.__unwrapped_begin(),
-    __source.__unwrapped_begin(),
-    sizeof(_Tp) * __source.size(),
-    cudaMemcpyKind::cudaMemcpyDefault,
-    __stream.get());
+  return __res;
+}
+
+_CCCL_TEMPLATE(class _Tp, class _Resource, class... _SourceProperties)
+_CCCL_REQUIRES(_CUDA_VMR::async_resource<_Resource> _CCCL_AND __has_default_queries<_Resource>)
+auto make_async_buffer(stream_ref __stream, _Resource&& __mr, const async_buffer<_Tp, _SourceProperties...>& __source)
+{
+  using __buffer_type =
+    __buffer_type_for_props<_Tp, typename _CUDA_VSTD::remove_reference_t<_Resource>::__default_queries>;
+  typename __buffer_type::__env_t __env{__mr, __stream};
+  auto __res = __buffer_type{__env, __source.size(), uninit};
+
+  __copy_cross_buffers(__stream, __res, __source);
 
   return __res;
 }

--- a/cudax/include/cuda/experimental/__memory_resource/any_resource.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/any_resource.cuh
@@ -305,6 +305,8 @@ public:
 
   // Inherit other constructors from basic_any
   using __base_t::__base_t;
+
+  using __default_queries = _CUDA_VSTD::__type_list<_Properties...>;
 };
 
 // ``any_async_resource`` wraps any given async_resource that satisfies the
@@ -336,6 +338,8 @@ private:
 public:
   // Inherit constructors from basic_any
   using __base_t::__base_t;
+
+  using __default_queries = _CUDA_VSTD::__type_list<_Properties...>;
 };
 
 //! @brief Type erased wrapper around a `resource` that satisfies \tparam _Properties
@@ -369,6 +373,8 @@ public:
 
   // Inherit other constructors from basic_any
   using __base_t::__base_t;
+
+  using __default_queries = _CUDA_VSTD::__type_list<_Properties...>;
 };
 
 //! @brief Type erased wrapper around a `async_resource` that satisfies \tparam _Properties
@@ -401,6 +407,8 @@ public:
 
   // Inherit other constructors from basic_any
   using __base_t::__base_t;
+
+  using __default_queries = _CUDA_VSTD::__type_list<_Properties...>;
 };
 
 _CCCL_TEMPLATE(class... _Properties, class _Resource)

--- a/cudax/include/cuda/experimental/__memory_resource/device_memory_resource.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/device_memory_resource.cuh
@@ -104,6 +104,8 @@ public:
   //! @brief Enables the \c device_accessible property for \c device_memory_resource.
   //! @relates device_memory_resource
   friend constexpr void get_property(device_memory_resource const&, device_accessible) noexcept {}
+
+  using __default_queries = _CUDA_VSTD::__type_list<device_accessible>;
 #endif // _CCCL_DOXYGEN_INVOKED
 };
 static_assert(_CUDA_VMR::resource_with<device_memory_resource, device_accessible>, "");

--- a/cudax/include/cuda/experimental/__memory_resource/pinned_memory_resource.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/pinned_memory_resource.cuh
@@ -95,6 +95,8 @@ public:
   friend constexpr void get_property(pinned_memory_resource const&, device_accessible) noexcept {}
   //! @brief Enables the \c host_accessible property
   friend constexpr void get_property(pinned_memory_resource const&, host_accessible) noexcept {}
+
+  using __default_queries = _CUDA_VSTD::__type_list<device_accessible, host_accessible>;
 #  endif // _CCCL_DOXYGEN_INVOKED
 };
 

--- a/cudax/include/cuda/experimental/__memory_resource/properties.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/properties.cuh
@@ -23,12 +23,23 @@
 
 #include <cuda/__memory_resource/get_property.h>
 #include <cuda/__memory_resource/properties.h>
+#include <cuda/std/__type_traits/type_list.h>
 
 namespace cuda::experimental
 {
 
 using ::cuda::mr::device_accessible;
 using ::cuda::mr::host_accessible;
+
+template <class _T>
+inline constexpr bool __is_queries_list = false;
+
+template <class... _T>
+inline constexpr bool __is_queries_list<cuda::std::__type_list<_T...>> = true;
+
+template <typename _Tp>
+_CCCL_CONCEPT __has_default_queries = _CCCL_REQUIRES_EXPR((_Tp), _Tp& __t)(
+  requires(__is_queries_list<typename _CUDA_VSTD::remove_reference_t<_Tp>::__default_queries>));
 
 } // namespace cuda::experimental
 

--- a/cudax/test/containers/async_buffer/copy.cu
+++ b/cudax/test/containers/async_buffer/copy.cu
@@ -160,25 +160,43 @@ C2H_TEST("make_async_buffer variants", "[container][async_buffer]")
   // straight from a resource
   auto buf = cuda::experimental::make_async_buffer(input.get_stream(), cudax::device_memory_resource{}, input);
   CUDAX_CHECK(equal_range(buf));
+  static_assert(_CUDA_VMR::resource_with<typename decltype(buf)::__resource_t, cuda::mr::device_accessible>);
+  static_assert(!_CUDA_VMR::resource_with<typename decltype(buf)::__resource_t, cuda::mr::host_accessible>);
+  static_assert(!_CUDA_VMR::resource_with<typename decltype(buf)::__resource_t, other_property>);
 
   auto buf2 = cuda::experimental::make_async_buffer<int, cuda::mr::device_accessible>(
     input.get_stream(), {cudax::device_memory_resource{}}, input);
   CUDAX_CHECK(equal_range(buf2));
+  static_assert(_CUDA_VMR::resource_with<typename decltype(buf2)::__resource_t, cuda::mr::device_accessible>);
+  static_assert(!_CUDA_VMR::resource_with<typename decltype(buf2)::__resource_t, other_property>);
+  static_assert(!_CUDA_VMR::resource_with<typename decltype(buf2)::__resource_t, cuda::mr::host_accessible>);
 
   // from any resource
   auto any_res =
     cudax::any_async_resource<cuda::mr::device_accessible, other_property>(cudax::device_memory_resource{});
   auto buf3 = cudax::make_async_buffer(input.get_stream(), any_res, input);
   CUDAX_CHECK(equal_range(buf3));
+  static_assert(_CUDA_VMR::resource_with<typename decltype(buf3)::__resource_t, cuda::mr::device_accessible>);
+  static_assert(_CUDA_VMR::resource_with<typename decltype(buf3)::__resource_t, other_property>);
+  static_assert(!_CUDA_VMR::resource_with<typename decltype(buf3)::__resource_t, cuda::mr::host_accessible>);
 
   auto buf4 = cudax::make_async_buffer<int, cuda::mr::device_accessible>(input.get_stream(), any_res, input);
   CUDAX_CHECK(equal_range(buf4));
+  static_assert(_CUDA_VMR::resource_with<typename decltype(buf4)::__resource_t, cuda::mr::device_accessible>);
+  static_assert(_CUDA_VMR::resource_with<typename decltype(buf4)::__resource_t, other_property>);
+  static_assert(!_CUDA_VMR::resource_with<typename decltype(buf4)::__resource_t, cuda::mr::host_accessible>);
 
   // from a resource reference
   auto res_ref = cudax::async_resource_ref<cuda::mr::device_accessible, other_property>{any_res};
   auto buf5    = cudax::make_async_buffer(input.get_stream(), res_ref, input);
   CUDAX_CHECK(equal_range(buf5));
+  static_assert(_CUDA_VMR::resource_with<typename decltype(buf5)::__resource_t, cuda::mr::device_accessible>);
+  static_assert(_CUDA_VMR::resource_with<typename decltype(buf5)::__resource_t, other_property>);
+  static_assert(!_CUDA_VMR::resource_with<typename decltype(buf5)::__resource_t, cuda::mr::host_accessible>);
 
   auto buf6 = cudax::make_async_buffer<int, cuda::mr::device_accessible>(input.get_stream(), {res_ref}, input);
   CUDAX_CHECK(equal_range(buf6));
+  static_assert(_CUDA_VMR::resource_with<typename decltype(buf6)::__resource_t, cuda::mr::device_accessible>);
+  static_assert(!_CUDA_VMR::resource_with<typename decltype(buf6)::__resource_t, other_property>);
+  static_assert(!_CUDA_VMR::resource_with<typename decltype(buf6)::__resource_t, cuda::mr::host_accessible>);
 }

--- a/cudax/test/containers/async_buffer/copy.cu
+++ b/cudax/test/containers/async_buffer/copy.cu
@@ -149,3 +149,36 @@ C2H_TEST("cudax::async_buffer make_async_buffer", "[container][async_buffer]", t
     }
   }
 }
+
+C2H_TEST("make_async_buffer variants", "[container][async_buffer]")
+{
+  cudax::stream stream{};
+  cudax::env_t<cuda::mr::device_accessible, other_property> env{cudax::device_memory_resource{}, stream};
+  const cudax::async_buffer<int, cuda::mr::device_accessible, other_property> input{
+    env, {int(1), int(42), int(1337), int(0), int(12), int(-1)}};
+
+  // straight from a resource
+  auto buf = cuda::experimental::make_async_buffer(input.get_stream(), cudax::device_memory_resource{}, input);
+  CUDAX_CHECK(equal_range(buf));
+
+  auto buf2 = cuda::experimental::make_async_buffer<int, cuda::mr::device_accessible>(
+    input.get_stream(), {cudax::device_memory_resource{}}, input);
+  CUDAX_CHECK(equal_range(buf2));
+
+  // from any resource
+  auto any_res =
+    cudax::any_async_resource<cuda::mr::device_accessible, other_property>(cudax::device_memory_resource{});
+  auto buf3 = cudax::make_async_buffer(input.get_stream(), any_res, input);
+  CUDAX_CHECK(equal_range(buf3));
+
+  auto buf4 = cudax::make_async_buffer<int, cuda::mr::device_accessible>(input.get_stream(), any_res, input);
+  CUDAX_CHECK(equal_range(buf4));
+
+  // from a resource reference
+  auto res_ref = cudax::async_resource_ref<cuda::mr::device_accessible, other_property>{any_res};
+  auto buf5    = cudax::make_async_buffer(input.get_stream(), res_ref, input);
+  CUDAX_CHECK(equal_range(buf5));
+
+  auto buf6 = cudax::make_async_buffer<int, cuda::mr::device_accessible>(input.get_stream(), {res_ref}, input);
+  CUDAX_CHECK(equal_range(buf6));
+}


### PR DESCRIPTION
Currently you have to specify properties of a buffer (or environment) to create a buffer. It would be more convenient if we were deducing it from a resource. This was feedback on one of my presentations about the project.

This PR adds `__default_queries` to resources and adds `make_async_resource` that will try to look for those default properties in order to deduce buffer properties. It might seem not worth it just for `make_async_resource`, but I will be adding more overloads soon. We could also think about using `__default_queries` to deduce environment template arguments.

If custom properties are added to a resource they will be missed in the deduction, but that should be ok.

Draft because I will probably move some stuff around and I need to implement the defaults for `shared_resource`