### PR TITLE
replace the simplistic eager customization mechanism with proper apply/transform_sender

### DIFF
--- a/cudax/include/cuda/experimental/__execution/apply_sender.cuh
+++ b/cudax/include/cuda/experimental/__execution/apply_sender.cuh
@@ -1,0 +1,84 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __CUDAX_EXECUTION_APPLY_SENDER
+#define __CUDAX_EXECUTION_APPLY_SENDER
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__type_traits/conditional.h>
+#include <cuda/std/__type_traits/is_valid_expansion.h>
+
+#include <cuda/experimental/__detail/utility.cuh>
+#include <cuda/experimental/__execution/domain.cuh>
+
+#include <cuda/experimental/__execution/prologue.cuh>
+
+namespace cuda::experimental::execution
+{
+//! A callable object that implements the `std::execution::apply_sender` functionality.
+//! This is used to apply a sender to a domain, tag, and arguments, as specified in the
+//! C++ standard draft. The implementation ensures compatibility with CUDA C++ Core
+//! Libraries.
+//! @see https://eel.is/c++draft/exec.snd.apply
+struct _CCCL_TYPE_VISIBILITY_DEFAULT apply_sender_t
+{
+private:
+  //! A type alias that determines the domain to apply the sender to. If the expansion of
+  //! `__apply_sender_result_t` is valid for the given domain and arguments, the domain is
+  //! used; otherwise, the `default_domain` is used.
+  //! @tparam _Domain The domain to check.
+  //! @tparam _Args The arguments to validate against the domain.
+  template <class _Domain, class... _Args>
+  using __apply_domain_t _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::
+    _If<_CUDA_VSTD::_IsValidExpansion<__apply_sender_result_t, _Domain, _Args...>::value, _Domain, default_domain>;
+
+public:
+  //! Applies a sender to a domain, tag, and arguments.
+  //! @tparam _Domain The domain used to select the algorithm implementation.
+  //! @tparam _Tag The tag associated with the algorithm.
+  //! @tparam _Sndr The sender to be applied.
+  //! @tparam _Args The arguments to pass to the algorithm.
+  //! @param __sndr The sender object.
+  //! @param __args The arguments to pass to the algorithm.
+  //! @return `DOM().apply_sender(_Tag(), __sndr, __args...)`, where `DOM` is the first of
+  //! [`_Domain`, `default_domain`] to make the expression well-formed.
+  //! @note This function is `constexpr` and `noexcept` if the underlying domain's
+  //! `apply_sender` is `noexcept`.
+  //! @throws Any exception thrown by the underlying domain's `apply_sender`.
+  template <class _Domain, class _Tag, class _Sndr, class... _Args>
+  _CCCL_TRIVIAL_API constexpr auto operator()(_Domain, _Tag, _Sndr&& __sndr, _Args&&... __args) const
+    noexcept(noexcept(__apply_domain_t<_Domain, _Tag, _Sndr, _Args...>{}.apply_sender(
+      _Tag{}, static_cast<_Sndr&&>(__sndr), static_cast<_Args&&>(__args)...)))
+      -> __apply_sender_result_t<__apply_domain_t<_Domain, _Tag, _Sndr, _Args...>, _Tag, _Sndr, _Args...>
+  {
+    using __dom_t _CCCL_NODEBUG_ALIAS = __apply_domain_t<_Domain, _Tag, _Sndr, _Args...>;
+    //! Calls the algorithm specified by _Tag using the determined domain.
+    return __dom_t{}.apply_sender(_Tag{}, static_cast<_Sndr&&>(__sndr), static_cast<_Args&&>(__args)...);
+  }
+};
+
+//! A global constant instance of `apply_sender_t`.
+//! This can be used directly to invoke the `apply_sender` functionality.
+_CCCL_GLOBAL_CONSTANT apply_sender_t apply_sender{};
+
+} // namespace cuda::experimental::execution
+
+#include <cuda/experimental/__execution/epilogue.cuh>
+
+#endif // __CUDAX_EXECUTION_APPLY_SENDER

--- a/cudax/include/cuda/experimental/__execution/completion_signatures.cuh
+++ b/cudax/include/cuda/experimental/__execution/completion_signatures.cuh
@@ -34,10 +34,9 @@
 #include <cuda/experimental/__detail/utility.cuh>
 #include <cuda/experimental/__execution/cpos.cuh>
 #include <cuda/experimental/__execution/exception.cuh>
+#include <cuda/experimental/__execution/transform_sender.cuh>
 #include <cuda/experimental/__execution/type_traits.cuh>
 #include <cuda/experimental/__execution/utility.cuh>
-
-#include <nv/target>
 
 // include this last:
 #include <cuda/experimental/__execution/prologue.cuh>
@@ -446,12 +445,15 @@ _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto get_completion_signatures()
   {
     return __get_completion_signatures_helper<_Sndr>();
   }
+  else if constexpr (!__has_sender_transform<_Sndr, _Env...>)
+  {
+    return __get_completion_signatures_helper<_Sndr, _Env...>();
+  }
   else
   {
-    // BUGBUG TODO:
     // Apply a lazy sender transform if one exists before computing the completion signatures:
-    // using _NewSndr _CCCL_NODEBUG_ALIAS = __transform_sender_result_t<__late_domain_of_t<_Sndr, _Env>, _Sndr, _Env>;
-    using _NewSndr _CCCL_NODEBUG_ALIAS = _Sndr;
+    using _NewSndr _CCCL_NODEBUG_ALIAS =
+      _CUDA_VSTD::__call_result_t<transform_sender_t, domain_for_t<_Sndr, _Env...>, _Sndr, _Env...>;
     return __get_completion_signatures_helper<_NewSndr, _Env...>();
   }
 }

