### PR TITLE
Refactor part of `<cuda/std/type_traits>`

### DIFF
--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -963,6 +963,8 @@
 #  define _CCCL_BUILTIN_INTEGER_PACK(...) __integer_pack(__VA_ARGS__)
 #endif // _CCCL_HAS_BUILTIN(__integer_pack)
 
+#define _CCCL_BUILTIN_IS_ABSTRACT(...) __is_abstract(__VA_ARGS__)
+
 #if _CCCL_CHECK_BUILTIN(is_aggregate) || _CCCL_COMPILER(GCC, >=, 7) || _CCCL_COMPILER(MSVC, >, 19, 14) \
   || _CCCL_COMPILER(NVRTC)
 #  define _CCCL_BUILTIN_IS_AGGREGATE(...) __is_aggregate(__VA_ARGS__)

--- a/libcudacxx/include/cuda/std/__functional/bind.h
+++ b/libcudacxx/include/cuda/std/__functional/bind.h
@@ -143,7 +143,7 @@ __mu(_Ti&, _Uj& __uj)
 
 template <class _Ti, class _Uj>
 _LIBCUDACXX_HIDE_FROM_ABI
-enable_if_t<!is_bind_expression<_Ti>::value && is_placeholder<_Ti>::value == 0 && !__is_reference_wrapper<_Ti>::value,
+enable_if_t<!is_bind_expression<_Ti>::value && is_placeholder<_Ti>::value == 0 && !__cccl_is_reference_wrapper_v<_Ti>,
             _Ti&>
 __mu(_Ti& __ti, _Uj&)
 {
@@ -192,7 +192,7 @@ template <class _Ti, class _TupleUj>
 struct __mu_return
     : public __mu_return_impl<
         _Ti,
-        __is_reference_wrapper<_Ti>::value,
+        __cccl_is_reference_wrapper_v<_Ti>,
         is_bind_expression<_Ti>::value,
         0 < is_placeholder<_Ti>::value && is_placeholder<_Ti>::value <= tuple_size<_TupleUj>::value,
         _TupleUj>

--- a/libcudacxx/include/cuda/std/__functional/invoke.h
+++ b/libcudacxx/include/cuda/std/__functional/invoke.h
@@ -283,7 +283,7 @@ using __enable_if_bullet1 =
 
 template <class _Fp, class _A0, class _DecayFp = decay_t<_Fp>, class _DecayA0 = typename decay<_A0>::type>
 using __enable_if_bullet2 =
-  enable_if_t<is_member_function_pointer<_DecayFp>::value && __is_reference_wrapper<_DecayA0>::value>;
+  enable_if_t<is_member_function_pointer<_DecayFp>::value && __cccl_is_reference_wrapper_v<_DecayA0>>;
 
 template <class _Fp,
           class _A0,
@@ -292,7 +292,7 @@ template <class _Fp,
           class _ClassT  = typename __member_pointer_class_type<_DecayFp>::type>
 using __enable_if_bullet3 =
   enable_if_t<is_member_function_pointer<_DecayFp>::value && !is_base_of<_ClassT, _DecayA0>::value
-              && !__is_reference_wrapper<_DecayA0>::value>;
+              && !__cccl_is_reference_wrapper_v<_DecayA0>>;
 
 template <class _Fp,
           class _A0,
@@ -304,7 +304,7 @@ using __enable_if_bullet4 =
 
 template <class _Fp, class _A0, class _DecayFp = decay_t<_Fp>, class _DecayA0 = typename decay<_A0>::type>
 using __enable_if_bullet5 =
-  enable_if_t<is_member_object_pointer<_DecayFp>::value && __is_reference_wrapper<_DecayA0>::value>;
+  enable_if_t<is_member_object_pointer<_DecayFp>::value && __cccl_is_reference_wrapper_v<_DecayA0>>;
 
 template <class _Fp,
           class _A0,
@@ -313,7 +313,7 @@ template <class _Fp,
           class _ClassT  = typename __member_pointer_class_type<_DecayFp>::type>
 using __enable_if_bullet6 =
   enable_if_t<is_member_object_pointer<_DecayFp>::value && !is_base_of<_ClassT, _DecayA0>::value
-              && !__is_reference_wrapper<_DecayA0>::value>;
+              && !__cccl_is_reference_wrapper_v<_DecayA0>>;
 
 // __invoke forward declarations
 

--- a/libcudacxx/include/cuda/std/__memory/uninitialized_algorithms.h
+++ b/libcudacxx/include/cuda/std/__memory/uninitialized_algorithms.h
@@ -361,7 +361,7 @@ __allocator_destroy_multidimensional(_Alloc& __alloc, _BidirIter __first, _Bidir
 
   if constexpr (_CCCL_TRAIT(is_array, _ValueType))
   {
-    static_assert(!__cccl_is_unbounded_array<_ValueType>::value,
+    static_assert(!is_unbounded_array_v<_ValueType>,
                   "arrays of unbounded arrays don't exist, but if they did we would mess up here");
 
     using _Element = remove_extent_t<_ValueType>;

--- a/libcudacxx/include/cuda/std/__type_traits/is_abstract.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_abstract.h
@@ -25,11 +25,11 @@
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_abstract : public bool_constant<__is_abstract(_Tp)>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_abstract : public bool_constant<_CCCL_BUILTIN_IS_ABSTRACT(_Tp)>
 {};
 
 template <class _Tp>
-inline constexpr bool is_abstract_v = __is_abstract(_Tp); // don't we want to rather use _CCCL_BUILTIN_IS_ABSTRACT here?
+inline constexpr bool is_abstract_v = _CCCL_BUILTIN_IS_ABSTRACT(_Tp);
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_abstract.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_abstract.h
@@ -29,7 +29,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT is_abstract : public bool_constant<__is_abs
 {};
 
 template <class _Tp>
-inline constexpr bool is_abstract_v = __is_abstract(_Tp);
+inline constexpr bool is_abstract_v = __is_abstract(_Tp); // don't we want to rather use _CCCL_BUILTIN_IS_ABSTRACT here?
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_abstract.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_abstract.h
@@ -25,7 +25,7 @@
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_abstract : public integral_constant<bool, __is_abstract(_Tp)>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_abstract : public bool_constant<__is_abstract(_Tp)>
 {};
 
 template <class _Tp>

--- a/libcudacxx/include/cuda/std/__type_traits/is_aggregate.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_aggregate.h
@@ -27,7 +27,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 #if defined(_CCCL_BUILTIN_IS_AGGREGATE)
 
 template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_aggregate : public integral_constant<bool, _CCCL_BUILTIN_IS_AGGREGATE(_Tp)>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_aggregate : public bool_constant<_CCCL_BUILTIN_IS_AGGREGATE(_Tp)>
 {};
 
 template <class _Tp>

--- a/libcudacxx/include/cuda/std/__type_traits/is_arithmetic.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_arithmetic.h
@@ -27,12 +27,11 @@
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_arithmetic
-    : public integral_constant<bool, is_integral<_Tp>::value || is_floating_point<_Tp>::value>
-{};
+inline constexpr bool is_arithmetic_v = is_integral_v<_Tp> || is_floating_point_v<_Tp>;
 
 template <class _Tp>
-inline constexpr bool is_arithmetic_v = is_arithmetic<_Tp>::value;
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_arithmetic : public bool_constant<is_arithmetic_v<_Tp>>
+{};
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_array.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_array.h
@@ -30,7 +30,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 #if defined(_CCCL_BUILTIN_IS_ARRAY) && !defined(_LIBCUDACXX_USE_IS_ARRAY_FALLBACK)
 
 template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_array : public integral_constant<bool, _CCCL_BUILTIN_IS_ARRAY(_Tp)>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_array : public bool_constant<_CCCL_BUILTIN_IS_ARRAY(_Tp)>
 {};
 
 template <class _Tp>
@@ -39,17 +39,17 @@ inline constexpr bool is_array_v = _CCCL_BUILTIN_IS_ARRAY(_Tp);
 #else
 
 template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_array : public false_type
-{};
-template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_array<_Tp[]> : public true_type
-{};
-template <class _Tp, size_t _Np>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_array<_Tp[_Np]> : public true_type
-{};
+inline constexpr bool is_array_v = false;
 
 template <class _Tp>
-inline constexpr bool is_array_v = is_array<_Tp>::value;
+inline constexpr bool is_array_v<_Tp[]> = true;
+
+template <class _Tp, size_t _Np>
+inline constexpr bool is_array_v<_Tp[_Np]> = true;
+
+template <class _Tp, size_t _Np>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_array : public bool_constant<is_array_v<_Tp>>
+{};
 
 #endif // defined(_CCCL_BUILTIN_IS_ARRAY) && !defined(_LIBCUDACXX_USE_IS_ARRAY_FALLBACK)
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_array.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_array.h
@@ -47,7 +47,7 @@ inline constexpr bool is_array_v<_Tp[]> = true;
 template <class _Tp, size_t _Np>
 inline constexpr bool is_array_v<_Tp[_Np]> = true;
 
-template <class _Tp, size_t _Np>
+template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT is_array : public bool_constant<is_array_v<_Tp>>
 {};
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_bounded_array.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_bounded_array.h
@@ -20,27 +20,20 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/std/__cstddef/types.h>
 #include <cuda/std/__type_traits/integral_constant.h>
-#include <cuda/std/cstddef>
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-template <class>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT __cccl_is_bounded_array : false_type
-{};
-template <class _Tp, size_t _Np>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT __cccl_is_bounded_array<_Tp[_Np]> : true_type
-{};
+template <class _Tp>
+inline constexpr bool is_bounded_array_v = false;
 
-template <class>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_bounded_array : false_type
-{};
 template <class _Tp, size_t _Np>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_bounded_array<_Tp[_Np]> : true_type
-{};
+inline constexpr bool is_bounded_array_v<_Tp[_Np]> = true;
 
 template <class _Tp>
-inline constexpr bool is_bounded_array_v = is_bounded_array<_Tp>::value;
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_bounded_array : public bool_constant<is_bounded_array_v<_Tp>>
+{};
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_char_like_type.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_char_like_type.h
@@ -18,7 +18,7 @@
 #  pragma clang system_header
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
 #  pragma system_header
-#endif // no system headerW
+#endif // no system header
 
 #include <cuda/std/__type_traits/conjunction.h>
 #include <cuda/std/__type_traits/is_standard_layout.h>

--- a/libcudacxx/include/cuda/std/__type_traits/is_char_like_type.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_char_like_type.h
@@ -18,7 +18,7 @@
 #  pragma clang system_header
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
 #  pragma system_header
-#endif // no system header
+#endif // no system headerW
 
 #include <cuda/std/__type_traits/conjunction.h>
 #include <cuda/std/__type_traits/is_standard_layout.h>
@@ -26,8 +26,8 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-template <class _CharT>
-using _IsCharLikeType = _And<is_standard_layout<_CharT>, is_trivial<_CharT>>;
+template <class _Tp>
+inline constexpr bool __cccl_is_char_like_type_v = is_standard_layout_v<_Tp> && is_trivial_v<_Tp>;
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_compound.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_compound.h
@@ -28,7 +28,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 #if defined(_CCCL_BUILTIN_IS_COMPOUND) && !defined(_LIBCUDACXX_USE_IS_COMPOUND_FALLBACK)
 
 template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_compound : public integral_constant<bool, _CCCL_BUILTIN_IS_COMPOUND(_Tp)>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_compound : public bool_constant<_CCCL_BUILTIN_IS_COMPOUND(_Tp)>
 {};
 
 template <class _Tp>
@@ -37,11 +37,11 @@ inline constexpr bool is_compound_v = _CCCL_BUILTIN_IS_COMPOUND(_Tp);
 #else // ^^^ _CCCL_BUILTIN_IS_COMPOUND ^^^ / vvv !_CCCL_BUILTIN_IS_COMPOUND vvv
 
 template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_compound : public integral_constant<bool, !is_fundamental<_Tp>::value>
-{};
+inline constexpr bool is_compound_v = !is_fundamental_v<_Tp>;
 
 template <class _Tp>
-inline constexpr bool is_compound_v = is_compound<_Tp>::value;
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_compound : public bool_constant<is_compound_v<_Tp>>
+{};
 
 #endif // !_CCCL_BUILTIN_IS_COMPOUND
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_const.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_const.h
@@ -27,7 +27,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 #if defined(_CCCL_BUILTIN_IS_CONST) && !defined(_LIBCUDACXX_USE_IS_CONST_FALLBACK)
 
 template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_const : public integral_constant<bool, _CCCL_BUILTIN_IS_CONST(_Tp)>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_const : public bool_constant<_CCCL_BUILTIN_IS_CONST(_Tp)>
 {};
 
 template <class _Tp>
@@ -36,14 +36,14 @@ inline constexpr bool is_const_v = _CCCL_BUILTIN_IS_CONST(_Tp);
 #else // ^^^ _CCCL_BUILTIN_IS_CONST ^^^ / vvv !_CCCL_BUILTIN_IS_CONST vvv
 
 template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_const : public false_type
-{};
-template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_const<_Tp const> : public true_type
-{};
+inline constexpr bool is_const_v = false;
 
 template <class _Tp>
-inline constexpr bool is_const_v = is_const<_Tp>::value;
+inline constexpr bool is_const_v<const _Tp> = true;
+
+template <class _Tp>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_const : public bool_constant<is_const_v<_Tp>>
+{};
 
 #endif // !_CCCL_BUILTIN_IS_CONST
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_extended_arithmetic.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_extended_arithmetic.h
@@ -27,8 +27,7 @@
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-inline constexpr bool __is_extended_arithmetic_v =
-  _CCCL_TRAIT(is_arithmetic, _Tp) || _CCCL_TRAIT(__is_extended_floating_point, _Tp);
+inline constexpr bool __is_extended_arithmetic_v = is_arithmetic_v<_Tp> || __is_extended_floating_point_v<_Tp>;
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_extended_floating_point.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_extended_floating_point.h
@@ -21,59 +21,32 @@
 #endif // no system header
 
 #include <cuda/std/__floating_point/nvfp_types.h>
-#include <cuda/std/__type_traits/integral_constant.h>
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-struct __is_extended_floating_point : false_type
-{};
-
-template <class _Tp>
-inline constexpr bool __is_extended_floating_point_v = __is_extended_floating_point<_Tp>::value;
+inline constexpr bool __is_extended_floating_point_v = false;
 
 #if _CCCL_HAS_NVFP16()
-template <>
-struct __is_extended_floating_point<__half> : true_type
-{};
-
 template <>
 inline constexpr bool __is_extended_floating_point_v<__half> = true;
 #endif // _CCCL_HAS_NVFP16
 
 #if _CCCL_HAS_NVBF16()
 template <>
-struct __is_extended_floating_point<__nv_bfloat16> : true_type
-{};
-
-template <>
 inline constexpr bool __is_extended_floating_point_v<__nv_bfloat16> = true;
 #endif // _CCCL_HAS_NVBF16
 
 #if _CCCL_HAS_NVFP8_E4M3()
 template <>
-struct __is_extended_floating_point<__nv_fp8_e4m3> : true_type
-{};
-#endif // _CCCL_HAS_NVFP8_E4M3()
-#if _CCCL_HAS_NVFP8_E5M2()
-template <>
-struct __is_extended_floating_point<__nv_fp8_e5m2> : true_type
-{};
-#endif // _CCCL_HAS_NVFP8_E5M2()
-#if _CCCL_HAS_NVFP8_E8M0()
-template <>
-struct __is_extended_floating_point<__nv_fp8_e8m0> : true_type
-{};
-#endif // _CCCL_HAS_NVFP8_E8M0()
-
-#if _CCCL_HAS_NVFP8_E4M3()
-template <>
 inline constexpr bool __is_extended_floating_point_v<__nv_fp8_e4m3> = true;
 #endif // _CCCL_HAS_NVFP8_E4M3()
+
 #if _CCCL_HAS_NVFP8_E5M2()
 template <>
 inline constexpr bool __is_extended_floating_point_v<__nv_fp8_e5m2> = true;
 #endif // _CCCL_HAS_NVFP8_E5M2()
+
 #if _CCCL_HAS_NVFP8_E8M0()
 template <>
 inline constexpr bool __is_extended_floating_point_v<__nv_fp8_e8m0> = true;
@@ -81,18 +54,9 @@ inline constexpr bool __is_extended_floating_point_v<__nv_fp8_e8m0> = true;
 
 #if _CCCL_HAS_NVFP6_E2M3()
 template <>
-struct __is_extended_floating_point<__nv_fp6_e2m3> : true_type
-{};
-#endif // _CCCL_HAS_NVFP6_E2M3()
-#if _CCCL_HAS_NVFP6_E3M2()
-template <>
-struct __is_extended_floating_point<__nv_fp6_e3m2> : true_type
-{};
-#endif // _CCCL_HAS_NVFP6_E3M2()
-#if _CCCL_HAS_NVFP6_E2M3()
-template <>
 inline constexpr bool __is_extended_floating_point_v<__nv_fp6_e2m3> = true;
 #endif // _CCCL_HAS_NVFP6_E2M3()
+
 #if _CCCL_HAS_NVFP6_E3M2()
 template <>
 inline constexpr bool __is_extended_floating_point_v<__nv_fp6_e3m2> = true;
@@ -100,19 +64,9 @@ inline constexpr bool __is_extended_floating_point_v<__nv_fp6_e3m2> = true;
 
 #if _CCCL_HAS_NVFP4_E2M1()
 template <>
-struct __is_extended_floating_point<__nv_fp4_e2m1> : true_type
-{};
-#endif // _CCCL_HAS_NVFP4_E2M1()
-#if _CCCL_HAS_NVFP4_E2M1()
-template <>
 inline constexpr bool __is_extended_floating_point_v<__nv_fp4_e2m1> = true;
 #endif // _CCCL_HAS_NVFP4_E2M1()
 
-#if _CCCL_HAS_FLOAT128()
-template <>
-struct __is_extended_floating_point<__float128> : true_type
-{};
-#endif // _CCCL_HAS_FLOAT128()
 #if _CCCL_HAS_FLOAT128()
 template <>
 inline constexpr bool __is_extended_floating_point_v<__float128> = true;

--- a/libcudacxx/include/cuda/std/__type_traits/is_final.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_final.h
@@ -20,6 +20,7 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/std/__type_traits/always_false.h>
 #include <cuda/std/__type_traits/integral_constant.h>
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
@@ -27,7 +28,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 #if defined(_CCCL_BUILTIN_IS_FINAL)
 
 template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_final : public integral_constant<bool, _CCCL_BUILTIN_IS_FINAL(_Tp)>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_final : public bool_constant<_CCCL_BUILTIN_IS_FINAL(_Tp)>
 {};
 
 template <class _Tp>
@@ -37,10 +38,12 @@ inline constexpr bool is_final_v = _CCCL_BUILTIN_IS_FINAL(_Tp);
 
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT is_final : public false_type
-{};
+{
+  static_assert(__always_false_v<_Tp>, "is_final requires compiler support");
+};
 
 template <class _Tp>
-inline constexpr bool is_final_v = false;
+inline constexpr bool is_final_v = is_final<_Tp>::value;
 
 #endif // !_CCCL_BUILTIN_IS_FINAL
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_floating_point.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_floating_point.h
@@ -26,24 +26,23 @@
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-struct __cccl_is_floating_point : public false_type
-{};
+inline constexpr bool __cccl_is_floating_point_helper_v = false;
+
 template <>
-struct __cccl_is_floating_point<float> : public true_type
-{};
+inline constexpr bool __cccl_is_floating_point_helper_v<float> = true;
+
 template <>
-struct __cccl_is_floating_point<double> : public true_type
-{};
+inline constexpr bool __cccl_is_floating_point_helper_v<double> = true;
+
 template <>
-struct __cccl_is_floating_point<long double> : public true_type
-{};
+inline constexpr bool __cccl_is_floating_point_helper_v<long double> = true;
 
 template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_floating_point : public __cccl_is_floating_point<remove_cv_t<_Tp>>
-{};
+inline constexpr bool is_floating_point_v = __cccl_is_floating_point_helper_v<remove_cv_t<_Tp>>;
 
 template <class _Tp>
-inline constexpr bool is_floating_point_v = is_floating_point<_Tp>::value;
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_floating_point : public bool_constant<is_floating_point_v<_Tp>>
+{};
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_fundamental.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_fundamental.h
@@ -30,7 +30,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 #if defined(_CCCL_BUILTIN_IS_FUNDAMENTAL) && !defined(_LIBCUDACXX_USE_IS_FUNDAMENTAL_FALLBACK)
 
 template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_fundamental : public integral_constant<bool, _CCCL_BUILTIN_IS_FUNDAMENTAL(_Tp)>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_fundamental : public bool_constant<_CCCL_BUILTIN_IS_FUNDAMENTAL(_Tp)>
 {};
 
 template <class _Tp>
@@ -39,12 +39,11 @@ inline constexpr bool is_fundamental_v = _CCCL_BUILTIN_IS_FUNDAMENTAL(_Tp);
 #else // ^^^ _CCCL_BUILTIN_IS_FUNDAMENTAL ^^^ / vvv !_CCCL_BUILTIN_IS_FUNDAMENTAL vvv
 
 template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_fundamental
-    : public integral_constant<bool, is_void<_Tp>::value || __is_nullptr_t<_Tp>::value || is_arithmetic<_Tp>::value>
-{};
+inline constexpr bool is_fundamental_v = is_void_v<_Tp> || is_null_pointer_v<_Tp> || is_arithmetic_v<_Tp>;
 
 template <class _Tp>
-inline constexpr bool is_fundamental_v = is_fundamental<_Tp>::value;
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_fundamental : public bool_constant<is_fundamental_v<_Tp>>
+{};
 
 #endif // !_CCCL_BUILTIN_IS_FUNDAMENTAL
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_integral.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_integral.h
@@ -37,7 +37,7 @@ inline constexpr bool is_integral_v = _CCCL_BUILTIN_IS_INTEGRAL(_Tp);
 #else // ^^^ _CCCL_BUILTIN_IS_INTEGRAL ^^^ / vvv !_CCCL_BUILTIN_IS_INTEGRAL vvv
 
 template <class _Tp>
-inline constexpr bool __cccl_is_integral_helper_v = true;
+inline constexpr bool __cccl_is_integral_helper_v = false;
 
 template <>
 inline constexpr bool __cccl_is_integral_helper_v<bool> = true;

--- a/libcudacxx/include/cuda/std/__type_traits/is_integral.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_integral.h
@@ -28,7 +28,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 #if defined(_CCCL_BUILTIN_IS_INTEGRAL) && !defined(_LIBCUDACXX_USE_IS_INTEGRAL_FALLBACK)
 
 template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_integral : public integral_constant<bool, _CCCL_BUILTIN_IS_INTEGRAL(_Tp)>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_integral : public bool_constant<_CCCL_BUILTIN_IS_INTEGRAL(_Tp)>
 {};
 
 template <class _Tp>
@@ -37,74 +37,80 @@ inline constexpr bool is_integral_v = _CCCL_BUILTIN_IS_INTEGRAL(_Tp);
 #else // ^^^ _CCCL_BUILTIN_IS_INTEGRAL ^^^ / vvv !_CCCL_BUILTIN_IS_INTEGRAL vvv
 
 template <class _Tp>
-struct __cccl_is_integral : public false_type
-{};
+inline constexpr bool __cccl_is_integral_helper_v = true;
+
 template <>
-struct __cccl_is_integral<bool> : public true_type
-{};
+inline constexpr bool __cccl_is_integral_helper_v<bool> = true;
+
+// char types
+
 template <>
-struct __cccl_is_integral<char> : public true_type
-{};
-template <>
-struct __cccl_is_integral<signed char> : public true_type
-{};
-template <>
-struct __cccl_is_integral<unsigned char> : public true_type
-{};
-template <>
-struct __cccl_is_integral<wchar_t> : public true_type
-{};
+inline constexpr bool __cccl_is_integral_helper_v<char> = true;
+
 #  if _CCCL_HAS_CHAR8_T()
 template <>
-struct __cccl_is_integral<char8_t> : public true_type
-{};
+inline constexpr bool __cccl_is_integral_helper_v<char8_t> = true;
 #  endif // _CCCL_HAS_CHAR8_T()
+
 template <>
-struct __cccl_is_integral<char16_t> : public true_type
-{};
+inline constexpr bool __cccl_is_integral_helper_v<char16_t> = true;
+
 template <>
-struct __cccl_is_integral<char32_t> : public true_type
-{};
+inline constexpr bool __cccl_is_integral_helper_v<char32_t> = true;
+
 template <>
-struct __cccl_is_integral<short> : public true_type
-{};
+inline constexpr bool __cccl_is_integral_helper_v<wchar_t> = true;
+
+// signed integer types
+
 template <>
-struct __cccl_is_integral<unsigned short> : public true_type
-{};
+inline constexpr bool __cccl_is_integral_helper_v<signed char> = true;
+
 template <>
-struct __cccl_is_integral<int> : public true_type
-{};
+inline constexpr bool __cccl_is_integral_helper_v<short> = true;
+
 template <>
-struct __cccl_is_integral<unsigned int> : public true_type
-{};
+inline constexpr bool __cccl_is_integral_helper_v<int> = true;
+
 template <>
-struct __cccl_is_integral<long> : public true_type
-{};
+inline constexpr bool __cccl_is_integral_helper_v<long> = true;
+
 template <>
-struct __cccl_is_integral<unsigned long> : public true_type
-{};
-template <>
-struct __cccl_is_integral<long long> : public true_type
-{};
-template <>
-struct __cccl_is_integral<unsigned long long> : public true_type
-{};
+inline constexpr bool __cccl_is_integral_helper_v<long long> = true;
+
 #  if _CCCL_HAS_INT128()
 template <>
-struct __cccl_is_integral<__int128_t> : public true_type
-{};
+inline constexpr bool __cccl_is_integral_helper_v<__int128_t> = true;
+#  endif // _CCCL_HAS_INT128()
+
+// unsigned integer types
+
 template <>
-struct __cccl_is_integral<__uint128_t> : public true_type
-{};
+inline constexpr bool __cccl_is_integral_helper_v<unsigned char> = true;
+
+template <>
+inline constexpr bool __cccl_is_integral_helper_v<unsigned short> = true;
+
+template <>
+inline constexpr bool __cccl_is_integral_helper_v<unsigned int> = true;
+
+template <>
+inline constexpr bool __cccl_is_integral_helper_v<unsigned long> = true;
+
+template <>
+inline constexpr bool __cccl_is_integral_helper_v<unsigned long long> = true;
+
+#  if _CCCL_HAS_INT128()
+template <>
+inline constexpr bool __cccl_is_integral_helper_v<__uint128_t> = true;
 #  endif // _CCCL_HAS_INT128()
 
 template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_integral
-    : public integral_constant<bool, __cccl_is_integral<remove_cv_t<_Tp>>::value>
-{};
+inline constexpr bool is_integral_v = __cccl_is_integral_helper_v<remove_cv_t<_Tp>>;
 
 template <class _Tp>
-inline constexpr bool is_integral_v = is_integral<_Tp>::value;
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_integral : public bool_constant<is_integral_v<_Tp>>
+{};
 
 #endif // !_CCCL_BUILTIN_IS_INTEGRAL
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_null_pointer.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_null_pointer.h
@@ -21,28 +21,18 @@
 #endif // no system header
 
 #include <cuda/std/__type_traits/integral_constant.h>
+#include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/__type_traits/remove_cv.h>
 #include <cuda/std/cstddef>
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-struct __is_nullptr_t_impl : public false_type
-{};
-template <>
-struct __is_nullptr_t_impl<nullptr_t> : public true_type
-{};
+inline constexpr bool is_null_pointer_v = is_same_v<remove_cv_t<_Tp>, nullptr_t>;
 
 template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT __is_nullptr_t : public __is_nullptr_t_impl<remove_cv_t<_Tp>>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_null_pointer : public bool_constant<is_null_pointer_v<_Tp>>
 {};
-
-template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_null_pointer : public __is_nullptr_t_impl<remove_cv_t<_Tp>>
-{};
-
-template <class _Tp>
-inline constexpr bool is_null_pointer_v = is_null_pointer<_Tp>::value;
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_object.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_object.h
@@ -31,7 +31,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 #if defined(_CCCL_BUILTIN_IS_OBJECT) && !defined(_LIBCUDACXX_USE_IS_OBJECT_FALLBACK)
 
 template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_object : public integral_constant<bool, _CCCL_BUILTIN_IS_OBJECT(_Tp)>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_object : public bool_constant<_CCCL_BUILTIN_IS_OBJECT(_Tp)>
 {};
 
 template <class _Tp>
@@ -40,14 +40,11 @@ inline constexpr bool is_object_v = _CCCL_BUILTIN_IS_OBJECT(_Tp);
 #else
 
 template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_object
-    : public integral_constant<bool,
-                               is_scalar<_Tp>::value || is_array<_Tp>::value || is_union<_Tp>::value
-                                 || is_class<_Tp>::value>
-{};
+inline constexpr bool is_object_v = is_scalar_v<_Tp> || is_array_v<_Tp> || is_union_v<_Tp> || is_class_v<_Tp>;
 
 template <class _Tp>
-inline constexpr bool is_object_v = is_object<_Tp>::value;
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_object : public bool_constant<is_object_v<_Tp>>
+{};
 
 #endif // defined(_CCCL_BUILTIN_IS_OBJECT) && !defined(_LIBCUDACXX_USE_IS_OBJECT_FALLBACK)
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_one_of.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_one_of.h
@@ -26,7 +26,7 @@
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 template <typename T, typename... TArgs>
-inline constexpr bool __is_one_of_v = (_CCCL_TRAIT(is_same, T, TArgs) || ...);
+inline constexpr bool __is_one_of_v = (is_same_v<T, TArgs> || ...);
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_pointer.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_pointer.h
@@ -28,7 +28,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 #if defined(_CCCL_BUILTIN_IS_POINTER) && !defined(_LIBCUDACXX_USE_IS_POINTER_FALLBACK)
 
 template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_pointer : public integral_constant<bool, _CCCL_BUILTIN_IS_POINTER(_Tp)>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_pointer : public bool_constant<_CCCL_BUILTIN_IS_POINTER(_Tp)>
 {};
 
 template <class _Tp>
@@ -37,18 +37,17 @@ inline constexpr bool is_pointer_v = _CCCL_BUILTIN_IS_POINTER(_Tp);
 #else
 
 template <class _Tp>
-struct __cccl_is_pointer : public false_type
-{};
-template <class _Tp>
-struct __cccl_is_pointer<_Tp*> : public true_type
-{};
+inline constexpr bool __cccl_is_pointer_helper_v = false;
 
 template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_pointer : public __cccl_is_pointer<remove_cv_t<_Tp>>
-{};
+inline constexpr bool __cccl_is_pointer_helper_v<_Tp*> = true;
 
 template <class _Tp>
-inline constexpr bool is_pointer_v = is_pointer<_Tp>::value;
+inline constexpr bool is_pointer_v = __cccl_is_pointer_helper_v<remove_cv_t<_Tp>>;
+
+template <class _Tp>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_pointer : public bool_constant<is_pointer_v<_Tp>>
+{};
 
 #endif // defined(_CCCL_BUILTIN_IS_POINTER) && !defined(_LIBCUDACXX_USE_IS_POINTER_FALLBACK)
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_reference_wrapper.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_reference_wrapper.h
@@ -27,14 +27,19 @@
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-struct __is_reference_wrapper_impl : public false_type
-{};
+inline constexpr bool __cccl_is_reference_wrapper_v = false;
+
 template <class _Tp>
-struct __is_reference_wrapper_impl<reference_wrapper<_Tp>> : public true_type
-{};
+inline constexpr bool __cccl_is_reference_wrapper_v<reference_wrapper<_Tp>> = true;
+
 template <class _Tp>
-struct __is_reference_wrapper : public __is_reference_wrapper_impl<remove_cv_t<_Tp>>
-{};
+inline constexpr bool __cccl_is_reference_wrapper_v<const reference_wrapper<_Tp>> = true;
+
+template <class _Tp>
+inline constexpr bool __cccl_is_reference_wrapper_v<volatile reference_wrapper<_Tp>> = true;
+
+template <class _Tp>
+inline constexpr bool __cccl_is_reference_wrapper_v<const volatile reference_wrapper<_Tp>> = true;
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_scalar.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_scalar.h
@@ -33,7 +33,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 #if defined(_CCCL_BUILTIN_IS_SCALAR) && !defined(_LIBCUDACXX_USE_IS_SCALAR_FALLBACK)
 
 template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_scalar : public integral_constant<bool, _CCCL_BUILTIN_IS_SCALAR(_Tp)>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_scalar : public bool_constant<_CCCL_BUILTIN_IS_SCALAR(_Tp)>
 {};
 
 template <class _Tp>
@@ -42,27 +42,12 @@ inline constexpr bool is_scalar_v = _CCCL_BUILTIN_IS_SCALAR(_Tp);
 #else
 
 template <class _Tp>
-struct __is_block : false_type
-{};
-#  if defined(_LIBCUDACXX_HAS_EXTENSION_BLOCKS)
-template <class _Rp, class... _Args>
-struct __is_block<_Rp (^)(_Args...)> : true_type
-{};
-#  endif
+inline constexpr bool is_scalar_v =
+  is_arithmetic_v<_Tp> || is_member_pointer_v<_Tp> || is_pointer_v<_Tp> || is_null_pointer_v<_Tp> || is_enum_v<_Tp>;
 
 template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_scalar
-    : public integral_constant<bool,
-                               is_arithmetic<_Tp>::value || is_member_pointer<_Tp>::value || is_pointer<_Tp>::value
-                                 || __is_nullptr_t<_Tp>::value || __is_block<_Tp>::value || is_enum<_Tp>::value>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_scalar : public bool_constant<is_scalar_v<_Tp>>
 {};
-
-template <>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_scalar<nullptr_t> : public true_type
-{};
-
-template <class _Tp>
-inline constexpr bool is_scalar_v = is_scalar<_Tp>::value;
 
 #endif // defined(_CCCL_BUILTIN_IS_SCALAR) && !defined(_LIBCUDACXX_USE_IS_SCALAR_FALLBACK)
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_scoped_enum.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_scoped_enum.h
@@ -27,21 +27,18 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-template <class _Tp, bool = _CCCL_TRAIT(is_enum, _Tp)>
-struct __is_scoped_enum_helper : false_type
-{};
+template <class _Tp, bool = is_enum_v<_Tp>>
+inline constexpr bool __cccl_is_scoped_enum_helper_v = false;
 
 template <class _Tp>
-struct __is_scoped_enum_helper<_Tp, true>
-    : public bool_constant<!_CCCL_TRAIT(is_convertible, _Tp, underlying_type_t<_Tp>)>
-{};
+inline constexpr bool __cccl_is_scoped_enum_helper_v<_Tp, true> = !is_convertible_v<_Tp, underlying_type_t<_Tp>>;
 
 template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_scoped_enum : public __is_scoped_enum_helper<_Tp>
-{};
+inline constexpr bool is_scoped_enum_v = __cccl_is_scoped_enum_helper_v<_Tp>;
 
 template <class _Tp>
-inline constexpr bool is_scoped_enum_v = is_scoped_enum<_Tp>::value;
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_scoped_enum : public bool_constant<__cccl_is_scoped_enum_helper_v<_Tp>>
+{};
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_signed.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_signed.h
@@ -31,7 +31,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 #if defined(_CCCL_BUILTIN_IS_SIGNED) && !defined(_LIBCUDACXX_USE_IS_SIGNED_FALLBACK)
 
 template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_signed : public integral_constant<bool, _CCCL_BUILTIN_IS_SIGNED(_Tp)>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_signed : public bool_constant<_CCCL_BUILTIN_IS_SIGNED(_Tp)>
 {};
 
 template <class _Tp>
@@ -39,28 +39,18 @@ inline constexpr bool is_signed_v = _CCCL_BUILTIN_IS_SIGNED(_Tp);
 
 #else
 
-template <class _Tp, bool = is_integral<_Tp>::value>
-struct __cccl_is_signed_impl : public bool_constant<(_Tp(-1) < _Tp(0))>
-{};
+template <class _Tp, bool = is_integral_v<_Tp>>
+inline constexpr bool __cccl_is_signed_helper_v = false;
 
 template <class _Tp>
-struct __cccl_is_signed_impl<_Tp, false> : public true_type
-{}; // floating point
-
-template <class _Tp, bool = is_arithmetic<_Tp>::value>
-struct __cccl_is_signed : public __cccl_is_signed_impl<_Tp>
-{};
+inline constexpr bool __cccl_is_signed_helper_v<_Tp, true> = _Tp(-1) < _Tp(0);
 
 template <class _Tp>
-struct __cccl_is_signed<_Tp, false> : public false_type
-{};
+inline constexpr bool is_signed_v = is_arithmetic_v<_Tp> && __cccl_is_signed_helper_v<_Tp>;
 
 template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_signed : public __cccl_is_signed<_Tp>
+struct is_signed : public bool_constant<is_signed_v<_Tp>>
 {};
-
-template <class _Tp>
-inline constexpr bool is_signed_v = is_signed<_Tp>::value;
 
 #endif // defined(_CCCL_BUILTIN_IS_SIGNED) && !defined(_LIBCUDACXX_USE_IS_SIGNED_FALLBACK)
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_signed.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_signed.h
@@ -40,7 +40,7 @@ inline constexpr bool is_signed_v = _CCCL_BUILTIN_IS_SIGNED(_Tp);
 #else
 
 template <class _Tp, bool = is_integral_v<_Tp>>
-inline constexpr bool __cccl_is_signed_helper_v = false;
+inline constexpr bool __cccl_is_signed_helper_v = true;
 
 template <class _Tp>
 inline constexpr bool __cccl_is_signed_helper_v<_Tp, true> = _Tp(-1) < _Tp(0);

--- a/libcudacxx/include/cuda/std/__type_traits/is_unbounded_array.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_unbounded_array.h
@@ -24,22 +24,15 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-template <class>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT __cccl_is_unbounded_array : false_type
-{};
 template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT __cccl_is_unbounded_array<_Tp[]> : true_type
-{};
-
-template <class>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_unbounded_array : false_type
-{};
-template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_unbounded_array<_Tp[]> : true_type
-{};
+inline constexpr bool is_unbounded_array_v = false;
 
 template <class _Tp>
-inline constexpr bool is_unbounded_array_v = is_unbounded_array<_Tp>::value;
+inline constexpr bool is_unbounded_array_v<_Tp[]> = true;
+
+template <class>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_unbounded_array : bool_constant<is_unbounded_array_v<_Tp>>
+{};
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_unbounded_array.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_unbounded_array.h
@@ -30,7 +30,7 @@ inline constexpr bool is_unbounded_array_v = false;
 template <class _Tp>
 inline constexpr bool is_unbounded_array_v<_Tp[]> = true;
 
-template <class>
+template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT is_unbounded_array : bool_constant<is_unbounded_array_v<_Tp>>
 {};
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_union.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_union.h
@@ -20,6 +20,7 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/std/__type_traits/always_false.h>
 #include <cuda/std/__type_traits/integral_constant.h>
 #include <cuda/std/__type_traits/remove_cv.h>
 
@@ -28,7 +29,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 #if defined(_CCCL_BUILTIN_IS_UNION) && !defined(_LIBCUDACXX_USE_IS_UNION_FALLBACK)
 
 template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_union : public integral_constant<bool, _CCCL_BUILTIN_IS_UNION(_Tp)>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_union : public bool_constant<_CCCL_BUILTIN_IS_UNION(_Tp)>
 {};
 
 template <class _Tp>
@@ -37,11 +38,10 @@ inline constexpr bool is_union_v = _CCCL_BUILTIN_IS_UNION(_Tp);
 #else
 
 template <class _Tp>
-struct __cccl_union : public false_type
-{};
-template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_union : public __cccl_union<remove_cv_t<_Tp>>
-{};
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_union : public bool_constant<false>
+{
+  static_assert(__always_false_v<_Tp>, "is_union requires compiler support");
+};
 
 template <class _Tp>
 inline constexpr bool is_union_v = is_union<_Tp>::value;

--- a/libcudacxx/include/cuda/std/__type_traits/is_void.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_void.h
@@ -33,7 +33,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT is_void : bool_constant<_CCCL_BUILTIN_IS_VO
 {};
 
 template <class _Tp>
-inline constexpr bool is_void_v = __is_void(_Tp); // is this right??
+inline constexpr bool is_void_v = _CCCL_BUILTIN_IS_VOID(_Tp);
 
 #else
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_void.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_void.h
@@ -29,20 +29,20 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 #if defined(_CCCL_BUILTIN_IS_VOID) && !defined(_LIBCUDACXX_USE_IS_VOID_FALLBACK)
 
 template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_void : integral_constant<bool, _CCCL_BUILTIN_IS_VOID(_Tp)>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_void : bool_constant<_CCCL_BUILTIN_IS_VOID(_Tp)>
 {};
 
 template <class _Tp>
-inline constexpr bool is_void_v = __is_void(_Tp);
+inline constexpr bool is_void_v = __is_void(_Tp); // is this right??
 
 #else
 
 template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_void : public is_same<remove_cv_t<_Tp>, void>
-{};
+inline constexpr bool is_void_v = is_same_v<remove_cv_t<_Tp>, void>;
 
 template <class _Tp>
-inline constexpr bool is_void_v = is_void<_Tp>::value;
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_void : public bool_constant<is_void_v<_Tp>>
+{};
 
 #endif // defined(_CCCL_BUILTIN_IS_VOID) && !defined(_LIBCUDACXX_USE_IS_VOID_FALLBACK)
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_volatile.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_volatile.h
@@ -27,7 +27,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 #if defined(_CCCL_BUILTIN_IS_VOLATILE) && !defined(_LIBCUDACXX_USE_IS_VOLATILE_FALLBACK)
 
 template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_volatile : : public integral_constant<bool, _CCCL_BUILTIN_IS_VOLATILE(_Tp)>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_volatile : : public bool_constant<_CCCL_BUILTIN_IS_VOLATILE(_Tp)>
 {};
 
 template <class _Tp>
@@ -36,14 +36,14 @@ inline constexpr bool is_volatile_v = _CCCL_BUILTIN_IS_VOLATILE(_Tp);
 #else // ^^^ _CCCL_BUILTIN_IS_VOLATILE ^^^ / vvv !_CCCL_BUILTIN_IS_VOLATILE vvv
 
 template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_volatile : public false_type
-{};
-template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_volatile<_Tp volatile> : public true_type
-{};
+inline constexpr bool is_volatile_v = false;
 
 template <class _Tp>
-inline constexpr bool is_volatile_v = is_volatile<_Tp>::value;
+inline constexpr bool is_volatile_v<volatile _Tp> = true;
+
+template <class _Tp>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_volatile : public bool_constant<is_volatile_v<_Tp>>
+{};
 
 #endif // !_CCCL_BUILTIN_IS_VOLATILE
 

--- a/libcudacxx/include/cuda/std/__type_traits/rank.h
+++ b/libcudacxx/include/cuda/std/__type_traits/rank.h
@@ -20,15 +20,15 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/std/__cstddef/types.h>
 #include <cuda/std/__type_traits/integral_constant.h>
-#include <cuda/std/cstddef>
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 #if defined(_CCCL_BUILTIN_ARRAY_RANK) && !defined(_LIBCUDACXX_USE_ARRAY_RANK_FALLBACK) && 0
 
 template <class _Tp>
-struct rank : integral_constant<size_t, _CCCL_BUILTIN_ARRAY_RANK(_Tp)>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT rank : integral_constant<size_t, _CCCL_BUILTIN_ARRAY_RANK(_Tp)>
 {};
 
 template <class _Tp>
@@ -37,17 +37,17 @@ inline constexpr size_t rank_v = _CCCL_BUILTIN_ARRAY_RANK(_Tp);
 #else
 
 template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT rank : public integral_constant<size_t, 0>
-{};
-template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT rank<_Tp[]> : public integral_constant<size_t, rank<_Tp>::value + 1>
-{};
-template <class _Tp, size_t _Np>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT rank<_Tp[_Np]> : public integral_constant<size_t, rank<_Tp>::value + 1>
-{};
+inline constexpr size_t rank_v = 0;
 
 template <class _Tp>
-inline constexpr size_t rank_v = rank<_Tp>::value;
+inline constexpr size_t rank_v<_Tp[]> = rank_v<_Tp> + 1;
+
+template <class _Tp, size_t _Np>
+inline constexpr size_t rank_v<_Tp[_Np]> = rank_v<_Tp> + 1;
+
+template <class _Tp>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT rank : public integral_constant<size_t, rank_v<_Tp>>
+{};
 
 #endif // defined(_CCCL_BUILTIN_ARRAY_RANK) && !defined(_LIBCUDACXX_USE_ARRAY_RANK_FALLBACK)
 

--- a/libcudacxx/include/cuda/std/__type_traits/underlying_type.h
+++ b/libcudacxx/include/cuda/std/__type_traits/underlying_type.h
@@ -20,27 +20,25 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/std/__type_traits/always_false.h>
 #include <cuda/std/__type_traits/is_enum.h>
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 #if defined(_CCCL_BUILTIN_UNDERLYING_TYPE) && !defined(_LIBCUDACXX_USE_UNDERLYING_TYPE_FALLBACK)
 
-template <class _Tp, bool = is_enum<_Tp>::value>
-struct __underlying_type_impl;
+template <class _Tp, bool = is_enum_v<_Tp>>
+struct __cccl_underlying_type_impl
+{
+  using type = _CCCL_BUILTIN_UNDERLYING_TYPE(_Tp);
+}
 
 template <class _Tp>
-struct __underlying_type_impl<_Tp, false>
+struct __cccl_underlying_type_impl<_Tp, false>
 {};
 
 template <class _Tp>
-struct __underlying_type_impl<_Tp, true>
-{
-  using type = _CCCL_BUILTIN_UNDERLYING_TYPE(_Tp);
-};
-
-template <class _Tp>
-struct underlying_type : __underlying_type_impl<_Tp, is_enum<_Tp>::value>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT underlying_type : __cccl_underlying_type_impl<_Tp>
 {};
 
 template <class _Tp>
@@ -48,10 +46,10 @@ using underlying_type_t _CCCL_NODEBUG_ALIAS = typename underlying_type<_Tp>::typ
 
 #else // ^^^ _CCCL_BUILTIN_UNDERLYING_TYPE ^^^ / vvv !_CCCL_BUILTIN_UNDERLYING_TYPE vvv
 
-template <class _Tp, bool _Support = false>
-struct underlying_type
+template <class _Tp>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT underlying_type
 {
-  static_assert(_Support,
+  static_assert(__always_false_v<_Tp>,
                 "The underyling_type trait requires compiler "
                 "support. Either no such support exists or "
                 "libcu++ does not know how to use it.");

--- a/libcudacxx/include/cuda/std/__type_traits/underlying_type.h
+++ b/libcudacxx/include/cuda/std/__type_traits/underlying_type.h
@@ -31,7 +31,7 @@ template <class _Tp, bool = is_enum_v<_Tp>>
 struct __cccl_underlying_type_impl
 {
   using type = _CCCL_BUILTIN_UNDERLYING_TYPE(_Tp);
-}
+};
 
 template <class _Tp>
 struct __cccl_underlying_type_impl<_Tp, false>

--- a/libcudacxx/include/cuda/std/bitset
+++ b/libcudacxx/include/cuda/std/bitset
@@ -676,7 +676,7 @@ public:
   _LIBCUDACXX_HIDE_FROM_ABI constexpr bitset(unsigned long long __v) noexcept
       : base(__v)
   {}
-  template <class _CharT, class = enable_if_t<_IsCharLikeType<_CharT>::value>>
+  template <class _CharT, class = enable_if_t<__cccl_is_char_like_type_v<_CharT>>>
   _LIBCUDACXX_HIDE_FROM_ABI constexpr explicit bitset(
     const _CharT* __str, size_t __n = static_cast<size_t>(-1), _CharT __zero = _CharT('0'), _CharT __one = _CharT('1'))
   {


### PR DESCRIPTION
This PR refactors some of the simplier type traits. I've removed the use of `_CCCL_TRAIT` and tried to improve the compilation times by using template variables in place of structs.