### PR TITLE
Introduce scan_op support to cuda.coop block_scan module.

### DIFF
--- a/python/cuda_cooperative/cuda/cooperative/experimental/_common.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/_common.py
@@ -6,14 +6,12 @@ import re
 import tempfile
 from collections import namedtuple
 from enum import Enum
-from typing import TYPE_CHECKING, Union
+from typing import Union
+
+import numba
+import numpy as np
 
 from ._typing import DimType
-
-# Import for type checking only
-if TYPE_CHECKING:
-    import numba
-    import numpy as np
 
 version = namedtuple("version", ("major", "minor"))
 code = namedtuple("code", ("kind", "version", "data"))

--- a/python/cuda_cooperative/cuda/cooperative/experimental/_scan_op.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/_scan_op.py
@@ -1,0 +1,181 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""
+cuda.cooperative.experimental._scan_op
+======================================
+
+This module implements the ``ScanOp`` class and related functions.
+"""
+
+import operator
+from enum import Enum
+
+import numpy as np
+
+from cuda.cooperative.experimental._typing import (
+    ScanOpType,
+)
+
+
+class ScanOpCategory(Enum):
+    """
+    Represents the category of a scan operator.  This is used to guide
+    specialization of the C++ API.
+    """
+
+    Sum = "Sum"
+    """
+    Represents a sum operator.
+    """
+
+    Known = "Known"
+    """
+    Represents one of the known, non-sum associative operators: multiply,
+    minimum, maximum, bitwise AND, bitwise OR, and bitwise XOR.
+    """
+
+    Callable = "Callable"
+    """
+    Represents a user-defined callable operator (e.g. a Python function).
+    """
+
+
+CUDA_STD_PLUS = "::cuda::std::plus<T>"
+CUDA_STD_MULTIPLIES = "::cuda::std::multiplies<T>"
+CUDA_STD_BIT_AND = "::cuda::std::bit_and<T>"
+CUDA_STD_BIT_OR = "::cuda::std::bit_or<T>"
+CUDA_STD_BIT_XOR = "::cuda::std::bit_xor<T>"
+# `std::min` and `std::max` are STL functions, not operators, so there aren't
+# `::cuda`-prefixed versions.  Instead, CUDA provides `::cuda::minimum<T>` and
+# `::cuda::maximum<T>`, which *are* function objects, which is what we want.
+CUDA_MINIMUM = "::cuda::minimum<T>"
+CUDA_MAXIMUM = "::cuda::maximum<T>"
+
+
+class ScanOp:
+    """
+    Represents an associative binary operator for a prefix scan operation.
+    This helper class is used to *normalize* the operator provided by a user,
+    which may be a string, NumPy/Python operator, or callable, to a form that
+    can be used in Numba CUDA JIT'd kernels.
+    """
+
+    # Set of all ops interpreted as sum (for (inclusive|exclusive)_sum).
+    SUM_OPS = {
+        "+",
+        "add",
+        "plus",
+        np.add,
+        operator.add,
+    }
+    """
+    Set of all ops interpreted as sum (for (inclusive|exclusive)_sum).
+    """
+
+    # Map of all known (non-sum) operators to their C++ type representations.
+    KNOWN_OPS = {
+        # String names
+        "mul": CUDA_STD_MULTIPLIES,
+        "multiplies": CUDA_STD_MULTIPLIES,
+        "min": CUDA_MINIMUM,
+        "minimum": CUDA_MINIMUM,
+        "max": CUDA_MAXIMUM,
+        "maximum": CUDA_MAXIMUM,
+        "bit_and": CUDA_STD_BIT_AND,
+        "bit_or": CUDA_STD_BIT_OR,
+        "bit_xor": CUDA_STD_BIT_XOR,
+        # String operators
+        "*": CUDA_STD_MULTIPLIES,
+        "&": CUDA_STD_BIT_AND,
+        "|": CUDA_STD_BIT_OR,
+        "^": CUDA_STD_BIT_XOR,
+        # NumPy functions
+        np.maximum: CUDA_MAXIMUM,
+        np.minimum: CUDA_MINIMUM,
+        np.multiply: CUDA_STD_MULTIPLIES,
+        np.bitwise_and: CUDA_STD_BIT_AND,
+        np.bitwise_or: CUDA_STD_BIT_OR,
+        np.bitwise_xor: CUDA_STD_BIT_XOR,
+        # Python operator module functions.
+        operator.mul: CUDA_STD_MULTIPLIES,
+        operator.and_: CUDA_STD_BIT_AND,
+        operator.or_: CUDA_STD_BIT_OR,
+        operator.xor: CUDA_STD_BIT_XOR,
+    }
+    """
+    Map of all known (non-sum) operators to their C++ type representations.
+    """
+
+    def __init__(self, op: ScanOpType):
+        """
+        Initializes the ScanOp instance.
+
+        :param op: Supplies the :ref:`ScanOpType` scan operator to use
+            for the block-wide scan.
+        :type op: ScanOpType
+
+        :raises ValueError: If the provided operator is not supported.
+
+        """
+        if isinstance(op, ScanOp):
+            # If op is already a ScanOp instance, just prime this instance
+            # with its values and return.
+            self.op = op.op
+            self.op_category = op.op_category
+            self.op_cpp = op.op_cpp
+            return
+
+        self.op = op
+        self.op_category = None
+        self.op_cpp = None
+
+        # Handle string names and operators.
+        if isinstance(op, str):
+            if op in self.SUM_OPS:
+                self.op_category = ScanOpCategory.Sum
+                self.op_cpp = CUDA_STD_PLUS
+            elif op in self.KNOWN_OPS:
+                self.op_category = ScanOpCategory.Known
+                self.op_cpp = self.KNOWN_OPS[op]
+            else:
+                raise ValueError(f"Unsupported scan operator: {op}")
+
+        # Handle NumPy functions or other callables.
+        elif callable(op):
+            if op in self.SUM_OPS:
+                self.op_category = ScanOpCategory.Sum
+                self.op_cpp = CUDA_STD_PLUS
+            elif op in self.KNOWN_OPS:
+                self.op_category = ScanOpCategory.Known
+                self.op_cpp = self.KNOWN_OPS[op]
+            else:
+                # Custom callable; no op_cpp representation.
+                self.op_category = ScanOpCategory.Callable
+        else:
+            raise ValueError(f"Unsupported scan op type: {type(op)}")
+
+    def __repr__(self):
+        return f"ScanOp({self.op})"
+
+    @property
+    def is_sum(self):
+        """
+        Returns ``True`` if the scan operator is a sum operator.
+        """
+        return self.op_category == ScanOpCategory.Sum
+
+    @property
+    def is_known(self):
+        """
+        Returns ``True`` if the scan operator is a known operator.
+        """
+        return self.op_category == ScanOpCategory.Known
+
+    @property
+    def is_callable(self):
+        """
+        Returns ``True`` if the scan operator is a callable.
+        """
+        return self.op_category == ScanOpCategory.Callable

--- a/python/cuda_cooperative/cuda/cooperative/experimental/_types.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/_types.py
@@ -371,7 +371,7 @@ class StatelessOperator:
         return False
 
 
-class DependentOperator:
+class DependentPythonOperator:
     def __init__(self, ret_dtype, arg_dtypes, op):
         self.ret_dtype = ret_dtype
         self.arg_dtypes = arg_dtypes

--- a/python/cuda_cooperative/cuda/cooperative/experimental/_types.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/_types.py
@@ -443,7 +443,7 @@ class CxxFunction(Parameter):
         return f"CxxFunction(cpp={self.cpp})"
 
     def mangled_name(self):
-        return f"F{mangle_cpp(self.cpp)}"
+        return f"F{internal_mangle_cpp(self.cpp)}"
 
     def dtype(self):
         return self.func_dtype
@@ -491,14 +491,17 @@ class TemplateParameter:
         return f"{self.name}"
 
 
-def mangle_cpp(cpp_name: str):
+def internal_mangle_cpp(cpp_name: str):
     """
-    Substitutes non-alphanumeric characters in a C++ name with underscores.
+    Substitutes non-alphanumeric characters in a C++ name with underscores,
+    such that they can be used as valid, unique identifiers in C code.  This
+    is for internal use only, and does not comport with C++ ABI name mangling.
 
     :param cpp_name: Supplies a C++ name to be mangled.
     :type cpp_name: str
 
-    :return: Returns the mangled C++ name.
+    :return: Returns the mangled C++ name with non-alphanumeric characters
+    substituted with underscores.
     :rtype: str
 
     Example
@@ -580,7 +583,7 @@ class Algorithm:
         template_list = ", ".join(template_list)
 
         # '::cuda::std::int32_t, 32' -> __cuda__std__int32_t__32
-        mangle = mangle_cpp(template_list)
+        mangle = internal_mangle_cpp(template_list)
 
         specialized_parameters = []
         for method in self.parameters:

--- a/python/cuda_cooperative/cuda/cooperative/experimental/_types.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/_types.py
@@ -251,15 +251,6 @@ class Constant:
         return self.val
 
 
-class DependentFunction:
-    def __init__(self, dep, op):
-        self.dep = dep
-        self.op = op
-
-    def resolve(self, template_arguments):
-        return template_arguments[self.dep]
-
-
 class StatefulFunction:
     def __init__(self, op, dtype):
         self.op = op
@@ -726,6 +717,8 @@ class Algorithm:
         device = cuda.get_current_device()
         cc_major, cc_minor = device.compute_capability
         cc = cc_major * 10 + cc_minor
+        # N.B. Uncomment this to immediately print generated source to stdout.
+        # print(src)
         _, lto_fn = nvrtc.compile(cpp=src, cc=cc, rdc=True, code="lto")
         lto_irs.append(lto_fn)
         return lto_irs

--- a/python/cuda_cooperative/cuda/cooperative/experimental/_types.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/_types.py
@@ -433,6 +433,39 @@ class DependentOperator:
             return StatelessOperator(mangled_name, ret_cpp_type, arg_cpp_types, ltoir)
 
 
+class CxxFunction(Parameter):
+    def __init__(self, cpp, func_dtype):
+        super().__init__()
+        self.cpp = cpp
+        self.func_dtype = func_dtype
+
+    def __repr__(self) -> str:
+        return f"CxxFunction(cpp={self.cpp})"
+
+    def mangled_name(self):
+        return f"F{mangle_cpp(self.cpp)}"
+
+    def dtype(self):
+        return self.func_dtype
+
+    def is_provided_by_user(self):
+        return False
+
+
+class DependentCxxOperator:
+    def __init__(self, dep: Dependency, cpp: str):
+        self.dep = dep
+        self.cpp = cpp
+
+    def specialize(self, template_arguments):
+        dtype = self.dep.resolve(template_arguments)
+        dtype_cpp = numba_type_to_cpp(dtype)
+        source = f"<{self.dep.dep}>"
+        target = f"<{dtype_cpp}>"
+        cpp = self.cpp.replace(source, target)
+        return CxxFunction(cpp=f"{cpp}{{}}", func_dtype=dtype)
+
+
 class DependentArray(Parameter):
     def __init__(self, value_dtype, size, is_output=False):
         self.value_dtype = value_dtype
@@ -456,6 +489,29 @@ class TemplateParameter:
 
     def __repr__(self) -> str:
         return f"{self.name}"
+
+
+def mangle_cpp(cpp_name: str):
+    """
+    Substitutes non-alphanumeric characters in a C++ name with underscores.
+
+    :param cpp_name: Supplies a C++ name to be mangled.
+    :type cpp_name: str
+
+    :return: Returns the mangled C++ name.
+    :rtype: str
+
+    Example
+    -------
+
+    .. code-block:: python
+
+        >>> mangle("std::vector<int>")
+        'std_vector_int_'
+        >>> mangle("::cuda::std::min<::cuda::std::uint32_t>{}")
+        '__cuda__std__min__cuda__std__uint32_t__'
+    """
+    return re.sub(r"[^a-zA-Z0-9]", "_", cpp_name)
 
 
 def mangle_symbol(name, template_parameters):
@@ -524,7 +580,7 @@ class Algorithm:
         template_list = ", ".join(template_list)
 
         # '::cuda::std::int32_t, 32' -> __cuda__std__int32_t__32
-        mangle = re.sub(r"[^a-zA-Z0-9]", "_", template_list)
+        mangle = mangle_cpp(template_list)
 
         specialized_parameters = []
         for method in self.parameters:
@@ -643,6 +699,8 @@ class Algorithm:
                     func_decls.append(param.wrap_decl(name))
                     param_args.append(name)
                     param_decls.append(param.cpp_decl(name))
+                elif isinstance(param, CxxFunction):
+                    param_args.append(param.cpp)
                 else:
                     name = f"param_{pid}"
                     param_decls.append(param.cpp_decl(name))
@@ -744,7 +802,9 @@ class Algorithm:
                 ret = None
                 arg_id = 0
                 for param in method:
-                    if not isinstance(param, StatelessOperator):
+                    if not isinstance(param, StatelessOperator) and not isinstance(
+                        param, CxxFunction
+                    ):
                         dtype = param.dtype()
                         if isinstance(param, StatefulOperator):
                             arg = args[arg_id]
@@ -810,7 +870,9 @@ class Algorithm:
             params = []
             ret = numba.types.void
             for param in method:
-                if not isinstance(param, StatelessOperator):
+                if not isinstance(param, StatelessOperator) and not isinstance(
+                    param, CxxFunction
+                ):
                     if param.is_output:
                         if ret is not numba.types.void:
                             raise ValueError("Multiple output parameters not supported")

--- a/python/cuda_cooperative/cuda/cooperative/experimental/_typing.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/_typing.py
@@ -3,10 +3,105 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from typing import TYPE_CHECKING, Tuple, Union
+from typing import TYPE_CHECKING, Callable, Literal, Tuple, Union
 
 if TYPE_CHECKING:
+    import numba
+    import numpy as np
+
     from cuda.cooperative.experimental._common import dim3
 
-# Type alias for dimension parameters that can be passed to CUDA functions
+# Type alias for dimension parameters that can be passed to CUDA functions.
 DimType = Union["dim3", int, Tuple[int, int], Tuple[int, int, int]]