--- a/cudax/include/cuda/experimental/__execution/continues_on.cuh
+++ b/cudax/include/cuda/experimental/__execution/continues_on.cuh
@@ -32,6 +32,7 @@
 #include <cuda/experimental/__execution/meta.cuh>
 #include <cuda/experimental/__execution/queries.cuh>
 #include <cuda/experimental/__execution/rcvr_ref.cuh>
+#include <cuda/experimental/__execution/transform_sender.cuh>
 #include <cuda/experimental/__execution/utility.cuh>
 #include <cuda/experimental/__execution/variant.cuh>
 #include <cuda/experimental/__execution/visit.cuh>
@@ -169,18 +170,7 @@ private:
     connect_result_t<schedule_result_t<_Sch>, __rcvr_ref<__rcvr_t<_Rcvr, __result_t>>> __opstate2_;
   };
 
-  struct _CCCL_TYPE_VISIBILITY_DEFAULT __fn
-  {
-    template <class _Sch, class _Sndr>
-    _CCCL_TRIVIAL_API constexpr auto operator()(_Sch __sch, _Sndr __sndr) const;
-  };
-
 public:
-  _CCCL_API static constexpr auto __apply() noexcept
-  {
-    return __fn{};
-  }
-
   template <class _Sndr, class _Sch>
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __sndr_t;
 
@@ -291,17 +281,11 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT continues_on_t::__sndr_t
   }
 };
 
-template <class _Sch, class _Sndr>
-_CCCL_TRIVIAL_API constexpr auto continues_on_t::__fn::operator()(_Sch __sch, _Sndr __sndr) const
-{
-  return __sndr_t<_Sndr, _Sch>{{}, __sch, static_cast<_Sndr&&>(__sndr)};
-}
-
 template <class _Sndr, class _Sch>
 _CCCL_TRIVIAL_API constexpr auto continues_on_t::operator()(_Sndr __sndr, _Sch __sch) const
 {
-  using __dom_t _CCCL_NODEBUG_ALIAS = early_domain_of_t<_Sndr>;
-  return __dom_t::__apply(*this)(static_cast<_Sch&&>(__sch), static_cast<_Sndr&&>(__sndr));
+  using __dom_t _CCCL_NODEBUG_ALIAS = domain_for_t<_Sndr>;
+  return transform_sender(__dom_t{}, __sndr_t<_Sndr, _Sch>{{}, __sch, static_cast<_Sndr&&>(__sndr)});
 }
 
 template <class _Sch>

--- a/cudax/include/cuda/experimental/__execution/domain.cuh
+++ b/cudax/include/cuda/experimental/__execution/domain.cuh
@@ -21,17 +21,123 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/std/__execution/env.h>
+
+#include <cuda/experimental/__detail/utility.cuh>
 #include <cuda/experimental/__execution/fwd.cuh>
 
 #include <cuda/experimental/__execution/prologue.cuh>
 
 namespace cuda::experimental::execution
 {
-template <class _Tag>
-_CCCL_API constexpr auto default_domain::__apply(_Tag) noexcept
+using _CUDA_STD_EXEC::__query_result_t;
+using _CUDA_STD_EXEC::__queryable_with;
+using _CUDA_STD_EXEC::env_of_t;
+
+template <class _DomainOrTag, class... _Args>
+using __apply_sender_result_t _CCCL_NODEBUG_ALIAS = decltype(_DomainOrTag{}.apply_sender(declval<_Args>()...));
+
+template <class _DomainOrTag, class _Sndr, class... _Env>
+using __transform_sender_result_t =
+  decltype(_DomainOrTag{}.transform_sender(declval<_Sndr>(), declval<const _Env&>()...));
+
+//! @brief A structure that selects the default set of algorithm implementations for
+//! senders.
+//!
+//! This structure defines static member functions to handle operations on senders, such
+//! as applying and transforming them. It is designed to work with CUDA's experimental
+//! execution framework.
+//! @see https://eel.is/c++draft/exec.domain.default
+struct _CCCL_TYPE_VISIBILITY_DEFAULT default_domain
 {
-  return _Tag::__apply();
+  //! @brief Applies a sender operation using the specified tag and arguments.
+  //!
+  //! @tparam _Tag The tag type that defines the operation to be applied.
+  //! @tparam _Sndr The type of the sender.
+  //! @tparam _Args Variadic template for additional arguments.
+  //! @param _Tag The tag instance specifying the operation.
+  //! @param __sndr The sender to which the operation is applied.
+  //! @param __args Additional arguments for the operation.
+  //! @return The result of applying the sender operation.
+  template <class _Tag, class _Sndr, class... _Args>
+  _CCCL_TRIVIAL_API static constexpr auto apply_sender(_Tag, _Sndr&& __sndr, _Args&&... __args) noexcept(noexcept(
+    _Tag{}.apply_sender(declval<_Sndr>(), declval<_Args>()...))) -> __apply_sender_result_t<_Tag, _Sndr, _Args...>
+  {
+    return _Tag{}.apply_sender(static_cast<_Sndr&&>(__sndr), static_cast<_Args&&>(__args)...);
+  }
+
+  //! @brief Transforms a sender with an optional environment.
+  //!
+  //! @tparam _Sndr The type of the sender.
+  //! @tparam _Env The type of the environment.
+  //! @param __sndr The sender to be transformed.
+  //! @param __env The environment used for the transformation.
+  //! @return The result of transforming the sender with the given environment.
+  template <class _Sndr, class _Env>
+  _CCCL_TRIVIAL_API static constexpr auto transform_sender(_Sndr&& __sndr, const _Env& __env) noexcept(
+    noexcept(tag_of_t<_Sndr>{}.transform_sender(static_cast<_Sndr&&>(__sndr), __env)))
+    -> __transform_sender_result_t<tag_of_t<_Sndr>, _Sndr, _Env>
+  {
+    return tag_of_t<_Sndr>{}.transform_sender(static_cast<_Sndr&&>(__sndr), __env);
+  }
+
+  //! @overload
+  template <class _Sndr>
+  _CCCL_TRIVIAL_API static constexpr auto transform_sender(_Sndr&& __sndr) noexcept -> _Sndr&&
+  {
+    // FUTURE TODO: add a transform for the split sender once we have a split sender
+    return static_cast<_Sndr&&>(__sndr);
+  }
+
+  //! @overload
+  template <class _Sndr>
+  _CCCL_TRIVIAL_API static constexpr auto transform_sender(_Sndr&& __sndr, _CUDA_VSTD::__ignore_t) noexcept -> _Sndr&&
+  {
+    return static_cast<_Sndr&&>(__sndr);
+  }
+};
+
+namespace __detail
+{
+// This function is used to determine the domain associated with a sender and
+// (optionally), an environment. It uses clues from the sender and environment to deduce
+// where the sender will execute (on what scheduler), and what the domain of that
+// scheduler is. It proceeds as follows:
+// 1. If the sender attributes has a domain, return it.
+// 2. Otherwise, if the sender has a completion scheduler, return its domain if any.
+// 3. Otherwise, if an environment is provided:
+//   - If the environment has a domain, return it.
+//   - If the environment has a scheduler, return its domain if any.
+// 4. Otherwise, return the default domain.
+template <class _GetScheduler, class _Env1, class _Env2 = _CUDA_STD_EXEC::prop<get_domain_t, default_domain>>
+_CCCL_TRIVIAL_API constexpr auto __domain_for() noexcept
+{
+  if constexpr (__queryable_with<_Env1, get_domain_t>)
+  {
+    return __query_result_t<_Env1, get_domain_t>{};
+  }
+  else if constexpr (__queryable_with<_Env1, _GetScheduler>)
+  {
+    if constexpr (__queryable_with<__query_result_t<_Env1, _GetScheduler>, get_domain_t>)
+    {
+      return __query_result_t<__query_result_t<_Env1, _GetScheduler>, get_domain_t>{};
+    }
+    else
+    {
+      return __domain_for<get_scheduler_t, _Env2>();
+    }
+  }
+  else
+  {
+    return __domain_for<get_scheduler_t, _Env2>();
+  }
 }
+} // namespace __detail
+
+template <class _Sndr, class... _Env>
+using domain_for_t _CCCL_NODEBUG_ALIAS =
+  decltype(__detail::__domain_for<get_completion_scheduler_t<set_value_t>, env_of_t<_Sndr>, _Env...>());
+
 } // namespace cuda::experimental::execution
 
 #include <cuda/experimental/__execution/epilogue.cuh>

