### PR TITLE
disable execution space checks for `cuda::std::exchange`

### DIFF
--- a/libcudacxx/include/cuda/std/__utility/exchange.h
+++ b/libcudacxx/include/cuda/std/__utility/exchange.h
@@ -27,6 +27,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _T1, class _T2 = _T1>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _T1 exchange(_T1& __obj, _T2&& __new_value) noexcept(
   is_nothrow_move_constructible<_T1>::value && is_nothrow_assignable<_T1&, _T2>::value)


### PR DESCRIPTION
## Description

`cuda::std::exchange` might evaluate a constructor, and the constructor might be `__host__`-only. a call of `cuda::std::exchange` on the host will complain:

```
/exchange.h(35): error #20011-D: calling a __host__ function("std::vector<int>::operator=(::
std::vector<int> &&)") from a __host__ __device__ function("cuda::std::__4::exchange<::std::
vector<int>, ::std::vector<int> >") is not allowed
```

exchanging vectors on host is not incorrect; the warning is over-eager in this case.

suppress the warning with `_CCCL_EXEC_CHECK_DISABLE`