### PR TITLE
Pass `cached_segment` by `span`

### DIFF
--- a/cub/cub/block/block_radix_rank.cuh
+++ b/cub/cub/block/block_radix_rank.cuh
@@ -52,6 +52,7 @@
 #include <cuda/std/__algorithm_>
 #include <cuda/std/cstdint>
 #include <cuda/std/limits>
+#include <cuda/std/span>
 #include <cuda/std/type_traits>
 
 CUB_NAMESPACE_BEGIN
@@ -309,7 +310,7 @@ private:
       {
         cached_segment[i] = smem_raking_ptr[i];
       }
-      return cub::ThreadReduce(cached_segment, ::cuda::std::plus<>{});
+      return cub::ThreadReduce(::cuda::std::span<PackedCounter, RAKING_SEGMENT>{cached_segment}, ::cuda::std::plus<>{});
     }
     else
     {


### PR DESCRIPTION
cuSparse has issues with deduction failures in ThreadReduce.

```
cub/thread/thread_reduce.cuh(410): note #3327-D: candidate function template "cub::CUB_300100_SM_870_880_1010_1100::ThreadReduce(const Input &, ReductionOp)" failed deduction
  [[nodiscard]] __attribute__((device)) __inline__ __attribute__((__always_inline__)) AccumT ThreadReduce(const Input& input, ReductionOp reduction_op
```

Avoid that by passing a `cuda::std::span`
