### PR TITLE
Backport `reference_wrapper` traits

### DIFF
--- a/libcudacxx/include/cuda/std/__functional/reference_wrapper.h
+++ b/libcudacxx/include/cuda/std/__functional/reference_wrapper.h
@@ -22,6 +22,7 @@
 
 #include <cuda/std/__functional/invoke.h>
 #include <cuda/std/__functional/weak_result_type.h>
+#include <cuda/std/__fwd/reference_wrapper.h>
 #include <cuda/std/__memory/addressof.h>
 #include <cuda/std/__type_traits/enable_if.h>
 #include <cuda/std/__type_traits/remove_cvref.h>

--- a/libcudacxx/include/cuda/std/__functional/unwrap_ref.h
+++ b/libcudacxx/include/cuda/std/__functional/unwrap_ref.h
@@ -3,7 +3,7 @@
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -20,50 +20,32 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/std/__fwd/reference_wrapper.h>
+#include <cuda/std/__type_traits/decay.h>
+
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-struct __unwrap_reference
+struct unwrap_reference
 {
   using type _CCCL_NODEBUG_ALIAS = _Tp;
 };
 
 template <class _Tp>
-class reference_wrapper;
-
-template <class _Tp>
-struct __unwrap_reference<reference_wrapper<_Tp>>
+struct unwrap_reference<reference_wrapper<_Tp>>
 {
   using type _CCCL_NODEBUG_ALIAS = _Tp&;
 };
 
 template <class _Tp>
-struct decay;
-
-#if _CCCL_STD_VER > 2017
-template <class _Tp>
-struct unwrap_reference : __unwrap_reference<_Tp>
-{};
-
-template <class _Tp>
 using unwrap_reference_t = typename unwrap_reference<_Tp>::type;
 
 template <class _Tp>
-struct unwrap_ref_decay : unwrap_reference<typename decay<_Tp>::type>
+struct unwrap_ref_decay : unwrap_reference<decay_t<_Tp>>
 {};
 
 template <class _Tp>
 using unwrap_ref_decay_t = typename unwrap_ref_decay<_Tp>::type;
-#endif // _CCCL_STD_VER > 2017
-
-template <class _Tp>
-struct __unwrap_ref_decay
-#if _CCCL_STD_VER > 2017
-    : unwrap_ref_decay<_Tp>
-#else
-    : __unwrap_reference<typename decay<_Tp>::type>
-#endif
-{};
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__fwd/reference_wrapper.h
+++ b/libcudacxx/include/cuda/std/__fwd/reference_wrapper.h
@@ -1,0 +1,30 @@
+//===---------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===---------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___FWD_REFERENCE_WRAPPER_H
+#define _LIBCUDACXX___FWD_REFERENCE_WRAPPER_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+_LIBCUDACXX_BEGIN_NAMESPACE_STD
+
+template <class _Tp>
+class _CCCL_TYPE_VISIBILITY_DEFAULT reference_wrapper;
+
+_LIBCUDACXX_END_NAMESPACE_STD
+
+#endif // _LIBCUDACXX___FWD_REFERENCE_WRAPPER_H

--- a/libcudacxx/include/cuda/std/__type_traits/is_reference_wrapper.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_reference_wrapper.h
@@ -3,7 +3,7 @@
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -20,13 +20,11 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/std/__fwd/reference_wrapper.h>
 #include <cuda/std/__type_traits/integral_constant.h>
 #include <cuda/std/__type_traits/remove_cv.h>
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
-
-template <class _Tp>
-class _CCCL_TYPE_VISIBILITY_DEFAULT reference_wrapper;
 
 template <class _Tp>
 struct __is_reference_wrapper_impl : public false_type

--- a/libcudacxx/include/cuda/std/__utility/pair.h
+++ b/libcudacxx/include/cuda/std/__utility/pair.h
@@ -639,10 +639,10 @@ swap(const pair<_T1, _T2>& __x, const pair<_T1, _T2>& __y) noexcept(noexcept(__x
 #endif // _CCCL_STD_VER >= 2023
 
 template <class _T1, class _T2>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr pair<typename __unwrap_ref_decay<_T1>::type, typename __unwrap_ref_decay<_T2>::type>
+_LIBCUDACXX_HIDE_FROM_ABI constexpr pair<unwrap_ref_decay_t<_T1>, unwrap_ref_decay_t<_T2>>
 make_pair(_T1&& __t1, _T2&& __t2)
 {
-  return pair<typename __unwrap_ref_decay<_T1>::type, typename __unwrap_ref_decay<_T2>::type>(
+  return pair<unwrap_ref_decay_t<_T1>, unwrap_ref_decay_t<_T2>>(
     _CUDA_VSTD::forward<_T1>(__t1), _CUDA_VSTD::forward<_T2>(__t2));
 }
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/tuple
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/tuple
@@ -1108,9 +1108,9 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr tuple<_Tp&...> tie(_Tp&... __t) noexcept
 }
 
 template <class... _Tp>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr tuple<typename __unwrap_ref_decay<_Tp>::type...> make_tuple(_Tp&&... __t)
+_LIBCUDACXX_HIDE_FROM_ABI constexpr tuple<unwrap_ref_decay_t<_Tp>...> make_tuple(_Tp&&... __t)
 {
-  return tuple<typename __unwrap_ref_decay<_Tp>::type...>(_CUDA_VSTD::forward<_Tp>(__t)...);
+  return tuple<unwrap_ref_decay_t<_Tp>...>(_CUDA_VSTD::forward<_Tp>(__t)...);
 }
 
 template <class... _Tp>

--- a/libcudacxx/test/libcudacxx/std/utilities/function.objects/refwrap/unwrap_ref_decay.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/function.objects/refwrap/unwrap_ref_decay.pass.cpp
@@ -15,9 +15,7 @@
 // template <class T>
 // using unwrap_ref_decay_t = typename unwrap_ref_decay<T>::type;
 
-// UNSUPPORTED: c++17
-
-// #include <cuda/std/functional>
+#include <cuda/std/functional>
 #include <cuda/std/type_traits>
 #include <cuda/std/utility>
 

--- a/libcudacxx/test/libcudacxx/std/utilities/function.objects/refwrap/unwrap_reference.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/function.objects/refwrap/unwrap_reference.pass.cpp
@@ -15,9 +15,7 @@
 // template <class T>
 // using unwrap_reference_t = typename unwrap_reference<T>::type;
 
-// UNSUPPORTED: c++17
-
-// #include <cuda/std/functional>
+#include <cuda/std/functional>
 #include <cuda/std/type_traits>
 #include <cuda/std/utility>
 


### PR DESCRIPTION
This PR backports `cuda::std::unwrap_reference` and `cuda::std::unwrap_ref_decay` traits to C++17.