--- a/cudax/include/cuda/experimental/__execution/env.cuh
+++ b/cudax/include/cuda/experimental/__execution/env.cuh
@@ -26,7 +26,6 @@
 #include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/__utility/move.h>
 
-#include <cuda/experimental/__execution/cpos.cuh>
 #include <cuda/experimental/__execution/policy.cuh>
 #include <cuda/experimental/__execution/queries.cuh>
 #include <cuda/experimental/__memory_resource/any_resource.cuh>
@@ -49,34 +48,6 @@ using _CUDA_STD_EXEC::prop;
 using _CUDA_STD_EXEC::__nothrow_queryable_with;
 using _CUDA_STD_EXEC::__query_result_t;
 using _CUDA_STD_EXEC::__queryable_with;
-
-struct __not_a_scheduler
-{
-  using scheduler_concept _CCCL_NODEBUG_ALIAS = scheduler_t;
-};
-
-using __no_completion_scheduler_t _CCCL_NODEBUG_ALIAS =
-  prop<get_completion_scheduler_t<set_value_t>, __not_a_scheduler>;
-using __no_scheduler_t = prop<get_scheduler_t, __not_a_scheduler>;
-
-// First look in the sender's environment for a domain. If none is found, look
-// in the sender's (value) completion scheduler, if any.
-template <class _Sndr>
-using __early_domain_env _CCCL_NODEBUG_ALIAS =
-  env<env_of_t<_Sndr>, __completion_scheduler_of_t<env<env_of_t<_Sndr>, __no_completion_scheduler_t>>>;
-
-template <class _Sndr>
-using early_domain_of_t _CCCL_NODEBUG_ALIAS = __domain_of_t<__early_domain_env<_Sndr>>;
-
-// First look in the sender's environment for a domain. If none is found, look
-// in the sender's (value) completion scheduler, if any. Then look in _Env for a
-// domain. If none is found, look in the environment's scheduler, if any.
-template <class _Sndr, class _Env>
-using __late_domain_env _CCCL_NODEBUG_ALIAS =
-  env<__early_domain_env<_Sndr>, env<_Env, __scheduler_of_t<env<_Env, __no_scheduler_t>>>>;
-
-template <class _Sndr, class _Env>
-using late_domain_of_t _CCCL_NODEBUG_ALIAS = __domain_of_t<__late_domain_env<_Sndr, _Env>>;
 } // namespace execution
 
 template <class... _Properties>

--- a/cudax/include/cuda/experimental/__execution/fwd.cuh
+++ b/cudax/include/cuda/experimental/__execution/fwd.cuh
@@ -21,10 +21,13 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/std/__tuple_dir/ignore.h>
 #include <cuda/std/__type_traits/remove_reference.h>
 #include <cuda/std/__type_traits/type_list.h>
 
+#include <cuda/experimental/__detail/utility.cuh>
 #include <cuda/experimental/__execution/meta.cuh>
+#include <cuda/experimental/__execution/visit.cuh>
 
 #include <cuda/experimental/__execution/prologue.cuh>
 
@@ -63,11 +66,7 @@ inline constexpr bool __is_scheduler = __type_valid_v<__scheduler_concept_t, _Ty
 struct stream_domain;
 struct dependent_sender_error;
 
