### PR TITLE
Expand cudax test matrix to test C++17 with all compilers

### DIFF
--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -44,11 +44,11 @@ workflows:
     # verify-codegen:
     - {jobs: ['verify_codegen'], project: 'libcudacxx'}
     # cudax has different CTK reqs:
-    - {jobs: ['build'], project: 'cudax', ctk: ['12.0'], std: 'all', cxx: ['msvc14.39', 'gcc10', 'clang14']}
+    - {jobs: ['build'], project: 'cudax', ctk: ['12.0'], std: 20,    cxx: ['msvc14.39', 'msvc2019', 'msvc']}
+    - {jobs: ['build'], project: 'cudax', ctk: ['12.0'], std: 'all', cxx: ['gcc10', 'clang14']}
     - {jobs: ['build'], project: 'cudax', ctk: ['curr'], std: 'all', cxx: ['gcc10', 'gcc11', 'gcc12']}
     - {jobs: ['build'], project: 'cudax', ctk: ['curr'], std: 'all', cxx: ['clang14', 'clang15', 'clang16', 'clang17', 'clang18']}
     - {jobs: ['build'], project: 'cudax', ctk: ['12.8'], std: 'all', cxx: ['nvhpc']}
-    - {jobs: ['build'], project: 'cudax', ctk: ['curr'], std: 'all', cxx: ['msvc']}
     - {jobs: ['build'], project: 'cudax', ctk: ['curr'], std: 17,    cxx: ['gcc'], sm: "90"}
     - {jobs: ['build'], project: 'cudax', ctk: ['curr'], std: 20,    cxx: ['gcc'], sm: "90a"}
     - {jobs: ['build'], project: 'cudax', ctk: ['curr'], std: 'all', cxx: ['gcc', 'clang'], cpu: 'arm64'}

--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -44,11 +44,11 @@ workflows:
     # verify-codegen:
     - {jobs: ['verify_codegen'], project: 'libcudacxx'}
     # cudax has different CTK reqs:
-    - {jobs: ['build'], project: 'cudax', ctk: ['12.0'], std: 20,    cxx: ['msvc14.39', 'gcc10', 'clang14']}
-    - {jobs: ['build'], project: 'cudax', ctk: ['curr'], std: 20,    cxx: ['gcc10', 'gcc11', 'gcc12']}
-    - {jobs: ['build'], project: 'cudax', ctk: ['curr'], std: 20,    cxx: ['clang14', 'clang15', 'clang16', 'clang17', 'clang18']}
+    - {jobs: ['build'], project: 'cudax', ctk: ['12.0'], std: 'all', cxx: ['msvc14.39', 'gcc10', 'clang14']}
+    - {jobs: ['build'], project: 'cudax', ctk: ['curr'], std: 'all', cxx: ['gcc10', 'gcc11', 'gcc12']}
+    - {jobs: ['build'], project: 'cudax', ctk: ['curr'], std: 'all', cxx: ['clang14', 'clang15', 'clang16', 'clang17', 'clang18']}
     - {jobs: ['build'], project: 'cudax', ctk: ['12.8'], std: 'all', cxx: ['nvhpc']}
-    - {jobs: ['build'], project: 'cudax', ctk: ['curr'], std: 20,    cxx: ['msvc']}
+    - {jobs: ['build'], project: 'cudax', ctk: ['curr'], std: 'all', cxx: ['msvc']}
     - {jobs: ['build'], project: 'cudax', ctk: ['curr'], std: 17,    cxx: ['gcc'], sm: "90"}
     - {jobs: ['build'], project: 'cudax', ctk: ['curr'], std: 20,    cxx: ['gcc'], sm: "90a"}
     - {jobs: ['build'], project: 'cudax', ctk: ['curr'], std: 'all', cxx: ['gcc', 'clang'], cpu: 'arm64'}

