### PR TITLE
Implement cuda.coop striped_to_blocked.

### DIFF
--- a/python/cuda_cccl/cuda/cccl/cooperative/experimental/block/__init__.py
+++ b/python/cuda_cccl/cuda/cccl/cooperative/experimental/block/__init__.py
@@ -3,7 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from cuda.cccl.cooperative.experimental.block._block_exchange import (
-    striped_to_blocked,
+    BlockExchangeType,
+    exchange,
 )
 from cuda.cccl.cooperative.experimental.block._block_load_store import load, store
 from cuda.cccl.cooperative.experimental.block._block_merge_sort import merge_sort_keys
@@ -21,17 +22,18 @@ from cuda.cccl.cooperative.experimental.block._block_scan import (
 )
 
 __all__ = [
-    "merge_sort_keys",
-    "reduce",
-    "sum",
-    "scan",
+    "BlockExchangeType",
+    "exchange",
     "exclusive_scan",
-    "inclusive_scan",
     "exclusive_sum",
+    "inclusive_scan",
     "inclusive_sum",
+    "load",
+    "merge_sort_keys",
     "radix_sort_keys",
     "radix_sort_keys_descending",
-    "load",
-    "striped_to_blocked",
+    "reduce",
+    "scan",
     "store",
+    "sum",
 ]

