### PR TITLE
improved diagnostics for `cuda::experimental::execution`

### DIFF
--- a/cudax/include/cuda/experimental/__execution/completion_signatures.cuh
+++ b/cudax/include/cuda/experimental/__execution/completion_signatures.cuh
@@ -223,6 +223,10 @@ completion_signatures() -> completion_signatures<>;
 template <class _Ty>
 _CCCL_CONCEPT __valid_completion_signatures = detail::__is_specialization_of<_Ty, completion_signatures>;
 
+template <class... _Sigs>
+_CCCL_API constexpr void __assert_valid_completion_signatures(completion_signatures<_Sigs...>)
+{}
+
 template <class _Derived>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __compile_time_error // : ::std::exception
 {

--- a/cudax/include/cuda/experimental/__execution/conditional.cuh
+++ b/cudax/include/cuda/experimental/__execution/conditional.cuh
@@ -243,13 +243,12 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT conditional_t::__closure
   _CCCL_TRIVIAL_API auto __mk_sender(_Sndr&& __sndr) -> __sndr_t<__closure, _Sndr>
   {
     using __dom_t _CCCL_NODEBUG_ALIAS = domain_for_t<_Sndr>;
-
+    // If the incoming sender is non-dependent, we can check the completion signatures of
+    // the composed sender immediately.
     if constexpr (!dependent_sender<_Sndr>)
     {
-      using __completions _CCCL_NODEBUG_ALIAS = completion_signatures_of_t<__sndr_t<__closure, _Sndr>>;
-      static_assert(__valid_completion_signatures<__completions>);
+      __assert_valid_completion_signatures(get_completion_signatures<__sndr_t<__closure, _Sndr>>());
     }
-
     return transform_sender(
       __dom_t{}, __sndr_t<__closure, _Sndr>{{}, static_cast<__closure&&>(*this), static_cast<_Sndr&&>(__sndr)});
   }

--- a/cudax/include/cuda/experimental/__execution/fwd.cuh
+++ b/cudax/include/cuda/experimental/__execution/fwd.cuh
@@ -94,21 +94,33 @@ struct connect_t;
 struct schedule_t;
 
 // sender factory algorithms:
-struct just_t;
-struct just_error_t;
-struct just_stopped_t;
-struct just_from_t;
-struct just_from_error_t;
-struct just_from_stopped_t;
+template <__disposition_t>
+struct __just_t;
+using just_t         = __just_t<__value>;
+using just_error_t   = __just_t<__error>;
+using just_stopped_t = __just_t<__stopped>;
+
+template <__disposition_t>
+struct __just_from_t;
+using just_from_t         = __just_from_t<__value>;
+using just_error_from_t   = __just_from_t<__error>;
+using just_stopped_from_t = __just_from_t<__stopped>;
+
 struct read_env_t;
 
 // sender adaptor algorithms:
-struct let_value_t;
-struct let_error_t;
-struct let_stopped_t;
-struct then_t;
-struct upon_error_t;
-struct upon_stopped_t;
+template <__disposition_t>
+struct __let_t;
+using let_value_t   = __let_t<__value>;
+using let_error_t   = __let_t<__error>;
+using let_stopped_t = __let_t<__stopped>;
+
+template <__disposition_t>
+struct __upon_t;
+using then_t         = __upon_t<__value>;
+using upon_error_t   = __upon_t<__error>;
+using upon_stopped_t = __upon_t<__stopped>;
+
 struct when_all_t;
 struct conditional_t;
 struct sequence_t;

--- a/cudax/include/cuda/experimental/__execution/just.cuh
+++ b/cudax/include/cuda/experimental/__execution/just.cuh
@@ -32,11 +32,6 @@
 
 namespace cuda::experimental::execution
 {
-// Forward declarations of the just* tag types:
-struct just_t;
-struct just_error_t;
-struct just_stopped_t;
-
 // Map from a disposition to the corresponding tag types:
 namespace __detail
 {
@@ -51,7 +46,8 @@ extern __fn_t<just_stopped_t>* __just_tag<__stopped, _Void>;
 } // namespace __detail
 
 template <__disposition_t _Disposition>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT __just_t
+struct _CCCL_TYPE_VISIBILITY_DEFAULT _CCCL_PREFERRED_NAME(just_t) _CCCL_PREFERRED_NAME(just_error_t)
+  _CCCL_PREFERRED_NAME(just_stopped_t) __just_t
 {
 private:
   using _JustTag _CCCL_NODEBUG_ALIAS = decltype(__detail::__just_tag<_Disposition>());
@@ -134,23 +130,15 @@ _CCCL_TRIVIAL_API constexpr auto __just_t<_Disposition>::operator()(_Ts... __ts)
 }
 
 template <class _Fn>
-inline constexpr size_t structured_binding_size<__just_t<__value>::__sndr_t<_Fn>> = 2;
+inline constexpr size_t structured_binding_size<just_t::__sndr_t<_Fn>> = 2;
 template <class _Fn>
-inline constexpr size_t structured_binding_size<__just_t<__error>::__sndr_t<_Fn>> = 2;
+inline constexpr size_t structured_binding_size<just_error_t::__sndr_t<_Fn>> = 2;
 template <class _Fn>
-inline constexpr size_t structured_binding_size<__just_t<__stopped>::__sndr_t<_Fn>> = 2;
+inline constexpr size_t structured_binding_size<just_stopped_t::__sndr_t<_Fn>> = 2;
 
-_CCCL_GLOBAL_CONSTANT struct just_t : __just_t<__value>
-{
-} just{};
-
-_CCCL_GLOBAL_CONSTANT struct just_error_t : __just_t<__error>
-{
-} just_error{};
-
-_CCCL_GLOBAL_CONSTANT struct just_stopped_t : __just_t<__stopped>
-{
-} just_stopped{};
+_CCCL_GLOBAL_CONSTANT auto just         = just_t{};
+_CCCL_GLOBAL_CONSTANT auto just_error   = just_error_t{};
+_CCCL_GLOBAL_CONSTANT auto just_stopped = just_stopped_t{};
 } // namespace cuda::experimental::execution
 
 #include <cuda/experimental/__execution/epilogue.cuh>

--- a/cudax/include/cuda/experimental/__execution/just_from.cuh
+++ b/cudax/include/cuda/experimental/__execution/just_from.cuh
@@ -34,11 +34,6 @@
 
 namespace cuda::experimental::execution
 {
-// Forward declarations of the just* tag types:
-struct just_from_t;
-struct just_error_from_t;
-struct just_stopped_from_t;
-
 // Map from a disposition to the corresponding tag types:
 namespace __detail
 {
@@ -56,7 +51,8 @@ struct _AN_ERROR_COMPLETION_MUST_HAVE_EXACTLY_ONE_ERROR_ARGUMENT;
 struct _A_STOPPED_COMPLETION_MUST_HAVE_NO_ARGUMENTS;
 
 template <__disposition_t _Disposition>
-struct __just_from_t
+struct _CCCL_TYPE_VISIBILITY_DEFAULT _CCCL_PREFERRED_NAME(just_from_t) _CCCL_PREFERRED_NAME(just_error_from_t)
+  _CCCL_PREFERRED_NAME(just_stopped_from_t) __just_from_t
 {
 private:
   using _JustTag _CCCL_NODEBUG_ALIAS = decltype(__detail::__just_from_tag<_Disposition>());
@@ -156,23 +152,16 @@ _CCCL_TRIVIAL_API constexpr auto __just_from_t<_Disposition>::operator()(_Fn __f
 }
 
 template <class _Fn>
-inline constexpr size_t structured_binding_size<__just_from_t<__value>::__sndr_t<_Fn>> = 2;
+inline constexpr size_t structured_binding_size<just_from_t::__sndr_t<_Fn>> = 2;
 template <class _Fn>
-inline constexpr size_t structured_binding_size<__just_from_t<__error>::__sndr_t<_Fn>> = 2;
+inline constexpr size_t structured_binding_size<just_error_from_t::__sndr_t<_Fn>> = 2;
 template <class _Fn>
-inline constexpr size_t structured_binding_size<__just_from_t<__stopped>::__sndr_t<_Fn>> = 2;
+inline constexpr size_t structured_binding_size<just_stopped_from_t::__sndr_t<_Fn>> = 2;
 
-_CCCL_GLOBAL_CONSTANT struct just_from_t : __just_from_t<__value>
-{
-} just_from{};
+_CCCL_GLOBAL_CONSTANT auto just_from         = just_from_t{};
+_CCCL_GLOBAL_CONSTANT auto just_error_from   = just_error_from_t{};
+_CCCL_GLOBAL_CONSTANT auto just_stopped_from = just_stopped_from_t{};
 
-_CCCL_GLOBAL_CONSTANT struct just_error_from_t : __just_from_t<__error>
-{
-} just_error_from{};
-
-_CCCL_GLOBAL_CONSTANT struct just_stopped_from_t : __just_from_t<__stopped>
-{
-} just_stopped_from{};
 } // namespace cuda::experimental::execution
 
 #include <cuda/experimental/__execution/epilogue.cuh>

--- a/cudax/include/cuda/experimental/__execution/then.cuh
+++ b/cudax/include/cuda/experimental/__execution/then.cuh
@@ -42,11 +42,6 @@
 
 namespace cuda::experimental::execution
 {
-// Forward-declate the then and upon_* algorithm tag types:
-struct then_t;
-struct upon_error_t;
-struct upon_stopped_t;
-
 // Map from a disposition to the corresponding tag types:
 namespace __detail
 {
@@ -99,7 +94,8 @@ using __completion _CCCL_NODEBUG_ALIAS = __completion_<__call_result_t<_Fn, _Ts.
 } // namespace __upon
 
 template <__disposition_t _Disposition>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT __upon_t
+struct _CCCL_TYPE_VISIBILITY_DEFAULT _CCCL_PREFERRED_NAME(then_t) _CCCL_PREFERRED_NAME(upon_error_t)
+  _CCCL_PREFERRED_NAME(upon_stopped_t) __upon_t
 {
 private:
   using _UponTag _CCCL_NODEBUG_ALIAS = decltype(__detail::__upon_tag<_Disposition>());
@@ -314,8 +310,7 @@ _CCCL_TRIVIAL_API constexpr auto __upon_t<_Disposition>::operator()(_Sndr __sndr
   // signatures of the composed sender immediately.
   if constexpr (!dependent_sender<_Sndr>)
   {
-    using __completions _CCCL_NODEBUG_ALIAS = completion_signatures_of_t<__sndr_t<_Fn, _Sndr>>;
-    static_assert(__valid_completion_signatures<__completions>);
+    __assert_valid_completion_signatures(get_completion_signatures<__sndr_t<_Fn, _Sndr>>());
   }
   return transform_sender(__dom_t{}, __sndr_t<_Fn, _Sndr>{{}, static_cast<_Fn&&>(__fn), static_cast<_Sndr&&>(__sndr)});
 }
@@ -328,23 +323,16 @@ _CCCL_TRIVIAL_API constexpr auto __upon_t<_Disposition>::operator()(_Fn __fn) co
 }
 
 template <class _Sndr, class _Fn>
-inline constexpr size_t structured_binding_size<__upon_t<__value>::__sndr_t<_Sndr, _Fn>> = 3;
+inline constexpr size_t structured_binding_size<then_t::__sndr_t<_Sndr, _Fn>> = 3;
 template <class _Sndr, class _Fn>
-inline constexpr size_t structured_binding_size<__upon_t<__error>::__sndr_t<_Sndr, _Fn>> = 3;
+inline constexpr size_t structured_binding_size<upon_error_t::__sndr_t<_Sndr, _Fn>> = 3;
 template <class _Sndr, class _Fn>
-inline constexpr size_t structured_binding_size<__upon_t<__stopped>::__sndr_t<_Sndr, _Fn>> = 3;
+inline constexpr size_t structured_binding_size<upon_stopped_t::__sndr_t<_Sndr, _Fn>> = 3;
 
-_CCCL_GLOBAL_CONSTANT struct then_t : __upon_t<__value>
-{
-} then{};
+_CCCL_GLOBAL_CONSTANT auto then         = then_t{};
+_CCCL_GLOBAL_CONSTANT auto upon_error   = upon_error_t{};
+_CCCL_GLOBAL_CONSTANT auto upon_stopped = upon_stopped_t{};
 
-_CCCL_GLOBAL_CONSTANT struct upon_error_t : __upon_t<__error>
-{
-} upon_error{};
-
-_CCCL_GLOBAL_CONSTANT struct upon_stopped_t : __upon_t<__stopped>
-{
-} upon_stopped{};
 } // namespace cuda::experimental::execution
 
 #include <cuda/experimental/__execution/epilogue.cuh>

--- a/cudax/include/cuda/experimental/__execution/when_all.cuh
+++ b/cudax/include/cuda/experimental/__execution/when_all.cuh
@@ -503,8 +503,7 @@ _CCCL_TRIVIAL_API constexpr auto when_all_t::operator()(_Sndrs... __sndrs) const
     // signatures of the composed sender immediately.
     if constexpr (((!dependent_sender<_Sndrs>) && ...))
     {
-      using __completions _CCCL_NODEBUG_ALIAS = completion_signatures_of_t<__sndr_t<_Sndrs...>>;
-      static_assert(__valid_completion_signatures<__completions>);
+      __assert_valid_completion_signatures(get_completion_signatures<__sndr_t<_Sndrs...>>());
     }
     return transform_sender(__dom_t{}, __sndr_t<_Sndrs...>{{{}, {}, static_cast<_Sndrs&&>(__sndrs)...}});
   }


### PR DESCRIPTION
## Description

when a type error happens in a sender expression, µstdex goes to some lengths to propagate the error to the API boundary so it can be reported concisely. but the technique used to report the error was hiding the error description from the user.

a bad sender expression, such as `just(3) | then([](){})` would result in the following error:

```
/home/coder/cccl/cudax/include/cuda/experimental/__execution/then.cuh(315): error: static assertion failed
      static_assert(__valid_completion_signatures<__completions>);
      ^
          detected during instantiation of "auto cuda::experimental::execution::__upon_t<_Disposition>::op
erator()(_Sndr, _Fn) const [with _Disposition=cuda::experimental::execution::__value, _Sndr=cuda::experime
ntal::execution::__just_t<cuda::experimental::execution::__value>::__sndr_t<int>, _Fn=lambda []()->int]" a
t line 26 of <source>
```

that's nice and short, but it doesn't communicate what the error is. after the change in this PR, the error is a bit longer, but it is also far more informative:

```
/home/coder/cccl/cudax/include/cuda/experimental/__execution/then.cuh(313): error: no instance of function
template "cuda::experimental::execution::__assert_valid_completion_signatures" matches the argument list
            argument types are: (cuda::experimental::execution::_ERROR<cuda::experimental::execution::_WHE
RE (cuda::experimental::execution::_IN_ALGORITHM, cuda::experimental::execution::then_t), cuda::experiment
al::execution::_WHAT (cuda::experimental::execution::_FUNCTION_IS_NOT_CALLABLE), cuda::experimental::execu
tion::_WITH_FUNCTION (lambda []()->int), cuda::experimental::execution::_WITH_ARGUMENTS (int)>)
      __assert_valid_completion_signatures(get_completion_signatures<__sndr_t<_Fn, _Sndr>>());
      ^
/home/coder/cccl/cudax/include/cuda/experimental/__execution/completion_signatures.cuh(227): note #3327-D:
candidate function template "cuda::experimental::execution::__assert_valid_completion_signatures" failed d
eduction
  __attribute__((host)) __attribute__((device)) __attribute__((__visibility__("hidden"))) __attribute__((e
xclude_from_explicit_instantiation)) constexpr void __assert_valid_completion_signatures(completion_signat
ures<_Sigs...>)
                                                    ^
          detected during instantiation of "auto cuda::experimental::execution::__upon_t<_Disposition>::op
erator()(_Sndr, _Fn) const [with _Disposition=cuda::experimental::execution::__value, _Sndr=cuda::experime
ntal::execution::__just_t<cuda::experimental::execution::__value>::__sndr_t<int>, _Fn=lambda []()->int]" a
t line 26 of <source>
```

this PR also uses the `__preferred_name__` attribute when it is available to simplify some template types in diagnostics.


## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
