### PR TITLE
Make `cudax::current_arch()` compatible with nvhpc

### DIFF
--- a/cudax/include/cuda/experimental/__device/arch_traits.cuh
+++ b/cudax/include/cuda/experimental/__device/arch_traits.cuh
@@ -26,6 +26,8 @@
 
 #include <cuda/experimental/__device/attributes.cuh>
 
+#include <nv/target>
+
 namespace cuda::experimental
 {
 
@@ -428,15 +430,49 @@ public:
 };
 
 //! @brief Provides architecture traits of the architecture matching __CUDA_ARCH__ macro
-_CCCL_DEVICE constexpr inline arch_traits_t current_arch()
+_CCCL_DEVICE inline arch_traits_t current_arch()
 {
-  // fixme: this doesn't work with nvc++ -cuda
-#ifdef __CUDA_ARCH__
-  return arch_traits(__CUDA_ARCH__);
-#else
-  // Should be unreachable in __device__ function
-  return arch_traits_t{};
-#endif
+  // The NV_DISPATCH_TARGET cannot handle all of the cases, so we need to split it up
+  NV_DISPATCH_TARGET(
+    NV_IS_EXACTLY_SM_35,
+    (return arch_traits(350);),
+    NV_IS_EXACTLY_SM_37,
+    (return arch_traits(370);),
+    NV_IS_EXACTLY_SM_50,
+    (return arch_traits(500);),
+    NV_IS_EXACTLY_SM_52,
+    (return arch_traits(520);),
+    NV_IS_EXACTLY_SM_53,
+    (return arch_traits(530);),
+    NV_IS_EXACTLY_SM_60,
+    (return arch_traits(600);),
+    NV_IS_EXACTLY_SM_61,
+    (return arch_traits(610);),
+    NV_IS_EXACTLY_SM_62,
+    (return arch_traits(620);),
+    NV_IS_EXACTLY_SM_70,
+    (return arch_traits(700);),
+    NV_IS_EXACTLY_SM_72,
+    (return arch_traits(720);),
+    NV_IS_EXACTLY_SM_75,
+    (return arch_traits(750);),
+    NV_IS_EXACTLY_SM_80,
+    (return arch_traits(800);),
+    NV_ANY_TARGET,
+    ())
+  NV_DISPATCH_TARGET(
+    NV_IS_EXACTLY_SM_86,
+    (return arch_traits(860);),
+    NV_IS_EXACTLY_SM_87,
+    (return arch_traits(870);),
+    NV_IS_EXACTLY_SM_89,
+    (return arch_traits(890);),
+    NV_IS_EXACTLY_SM_90,
+    (return arch_traits(900);),
+    NV_IS_EXACTLY_SM_100,
+    (return arch_traits(1000);),
+    NV_ANY_TARGET,
+    (return arch_traits_t{};))
 }
 
 namespace detail

--- a/cudax/test/device/arch_traits.cu
+++ b/cudax/test/device/arch_traits.cu
@@ -16,25 +16,24 @@ template <typename Arch>
 __global__ void arch_specific_kernel_mock_do_not_launch()
 {
   // I will try to pack something like this into an API
-  if constexpr (Arch::compute_capability != cudax::current_arch().compute_capability)
+  if (Arch::compute_capability != cudax::current_arch().compute_capability)
   {
     return;
   }
 
   [[maybe_unused]] __shared__ int array[Arch::max_shared_memory_per_block / sizeof(int)];
 
-  // constexpr is useless and I can't use intrinsics here :(
-  if constexpr (cudax::current_arch().cluster_supported)
+  if (cudax::current_arch().cluster_supported)
   {
     [[maybe_unused]] int dummy;
     asm volatile("mov.u32 %0, %%cluster_ctarank;" : "=r"(dummy));
   }
-  if constexpr (cudax::current_arch().redux_intrinisic)
+  if (cudax::current_arch().redux_intrinisic)
   {
     [[maybe_unused]] int dummy1 = 0, dummy2 = 0;
     asm volatile("redux.sync.add.s32 %0, %1, 0xffffffff;" : "=r"(dummy1) : "r"(dummy2));
   }
-  if constexpr (cudax::current_arch().cp_async_supported)
+  if (cudax::current_arch().cp_async_supported)
   {
     asm volatile("cp.async.commit_group;");
   }


### PR DESCRIPTION
When compiling with `nvc++ -cuda`, the current target cannot be part of a constant expression. This PR removes the `constexpr` support from the `cudax::current_arch()` function and makes it compatible with nvhpc.