### PR TITLE
rename `start_on` and `continue_on` to `starts_on` and `continues_on` per WG21

### DIFF
--- a/cudax/include/cuda/experimental/__execution/continues_on.cuh
+++ b/cudax/include/cuda/experimental/__execution/continues_on.cuh
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CUDAX_ASYNC_DETAIL_CONTINUE_ON
-#define __CUDAX_ASYNC_DETAIL_CONTINUE_ON
+#ifndef __CUDAX_ASYNC_DETAIL_CONTINUES_ON
+#define __CUDAX_ASYNC_DETAIL_CONTINUES_ON
 
 #include <cuda/std/detail/__config>
 
@@ -40,7 +40,7 @@
 
 namespace cuda::experimental::execution
 {
-struct _CCCL_TYPE_VISIBILITY_DEFAULT continue_on_t
+struct _CCCL_TYPE_VISIBILITY_DEFAULT continues_on_t
 {
 private:
   template <class... _As>
@@ -195,14 +195,14 @@ public:
 };
 
 template <class _Sch>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT continue_on_t::__closure_t
+struct _CCCL_TYPE_VISIBILITY_DEFAULT continues_on_t::__closure_t
 {
   _Sch __sch;
 
   template <class _Sndr>
   _CCCL_TRIVIAL_API friend constexpr auto operator|(_Sndr __sndr, __closure_t __self)
   {
-    return continue_on_t()(static_cast<_Sndr&&>(__sndr), static_cast<_Sch&&>(__self.__sch));
+    return continues_on_t()(static_cast<_Sndr&&>(__sndr), static_cast<_Sch&&>(__self.__sch));
   }
 };
 
@@ -214,7 +214,7 @@ struct __decay_args
   {
     if constexpr (!__decay_copyable<_Ts...>)
     {
-      return invalid_completion_signature<_WHERE(_IN_ALGORITHM, continue_on_t),
+      return invalid_completion_signature<_WHERE(_IN_ALGORITHM, continues_on_t),
                                           _WHAT(_ARGUMENTS_ARE_NOT_DECAY_COPYABLE),
                                           _WITH_ARGUMENTS(_Ts...)>();
     }
@@ -230,10 +230,10 @@ struct __decay_args
 };
 
 template <class _Sndr, class _Sch>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT continue_on_t::__sndr_t
+struct _CCCL_TYPE_VISIBILITY_DEFAULT continues_on_t::__sndr_t
 {
   using sender_concept _CCCL_NODEBUG_ALIAS = sender_t;
-  _CCCL_NO_UNIQUE_ADDRESS continue_on_t __tag_;
+  _CCCL_NO_UNIQUE_ADDRESS continues_on_t __tag_;
   _Sch __sch_;
   _Sndr __sndr_;
 
@@ -292,28 +292,28 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT continue_on_t::__sndr_t
 };
 
 template <class _Sch, class _Sndr>
-_CCCL_TRIVIAL_API constexpr auto continue_on_t::__fn::operator()(_Sch __sch, _Sndr __sndr) const
+_CCCL_TRIVIAL_API constexpr auto continues_on_t::__fn::operator()(_Sch __sch, _Sndr __sndr) const
 {
   return __sndr_t<_Sndr, _Sch>{{}, __sch, static_cast<_Sndr&&>(__sndr)};
 }
 
 template <class _Sndr, class _Sch>
-_CCCL_TRIVIAL_API constexpr auto continue_on_t::operator()(_Sndr __sndr, _Sch __sch) const
+_CCCL_TRIVIAL_API constexpr auto continues_on_t::operator()(_Sndr __sndr, _Sch __sch) const
 {
   using __dom_t _CCCL_NODEBUG_ALIAS = early_domain_of_t<_Sndr>;
   return __dom_t::__apply(*this)(static_cast<_Sch&&>(__sch), static_cast<_Sndr&&>(__sndr));
 }
 
 template <class _Sch>
-_CCCL_TRIVIAL_API constexpr auto continue_on_t::operator()(_Sch __sch) const noexcept -> __closure_t<_Sch>
+_CCCL_TRIVIAL_API constexpr auto continues_on_t::operator()(_Sch __sch) const noexcept -> __closure_t<_Sch>
 {
   return __closure_t<_Sch>{__sch};
 }
 
 template <class _Sndr, class _Sch>
-inline constexpr size_t structured_binding_size<continue_on_t::__sndr_t<_Sndr, _Sch>> = 3;
+inline constexpr size_t structured_binding_size<continues_on_t::__sndr_t<_Sndr, _Sch>> = 3;
 
-_CCCL_GLOBAL_CONSTANT continue_on_t continue_on{};
+_CCCL_GLOBAL_CONSTANT continues_on_t continues_on{};
 } // namespace cuda::experimental::execution
 
 #include <cuda/experimental/__execution/epilogue.cuh>