+"""
+.. _DimType:
+
+Dimension parameter specification for CUDA functions.
+
+This type alias accepts the following forms:
+
+- A single integer (1D thread/block configuration).
+- A tuple of two or three integers representing multi-dimensional
+  (2D/3D) CUDA dimensions.
+- A ``dim3`` object, which is a namedtuple with three fields: ``x``,
+  ``y``, and ``z``.
+
+Examples
+--------
+.. code-block:: python
+
+    threads = 128  # 1D
+    threads = (16, 16)  # 2D
+    threads = (8, 8, 4)  # 3D
+
+See Also
+--------
+- `CUDA dim3 documentation <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#dim3>`_
+"""
+
+DtypeType = Union[str, type, "np.number", "np.dtype", "numba.types.Type"]
+"""
+.. _DtypeType:
+
+Data type specification for CUDA kernel parameters and operations.
+
+Acceptable forms include:
+
+- Built-in Python numeric types (e.g., ``int``, ``float``).
+- NumPy scalar types (e.g., ``np.float32``) or NumPy dtypes (e.g.,
+  ``np.dtype('float32')``).
+- Numba types (e.g., ``numba.int32``).
+- Strings describing the data type (e.g., ``"float32"`` or ``"int64"``).
+
+Examples
+--------
+.. code-block:: python
+
+    dtype = np.float32
+    dtype = "int32"
+    dtype = numba.types.float64
+
+See Also
+--------
+- :mod:`numpy`
+- :mod:`numba.types`
+"""
+
+# Type alias for scan operators.
+ScanOpType = Union[
+    # Explicitly named operators.
+    Literal[
+        "add",
+        "plus",
+        "mul",
+        "multiplies",
+        "min",
+        "minimum",
+        "max",
+        "maximum",
+        "bit_and",
+        "bit_or",
+        "bit_xor",
+    ],
+    # Short-hand operators.
+    Literal["+", "*", "&", "|", "^"],
+    # Callable objects.
+    Callable[["numba.types.Number", "numba.types.Number"], "numba.types.Number"],
+    Callable[["np.ndarray", "np.ndarray"], "np.ndarray"],
+    Callable[["np.number", "np.number"], "np.number"],
+]
+"""
+.. _ScanOpType:
+
+Specification for binary scan operator used in block-wide CUDA scan operations.
+
+This type can be one of the following:
+
+- **Named operators** (as strings): ``"add"``, ``"mul"``, ``"min"``,
+  ``"max"``, ``"bit_and"``, ``"bit_or"``, and ``"bit_xor"``.
+- **Symbolic short-hand operators**: ``"+"``, ``"*"``, ``"&"``,
+  ``"|"``, and ``"^"``.
+- **User-defined callable** that accepts two input values and returns a single
+  output value.
+
+"""

--- a/python/cuda_cooperative/cuda/cooperative/experimental/block/__init__.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/block/__init__.py
@@ -10,7 +10,10 @@ from cuda.cooperative.experimental.block._block_radix_sort import (
 )
 from cuda.cooperative.experimental.block._block_reduce import reduce, sum
 from cuda.cooperative.experimental.block._block_scan import (
+    block_scan,
+    exclusive_scan,
     exclusive_sum,
+    inclusive_scan,
     inclusive_sum,
 )
 