-struct default_domain
-{
-  template <class _Tag>
-  _CCCL_API static constexpr auto __apply(_Tag) noexcept;
-};
+struct default_domain;
 
 template <class... _Sigs>
 struct completion_signatures;
@@ -92,8 +91,34 @@ struct set_stopped_t;
 struct start_t;
 struct connect_t;
 struct schedule_t;
-struct get_env_t;
 struct sync_wait_t;
+struct start_detached_t;
+
+struct get_allocator_t;
+struct get_stop_token_t;
+struct get_scheduler_t;
+struct get_delegation_scheduler_t;
+template <class _Tag>
+struct get_completion_scheduler_t;
+struct get_forward_progress_guarantee_t;
+struct get_domain_t;
+
+namespace __detail
+{
+struct __get_tag
+{
+  template <class _Tag, class... _Child>
+  _CCCL_TRIVIAL_API constexpr auto operator()(_CUDA_VSTD::__ignore_t, _Tag, _CUDA_VSTD::__ignore_t, _Child&&...) const
+    -> _Tag
+  {
+    return _Tag{};
+  }
+};
+} // namespace __detail
+
+template <class _Sndr>
+using tag_of_t _CCCL_NODEBUG_ALIAS =
+  decltype(visit(declval<__detail::__get_tag&>(), declval<_Sndr>(), declval<int&>()));
 
 namespace __detail
 {

--- a/cudax/include/cuda/experimental/__execution/rcvr_with_env.cuh
+++ b/cudax/include/cuda/experimental/__execution/rcvr_with_env.cuh
@@ -54,7 +54,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __rcvr_with_env_t : _Rcvr
       noexcept(__nothrow_queryable_with<__1st_env_t<_Query>, _Query>) //
       -> __query_result_t<__1st_env_t<_Query>, _Query>
     {
-      return __env_t::__get_1st<_Query>(*this);
+      return __env_t::__get_1st<_Query>(*this).query(_Query{});
     }
 
     __rcvr_with_env_t const* __rcvr_;

--- a/cudax/include/cuda/experimental/__execution/sequence.cuh
+++ b/cudax/include/cuda/experimental/__execution/sequence.cuh
@@ -29,6 +29,7 @@
 #include <cuda/experimental/__execution/exception.cuh>
 #include <cuda/experimental/__execution/lazy.cuh>
 #include <cuda/experimental/__execution/rcvr_ref.cuh>
+#include <cuda/experimental/__execution/transform_sender.cuh>
 #include <cuda/experimental/__execution/utility.cuh>
 #include <cuda/experimental/__execution/variant.cuh>
 #include <cuda/experimental/__execution/visit.cuh>
@@ -99,18 +100,7 @@ private:
     connect_result_t<__sndr2_t, __rcvr_ref<__rcvr_t>> __opstate2_;
   };
 
-  struct __fn
-  {
-    template <class _Sndr1, class _Sndr2>
-    _CCCL_TRIVIAL_API constexpr auto operator()(__ignore, _Sndr1 __sndr1, _Sndr2 __sndr2) const;
-  };
-
 public:
-  _CCCL_API static constexpr auto __apply() noexcept
-  {
-    return __fn{};
-  }
-
   template <class _Sndr1, class _Sndr2>
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __sndr_t;
 
@@ -166,17 +156,11 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __seq_t::__sndr_t
 };
 
 template <class _Sndr1, class _Sndr2>
-_CCCL_TRIVIAL_API constexpr auto __seq_t::__fn::operator()(__ignore, _Sndr1 __sndr1, _Sndr2 __sndr2) const
-{
-  using __sndr_t _CCCL_NODEBUG_ALIAS = __seq_t::__sndr_t<_Sndr1, _Sndr2>;
-  return __sndr_t{{}, {}, static_cast<_Sndr1&&>(__sndr1), static_cast<_Sndr2&&>(__sndr2)};
-}
-
-template <class _Sndr1, class _Sndr2>
 _CCCL_TRIVIAL_API constexpr auto __seq_t::operator()(_Sndr1 __sndr1, _Sndr2 __sndr2) const
 {
-  using __dom_t _CCCL_NODEBUG_ALIAS = early_domain_of_t<_Sndr1>;
-  return __dom_t::__apply(*this)(__ignore{}, static_cast<_Sndr1&&>(__sndr1), static_cast<_Sndr2&&>(__sndr2));
+  using __dom_t _CCCL_NODEBUG_ALIAS  = domain_for_t<_Sndr1>;
+  using __sndr_t _CCCL_NODEBUG_ALIAS = __seq_t::__sndr_t<_Sndr1, _Sndr2>;
+  return transform_sender(__dom_t{}, __sndr_t{{}, {}, static_cast<_Sndr1&&>(__sndr1), static_cast<_Sndr2&&>(__sndr2)});
 }
 
 template <class _Sndr1, class _Sndr2>

--- a/cudax/include/cuda/experimental/__execution/starts_on.cuh
+++ b/cudax/include/cuda/experimental/__execution/starts_on.cuh
@@ -85,18 +85,7 @@ private:
     connect_result_t<_CvSndr, __rcvr_ref<__rcvr_with_sch_t>> __opstate2_;
   };
 
-  struct _CCCL_TYPE_VISIBILITY_DEFAULT __fn
-  {
-    template <class _Sch, class _Sndr>
-    _CCCL_TRIVIAL_API constexpr auto operator()(_Sch __sch, _Sndr __sndr) const;
-  };
-
 public:
-  _CCCL_API static constexpr auto __apply() noexcept
-  {
-    return __fn{};
-  }
-
   template <class _Sch, class _Sndr>
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __sndr_t;
 
@@ -152,16 +141,11 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT starts_on_t::__sndr_t
 };
 
 template <class _Sch, class _Sndr>
