### PR TITLE
Ignore `Wmaybe-uninitialized` in dispatch_reduce.cuh.

### DIFF
--- a/cub/cub/device/dispatch/dispatch_reduce.cuh
+++ b/cub/cub/device/dispatch/dispatch_reduce.cuh
@@ -529,8 +529,13 @@ struct DispatchReduce
         kernel_source,
         launcher_factory);
 
+      // Ignore Wmaybe-uninitialized to work around a GCC 13 issue:
+      // https://github.com/NVIDIA/cccl/issues/4053
+      _CCCL_DIAG_PUSH
+      _CCCL_DIAG_SUPPRESS_GCC("-Wmaybe-uninitialized")
       // Dispatch to chained policy
       error = CubDebug(max_policy.Invoke(ptx_version, dispatch));
+      _CCCL_DIAG_POP
       if (cudaSuccess != error)
       {
         break;


### PR DESCRIPTION
## Description

This forward-ports https://github.com/NVIDIA/cccl/pull/4054 to `branch/3.0.x`.

I am seeing https://github.com/NVIDIA/cccl/issues/4053 `-Wmaybe-uninitialized` in `dispatch_reduce.cuh` again. From my testing, the changes in https://github.com/NVIDIA/cccl/pull/4054 are also needed in CCCL 3.0.x but not in `main`. I targeted `branch/3.0.x` for this reason.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