--- a/cudax/include/cuda/experimental/__execution/starts_on.cuh
+++ b/cudax/include/cuda/experimental/__execution/starts_on.cuh
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CUDAX_ASYNC_DETAIL_START_ON
-#define __CUDAX_ASYNC_DETAIL_START_ON
+#ifndef __CUDAX_ASYNC_DETAIL_STARTS_ON
+#define __CUDAX_ASYNC_DETAIL_STARTS_ON
 
 #include <cuda/std/detail/__config>
 
@@ -48,7 +48,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __sch_env_t
   }
 };
 
-struct start_on_t
+struct starts_on_t
 {
 private:
   template <class _Rcvr, class _Sch, class _CvSndr>
@@ -105,10 +105,10 @@ public:
 };
 
 template <class _Sch, class _Sndr>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT start_on_t::__sndr_t
+struct _CCCL_TYPE_VISIBILITY_DEFAULT starts_on_t::__sndr_t
 {
   using sender_concept _CCCL_NODEBUG_ALIAS = sender_t;
-  _CCCL_NO_UNIQUE_ADDRESS start_on_t __tag_;
+  _CCCL_NO_UNIQUE_ADDRESS starts_on_t __tag_;
   _Sch __sch_;
   _Sndr __sndr_;
 
@@ -152,22 +152,22 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT start_on_t::__sndr_t
 };
 
 template <class _Sch, class _Sndr>
-_CCCL_TRIVIAL_API constexpr auto start_on_t::__fn::operator()(_Sch __sch, _Sndr __sndr) const
+_CCCL_TRIVIAL_API constexpr auto starts_on_t::__fn::operator()(_Sch __sch, _Sndr __sndr) const
 {
   return __sndr_t<_Sch, _Sndr>{{}, __sch, __sndr};
 }
 
 template <class _Sch, class _Sndr>
-_CCCL_TRIVIAL_API constexpr auto start_on_t::operator()(_Sch __sch, _Sndr __sndr) const
+_CCCL_TRIVIAL_API constexpr auto starts_on_t::operator()(_Sch __sch, _Sndr __sndr) const
 {
   using __dom_t _CCCL_NODEBUG_ALIAS = __domain_of_t<_Sch>; // see [exec.starts.on]
   return __dom_t::__apply(*this)(static_cast<_Sch&&>(__sch), static_cast<_Sndr&&>(__sndr));
 }
 
 template <class _Sch, class _Sndr>
-inline constexpr size_t structured_binding_size<start_on_t::__sndr_t<_Sch, _Sndr>> = 3;
+inline constexpr size_t structured_binding_size<starts_on_t::__sndr_t<_Sch, _Sndr>> = 3;
 
-_CCCL_GLOBAL_CONSTANT start_on_t start_on{};
+_CCCL_GLOBAL_CONSTANT starts_on_t starts_on{};
 } // namespace cuda::experimental::execution
 
 #include <cuda/experimental/__execution/epilogue.cuh>

--- a/cudax/include/cuda/experimental/execution.cuh
+++ b/cudax/include/cuda/experimental/execution.cuh
@@ -13,7 +13,7 @@
 
 // IWYU pragma: begin_exports
 #include <cuda/experimental/__execution/conditional.cuh>
-#include <cuda/experimental/__execution/continue_on.cuh>
+#include <cuda/experimental/__execution/continues_on.cuh>
 #include <cuda/experimental/__execution/cpos.cuh>
 #include <cuda/experimental/__execution/domain.cuh>
 #include <cuda/experimental/__execution/env.cuh>