-_CCCL_TRIVIAL_API constexpr auto starts_on_t::__fn::operator()(_Sch __sch, _Sndr __sndr) const
-{
-  return __sndr_t<_Sch, _Sndr>{{}, __sch, __sndr};
-}
-
-template <class _Sch, class _Sndr>
 _CCCL_TRIVIAL_API constexpr auto starts_on_t::operator()(_Sch __sch, _Sndr __sndr) const
 {
-  using __dom_t _CCCL_NODEBUG_ALIAS = __domain_of_t<_Sch>; // see [exec.starts.on]
-  return __dom_t::__apply(*this)(static_cast<_Sch&&>(__sch), static_cast<_Sndr&&>(__sndr));
+  using __dom_t _CCCL_NODEBUG_ALIAS  = __domain_of_t<_Sch>; // see [exec.starts.on]
+  using __sndr_t _CCCL_NODEBUG_ALIAS = starts_on_t::__sndr_t<_Sch, _Sndr>;
+  return transform_sender(__dom_t{}, __sndr_t{{}, static_cast<_Sch&&>(__sch), static_cast<_Sndr&&>(__sndr)});
 }
 
 template <class _Sch, class _Sndr>

--- a/cudax/include/cuda/experimental/__execution/transform_sender.cuh
+++ b/cudax/include/cuda/experimental/__execution/transform_sender.cuh
@@ -1,0 +1,128 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __CUDAX_EXECUTION_TRANSFORM_SENDER
+#define __CUDAX_EXECUTION_TRANSFORM_SENDER
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__type_traits/conditional.h>
+#include <cuda/std/__type_traits/is_valid_expansion.h>
+
+#include <cuda/experimental/__detail/utility.cuh>
+#include <cuda/experimental/__execution/domain.cuh>
+#include <cuda/experimental/__execution/env.cuh>
+
+#include <cuda/experimental/__execution/prologue.cuh>
+
+namespace cuda::experimental::execution
+{
+struct _CCCL_TYPE_VISIBILITY_DEFAULT transform_sender_t
+{
+  template <class _Domain, class _Sndr, class... _Env>
+  using __transform_domain_t =
+    _CUDA_VSTD::_If<_CUDA_VSTD::_IsValidExpansion<__transform_sender_result_t, _Domain, _Sndr, _Env...>::value,
+                    _Domain,
+                    default_domain>;
+
+  enum class __strategy
+  {
+    __passthru,
+    __transform,
+    __transform_recurse
+  };
+
+  struct __transform_strategy_t
+  {
+    bool __nothrow_;
+    __strategy __strategy_;
+  };
+
+  template <class _Self, class _Domain, class _Sndr, class... _Env>
+  _CCCL_TRIVIAL_API static constexpr auto __get_transform_strategy() noexcept -> __transform_strategy_t
+  {
+    using __dom_t _CCCL_NODEBUG_ALIAS    = __transform_domain_t<_Domain, _Sndr, _Env...>;
+    using __result_t _CCCL_NODEBUG_ALIAS = __transform_sender_result_t<__dom_t, _Sndr, _Env...>;
+
+    if constexpr (_CUDA_VSTD::_IsSame<__result_t&&, _Sndr&&>::value)
+    {
+      return __transform_strategy_t{true, __strategy::__passthru};
+    }
+    else
+    {
+      using __dom2_t _CCCL_NODEBUG_ALIAS = __transform_domain_t<domain_for_t<__result_t, _Env...>, __result_t, _Env...>;
+      using __result2_t _CCCL_NODEBUG_ALIAS = __transform_sender_result_t<__dom2_t, _Sndr, _Env...>;
+
+      if constexpr (_CUDA_VSTD::_IsSame<__result2_t&&, __result_t&&>::value)
+      {
+        constexpr bool __nothrow_ = noexcept(__dom_t{}.transform_sender(declval<_Sndr>(), declval<const _Env&>()...));
+        return __transform_strategy_t{__nothrow_, __strategy::__transform};
+      }
+      else
+      {
+        constexpr bool __nothrow_ = noexcept(
+          _Self{}(__dom2_t{},
+                  __dom_t{}.transform_sender(declval<_Sndr>(), declval<const _Env&>()...),
+                  declval<const _Env&>()...));
+        return __transform_strategy_t{__nothrow_, __strategy::__transform_recurse};
+      }
+    }
+  }
+
+  _CCCL_TEMPLATE(class _Self = transform_sender_t, class _Domain, class _Sndr, class... _Env)
+  _CCCL_REQUIRES((__get_transform_strategy<_Self, _Domain, _Sndr, _Env...>().__strategy_ == __strategy::__passthru))
+  _CCCL_TRIVIAL_API constexpr auto operator()(_Domain, _Sndr&& __sndr, const _Env&...) const noexcept -> _Sndr&&
+  {
+    return static_cast<_Sndr&&>(__sndr);
+  }
+
+  _CCCL_TEMPLATE(class _Self = transform_sender_t, class _Domain, class _Sndr, class... _Env)
+  _CCCL_REQUIRES((__get_transform_strategy<_Self, _Domain, _Sndr, _Env...>().__strategy_ == __strategy::__transform))
+  _CCCL_TRIVIAL_API constexpr auto operator()(_Domain, _Sndr&& __sndr, const _Env&... __env) const
+    noexcept(__get_transform_strategy<_Self, _Domain, _Sndr, _Env...>().__nothrow_) -> decltype(auto)
+  {
+    using __dom_t _CCCL_NODEBUG_ALIAS = __transform_domain_t<_Domain, _Sndr, _Env...>;
+    return __dom_t{}.transform_sender(static_cast<_Sndr&&>(__sndr), __env...);
+  }
+
+  _CCCL_TEMPLATE(class _Self = transform_sender_t, class _Domain, class _Sndr, class... _Env)
+  _CCCL_REQUIRES((__get_transform_strategy<_Self, _Domain, _Sndr, _Env...>().__strategy_
+                  == __strategy::__transform_recurse))
+  _CCCL_TRIVIAL_API constexpr auto operator()(_Domain, _Sndr&& __sndr, const _Env&... __env) const
+    noexcept(__get_transform_strategy<_Self, _Domain, _Sndr, _Env...>().__nothrow_) -> decltype(auto)
+  {
+    using __dom1_t _CCCL_NODEBUG_ALIAS    = __transform_domain_t<_Domain, _Sndr, _Env...>;
+    using __result1_t _CCCL_NODEBUG_ALIAS = __transform_sender_result_t<__dom1_t, _Sndr, _Env...>;
+    using __dom2_t _CCCL_NODEBUG_ALIAS    = __transform_domain_t<domain_for_t<__result1_t>, __result1_t, _Env...>;
+    return (*this)(__dom2_t{}, __dom1_t{}.transform_sender(static_cast<_Sndr&&>(__sndr), __env...), __env...);
+  }
+};
+
+_CCCL_GLOBAL_CONSTANT transform_sender_t transform_sender{};
+
+template <class _Sndr, class... _Env>
+_CCCL_CONCEPT __has_sender_transform =
+  transform_sender_t::__get_transform_strategy<transform_sender_t, domain_for_t<_Sndr, _Env...>, _Sndr, _Env...>()
+    .__strategy_
+  != transform_sender_t::__strategy::__passthru;
+
+} // namespace cuda::experimental::execution
+
+#include <cuda/experimental/__execution/epilogue.cuh>
+
+#endif // __CUDAX_EXECUTION_TRANSFORM_SENDER