--- a/python/cuda_cccl/cuda/cccl/cooperative/experimental/block/__init__.py
+++ b/python/cuda_cccl/cuda/cccl/cooperative/experimental/block/__init__.py
@@ -1,7 +1,10 @@
-# Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+from cuda.cccl.cooperative.experimental.block._block_exchange import (
+    striped_to_blocked,
+)
 from cuda.cccl.cooperative.experimental.block._block_load_store import load, store
 from cuda.cccl.cooperative.experimental.block._block_merge_sort import merge_sort_keys
 from cuda.cccl.cooperative.experimental.block._block_radix_sort import (
@@ -29,5 +32,6 @@ __all__ = [
     "radix_sort_keys",
     "radix_sort_keys_descending",
     "load",
+    "striped_to_blocked",
     "store",
 ]

--- a/python/cuda_cccl/cuda/cccl/cooperative/experimental/block/_block_exchange.py
+++ b/python/cuda_cccl/cuda/cccl/cooperative/experimental/block/_block_exchange.py
@@ -1,0 +1,221 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""
+cuda.cccl.cooperative.block_exchange
+====================================
+
+This module provides a set of :ref:`collective <collective-primitives>` methods
+for rearranging data partitioned across CUDA thread blocks.
+
+Supported C++ APIs
+++++++++++++++++++
+
+The following :cpp:class:`cub.BlockExchange` APIs are supported:
+
+    StripedToBlocked template void (const T (&)[ITEMS_PER_THREAD], OutputT (&)[ITEMS_PER_THREAD])
+    StripedToBlocked template void (const T (&)[ITEMS_PER_THREAD], OutputT (&)[ITEMS_PER_THREAD], ::cuda::std::false_type)
+    StripedToBlocked template void (const T (&)[ITEMS_PER_THREAD], OutputT (&)[ITEMS_PER_THREAD], ::cuda::std::true_type)
+    StripedToBlocked void (T (&)[ITEMS_PER_THREAD])
+
+Unsupported C++ APIs
+++++++++++++++++++++
+
+The following :cpp:class:`cub.BlockExchange` APIs are not yet supported:
+
+    BlockedToStriped template void (const T (&)[ITEMS_PER_THREAD], OutputT (&)[ITEMS_PER_THREAD])
+    BlockedToStriped template void (const T (&)[ITEMS_PER_THREAD], OutputT (&)[ITEMS_PER_THREAD], ::cuda::std::false_type)
+    BlockedToStriped template void (const T (&)[ITEMS_PER_THREAD], OutputT (&)[ITEMS_PER_THREAD], ::cuda::std::true_type)
+    BlockedToStriped void (T (&)[ITEMS_PER_THREAD])
+
+    BlockedToWarpStriped template void (const T (&)[ITEMS_PER_THREAD], OutputT (&)[ITEMS_PER_THREAD])
+    BlockedToWarpStriped template void (const T (&)[ITEMS_PER_THREAD], OutputT (&)[ITEMS_PER_THREAD], ::cuda::std::false_type)
+    BlockedToWarpStriped template void (const T (&)[ITEMS_PER_THREAD], OutputT (&)[ITEMS_PER_THREAD], ::cuda::std::true_type)
+    BlockedToWarpStriped void (T (&)[ITEMS_PER_THREAD])
+
+    ScatterToBlocked template void (const T (&)[ITEMS_PER_THREAD], OutputT (&)[ITEMS_PER_THREAD], OffsetT (&)[ITEMS_PER_THREAD])
+    ScatterToBlocked template void (const T (&)[ITEMS_PER_THREAD], OutputT (&)[ITEMS_PER_THREAD], OffsetT (&)[ITEMS_PER_THREAD], ::cuda::std::false_type)
+    ScatterToBlocked template void (const T (&)[ITEMS_PER_THREAD], OutputT (&)[ITEMS_PER_THREAD], OffsetT (&)[ITEMS_PER_THREAD], ::cuda::std::true_type)
+    ScatterToBlocked template void (T (&)[ITEMS_PER_THREAD], OffsetT (&)[ITEMS_PER_THREAD])
+
+    ScatterToStripedFlagged template void (const T (&)[ITEMS_PER_THREAD], OutputT (&)[ITEMS_PER_THREAD], OffsetT (&)[ITEMS_PER_THREAD], ValidFlag (&)[ITEMS_PER_THREAD])
+    ScatterToStripedFlagged template void (T (&)[ITEMS_PER_THREAD], OffsetT (&)[ITEMS_PER_THREAD], ValidFlag (&)[ITEMS_PER_THREAD])
+
+    ScatterToStripedGuarded template void (const T (&)[ITEMS_PER_THREAD], OutputT (&)[ITEMS_PER_THREAD], OffsetT (&)[ITEMS_PER_THREAD])
+    ScatterToStripedGuarded template void (T (&)[ITEMS_PER_THREAD], OffsetT (&)[ITEMS_PER_THREAD])
+
+    ScatterToStriped template void (const T (&)[ITEMS_PER_THREAD], OutputT (&)[ITEMS_PER_THREAD], OffsetT (&)[ITEMS_PER_THREAD])
+    ScatterToStriped template void (const T (&)[ITEMS_PER_THREAD], OutputT (&)[ITEMS_PER_THREAD], OffsetT (&)[ITEMS_PER_THREAD], ::cuda::std::false_type)
+    ScatterToStriped template void (const T (&)[ITEMS_PER_THREAD], OutputT (&)[ITEMS_PER_THREAD], OffsetT (&)[ITEMS_PER_THREAD], ::cuda::std::true_type)
+    ScatterToStriped template void (T (&)[ITEMS_PER_THREAD], OffsetT (&)[ITEMS_PER_THREAD])
+
+    WarpStripedToBlocked template void (const T (&)[ITEMS_PER_THREAD], OutputT (&)[ITEMS_PER_THREAD])
+    WarpStripedToBlocked template void (const T (&)[ITEMS_PER_THREAD], OutputT (&)[ITEMS_PER_THREAD], ::cuda::std::false_type)
+    WarpStripedToBlocked template void (const T (&)[ITEMS_PER_THREAD], OutputT (&)[ITEMS_PER_THREAD], ::cuda::std::true_type)
+    WarpStripedToBlocked void (T (&)[ITEMS_PER_THREAD])
+"""
+
+import numba
+
+from .._common import (
+    make_binary_tempfile,
+    normalize_dim_param,
+    normalize_dtype_param,
+)
+from .._types import (
+    Algorithm,
+    Dependency,
+    DependentArray,
+    Invocable,
+    Pointer,
+    TemplateParameter,
+    numba_type_to_wrapper,
+)
+from .._typing import (
+    DimType,
+    DtypeType,
+)
+
+
+def striped_to_blocked(
+    dtype: DtypeType,
+    threads_per_block: DimType,
+    items_per_thread: int,
+    warp_time_slicing: bool = False,
+    methods: dict = None,
+):
+    """
+    Transpose data from a striped layout to a blocked layout.
+
+    :param dtype: Supplies the data type of the input and output arrays.
+    :type dtype: :py:class:`cuda.cccl.cooperative.experimental._typing.DtypeType`
+
+    :param threads_per_block: Supplies the number of threads in the block,
+        either as an integer for a 1D block or a tuple of two or three integers
+        for a 2D or 3D block, respectively.
+    :type threads_per_block:
+        :py:class:`cuda.cccl.cooperative.experimental._typing.DimType`
+
+    :param items_per_thread: Supplies the number of items partitioned onto each
+        thread.
+    :type  items_per_thread: int
+
+    :param warp_time_slicing: Supplies a boolean indicating whether warp
+        time-slicing is used.  If set to `True`, the algorithm will only use
+        enough shared memory to accommodate a single warp's worth of tile data,
+        time-slicing the block-wide exchange over multiple synchronized rounds.
+        Yields a much smaller shared-memory footprint at the expense of
+        decreased parallelism.  Defaults to `False`.
+    :type warp_time_slicing: bool, optional
+
+    :param methods: Optionally supplies a dictionary of methods to use for
+        user-defined types.  The default is *None*.
+    :type  methods: dict, optional
+
+    :raises ValueError: If ``items_per_thread`` is less than 1.
+
+    :raises ValueError: If ``items_per_thread`` is greater than 1 and
+        ``methods`` is not *None* (i.e. a user-defined type is being used).
+
+    :returns: An :py:class:`cuda.cccl.cooperative.experimental._types.Invocable`
+        object representing the specialized kernel that call be called from
+        a Numba JIT'd CUDA kernel.
+
+    """
+    # Validate initial parameters.
+    if items_per_thread < 1:
+        raise ValueError("items_per_thread must be greater than or equal to 1")
+
+    # Normalize parameters.
+    dim = normalize_dim_param(threads_per_block)
+    dtype = normalize_dtype_param(dtype)
+
+    specialization_kwds = {
+        "T": dtype,
+        "BLOCK_DIM_X": dim[0],
+        "ITEMS_PER_THREAD": items_per_thread,
+        "WARP_TIME_SLICING": int(warp_time_slicing),
+        "BLOCK_DIM_Y": dim[1],
+        "BLOCK_DIM_Z": dim[2],
+    }
+
+    template_parameters = [
+        TemplateParameter("T"),
+        TemplateParameter("BLOCK_DIM_X"),
+        TemplateParameter("ITEMS_PER_THREAD"),
+        TemplateParameter("WARP_TIME_SLICING"),
+        TemplateParameter("BLOCK_DIM_Y"),
+        TemplateParameter("BLOCK_DIM_Z"),
+    ]
+
+    # In other modules, like block scan, items_per_thread affects the calling
+    # convention the user needs to adopt in their kernel, as it pertains to
+    # input and return parameters, e.g., with items_per_thread = 1, you'd use
+    #   output = block_scan(temp_storage, input)
+    # Whereas with items_per_thread > 1, you'd use:
+    #   block_scan(temp_storage, input, output)
+    # This idiom does not apply for block exchange, so we don't specialize
+    # the parameters based on items_per_thread.
+    parameters = [
+        # Signature:
+        # void BlockExchange<T, BLOCK_DIM_X, ITEMS_PER_THREAD,
+        #                    WARP_TIME_SLICING, BLOCK_DIM_Y, BLOCK_DIM_Z>(
+        #     temp_storage
+        # )::StripedToBlocked(
+        #   const T (&)[ITEMS_PER_THREAD] input_items,
+        #   OutputT (&)[ITEMS_PER_THREAD] output_items,
+        # )
+        [
+            # temp_storage
+            Pointer(numba.uint8),
+            # T (&)[ITEMS_PER_THREAD] items
+            DependentArray(Dependency("T"), Dependency("ITEMS_PER_THREAD")),
+        ],
+        # Signature:
+        # void BlockExchange<T, BLOCK_DIM_X, ITEMS_PER_THREAD,
+        #                    WARP_TIME_SLICING, BLOCK_DIM_Y, BLOCK_DIM_Z>(
+        #     temp_storage
+        # )::StripedToBlocked(
+        #   const T (&)[ITEMS_PER_THREAD] input_items,
+        #   OutputT (&)[ITEMS_PER_THREAD] output_items,
+        # )
+        [
+            # temp_storage
+            Pointer(numba.uint8),
+            # const T (&)[ITEMS_PER_THREAD] input_items
+            DependentArray(Dependency("T"), Dependency("ITEMS_PER_THREAD")),
+            # OutputT (&)[ITEMS_PER_THREAD] output_items
+            DependentArray(Dependency("T"), Dependency("ITEMS_PER_THREAD")),
+        ],
+    ]
+
+    # If we have a non-None `methods`, we're dealing with user-defined types.
+    if methods is not None:
+        type_definitions = [
+            numba_type_to_wrapper(dtype, methods=methods),
+        ]
+    else:
+        type_definitions = None
+
+    template = Algorithm(
+        "BlockExchange",
+        "StripedToBlocked",
+        "block_exchange",
+        ["cub/block/block_exchange.cuh"],
+        template_parameters,
+        parameters,
+        fake_return=False,
+        type_definitions=type_definitions,
+    )
+
+    specialization = template.specialize(specialization_kwds)
+    return Invocable(
+        temp_files=[
+            make_binary_tempfile(ltoir, ".ltoir")
+            for ltoir in specialization.get_lto_ir()
+        ],
+        temp_storage_bytes=specialization.temp_storage_bytes,
+        temp_storage_alignment=specialization.temp_storage_alignment,
+        algorithm=specialization,
+    )

--- a/python/cuda_cccl/tests/cooperative/test_block_exchange.py
+++ b/python/cuda_cccl/tests/cooperative/test_block_exchange.py
@@ -8,7 +8,7 @@ test_block_exchange.py
 This file contains unit tests for cuda.cooperative.block_exchange.
 """
 
-from functools import reduce
+from functools import partial, reduce
 from operator import mul
 
 import numba
@@ -26,6 +26,11 @@ from numba import cuda, types
 import cuda.cccl.cooperative.experimental as cudax
 
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
+
+striped_to_blocked = partial(
+    cudax.block.exchange,
+    block_exchange_type=cudax.block.BlockExchangeType.StripedToBlocked,
+)
 
 
 @pytest.mark.parametrize("T", [types.int32, types.float64])
@@ -50,7 +55,7 @@ def test_striped_to_blocked(
         else reduce(mul, threads_per_block)
     )
 
-    block_exchange_op = cudax.block.striped_to_blocked(
+    block_exchange_op = striped_to_blocked(
         dtype=T,
         threads_per_block=threads_per_block,
         items_per_thread=items_per_thread,
@@ -181,7 +186,7 @@ def test_striped_to_blocked_user_defined_type(
         else reduce(mul, threads_per_block)
     )
 
-    block_exchange_op = cudax.block.striped_to_blocked(
+    block_exchange_op = striped_to_blocked(
         dtype=T_complex,
         threads_per_block=threads_per_block,
         items_per_thread=items_per_thread,

--- a/python/cuda_cccl/tests/cooperative/test_block_exchange.py
+++ b/python/cuda_cccl/tests/cooperative/test_block_exchange.py
@@ -1,0 +1,271 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""
+test_block_exchange.py
+
+This file contains unit tests for cuda.cooperative.block_exchange.
+"""
+
+from functools import reduce
+from operator import mul
+
+import numba
+import numpy as np
+import pytest
+from helpers import (
+    NUMBA_TYPES_TO_NP,
+    Complex,
+    complex_type,
+    random_int,
+    row_major_tid,
+)
+from numba import cuda, types
+
+import cuda.cccl.cooperative.experimental as cudax
+
+numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
+
+
+@pytest.mark.parametrize("T", [types.int32, types.float64])
+@pytest.mark.parametrize("threads_per_block", [32, (4, 16), (4, 8, 8)])
+@pytest.mark.parametrize("items_per_thread", [1, 4])
+@pytest.mark.parametrize("warp_time_slicing", [False, True])
+@pytest.mark.parametrize("separate_input_output_arrays", [False, True])
+def test_striped_to_blocked(
+    T,
+    threads_per_block,
+    items_per_thread,
+    warp_time_slicing,
+    separate_input_output_arrays,
+):
+    """
+    Tests the striped_to_blocked block-wide data exchange.
+    """
+    T_np = NUMBA_TYPES_TO_NP[T]
+    num_threads = (
+        threads_per_block
+        if isinstance(threads_per_block, int)
+        else reduce(mul, threads_per_block)
+    )
+
+    block_exchange_op = cudax.block.striped_to_blocked(
+        dtype=T,
+        threads_per_block=threads_per_block,
+        items_per_thread=items_per_thread,
+        warp_time_slicing=warp_time_slicing,
+    )
+    temp_storage_bytes = block_exchange_op.temp_storage_bytes
+
+    if separate_input_output_arrays:
+
+        @cuda.jit(link=block_exchange_op.files)
+        def kernel(input_arr, output_arr):
+            tid = row_major_tid()
+            temp_storage = cuda.shared.array(
+                shape=temp_storage_bytes,
+                dtype=numba.uint8,
+            )
+
+            thread_data_in = cuda.local.array(items_per_thread, dtype=T)
+            thread_data_out = cuda.local.array(items_per_thread, dtype=T)
+
+            # Load input data (striped)
+            for i in range(items_per_thread):
+                idx = tid + i * num_threads
+                if idx < input_arr.shape[0]:
+                    thread_data_in[i] = input_arr[idx]
+
+            block_exchange_op(temp_storage, thread_data_in, thread_data_out)
+
+            # Store output data (blocked)
+            for i in range(items_per_thread):
+                idx = tid * items_per_thread + i
+                if idx < output_arr.shape[0]:
+                    output_arr[idx] = thread_data_out[i]
+
+    else:
+
+        @cuda.jit(link=block_exchange_op.files)
+        def kernel(input_arr, output_arr):
+            tid = row_major_tid()
+            temp_storage = cuda.shared.array(
+                shape=temp_storage_bytes,
+                dtype=numba.uint8,
+            )
+
+            items = cuda.local.array(items_per_thread, dtype=T)
+
+            # Load input data (striped)
+            for i in range(items_per_thread):
+                idx = tid + i * num_threads
+                if idx < input_arr.shape[0]:
+                    items[i] = input_arr[idx]
+
+            block_exchange_op(temp_storage, items)
+
+            # Store output data (blocked)
+            for i in range(items_per_thread):
+                idx = tid * items_per_thread + i
+                if idx < output_arr.shape[0]:
+                    output_arr[idx] = items[i]
+
+    total_items = num_threads * items_per_thread
+    h_input = random_int(total_items, T_np)
+
+    d_input = cuda.to_device(h_input)
+    d_output = cuda.device_array(total_items, dtype=T_np)
+
+    kernel[1, threads_per_block](d_input, d_output)
+    cuda.synchronize()
+
+    output = d_output.copy_to_host()
+
+    # Calculate reference result
+    h_ref = np.zeros(total_items, dtype=T_np)
+    # Iterate over each position in the destination (blocked) array
+    for blocked_idx in range(total_items):
+        # Determine which source thread (s_tid) and which item within
+        # that thread's stripe (s_item_idx_in_stripe) contributed to
+        # h_ref[blocked_idx].
+        #
+        # This is based on the CUB definition for StripedToBlocked:
+        #   Output element at global_blocked_idx comes from an input
+        #   element defined by:
+        #       source_thread_idx = global_blocked_idx % num_threads
+        #       source_item_in_stripe_idx = global_blocked_idx // num_threads
+
+        s_tid = blocked_idx % num_threads
+        s_item_idx_in_stripe = blocked_idx // num_threads
+
+        # Convert these (s_tid, s_item_idx_in_stripe) 2D-like indices
+        # to a 1D index into the h_input array (which is striped).
+        # In a striped layout, element (thread_k, item_j) is at
+        # k + j * num_threads.
+        src_striped_1d_idx = s_tid + s_item_idx_in_stripe * num_threads
+
+        h_ref[blocked_idx] = h_input[src_striped_1d_idx]
+
+    # We just transformed data; we didn't do any math that may have introduced
+    # floating point errors, so we can use np.testing.assert_array_equal for
+    # both float and int types.
+    np.testing.assert_array_equal(output, h_ref)
+
+    sig = (T[::1], T[::1])  # Signature for 1D arrays of type T
+    sass = kernel.inspect_sass(sig)
+    assert "LDL" not in sass  # Check for global loads
+    assert "STL" not in sass  # Check for global stores
+
+
+@pytest.mark.parametrize("threads_per_block", [32, (4, 16), (4, 8, 8)])
+@pytest.mark.parametrize("items_per_thread", [1])
+@pytest.mark.parametrize("warp_time_slicing", [False, True])
+def test_striped_to_blocked_user_defined_type(
+    threads_per_block, items_per_thread, warp_time_slicing
+):
+    """
+    Tests the striped_to_blocked block-wide data exchange for Complex
+    user-defined type.
+
+    N.B. User-defined types are currently restricted to items_per_thread == 1.
+         However, the test has been written to handle multiple items per thread
+         for if and when this support is added.
+    """
+    T_complex = complex_type
+    T_complex_np_component = np.int32
+
+    num_threads = (
+        threads_per_block
+        if isinstance(threads_per_block, int)
+        else reduce(mul, threads_per_block)
+    )
+
+    block_exchange_op = cudax.block.striped_to_blocked(
+        dtype=T_complex,
+        threads_per_block=threads_per_block,
+        items_per_thread=items_per_thread,
+        warp_time_slicing=warp_time_slicing,
+        methods={"construct": Complex.construct, "assign": Complex.assign},
+    )
+    temp_storage_bytes = block_exchange_op.temp_storage_bytes
+
+    @cuda.jit(link=block_exchange_op.files)
+    def kernel(input_arr, output_arr):
+        tid = row_major_tid()
+        temp_storage = cuda.shared.array(shape=temp_storage_bytes, dtype=numba.uint8)
+
+        thread_data_in = cuda.local.array(items_per_thread, dtype=T_complex)
+        thread_data_out = cuda.local.array(items_per_thread, dtype=T_complex)
+
+        total_complex_items_in_block = num_threads * items_per_thread
+
+        for i in range(items_per_thread):
+            striped_idx_of_complex_item = tid + i * num_threads
+            if striped_idx_of_complex_item < total_complex_items_in_block:
+                real_val = input_arr[striped_idx_of_complex_item]
+                imag_val = input_arr[
+                    striped_idx_of_complex_item + total_complex_items_in_block
+                ]
+                thread_data_in[i] = Complex(real_val, imag_val)
+
+        block_exchange_op(temp_storage, thread_data_in, thread_data_out)
+
+        for i in range(items_per_thread):
+            blocked_idx_of_complex_item = tid * items_per_thread + i
+            if blocked_idx_of_complex_item < total_complex_items_in_block:
+                output_arr[blocked_idx_of_complex_item] = thread_data_out[i].real
+                output_arr[
+                    blocked_idx_of_complex_item + total_complex_items_in_block
+                ] = thread_data_out[i].imag
+
+    total_complex_items = num_threads * items_per_thread
+    h_input_real = random_int(total_complex_items, T_complex_np_component)
+    h_input_imag = random_int(total_complex_items, T_complex_np_component)
+    h_input_combined = np.concatenate((h_input_real, h_input_imag))
+
+    d_input = cuda.to_device(h_input_combined)
+    d_output = cuda.device_array(2 * total_complex_items, dtype=T_complex_np_component)
+
+    kernel[1, threads_per_block](d_input, d_output)
+    cuda.synchronize()
+
+    output_combined = d_output.copy_to_host()
+    output_real = output_combined[:total_complex_items]
+    output_imag = output_combined[total_complex_items:]
+
+    h_input_complex_objects = np.array(
+        [Complex(r, i) for r, i in zip(h_input_real, h_input_imag)], dtype=object
+    )
+    h_ref_complex_objects = np.empty(total_complex_items, dtype=object)
+
+    # The striped_to_blocked transformation:
+    for blocked_complex_idx in range(total_complex_items):
+        s_tid = blocked_complex_idx % num_threads
+        s_item_idx_in_stripe = blocked_complex_idx // num_threads
+
+        # Convert to 1D index in the striped h_input_complex_objects array
+        src_striped_1d_complex_idx = s_tid + s_item_idx_in_stripe * num_threads
+        h_ref_complex_objects[blocked_complex_idx] = h_input_complex_objects[
+            src_striped_1d_complex_idx
+        ]
+
+    # Split the reference Complex objects back into real and imaginary parts
+    h_ref_real = np.array(
+        [c.real for c in h_ref_complex_objects], dtype=T_complex_np_component
+    )
+    h_ref_imag = np.array(
+        [c.imag for c in h_ref_complex_objects], dtype=T_complex_np_component
+    )
+
+    np.testing.assert_array_equal(output_real, h_ref_real)
+    np.testing.assert_array_equal(output_imag, h_ref_imag)
+
+    # Signature for SASS inspection (input and output arrays are of int32)
+    sig = (
+        numba.types.int32[::1],
+        numba.types.int32[::1],
+    )
+    sass = kernel.inspect_sass(sig)
+    assert "LDL" not in sass
+    assert "STL" not in sass


### PR DESCRIPTION
This work is based on Bryce's PR: https://github.com/NVIDIA/cccl/pull/3163

I have purposely limited the implementation to just `striped_to_blocked` for now in order to unblock Bryce with regards to some upcoming presentations that rely on said method existing.

## Checklist
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
