### PR TITLE
CPM fetch nvbench entropy-criterion fix on cccl side

### DIFF
--- a/cmake/CCCLGetDependencies.cmake
+++ b/cmake/CCCLGetDependencies.cmake
@@ -22,7 +22,7 @@ macro(cccl_get_fmt)
   CPMAddPackage("gh:fmtlib/fmt#11.0.1")
 endmacro()
 
-set(CCCL_NVBENCH_SHA "9d189280de0dcb1e59e974aa531abec32faf829f" CACHE STRING "SHA/tag to use for CCCL's NVBench.")
+set(CCCL_NVBENCH_SHA "a36e15f6ca936525cadcef65e6d9a85df0e21441" CACHE STRING "SHA/tag to use for CCCL's NVBench.")
 mark_as_advanced(CCCL_NVBENCH_SHA)
 macro(cccl_get_nvbench)
   include("${_cccl_cpm_file}")


### PR DESCRIPTION
CCCL fetches nvbench with cpm so it still suffers from:

https://github.com/NVIDIA/nvbench/issues/220

when it uses nvbench. 

This updates the nvbench fetch to the latest hash so cccl gets the fix too.

@alliepiper Not sure if hardcoding it is the way to do it, but hash needs to be updated somehow

