### PR TITLE
Improve code and coverage of `DeviceFor::ForEachInExtents`

### DIFF
--- a/cub/cub/detail/mdspan_utils.cuh
+++ b/cub/cub/detail/mdspan_utils.cuh
@@ -43,7 +43,7 @@
 #include <cuda/std/cstddef> // size_t
 #include <cuda/std/mdspan>
 #include <cuda/std/type_traits> // make_unsigned_t
-#include <cuda/std/utility> // ::cuda::std::index_sequence
+#include <cuda/std/utility> // _CUDA_VSTD::index_sequence
 
 CUB_NAMESPACE_BEGIN
 
@@ -51,11 +51,11 @@ namespace detail
 {
 
 // Compute the submdspan size of a given rank
-template <::cuda::std::size_t Rank, typename IndexType, ::cuda::std::size_t Extent0, ::cuda::std::size_t... Extents>
-[[nodiscard]] _CCCL_HOST_DEVICE _CCCL_FORCEINLINE constexpr ::cuda::std::make_unsigned_t<IndexType>
-sub_size(const ::cuda::std::extents<IndexType, Extent0, Extents...>& ext)
+template <_CUDA_VSTD::size_t Rank, typename IndexType, _CUDA_VSTD::size_t Extent0, _CUDA_VSTD::size_t... Extents>
+[[nodiscard]] _CCCL_HOST_DEVICE _CCCL_FORCEINLINE constexpr _CUDA_VSTD::make_unsigned_t<IndexType>
+sub_size(const _CUDA_VSTD::extents<IndexType, Extent0, Extents...>& ext)
 {
-  ::cuda::std::make_unsigned_t<IndexType> s = 1;
+  _CUDA_VSTD::make_unsigned_t<IndexType> s = 1;
   for (IndexType i = Rank; i < IndexType{1 + sizeof...(Extents)}; i++) // <- pointless comparison with zero-rank extent
   {
     s *= ext.extent(i);
@@ -64,38 +64,38 @@ sub_size(const ::cuda::std::extents<IndexType, Extent0, Extents...>& ext)
 }
 
 // avoid pointless comparison of unsigned integer with zero (nvcc 11.x doesn't support nv_diag warning suppression)
-template <::cuda::std::size_t Rank, typename IndexType>
-[[nodiscard]] _CCCL_HOST_DEVICE _CCCL_FORCEINLINE constexpr ::cuda::std::make_unsigned_t<IndexType>
-sub_size(const ::cuda::std::extents<IndexType>&)
+template <_CUDA_VSTD::size_t Rank, typename IndexType>
+[[nodiscard]] _CCCL_HOST_DEVICE _CCCL_FORCEINLINE constexpr _CUDA_VSTD::make_unsigned_t<IndexType>
+sub_size(const _CUDA_VSTD::extents<IndexType>&)
 {
-  return ::cuda::std::make_unsigned_t<IndexType>{1};
+  return _CUDA_VSTD::make_unsigned_t<IndexType>{1};
 }
 
 // TODO: move to cuda::std
-template <typename IndexType, ::cuda::std::size_t... Extents>
-[[nodiscard]] _CCCL_HOST_DEVICE _CCCL_FORCEINLINE constexpr ::cuda::std::make_unsigned_t<IndexType>
-size(const ::cuda::std::extents<IndexType, Extents...>& ext)
+template <typename IndexType, _CUDA_VSTD::size_t... Extents>
+[[nodiscard]] _CCCL_HOST_DEVICE _CCCL_FORCEINLINE constexpr _CUDA_VSTD::make_unsigned_t<IndexType>
+size(const _CUDA_VSTD::extents<IndexType, Extents...>& ext)
 {
-  return sub_size<0>(ext);
+  return cub::detail::sub_size<0>(ext);
 }
 
 // precompute modulo/division for each submdspan size (by rank)
-template <typename IndexType, ::cuda::std::size_t... E, ::cuda::std::size_t... Ranks>
+template <typename IndexType, _CUDA_VSTD::size_t... E, _CUDA_VSTD::size_t... Ranks>
 [[nodiscard]] _CCCL_HOST_DEVICE _CCCL_FORCEINLINE auto
-sub_sizes_fast_div_mod(const ::cuda::std::extents<IndexType, E...>& ext, ::cuda::std::index_sequence<Ranks...> = {})
+sub_sizes_fast_div_mod(const _CUDA_VSTD::extents<IndexType, E...>& ext, _CUDA_VSTD::index_sequence<Ranks...> = {})
 {
   // deduction guides don't work with nvcc 11.x
   using fast_mod_div_t = fast_div_mod<IndexType>;
-  return ::cuda::std::array<fast_mod_div_t, sizeof...(Ranks)>{fast_mod_div_t(sub_size<Ranks + 1>(ext))...};
+  return _CUDA_VSTD::array<fast_mod_div_t, sizeof...(Ranks)>{fast_mod_div_t(sub_size<Ranks + 1>(ext))...};
 }
 
 // precompute modulo/division for each mdspan extent
-template <typename IndexType, ::cuda::std::size_t... E, ::cuda::std::size_t... Ranks>
+template <typename IndexType, _CUDA_VSTD::size_t... E, _CUDA_VSTD::size_t... Ranks>
 [[nodiscard]] _CCCL_HOST_DEVICE _CCCL_FORCEINLINE auto
-extents_fast_div_mod(const ::cuda::std::extents<IndexType, E...>& ext, ::cuda::std::index_sequence<Ranks...> = {})
+extents_fast_div_mod(const _CUDA_VSTD::extents<IndexType, E...>& ext, _CUDA_VSTD::index_sequence<Ranks...> = {})
 {
   using fast_mod_div_t = fast_div_mod<IndexType>;
-  return ::cuda::std::array<fast_mod_div_t, sizeof...(Ranks)>{fast_mod_div_t(ext.extent(Ranks))...};
+  return _CUDA_VSTD::array<fast_mod_div_t, sizeof...(Ranks)>{fast_mod_div_t(ext.extent(Ranks))...};
 }
 
 // GCC <= 9 constexpr workaround: Extent must be passed as type only, even const Extent& doesn't work
@@ -105,7 +105,7 @@ template <int Rank, typename Extents>
   using index_type = typename Extents::index_type;
   for (index_type i = Rank; i < Extents::rank(); i++)
   {
-    if (Extents::static_extent(i) == ::cuda::std::dynamic_extent)
+    if (Extents::static_extent(i) == _CUDA_VSTD::dynamic_extent)
     {
       return false;
     }

--- a/cub/cub/device/dispatch/kernels/for_each_in_extents_kernel.cuh
+++ b/cub/cub/device/dispatch/kernels/for_each_in_extents_kernel.cuh
@@ -1,29 +1,25 @@
-/******************************************************************************
- * Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+/***********************************************************************************************************************
+ * Copyright (c) 2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2025, NVIDIA CORPORATION.  All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *     * Redistributions of source code must retain the above copyright
- *       notice, this list of conditions and the following disclaimer.
- *     * Redistributions in binary form must reproduce the above copyright
- *       notice, this list of conditions and the following disclaimer in the
- *       documentation and/or other materials provided with the distribution.
- *     * Neither the name of the NVIDIA CORPORATION nor the
- *       names of its contributors may be used to endorse or promote products
- *       derived from this software without specific prior written permission.
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *     * Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ *       following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ *       following disclaimer in the documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the names of its contributors may be used to endorse or promote
+ *       products derived from this software without specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
- * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- ******************************************************************************/
+ **********************************************************************************************************************/
 
 #pragma once
 
@@ -43,135 +39,95 @@
 
 #include <cuda/std/cstddef> // size_t
 #include <cuda/std/mdspan> // dynamic_extent
-#include <cuda/std/type_traits> // enable_if
-#include <cuda/std/utility> // index_sequence
+#include <cuda/std/type_traits> // make_unsigned_t
 
 CUB_NAMESPACE_BEGIN
-
-namespace detail
-{
-namespace for_each_in_extents
+namespace detail::for_each_in_extents
 {
 
+// Return the extents at the given rank. If the extents is static, return it, otherwise return the precomputed value
 template <int Rank, typename ExtentType, typename FastDivModType>
-_CCCL_DEVICE _CCCL_FORCEINLINE auto get_extent_size(ExtentType ext, FastDivModType extent_size)
+_CCCL_DEVICE _CCCL_FORCEINLINE auto dispatch_extent_at(ExtentType extents, FastDivModType dynamic_extent)
 {
-  if constexpr (ExtentType::static_extent(Rank) != ::cuda::std::dynamic_extent)
+  if constexpr (ExtentType::static_extent(Rank) != _CUDA_VSTD::dynamic_extent)
   {
     using extent_index_type   = typename ExtentType::index_type;
     using index_type          = implicit_prom_t<extent_index_type>;
-    using unsigned_index_type = ::cuda::std::make_unsigned_t<index_type>;
-    return static_cast<unsigned_index_type>(ext.static_extent(Rank));
+    using unsigned_index_type = _CUDA_VSTD::make_unsigned_t<index_type>;
+    return static_cast<unsigned_index_type>(extents.static_extent(Rank));
   }
   else
   {
-    return extent_size;
+    return dynamic_extent;
   }
 }
 
 template <int Rank, typename ExtentType, typename FastDivModType>
-_CCCL_DEVICE _CCCL_FORCEINLINE auto get_extents_sub_size(ExtentType ext, FastDivModType extents_sub_size)
+_CCCL_DEVICE _CCCL_FORCEINLINE auto get_extents_sub_size(ExtentType extents, FastDivModType extent_sub_size)
 {
   if constexpr (cub::detail::is_sub_size_static<Rank + 1, ExtentType>())
   {
-    return sub_size<Rank + 1>(ext);
+    return cub::detail::sub_size<Rank + 1>(extents);
   }
   else
   {
-    return extents_sub_size;
+    return extent_sub_size;
   }
 }
 
 template <int Rank, typename IndexType, typename ExtentType, typename FastDivModType>
 _CCCL_DEVICE _CCCL_FORCEINLINE auto
-coordinate_at(IndexType index, ExtentType ext, FastDivModType extents_sub_size, FastDivModType extent_size)
+coordinate_at(IndexType index, ExtentType extents, FastDivModType extent_sub_size, FastDivModType dynamic_extent)
 {
+  using cub::detail::for_each_in_extents::dispatch_extent_at;
+  using cub::detail::for_each_in_extents::get_extents_sub_size;
   using extent_index_type = typename ExtentType::index_type;
   return static_cast<extent_index_type>(
-    (index / get_extents_sub_size<Rank>(ext, extents_sub_size)) % get_extent_size<Rank>(ext, extent_size));
-}
-
-template <typename IndexType,
-          typename Func,
-          typename ExtentType,
-          typename FastDivModArrayType, //
-          ::cuda::std::size_t... Ranks>
-_CCCL_DEVICE _CCCL_FORCEINLINE void computation(
-  IndexType id,
-  [[maybe_unused]] IndexType stride,
-  Func func,
-  [[maybe_unused]] ExtentType ext,
-  [[maybe_unused]] FastDivModArrayType sub_sizes_div_array,
-  [[maybe_unused]] FastDivModArrayType extents_mod_array)
-{
-  using extent_index_type = typename ExtentType::index_type;
-  if constexpr (ExtentType::rank() > 0)
-  {
-    for (auto i = id; i < cub::detail::size(ext); i += stride)
-    {
-      func(i, coordinate_at<Ranks>(i, ext, sub_sizes_div_array[Ranks], extents_mod_array[Ranks])...);
-    }
-  }
-  else
-  {
-    using extent_index_type = typename ExtentType::index_type;
-    if (id == 0)
-    {
-      func(0);
-    }
-  }
+    (index / get_extents_sub_size<Rank>(extents, extent_sub_size)) % dispatch_extent_at<Rank>(extents, dynamic_extent));
 }
 
 /***********************************************************************************************************************
  * Kernel entry points
  **********************************************************************************************************************/
 
-template <typename ChainedPolicyT,
-          typename Func,
-          typename ExtentType,
-          typename FastDivModArrayType,
-          ::cuda::std::size_t... Ranks>
+template <typename ChainedPolicyT, typename Func, typename ExtentType, typename FastDivModArrayType, size_t... Ranks>
 __launch_bounds__(ChainedPolicyT::ActivePolicy::for_policy_t::block_threads)
   CUB_DETAIL_KERNEL_ATTRIBUTES void static_kernel(
     [[maybe_unused]] Func func,
-    [[maybe_unused]] _CCCL_GRID_CONSTANT const ExtentType ext,
+    [[maybe_unused]] _CCCL_GRID_CONSTANT const ExtentType extents,
     [[maybe_unused]] _CCCL_GRID_CONSTANT const FastDivModArrayType sub_sizes_div_array,
     [[maybe_unused]] _CCCL_GRID_CONSTANT const FastDivModArrayType extents_mod_array)
-{
-  using active_policy_t        = typename ChainedPolicyT::ActivePolicy::for_policy_t;
-  using extent_index_type      = typename ExtentType::index_type;
-  using offset_t               = implicit_prom_t<extent_index_type>;
-  constexpr auto block_threads = offset_t{active_policy_t::block_threads};
-  constexpr auto stride        = offset_t{block_threads * active_policy_t::items_per_thread};
-  auto stride1                 = (stride >= cub::detail::size(ext)) ? block_threads : stride;
-  auto id                      = static_cast<offset_t>(threadIdx.x + blockIdx.x * block_threads);
-  computation<offset_t, Func, ExtentType, FastDivModArrayType, Ranks...>(
-    id, stride1, func, ext, sub_sizes_div_array, extents_mod_array);
-}
-
-template <typename ChainedPolicyT,
-          typename Func,
-          typename ExtentType,
-          typename FastDivModArrayType,
-          ::cuda::std::size_t... Ranks>
-CUB_DETAIL_KERNEL_ATTRIBUTES void dynamic_kernel(
-  Func func,
-  _CCCL_GRID_CONSTANT const ExtentType ext,
-  _CCCL_GRID_CONSTANT const FastDivModArrayType sub_sizes_div_array,
-  _CCCL_GRID_CONSTANT const FastDivModArrayType extents_mod_array)
 {
   using active_policy_t   = typename ChainedPolicyT::ActivePolicy::for_policy_t;
   using extent_index_type = typename ExtentType::index_type;
   using offset_t          = implicit_prom_t<extent_index_type>;
-  auto block_threads      = offset_t{blockDim.x};
-  auto stride             = static_cast<offset_t>(blockDim.x * active_policy_t::items_per_thread);
-  auto stride1            = (stride >= cub::detail::size(ext)) ? block_threads : stride;
-  auto id                 = static_cast<offset_t>(threadIdx.x + blockIdx.x * blockDim.x);
-  computation<offset_t, Func, ExtentType, FastDivModArrayType, Ranks...>(
-    id, stride1, func, ext, sub_sizes_div_array, extents_mod_array);
+  constexpr auto stride   = offset_t{active_policy_t::block_threads};
+  auto id                 = static_cast<offset_t>(threadIdx.x + blockIdx.x * active_policy_t::block_threads);
+  using cub::detail::for_each_in_extents::coordinate_at;
+  for (auto i = id; i < cub::detail::size(extents); i += stride)
+  {
+    func(i, coordinate_at<Ranks>(i, extents, sub_sizes_div_array[Ranks], extents_mod_array[Ranks])...);
+  }
 }
 
-} // namespace for_each_in_extents
-} // namespace detail
+template <typename ChainedPolicyT, typename Func, typename ExtentType, typename FastDivModArrayType, size_t... Ranks>
+CUB_DETAIL_KERNEL_ATTRIBUTES void dynamic_kernel(
+  _CCCL_GRID_CONSTANT const Func func,
+  _CCCL_GRID_CONSTANT const ExtentType extents,
+  _CCCL_GRID_CONSTANT const FastDivModArrayType sub_sizes_div_array,
+  _CCCL_GRID_CONSTANT const FastDivModArrayType extents_mod_array)
+{
+  using cub::detail::for_each_in_extents::coordinate_at;
+  using extent_index_type = typename ExtentType::index_type;
+  using offset_t          = implicit_prom_t<extent_index_type>;
+  auto block_threads      = static_cast<offset_t>(blockDim.x);
+  auto stride             = static_cast<offset_t>(blockDim.x);
+  auto id                 = static_cast<offset_t>(threadIdx.x + blockIdx.x * blockDim.x);
+  for (auto i = id; i < cub::detail::size(extents); i += stride)
+  {
+    func(i, coordinate_at<Ranks>(i, extents, sub_sizes_div_array[Ranks], extents_mod_array[Ranks])...);
+  }
+}
 
+} // namespace detail::for_each_in_extents
 CUB_NAMESPACE_END

--- a/cub/cub/device/dispatch/kernels/for_each_in_extents_kernel.cuh
+++ b/cub/cub/device/dispatch/kernels/for_each_in_extents_kernel.cuh
@@ -98,21 +98,21 @@ __launch_bounds__(ChainedPolicyT::ActivePolicy::for_policy_t::block_threads)
     [[maybe_unused]] _CCCL_GRID_CONSTANT const FastDivModArrayType sub_sizes_div_array,
     [[maybe_unused]] _CCCL_GRID_CONSTANT const FastDivModArrayType extents_mod_array)
 {
+  using cub::detail::for_each_in_extents::coordinate_at;
   using active_policy_t   = typename ChainedPolicyT::ActivePolicy::for_policy_t;
   using extent_index_type = typename ExtentType::index_type;
   using offset_t          = implicit_prom_t<extent_index_type>;
   constexpr auto stride   = offset_t{active_policy_t::block_threads};
   auto id                 = static_cast<offset_t>(threadIdx.x + blockIdx.x * active_policy_t::block_threads);
-  using cub::detail::for_each_in_extents::coordinate_at;
   for (auto i = id; i < cub::detail::size(extents); i += stride)
   {
     func(i, coordinate_at<Ranks>(i, extents, sub_sizes_div_array[Ranks], extents_mod_array[Ranks])...);
   }
 }
 
