### PR TITLE
fix the spelling of the `_CCCL_PREFERED_NAME` macro

### DIFF
--- a/libcudacxx/include/cuda/std/__cccl/attributes.h
+++ b/libcudacxx/include/cuda/std/__cccl/attributes.h
@@ -186,12 +186,12 @@
 #  define _CCCL_NO_UNIQUE_ADDRESS
 #endif // _CCCL_HAS_ATTRIBUTE_NO_UNIQUE_ADDRESS() && _CCCL_COMPILER(CLANG)
 
-// _CCCL_PREFERED_NAME
+// _CCCL_PREFERRED_NAME
 
 #if _CCCL_HAS_ATTRIBUTE(__preferred_name__)
-#  define _CCCL_PREFERED_NAME(x) __attribute__((__preferred_name__(x)))
+#  define _CCCL_PREFERRED_NAME(x) __attribute__((__preferred_name__(x)))
 #else
-#  define _CCCL_PREFERED_NAME(x)
+#  define _CCCL_PREFERRED_NAME(x)
 #endif
 
 #if _CCCL_HAS_ATTRIBUTE(__require_constant_initialization__)

--- a/libcudacxx/include/cuda/std/__fwd/string.h
+++ b/libcudacxx/include/cuda/std/__fwd/string.h
@@ -56,20 +56,20 @@ using u32string = basic_string<char32_t>;
 
 // clang-format off
 template <class _CharT, class _Traits, class _Allocator>
-class _CCCL_PREFERED_NAME(string)
-      _CCCL_PREFERED_NAME(wstring)
+class _CCCL_PREFERRED_NAME(string)
+      _CCCL_PREFERRED_NAME(wstring)
 #if _CCCL_HAS_CHAR8_T()
-      _CCCL_PREFERED_NAME(u8string)
+      _CCCL_PREFERRED_NAME(u8string)
 #endif // _CCCL_HAS_CHAR8_T()
-      _CCCL_PREFERED_NAME(u16string)
-      _CCCL_PREFERED_NAME(u32string)
-      _CCCL_PREFERED_NAME(pmr::string)
-      _CCCL_PREFERED_NAME(pmr::wstring)
+      _CCCL_PREFERRED_NAME(u16string)
+      _CCCL_PREFERRED_NAME(u32string)
+      _CCCL_PREFERRED_NAME(pmr::string)
+      _CCCL_PREFERRED_NAME(pmr::wstring)
 #  if _CCCL_HAS_CHAR8_T()
-      _CCCL_PREFERED_NAME(pmr::u8string)
+      _CCCL_PREFERRED_NAME(pmr::u8string)
 #  endif // _CCCL_HAS_CHAR8_T()
-      _CCCL_PREFERED_NAME(pmr::u16string)
-      _CCCL_PREFERED_NAME(pmr::u32string)
+      _CCCL_PREFERRED_NAME(pmr::u16string)
+      _CCCL_PREFERRED_NAME(pmr::u32string)
       basic_string;
 // clang-format on
 #endif // 0

--- a/libcudacxx/include/cuda/std/__fwd/string_view.h
+++ b/libcudacxx/include/cuda/std/__fwd/string_view.h
@@ -39,14 +39,14 @@ using wstring_view = basic_string_view<wchar_t>;
 
 // clang-format off
 template <class _CharT, class _Traits>
-class _CCCL_PREFERED_NAME(string_view)
+class _CCCL_PREFERRED_NAME(string_view)
 #if _CCCL_HAS_CHAR8_T()
-_CCCL_PREFERED_NAME(u8string_view)
+_CCCL_PREFERRED_NAME(u8string_view)
 #endif // _CCCL_HAS_CHAR8_T()
-_CCCL_PREFERED_NAME(u16string_view)
-_CCCL_PREFERED_NAME(u32string_view)
+_CCCL_PREFERRED_NAME(u16string_view)
+_CCCL_PREFERRED_NAME(u32string_view)
 #if _CCCL_HAS_WCHAR_T()
-_CCCL_PREFERED_NAME(wstring_view)
+_CCCL_PREFERRED_NAME(wstring_view)
 #endif // _CCCL_HAS_WCHAR_T()
       basic_string_view;
 // clang-format on


### PR DESCRIPTION
## Description

**_preferred_** adjective
pre·​ferred pri-ˈfərd 

1. : liked better or best : used or wanted in preference to others
   | a _preferred_ method
   | 'Leveled' is the _preferred_ spelling in American English.
2. : having special status or receiving special treatment or benefits
   | _preferred_ customers

## Checklist
- [x] we don't need no stinkin' tests
- [x] we don't need no stinkin' docs