--- a/cudax/include/cuda/experimental/__execution/visit.cuh
+++ b/cudax/include/cuda/experimental/__execution/visit.cuh
@@ -27,12 +27,50 @@
 
 #include <cuda/experimental/__execution/prologue.cuh>
 
+#define _CCCL_BIND_CHILD(_Ord) , _CCCL_PP_CAT(__child, _Ord)
+#define _CCCL_FWD_CHILD(_Ord)  , _CCCL_FWD_LIKE(_Sndr, _CCCL_PP_CAT(__child, _Ord))
+#define _CCCL_FWD_LIKE(_X, _Y) static_cast<_CUDA_VSTD::__copy_cvref_t<_X&&, decltype(_Y)>>(_Y)
+
 namespace cuda::experimental::execution
 {
+#if _CCCL_HAS_BUILTIN(__builtin_structured_binding_size)
+
+template <class _Sndr>
+inline constexpr size_t structured_binding_size = __builtin_structured_binding_size(_Sndr);
+
+#else // ^^^ _CCCL_HAS_BUILTIN(__builtin_structured_binding_size) ^^^ /
+      // vvv !_CCCL_HAS_BUILTIN(__builtin_structured_binding_size) vvv
 
 // Specialize this for each sender type that can be used to initialize a structured binding.
 template <class _Sndr>
 inline constexpr size_t structured_binding_size = static_cast<size_t>(-1);
+
+#endif // _CCCL_HAS_BUILTIN(__builtin_structured_binding_size)
+
+template <class _Sndr>
+inline constexpr size_t structured_binding_size<_Sndr&> = structured_binding_size<_Sndr>;
+
+template <class _Sndr>
+inline constexpr size_t structured_binding_size<_Sndr const&> = structured_binding_size<_Sndr>;
+
+// If structured bindings can be used to introduce a pack, then `visit` has a very simple
+// implementation. Otherwise, we need an `__unpack` function template specialized for
+#if __cpp_structured_bindings >= 202411L
+
+// C++26, structured binding can introduce a pack.
+struct _CCCL_TYPE_VISIBILITY_DEFAULT visit_t
+{
+  template <class _Visitor, class _CvSndr, class _Context>
+    requires(static_cast<int>(structured_binding_size<_CvSndr>) >= 2)
+  _CCCL_TRIVIAL_API constexpr auto operator()(_Visitor& __visitor, _CvSndr&& __sndr, _Context& __context) const
+    -> decltype(auto)
+  {
+    auto&& [__tag, __data, ... __children] = static_cast<_CvSndr&&>(__sndr);
+    return __visitor(__context, __tag, _CCCL_FWD_LIKE(_CvSndr, __data), _CCCL_FWD_LIKE(_CvSndr, __children)...);
+  }
+};
+
+#else // ^^^ __cpp_structured_bindings >= 202411L / !__cpp_structured_bindings >= 202411L vvv
 
 template <size_t _Arity>
 struct __sender_type_cannot_be_used_to_initialize_a_structured_binding;
@@ -40,19 +78,15 @@ struct __sender_type_cannot_be_used_to_initialize_a_structured_binding;
 template <size_t _Arity>
 extern __sender_type_cannot_be_used_to_initialize_a_structured_binding<_Arity> __unpack;
 
-#define _CCCL_BIND_CHILD(_Ord) , _CCCL_PP_CAT(__child, _Ord)
-#define _CCCL_FWD_CHILD(_Ord)  , _CCCL_FWD_LIKE(_Sndr, _CCCL_PP_CAT(__child, _Ord))
-#define _CCCL_FWD_LIKE(_X, _Y) static_cast<_CUDA_VSTD::__copy_cvref_t<_X&&, decltype(_Y)>>(_Y)
-
-#define _CCCL_UNPACK_SENDER(_Arity)                                                                             \
-  template <>                                                                                                   \
-  [[maybe_unused]]                                                                                              \
-  _CCCL_GLOBAL_CONSTANT auto __unpack<2 + _Arity> =                                                             \
-    [](auto& __visitor, auto&& __sndr, auto& __context) -> decltype(auto) {                                     \
-    using _Sndr _CCCL_NODEBUG_ALIAS                                  = decltype(__sndr);                        \
-    auto&& [__tag, __data _CCCL_PP_REPEAT(_Arity, _CCCL_BIND_CHILD)] = static_cast<_Sndr&&>(__sndr);            \
-    return __visitor(__context, __tag, _CCCL_FWD_LIKE(_Sndr, __data) _CCCL_PP_REPEAT(_Arity, _CCCL_FWD_CHILD)); \
-  }
+#  define _CCCL_UNPACK_SENDER(_Arity)                                                                             \
+    template <>                                                                                                   \
+    [[maybe_unused]]                                                                                              \
+    _CCCL_GLOBAL_CONSTANT auto __unpack<2 + _Arity> =                                                             \
+      [](auto& __visitor, auto&& __sndr, auto& __context) -> decltype(auto) {                                     \
+      using _Sndr _CCCL_NODEBUG_ALIAS                                  = decltype(__sndr);                        \
+      auto&& [__tag, __data _CCCL_PP_REPEAT(_Arity, _CCCL_BIND_CHILD)] = static_cast<_Sndr&&>(__sndr);            \
+      return __visitor(__context, __tag, _CCCL_FWD_LIKE(_Sndr, __data) _CCCL_PP_REPEAT(_Arity, _CCCL_FWD_CHILD)); \
+    }
 
 _CCCL_UNPACK_SENDER(0);
 _CCCL_UNPACK_SENDER(1);
@@ -63,17 +97,34 @@ _CCCL_UNPACK_SENDER(5);
 _CCCL_UNPACK_SENDER(6);
 _CCCL_UNPACK_SENDER(7);
 
+struct _CCCL_TYPE_VISIBILITY_DEFAULT visit_t
+{
+  _CCCL_TEMPLATE(class _Visitor, class _Sndr, class _Context)
+  _CCCL_REQUIRES((static_cast<int>(structured_binding_size<_Sndr>) >= 2))
+  _CCCL_TRIVIAL_API constexpr auto operator()(_Visitor& __visitor, _Sndr&& __sndr, _Context& __context) const
+    -> decltype(auto)
+  {
+    // This `if constexpr` shouldn't be needed given the `requires` clause above. It is
+    // here because nvcc 12.0 have a bug where the full signature of the function template
+    // -- including the return type -- is instantiated before the `requires` clause is
+    // checked.
+    if constexpr (static_cast<int>(structured_binding_size<_Sndr>) >= 2)
+    {
+      return __unpack<structured_binding_size<_Sndr>>(__visitor, static_cast<_Sndr&&>(__sndr), __context);
+    }
+  }
+};
+
+#endif // ^^^ __cpp_structured_bindings < 202411L
+
+[[maybe_unused]]
+_CCCL_GLOBAL_CONSTANT visit_t visit{};
+
+} // namespace cuda::experimental::execution
+
 #undef _CCCL_FWD_LIKE
 #undef _CCCL_FWD_CHILD
 #undef _CCCL_BIND_CHILD