@@ -26,7 +26,7 @@
 #include <cuda/experimental/__execution/run_loop.cuh>
 #include <cuda/experimental/__execution/sequence.cuh>
 #include <cuda/experimental/__execution/start_detached.cuh>
-#include <cuda/experimental/__execution/start_on.cuh>
+#include <cuda/experimental/__execution/starts_on.cuh>
 #include <cuda/experimental/__execution/stop_token.cuh>
 #include <cuda/experimental/__execution/sync_wait.cuh>
 #include <cuda/experimental/__execution/then.cuh>

--- a/cudax/test/CMakeLists.txt
+++ b/cudax/test/CMakeLists.txt
@@ -82,7 +82,7 @@ foreach(cn_target IN LISTS cudax_TARGETS)
     execution/policies/get_execution_policy.cu
     execution/test_concepts.cu
     execution/test_conditional.cu
-    execution/test_continue_on.cu
+    execution/test_continues_on.cu
     execution/test_just.cu
     execution/test_sequence.cu
     execution/test_visit.cu

--- a/cudax/test/execution/test_continues_on.cu
+++ b/cudax/test/execution/test_continues_on.cu
@@ -21,9 +21,9 @@
 
 namespace
 {
-C2H_TEST("continue_on simple example", "[adaptors][continue_on]")
+C2H_TEST("continues_on simple example", "[adaptors][continues_on]")
 {
-  auto snd = cudax_async::continue_on(cudax_async::just(13), inline_scheduler{});
+  auto snd = cudax_async::continues_on(cudax_async::just(13), inline_scheduler{});
   auto op  = cudax_async::connect(std::move(snd), checked_value_receiver{13});
   cudax_async::start(op);
   // The receiver checks if we receive the right value
@@ -31,13 +31,13 @@ C2H_TEST("continue_on simple example", "[adaptors][continue_on]")
 
 #if !defined(__CUDA_ARCH__)
 
-C2H_TEST("continue_on can be piped", "[adaptors][continue_on]")
+C2H_TEST("continues_on can be piped", "[adaptors][continues_on]")
 {
-  // Just continue_on a value to the impulse scheduler
+  // Just continues_on a value to the impulse scheduler
   bool called{false};
   auto sched = impulse_scheduler{};
   auto snd   = cudax_async::just(13) //
-           | cudax_async::continue_on(sched) //
+           | cudax_async::continues_on(sched) //
            | cudax_async::then([&](int val) {
                called = true;
                return val;
@@ -52,11 +52,11 @@ C2H_TEST("continue_on can be piped", "[adaptors][continue_on]")
   CUDAX_REQUIRE(called);
 }
 
-C2H_TEST("continue_on calls the receiver when the scheduler dictates", "[adaptors][continue_on]")
+C2H_TEST("continues_on calls the receiver when the scheduler dictates", "[adaptors][continues_on]")
 {
   bool called{false};
   impulse_scheduler sched;
-  auto snd = cudax_async::then(cudax_async::continue_on(cudax_async::just(13), sched), [&](int val) {
+  auto snd = cudax_async::then(cudax_async::continues_on(cudax_async::just(13), sched), [&](int val) {
     called = true;
     return val;
   });
@@ -70,7 +70,7 @@ C2H_TEST("continue_on calls the receiver when the scheduler dictates", "[adaptor
   CUDAX_CHECK(called);
 }
 
-C2H_TEST("continue_on calls the given sender when the scheduler dictates", "[adaptors][continue_on]")
+C2H_TEST("continues_on calls the given sender when the scheduler dictates", "[adaptors][continues_on]")
 {
   int counter{0};
   auto snd_base = cudax_async::just() //
@@ -80,7 +80,7 @@ C2H_TEST("continue_on calls the given sender when the scheduler dictates", "[ada
                   });
 
   impulse_scheduler sched;
-  auto snd = cudax_async::then(cudax_async::continue_on(std::move(snd_base), sched), [&](int val) {
+  auto snd = cudax_async::then(cudax_async::continues_on(std::move(snd_base), sched), [&](int val) {
     ++counter;
     return val;
   });
@@ -97,14 +97,14 @@ C2H_TEST("continue_on calls the given sender when the scheduler dictates", "[ada
   CUDAX_CHECK(counter == 2);
 }
 
-C2H_TEST("continue_on works when changing threads", "[adaptors][continue_on]")
+C2H_TEST("continues_on works when changing threads", "[adaptors][continues_on]")
 {
   cudax_async::thread_context thread;
   bool called{false};
 
   {
     // lunch some work on the thread pool
-    auto snd = cudax_async::continue_on(cudax_async::just(), thread.get_scheduler()) //
+    auto snd = cudax_async::continues_on(cudax_async::just(), thread.get_scheduler()) //
              | cudax_async::then([&] {
                  called = true;
                });
@@ -119,102 +119,102 @@ C2H_TEST("continue_on works when changing threads", "[adaptors][continue_on]")
 
 #endif
 
-C2H_TEST("continue_on can be called with rvalue ref scheduler", "[adaptors][continue_on]")
+C2H_TEST("continues_on can be called with rvalue ref scheduler", "[adaptors][continues_on]")
 {
-  auto snd = cudax_async::continue_on(cudax_async::just(13), inline_scheduler{});
+  auto snd = cudax_async::continues_on(cudax_async::just(13), inline_scheduler{});
   auto op  = cudax_async::connect(std::move(snd), checked_value_receiver{13});
   cudax_async::start(op);
   // The receiver checks if we receive the right value
 }
 
-C2H_TEST("continue_on can be called with const ref scheduler", "[adaptors][continue_on]")
+C2H_TEST("continues_on can be called with const ref scheduler", "[adaptors][continues_on]")
 {
   const inline_scheduler sched;
-  auto snd = cudax_async::continue_on(cudax_async::just(13), sched);
+  auto snd = cudax_async::continues_on(cudax_async::just(13), sched);
   auto op  = cudax_async::connect(std::move(snd), checked_value_receiver{13});
   cudax_async::start(op);
   // The receiver checks if we receive the right value
 }
 
-C2H_TEST("continue_on can be called with ref scheduler", "[adaptors][continue_on]")
+C2H_TEST("continues_on can be called with ref scheduler", "[adaptors][continues_on]")
 {
   inline_scheduler sched;
-  auto snd = cudax_async::continue_on(cudax_async::just(13), sched);
+  auto snd = cudax_async::continues_on(cudax_async::just(13), sched);
   auto op  = cudax_async::connect(std::move(snd), checked_value_receiver{13});
   cudax_async::start(op);
   // The receiver checks if we receive the right value
 }
 
-C2H_TEST("continue_on forwards set_error calls", "[adaptors][continue_on]")
+C2H_TEST("continues_on forwards set_error calls", "[adaptors][continues_on]")
 {
   auto ec = error_code{std::errc::invalid_argument};
   error_scheduler<error_code> sched{ec};
-  auto snd = cudax_async::continue_on(cudax_async::just(13), sched);
+  auto snd = cudax_async::continues_on(cudax_async::just(13), sched);
   auto op  = cudax_async::connect(std::move(snd), checked_error_receiver{ec});
   cudax_async::start(op);
   // The receiver checks if we receive an error
 }
 
-C2H_TEST("continue_on forwards set_error calls of other types", "[adaptors][continue_on]")
+C2H_TEST("continues_on forwards set_error calls of other types", "[adaptors][continues_on]")
 {
   error_scheduler<string> sched{string{"error"}};
-  auto snd = cudax_async::continue_on(cudax_async::just(13), sched);
+  auto snd = cudax_async::continues_on(cudax_async::just(13), sched);
   auto op  = cudax_async::connect(std::move(snd), checked_error_receiver{string{"error"}});
   cudax_async::start(op);
   // The receiver checks if we receive an error
 }
 
-C2H_TEST("continue_on forwards set_stopped calls", "[adaptors][continue_on]")
+C2H_TEST("continues_on forwards set_stopped calls", "[adaptors][continues_on]")
 {
   stopped_scheduler sched{};
-  auto snd = cudax_async::continue_on(cudax_async::just(13), sched);
+  auto snd = cudax_async::continues_on(cudax_async::just(13), sched);
   auto op  = cudax_async::connect(std::move(snd), checked_stopped_receiver{});
   cudax_async::start(op);
   // The receiver checks if we receive the stopped signal
 }
 
-C2H_TEST("continue_on has the values_type corresponding to the given values", "[adaptors][continue_on]")
+C2H_TEST("continues_on has the values_type corresponding to the given values", "[adaptors][continues_on]")
 {
   inline_scheduler sched{};
 
-  check_value_types<types<int>>(cudax_async::continue_on(cudax_async::just(1), sched));
-  check_value_types<types<int, double>>(cudax_async::continue_on(cudax_async::just(3, 0.14), sched));
+  check_value_types<types<int>>(cudax_async::continues_on(cudax_async::just(1), sched));
+  check_value_types<types<int, double>>(cudax_async::continues_on(cudax_async::just(3, 0.14), sched));
   check_value_types<types<int, double, string>>(
-    cudax_async::continue_on(cudax_async::just(3, 0.14, string{"pi"}), sched));
+    cudax_async::continues_on(cudax_async::just(3, 0.14, string{"pi"}), sched));
 }
 
-C2H_TEST("continue_on keeps error_types from scheduler's sender", "[adaptors][continue_on]")
+C2H_TEST("continues_on keeps error_types from scheduler's sender", "[adaptors][continues_on]")
 {
   inline_scheduler sched1{};
   error_scheduler<std::error_code> sched2{std::make_error_code(std::errc::invalid_argument)};
   error_scheduler<int> sched3{43};
 
-  check_error_types<>(cudax_async::continue_on(cudax_async::just(1), sched1));
-  check_error_types<std::error_code>(cudax_async::continue_on(cudax_async::just(2), sched2));
-  check_error_types<int>(cudax_async::continue_on(cudax_async::just(3), sched3));
+  check_error_types<>(cudax_async::continues_on(cudax_async::just(1), sched1));
+  check_error_types<std::error_code>(cudax_async::continues_on(cudax_async::just(2), sched2));
+  check_error_types<int>(cudax_async::continues_on(cudax_async::just(3), sched3));
 }
 
-C2H_TEST("continue_on sends an exception_ptr if value types are potentially throwing when copied",
-         "[adaptors][continue_on]")
+C2H_TEST("continues_on sends an exception_ptr if value types are potentially throwing when copied",
+         "[adaptors][continues_on]")
 {
   inline_scheduler sched{};
 
 #if !defined(__CUDA_ARCH__)
-  check_error_types<std::exception_ptr>(cudax_async::continue_on(cudax_async::just(potentially_throwing{}), sched));
+  check_error_types<std::exception_ptr>(cudax_async::continues_on(cudax_async::just(potentially_throwing{}), sched));
 #else
   // No exceptions in device code:
-  check_error_types<>(cudax_async::continue_on(cudax_async::just(potentially_throwing{}), sched));
+  check_error_types<>(cudax_async::continues_on(cudax_async::just(potentially_throwing{}), sched));
 #endif
 }
 
-C2H_TEST("continue_on keeps sends_stopped from scheduler's sender", "[adaptors][continue_on]")
+C2H_TEST("continues_on keeps sends_stopped from scheduler's sender", "[adaptors][continues_on]")
 {
   inline_scheduler sched1{};
   error_scheduler<error_code> sched2{error_code{std::errc::invalid_argument}};
   stopped_scheduler sched3{};
 
-  check_sends_stopped<false>(cudax_async::continue_on(cudax_async::just(1), sched1));
-  check_sends_stopped<true>(cudax_async::continue_on(cudax_async::just(2), sched2));
-  check_sends_stopped<true>(cudax_async::continue_on(cudax_async::just(3), sched3));
+  check_sends_stopped<false>(cudax_async::continues_on(cudax_async::just(1), sched1));
+  check_sends_stopped<true>(cudax_async::continues_on(cudax_async::just(2), sched2));
+  check_sends_stopped<true>(cudax_async::continues_on(cudax_async::just(3), sched3));
 }
 } // namespace

--- a/cudax/test/execution/test_when_all.cu
+++ b/cudax/test/execution/test_when_all.cu
@@ -72,9 +72,9 @@ C2H_TEST("when_all completes when children complete", "[when_all]")
 {
   impulse_scheduler sched;
   bool called{false};
-  auto snd = cudax_async::when_all(cudax_async::just(11) | cudax_async::continue_on(sched),
-                                   cudax_async::just(13) | cudax_async::continue_on(sched),
-                                   cudax_async::just(17) | cudax_async::continue_on(sched))
+  auto snd = cudax_async::when_all(cudax_async::just(11) | cudax_async::continues_on(sched),
+                                   cudax_async::just(13) | cudax_async::continues_on(sched),
+                                   cudax_async::just(17) | cudax_async::continues_on(sched))
            | cudax_async::then([&](int a, int b, int c) {
                called = true;
                return a + b + c;
@@ -104,7 +104,7 @@ C2H_TEST("when_all terminates with error if one child terminates with error", "[
 {
   error_scheduler sched{42};
   auto snd = cudax_async::when_all(
-    cudax_async::just(2), cudax_async::just(5) | cudax_async::continue_on(sched), cudax_async::just(7));
+    cudax_async::just(2), cudax_async::just(5) | cudax_async::continues_on(sched), cudax_async::just(7));
   auto op = cudax_async::connect(std::move(snd), checked_error_receiver{42});
   cudax_async::start(op);
 }
@@ -113,7 +113,7 @@ C2H_TEST("when_all terminates with stopped if one child is cancelled", "[when_al
 {
   stopped_scheduler sched;
   auto snd = cudax_async::when_all(
-    cudax_async::just(2), cudax_async::just(5) | cudax_async::continue_on(sched), cudax_async::just(7));
+    cudax_async::just(2), cudax_async::just(5) | cudax_async::continues_on(sched), cudax_async::just(7));
   auto op = cudax_async::connect(std::move(snd), checked_stopped_receiver{});
   cudax_async::start(op);
 }
@@ -128,11 +128,11 @@ C2H_TEST("when_all cancels remaining children if error is detected", "[when_all]
   bool called3{false};
   bool cancelled{false};
   auto snd = cudax_async::when_all(
-    cudax_async::start_on(sched, cudax_async::just()) | cudax_async::then([&] {
+    cudax_async::starts_on(sched, cudax_async::just()) | cudax_async::then([&] {
       called1 = true;
     }),
-    cudax_async::start_on(sched, cudax_async::just(5) | cudax_async::continue_on(err_sched)),
-    cudax_async::start_on(sched, cudax_async::just()) | cudax_async::then([&] {
+    cudax_async::starts_on(sched, cudax_async::just(5) | cudax_async::continues_on(err_sched)),
+    cudax_async::starts_on(sched, cudax_async::just()) | cudax_async::then([&] {
       called3 = true;
     }) | cudax_async::let_stopped([&] {
       cancelled = true;
@@ -160,11 +160,11 @@ C2H_TEST("when_all cancels remaining children if cancel is detected", "[when_all
   bool called3{false};
   bool cancelled{false};
   auto snd = cudax_async::when_all(
-    cudax_async::start_on(sched, cudax_async::just()) | cudax_async::then([&] {
+    cudax_async::starts_on(sched, cudax_async::just()) | cudax_async::then([&] {
       called1 = true;
     }),
-    cudax_async::start_on(sched, cudax_async::just(5) | cudax_async::continue_on(stopped_sched)),
-    cudax_async::start_on(sched, cudax_async::just()) | cudax_async::then([&] {
+    cudax_async::starts_on(sched, cudax_async::just(5) | cudax_async::continues_on(stopped_sched)),
+    cudax_async::starts_on(sched, cudax_async::just()) | cudax_async::then([&] {
       called3 = true;
     }) | cudax_async::let_stopped([&] {
       cancelled = true;


### PR DESCRIPTION
## Description

the c++ committee decided to change the names of the `start_on` and `continue_on` algorithms to `starts_on` and `continues_on`. this PR brings ustdex into line with the current working draft of C++.

this PR is based on #4626; hence the extra commits. my kingdom for stacked PRs.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