-template <typename ChainedPolicyT, typename Func, typename ExtentType, typename FastDivModArrayType, size_t... Ranks>
+template <typename Func, typename ExtentType, typename FastDivModArrayType, size_t... Ranks>
 CUB_DETAIL_KERNEL_ATTRIBUTES void dynamic_kernel(
-  _CCCL_GRID_CONSTANT const Func func,
+  Func func,
   _CCCL_GRID_CONSTANT const ExtentType extents,
   _CCCL_GRID_CONSTANT const FastDivModArrayType sub_sizes_div_array,
   _CCCL_GRID_CONSTANT const FastDivModArrayType extents_mod_array)
@@ -120,7 +120,6 @@ CUB_DETAIL_KERNEL_ATTRIBUTES void dynamic_kernel(
   using cub::detail::for_each_in_extents::coordinate_at;
   using extent_index_type = typename ExtentType::index_type;
   using offset_t          = implicit_prom_t<extent_index_type>;
-  auto block_threads      = static_cast<offset_t>(blockDim.x);
   auto stride             = static_cast<offset_t>(blockDim.x);
   auto id                 = static_cast<offset_t>(threadIdx.x + blockIdx.x * blockDim.x);
   for (auto i = id; i < cub::detail::size(extents); i += stride)


### PR DESCRIPTION
## Description

- Simplify the code by using C++17 utilities
- Extend coverage to test dynamic kernel configuration
- Try to enable MSVC for excluding empty `index_sequence`