### PR TITLE
Make transform iterator utility in c parallel test suite

### DIFF
--- a/c/parallel/test/test_for.cpp
+++ b/c/parallel/test/test_for.cpp
@@ -214,7 +214,7 @@ C2H_TEST("for works with iterators", "[for]")
   const int num_items = GENERATE(1, 42, take(4, random(1 << 12, 1 << 16)));
 
   iterator_t<int, constant_iterator_state_t<int>> input_it = make_iterator<int, constant_iterator_state_t<int>>(
-    "struct constant_iterator_state_t { int value; };\n",
+    {"constant_iterator_state_t", "struct constant_iterator_state_t { int value; };\n"},
     {"in_advance", "extern \"C\" __device__ void in_advance(constant_iterator_state_t*, unsigned long long) {}"},
     {"in_dereference",
      "extern \"C\" __device__ int in_dereference(constant_iterator_state_t* state) { \n"

--- a/c/parallel/test/test_merge_sort.cpp
+++ b/c/parallel/test/test_merge_sort.cpp
@@ -341,7 +341,7 @@ C2H_TEST("DeviceMergeSort::SortKeys works with output iterators", "[merge_sort]"
   operation_t op = make_operation("op", get_merge_sort_op(get_type_info<TestType>().type));
   iterator_t<TestType, random_access_iterator_state_t> output_keys_it =
     make_iterator<TestType, random_access_iterator_state_t>(
-      "struct random_access_iterator_state_t { int* d_input; };\n",
+      {"random_access_iterator_state_t", "struct random_access_iterator_state_t { int* d_input; };\n"},
       {"advance",
        "extern \"C\" __device__ void advance(random_access_iterator_state_t* state, unsigned long long offset) {\n"
        "  state->d_input += offset;\n"

--- a/c/parallel/test/test_segmented_reduce.cpp
+++ b/c/parallel/test/test_segmented_reduce.cpp
@@ -629,11 +629,12 @@ extern "C" __device__ {2} {0}({1} *functor_state, {2} n) {{
   using HostTransformStateT = decltype(start_offsets_it.state);
 
   // end_offsets_it reuses advance/dereference definitions provided by start_offsets_it
-  constexpr std::string_view empty_src = "";
-  auto end_offsets_it                  = make_iterator<IndexT, HostTransformStateT>(
-    {start_offsets_it.state_name, empty_src},
-    {start_offsets_it.advance.name, empty_src},
-    {start_offsets_it.dereference.name, empty_src});
+  constexpr std::string_view reuse_prior_definitions = "";
+
+  auto end_offsets_it = make_iterator<IndexT, HostTransformStateT>(
+    {start_offsets_it.state_name, reuse_prior_definitions},
+    {start_offsets_it.advance.name, reuse_prior_definitions},
+    {start_offsets_it.dereference.name, reuse_prior_definitions});
 
   // Initialize the state of end_offset_it
   end_offsets_it.state.base_it_state.value = IndexT(0);
@@ -648,7 +649,8 @@ extern "C" __device__ void {0}(const void *x1_p, const void *x2_p, void *out_p) 
   *out_tp = (*x1_tp) + (*x2_tp);
 }}
 )XXX";
-  const std::string binary_op_src                      = std::format(binary_op_src_tmpl, binary_op_name, data_ty_name);
+
+  const std::string binary_op_src = std::format(binary_op_src_tmpl, binary_op_name, data_ty_name);
 
   auto binary_op = make_operation(binary_op_name, binary_op_src);
 

--- a/c/parallel/test/test_util.h
+++ b/c/parallel/test/test_util.h
@@ -28,7 +28,7 @@
 #include <cccl/c/types.h>
 #include <nvrtc.h>
 
-static std::string inspect_sass(const void* cubin, size_t cubin_size)
+inline std::string inspect_sass(const void* cubin, size_t cubin_size)
 {
   namespace fs = std::filesystem;
 
@@ -78,7 +78,7 @@ static std::string inspect_sass(const void* cubin, size_t cubin_size)
   return sass;
 }
 
-static std::string compile(const std::string& source)
+inline std::string compile(const std::string& source)
 {
   // compile source to LTO-IR using nvrtc
 
@@ -201,7 +201,7 @@ cccl_type_info get_type_info()
 
 // TOOD: using more than than one `op` in the same TU will fail because
 // of the lack of name mangling. Ditto for all `get_*_op` functions.
-static std::string get_reduce_op(cccl_type_enum t)
+inline std::string get_reduce_op(cccl_type_enum t)
 {
   switch (t)
   {
@@ -260,7 +260,7 @@ static std::string get_reduce_op(cccl_type_enum t)
   return "";
 }
 
-static std::string get_for_op(cccl_type_enum t)
+inline std::string get_for_op(cccl_type_enum t)
 {
   switch (t)
   {
@@ -295,7 +295,7 @@ static std::string get_for_op(cccl_type_enum t)
   return "";
 }
 
-static std::string get_merge_sort_op(cccl_type_enum t)
+inline std::string get_merge_sort_op(cccl_type_enum t)
 {
   switch (t)
   {
@@ -375,7 +375,7 @@ static std::string get_merge_sort_op(cccl_type_enum t)
   return "";
 }
 
-static std::string get_unique_by_key_op(cccl_type_enum t)
+inline std::string get_unique_by_key_op(cccl_type_enum t)
 {
   switch (t)
   {
@@ -455,7 +455,7 @@ static std::string get_unique_by_key_op(cccl_type_enum t)
   return "";
 }
 
-static std::string get_unary_op(cccl_type_enum t)
+inline std::string get_unary_op(cccl_type_enum t)
 {
   switch (t)
   {
@@ -507,7 +507,7 @@ static std::string get_unary_op(cccl_type_enum t)
   return "";
 }
 
-static std::string get_radix_sort_decomposer_op(cccl_type_enum t)
+inline std::string get_radix_sort_decomposer_op(cccl_type_enum t)
 {
   switch (t)
   {
@@ -714,13 +714,13 @@ struct stateful_operation_t
   }
 };
 
-static operation_t make_operation(std::string_view name, const std::string& code)
+inline operation_t make_operation(std::string_view name, const std::string& code)
 {
   return operation_t{name, compile(code)};
 }
 
 template <class OpT>
-static stateful_operation_t<OpT> make_operation(std::string_view name, const std::string& code, OpT op)
+stateful_operation_t<OpT> make_operation(std::string_view name, const std::string& code, OpT op)
 {
   return {op, name, compile(code)};
 }
@@ -857,8 +857,9 @@ iterator_t<ValueT, random_access_iterator_state_t<ValueT>> make_random_access_it
   std::string advance_fn_name     = std::format("{0}advance", prefix);
   std::string dereference_fn_name = std::format("{0}dereference", prefix);
 
-  auto [iterator_state_def_src, advance_fn_def_src, dereference_fn_def_src] = make_random_access_iterator_sources(
-    kind, value_type, iterator_state_name, advance_fn_name, dereference_fn_name, transform);
+  const auto& [iterator_state_def_src, advance_fn_def_src, dereference_fn_def_src] =
+    make_random_access_iterator_sources(
+      kind, value_type, iterator_state_name, advance_fn_name, dereference_fn_name, transform);
 
   name_source_t iterator_state = {iterator_state_name, iterator_state_def_src};
   operation_t advance          = {advance_fn_name, advance_fn_def_src};
@@ -900,7 +901,7 @@ make_counting_iterator(std::string_view value_type, std::string_view prefix = ""
   std::string advance_fn_name     = std::format("{0}advance", prefix);
   std::string dereference_fn_name = std::format("{0}dereference", prefix);
 
-  auto [iterator_state_src, advance_fn_def_src, dereference_fn_def_src] =
+  const auto& [iterator_state_src, advance_fn_def_src, dereference_fn_def_src] =
     make_counting_iterator_sources(value_type, iterator_state_name, advance_fn_name, dereference_fn_name);
 
   name_source_t iterator_state = {iterator_state_name, iterator_state_src};
@@ -940,7 +941,7 @@ make_constant_iterator(std::string_view value_type, std::string_view prefix = ""
   std::string advance_fn_name     = std::format("{0}advance", prefix);
   std::string dereference_fn_name = std::format("{0}dereference", prefix);
 
-  auto [iterator_state_src, advance_fn_src, dereference_fn_src] =
+  const auto& [iterator_state_src, advance_fn_src, dereference_fn_src] =
     make_constant_iterator_sources(value_type, iterator_state_name, advance_fn_name, dereference_fn_name);
 
   name_source_t iterator_state = {iterator_state_name, iterator_state_src};
@@ -1000,7 +1001,7 @@ iterator_t<ValueT, random_access_iterator_state_t<ValueT>> make_reverse_iterator
   std::string advance_fn_name     = std::format("{0}advance", prefix);
   std::string dereference_fn_name = std::format("{0}dereference", prefix);
 
-  auto [iterator_state_src, advance_fn_src, dereference_fn_src] = make_reverse_iterator_sources(
+  const auto& [iterator_state_src, advance_fn_src, dereference_fn_src] = make_reverse_iterator_sources(
     kind, value_type, iterator_state_name, advance_fn_name, dereference_fn_name, transform);
 
   name_source_t iterator_state = {iterator_state_name, iterator_state_src};
@@ -1010,16 +1011,17 @@ iterator_t<ValueT, random_access_iterator_state_t<ValueT>> make_reverse_iterator
   return make_iterator<ValueT, random_access_iterator_state_t<ValueT>>(iterator_state, advance, dereference);
 }
 
-template <typename ValueT, typename BaseIteratorStateT, typename TransformerStateT>
-auto make_stateful_transform_input_iterator(
+inline std::tuple<std::string, std::string, std::string> make_stateful_transform_input_iterator_sources(
+  std::string_view transform_it_state_name,
+  std::string_view transform_it_advance_fn_name,
+  std::string_view transform_it_dereference_fn_name,
   std::string_view transformed_value_type,
-  name_source_t base_state,
+  name_source_t base_it_state,
   name_source_t base_it_advance_fn,
   name_source_t base_it_dereference_fn,
   name_source_t transform_state,
   name_source_t transform_op)
 {
-  static constexpr std::string_view transform_it_state_name     = "stateful_transform_iterator_state_t";
   static constexpr std::string_view transform_it_state_src_tmpl = R"XXX(
 /* Define state of stateful transform operation */
 {3}
@@ -1030,43 +1032,43 @@ struct {0} {{
   {2} functor_state;
 }};
 )XXX";
-  const std::string transform_it_state_src                      = std::format(
+
+  const std::string transform_it_state_src = std::format(
     transform_it_state_src_tmpl,
     /* 0 */ transform_it_state_name,
-    /* 1 */ base_state.name,
+    /* 1 */ base_it_state.name,
     /* 2 */ transform_state.name,
     /* 3 */ transform_state.def_src,
-    /* 4 */ base_state.def_src);
+    /* 4 */ base_it_state.def_src);
 
-  static constexpr std::string_view transform_it_advance_fn_name     = "advance_stateful_transform_it";
   static constexpr std::string_view transform_it_advance_fn_src_tmpl = R"XXX(
-  {3}
-  extern "C" __device__ void {0}({1} *transform_it_state, unsigned long long offset) {{
-      {2}(&(transform_it_state->base_it_state), offset);
-  }}
-  )XXX";
-  const std::string transform_it_advance_fn_src                      = std::format(
+{3}
+extern "C" __device__ void {0}({1} *transform_it_state, unsigned long long offset) {{
+    {2}(&(transform_it_state->base_it_state), offset);
+}}
+)XXX";
+
+  const std::string transform_it_advance_fn_src = std::format(
     transform_it_advance_fn_src_tmpl,
     /* 0 */ transform_it_advance_fn_name,
     /* 1 */ transform_it_state_name,
     /* 2 */ base_it_advance_fn.name,
     /* 3 */ base_it_advance_fn.def_src);
 
-  static constexpr std::string_view transform_it_deref_fn_name     = "dereference_stateful_transform_it";
-  static constexpr std::string_view transform_it_deref_fn_src_tmpl = R"XXX(
-  {5}
-  {6}
-  extern "C" __device__ {2} {0}({1} *transform_it_state) {{
-      return {3}(
-          &(transform_it_state->functor_state),
-          {4}(&(transform_it_state->base_it_state))
-      );
-  }}
-  )XXX";
+  static constexpr std::string_view transform_it_dereference_fn_src_tmpl = R"XXX(
+{5}
+{6}
+extern "C" __device__ {2} {0}({1} *transform_it_state) {{
+    return {3}(
+        &(transform_it_state->functor_state),
+        {4}(&(transform_it_state->base_it_state))
+    );
+}}
+)XXX";
 
-  const std::string transform_it_deref_fn_src = std::format(
-    transform_it_deref_fn_src_tmpl,
-    /* 0 */ transform_it_deref_fn_name /* name of transform's deref function */,
+  const std::string transform_it_dereference_fn_src = std::format(
+    transform_it_dereference_fn_src_tmpl,
+    /* 0 */ transform_it_dereference_fn_name /* name of transform's deref function */,
     /* 1 */ transform_it_state_name /* name of transform's state*/,
     /* 2 */ transformed_value_type /* function return type name */,
     /* 3 */ transform_op.name /* transformation functor function name */,
@@ -1074,24 +1076,54 @@ struct {0} {{
     /* 5 */ base_it_dereference_fn.def_src,
     /* 6 */ transform_op.def_src);
 
+  return std::make_tuple(transform_it_state_src, transform_it_advance_fn_src, transform_it_dereference_fn_src);
+}
+
+template <typename ValueT, typename BaseIteratorStateT, typename TransformerStateT>
+auto make_stateful_transform_input_iterator(
+  std::string_view transformed_value_type,
+  name_source_t base_it_state,
+  name_source_t base_it_advance_fn,
+  name_source_t base_it_dereference_fn,
+  name_source_t transform_state,
+  name_source_t transform_op)
+{
+  static constexpr std::string_view transform_it_state_name          = "stateful_transform_iterator_state_t";
+  static constexpr std::string_view transform_it_advance_fn_name     = "advance_stateful_transform_it";
+  static constexpr std::string_view transform_it_dereference_fn_name = "dereference_stateful_transform_it";
+
+  const auto& [transform_it_state_src, transform_it_advance_fn_src, transform_it_dereference_fn_src] =
+    make_stateful_transform_input_iterator_sources(
+      transform_it_state_name,
+      transform_it_advance_fn_name,
+      transform_it_dereference_fn_name,
+      transformed_value_type,
+      base_it_state,
+      base_it_advance_fn,
+      base_it_dereference_fn,
+      transform_state,
+      transform_op);
+
   using HostTransformStateT = stateful_transform_it_state<BaseIteratorStateT, TransformerStateT>;
   auto transform_it         = make_iterator<ValueT, HostTransformStateT>(
     {transform_it_state_name, transform_it_state_src},
     {transform_it_advance_fn_name, transform_it_advance_fn_src},
-    {transform_it_deref_fn_name, transform_it_deref_fn_src});
+    {transform_it_dereference_fn_name, transform_it_dereference_fn_src});
 
   return transform_it;
 }
 
-template <typename ValueT, typename BaseIteratorStateT>
-auto make_stateless_transform_input_iterator(
+/*! @brief Generate source code with definitions for state of transformed iterator and functions to operator on it */
+inline std::tuple<std::string, std::string, std::string> make_stateless_transform_input_iterator_sources(
+  std::string_view transform_it_state_name,
+  std::string_view transform_it_advance_fn_name,
+  std::string_view transform_it_dereference_fn_name,
   std::string_view transformed_value_type,
-  name_source_t base_state,
+  name_source_t base_it_state,
   name_source_t base_it_advance_fn,
   name_source_t base_it_dereference_fn,
   name_source_t transform_op)
 {
-  static constexpr std::string_view transform_it_state_name     = "stateless_transform_iterator_state_t";
   static constexpr std::string_view transform_it_state_src_tmpl = R"XXX(
 /* Define state of base iterator over whose values transformation is applied */
 {2}
@@ -1099,28 +1131,28 @@ struct {0} {{
   {1} base_it_state;
 }};
 )XXX";
-  const std::string transform_it_state_src                      = std::format(
+
+  const std::string transform_it_state_src = std::format(
     transform_it_state_src_tmpl,
     /* 0 */ transform_it_state_name,
-    /* 1 */ base_state.name,
-    /* 2 */ base_state.def_src);
+    /* 1 */ base_it_state.name,
+    /* 2 */ base_it_state.def_src);
 
-  static constexpr std::string_view transform_it_advance_fn_name     = "advance_stateless_transform_it";
   static constexpr std::string_view transform_it_advance_fn_src_tmpl = R"XXX(
 {3}
 extern "C" __device__ void {0}({1} *transform_it_state, unsigned long long offset) {{
     {2}(&(transform_it_state->base_it_state), offset);
 }}
 )XXX";
-  const std::string transform_it_advance_fn_src                      = std::format(
+
+  const std::string transform_it_advance_fn_src = std::format(
     transform_it_advance_fn_src_tmpl,
     /* 0 */ transform_it_advance_fn_name,
     /* 1 */ transform_it_state_name,
     /* 2 */ base_it_advance_fn.name,
     /* 3 */ base_it_advance_fn.def_src);
 
-  static constexpr std::string_view transform_it_deref_fn_name     = "dereference_stateless_transform_it";
-  static constexpr std::string_view transform_it_deref_fn_src_tmpl = R"XXX(
+  static constexpr std::string_view transform_it_dereference_fn_src_tmpl = R"XXX(
 {5}
 {6}
 extern "C" __device__ {2} {0}({1} *transform_it_state) {{
@@ -1130,15 +1162,41 @@ extern "C" __device__ {2} {0}({1} *transform_it_state) {{
 }}
 )XXX";
 
-  const std::string transform_it_deref_fn_src = std::format(
-    transform_it_deref_fn_src_tmpl,
-    /* 0 */ transform_it_deref_fn_name /* name of transform's deref function */,
+  const std::string transform_it_dereference_fn_src = std::format(
+    transform_it_dereference_fn_src_tmpl,
+    /* 0 */ transform_it_dereference_fn_name /* name of transform's deref function */,
     /* 1 */ transform_it_state_name /* name of transform's state*/,
     /* 2 */ transformed_value_type /* function return type name */,
     /* 3 */ transform_op.name /* transformation functor function name */,
     /* 4 */ base_it_dereference_fn.name /* deref function of base iterator */,
     /* 5 */ base_it_dereference_fn.def_src,
     /* 6 */ transform_op.def_src);
+
+  return std::make_tuple(transform_it_state_src, transform_it_advance_fn_src, transform_it_dereference_fn_src);
+}
+
+template <typename ValueT, typename BaseIteratorStateT>
+auto make_stateless_transform_input_iterator(
+  std::string_view transformed_value_type,
+  name_source_t base_it_state,
+  name_source_t base_it_advance_fn,
+  name_source_t base_it_dereference_fn,
+  name_source_t transform_op)
+{
+  static constexpr std::string_view transform_it_state_name      = "stateless_transform_iterator_state_t";
+  static constexpr std::string_view transform_it_advance_fn_name = "advance_stateless_transform_it";
+  static constexpr std::string_view transform_it_deref_fn_name   = "dereference_stateless_transform_it";
+
+  const auto& [transform_it_state_src, transform_it_advance_fn_src, transform_it_deref_fn_src] =
+    make_stateless_transform_input_iterator_sources(
+      transform_it_state_name,
+      transform_it_advance_fn_name,
+      transform_it_deref_fn_name,
+      transformed_value_type,
+      base_it_state,
+      base_it_advance_fn,
+      base_it_dereference_fn,
+      transform_op);
 
   using HostTransformStateT = stateless_transform_it_state<BaseIteratorStateT>;
   auto transform_it         = make_iterator<ValueT, HostTransformStateT>(


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes #4643
closes #4644

<!-- Provide a standalone description of changes in this PR. -->

<s>This PR build on top of #4609 and should only be merged after #4609 is merged.</s> **UPD**: The PR has been rebased since #4609 has been merged.

Summary of changes:

1. Utilities such as `make_operator` and `make_iterator` now support arguments of type `std::string_view` and `const char *` (thanks @ericniebler for helping me streamline my clunky implementation)
2. Introduce utilities to obtain source strings defining iterator state, iterator's `advance` function and iterator's `dereference` function.
3. Modified `make_counting_iterator` and others to use code-definition generation utilities,
4. Modified `iterator_t` to add member `std::string state_name`, and modified `make_iterator` utility to accept `state_name` argument in addition to `state_def_src`.
5. Introduce simple struct `name_source_t` to bind entity name and its code definition
6. Introduce `make_stateful_transform_iterator`  and `make_stateless_transform_iterator` which take name/source pairs for base iterator state, base iterator `advance` function, base iterator `dereference` function, as well as for transform operator state, transform operator implementation function.
7. Modified `"test_segmented_reduce.cpp"` to use new iterator utilities.
8. Add a test to `"test_segmented_reduce.cpp"` that  uses `make_stateful_transformed_iterator` that is ready to test implementation of host-streaming approach to support `num_segments` that exceed `INT_MAX` value.

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