@@ -18,6 +21,9 @@ __all__ = [
     "merge_sort_keys",
     "reduce",
     "sum",
+    "block_scan",
+    "exclusive_scan",
+    "inclusive_scan",
     "exclusive_sum",
     "inclusive_sum",
     "radix_sort_keys",

--- a/python/cuda_cooperative/cuda/cooperative/experimental/block/__init__.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/block/__init__.py
@@ -10,18 +10,18 @@ from cuda.cooperative.experimental.block._block_radix_sort import (
 )
 from cuda.cooperative.experimental.block._block_reduce import reduce, sum
 from cuda.cooperative.experimental.block._block_scan import (
-    block_scan,
     exclusive_scan,
     exclusive_sum,
     inclusive_scan,
     inclusive_sum,
+    scan,
 )
 
 __all__ = [
     "merge_sort_keys",
     "reduce",
     "sum",
-    "block_scan",
+    "scan",
     "exclusive_scan",
     "inclusive_scan",
     "exclusive_sum",

--- a/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_merge_sort.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_merge_sort.py
@@ -16,7 +16,7 @@ from cuda.cooperative.experimental._types import (
     Constant,
     Dependency,
     DependentArray,
-    DependentOperator,
+    DependentPythonOperator,
     Invocable,
     Pointer,
     TemplateParameter,
@@ -94,7 +94,7 @@ def merge_sort_keys(
             [
                 Pointer(numba.uint8),
                 DependentArray(Dependency("KeyT"), Dependency("ITEMS_PER_THREAD")),
-                DependentOperator(
+                DependentPythonOperator(
                     Constant(numba.int8),
                     [Dependency("KeyT"), Dependency("KeyT")],
                     Dependency("Op"),

--- a/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_reduce.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_reduce.py
@@ -16,7 +16,7 @@ from cuda.cooperative.experimental._types import (
     Algorithm,
     Dependency,
     DependentArray,
-    DependentOperator,
+    DependentPythonOperator,
     DependentReference,
     Invocable,
     Pointer,
@@ -108,7 +108,7 @@ def _reduce(
                 [
                     Pointer(numba.uint8),
                     DependentReference(Dependency("T")),
-                    DependentOperator(
+                    DependentPythonOperator(
                         Dependency("T"),
                         [Dependency("T"), Dependency("T")],
                         Dependency("Op"),
@@ -119,7 +119,7 @@ def _reduce(
                 [
                     Pointer(numba.uint8),
                     DependentReference(Dependency("T")),
-                    DependentOperator(
+                    DependentPythonOperator(
                         Dependency("T"),
                         [Dependency("T"), Dependency("T")],
                         Dependency("Op"),
@@ -139,7 +139,7 @@ def _reduce(
                 [
                     Pointer(numba.uint8),
                     DependentArray(Dependency("T"), Dependency("ITEMS_PER_THREAD")),
-                    DependentOperator(
+                    DependentPythonOperator(
                         Dependency("T"),
                         [Dependency("T"), Dependency("T")],
                         Dependency("Op"),

--- a/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_scan.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_scan.py
@@ -101,7 +101,7 @@ from cuda.cooperative.experimental._typing import (
 )
 
 
-def block_scan(
+def scan(
     dtype: DtypeType,
     threads_per_block: DimType,
     items_per_thread: int = 1,
@@ -741,7 +741,7 @@ def exclusive_sum(
         the block-wide exclusive prefix scan.
     :rtype: Callable
     """
-    return block_scan(
+    return scan(
         dtype=dtype,
         threads_per_block=threads_per_block,
         items_per_thread=items_per_thread,
@@ -804,7 +804,7 @@ def inclusive_sum(
         the block-wide inclusive prefix scan.
     :rtype: Callable
     """
-    return block_scan(
+    return scan(
         dtype=dtype,
         threads_per_block=threads_per_block,
         items_per_thread=items_per_thread,
@@ -895,7 +895,7 @@ def exclusive_scan(
         perform the block-wide exclusive prefix scan.
     :rtype: Callable
     """
-    return block_scan(
+    return scan(
         dtype=dtype,
         threads_per_block=threads_per_block,
         items_per_thread=items_per_thread,
@@ -979,7 +979,7 @@ def inclusive_scan(
         perform the block-wide inclusive prefix scan.
     :rtype: Callable
     """
-    return block_scan(
+    return scan(
         dtype=dtype,
         threads_per_block=threads_per_block,
         items_per_thread=items_per_thread,

--- a/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_scan.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_scan.py
@@ -16,7 +16,7 @@ from cuda.cooperative.experimental._types import (
     Algorithm,
     Dependency,
     DependentArray,
-    DependentOperator,
+    DependentPythonOperator,
     DependentReference,
     Invocable,
     Pointer,
@@ -109,7 +109,7 @@ def _scan(
                     # T& output
                     DependentReference(Dependency("T"), is_output=True),
                     # BlockPrefixCallbackOp& block_prefix_callback_op
-                    DependentOperator(
+                    DependentPythonOperator(
                         Dependency("T"),
                         [Dependency("T")],
                         Dependency("BlockPrefixCallbackOp"),
@@ -154,7 +154,7 @@ def _scan(
                     # T (&)[ITEMS_PER_THREAD] output
                     DependentArray(Dependency("T"), Dependency("ITEMS_PER_THREAD")),
                     # BlockPrefixCallbackOp& block_prefix_callback_op
-                    DependentOperator(
+                    DependentPythonOperator(
                         Dependency("T"),
                         [Dependency("T")],
                         Dependency("BlockPrefixCallbackOp"),

--- a/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_scan.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_scan.py
@@ -2,7 +2,74 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from typing import TYPE_CHECKING, Callable, Literal, Union
+"""
+cuda.cooperative.block_scan
+===========================
+
+This module provides a set of :ref:`collective <collective-primitives>`
+for computing parallel prefix scans of items partitioned across CUDA
+thread blocks.  It is based on the :class:`cub.BlockScan` C++ class in
+the CUB library.
+
+Supported C++ APIs
+++++++++++++++++++
+
+The following :class:`cub.BlockScan` C++ APIs are supported:
+
+
+    ExclusiveSum(T input, T &output)
+    ExclusiveSum(T input, T &output, BlockPrefixCallbackOp &prefix_op)
+    ExclusiveSum(T&)[ITEMS_PER_THREAD] input, T(&)[ITEMS_PER_THREAD] output)
+    ExclusiveSum(T&)[ITEMS_PER_THREAD] input, T(&)[ITEMS_PER_THREAD] output, BlockPrefixCallbackOp &prefix_op)
+
+    InclusiveSum(T input, T &output)
+    InclusiveSum(T input, T &output, BlockPrefixCallbackOp &prefix_op)
+    InclusiveSum(T&)[ITEMS_PER_THREAD] input, T(&)[ITEMS_PER_THREAD] output)
+    InclusiveSum(T&)[ITEMS_PER_THREAD] input, T(&)[ITEMS_PER_THREAD] output, BlockPrefixCallbackOp &prefix_op)
+
+    ExclusiveScan(T input, T &output, ScanOp scan_op)
+    ExclusiveScan(T input, T &output, ScanOp scan_op, BlockPrefixCallbackOp &prefix_op)
+    ExclusiveScan(T input, T &output, T initial_value, ScanOp scan_op)
+    ExclusiveScan(T&)[ITEMS_PER_THREAD] input, T(&)[ITEMS_PER_THREAD] output, ScanOp scan_op)
+    ExclusiveScan(T&)[ITEMS_PER_THREAD] input, T(&)[ITEMS_PER_THREAD] output, ScanOp scan_op, BlockPrefixCallbackOp &prefix_op)
+    ExclusiveScanT(&)[ITEMS_PER_THREAD] input, T(&)[ITEMS_PER_THREAD] output, T initial_value, ScanOp scan_op)
+
+    InclusiveScan(T input, T &output, ScanOp scan_op)
+    InclusiveScan(T input, T &output, ScanOp scan_op, BlockPrefixCallbackOp &prefix_op)
+    InclusiveScan(T&)[ITEMS_PER_THREAD] input, T(&)[ITEMS_PER_THREAD] output, ScanOp scan_op)
+    InclusiveScan(T&)[ITEMS_PER_THREAD] input, T(&)[ITEMS_PER_THREAD] output, ScanOp scan_op, BlockPrefixCallbackOp &prefix_op)
+    InclusiveScanT(&)[ITEMS_PER_THREAD] input, T(&)[ITEMS_PER_THREAD] output, T initial_value, ScanOp scan_op)
+
+Unsupported C++ APIs
+++++++++++++++++++++
+
+This module does not support any of the :class:`cub.BlockScan` C++ APIs
+that take a block aggregate reference as an argument.  That being said, the
+`BlockPrefixCallbackOp` callable is supported, and thus, block aggregates can
+be obtained using those measures.
+
+The reason the `T &block_aggregate` pattern is not supported as it will usually
+result in two output parameters, which we don't support in our underlying type
+machinery (i.e. _types.py).
+
+The unsupported APIs are as follows:
+
+    ExclusiveSum(T input, T &output, T &block_aggregate)
+    ExclusiveSum(T&)[ITEMS_PER_THREAD] input, T(&)[ITEMS_PER_THREAD] output, T &block_aggregate)
+
+    InclusiveSum(T input, T &output, T &block_aggregate)
+    InclusiveSum(T&)[ITEMS_PER_THREAD] input, T(&)[ITEMS_PER_THREAD] output, T &block_aggregate)
+
+    ExclusiveScan(T input, T &output, ScanOp scan_op, T &block_aggregate)
+    ExclusiveScan(T input, T &output, T initial_value, ScanOp scan_op, T &block_aggregate)
+    ExclusiveScan(T&)[ITEMS_PER_THREAD] input, T(&)[ITEMS_PER_THREAD] output, ScanOp scan_op, T &block_aggregate)
+    ExclusiveScan(T&)[ITEMS_PER_THREAD] input, T(&)[ITEMS_PER_THREAD] output, T initial_value, ScanOp scan_op, T &block_aggregate)
+
+    InclusiveScan(T input, T &output, ScanOp scan_op, T &block_aggregate)
+    InclusiveScan(T&)[ITEMS_PER_THREAD] input, T(&)[ITEMS_PER_THREAD] output, T initial_value, ScanOp scan_op, T &block_aggregate)
+"""
+
+from typing import Any, Callable, Literal
 
 import numba
 
@@ -12,31 +79,122 @@ from cuda.cooperative.experimental._common import (
     normalize_dim_param,
     normalize_dtype_param,
 )
+from cuda.cooperative.experimental._scan_op import (
+    ScanOp,
+)
 from cuda.cooperative.experimental._types import (
     Algorithm,
     Dependency,
     DependentArray,
+    DependentCxxOperator,
     DependentPythonOperator,
     DependentReference,
     Invocable,
     Pointer,
     TemplateParameter,
+    numba_type_to_wrapper,
 )
-from cuda.cooperative.experimental._typing import DimType
+from cuda.cooperative.experimental._typing import (
+    DimType,
+    DtypeType,
+    ScanOpType,
+)
 
-if TYPE_CHECKING:
-    import numpy as np
 
-
-def _scan(
-    dtype: Union[str, type, "np.dtype", "numba.types.Type"],
+def block_scan(
+    dtype: DtypeType,
     threads_per_block: DimType,
     items_per_thread: int = 1,
+    initial_value: Any = None,
     mode: Literal["exclusive", "inclusive"] = "exclusive",
-    scan_op: Literal["+"] = "+",
+    scan_op: ScanOpType = "+",
     block_prefix_callback_op: Callable = None,
     algorithm: Literal["raking", "raking_memoize", "warp_scans"] = "raking",
+    methods: dict = None,
 ) -> Callable:
+    """
+    Creates a block-wide prefix scan primitive based on the CUB library's
+    BlockScan functionality.
+
+    This function is the low-level implementation used by the higher-level
+    APIs such as ``exclusive_sum``, ``inclusive_sum``, ``exclusive_scan``,
+    and ``inclusive_scan``.
+
+    :param dtype: Supplies the data type of the input and output arrays.
+    :type  dtype: DtypeType
+
+    :param threads_per_block: Supplies the number of threads in the block,
+        either as an integer for a 1D block or a tuple of two or three integers
+        for a 2D or 3D block, respectively.
+    :type  threads_per_block: DimType
+
+    :param items_per_thread: Supplies the number of items partitioned onto each
+        thread.
+    :type  items_per_thread: int, optional
+
+    :param initial_value: Optionally supplies the initial value to use for the
+        block-wide scan.
+    :type  initial_value: Any, optional
+
+    :param mode: Supplies the scan mode to use. Must be one of ``"exclusive"``
+        or ``"inclusive"``. The default is ``"exclusive"``.
+    :type  mode: Literal["exclusive", "inclusive"], optional
+
+    :param scan_op: Supplies the scan operator to use for the block-wide scan.
+        The default is the sum operator (``+``).
+    :type  scan_op: ScanOpType, optional
+
+    :param block_prefix_callback_op: Optionally supplies a callable that will be
+        invoked by the first warp of threads in a block with the block aggregate
+        value; only the return value of the first lane in the warp is applied as
+        the prefix value.
+    :type  block_prefix_callback_op: Callable, optional
+
+    :param algorithm: Supplies the algorithm to use for the block-wide scan.
+        Must be one of ``"raking"``, ``"raking_memoize"``, or ``"warp_scans"``.
+        The default is ``"raking"``.
+    :type  algorithm: Literal["raking", "raking_memoize", "warp_scans"], optional
+
+    :param methods: Optionally supplies a dictionary of methods to use for
+        user-defined types.  The default is *None*.  Not supported if
+        ``items_per_thread > 1``.
+    :type  methods: dict, optional
+
+    :raises ValueError: If ``algorithm`` is not one of the supported algorithms
+        (``"raking"``, ``"raking_memoize"``, or ``"warp_scans"``).
+
+    :raises ValueError: If ``items_per_thread`` is less than 1.
+
+    :raises ValueError: If ``items_per_thread`` is greater than 1 and ``methods``
+        is not *None* (i.e. a user-defined type is being used).
+
+    :raises ValueError: If ``mode`` is not one of the supported modes
+        (``"exclusive"`` or ``"inclusive"``).
+
+    :raises ValueError: If ``scan_op`` is an unsupported operator type.
+
+    :raises ValueError: If ``initial_value`` is provided but the ``scan_op``
+        is a sum operator (sum operators do not support initial values).
+
+    :raises ValueError: If ``initial_value`` is provided with an inclusive scan
+        (``mode="inclusive"``) and ``items_per_thread=1`` (initial values are
+        not supported for inclusive scans with a single item per thread).
+
+    :raises ValueError: If ``initial_value`` is provided with an exclusive scan
+        (``mode="exclusive"``), ``items_per_thread=1``, and
+        ``block_prefix_callback_op`` is not *None* (this combination is not
+        supported).
+
+    :raises ValueError: If ``initial_value`` is required but not provided.
+        An initial value is required when ``items_per_thread > 1`` and
+        ``block_prefix_callback_op`` is *None*.  If not provided, the function
+        will attempt to create a default value (``0``) for the given data type,
+        but will raise an error if this is not possible.
+
+    :returns: A callable that can be linked to a CUDA kernel and invoked to
+        perform the block-wide prefix scan.
+    :rtype: Callable
+    """
     if algorithm not in CUB_BLOCK_SCAN_ALGOS:
         raise ValueError(f"Unsupported algorithm: {algorithm}")
 
@@ -52,6 +210,73 @@ def _scan(
         if mode != "inclusive":
             raise ValueError(f"Unsupported mode: {mode}")
         cpp_func_prefix = "Inclusive"
+
+    # This will raise an error if scan_op is invalid.
+    scan_op = ScanOp(scan_op)
+    if scan_op.is_sum:
+        # Make sure we specialize the correct CUB API for exclusive sum.
+        cpp_function_name = f"{cpp_func_prefix}Sum"
+    else:
+        cpp_function_name = f"{cpp_func_prefix}Scan"
+
+    # If items_per_thread > 1, we need to check that methods is not None.
+    if items_per_thread > 1 and methods is not None:
+        raise ValueError(
+            "user-defined types are not supported for items_per_thread > 1"
+        )
+
+    # An initial value is not supported for inclusive and exclusive sums.
+    if initial_value is not None and scan_op.is_sum:
+        raise ValueError(
+            "initial_value is not supported for inclusive and exclusive sums"
+        )
+
+    # An initial value is not supported for inclusive scans with a single
+    # item per thread.
+    invalid_initial_value = (
+        initial_value is not None and items_per_thread == 1 and mode == "inclusive"
+    )
+    if invalid_initial_value:
+        raise ValueError(
+            "initial_value is not supported for inclusive scans with "
+            "items_per_thread == 1"
+        )
+
+    # An initial value is not supported for exclusive scans with a
+    # single item per thread and a block prefix callback operator.
+    invalid_initial_value = (
+        items_per_thread == 1
+        and initial_value is not None
+        and mode == "exclusive"
+        and block_prefix_callback_op is not None
+    )
+    if invalid_initial_value:
+        raise ValueError(
+            "initial_value is not supported for exclusive scans with "
+            "items_per_thread == 1 and a block prefix callback operator"
+        )
+
+    # An initial value is required for both inclusive and exclusive scans
+    # when items_per_thread > 1 and a block prefix callback operator is
+    # not supplied by the caller.
+    initial_value_required = items_per_thread > 1 and block_prefix_callback_op is None
+    if initial_value_required and initial_value is None:
+        # We require an initial value, but one was not supplied.
+        # Attempt to create a default value for the given dtype.
+        # If we can't, raise an error.
+        try:
+            initial_value = dtype.cast_python_value(0)
+        except (TypeError, NotImplementedError) as e:
+            # We can't create a default value for the given dtype.
+            # Raise an error.
+            msg = (
+                "initial_value is required for both inclusive and "
+                "exclusive scans when items_per_thread > 1 and no "
+                "block prefix callback operator has been supplied; "
+                "attempted to create a default value for the given "
+                f"dtype, but failed: {e}"
+            )
+            raise ValueError(msg) from e
 
     specialization_kwds = {
         "T": dtype,
@@ -69,110 +294,356 @@ def _scan(
         TemplateParameter("BLOCK_DIM_Z"),
     ]
 
-    fake_return = False
-
-    if scan_op != "+":
-        raise ValueError(f"Unsupported scan_op: {scan_op}")
+    if items_per_thread == 1:
+        fake_return = True
     else:
-        if items_per_thread == 1:
-            parameters = [
-                # Signature:
-                # void BlockScan<T, BLOCK_DIM_X, ALGORITHM,
-                #                   BLOCK_DIM_Y, BLOCK_DIM_Z>(
-                #     temp_storage
-                # ).<Inclusive|Exclusive>Sum(
-                #     T, # input
-                #     T& # output
-                # )
-                [
-                    # temp_storage
-                    Pointer(numba.uint8),
-                    # T input
-                    DependentReference(Dependency("T")),
-                    # T& output
-                    DependentReference(Dependency("T"), is_output=True),
-                ],
-                # Signature:
-                # void BlockScan<T, BLOCK_DIM_X, ALGORITHM,
-                #                   BLOCK_DIM_Y, BLOCK_DIM_Z>(
-                #     temp_storage
-                # ).<Inclusive|Exclusive>Sum(
-                #     T,                     # input
-                #     T&,                    # output
-                #     BlockPrefixCallbackOp& # block_prefix_callback_op
-                # )
-                [
-                    # temp_storage
-                    Pointer(numba.uint8),
-                    # T input
-                    DependentReference(Dependency("T")),
-                    # T& output
-                    DependentReference(Dependency("T"), is_output=True),
-                    # BlockPrefixCallbackOp& block_prefix_callback_op
-                    DependentPythonOperator(
-                        Dependency("T"),
-                        [Dependency("T")],
-                        Dependency("BlockPrefixCallbackOp"),
-                    ),
-                ],
-            ]
+        specialization_kwds["ITEMS_PER_THREAD"] = items_per_thread
+        fake_return = False
 
-            fake_return = True
+    # A "known" scan op is the standard set of associative operators,
+    # e.g. ::cuda::std::plus<>, etc.  A "callable" scan op is a Python
+    # callable that has been furnished by the caller.  Thus, we need to
+    # generate different parameters for each case.
+    if scan_op.is_known:
+
+        def make_dependent_scan_op():
+            return DependentCxxOperator(
+                dep=Dependency("T"),
+                cpp=scan_op.op_cpp,
+            )
+
+    elif scan_op.is_callable:
+
+        def make_dependent_scan_op():
+            return DependentPythonOperator(
+                ret_dtype=Dependency("T"),
+                arg_dtypes=[Dependency("T"), Dependency("T")],
+                op=Dependency("ScanOp"),
+            )
+
+    if block_prefix_callback_op is not None:
+
+        def make_dependent_block_prefix_callback_op():
+            return DependentPythonOperator(
+                ret_dtype=Dependency("T"),
+                arg_dtypes=[Dependency("T")],
+                op=Dependency("BlockPrefixCallbackOp"),
+            )
+
+    if scan_op.is_sum:
+        if items_per_thread == 1:
+            if block_prefix_callback_op is None:
+                parameters = [
+                    # Signature:
+                    # void BlockScan<T, BLOCK_DIM_X, ALGORITHM,
+                    #                   BLOCK_DIM_Y, BLOCK_DIM_Z>(
+                    #     temp_storage
+                    # ).<Inclusive|Exclusive>Sum(
+                    #     T, # input
+                    #     T& # output
+                    # )
+                    [
+                        # temp_storage
+                        Pointer(numba.uint8),
+                        # T input
+                        DependentReference(Dependency("T")),
+                        # T& output
+                        DependentReference(Dependency("T"), is_output=True),
+                    ],
+                ]
+            else:
+                parameters = [
+                    # Signature:
+                    # void BlockScan<T, BLOCK_DIM_X, ALGORITHM,
+                    #                   BLOCK_DIM_Y, BLOCK_DIM_Z>(
+                    #     temp_storage
+                    # ).<Inclusive|Exclusive>Sum(
+                    #     T,                     # input
+                    #     T&,                    # output
+                    #     BlockPrefixCallbackOp& # block_prefix_callback_op
+                    # )
+                    [
+                        # temp_storage
+                        Pointer(numba.uint8),
+                        # T input
+                        DependentReference(Dependency("T")),
+                        # T& output
+                        DependentReference(Dependency("T"), is_output=True),
+                        # BlockPrefixCallbackOp& block_prefix_callback_op
+                        make_dependent_block_prefix_callback_op(),
+                    ],
+                ]
 
         else:
             assert items_per_thread > 1, items_per_thread
+            if block_prefix_callback_op is not None:
+                parameters = [
+                    # Signature:
+                    # void BlockScan<T, BLOCK_DIM_X, ALGORITHM,
+                    #                   BLOCK_DIM_Y, BLOCK_DIM_Z>(
+                    #     temp_storage
+                    # ).<Inclusive|Exclusive>Sum(
+                    #     T (&)[ITEMS_PER_THREAD], # input
+                    #     T (&)[ITEMS_PER_THREAD], # output
+                    #     BlockPrefixCallbackOp&   # block_prefix_callback_op
+                    # )
+                    [
+                        # temp_storage
+                        Pointer(numba.uint8),
+                        # T (&)[ITEMS_PER_THREAD] input
+                        DependentArray(Dependency("T"), Dependency("ITEMS_PER_THREAD")),
+                        # T (&)[ITEMS_PER_THREAD] output
+                        DependentArray(Dependency("T"), Dependency("ITEMS_PER_THREAD")),
+                        # BlockPrefixCallbackOp& block_prefix_callback_op
+                        make_dependent_block_prefix_callback_op(),
+                    ],
+                ]
+            else:
+                parameters = [
+                    # Signature:
+                    # void BlockScan<T, BLOCK_DIM_X, ALGORITHM,
+                    #                   BLOCK_DIM_Y, BLOCK_DIM_Z>(
+                    #     temp_storage
+                    # ).<Inclusive|Exclusive>Sum(
+                    #     T (&)[ITEMS_PER_THREAD], # input
+                    #     T (&)[ITEMS_PER_THREAD]  # output
+                    # )
+                    [
+                        # temp_storage
+                        Pointer(numba.uint8),
+                        # T (&)[ITEMS_PER_THREAD] input
+                        DependentArray(Dependency("T"), Dependency("ITEMS_PER_THREAD")),
+                        # T (&)[ITEMS_PER_THREAD] output
+                        DependentArray(Dependency("T"), Dependency("ITEMS_PER_THREAD")),
+                    ],
+                ]
 
-            parameters = [
-                # Signature:
-                # void BlockScan<T, BLOCK_DIM_X, ITEMS_PER_THREAD, ALGORITHM>(
-                #     temp_storage
-                # ).<Inclusive|Exclusive>Sum(
-                #     T (&)[ITEMS_PER_THREAD], # input
-                #     T (&)[ITEMS_PER_THREAD]  # output
-                # )
-                [
-                    # temp_storage
-                    Pointer(numba.uint8),
-                    # T (&)[ITEMS_PER_THREAD] input
-                    DependentArray(Dependency("T"), Dependency("ITEMS_PER_THREAD")),
-                    # T (&)[ITEMS_PER_THREAD] output
-                    DependentArray(Dependency("T"), Dependency("ITEMS_PER_THREAD")),
-                ],
-                # Signature:
-                # void BlockScan<T, BLOCK_DIM_X, ITEMS_PER_THREAD, ALGORITHM>(
-                #     temp_storage
-                # ).<Inclusive|Exclusive>Sum(
-                #     T (&)[ITEMS_PER_THREAD], # input
-                #     T (&)[ITEMS_PER_THREAD], # output
-                #     BlockPrefixCallbackOp&   # block_prefix_callback_op
-                # )
-                [
-                    # temp_storage
-                    Pointer(numba.uint8),
-                    # T (&)[ITEMS_PER_THREAD] input
-                    DependentArray(Dependency("T"), Dependency("ITEMS_PER_THREAD")),
-                    # T (&)[ITEMS_PER_THREAD] output
-                    DependentArray(Dependency("T"), Dependency("ITEMS_PER_THREAD")),
-                    # BlockPrefixCallbackOp& block_prefix_callback_op
-                    DependentPythonOperator(
-                        Dependency("T"),
-                        [Dependency("T")],
-                        Dependency("BlockPrefixCallbackOp"),
-                    ),
-                ],
-            ]
+    elif scan_op.is_known or scan_op.is_callable:
+        if items_per_thread == 1:
+            if mode == "exclusive":
+                if block_prefix_callback_op is not None:
+                    assert initial_value is None
+                    parameters = [
+                        # Signature:
+                        # void BlockScan<T, BLOCK_DIM_X, ALGORITHM,
+                        #                   BLOCK_DIM_Y, BLOCK_DIM_Z>(
+                        #     temp_storage
+                        # )<ScanOp>ExclusiveScan(
+                        #     T,                     # input
+                        #     T&,                    # output
+                        #     ScanOp,                # scan_op
+                        #     BlockPrefixCallbackOp& # block_prefix_callback_op
+                        # )
+                        [
+                            # temp_storage
+                            Pointer(numba.uint8),
+                            # T input
+                            DependentReference(Dependency("T")),
+                            # T& output
+                            DependentReference(Dependency("T"), is_output=True),
+                            # ScanOp scan_op
+                            make_dependent_scan_op(),
+                            # BlockPrefixCallbackOp& block_prefix_callback_op
+                            make_dependent_block_prefix_callback_op(),
+                        ],
+                    ]
+                else:
+                    parameters = [
+                        # Signature:
+                        # void BlockScan<T, BLOCK_DIM_X, ALGORITHM,
+                        #                   BLOCK_DIM_Y, BLOCK_DIM_Z>(
+                        #     temp_storage
+                        # )<ScanOp>ExclusiveScan(
+                        #     T,     # input
+                        #     T&,    # output
+                        #     ScanOp # scan_op
+                        # )
+                        [
+                            # temp_storage
+                            Pointer(numba.uint8),
+                            # T input
+                            DependentReference(Dependency("T")),
+                            # T& output
+                            DependentReference(Dependency("T"), is_output=True),
+                            # ScanOp scan_op
+                            make_dependent_scan_op(),
+                        ],
+                        # Signature:
+                        # void BlockScan<T, BLOCK_DIM_X, ALGORITHM,
+                        #                   BLOCK_DIM_Y, BLOCK_DIM_Z>(
+                        #     temp_storage
+                        # )<ScanOp>ExclusiveScan(
+                        #     T,     # input
+                        #     T&,    # output
+                        #     T,     # initial_value
+                        #     ScanOp # scan_op
+                        # )
+                        [
+                            # temp_storage
+                            Pointer(numba.uint8),
+                            # T input
+                            DependentReference(Dependency("T")),
+                            # T& output
+                            DependentReference(Dependency("T"), is_output=True),
+                            # T initial_value
+                            DependentReference(Dependency("T")),
+                            # ScanOp scan_op
+                            make_dependent_scan_op(),
+                        ],
+                    ]
 
-            specialization_kwds["ITEMS_PER_THREAD"] = items_per_thread
+            else:
+                assert mode == "inclusive" or initial_value is None
+                if block_prefix_callback_op is not None:
+                    parameters = [
+                        # Signature:
+                        # void BlockScan<T, BLOCK_DIM_X, ALGORITHM,
+                        #                   BLOCK_DIM_Y, BLOCK_DIM_Z>(
+                        #     temp_storage
+                        # )<ScanOp><Inclusive|Exclusive>Scan(
+                        #     T,                     # input
+                        #     T&,                    # output
+                        #     ScanOp,                # scan_op
+                        #     BlockPrefixCallbackOp& # block_prefix_callback_op
+                        # )
+                        [
+                            # temp_storage
+                            Pointer(numba.uint8),
+                            # T input
+                            DependentReference(Dependency("T")),
+                            # T& output
+                            DependentReference(Dependency("T"), is_output=True),
+                            # ScanOp scan_op
+                            make_dependent_scan_op(),
+                            # BlockPrefixCallbackOp& block_prefix_callback_op
+                            make_dependent_block_prefix_callback_op(),
+                        ],
+                    ]
+                else:
+                    parameters = [
+                        # Signature:
+                        # void BlockScan<T, BLOCK_DIM_X, ALGORITHM,
+                        #                   BLOCK_DIM_Y, BLOCK_DIM_Z>(
+                        #     temp_storage
+                        # )<ScanOp><Inclusive|Exclusive>Scan(
+                        #     T,     # input
+                        #     T&,    # output
+                        #     ScanOp # scan_op
+                        # )
+                        [
+                            # temp_storage
+                            Pointer(numba.uint8),
+                            # T input
+                            DependentReference(Dependency("T")),
+                            # T& output
+                            DependentReference(Dependency("T"), is_output=True),
+                            # ScanOp scan_op
+                            make_dependent_scan_op(),
+                        ],
+                    ]
+
+        else:
+            assert items_per_thread > 1, items_per_thread
+            if block_prefix_callback_op is not None:
+                assert initial_value is None
+                parameters = [
+                    # Signature:
+                    # void BlockScan<T, BLOCK_DIM_X, ALGORITHM,
+                    #                   BLOCK_DIM_Y, BLOCK_DIM_Z>(
+                    #     temp_storage
+                    # )<ITEMS_PER_THREAD, ScanOp><Inclusive|Exclusive>Scan(
+                    #     T (&)[ITEMS_PER_THREAD], # input
+                    #     T (&)[ITEMS_PER_THREAD], # output
+                    #     ScanOp,                  # scan_op
+                    #     BlockPrefixCallbackOp&   # block_prefix_callback_op
+                    # )
+                    [
+                        # temp_storage
+                        Pointer(numba.uint8),
+                        # T (&)[ITEMS_PER_THREAD] input
+                        DependentArray(Dependency("T"), Dependency("ITEMS_PER_THREAD")),
+                        # T (&)[ITEMS_PER_THREAD] output
+                        DependentArray(Dependency("T"), Dependency("ITEMS_PER_THREAD")),
+                        # ScanOp scan_op
+                        make_dependent_scan_op(),
+                        # BlockPrefixCallbackOp& block_prefix_callback_op
+                        make_dependent_block_prefix_callback_op(),
+                    ],
+                ]
+            else:
+                parameters = [
+                    # Signature:
+                    # void BlockScan<T, BLOCK_DIM_X, ALGORITHM,
+                    #                   BLOCK_DIM_Y, BLOCK_DIM_Z>(
+                    #     temp_storage
+                    # )<ITEMS_PER_THREAD, ScanOp><Inclusive|Exclusive>Scan(
+                    #     T (&)[ITEMS_PER_THREAD], # input
+                    #     T (&)[ITEMS_PER_THREAD], # output
+                    #     ScanOp                   # scan_op
+                    # )
+                    [
+                        # temp_storage
+                        Pointer(numba.uint8),
+                        # T (&)[ITEMS_PER_THREAD] input
+                        DependentArray(Dependency("T"), Dependency("ITEMS_PER_THREAD")),
+                        # T (&)[ITEMS_PER_THREAD] output
+                        DependentArray(Dependency("T"), Dependency("ITEMS_PER_THREAD")),
+                        # ScanOp scan_op
+                        make_dependent_scan_op(),
+                    ],
+                    # Signature:
+                    # void BlockScan<T, BLOCK_DIM_X, ALGORITHM,
+                    #                   BLOCK_DIM_Y, BLOCK_DIM_Z>(
+                    #     temp_storage
+                    # )<ITEMS_PER_THREAD, ScanOp><Inclusive|Exclusive>Scan(
+                    #     T (&)[ITEMS_PER_THREAD], # input
+                    #     T (&)[ITEMS_PER_THREAD], # output
+                    #     T,                       # initial_value
+                    #     ScanOp                   # scan_op
+                    # )
+                    [
+                        # temp_storage
+                        Pointer(numba.uint8),
+                        # T (&)[ITEMS_PER_THREAD] input
+                        DependentArray(Dependency("T"), Dependency("ITEMS_PER_THREAD")),
+                        # T (&)[ITEMS_PER_THREAD] output
+                        DependentArray(Dependency("T"), Dependency("ITEMS_PER_THREAD")),
+                        # T initial_value
+                        DependentReference(Dependency("T")),
+                        # ScanOp scan_op
+                        make_dependent_scan_op(),
+                    ],
+                ]
+
+    else:
+        # We shouldn't ever hit this; there are only three types of scan ops
+        # supported: sum, known, and callable.
+        raise RuntimeError("Unreachable code")
+
+    # Invariant check: if we get here, parameters shouldn't be empty.
+    assert parameters, "parameters should not be empty"
+
+    # If we have a non-None `methods`, we're dealing with user-defined types.
+    if methods is not None:
+        type_definitions = [
+            numba_type_to_wrapper(dtype, methods=methods),
+        ]
+    else:
+        type_definitions = None
 
     template = Algorithm(
         "BlockScan",
-        f"{cpp_func_prefix}Sum",
+        cpp_function_name,
         "block_scan",
         ["cub/block/block_scan.cuh"],
         template_parameters,
         parameters,
         fake_return=fake_return,
+        type_definitions=type_definitions,
     )
+
+    if scan_op.is_callable:
+        specialization_kwds["ScanOp"] = scan_op.op
 
     if block_prefix_callback_op is not None:
         specialization_kwds["BlockPrefixCallbackOp"] = block_prefix_callback_op
@@ -189,11 +660,12 @@ def _scan(
 
 
 def exclusive_sum(
-    dtype: Union[str, type, "np.dtype", "numba.types.Type"],
+    dtype: DtypeType,
     threads_per_block: DimType,
     items_per_thread: int = 1,
     prefix_op: Callable = None,
     algorithm: Literal["raking", "raking_memoize", "warp_scans"] = "raking",
+    methods: dict = None,
 ) -> Callable:
     """
     Computes an exclusive block-wide prefix scan using addition (+) as the
@@ -227,32 +699,49 @@ def exclusive_sum(
         The corresponding output ``thread_data`` in those threads will be
         ``{ [0, 1, 2, 3], [4, 5, 6, 7], ..., [508, 509, 510, 511] }``.
 
-    Args:
-        dtype: Supplies the data type of the input and output arrays.
+    :param dtype: Supplies the data type of the input and output arrays.
+    :type  dtype: DtypeType
 
-        threads_per_block: Supplies the number of threads in the block, either
-            as an integer for a 1D block or a tuple of two or three integers
-            for a 2D or 3D block, respectively.
+    :param threads_per_block: Supplies the number of threads in the block,
+        either as an integer for a 1D block or a tuple of two or three integers
+        for a 2D or 3D block, respectively.
+    :type  threads_per_block: DimType
 
-        items_per_thread: Supplies the number of items partitioned onto each
-            thread.
+    :param items_per_thread: Supplies the number of items partitioned onto each
+        thread.
+    :type  items_per_thread: int, optional
 
-        prefix_op: Optionally supplies a callable that will be invoked by the
-            first warp of threads in a block with the block aggregate value;
-            only the return value of the first lane in the warp is applied as
-            the prefix value.
+    :param prefix_op: Optionally supplies a callable that will be invoked by the
+        first warp of threads in a block with the block aggregate value;
+        only the return value of the first lane in the warp is applied as
+        the prefix value.
+    :type  prefix_op: Callable, optional
 
-        algorithm: Optionally supplies the algorithm to use for the block-wide
-            scan.  Must be one of the following: ``"raking"``,
-            ``"raking_memoize"``, or ``"warp_scans"``.  The default is
-            ``"raking"``.
+    :param algorithm: Optionally supplies the algorithm to use for the block-wide
+        scan.  Must be one of the following: ``"raking"``,
+        ``"raking_memoize"``, or ``"warp_scans"``.  The default is
+        ``"raking"``.
+    :type  algorithm: Literal["raking", "raking_memoize", "warp_scans"],
+        optional
 
-    Returns:
-        A callable that can be linked to a CUDA kernel and invoked to perform
+    :param methods: Optionally supplies a dictionary of methods to use for
+        user-defined types.  The default is *None*.  Not supported if
+        ``items_per_thread > 1``.
+    :type  methods: dict, optional
+
+    :raises ValueError: If ``algorithm`` is not one of the supported algorithms
+        (``"raking"``, ``"raking_memoize"``, or ``"warp_scans"``).
+
+    :raises ValueError: If ``items_per_thread`` is less than 1.
+
+    :raises ValueError: If ``items_per_thread`` is greater than 1 and ``methods``
+        is not *None* (i.e. a user-defined type is being used).
+
+    :returns: A callable that can be linked to a CUDA kernel and invoked to perform
         the block-wide exclusive prefix scan.
-
+    :rtype: Callable
     """
-    return _scan(
+    return block_scan(
         dtype=dtype,
         threads_per_block=threads_per_block,
         items_per_thread=items_per_thread,
@@ -260,45 +749,62 @@ def exclusive_sum(
         scan_op="+",
         block_prefix_callback_op=prefix_op,
         algorithm=algorithm,
+        methods=methods,
     )
 
 
 def inclusive_sum(
-    dtype: Union[str, type, "np.dtype", "numba.types.Type"],
+    dtype: DtypeType,
     threads_per_block: DimType,
     items_per_thread: int = 1,
     prefix_op: Callable = None,
     algorithm: Literal["raking", "raking_memoize", "warp_scans"] = "raking",
+    methods: dict = None,
 ) -> Callable:
     """
     Computes an inclusive block-wide prefix scan using addition (+) as the
     scan operator.
 
-    Args:
-        dtype: Supplies the data type of the input and output arrays.
+    :param dtype: Supplies the data type of the input and output arrays.
+    :type  dtype: DtypeType
 
-        threads_per_block: Supplies the number of threads in the block, either
-            as an integer for a 1D block or a tuple of two or three integers
-            for a 2D or 3D block, respectively.
+    :param threads_per_block: Supplies the number of threads in the block,
+        either as an integer for a 1D block or a tuple of two or three integers
+        for a 2D or 3D block, respectively.
+    :type  threads_per_block: DimType
 
-        items_per_thread: Supplies the number of items partitioned onto each
-            thread.
+    :param items_per_thread: Supplies the number of items partitioned onto each
+        thread.
+    :type  items_per_thread: int, optional
 
-        prefix_op: Optionally supplies a callable that will be invoked by the
-            first warp of threads in a block with the block aggregate value;
-            only the return value of the first lane in the warp is applied as
-            the prefix value.
+    :param prefix_op: Optionally supplies a callable that will be invoked by the
+        first warp of threads in a block with the block aggregate value;
+        only the return value of the first lane in the warp is applied as
+        the prefix value.
+    :type  prefix_op: Callable, optional
 
-        algorithm: Optionally supplies the algorithm to use for the block-wide
-            scan.  Must be one of the following: ``"raking"``,
-            ``"raking_memoize"``, or ``"warp_scans"``.  The default is
-            ``"raking"``.
+    :param algorithm: Optionally supplies the algorithm to use for the block-wide
+        scan.  Must be one of the following: ``"raking"``,
+        ``"raking_memoize"``, or ``"warp_scans"``.  The default is
+        ``"raking"``.
+    :type  algorithm: Literal["raking", "raking_memoize", "warp_scans"],
+        optional
 
-    Returns:
-        A callable that can be linked to a CUDA kernel and invoked to perform
+    :param methods: Optionally supplies a dictionary of methods to use for
+        user-defined types.  The default is *None*.  Not supported if
+        ``items_per_thread > 1``.
+    :type  methods: dict, optional
+
+    :raises ValueError: If ``algorithm`` is not one of the supported algorithms
+        (``"raking"``, ``"raking_memoize"``, or ``"warp_scans"``).
+
+    :raises ValueError: If ``items_per_thread`` is less than 1.
+
+    :returns: A callable that can be linked to a CUDA kernel and invoked to perform
         the block-wide inclusive prefix scan.
+    :rtype: Callable
     """
-    return _scan(
+    return block_scan(
         dtype=dtype,
         threads_per_block=threads_per_block,
         items_per_thread=items_per_thread,
@@ -306,4 +812,181 @@ def inclusive_sum(
         scan_op="+",
         block_prefix_callback_op=prefix_op,
         algorithm=algorithm,
+        methods=methods,
+    )
+
+
+def exclusive_scan(
+    dtype: DtypeType,
+    threads_per_block: DimType,
+    scan_op: ScanOpType,
+    initial_value: Any = None,
+    items_per_thread: int = 1,
+    prefix_op: Callable = None,
+    algorithm: Literal["raking", "raking_memoize", "warp_scans"] = "raking",
+    methods: dict = None,
+) -> Callable:
+    """
+    Computes an exclusive block-wide prefix scan using the specified scan
+    operator.
+
+    :param dtype: Supplies the data type of the input and output arrays.
+    :type  dtype: DtypeType
+
+    :param threads_per_block: Supplies the number of threads in the block,
+        either as an integer for a 1-D block or a tuple of two or three
+        integers for a 2-D or 3-D block, respectively.
+    :type  threads_per_block: DimType
+
+    :param scan_op: Supplies the scan operator to use for the block-wide scan.
+    :type  scan_op: ScanOpType
+
+    :param initial_value: Optionally supplies the initial value to use for the
+        block-wide scan.  If a non-None value is supplied, ``prefix_op`` must
+        be *None*.
+    :type  initial_value: Any, optional
+
+    :param items_per_thread: Optionally supplies the number of items
+        partitioned onto each thread.  Defaults to *1*.
+    :type  items_per_thread: int, optional
+
+    :param prefix_op: Optionally supplies a callable that will be invoked by
+        the first warp of threads in a block with the block aggregate value;
+        only the return value of the first lane in the warp is applied as the
+        prefix value.  If a non-None value is supplied, ``initial_value`` must
+        be *None*.
+    :type  prefix_op: Callable, optional
+
+    :param algorithm: Optionally supplies the algorithm to use for the
+        block-wide scan. Must be one of ``"raking"``, ``"raking_memoize"``,
+        or ``"warp_scans"``. The default is ``"raking"``.
+    :type  algorithm: Literal["raking", "raking_memoize", "warp_scans"],
+        optional
+
+    :param methods: Optionally supplies a dictionary of methods to use for
+        user-defined types.  The default is *None*.  Not supported if
+        ``items_per_thread > 1``.
+    :type  methods: dict, optional
+
+    :raises ValueError: If ``algorithm`` is not one of the supported algorithms
+        (``"raking"``, ``"raking_memoize"``, or ``"warp_scans"``).
+
+    :raises ValueError: If ``items_per_thread`` is less than 1.
+
+    :raises ValueError: If ``items_per_thread`` is greater than 1 and ``methods``
+        is not *None* (i.e. a user-defined type is being used).
+
+    :raises ValueError: If ``scan_op`` is an unsupported operator type.
+
+    :raises ValueError: If ``initial_value`` is provided but the ``scan_op``
+        is a sum operator (sum operators do not support initial values).
+
+    :raises ValueError: If ``initial_value`` is provided with
+        ``items_per_thread=1``, and ``block_prefix_callback_op`` is not *None*
+        (this combination is not supported).
+
+    :raises ValueError: If ``initial_value`` is required but not provided.
+        An initial value is required when ``items_per_thread > 1`` and
+        ``block_prefix_callback_op`` is *None*.  If not provided, the function
+        will attempt to create a default value (``0``) for the given data type,
+        but will raise an error if this is not possible.
+
+    :returns: A callable that can be linked to a CUDA kernel and invoked to
+        perform the block-wide exclusive prefix scan.
+    :rtype: Callable
+    """
+    return block_scan(
+        dtype=dtype,
+        threads_per_block=threads_per_block,
+        items_per_thread=items_per_thread,
+        initial_value=initial_value,
+        mode="exclusive",
+        scan_op=scan_op,
+        block_prefix_callback_op=prefix_op,
+        algorithm=algorithm,
+        methods=methods,
+    )
+
+
+def inclusive_scan(
+    dtype: DtypeType,
+    threads_per_block: DimType,
+    scan_op: ScanOpType,
+    initial_value: Any = None,
+    items_per_thread: int = 1,
+    prefix_op: Callable = None,
+    algorithm: Literal["raking", "raking_memoize", "warp_scans"] = "raking",
+    methods: dict = None,
+) -> Callable:
+    """
+    Computes an inclusive block-wide prefix scan using the specified scan
+    operator.
+
+    :param dtype: Supplies the data type of the input and output arrays.
+    :type  dtype: DtypeType
+
+    :param threads_per_block: Supplies the number of threads in the block,
+        either as an integer for a 1-D block or a tuple of two or three
+        integers for a 2-D or 3-D block, respectively.
+    :type  threads_per_block: DimType
+
+    :param scan_op: Supplies the scan operator to use for the block-wide scan.
+    :type  scan_op: ScanOpType
+
+    :param initial_value: Optionally supplies the initial value to use for the
+        block-wide scan.  If a non-None value is supplied, ``prefix_op`` must
+        be *None*.  Only supported when ``items_per_thread > 1``; a
+        ``ValueError`` will be raised if this is not the case.
+    :type  initial_value: Any, optional
+
+    :param items_per_thread: Optionally supplies the number of items
+        partitioned onto each thread.  Defaults to *1*.
+    :type  items_per_thread: int, optional
+
+    :param prefix_op: Optionally supplies a callable that will be invoked by
+        the first warp of threads in a block with the block aggregate value;
+        only the return value of the first lane in the warp is applied as the
+        prefix value.  If a non-None value is supplied, ``initial_value`` must
+        be *None*; a ``ValueError`` will be raised if this is not the case.
+    :type  prefix_op: Callable, optional
+
+    :param algorithm: Optionally supplies the algorithm to use for the
+        block-wide scan. Must be one of ``"raking"``, ``"raking_memoize"``,
+        or ``"warp_scans"``. The default is ``"raking"``.
+    :type  algorithm: Literal["raking", "raking_memoize", "warp_scans"],
+        optional
+
+    :param methods: Optionally supplies a dictionary of methods to use for
+        user-defined types.  The default is *None*.  Not supported if
+        ``items_per_thread > 1``.
+    :type  methods: dict, optional
+
+    :raises ValueError: If ``algorithm`` is not one of the supported algorithms
+        (``"raking"``, ``"raking_memoize"``, or ``"warp_scans"``).
+
+    :raises ValueError: If ``items_per_thread`` is less than 1.
+
+    :raises ValueError: If ``scan_op`` is an unsupported operator type.
+
+    :raises ValueError: If ``initial_value`` is provided but the ``scan_op``
+        is a sum operator (sum operators do not support initial values).
+
+    :raises ValueError: If ``initial_value`` is provided with
+        ``items_per_thread=1`` (initial values are not supported for inclusive
+        scans with a single item per thread).
+
+    :returns: A callable that can be linked to a CUDA kernel and invoked to
+        perform the block-wide inclusive prefix scan.
+    :rtype: Callable
+    """
+    return block_scan(
+        dtype=dtype,
+        threads_per_block=threads_per_block,
+        items_per_thread=items_per_thread,
+        initial_value=initial_value,
+        mode="inclusive",
+        scan_op=scan_op,
+        block_prefix_callback_op=prefix_op,
+        algorithm=algorithm,
+        methods=methods,
     )

--- a/python/cuda_cooperative/cuda/cooperative/experimental/warp/_warp_merge_sort.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/warp/_warp_merge_sort.py
@@ -10,7 +10,7 @@ from cuda.cooperative.experimental._types import (
     Constant,
     Dependency,
     DependentArray,
-    DependentOperator,
+    DependentPythonOperator,
     Invocable,
     Pointer,
     TemplateParameter,
@@ -70,7 +70,7 @@ def merge_sort_keys(
             [
                 Pointer(numba.uint8),
                 DependentArray(Dependency("KeyT"), Dependency("ITEMS_PER_THREAD")),
-                DependentOperator(
+                DependentPythonOperator(
                     Constant(numba.int8),
                     [Dependency("KeyT"), Dependency("KeyT")],
                     Dependency("Op"),

--- a/python/cuda_cooperative/cuda/cooperative/experimental/warp/_warp_reduce.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/warp/_warp_reduce.py
@@ -8,7 +8,7 @@ from cuda.cooperative.experimental._common import make_binary_tempfile
 from cuda.cooperative.experimental._types import (
     Algorithm,
     Dependency,
-    DependentOperator,
+    DependentPythonOperator,
     DependentReference,
     Invocable,
     Pointer,
@@ -64,7 +64,7 @@ def reduce(dtype, binary_op, threads_in_warp=32, methods=None):
             [
                 Pointer(numba.uint8),
                 DependentReference(Dependency("T")),
-                DependentOperator(
+                DependentPythonOperator(
                     Dependency("T"),
                     [Dependency("T"), Dependency("T")],
                     Dependency("Op"),

--- a/python/cuda_cooperative/tests/helpers.py
+++ b/python/cuda_cooperative/tests/helpers.py
@@ -2,8 +2,18 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+import numba
 import numpy as np
 from numba import cuda, types
+from numba.core import cgutils
+from numba.core.extending import (
+    lower_builtin,
+    make_attribute_wrapper,
+    models,
+    register_model,
+    type_callable,
+    typeof_impl,
+)
 
 NUMBA_TYPES_TO_NP = {
     types.int8: np.int8,
@@ -32,3 +42,59 @@ def row_major_tid():
         + (0 if dim.y == 1 else idx.y * dim.x)
         + idx.x
     )
+
+
+class Complex:
+    def __init__(self, real, imag):
+        self.real = real
+        self.imag = imag
+
+    def construct(this):
+        default_value = numba.int32(0)
+        this[0] = Complex(default_value, default_value)
+
+    def assign(this, that):
+        this[0] = Complex(that[0].real, that[0].imag)
+
+
+class ComplexType(types.Type):
+    def __init__(self):
+        super().__init__(name="Complex")
+
+
+complex_type = ComplexType()
+
+
+@typeof_impl.register(Complex)
+def typeof_complex(val, c):
+    return complex_type
+
+
+@type_callable(Complex)
+def type__complex(context):
+    def typer(real, imag):
+        if isinstance(real, types.Integer) and isinstance(imag, types.Integer):
+            return complex_type
+
+    return typer
+
+
+@register_model(ComplexType)
+class ComplexModel(models.StructModel):
+    def __init__(self, dmm, fe_type):
+        members = [("real", types.int32), ("imag", types.int32)]
+        models.StructModel.__init__(self, dmm, fe_type, members)
+
+
+make_attribute_wrapper(ComplexType, "real", "real")
+make_attribute_wrapper(ComplexType, "imag", "imag")
+
+
+@lower_builtin(Complex, types.Integer, types.Integer)
+def impl_complex(context, builder, sig, args):
+    typ = sig.return_type
+    real, imag = args
+    state = cgutils.create_struct_proxy(typ)(context, builder)
+    state.real = real
+    state.imag = imag
+    return state._getvalue()

--- a/python/cuda_cooperative/tests/test_block_scan.py
+++ b/python/cuda_cooperative/tests/test_block_scan.py
@@ -2,13 +2,28 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+"""
+test_block_scan.py
+
+This file contains unit tests for cuda.cooperative.block_scan. It covers both
+valid and invalid usage scenarios, tests sum-based scans, user-defined operators
+and types, prefix callback operators, and known operators such as min, max, and
+bitwise XOR.
+"""
+
 from functools import reduce
 from operator import mul
 
 import numba
 import numpy as np
 import pytest
-from helpers import NUMBA_TYPES_TO_NP, random_int, row_major_tid
+from helpers import (
+    NUMBA_TYPES_TO_NP,
+    Complex,
+    complex_type,
+    random_int,
+    row_major_tid,
+)
 from numba import cuda, types
 from numba.core import cgutils
 from numba.core.extending import (
@@ -22,86 +37,21 @@ from numba.core.extending import (
 from pynvjitlink import patch
 
 import cuda.cooperative.experimental as cudax
+from cuda.cooperative.experimental.block._block_scan import (
+    ScanOp,
+)
 
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
 
-
+# Patching the Numba linker to enable LTO as needed.
 patch.patch_numba_linker(lto=True)
 
 
-@pytest.mark.parametrize("T", [types.uint32, types.uint64])
-@pytest.mark.parametrize(
-    "threads_per_block", [32, 64, 128, 256, 512, 1024, (8, 16), (2, 4, 8)]
-)
-@pytest.mark.parametrize("items_per_thread", [1, 2, 3, 4])
-@pytest.mark.parametrize("mode", ["inclusive", "exclusive"])
-@pytest.mark.parametrize("algorithm", ["raking", "raking_memoize", "warp_scans"])
-def test_block_sum(T, threads_per_block, items_per_thread, mode, algorithm):
-    num_threads_per_block = (
-        threads_per_block
-        if isinstance(threads_per_block, int)
-        else reduce(mul, threads_per_block)
-    )
-
-    if algorithm == "raking_memoize" and num_threads_per_block >= 512:
-        # We can hit CUDA_ERROR_LAUNCH_OUT_OF_RESOURCES with raking_memoize in
-        # certain configurations, e.g.: 1024 threads_per_block, or 512
-        # threads_per_block, 3 items_per_thread, and T == uint64, etc.
-        pytest.skip("raking_memoize: skipping threads_per_block >= 512")
-
-    if mode == "inclusive":
-        target_sum = cudax.block.inclusive_sum
-    else:
-        target_sum = cudax.block.exclusive_sum
-
-    block_sum = target_sum(
-        dtype=T,
-        threads_per_block=threads_per_block,
-        items_per_thread=items_per_thread,
-        algorithm=algorithm,
-    )
-    temp_storage_bytes = block_sum.temp_storage_bytes
-
-    @cuda.jit(link=block_sum.files)
-    def kernel(input, output):
-        tid = row_major_tid()
-        temp_storage = cuda.shared.array(shape=temp_storage_bytes, dtype="uint8")
-        thread_data = cuda.local.array(shape=items_per_thread, dtype=T)
-        for i in range(items_per_thread):
-            thread_data[i] = input[tid * items_per_thread + i]
-        if items_per_thread == 1:
-            thread_data[0] = block_sum(temp_storage, thread_data[0])
-        else:
-            block_sum(temp_storage, thread_data, thread_data)
-        for i in range(items_per_thread):
-            output[tid * items_per_thread + i] = thread_data[i]
-
-    dtype_np = NUMBA_TYPES_TO_NP[T]
-    items_per_tile = num_threads_per_block * items_per_thread
-    h_input = random_int(items_per_tile, dtype_np)
-    d_input = cuda.to_device(h_input)
-    d_output = cuda.device_array(items_per_tile, dtype=dtype_np)
-    kernel[1, threads_per_block](d_input, d_output)
-    cuda.synchronize()
-
-    output = d_output.copy_to_host()
-
-    if mode == "inclusive":
-        reference = np.cumsum(h_input)
-    else:
-        reference = np.cumsum(h_input) - h_input
-
-    for i in range(items_per_tile):
-        assert output[i] == reference[i]
-
-    sig = (T[::1], T[::1])
-    sass = kernel.inspect_sass(sig)
-
-    assert "LDL" not in sass
-    assert "STL" not in sass
-
-
 class BlockPrefixCallbackOp:
+    """
+    A sample prefix callback operator that stores and updates a running total.
+    """
+
     def __init__(self, running_total):
         self.running_total = running_total
 
@@ -152,26 +102,101 @@ def impl_block_prefix_callback_op(context, builder, sig, args):
     return state._getvalue()
 
 
-@pytest.mark.parametrize(
-    "threads_per_block", [32, 64, 128, 256, 512, 1024, (8, 16), (2, 4, 8)]
-)
-@pytest.mark.parametrize("items_per_thread", [1, 2, 3, 4])
+@pytest.mark.parametrize("T", [types.uint32])
+@pytest.mark.parametrize("threads_per_block", [32, (4, 16), (4, 8, 8)])
+@pytest.mark.parametrize("items_per_thread", [1, 4])
 @pytest.mark.parametrize("mode", ["inclusive", "exclusive"])
-@pytest.mark.parametrize("algorithm", ["raking", "raking_memoize", "warp_scans"])
-def test_block_sum_prefix(threads_per_block, items_per_thread, mode, algorithm):
-    num_threads_per_block = (
+@pytest.mark.parametrize("algorithm", ["raking"])
+def test_block_sum(T, threads_per_block, items_per_thread, mode, algorithm):
+    """
+    Tests block-wide sums with either inclusive or exclusive scans.
+    Checks correctness of results and verifies no device memory ops
+    occur in generated SASS.
+    """
+    num_threads = (
         threads_per_block
         if isinstance(threads_per_block, int)
         else reduce(mul, threads_per_block)
     )
 
-    if algorithm == "raking_memoize" and num_threads_per_block >= 512:
-        # We can hit CUDA_ERROR_LAUNCH_OUT_OF_RESOURCES with raking_memoize in
-        # certain configurations, e.g.: 1024 threads_per_block, or 512
-        # threads_per_block, 3 items_per_thread, and T == uint64, etc.
-        pytest.skip("raking_memoize: skipping threads_per_block >= 512")
+    # Avoid resource issues in some configurations for raking_memoize.
+    if algorithm == "raking_memoize" and num_threads >= 512:
+        pytest.skip("raking_memoize can exceed resources for >= 512 threads.")
 
-    tile_items = num_threads_per_block * items_per_thread
+    if mode == "inclusive":
+        scan_func = cudax.block.inclusive_sum
+    else:
+        scan_func = cudax.block.exclusive_sum
+
+    block_sum = scan_func(
+        dtype=T,
+        threads_per_block=threads_per_block,
+        items_per_thread=items_per_thread,
+        algorithm=algorithm,
+    )
+    temp_storage_bytes = block_sum.temp_storage_bytes
+
+    @cuda.jit(link=block_sum.files)
+    def kernel(input_arr, output_arr):
+        tid = row_major_tid()
+        temp_storage = cuda.shared.array(shape=temp_storage_bytes, dtype=numba.uint8)
+        thread_data = cuda.local.array(items_per_thread, dtype=T)
+
+        for i in range(items_per_thread):
+            thread_data[i] = input_arr[tid * items_per_thread + i]
+
+        if items_per_thread == 1:
+            thread_data[0] = block_sum(temp_storage, thread_data[0])
+        else:
+            block_sum(temp_storage, thread_data, thread_data)
+
+        for i in range(items_per_thread):
+            output_arr[tid * items_per_thread + i] = thread_data[i]
+
+    dtype_np = NUMBA_TYPES_TO_NP[T]
+    items_per_tile = num_threads * items_per_thread
+    h_input = random_int(items_per_tile, dtype_np)
+    d_input = cuda.to_device(h_input)
+    d_output = cuda.device_array(items_per_tile, dtype=dtype_np)
+
+    kernel[1, threads_per_block](d_input, d_output)
+    cuda.synchronize()
+
+    output = d_output.copy_to_host()
+    if mode == "inclusive":
+        reference = np.cumsum(h_input)
+    else:
+        reference = np.cumsum(h_input) - h_input
+
+    np.testing.assert_array_equal(output, reference)
+
+    sig = (T[::1], T[::1])
+    sass = kernel.inspect_sass(sig)
+    # Check that no device memory loads/stores appear in SASS.
+    assert "LDL" not in sass
+    assert "STL" not in sass
+
+
+@pytest.mark.parametrize("threads_per_block", [32, (4, 16), (4, 8, 8)])
+@pytest.mark.parametrize("items_per_thread", [1, 4])
+@pytest.mark.parametrize("mode", ["inclusive", "exclusive"])
+@pytest.mark.parametrize("algorithm", ["raking"])
+def test_block_sum_prefix_op(threads_per_block, items_per_thread, mode, algorithm):
+    """
+    Tests block-wide sums with a user-supplied prefix callback operator.
+    Each tile of data is scanned and the prefix operator updates a running
+    total for each tile within a segment.
+    """
+    num_threads = (
+        threads_per_block
+        if isinstance(threads_per_block, int)
+        else reduce(mul, threads_per_block)
+    )
+
+    if algorithm == "raking_memoize" and num_threads >= 512:
+        pytest.skip("raking_memoize can exceed resources for >= 512 threads.")
+
+    tile_items = num_threads * items_per_thread
     segment_size = 2 * 1024
     num_segments = 128
     num_elements = segment_size * num_segments
@@ -181,12 +206,12 @@ def test_block_sum_prefix(threads_per_block, items_per_thread, mode, algorithm):
     )
 
     if mode == "inclusive":
-        target_sum = cudax.block.inclusive_sum
+        sum_func = cudax.block.inclusive_sum
     else:
-        target_sum = cudax.block.exclusive_sum
+        sum_func = cudax.block.exclusive_sum
 
-    block_sum = target_sum(
-        dtype=numba.types.int32,
+    block_sum = sum_func(
+        dtype=numba.int32,
         threads_per_block=threads_per_block,
         items_per_thread=items_per_thread,
         prefix_op=prefix_op,
@@ -195,13 +220,13 @@ def test_block_sum_prefix(threads_per_block, items_per_thread, mode, algorithm):
     temp_storage_bytes = block_sum.temp_storage_bytes
 
     @cuda.jit(link=block_sum.files)
-    def kernel(input, output):
+    def kernel(input_arr, output_arr):
         segment_offset = cuda.blockIdx.x * segment_size
-        temp_storage = cuda.shared.array(shape=temp_storage_bytes, dtype="uint8")
+        temp_storage = cuda.shared.array(shape=temp_storage_bytes, dtype=numba.uint8)
         block_prefix_op = cuda.local.array(shape=1, dtype=block_prefix_callback_op_type)
         block_prefix_op[0] = BlockPrefixCallbackOp(0)
-        thread_input = cuda.local.array(shape=items_per_thread, dtype="int32")
-        thread_output = cuda.local.array(shape=items_per_thread, dtype="int32")
+        thread_in = cuda.local.array(items_per_thread, dtype=numba.int32)
+        thread_out = cuda.local.array(items_per_thread, dtype=numba.int32)
 
         tid = row_major_tid()
         tile_offset = 0
@@ -209,96 +234,655 @@ def test_block_sum_prefix(threads_per_block, items_per_thread, mode, algorithm):
         while tile_offset < segment_size:
             for item in range(items_per_thread):
                 item_offset = tile_offset + tid * items_per_thread + item
-                thread_input[item] = (
-                    input[segment_offset + item_offset]
-                    if item_offset < segment_size
-                    else 0
-                )
+                if item_offset < segment_size:
+                    thread_in[item] = input_arr[segment_offset + item_offset]
+                else:
+                    thread_in[item] = 0
 
             if items_per_thread == 1:
-                thread_output[0] = block_sum(
-                    temp_storage, thread_input[0], block_prefix_op
-                )
+                thread_out[0] = block_sum(temp_storage, thread_in[0], block_prefix_op)
             else:
-                block_sum(temp_storage, thread_input, thread_output, block_prefix_op)
+                block_sum(temp_storage, thread_in, thread_out, block_prefix_op)
 
             for item in range(items_per_thread):
                 item_offset = tile_offset + tid * items_per_thread + item
                 if item_offset < segment_size:
-                    output[segment_offset + item_offset] = thread_output[item]
+                    output_arr[segment_offset + item_offset] = thread_out[item]
 
             tile_offset += tile_items
 
-    h_input = np.arange(num_elements, dtype="int32")
+    h_input = np.arange(num_elements, dtype=np.int32)
     d_input = cuda.to_device(h_input)
-    d_output = cuda.to_device(np.zeros(num_elements, dtype="int32"))
+    d_output = cuda.to_device(np.zeros(num_elements, dtype=np.int32))
+
     kernel[num_segments, threads_per_block](d_input, d_output)
     cuda.synchronize()
 
     h_output = d_output.copy_to_host()
-    h_reference = np.zeros(segment_size * num_segments, dtype="int32")
+    ref = np.zeros_like(h_input)
 
+    # Build the reference result for each segment.
     if mode == "inclusive":
-        for sid in range(num_segments):
+        for seg_id in range(num_segments):
+            seg_start = seg_id * segment_size
             for i in range(segment_size):
                 if i == 0:
-                    h_reference[sid * segment_size + i] = h_input[
-                        sid * segment_size + i
-                    ]
+                    ref[seg_start + i] = h_input[seg_start + i]
                 else:
-                    h_reference[sid * segment_size + i] = (
-                        h_reference[sid * segment_size + i - 1]
-                        + h_input[sid * segment_size + i]
-                    )
+                    ref[seg_start + i] = ref[seg_start + i - 1] + h_input[seg_start + i]
     else:
-        for sid in range(num_segments):
-            h_reference[sid * segment_size] = 0
+        for seg_id in range(num_segments):
+            seg_start = seg_id * segment_size
+            ref[seg_start] = 0
             for i in range(1, segment_size):
-                h_reference[sid * segment_size + i] = (
-                    h_reference[sid * segment_size + i - 1]
-                    + h_input[sid * segment_size + i - 1]
-                )
+                ref[seg_start + i] = ref[seg_start + i - 1] + h_input[seg_start + i - 1]
 
-    for sid in range(num_segments):
-        for i in range(segment_size):
-            if h_output[sid * segment_size + i] != h_reference[sid * segment_size + i]:
-                print(
-                    sid,
-                    i,
-                    h_output[sid * segment_size + i],
-                    h_reference[sid * segment_size + i],
-                )
+    np.testing.assert_array_equal(h_output, ref)
 
     sig = (types.int32[::1], types.int32[::1])
     sass = kernel.inspect_sass(sig)
-
     assert "LDL" not in sass
     assert "STL" not in sass
 
 
-@pytest.mark.parametrize(
-    "threads_per_block", [32, 64, 128, 256, 512, 1024, (8, 16), (2, 4, 8)]
-)
+@pytest.mark.parametrize("threads_per_block", [32, (8, 16), (2, 4, 8)])
 @pytest.mark.parametrize("items_per_thread", [0, -1, -127])
 @pytest.mark.parametrize("mode", ["inclusive", "exclusive"])
-def test_block_scan_exclusive_sum_invalid_items_per_thread(
+def test_block_scan_sum_invalid_items_per_thread(
     threads_per_block, items_per_thread, mode
 ):
+    """
+    Tests that invalid items_per_thread (< 1) raises a ValueError for both
+    inclusive_sum and exclusive_sum.
+    """
     if mode == "inclusive":
-        target_sum = cudax.block.inclusive_sum
+        sum_func = cudax.block.inclusive_sum
     else:
-        target_sum = cudax.block.exclusive_sum
+        sum_func = cudax.block.exclusive_sum
 
     with pytest.raises(ValueError):
-        target_sum(numba.int32, threads_per_block, items_per_thread)
+        sum_func(numba.int32, threads_per_block, items_per_thread)
 
 
 @pytest.mark.parametrize("mode", ["inclusive", "exclusive"])
 def test_block_scan_sum_invalid_algorithm(mode):
+    """
+    Tests that supplying an unsupported algorithm to the sum-based scans
+    raises a ValueError.
+    """
     if mode == "inclusive":
-        target_sum = cudax.block.inclusive_sum
+        sum_func = cudax.block.inclusive_sum
     else:
-        target_sum = cudax.block.exclusive_sum
+        sum_func = cudax.block.exclusive_sum
 
     with pytest.raises(ValueError):
-        target_sum(numba.int32, 128, algorithm="invalid_algorithm")
+        sum_func(numba.int32, 128, algorithm="invalid_algorithm")
+
+
+@pytest.mark.parametrize("initial_value", [None, Complex(0, 0), Complex(1, 1)])
+@pytest.mark.parametrize("threads_per_block", [32, (4, 16), (4, 8, 8)])
+@pytest.mark.parametrize("items_per_thread", [1, 4])
+@pytest.mark.parametrize("mode", ["inclusive", "exclusive"])
+@pytest.mark.parametrize("algorithm", ["raking"])
+def test_block_scan_user_defined_type(
+    initial_value, items_per_thread, threads_per_block, mode, algorithm
+):
+    """
+    Tests block-wide scans for a user-defined (Complex) type. Uses an addition
+    operator to sum real and imaginary parts respectively.
+    """
+    num_threads = (
+        threads_per_block
+        if isinstance(threads_per_block, int)
+        else reduce(mul, threads_per_block)
+    )
+
+    if algorithm == "raking_memoize" and num_threads >= 512:
+        pytest.skip("raking_memoize can exceed resources for >= 512 threads.")
+
+    # Numba balks at the `block_op(temp_storage, thread_in, thread_out)`
+    # call for items_per_thread > 1 when using user-defined types.
+    if items_per_thread > 1:
+        pytest.skip("items_per_thread>1 not supported for user defined type.")
+
+    # Our custom operator (add complex).
+    def op(result_ptr, lhs_ptr, rhs_ptr):
+        # We need the explicit cast to prevent automatic up-casting to i64.
+        real_val = numba.int32(lhs_ptr[0].real + rhs_ptr[0].real)
+        imag_val = numba.int32(lhs_ptr[0].imag + rhs_ptr[0].imag)
+        result_ptr[0] = Complex(real_val, imag_val)
+
+    if mode == "inclusive":
+        scan_func = cudax.block.inclusive_scan
+        if items_per_thread == 1:
+            # Initial values aren't supported for inclusive scans with
+            # items_per_thread=1.
+            if initial_value is not None:
+                pytest.skip(
+                    "initial_value not supported for inclusive "
+                    "scans with items_per_thread=1"
+                )
+    else:
+        if initial_value is not None:
+            pytest.skip("initial_value not supported for exclusive scans")
+        scan_func = cudax.block.exclusive_scan
+
+    block_op = scan_func(
+        dtype=complex_type,
+        scan_op=op,
+        threads_per_block=threads_per_block,
+        items_per_thread=items_per_thread,
+        initial_value=initial_value,
+        algorithm=algorithm,
+        methods={
+            "construct": Complex.construct,
+            "assign": Complex.assign,
+        },
+    )
+    temp_storage_bytes = block_op.temp_storage_bytes
+
+    # N.B. I had to use two separate kernels here, because having a single
+    #      kernel with `if initial_value is not None` did not yield a kernel
+    #      that Numba could compile.
+    if initial_value is not None:
+
+        @cuda.jit(link=block_op.files)
+        def kernel(input_arr, output_arr):
+            tid = row_major_tid()
+            temp_storage = cuda.shared.array(
+                shape=temp_storage_bytes, dtype=numba.uint8
+            )
+            thread_in = cuda.local.array(items_per_thread, dtype=complex_type)
+            thread_out = cuda.local.array(items_per_thread, dtype=complex_type)
+
+            for i in range(items_per_thread):
+                thread_in[i] = Complex(
+                    input_arr[tid * items_per_thread + i],
+                    input_arr[num_threads + tid * items_per_thread + i],
+                )
+
+            if items_per_thread == 1:
+                thread_out[0] = block_op(temp_storage, thread_in[0], initial_value)
+            else:
+                block_op(temp_storage, thread_in, thread_out, initial_value)
+
+            for i in range(items_per_thread):
+                output_arr[tid * items_per_thread + i] = thread_out[i].real
+                output_arr[num_threads + tid * items_per_thread + i] = thread_out[
+                    i
+                ].imag
+
+    else:
+
+        @cuda.jit(link=block_op.files)
+        def kernel(input_arr, output_arr):
+            tid = row_major_tid()
+            temp_storage = cuda.shared.array(
+                shape=temp_storage_bytes, dtype=numba.uint8
+            )
+            thread_in = cuda.local.array(items_per_thread, dtype=complex_type)
+            thread_out = cuda.local.array(items_per_thread, dtype=complex_type)
+
+            for i in range(items_per_thread):
+                thread_in[i] = Complex(
+                    input_arr[tid * items_per_thread + i],
+                    input_arr[num_threads + tid * items_per_thread + i],
+                )
+
+            if items_per_thread == 1:
+                thread_out[0] = block_op(temp_storage, thread_in[0])
+            else:
+                block_op(temp_storage, thread_in, thread_out)
+
+            for i in range(items_per_thread):
+                output_arr[tid * items_per_thread + i] = thread_out[i].real
+                output_arr[num_threads + tid * items_per_thread + i] = thread_out[
+                    i
+                ].imag
+
+    h_input = random_int(2 * num_threads, "int32")
+    d_input = cuda.to_device(h_input)
+    d_output = cuda.device_array(2 * num_threads, dtype=np.int32)
+    kernel[1, threads_per_block](d_input, d_output)
+    cuda.synchronize()
+
+    h_output = d_output.copy_to_host()
+    real_vals = h_input[:num_threads]
+    imag_vals = h_input[num_threads:]
+
+    if mode == "inclusive":
+        real_ref = np.cumsum(real_vals)
+        imag_ref = np.cumsum(imag_vals)
+    else:
+        real_ref = np.zeros_like(real_vals)
+        imag_ref = np.zeros_like(imag_vals)
+
+        if len(real_vals) > 1:
+            real_ref[1:] = np.cumsum(real_vals)[:-1]
+            imag_ref[1:] = np.cumsum(imag_vals)[:-1]
+
+        if initial_value is None:
+            real_ref[0] = h_output[0]
+            imag_ref[0] = h_output[num_threads]
+
+    np.testing.assert_array_equal(h_output[:num_threads], real_ref)
+    np.testing.assert_array_equal(h_output[num_threads:], imag_ref)
+
+    sig = (numba.int32[::1], numba.int32[::1])
+    sass = kernel.inspect_sass(sig)
+    assert "LDL" not in sass
+    assert "STL" not in sass
+
+
+@pytest.mark.parametrize("T", [types.uint32, types.float64])
+@pytest.mark.parametrize("threads_per_block", [32, (4, 16), (4, 8, 8)])
+@pytest.mark.parametrize("items_per_thread", [1, 4])
+@pytest.mark.parametrize("mode", ["inclusive", "exclusive"])
+@pytest.mark.parametrize("algorithm", ["raking"])
+def test_block_scan_with_callable(
+    T, threads_per_block, items_per_thread, mode, algorithm
+):
+    """
+    Tests block-wide scans with a user-supplied Python callable as the scan
+    operator. Verifies correctness for inclusive and exclusive scans.
+    """
+    num_threads = (
+        threads_per_block
+        if isinstance(threads_per_block, int)
+        else reduce(mul, threads_per_block)
+    )
+
+    if algorithm == "raking_memoize" and num_threads >= 512:
+        pytest.skip("raking_memoize can exceed resources for >= 512 threads.")
+
+    if mode == "inclusive":
+        scan_func = cudax.block.inclusive_scan
+    else:
+        scan_func = cudax.block.exclusive_scan
+
+    # Example custom operator that just adds two operands.
+    def op(a: T, b: T) -> T:
+        return T(a + b)  # Casting to match T if needed.
+
+    block_op = scan_func(
+        dtype=T,
+        threads_per_block=threads_per_block,
+        scan_op=op,
+        items_per_thread=items_per_thread,
+        algorithm=algorithm,
+    )
+    temp_storage_bytes = block_op.temp_storage_bytes
+
+    @cuda.jit(link=block_op.files)
+    def kernel(input_arr, output_arr):
+        # Get the correct thread ID based on thread configuration
+        tid = row_major_tid()
+        temp_storage = cuda.shared.array(shape=temp_storage_bytes, dtype=numba.uint8)
+        thread_in = cuda.local.array(items_per_thread, dtype=T)
+        thread_out = cuda.local.array(items_per_thread, dtype=T)
+
+        # Load the input data
+        for i in range(items_per_thread):
+            thread_in[i] = input_arr[tid * items_per_thread + i]
+
+        if items_per_thread == 1:
+            thread_out[0] = block_op(temp_storage, thread_in[0])
+        else:
+            block_op(temp_storage, thread_in, thread_out)
+
+        # Store the output data
+        for i in range(items_per_thread):
+            output_arr[tid * items_per_thread + i] = thread_out[i]
+
+    dtype_np = NUMBA_TYPES_TO_NP[T]
+    total_items = num_threads * items_per_thread
+    h_input = random_int(total_items, dtype_np)
+    d_input = cuda.to_device(h_input)
+    d_output = cuda.device_array(total_items, dtype=dtype_np)
+
+    kernel[1, threads_per_block](d_input, d_output)
+    cuda.synchronize()
+
+    output = d_output.copy_to_host()
+
+    # Calculate reference result
+    if mode == "inclusive":
+        ref = np.cumsum(h_input)
+    else:
+        # For exclusive scan:
+        # - First thread gets first value directly (CUB behavior)
+        # - Other elements are shifted by 1
+        ref = np.zeros_like(h_input)
+        # Copy the first value from the actual output
+        # since CUB's behavior for first element can vary
+        ref[0] = output[0]
+        # For all other elements, it's the cumulative sum up to the previous element
+        if len(h_input) > 1:
+            ref[1:] = np.cumsum(h_input[:-1])
+
+    # If T is an integer type, use assert_array_equal.  Otherwise, if
+    # floating point, use assert_array_almost_equal.
+    if isinstance(T, types.Integer):
+        np.testing.assert_array_equal(output, ref)
+    else:
+        np.testing.assert_array_almost_equal(output, ref)
+
+    sig = (T[::1], T[::1])
+    sass = kernel.inspect_sass(sig)
+    assert "LDL" not in sass
+    assert "STL" not in sass
+
+
+@pytest.mark.parametrize("mode", ["inclusive", "exclusive"])
+def test_block_scan_invariants(mode):
+    """
+    Tests invariants:
+      1) Initial value unsupported for inclusive scans with 1 item/thread.
+      2) Initial value unsupported for exclusive scans with 1 item/thread and
+         a block prefix callback.
+      3) When items_per_thread > 1 and no prefix callback is supplied, an
+         initial value is required.
+      4) User-defined types are not supported for items_per_thread > 1.
+    """
+    if mode == "inclusive":
+        scan_func = cudax.block.inclusive_scan
+    else:
+        scan_func = cudax.block.exclusive_scan
+
+    # 1) For inclusive scans with items_per_thread=1, initial_value is invalid.
+    if mode == "inclusive":
+        with pytest.raises(
+            ValueError,
+            match=(
+                "initial_value is not supported for inclusive scans "
+                "with items_per_thread == 1"
+            ),
+        ):
+            scan_func(numba.int32, 128, scan_op="*", initial_value=0)
+
+    # 2) For exclusive scans with items_per_thread=1 and a prefix callback,
+    #    initial_value is invalid.
+    if mode == "exclusive":
+        prefix_op = cudax.StatefulFunction(
+            BlockPrefixCallbackOp, block_prefix_callback_op_type
+        )
+        with pytest.raises(
+            ValueError,
+            match=(
+                "initial_value is not supported for exclusive scans "
+                "with items_per_thread == 1 and a block prefix "
+                "callback operator"
+            ),
+        ):
+            scan_func(
+                numba.int32,
+                128,
+                scan_op="*",
+                initial_value=0,
+                prefix_op=prefix_op,
+            )
+
+    # 3) For items_per_thread>1 and no prefix callback, initial_value is
+    #    required.  We use `complex_type` here instead of a simpler type
+    #    (like an int32), because the latter will be auto-defaulted to a
+    #    value of 0.
+    with pytest.raises(
+        ValueError,
+        match=(
+            "initial_value is required for both inclusive and exclusive "
+            "scans when items_per_thread > 1 and no block prefix callback "
+            "operator has been supplied"
+        ),
+    ):
+        scan_func(complex_type, 128, scan_op="+", items_per_thread=2)
+
+    # 4) User-defined types are not supported for items_per_thread > 1.
+    with pytest.raises(
+        ValueError,
+        match="user-defined types are not supported for items_per_thread > 1",
+    ):
+        scan_func(
+            complex_type,
+            128,
+            scan_op="+",
+            items_per_thread=2,
+            methods={
+                "construct": Complex.construct,
+                "assign": Complex.assign,
+            },
+        )
+
+
+@pytest.mark.parametrize("T", [types.int32])
+@pytest.mark.parametrize("threads_per_block", [32, 64])
+@pytest.mark.parametrize("items_per_thread", [2, 3])
+@pytest.mark.parametrize("initial_value", [-1, 0, 100])
+@pytest.mark.parametrize("mode", ["inclusive", "exclusive"])
+def test_block_scan_with_prefix_op_multi_items(
+    T, threads_per_block, items_per_thread, initial_value, mode
+):
+    """
+    Tests scans with a prefix callback operator in a multi-items-per-thread
+    setup. The prefix callback operator is initialized with 'initial_value'
+    which is applied as the starting prefix for the entire block.
+    """
+    num_threads = (
+        threads_per_block
+        if isinstance(threads_per_block, int)
+        else reduce(mul, threads_per_block)
+    )
+
+    def add_op(a, b):
+        return a + b
+
+    prefix_op = cudax.StatefulFunction(
+        BlockPrefixCallbackOp, block_prefix_callback_op_type
+    )
+
+    if mode == "inclusive":
+        scan_func = cudax.block.inclusive_scan
+    else:
+        scan_func = cudax.block.exclusive_scan
+
+    block_op = scan_func(
+        dtype=T,
+        threads_per_block=threads_per_block,
+        scan_op=add_op,
+        items_per_thread=items_per_thread,
+        prefix_op=prefix_op,
+    )
+    temp_storage_bytes = block_op.temp_storage_bytes
+
+    @cuda.jit(link=block_op.files)
+    def kernel(input_arr, output_arr):
+        tid = row_major_tid()
+        temp_storage = cuda.shared.array(shape=temp_storage_bytes, dtype=numba.uint8)
+        thread_data = cuda.local.array(items_per_thread, dtype=T)
+        for i in range(items_per_thread):
+            thread_data[i] = input_arr[tid * items_per_thread + i]
+
+        # Initialize the prefix callback operator with 'initial_value'.
+        block_prefix_op = cuda.local.array(shape=1, dtype=block_prefix_callback_op_type)
+        block_prefix_op[0] = BlockPrefixCallbackOp(initial_value)
+
+        block_op(temp_storage, thread_data, thread_data, block_prefix_op)
+
+        for i in range(items_per_thread):
+            output_arr[tid * items_per_thread + i] = thread_data[i]
+
+    dtype_np = NUMBA_TYPES_TO_NP[T]
+    total_items = num_threads * items_per_thread
+    h_input = random_int(total_items, dtype_np)
+    d_input = cuda.to_device(h_input)
+    d_output = cuda.device_array(total_items, dtype=dtype_np)
+
+    kernel[1, threads_per_block](d_input, d_output)
+    cuda.synchronize()
+
+    output = d_output.copy_to_host()
+
+    # Build reference with the prefix included.
+    if mode == "inclusive":
+        ref = np.zeros_like(h_input)
+        running = initial_value
+        for i in range(total_items):
+            running = running + h_input[i]
+            ref[i] = running
+    else:
+        ref = np.zeros_like(h_input)
+        running = initial_value
+        for i in range(total_items):
+            ref[i] = running
+            running = running + h_input[i]
+
+    np.testing.assert_array_equal(output, ref)
+
+    sig = (T[::1], T[::1])
+    sass = kernel.inspect_sass(sig)
+    assert "LDL" not in sass
+    assert "STL" not in sass
+
+
+@pytest.mark.parametrize("mode", ["inclusive", "exclusive"])
+@pytest.mark.parametrize(
+    "scan_op", ["max", "min", "multiplies", "bit_and", "bit_or", "bit_xor"]
+)
+@pytest.mark.parametrize("T", [types.uint32])
+@pytest.mark.parametrize("threads_per_block", [32, (4, 8, 8)])
+@pytest.mark.parametrize("items_per_thread", [1, 4])
+@pytest.mark.parametrize("algorithm", ["raking"])
+def test_block_scan_known_ops(
+    mode, scan_op, T, threads_per_block, items_per_thread, algorithm
+):
+    """
+    Tests block-wide scans with known operators:
+      - max
+      - min
+      - multiplies
+      - bit_and
+      - bit_or
+      - bit_xor
+    Verifies correctness against a Python-based reference for both
+    inclusive and exclusive scans.
+    """
+    num_threads = (
+        threads_per_block
+        if isinstance(threads_per_block, int)
+        else reduce(mul, threads_per_block)
+    )
+
+    # We skip raking_memoize in this test for brevity, but you can add it if
+    # desired and check resource constraints.
+    if algorithm not in ["raking", "warp_scans"]:
+        pytest.skip(f"Skipping algorithm {algorithm} for known ops test.")
+
+    if mode == "inclusive":
+        scan_func = cudax.block.inclusive_scan
+    else:
+        scan_func = cudax.block.exclusive_scan
+
+    op = ScanOp(scan_op)
+    assert op.is_known
+
+    block_op = scan_func(
+        dtype=T,
+        threads_per_block=threads_per_block,
+        items_per_thread=items_per_thread,
+        scan_op=scan_op,
+        algorithm=algorithm,
+    )
+    temp_storage_bytes = block_op.temp_storage_bytes
+
+    @cuda.jit(link=block_op.files)
+    def kernel(input_arr, output_arr):
+        tid = row_major_tid()
+        temp_storage = cuda.shared.array(shape=temp_storage_bytes, dtype=numba.uint8)
+        thread_data = cuda.local.array(items_per_thread, dtype=T)
+        for i in range(items_per_thread):
+            thread_data[i] = input_arr[tid * items_per_thread + i]
+
+        if items_per_thread == 1:
+            thread_data[0] = block_op(temp_storage, thread_data[0])
+        else:
+            block_op(temp_storage, thread_data, thread_data)
+
+        for i in range(items_per_thread):
+            output_arr[tid * items_per_thread + i] = thread_data[i]
+
+    # Prepare host data.
+    dtype_np = NUMBA_TYPES_TO_NP[T]
+    total_items = num_threads * items_per_thread
+
+    # Generate appropriate test data based on operation.
+    if scan_op == "multiplies":
+        # For multiplication, use very small values (1-2) to avoid overflow.
+        h_input = np.ones(total_items, dtype=dtype_np)
+        # Set a few values to 2 for a meaningful test (only ~10% of elements)
+        rng = np.random.default_rng(42)
+        indices = rng.choice(
+            total_items, size=min(10, total_items // 10), replace=False
+        )
+        h_input[indices] = 2
+    else:
+        h_input = random_int(total_items, dtype_np)
+
+    d_input = cuda.to_device(h_input)
+    d_output = cuda.device_array(total_items, dtype=dtype_np)
+
+    k = kernel[1, threads_per_block]
+    k(d_input, d_output)
+    cuda.synchronize()
+
+    output = d_output.copy_to_host()
+
+    # Choose the appropriate operator based on scan_op.
+    if scan_op == "multiplies":
+        py_op = np.multiply
+    elif scan_op == "bit_and":
+        py_op = np.bitwise_and
+    elif scan_op == "bit_or":
+        py_op = np.bitwise_or
+    elif scan_op == "bit_xor":
+        py_op = np.bitwise_xor
+    elif scan_op == "min":
+        py_op = np.minimum
+    elif scan_op == "max":
+        py_op = np.maximum
+    else:
+        raise ValueError(f"Unexpected scan_op: {scan_op}")
+
+    # Calculate reference results
+    ref = np.zeros_like(h_input)
+    if mode == "inclusive":
+        if scan_op == "multiplies":
+            # Use numpy's cumprod for inclusive scan with multiplication.
+            ref = np.cumprod(h_input, dtype=dtype_np).astype(dtype_np)
+        else:
+            # For other operations, use our own loop-based implementation.
+            accum = h_input[0]
+            ref[0] = accum
+            for i in range(1, total_items):
+                accum = py_op(accum, h_input[i])
+                ref[i] = accum
+    else:
+        # Initial value will default to 0 for exclusive scan when we provide
+        # no alternate initial value.
+        ref[0] = output[0]
+
+        if scan_op == "multiplies":
+            accum = np.array(h_input[0], dtype=dtype_np)
+            for i in range(1, total_items):
+                ref[i] = accum
+                accum = py_op(accum, h_input[i])
+        else:
+            accum = h_input[0]
+            for i in range(1, total_items):
+                ref[i] = accum
+                accum = py_op(accum, h_input[i])
+
+    np.testing.assert_array_equal(output, ref)
+
+    sig = (T[::1], T[::1])
+    sass = kernel.inspect_sass(sig)
+    assert "LDL" not in sass
+    assert "STL" not in sass

--- a/python/cuda_cooperative/tests/test_scan_op.py
+++ b/python/cuda_cooperative/tests/test_scan_op.py
@@ -1,0 +1,141 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""
+test_scan_op.py
+
+This file contains unit tests for the cuda.cooperative.experimental._scan_op
+module's ``ScanOp`` class and related functionality.
+"""
+
+import operator
+
+import numpy as np
+import pytest
+
+from cuda.cooperative.experimental._scan_op import (
+    CUDA_MAXIMUM,
+    CUDA_MINIMUM,
+    CUDA_STD_BIT_AND,
+    CUDA_STD_BIT_OR,
+    CUDA_STD_BIT_XOR,
+    CUDA_STD_MULTIPLIES,
+    CUDA_STD_PLUS,
+    ScanOp,
+    ScanOpCategory,
+)
+
+
+class TestScanOp:
+    @pytest.mark.parametrize(
+        "op, expected_category, expected_cpp",
+        [
+            ("add", ScanOpCategory.Sum, CUDA_STD_PLUS),
+            ("mul", ScanOpCategory.Known, CUDA_STD_MULTIPLIES),
+            ("multiplies", ScanOpCategory.Known, CUDA_STD_MULTIPLIES),
+            ("min", ScanOpCategory.Known, CUDA_MINIMUM),
+            ("minimum", ScanOpCategory.Known, CUDA_MINIMUM),
+            ("max", ScanOpCategory.Known, CUDA_MAXIMUM),
+            ("maximum", ScanOpCategory.Known, CUDA_MAXIMUM),
+            ("bit_and", ScanOpCategory.Known, CUDA_STD_BIT_AND),
+            ("bit_or", ScanOpCategory.Known, CUDA_STD_BIT_OR),
+            ("bit_xor", ScanOpCategory.Known, CUDA_STD_BIT_XOR),
+        ],
+    )
+    def test_string_names(self, op, expected_category, expected_cpp):
+        """Test that string operators are correctly processed."""
+        scan_op = ScanOp(op)
+        assert scan_op.op == op
+        assert scan_op.op_category == expected_category
+        assert scan_op.op_cpp == expected_cpp
+
+    @pytest.mark.parametrize(
+        "op, expected_category, expected_cpp",
+        [
+            ("+", ScanOpCategory.Sum, CUDA_STD_PLUS),
+            ("*", ScanOpCategory.Known, CUDA_STD_MULTIPLIES),
+            ("&", ScanOpCategory.Known, CUDA_STD_BIT_AND),
+            ("|", ScanOpCategory.Known, CUDA_STD_BIT_OR),
+            ("^", ScanOpCategory.Known, CUDA_STD_BIT_XOR),
+        ],
+    )
+    def test_string_operators(self, op, expected_category, expected_cpp):
+        """Test that string operators are correctly processed."""
+        scan_op = ScanOp(op)
+        assert scan_op.op == op
+        assert scan_op.op_category == expected_category
+        assert scan_op.op_cpp == expected_cpp
+
+    @pytest.mark.parametrize(
+        "op, expected_category, expected_cpp",
+        [
+            (np.add, ScanOpCategory.Sum, CUDA_STD_PLUS),
+            (np.multiply, ScanOpCategory.Known, CUDA_STD_MULTIPLIES),
+            (np.minimum, ScanOpCategory.Known, CUDA_MINIMUM),
+            (np.maximum, ScanOpCategory.Known, CUDA_MAXIMUM),
+            (np.bitwise_and, ScanOpCategory.Known, CUDA_STD_BIT_AND),
+            (np.bitwise_or, ScanOpCategory.Known, CUDA_STD_BIT_OR),
+            (np.bitwise_xor, ScanOpCategory.Known, CUDA_STD_BIT_XOR),
+        ],
+    )
+    def test_numpy_functions(self, op, expected_category, expected_cpp):
+        """Test that NumPy functions are correctly processed."""
+        scan_op = ScanOp(op)
+        assert scan_op.op == op
+        assert scan_op.op_category == expected_category
+        assert scan_op.op_cpp == expected_cpp
+
+    @pytest.mark.parametrize(
+        "op, expected_category, expected_cpp",
+        [
+            (operator.add, ScanOpCategory.Sum, CUDA_STD_PLUS),
+            (operator.mul, ScanOpCategory.Known, CUDA_STD_MULTIPLIES),
+            (operator.and_, ScanOpCategory.Known, CUDA_STD_BIT_AND),
+            (operator.or_, ScanOpCategory.Known, CUDA_STD_BIT_OR),
+            (operator.xor, ScanOpCategory.Known, CUDA_STD_BIT_XOR),
+        ],
+    )
+    def test_python_operator_module_functions(
+        self, op, expected_category, expected_cpp
+    ):
+        """Test that Python operator module functions are correctly processed."""
+        scan_op = ScanOp(op)
+        assert scan_op.op == op
+        assert scan_op.op_category == expected_category
+        assert scan_op.op_cpp == expected_cpp
+
+    def test_custom_callable(self):
+        """Test that custom callables are correctly processed."""
+
+        def custom_add(a, b):
+            return a + b
+
+        scan_op = ScanOp(custom_add)
+        assert scan_op.op == custom_add
+        assert scan_op.op_category == ScanOpCategory.Callable
+        assert scan_op.op_cpp is None
+
+    @pytest.mark.parametrize(
+        "op",
+        [
+            "unsupported_op",
+            123,
+            [1, 2, 3],
+            {"op": "+"},
+            None,
+        ],
+    )
+    def test_invalid_operators(self, op):
+        """Test that invalid operators raise ValueError."""
+        with pytest.raises(ValueError):
+            ScanOp(op)
+
+    def test_repr(self):
+        """Test the string representation of ScanOp."""
+        scan_op = ScanOp("+")
+        assert repr(scan_op) == "ScanOp(+)"
+
+        scan_op = ScanOp(np.add)
+        assert "ScanOp(" in repr(scan_op)
+        assert "add" in repr(scan_op)


### PR DESCRIPTION
This PR adds scan_op support to the cuda.cooperative block_scan module, allowing us to implement `inclusive_scan` and `exclusive_scan` routines (instead of just the sum-based routines we have today).  A lot of effort was put into allowing the most flexibility with regards to how a user can specify a "scan op"--see the `ScanOp` class for more information.

The "known" category of scan op operators refers to the standard add, multiply, min, max, bit and, bit or, bit xor operators.  These get special-cased in the generated C++ so that we're calling out directly to e.g. `algo(temp_storage).BlockScan(input, output, ScanOp=::cuda::std::plus<uint32_t>{})`, obviating the need to provide Python ops for simple operators (e.g. `def scan_op(a, b): return a + b`).  This also ensures any future-proofing if we specialize CUB with more operators (in addition to plus).

The commits in this PR have been crafted to ease review.  You should review each commit in isolation versus trying to make sense of the entire diff as a whole.

- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
