### PR TITLE
User-friendly pow2 functions derived from `std/bit`

### DIFF
--- a/libcudacxx/include/cuda/__cmath/pow2.h
+++ b/libcudacxx/include/cuda/__cmath/pow2.h
@@ -1,0 +1,70 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA___CMATH_POW2
+#define _CUDA___CMATH_POW2
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__bit/has_single_bit.h>
+#include <cuda/std/__bit/integral.h>
+#include <cuda/std/__type_traits/is_integer.h>
+#include <cuda/std/__type_traits/is_signed.h>
+#include <cuda/std/__type_traits/make_unsigned.h>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_CUDA
+
+_CCCL_TEMPLATE(typename _Tp)
+_CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::__cccl_is_integer, _Tp))
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr bool is_power_of_two(_Tp __t) noexcept
+{
+  if constexpr (_CCCL_TRAIT(_CUDA_VSTD::is_signed, _Tp))
+  {
+    _CCCL_ASSERT(__t >= _Tp{0}, "cuda::is_power_of_two requires non-negative input");
+  }
+  using _Up = _CUDA_VSTD::make_unsigned_t<_Tp>;
+  return _CUDA_VSTD::has_single_bit(static_cast<_Up>(__t));
+}
+
+_CCCL_TEMPLATE(typename _Tp)
+_CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::__cccl_is_integer, _Tp))
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp next_power_of_two(_Tp __t) noexcept
+{
+  if constexpr (_CCCL_TRAIT(_CUDA_VSTD::is_signed, _Tp))
+  {
+    _CCCL_ASSERT(__t >= _Tp{0}, "cuda::is_power_of_two requires non-negative input");
+  }
+  using _Up = _CUDA_VSTD::make_unsigned_t<_Tp>;
+  return _CUDA_VSTD::bit_ceil(static_cast<_Up>(__t));
+}
+
+_CCCL_TEMPLATE(typename _Tp)
+_CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::__cccl_is_integer, _Tp))
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp prev_power_of_two(_Tp __t) noexcept
+{
+  if constexpr (_CCCL_TRAIT(_CUDA_VSTD::is_signed, _Tp))
+  {
+    _CCCL_ASSERT(__t >= _Tp{0}, "cuda::is_power_of_two requires non-negative input");
+  }
+  using _Up = _CUDA_VSTD::make_unsigned_t<_Tp>;
+  return _CUDA_VSTD::bit_floor(static_cast<_Up>(__t));
+}
+
+_LIBCUDACXX_END_NAMESPACE_CUDA
+
+#endif // _CUDA___CMATH_POW2


### PR DESCRIPTION
## Description

Very common functions are to check if a number is a power of two, or to calculate the previous/next power of two.
We currently use the following patterns:
```cpp
using U = _CUDA_VSTD::make_unsigned_t<T>;
_CUDA_VSTD::has_single_bit(static_cast<U>(value)); // is power of two?
_CUDA_VSTD::bit_ceil(static_cast<U>(value));       // next power of two
_CUDA_VSTD::bit_floor(static_cast<U>(value));      // previous power of two
```
that are very verbose and do not express the real intent.

The PR proposes public API to be exposed in `<cuda/cmath>`.
Alternatives that are also _perfectly fine_:

- constexpr variables, e.g. `is_power_of_two_v`
- internal usage only, e.g. `__is_power_of_two_v`