-
-[[maybe_unused]]
-_CCCL_GLOBAL_CONSTANT auto visit = [](auto& __visitor, auto&& sndr, auto& __context) -> decltype(auto) {
-  using _Sndr _CCCL_NODEBUG_ALIAS = __decay_t<decltype(sndr)>;
-  return __unpack<structured_binding_size<_Sndr>>(__visitor, static_cast<decltype(sndr)&&>(sndr), __context);
-};
-
-} // namespace cuda::experimental::execution
 
 #include <cuda/experimental/__execution/epilogue.cuh>
 

--- a/cudax/include/cuda/experimental/__execution/when_all.cuh
+++ b/cudax/include/cuda/experimental/__execution/when_all.cuh
@@ -42,6 +42,7 @@
 #include <cuda/experimental/__execution/meta.cuh>
 #include <cuda/experimental/__execution/queries.cuh>
 #include <cuda/experimental/__execution/stop_token.cuh>
+#include <cuda/experimental/__execution/transform_sender.cuh>
 #include <cuda/experimental/__execution/type_traits.cuh>
 #include <cuda/experimental/__execution/utility.cuh>
 #include <cuda/experimental/__execution/variant.cuh>
@@ -380,18 +381,7 @@ private:
   template <class... _Ts>
   using __decay_all _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::__type_list<_CUDA_VSTD::decay_t<_Ts>...>;
 
-  struct _CCCL_TYPE_VISIBILITY_DEFAULT __fn
-  {
-    template <class... _Sndrs>
-    _CCCL_TRIVIAL_API constexpr auto operator()(_Sndrs... __sndrs) const;
-  };
-
 public:
-  _CCCL_API static constexpr auto __apply() noexcept
-  {
-    return __fn{};
-  }
-
   template <class... _Sndrs>
   _CCCL_TRIVIAL_API constexpr auto operator()(_Sndrs... __sndrs) const;
 };
@@ -495,34 +485,28 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT when_all_t::__sndr_t : _CUDA_VSTD::__tuple<
 };
 
 template <class... _Sndrs>