--- a/ci/windows/build_common.psm1
+++ b/ci/windows/build_common.psm1
@@ -2,7 +2,7 @@ Param(
     [Parameter(Mandatory = $false)]
     [Alias("std")]
     [ValidateNotNullOrEmpty()]
-    [ValidateSet(11, 14, 17, 20)]
+    [ValidateSet(17, 20)]
     [int]$CXX_STANDARD = 17,
     [Parameter(Mandatory = $false)]
     [ValidateNotNullOrEmpty()]

--- a/ci/windows/build_cub.ps1
+++ b/ci/windows/build_cub.ps1
@@ -2,7 +2,7 @@ Param(
     [Parameter(Mandatory = $false)]
     [Alias("std")]
     [ValidateNotNullOrEmpty()]
-    [ValidateSet(11, 14, 17, 20)]
+    [ValidateSet(17, 20)]
     [int]$CXX_STANDARD = 17,
     [Parameter(Mandatory = $false)]
     [ValidateNotNullOrEmpty()]

--- a/ci/windows/build_cudax.ps1
+++ b/ci/windows/build_cudax.ps1
@@ -3,8 +3,8 @@ Param(
     [Parameter(Mandatory = $false)]
     [Alias("std")]
     [ValidateNotNullOrEmpty()]
-    [ValidateSet(20)]
-    [int]$CXX_STANDARD = 20,
+    [ValidateSet(17, 20)]
+    [int]$CXX_STANDARD = 17,
     [Parameter(Mandatory = $false)]
     [ValidateNotNullOrEmpty()]
     [Alias("arch")]

--- a/ci/windows/build_libcudacxx.ps1
+++ b/ci/windows/build_libcudacxx.ps1
@@ -2,7 +2,7 @@ Param(
     [Parameter(Mandatory = $false)]
     [Alias("std")]
     [ValidateNotNullOrEmpty()]
-    [ValidateSet(11, 14, 17, 20)]
+    [ValidateSet(17, 20)]
     [int]$CXX_STANDARD = 17,
     [Parameter(Mandatory = $false)]
     [ValidateNotNullOrEmpty()]

--- a/ci/windows/build_thrust.ps1
+++ b/ci/windows/build_thrust.ps1
@@ -2,7 +2,7 @@ Param(
     [Parameter(Mandatory = $false)]
     [Alias("std")]
     [ValidateNotNullOrEmpty()]
-    [ValidateSet(11, 14, 17, 20)]
+    [ValidateSet(17, 20)]
     [int]$CXX_STANDARD = 17,
     [Parameter(Mandatory = $false)]
     [ValidateNotNullOrEmpty()]

--- a/ci/windows/test_thrust.ps1
+++ b/ci/windows/test_thrust.ps1
@@ -2,7 +2,7 @@ Param(
     [Parameter(Mandatory = $false)]
     [Alias("std")]
     [ValidateNotNullOrEmpty()]
-    [ValidateSet(11, 14, 17, 20)]
+    [ValidateSet(17, 20)]
     [int]$CXX_STANDARD = 17,
     [Parameter(Mandatory = $false)]
     [ValidateNotNullOrEmpty()]

--- a/cmake/CCCLBuildCompilerTargets.cmake
+++ b/cmake/CCCLBuildCompilerTargets.cmake
@@ -31,13 +31,17 @@ function(cccl_build_compiler_interface interface_target cuda_compile_options cxx
   if (CCCL_TOPLEVEL_PROJECT AND
       CMAKE_CUDA_COMPILER_ID STREQUAL "NVIDIA" AND
       NOT CMAKE_CUDA_HOST_COMPILER STREQUAL CMAKE_CXX_COMPILER)
-    message(FATAL_ERROR
-    "CCCL developer builds require that CMAKE_CUDA_HOST_COMPILER exactly matches "
-    "CMAKE_CXX_COMPILER when using nvcc:\n"
-    "CMAKE_CUDA_COMPILER: ${CMAKE_CUDA_COMPILER}\n"
-    "CMAKE_CUDA_HOST_COMPILER: ${CMAKE_CUDA_HOST_COMPILER}\n"
-    "CMAKE_CXX_COMPILER: ${CMAKE_CXX_COMPILER}\n"
-    )
+    if (CMAKE_CUDA_HOST_COMPILER STREQUAL "")
+      SET(CMAKE_CUDA_HOST_COMPILER CMAKE_CXX_COMPILER)
+    else()
+      message(FATAL_ERROR
+      "CCCL developer builds require that CMAKE_CUDA_HOST_COMPILER exactly matches "
+      "CMAKE_CXX_COMPILER when using nvcc:\n"
+      "CMAKE_CUDA_COMPILER: ${CMAKE_CUDA_COMPILER}\n"
+      "CMAKE_CUDA_HOST_COMPILER: ${CMAKE_CUDA_HOST_COMPILER}\n"
+      "CMAKE_CXX_COMPILER: ${CMAKE_CXX_COMPILER}\n"
+      )
+    endif()
   endif()
 
   add_library(${interface_target} INTERFACE)

--- a/cudax/test/hierarchy/hierarchy_smoke.cu
+++ b/cudax/test/hierarchy/hierarchy_smoke.cu
@@ -149,7 +149,7 @@ struct basic_test_mixed
 
   void run()
   {
-    auto dims_mixed = cudax::make_hierarchy(cudax::block_dims<block_size>(), cudax::grid_dims(dim3(8, 4, 2)));
+    constexpr auto dims_mixed = cudax::make_hierarchy(cudax::block_dims<block_size>(), cudax::grid_dims(dim3(8, 4, 2)));
 
     test_host_dev(dims_mixed, *this);
     static_assert(dims_mixed.extents(cudax::thread, cudax::block) == block_size);

--- a/cudax/test/utility/basic_any.cu
+++ b/cudax/test/utility/basic_any.cu
@@ -272,8 +272,7 @@ TEMPLATE_TEST_CASE_METHOD(BasicAnyTestsFixture, "basic_any tests", "[utility][ba
     CHECK(a.interface() == _CCCL_TYPEID(iempty<>));
     CHECK(a.__in_situ() == true);
 
-    [[maybe_unused]]
-    immovable** p = cudax::any_cast<immovable*>(&a);
+    [[maybe_unused]] immovable** p = cudax::any_cast<immovable*>(&a);
     CHECK((p && *p == &im));
 
     int i    = 42;
@@ -490,7 +489,7 @@ TEMPLATE_TEST_CASE_METHOD(BasicAnyTestsFixture, "basic_any tests", "[utility][ba
 
   SECTION("cudax::dynamic_any_cast")
   {
-    auto cast_to_derived_fn =
+    [[maybe_unused]] auto cast_to_derived_fn =
       [](auto&& arg) -> decltype(cudax::dynamic_any_cast<iderived<>>(static_cast<decltype(arg)>(arg))) {
       throw;
     };


### PR DESCRIPTION
I locally found segfaults in some of the cudax tests with 12.9.

The CPU runners are plenty, so there is no reason to not test both standard modes