-_CCCL_TRIVIAL_API constexpr auto when_all_t::__fn::operator()(_Sndrs... __sndrs) const
-{
-  // If the incoming senders are non-dependent, we can check the completion
-  // signatures of the composed sender immediately.
-  if constexpr (((!dependent_sender<_Sndrs>) && ...))
-  {
-    using __completions _CCCL_NODEBUG_ALIAS = completion_signatures_of_t<__sndr_t<_Sndrs...>>;
-    static_assert(__valid_completion_signatures<__completions>);
-  }
-  return __sndr_t<_Sndrs...>{{{}, {}, static_cast<_Sndrs&&>(__sndrs)...}};
-}
-
-template <class... _Sndrs>
 _CCCL_TRIVIAL_API constexpr auto when_all_t::operator()(_Sndrs... __sndrs) const
 {
   if constexpr (sizeof...(_Sndrs) == 0)
   {
     return __sndr_t{};
   }
-  else if constexpr (!__type_valid_v<_CUDA_VSTD::common_type_t, early_domain_of_t<_Sndrs>...>)
+  else if constexpr (!__type_valid_v<_CUDA_VSTD::common_type_t, domain_for_t<_Sndrs>...>)
   {
-    static_assert(__type_valid_v<_CUDA_VSTD::common_type_t, early_domain_of_t<_Sndrs>...>,
+    static_assert(__type_valid_v<_CUDA_VSTD::common_type_t, domain_for_t<_Sndrs>...>,
                   "when_all: all child senders must have the same domain");
   }
   else
   {
-    using __dom_t _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::common_type_t<early_domain_of_t<_Sndrs>...>;
-    return __dom_t::__apply(*this)(static_cast<_Sndrs&&>(__sndrs)...);
+    using __dom_t _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::common_type_t<domain_for_t<_Sndrs>...>;
+    // If the incoming senders are non-dependent, we can check the completion
+    // signatures of the composed sender immediately.
+    if constexpr (((!dependent_sender<_Sndrs>) && ...))
+    {
+      using __completions _CCCL_NODEBUG_ALIAS = completion_signatures_of_t<__sndr_t<_Sndrs...>>;
+      static_assert(__valid_completion_signatures<__completions>);
+    }
+    return transform_sender(__dom_t{}, __sndr_t<_Sndrs...>{{{}, {}, static_cast<_Sndrs&&>(__sndrs)...}});
   }
 }
 

--- a/cudax/include/cuda/experimental/__execution/write_env.cuh
+++ b/cudax/include/cuda/experimental/__execution/write_env.cuh
@@ -28,6 +28,7 @@
 #include <cuda/experimental/__execution/queries.cuh>
 #include <cuda/experimental/__execution/rcvr_ref.cuh>
 #include <cuda/experimental/__execution/rcvr_with_env.cuh>
+#include <cuda/experimental/__execution/transform_sender.cuh>
 #include <cuda/experimental/__execution/utility.cuh>
 #include <cuda/experimental/__execution/visit.cuh>
 
@@ -59,18 +60,7 @@ private:
     connect_result_t<_Sndr, __rcvr_ref<__rcvr_with_env_t<_Rcvr, _Env>>> __opstate_;
   };
 
-  struct _CCCL_TYPE_VISIBILITY_DEFAULT __fn
-  {
-    template <class _Env, class _Sndr>
-    _CCCL_TRIVIAL_API constexpr auto operator()(_Env __env, _Sndr __sndr) const;
-  };
-
 public:
-  _CCCL_TRIVIAL_API static constexpr auto __apply() noexcept
-  {
-    return __fn{};
-  }
-
   template <class _Sndr, class _Env>
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __sndr_t;
 
@@ -115,17 +105,12 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT write_env_t::__sndr_t
   _Sndr __sndr_;
 };
 
-template <class _Env, class _Sndr>
-_CCCL_TRIVIAL_API constexpr auto write_env_t::__fn::operator()(_Env __env, _Sndr __sndr) const
-{
-  return __sndr_t<_Sndr, _Env>{{}, static_cast<_Env&&>(__env), static_cast<_Sndr&&>(__sndr)};
-}
-
 template <class _Sndr, class _Env>
 _CCCL_TRIVIAL_API constexpr auto write_env_t::operator()(_Sndr __sndr, _Env __env) const
 {
-  using __dom_t _CCCL_NODEBUG_ALIAS = __domain_of_t<_Env>;
-  return __dom_t::__apply(*this)(static_cast<_Env&&>(__env), static_cast<_Sndr&&>(__sndr));
+  using __dom_t _CCCL_NODEBUG_ALIAS  = __domain_of_t<_Env>;
+  using __sndr_t _CCCL_NODEBUG_ALIAS = write_env_t::__sndr_t<_Sndr, _Env>;
+  return transform_sender(__dom_t{}, __sndr_t{{}, static_cast<_Env&&>(__env), static_cast<_Sndr&&>(__sndr)});
 }
 
 template <class _Sndr, class _Env>

--- a/cudax/include/cuda/experimental/execution.cuh
+++ b/cudax/include/cuda/experimental/execution.cuh
@@ -12,6 +12,7 @@
 #define __CUDAX_EXECUTION__
 
 // IWYU pragma: begin_exports
+#include <cuda/experimental/__execution/apply_sender.cuh>
 #include <cuda/experimental/__execution/conditional.cuh>
 #include <cuda/experimental/__execution/continues_on.cuh>
 #include <cuda/experimental/__execution/cpos.cuh>
@@ -31,6 +32,7 @@
 #include <cuda/experimental/__execution/sync_wait.cuh>
 #include <cuda/experimental/__execution/then.cuh>
 #include <cuda/experimental/__execution/thread_context.cuh>
+#include <cuda/experimental/__execution/transform_sender.cuh>
 #include <cuda/experimental/__execution/visit.cuh>
 #include <cuda/experimental/__execution/when_all.cuh>
 #include <cuda/experimental/__execution/write_env.cuh>

--- a/cudax/test/execution/common/error_scheduler.cuh
+++ b/cudax/test/execution/common/error_scheduler.cuh
@@ -91,6 +91,8 @@ private:
 public:
   using scheduler_concept = cudax_async::scheduler_t;
 
+  _CCCL_HIDE_FROM_ABI error_scheduler() = default;
+
   _CCCL_HOST_DEVICE explicit error_scheduler(Error err)
       : _err(static_cast<Error&&>(err))
   {}


### PR DESCRIPTION
## Description

currently ustdex has a rather simplistic dispatch mechanism for finding algorithm customizations that does not handle _late_ customization (at `connect` time). that support will be needed to implement the `schedule_from` algorithm, since `continues_on` lowers to `schedule_from` by default using a late customization hook. and `schedule_from` is needed to properly handle transitions to and from the GPU in the stream and graph schedulers (coming!).

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
