### PR TITLE
Build and test python wheels in CI

### DIFF
--- a/.devcontainer/cccl-entrypoint.sh
+++ b/.devcontainer/cccl-entrypoint.sh
@@ -10,6 +10,37 @@ devcontainer-utils-post-attach-command;
 
 cd /home/coder/cccl/
 
+# Check if docker CLI is available, and if not, install docker-outside-of-docker feature if specified in devcontainer.json
+if ! command -v docker >/dev/null 2>&1; then
+    # Find the devcontainer.json file (search up from current dir)
+    search_dir="$(pwd)"
+    found_json=""
+    while [[ "$search_dir" != "/" ]]; do
+        if [[ -f "$search_dir/.devcontainer/devcontainer.json" ]]; then
+            found_json="$search_dir/.devcontainer/devcontainer.json"
+            break
+        fi
+        search_dir="$(dirname "$search_dir")"
+    done
+    if [[ -n "$found_json" ]] && grep -q 'docker-outside-of-docker' "$found_json"; then
+        echo "Installing docker-outside-of-docker feature..."
+        git clone --depth=1 https://github.com/devcontainers/features.git /tmp/features
+        cd /tmp/features/src/docker-outside-of-docker
+        chmod +x install.sh
+        sudo SOURCE_SOCKET=/var/run/docker.sock TARGET_SOCKET=/var/run/docker.sock MOBY=false ./install.sh || { echo "docker-outside-of-docker install failed"; exit 1; }
+        cd -
+
+        # Install nvidia-container-toolkit
+        curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg \
+        && curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
+            sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
+            sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+        sudo sed -i -e '/experimental/ s/^#//g' /etc/apt/sources.list.d/nvidia-container-toolkit.list
+        sudo apt-get update
+        sudo apt-get install -y nvidia-container-toolkit
+    fi
+fi
+
 if test $# -gt 0; then
     exec "$@";
 else

--- a/.devcontainer/cuda12.0-gcc10/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc10/devcontainer.json
@@ -7,7 +7,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; else docker volume create cccl-build; fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse; else docker volume create cccl-build; docker volume create cccl-wheelhouse; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",
@@ -19,7 +19,8 @@
     "CCCL_HOST_COMPILER": "gcc",
     "CCCL_HOST_COMPILER_VERSION": "10",
     "CCCL_BUILD_INFIX": "cuda12.0-gcc10",
-    "CCCL_CUDA_EXTENDED": "false"
+    "CCCL_CUDA_EXTENDED": "false",
+    "HOST_WORKSPACE": "${localWorkspaceFolder}"
   },
   "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
   "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
@@ -27,7 +28,8 @@
     "source=${localWorkspaceFolder}/.aws,target=/home/coder/.aws,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.cache,target=/home/coder/.cache,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.config,target=/home/coder/.config,type=bind,consistency=consistent",
-    "source=cccl-build,target=/home/coder/cccl/build"
+    "source=cccl-build,target=/home/coder/cccl/build",
+    "source=cccl-wheelhouse,target=/home/coder/cccl/wheelhouse"
   ],
   "customizations": {
     "vscode": {
@@ -50,5 +52,10 @@
       }
     }
   },
-  "name": "cuda12.0-gcc10"
+  "name": "cuda12.0-gcc10",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "moby": false
+    }
+  }
 }

--- a/.devcontainer/cuda12.0-gcc11/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc11/devcontainer.json
@@ -7,7 +7,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; else docker volume create cccl-build; fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse; else docker volume create cccl-build; docker volume create cccl-wheelhouse; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",
@@ -19,7 +19,8 @@
     "CCCL_HOST_COMPILER": "gcc",
     "CCCL_HOST_COMPILER_VERSION": "11",
     "CCCL_BUILD_INFIX": "cuda12.0-gcc11",
-    "CCCL_CUDA_EXTENDED": "false"
+    "CCCL_CUDA_EXTENDED": "false",
+    "HOST_WORKSPACE": "${localWorkspaceFolder}"
   },
   "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
   "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
@@ -27,7 +28,8 @@
     "source=${localWorkspaceFolder}/.aws,target=/home/coder/.aws,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.cache,target=/home/coder/.cache,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.config,target=/home/coder/.config,type=bind,consistency=consistent",
-    "source=cccl-build,target=/home/coder/cccl/build"
+    "source=cccl-build,target=/home/coder/cccl/build",
+    "source=cccl-wheelhouse,target=/home/coder/cccl/wheelhouse"
   ],
   "customizations": {
     "vscode": {
@@ -50,5 +52,10 @@
       }
     }
   },
-  "name": "cuda12.0-gcc11"
+  "name": "cuda12.0-gcc11",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "moby": false
+    }
+  }
 }

--- a/.devcontainer/cuda12.0-gcc12/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc12/devcontainer.json
@@ -7,7 +7,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; else docker volume create cccl-build; fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse; else docker volume create cccl-build; docker volume create cccl-wheelhouse; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",
@@ -19,7 +19,8 @@
     "CCCL_HOST_COMPILER": "gcc",
     "CCCL_HOST_COMPILER_VERSION": "12",
     "CCCL_BUILD_INFIX": "cuda12.0-gcc12",
-    "CCCL_CUDA_EXTENDED": "false"
+    "CCCL_CUDA_EXTENDED": "false",
+    "HOST_WORKSPACE": "${localWorkspaceFolder}"
   },
   "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
   "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
@@ -27,7 +28,8 @@
     "source=${localWorkspaceFolder}/.aws,target=/home/coder/.aws,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.cache,target=/home/coder/.cache,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.config,target=/home/coder/.config,type=bind,consistency=consistent",
-    "source=cccl-build,target=/home/coder/cccl/build"
+    "source=cccl-build,target=/home/coder/cccl/build",
+    "source=cccl-wheelhouse,target=/home/coder/cccl/wheelhouse"
   ],
   "customizations": {
     "vscode": {
@@ -50,5 +52,10 @@
       }
     }
   },
-  "name": "cuda12.0-gcc12"
+  "name": "cuda12.0-gcc12",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "moby": false
+    }
+  }
 }

--- a/.devcontainer/cuda12.0-gcc7/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc7/devcontainer.json
@@ -7,7 +7,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; else docker volume create cccl-build; fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse; else docker volume create cccl-build; docker volume create cccl-wheelhouse; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",
@@ -19,7 +19,8 @@
     "CCCL_HOST_COMPILER": "gcc",
     "CCCL_HOST_COMPILER_VERSION": "7",
     "CCCL_BUILD_INFIX": "cuda12.0-gcc7",
-    "CCCL_CUDA_EXTENDED": "false"
+    "CCCL_CUDA_EXTENDED": "false",
+    "HOST_WORKSPACE": "${localWorkspaceFolder}"
   },
   "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
   "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
@@ -27,7 +28,8 @@
     "source=${localWorkspaceFolder}/.aws,target=/home/coder/.aws,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.cache,target=/home/coder/.cache,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.config,target=/home/coder/.config,type=bind,consistency=consistent",
-    "source=cccl-build,target=/home/coder/cccl/build"
+    "source=cccl-build,target=/home/coder/cccl/build",
+    "source=cccl-wheelhouse,target=/home/coder/cccl/wheelhouse"
   ],
   "customizations": {
     "vscode": {
@@ -50,5 +52,10 @@
       }
     }
   },
-  "name": "cuda12.0-gcc7"
+  "name": "cuda12.0-gcc7",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "moby": false
+    }
+  }
 }

--- a/.devcontainer/cuda12.0-gcc8/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc8/devcontainer.json
@@ -7,7 +7,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; else docker volume create cccl-build; fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse; else docker volume create cccl-build; docker volume create cccl-wheelhouse; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",
@@ -19,7 +19,8 @@
     "CCCL_HOST_COMPILER": "gcc",
     "CCCL_HOST_COMPILER_VERSION": "8",
     "CCCL_BUILD_INFIX": "cuda12.0-gcc8",
-    "CCCL_CUDA_EXTENDED": "false"
+    "CCCL_CUDA_EXTENDED": "false",
+    "HOST_WORKSPACE": "${localWorkspaceFolder}"
   },
   "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
   "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
@@ -27,7 +28,8 @@
     "source=${localWorkspaceFolder}/.aws,target=/home/coder/.aws,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.cache,target=/home/coder/.cache,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.config,target=/home/coder/.config,type=bind,consistency=consistent",
-    "source=cccl-build,target=/home/coder/cccl/build"
+    "source=cccl-build,target=/home/coder/cccl/build",
+    "source=cccl-wheelhouse,target=/home/coder/cccl/wheelhouse"
   ],
   "customizations": {
     "vscode": {
@@ -50,5 +52,10 @@
       }
     }
   },
-  "name": "cuda12.0-gcc8"
+  "name": "cuda12.0-gcc8",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "moby": false
+    }
+  }
 }

--- a/.devcontainer/cuda12.0-gcc9/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc9/devcontainer.json
@@ -7,7 +7,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; else docker volume create cccl-build; fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse; else docker volume create cccl-build; docker volume create cccl-wheelhouse; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",
@@ -19,7 +19,8 @@
     "CCCL_HOST_COMPILER": "gcc",
     "CCCL_HOST_COMPILER_VERSION": "9",
     "CCCL_BUILD_INFIX": "cuda12.0-gcc9",
-    "CCCL_CUDA_EXTENDED": "false"
+    "CCCL_CUDA_EXTENDED": "false",
+    "HOST_WORKSPACE": "${localWorkspaceFolder}"
   },
   "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
   "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
@@ -27,7 +28,8 @@
     "source=${localWorkspaceFolder}/.aws,target=/home/coder/.aws,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.cache,target=/home/coder/.cache,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.config,target=/home/coder/.config,type=bind,consistency=consistent",
-    "source=cccl-build,target=/home/coder/cccl/build"
+    "source=cccl-build,target=/home/coder/cccl/build",
+    "source=cccl-wheelhouse,target=/home/coder/cccl/wheelhouse"
   ],
   "customizations": {
     "vscode": {
@@ -50,5 +52,10 @@
       }
     }
   },
-  "name": "cuda12.0-gcc9"
+  "name": "cuda12.0-gcc9",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "moby": false
+    }
+  }
 }

--- a/.devcontainer/cuda12.0-llvm14/devcontainer.json
+++ b/.devcontainer/cuda12.0-llvm14/devcontainer.json
@@ -7,7 +7,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; else docker volume create cccl-build; fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse; else docker volume create cccl-build; docker volume create cccl-wheelhouse; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",
@@ -19,7 +19,8 @@
     "CCCL_HOST_COMPILER": "llvm",
     "CCCL_HOST_COMPILER_VERSION": "14",
     "CCCL_BUILD_INFIX": "cuda12.0-llvm14",
-    "CCCL_CUDA_EXTENDED": "false"
+    "CCCL_CUDA_EXTENDED": "false",
+    "HOST_WORKSPACE": "${localWorkspaceFolder}"
   },
   "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
   "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
@@ -27,7 +28,8 @@
     "source=${localWorkspaceFolder}/.aws,target=/home/coder/.aws,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.cache,target=/home/coder/.cache,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.config,target=/home/coder/.config,type=bind,consistency=consistent",
-    "source=cccl-build,target=/home/coder/cccl/build"
+    "source=cccl-build,target=/home/coder/cccl/build",
+    "source=cccl-wheelhouse,target=/home/coder/cccl/wheelhouse"
   ],
   "customizations": {
     "vscode": {
@@ -50,5 +52,10 @@
       }
     }
   },
-  "name": "cuda12.0-llvm14"
+  "name": "cuda12.0-llvm14",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "moby": false
+    }
+  }
 }

--- a/.devcontainer/cuda12.8-gcc10/devcontainer.json
+++ b/.devcontainer/cuda12.8-gcc10/devcontainer.json
@@ -7,7 +7,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; else docker volume create cccl-build; fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse; else docker volume create cccl-build; docker volume create cccl-wheelhouse; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",
@@ -19,7 +19,8 @@
     "CCCL_HOST_COMPILER": "gcc",
     "CCCL_HOST_COMPILER_VERSION": "10",
     "CCCL_BUILD_INFIX": "cuda12.8-gcc10",
-    "CCCL_CUDA_EXTENDED": "false"
+    "CCCL_CUDA_EXTENDED": "false",
+    "HOST_WORKSPACE": "${localWorkspaceFolder}"
   },
   "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
   "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
@@ -27,7 +28,8 @@
     "source=${localWorkspaceFolder}/.aws,target=/home/coder/.aws,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.cache,target=/home/coder/.cache,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.config,target=/home/coder/.config,type=bind,consistency=consistent",
-    "source=cccl-build,target=/home/coder/cccl/build"
+    "source=cccl-build,target=/home/coder/cccl/build",
+    "source=cccl-wheelhouse,target=/home/coder/cccl/wheelhouse"
   ],
   "customizations": {
     "vscode": {
@@ -50,5 +52,10 @@
       }
     }
   },
-  "name": "cuda12.8-gcc10"
+  "name": "cuda12.8-gcc10",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "moby": false
+    }
+  }
 }

--- a/.devcontainer/cuda12.8-gcc11/devcontainer.json
+++ b/.devcontainer/cuda12.8-gcc11/devcontainer.json
@@ -7,7 +7,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; else docker volume create cccl-build; fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse; else docker volume create cccl-build; docker volume create cccl-wheelhouse; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",
@@ -19,7 +19,8 @@
     "CCCL_HOST_COMPILER": "gcc",
     "CCCL_HOST_COMPILER_VERSION": "11",
     "CCCL_BUILD_INFIX": "cuda12.8-gcc11",
-    "CCCL_CUDA_EXTENDED": "false"
+    "CCCL_CUDA_EXTENDED": "false",
+    "HOST_WORKSPACE": "${localWorkspaceFolder}"
   },
   "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
   "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
@@ -27,7 +28,8 @@
     "source=${localWorkspaceFolder}/.aws,target=/home/coder/.aws,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.cache,target=/home/coder/.cache,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.config,target=/home/coder/.config,type=bind,consistency=consistent",
-    "source=cccl-build,target=/home/coder/cccl/build"
+    "source=cccl-build,target=/home/coder/cccl/build",
+    "source=cccl-wheelhouse,target=/home/coder/cccl/wheelhouse"
   ],
   "customizations": {
     "vscode": {
@@ -50,5 +52,10 @@
       }
     }
   },
-  "name": "cuda12.8-gcc11"
+  "name": "cuda12.8-gcc11",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "moby": false
+    }
+  }
 }

--- a/.devcontainer/cuda12.8-gcc12/devcontainer.json
+++ b/.devcontainer/cuda12.8-gcc12/devcontainer.json
@@ -7,7 +7,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; else docker volume create cccl-build; fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse; else docker volume create cccl-build; docker volume create cccl-wheelhouse; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",
@@ -19,7 +19,8 @@
     "CCCL_HOST_COMPILER": "gcc",
     "CCCL_HOST_COMPILER_VERSION": "12",
     "CCCL_BUILD_INFIX": "cuda12.8-gcc12",
-    "CCCL_CUDA_EXTENDED": "false"
+    "CCCL_CUDA_EXTENDED": "false",
+    "HOST_WORKSPACE": "${localWorkspaceFolder}"
   },
   "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
   "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
@@ -27,7 +28,8 @@
     "source=${localWorkspaceFolder}/.aws,target=/home/coder/.aws,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.cache,target=/home/coder/.cache,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.config,target=/home/coder/.config,type=bind,consistency=consistent",
-    "source=cccl-build,target=/home/coder/cccl/build"
+    "source=cccl-build,target=/home/coder/cccl/build",
+    "source=cccl-wheelhouse,target=/home/coder/cccl/wheelhouse"
   ],
   "customizations": {
     "vscode": {
@@ -50,5 +52,10 @@
       }
     }
   },
-  "name": "cuda12.8-gcc12"
+  "name": "cuda12.8-gcc12",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "moby": false
+    }
+  }
 }

--- a/.devcontainer/cuda12.8-gcc13/devcontainer.json
+++ b/.devcontainer/cuda12.8-gcc13/devcontainer.json
@@ -7,7 +7,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; else docker volume create cccl-build; fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse; else docker volume create cccl-build; docker volume create cccl-wheelhouse; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",
@@ -19,7 +19,8 @@
     "CCCL_HOST_COMPILER": "gcc",
     "CCCL_HOST_COMPILER_VERSION": "13",
     "CCCL_BUILD_INFIX": "cuda12.8-gcc13",
-    "CCCL_CUDA_EXTENDED": "false"
+    "CCCL_CUDA_EXTENDED": "false",
+    "HOST_WORKSPACE": "${localWorkspaceFolder}"
   },
   "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
   "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
@@ -27,7 +28,8 @@
     "source=${localWorkspaceFolder}/.aws,target=/home/coder/.aws,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.cache,target=/home/coder/.cache,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.config,target=/home/coder/.config,type=bind,consistency=consistent",
-    "source=cccl-build,target=/home/coder/cccl/build"
+    "source=cccl-build,target=/home/coder/cccl/build",
+    "source=cccl-wheelhouse,target=/home/coder/cccl/wheelhouse"
   ],
   "customizations": {
     "vscode": {
@@ -50,5 +52,10 @@
       }
     }
   },
-  "name": "cuda12.8-gcc13"
+  "name": "cuda12.8-gcc13",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "moby": false
+    }
+  }
 }

--- a/.devcontainer/cuda12.8-gcc7/devcontainer.json
+++ b/.devcontainer/cuda12.8-gcc7/devcontainer.json
@@ -7,7 +7,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; else docker volume create cccl-build; fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse; else docker volume create cccl-build; docker volume create cccl-wheelhouse; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",
@@ -19,7 +19,8 @@
     "CCCL_HOST_COMPILER": "gcc",
     "CCCL_HOST_COMPILER_VERSION": "7",
     "CCCL_BUILD_INFIX": "cuda12.8-gcc7",
-    "CCCL_CUDA_EXTENDED": "false"
+    "CCCL_CUDA_EXTENDED": "false",
+    "HOST_WORKSPACE": "${localWorkspaceFolder}"
   },
   "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
   "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
@@ -27,7 +28,8 @@
     "source=${localWorkspaceFolder}/.aws,target=/home/coder/.aws,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.cache,target=/home/coder/.cache,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.config,target=/home/coder/.config,type=bind,consistency=consistent",
-    "source=cccl-build,target=/home/coder/cccl/build"
+    "source=cccl-build,target=/home/coder/cccl/build",
+    "source=cccl-wheelhouse,target=/home/coder/cccl/wheelhouse"
   ],
   "customizations": {
     "vscode": {
@@ -50,5 +52,10 @@
       }
     }
   },
-  "name": "cuda12.8-gcc7"
+  "name": "cuda12.8-gcc7",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "moby": false
+    }
+  }
 }

--- a/.devcontainer/cuda12.8-gcc8/devcontainer.json
+++ b/.devcontainer/cuda12.8-gcc8/devcontainer.json
@@ -7,7 +7,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; else docker volume create cccl-build; fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse; else docker volume create cccl-build; docker volume create cccl-wheelhouse; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",
@@ -19,7 +19,8 @@
     "CCCL_HOST_COMPILER": "gcc",
     "CCCL_HOST_COMPILER_VERSION": "8",
     "CCCL_BUILD_INFIX": "cuda12.8-gcc8",
-    "CCCL_CUDA_EXTENDED": "false"
+    "CCCL_CUDA_EXTENDED": "false",
+    "HOST_WORKSPACE": "${localWorkspaceFolder}"
   },
   "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
   "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
@@ -27,7 +28,8 @@
     "source=${localWorkspaceFolder}/.aws,target=/home/coder/.aws,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.cache,target=/home/coder/.cache,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.config,target=/home/coder/.config,type=bind,consistency=consistent",
-    "source=cccl-build,target=/home/coder/cccl/build"
+    "source=cccl-build,target=/home/coder/cccl/build",
+    "source=cccl-wheelhouse,target=/home/coder/cccl/wheelhouse"
   ],
   "customizations": {
     "vscode": {
@@ -50,5 +52,10 @@
       }
     }
   },
-  "name": "cuda12.8-gcc8"
+  "name": "cuda12.8-gcc8",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "moby": false
+    }
+  }
 }

--- a/.devcontainer/cuda12.8-gcc9/devcontainer.json
+++ b/.devcontainer/cuda12.8-gcc9/devcontainer.json
@@ -7,7 +7,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; else docker volume create cccl-build; fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse; else docker volume create cccl-build; docker volume create cccl-wheelhouse; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",
@@ -19,7 +19,8 @@
     "CCCL_HOST_COMPILER": "gcc",
     "CCCL_HOST_COMPILER_VERSION": "9",
     "CCCL_BUILD_INFIX": "cuda12.8-gcc9",
-    "CCCL_CUDA_EXTENDED": "false"
+    "CCCL_CUDA_EXTENDED": "false",
+    "HOST_WORKSPACE": "${localWorkspaceFolder}"
   },
   "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
   "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
@@ -27,7 +28,8 @@
     "source=${localWorkspaceFolder}/.aws,target=/home/coder/.aws,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.cache,target=/home/coder/.cache,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.config,target=/home/coder/.config,type=bind,consistency=consistent",
-    "source=cccl-build,target=/home/coder/cccl/build"
+    "source=cccl-build,target=/home/coder/cccl/build",
+    "source=cccl-wheelhouse,target=/home/coder/cccl/wheelhouse"
   ],
   "customizations": {
     "vscode": {
@@ -50,5 +52,10 @@
       }
     }
   },
-  "name": "cuda12.8-gcc9"
+  "name": "cuda12.8-gcc9",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "moby": false
+    }
+  }
 }

--- a/.devcontainer/cuda12.8-llvm14/devcontainer.json
+++ b/.devcontainer/cuda12.8-llvm14/devcontainer.json
@@ -7,7 +7,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; else docker volume create cccl-build; fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse; else docker volume create cccl-build; docker volume create cccl-wheelhouse; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",
@@ -19,7 +19,8 @@
     "CCCL_HOST_COMPILER": "llvm",
     "CCCL_HOST_COMPILER_VERSION": "14",
     "CCCL_BUILD_INFIX": "cuda12.8-llvm14",
-    "CCCL_CUDA_EXTENDED": "false"
+    "CCCL_CUDA_EXTENDED": "false",
+    "HOST_WORKSPACE": "${localWorkspaceFolder}"
   },
   "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
   "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
@@ -27,7 +28,8 @@
     "source=${localWorkspaceFolder}/.aws,target=/home/coder/.aws,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.cache,target=/home/coder/.cache,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.config,target=/home/coder/.config,type=bind,consistency=consistent",
-    "source=cccl-build,target=/home/coder/cccl/build"
+    "source=cccl-build,target=/home/coder/cccl/build",
+    "source=cccl-wheelhouse,target=/home/coder/cccl/wheelhouse"
   ],
   "customizations": {
     "vscode": {
@@ -50,5 +52,10 @@
       }
     }
   },
-  "name": "cuda12.8-llvm14"
+  "name": "cuda12.8-llvm14",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "moby": false
+    }
+  }
 }

--- a/.devcontainer/cuda12.8-llvm15/devcontainer.json
+++ b/.devcontainer/cuda12.8-llvm15/devcontainer.json
@@ -7,7 +7,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; else docker volume create cccl-build; fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse; else docker volume create cccl-build; docker volume create cccl-wheelhouse; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",
@@ -19,7 +19,8 @@
     "CCCL_HOST_COMPILER": "llvm",
     "CCCL_HOST_COMPILER_VERSION": "15",
     "CCCL_BUILD_INFIX": "cuda12.8-llvm15",
-    "CCCL_CUDA_EXTENDED": "false"
+    "CCCL_CUDA_EXTENDED": "false",
+    "HOST_WORKSPACE": "${localWorkspaceFolder}"
   },
   "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
   "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
@@ -27,7 +28,8 @@
     "source=${localWorkspaceFolder}/.aws,target=/home/coder/.aws,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.cache,target=/home/coder/.cache,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.config,target=/home/coder/.config,type=bind,consistency=consistent",
-    "source=cccl-build,target=/home/coder/cccl/build"
+    "source=cccl-build,target=/home/coder/cccl/build",
+    "source=cccl-wheelhouse,target=/home/coder/cccl/wheelhouse"
   ],
   "customizations": {
     "vscode": {
@@ -50,5 +52,10 @@
       }
     }
   },
-  "name": "cuda12.8-llvm15"
+  "name": "cuda12.8-llvm15",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "moby": false
+    }
+  }
 }

--- a/.devcontainer/cuda12.8-llvm16/devcontainer.json
+++ b/.devcontainer/cuda12.8-llvm16/devcontainer.json
@@ -7,7 +7,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; else docker volume create cccl-build; fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse; else docker volume create cccl-build; docker volume create cccl-wheelhouse; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",
@@ -19,7 +19,8 @@
     "CCCL_HOST_COMPILER": "llvm",
     "CCCL_HOST_COMPILER_VERSION": "16",
     "CCCL_BUILD_INFIX": "cuda12.8-llvm16",
-    "CCCL_CUDA_EXTENDED": "false"
+    "CCCL_CUDA_EXTENDED": "false",
+    "HOST_WORKSPACE": "${localWorkspaceFolder}"
   },
   "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
   "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
@@ -27,7 +28,8 @@
     "source=${localWorkspaceFolder}/.aws,target=/home/coder/.aws,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.cache,target=/home/coder/.cache,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.config,target=/home/coder/.config,type=bind,consistency=consistent",
-    "source=cccl-build,target=/home/coder/cccl/build"
+    "source=cccl-build,target=/home/coder/cccl/build",
+    "source=cccl-wheelhouse,target=/home/coder/cccl/wheelhouse"
   ],
   "customizations": {
     "vscode": {
@@ -50,5 +52,10 @@
       }
     }
   },
-  "name": "cuda12.8-llvm16"
+  "name": "cuda12.8-llvm16",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "moby": false
+    }
+  }
 }

--- a/.devcontainer/cuda12.8-llvm17/devcontainer.json
+++ b/.devcontainer/cuda12.8-llvm17/devcontainer.json
@@ -7,7 +7,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; else docker volume create cccl-build; fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse; else docker volume create cccl-build; docker volume create cccl-wheelhouse; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",
@@ -19,7 +19,8 @@
     "CCCL_HOST_COMPILER": "llvm",
     "CCCL_HOST_COMPILER_VERSION": "17",
     "CCCL_BUILD_INFIX": "cuda12.8-llvm17",
-    "CCCL_CUDA_EXTENDED": "false"
+    "CCCL_CUDA_EXTENDED": "false",
+    "HOST_WORKSPACE": "${localWorkspaceFolder}"
   },
   "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
   "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
@@ -27,7 +28,8 @@
     "source=${localWorkspaceFolder}/.aws,target=/home/coder/.aws,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.cache,target=/home/coder/.cache,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.config,target=/home/coder/.config,type=bind,consistency=consistent",
-    "source=cccl-build,target=/home/coder/cccl/build"
+    "source=cccl-build,target=/home/coder/cccl/build",
+    "source=cccl-wheelhouse,target=/home/coder/cccl/wheelhouse"
   ],
   "customizations": {
     "vscode": {
@@ -50,5 +52,10 @@
       }
     }
   },
-  "name": "cuda12.8-llvm17"
+  "name": "cuda12.8-llvm17",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "moby": false
+    }
+  }
 }

--- a/.devcontainer/cuda12.8-llvm18/devcontainer.json
+++ b/.devcontainer/cuda12.8-llvm18/devcontainer.json
@@ -7,7 +7,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; else docker volume create cccl-build; fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse; else docker volume create cccl-build; docker volume create cccl-wheelhouse; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",
@@ -19,7 +19,8 @@
     "CCCL_HOST_COMPILER": "llvm",
     "CCCL_HOST_COMPILER_VERSION": "18",
     "CCCL_BUILD_INFIX": "cuda12.8-llvm18",
-    "CCCL_CUDA_EXTENDED": "false"
+    "CCCL_CUDA_EXTENDED": "false",
+    "HOST_WORKSPACE": "${localWorkspaceFolder}"
   },
   "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
   "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
@@ -27,7 +28,8 @@
     "source=${localWorkspaceFolder}/.aws,target=/home/coder/.aws,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.cache,target=/home/coder/.cache,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.config,target=/home/coder/.config,type=bind,consistency=consistent",
-    "source=cccl-build,target=/home/coder/cccl/build"
+    "source=cccl-build,target=/home/coder/cccl/build",
+    "source=cccl-wheelhouse,target=/home/coder/cccl/wheelhouse"
   ],
   "customizations": {
     "vscode": {
@@ -50,5 +52,10 @@
       }
     }
   },
-  "name": "cuda12.8-llvm18"
+  "name": "cuda12.8-llvm18",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "moby": false
+    }
+  }
 }

--- a/.devcontainer/cuda12.8-llvm19/devcontainer.json
+++ b/.devcontainer/cuda12.8-llvm19/devcontainer.json
@@ -7,7 +7,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; else docker volume create cccl-build; fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse; else docker volume create cccl-build; docker volume create cccl-wheelhouse; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",
@@ -19,7 +19,8 @@
     "CCCL_HOST_COMPILER": "llvm",
     "CCCL_HOST_COMPILER_VERSION": "19",
     "CCCL_BUILD_INFIX": "cuda12.8-llvm19",
-    "CCCL_CUDA_EXTENDED": "false"
+    "CCCL_CUDA_EXTENDED": "false",
+    "HOST_WORKSPACE": "${localWorkspaceFolder}"
   },
   "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
   "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
@@ -27,7 +28,8 @@
     "source=${localWorkspaceFolder}/.aws,target=/home/coder/.aws,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.cache,target=/home/coder/.cache,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.config,target=/home/coder/.config,type=bind,consistency=consistent",
-    "source=cccl-build,target=/home/coder/cccl/build"
+    "source=cccl-build,target=/home/coder/cccl/build",
+    "source=cccl-wheelhouse,target=/home/coder/cccl/wheelhouse"
   ],
   "customizations": {
     "vscode": {
@@ -50,5 +52,10 @@
       }
     }
   },
-  "name": "cuda12.8-llvm19"
+  "name": "cuda12.8-llvm19",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "moby": false
+    }
+  }
 }

--- a/.devcontainer/cuda12.8-nvhpc25.3/devcontainer.json
+++ b/.devcontainer/cuda12.8-nvhpc25.3/devcontainer.json
@@ -7,7 +7,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; else docker volume create cccl-build; fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse; else docker volume create cccl-build; docker volume create cccl-wheelhouse; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",
@@ -19,7 +19,8 @@
     "CCCL_HOST_COMPILER": "nvhpc",
     "CCCL_HOST_COMPILER_VERSION": "25.3",
     "CCCL_BUILD_INFIX": "cuda12.8-nvhpc25.3",
-    "CCCL_CUDA_EXTENDED": "false"
+    "CCCL_CUDA_EXTENDED": "false",
+    "HOST_WORKSPACE": "${localWorkspaceFolder}"
   },
   "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
   "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
@@ -27,7 +28,8 @@
     "source=${localWorkspaceFolder}/.aws,target=/home/coder/.aws,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.cache,target=/home/coder/.cache,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.config,target=/home/coder/.config,type=bind,consistency=consistent",
-    "source=cccl-build,target=/home/coder/cccl/build"
+    "source=cccl-build,target=/home/coder/cccl/build",
+    "source=cccl-wheelhouse,target=/home/coder/cccl/wheelhouse"
   ],
   "customizations": {
     "vscode": {
@@ -50,5 +52,10 @@
       }
     }
   },
-  "name": "cuda12.8-nvhpc25.3"
+  "name": "cuda12.8-nvhpc25.3",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "moby": false
+    }
+  }
 }

--- a/.devcontainer/cuda12.8ext-gcc13/devcontainer.json
+++ b/.devcontainer/cuda12.8ext-gcc13/devcontainer.json
@@ -7,7 +7,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; else docker volume create cccl-build; fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse; else docker volume create cccl-build; docker volume create cccl-wheelhouse; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",
@@ -19,7 +19,8 @@
     "CCCL_HOST_COMPILER": "gcc",
     "CCCL_HOST_COMPILER_VERSION": "13",
     "CCCL_BUILD_INFIX": "cuda12.8ext-gcc13",
-    "CCCL_CUDA_EXTENDED": "true"
+    "CCCL_CUDA_EXTENDED": "true",
+    "HOST_WORKSPACE": "${localWorkspaceFolder}"
   },
   "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
   "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
@@ -27,7 +28,8 @@
     "source=${localWorkspaceFolder}/.aws,target=/home/coder/.aws,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.cache,target=/home/coder/.cache,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.config,target=/home/coder/.config,type=bind,consistency=consistent",
-    "source=cccl-build,target=/home/coder/cccl/build"
+    "source=cccl-build,target=/home/coder/cccl/build",
+    "source=cccl-wheelhouse,target=/home/coder/cccl/wheelhouse"
   ],
   "customizations": {
     "vscode": {
@@ -50,5 +52,10 @@
       }
     }
   },
-  "name": "cuda12.8ext-gcc13"
+  "name": "cuda12.8ext-gcc13",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "moby": false
+    }
+  }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/build; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; else docker volume create cccl-build; fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse; else docker volume create cccl-build; docker volume create cccl-wheelhouse; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",
@@ -19,7 +19,8 @@
     "CCCL_HOST_COMPILER": "gcc",
     "CCCL_HOST_COMPILER_VERSION": "13",
     "CCCL_BUILD_INFIX": "cuda12.8-gcc13",
-    "CCCL_CUDA_EXTENDED": "false"
+    "CCCL_CUDA_EXTENDED": "false",
+    "HOST_WORKSPACE": "${localWorkspaceFolder}"
   },
   "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
   "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
@@ -27,7 +28,8 @@
     "source=${localWorkspaceFolder}/.aws,target=/home/coder/.aws,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.cache,target=/home/coder/.cache,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.config,target=/home/coder/.config,type=bind,consistency=consistent",
-    "source=cccl-build,target=/home/coder/cccl/build"
+    "source=cccl-build,target=/home/coder/cccl/build",
+    "source=cccl-wheelhouse,target=/home/coder/cccl/wheelhouse"
   ],
   "customizations": {
     "vscode": {
@@ -50,5 +52,10 @@
       }
     }
   },
-  "name": "cuda12.8-gcc13"
+  "name": "cuda12.8-gcc13",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "moby": false
+    }
+  }
 }

--- a/.devcontainer/launch.sh
+++ b/.devcontainer/launch.sh
@@ -224,6 +224,7 @@ launch_docker() {
 
     if test -n "${SSH_AUTH_SOCK:-}" && test -e "${SSH_AUTH_SOCK:-}"; then
         ENV_VARS+=(--env "SSH_AUTH_SOCK=/tmp/ssh-auth-sock")
+        ENV_VARS+=(--env "HOST_WORKSPACE=$(pwd)")
         MOUNTS+=(--mount "source=${SSH_AUTH_SOCK},target=/tmp/ssh-auth-sock,type=bind")
     fi
 
@@ -231,6 +232,9 @@ launch_docker() {
     if test -v volumes && test ${#volumes[@]} -gt 0; then
         MOUNTS+=("${volumes[@]}")
     fi
+
+    # mount /var/run/docker.sock
+    MOUNTS+=(--mount "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind")
 
     # Append user-provided envvars
     if test -v env_vars && test ${#env_vars[@]} -gt 0; then

--- a/.github/actions/workflow-build/build-workflow.py
+++ b/.github/actions/workflow-build/build-workflow.py
@@ -478,6 +478,8 @@ def generate_dispatch_job_command(matrix_job, job_type):
     cuda_compile_arch = matrix_job["sm"] if "sm" in matrix_job else ""
     cmake_options = matrix_job["cmake_options"] if "cmake_options" in matrix_job else ""
 
+    py_version = matrix_job["py_version"] if "py_version" in matrix_job else ""
+
     command = f'"{script_name}"'
     if job_args:
         command += f" {job_args}"
@@ -489,6 +491,8 @@ def generate_dispatch_job_command(matrix_job, job_type):
         command += f" -cuda \"{device_compiler['exe']}\""
     if cmake_options:
         command += f' -cmake-options "{cmake_options}"'
+    if py_version:
+        command += f' -py-version "{py_version}"'
 
     return command
 

--- a/.github/actions/workflow-build/build-workflow.py
+++ b/.github/actions/workflow-build/build-workflow.py
@@ -398,6 +398,9 @@ def generate_dispatch_job_name(matrix_job, job_type):
     std_str = ("C++" + str(matrix_job["std"]) + " ") if "std" in matrix_job else ""
     cpu_str = matrix_job["cpu"]
     gpu_str = (", " + matrix_job["gpu"].upper()) if job_info["gpu"] else ""
+    py_version = (
+        (", py" + matrix_job["py_version"]) if "py_version" in matrix_job else ""
+    )
     cuda_compile_arch = (
         (" sm{" + str(matrix_job["sm"]) + "}") if "sm" in matrix_job else ""
     )
@@ -415,7 +418,9 @@ def generate_dispatch_job_name(matrix_job, job_type):
         else ""
     )
 
-    return f"[{config_tag}] {job_info['name']}({cpu_str}{gpu_str}){extra_info}"
+    return (
+        f"[{config_tag}] {job_info['name']}({cpu_str}{gpu_str}{py_version}){extra_info}"
+    )
 
 
 def generate_dispatch_job_runner(matrix_job, job_type):

--- a/.github/actions/workflow-run-job-linux/action.yml
+++ b/.github/actions/workflow-run-job-linux/action.yml
@@ -20,6 +20,9 @@ inputs:
   host:
     description: "The host compiler to use when selecting a devcontainer."
     required: true
+  producer_id:
+    description: "The producer job's ID, if downloading a wheelhouse from a producer."
+    required: false
 
 runs:
   using: "composite"
@@ -45,6 +48,12 @@ runs:
         role-to-assume: arn:aws:iam::279114543810:role/gha-oidc-NVIDIA
         aws-region: us-east-2
         role-duration-seconds: 43200 # 12 hours
+    - name: Download wheelhouse artifact if it exists
+      uses: actions/download-artifact@v4
+      with:
+        name: wheelhouse-${{ inputs.producer_id || inputs.id }}
+        path: ${{github.event.repository.name}}/wheelhouse/
+      continue-on-error: true
     - name: Run command # Do not change this step's name, it is checked in parse-job-times.py
       shell: bash --noprofile --norc -euo pipefail {0}
       env:
@@ -58,7 +67,7 @@ runs:
         AWS_SESSION_TOKEN: "${{env.AWS_SESSION_TOKEN}}"
         AWS_SECRET_ACCESS_KEY: "${{env.AWS_SECRET_ACCESS_KEY}}"
       run: |
-        mkdir artifacts
+        mkdir -p artifacts
 
         cat <<'EOF' > ci.sh
         #! /usr/bin/env bash
@@ -154,6 +163,8 @@ runs:
           --env "GITHUB_WORKSPACE=$GITHUB_WORKSPACE" \
           --env "GITHUB_REPOSITORY=$GITHUB_REPOSITORY" \
           --env "GITHUB_STEP_SUMMARY=$GITHUB_STEP_SUMMARY" \
+          --env "HOST_WORKSPACE=${{github.workspace}}" \
+          --env "NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES" \
           --volume "${{github.workspace}}/ci.sh:/ci.sh" \
           --volume "${{github.workspace}}/artifacts:/artifacts" \
           -- /ci.sh
@@ -181,4 +192,12 @@ runs:
       with:
         name: jobs-${{inputs.id}}
         path: jobs
+        compression-level: 0
+
+    - name: Upload wheelhouse
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: wheelhouse-${{inputs.id}}
+        path: ${{github.event.repository.name}}/wheelhouse/
         compression-level: 0

--- a/.github/workflows/workflow-dispatch-two-stage-linux.yml
+++ b/.github/workflows/workflow-dispatch-two-stage-linux.yml
@@ -25,11 +25,16 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    outputs:
+      producer_id: ${{ steps.set_id.outputs.id }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
           persist-credentials: false
+      - name: Set producer ID output
+        id: set_id
+        run: echo "id=${{ fromJSON(inputs.producers)[0].id }}" >> $GITHUB_OUTPUT
       - name: Run job
         uses: ./.github/actions/workflow-run-job-linux
         with:
@@ -65,3 +70,4 @@ jobs:
           runner:  ${{ matrix.runner }}
           cuda:    ${{ matrix.cuda }}
           host:    ${{ matrix.host }}
+          producer_id : ${{ needs.producer.outputs.producer_id }}

--- a/ci/build_cuda_cccl_python.sh
+++ b/ci/build_cuda_cccl_python.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+source "$(dirname "$0")/pyenv_helper.sh"
+
+# Get the Python version from the command line arguments e.g., -py-version=3.10
+py_version=${2#*=}
+echo "Python version: ${py_version}"
+
+# Setup Python environment
+setup_python_env "${py_version}"
+
+# Build the wheel and output to the wheelhouse directory
+cd /home/coder/cccl/python/cuda_cccl
+python -m pip wheel --no-deps . && cp *.whl /home/coder/cccl/wheelhouse

--- a/ci/build_cuda_cooperative_python.sh
+++ b/ci/build_cuda_cooperative_python.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euo pipefail
+source "$(dirname "$0")/pyenv_helper.sh"
+
+# Get the Python version from the command line arguments -py-version=3.10
+py_version=${2#*=}
+echo "Python version: ${py_version}"
+
+# Setup Python environment
+setup_python_env "${py_version}"
+
+cd /home/coder/cccl/python/cuda_cooperative
+
+# Build the cccl wheel and copy it to the wheelhouse directory
+python -m pip wheel --no-deps /home/coder/cccl/python/cuda_cccl && \
+cp cuda_cccl-*.whl /home/coder/cccl/wheelhouse
+
+# Build the wheel and output to the wheelhouse directory
+python -m pip wheel --no-deps . && \
+cp cuda_cooperative-*.whl /home/coder/cccl/wheelhouse

--- a/ci/build_cuda_parallel_python.sh
+++ b/ci/build_cuda_parallel_python.sh
@@ -5,8 +5,11 @@ set -euo pipefail
 py_version=${2#*=}
 echo "Docker socket: " $(ls /var/run/docker.sock)
 
-# given the py_version build the wheel and output the artifact
-# to the artifacts directory
+
+# cuda_parallel must be built in a container that can produce manylinux wheels,
+# and has the CUDA toolkit installed. We use the rapidsai/ci-wheel image for this.
+# These images don't come with a new enough version of gcc installed, so that
+# must be installed manually.
 docker run --rm -i \
   --workdir /workspace/python/cuda_parallel \
   --mount type=bind,source=${HOST_WORKSPACE},target=/workspace/ \

--- a/ci/build_cuda_parallel_python.sh
+++ b/ci/build_cuda_parallel_python.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -euo pipefail
+
+# Get the Python version from the command line arguments -py-version=3.10
+py_version=${2#*=}
+echo "Docker socket: " $(ls /var/run/docker.sock)
+
+# given the py_version build the wheel and output the artifact
+# to the artifacts directory
+docker run --rm -i \
+  --workdir /workspace/python/cuda_parallel \
+  --mount type=bind,source=${HOST_WORKSPACE},target=/workspace/ \
+  --env py_version=${py_version} \
+  rapidsai/ci-wheel:cuda12.8.0-rockylinux8-py3.10 \
+  bash -c '\
+    source /workspace/ci/pyenv_helper.sh && \
+    setup_python_env "${py_version}" && \
+    echo "Done setting up python env" && \
+    python -m pip wheel --no-deps /workspace/python/cuda_cccl && \
+    dnf -y install gcc-toolset-13-gcc gcc-toolset-13-gcc-c++ && \
+    echo -e "#!/bin/bash\nsource /opt/rh/gcc-toolset-13/enable" > /etc/profile.d/enable_devtools.sh && \
+    source /etc/profile.d/enable_devtools.sh && \
+    which python && \
+    python -m pip wheel --no-deps . && \
+    python -m pip install patchelf auditwheel && \
+    python --version && \
+    python -m auditwheel repair cuda_parallel-*.whl --exclude libcuda.so.1 && \
+    mv cuda_cccl-*.whl /workspace/cccl/wheelhouse && \
+    mv wheelhouse/cuda_parallel-*.whl /workspace/cccl/wheelhouse/'

--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -7,9 +7,9 @@ workflows:
   # override:
   #   - {jobs: ['test'], project: 'thrust', std: 17, ctk: 'curr', cxx: ['gcc12', 'clang16']}
   #
+  override:
 
-# Only run python build and test jobs for testing
-# TODO: for 3.9, we need a newer build of pynvjitlink
+
   pull_request:
     # Old CTK/compiler
     - {jobs: ['build'], std: 'minmax', ctk: '12.0', cxx: ['gcc7', 'gcc9', 'clang14', 'msvc2019']}

--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -8,10 +8,7 @@ workflows:
   #   - {jobs: ['test'], project: 'thrust', std: 17, ctk: 'curr', cxx: ['gcc12', 'clang16']}
   #
   override:
-    - {jobs: ['build_cuda_cccl', 'build_cuda_cooperative', 'build_cuda_parallel'], project: 'python', py_version: '3.12'}
-    - {jobs: ['test_cuda_cccl', 'test_cuda_cooperative', 'test_cuda_parallel'], project: 'python', py_version: '3.12'}
-    - {jobs: ['build_cuda_cccl', 'build_cuda_cooperative', 'build_cuda_parallel'], project: 'python', py_version: '3.13'}
-    - {jobs: ['test_cuda_cccl', 'test_cuda_cooperative', 'test_cuda_parallel'], project: 'python', py_version: '3.13'}
+    - {jobs: ['test'], project: 'python', py_version: ['3.10', '3.13'], gpu: 'rtxa6000'}
 
 # Only run python build and test jobs for testing
 # TODO: for 3.9, we need a newer build of pynvjitlink

--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -7,8 +7,6 @@ workflows:
   # override:
   #   - {jobs: ['test'], project: 'thrust', std: 17, ctk: 'curr', cxx: ['gcc12', 'clang16']}
   #
-  override:
-    - {jobs: ['test'], project: 'python', py_version: ['3.10', '3.13'], gpu: 'rtxa6000'}
 
 # Only run python build and test jobs for testing
 # TODO: for 3.9, we need a newer build of pynvjitlink

--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -8,6 +8,11 @@ workflows:
   #   - {jobs: ['test'], project: 'thrust', std: 17, ctk: 'curr', cxx: ['gcc12', 'clang16']}
   #
   override:
+    - {jobs: ['build_cuda_cccl', 'build_cuda_cooperative', 'build_cuda_parallel'], project: 'python', py_version: '3.12'}
+    - {jobs: ['test_cuda_cccl', 'test_cuda_cooperative', 'test_cuda_parallel'], project: 'python', py_version: '3.12'}
+    - {jobs: ['build_cuda_cccl', 'build_cuda_cooperative', 'build_cuda_parallel'], project: 'python', py_version: '3.13'}
+    - {jobs: ['test_cuda_cccl', 'test_cuda_cooperative', 'test_cuda_parallel'], project: 'python', py_version: '3.13'}
+
 # Only run python build and test jobs for testing
 # TODO: for 3.9, we need a newer build of pynvjitlink
   pull_request:

--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -8,7 +8,8 @@ workflows:
   #   - {jobs: ['test'], project: 'thrust', std: 17, ctk: 'curr', cxx: ['gcc12', 'clang16']}
   #
   override:
-
+# Only run python build and test jobs for testing
+# TODO: for 3.9, we need a newer build of pynvjitlink
   pull_request:
     # Old CTK/compiler
     - {jobs: ['build'], std: 'minmax', ctk: '12.0', cxx: ['gcc7', 'gcc9', 'clang14', 'msvc2019']}
@@ -54,7 +55,12 @@ workflows:
     - {jobs: ['build'], project: 'cudax', ctk: ['curr'], std: 'all', cxx: ['gcc', 'clang'], cpu: 'arm64'}
     - {jobs: ['test'],  project: 'cudax', ctk: ['curr'], std: 20,    cxx: ['gcc', 'clang', 'msvc'], gpu: 'rtx2080'}
     # Python and c/parallel jobs:
-    - {jobs: ['test'], project: ['cccl_c_parallel', 'python'], gpu: 'rtx2080'}
+    - {jobs: ['build_cuda_cccl', 'build_cuda_cooperative', 'build_cuda_parallel'], project: 'python', py_version: '3.10'}
+    - {jobs: ['build_cuda_cccl', 'build_cuda_cooperative', 'build_cuda_parallel'], project: 'python', py_version: '3.12'}
+    - {jobs: ['build_cuda_cccl', 'build_cuda_cooperative', 'build_cuda_parallel'], project: 'python', py_version: '3.13'}
+    - {jobs: ['test_cuda_cccl', 'test_cuda_cooperative', 'test_cuda_parallel'], project: 'python', gpu: 'rtxa6000', py_version: '3.10'}
+    - {jobs: ['test_cuda_cccl', 'test_cuda_cooperative', 'test_cuda_parallel'], project: 'python', gpu: 'rtxa6000', py_version: '3.12'}
+    - {jobs: ['test_cuda_cccl', 'test_cuda_cooperative', 'test_cuda_parallel'], project: 'python', gpu: 'rtxa6000', py_version: '3.13'}
     # cccl-infra:
     - {jobs: ['infra'], project: 'cccl', ctk: '12.0', cxx: ['gcc12', 'clang14'], gpu: 'rtx2080'}
     - {jobs: ['infra'], project: 'cccl', ctk: 'curr', cxx: ['gcc',   'clang'],   gpu: 'rtx2080'}
@@ -239,9 +245,12 @@ jobs:
   test_gpu: { name: 'TestGPU', gpu: true,  needs: 'build', invoke: { prefix: 'test', args: '-gpu-only'} }
 
   # Python:
-  test_cuda_cccl:        { name: "cuda.cccl",        gpu: true }
-  test_cuda_cooperative: { name: "cuda.cooperative", gpu: true }
-  test_cuda_parallel:    { name: "cuda.parallel",    gpu: true }
+  build_cuda_cccl:        { name: "Build cuda.cccl",        gpu: false }
+  build_cuda_cooperative: { name: "Build cuda.cooperative", gpu: false }
+  build_cuda_parallel:    { name: "Build cuda.parallel",    gpu: false }
+  test_cuda_cccl:         { name: "Test cuda.cccl",         gpu: true, needs: 'build_cuda_cccl' }
+  test_cuda_cooperative:  { name: "Test cuda.cooperative",  gpu: true, needs: 'build_cuda_cooperative' }
+  test_cuda_parallel:     { name: "Test cuda.parallel",     gpu: true, needs: 'build_cuda_parallel' }
 
 # Projects have the following properties:
 #
@@ -285,7 +294,9 @@ projects:
     stds: [17, 20]
   python:
     name: "Python"
-    job_map: { build: [], test: ['test_cuda_cccl', 'test_cuda_cooperative', 'test_cuda_parallel'] }
+    job_map:
+      build: ['build_cuda_cccl', 'build_cuda_cooperative', 'build_cuda_parallel']
+      test:  ['test_cuda_cccl', 'test_cuda_cooperative', 'test_cuda_parallel']
   cccl_c_parallel:
     name: 'CCCL C Parallel'
     stds: [20]
@@ -325,6 +336,8 @@ tags:
   # Project name (e.g. libcudacxx, cub, thrust, cccl)
   # See the `projects` map.
   project: { default: ['libcudacxx', 'cub', 'thrust'] }
+  # Python version for Python builds/tests
+  py_version: { required: false }
   # C++ standard
   # If set to 'all', all stds supported by the ctk/compilers/project are used.
   # If set to 'min', 'max', or 'minmax', the minimum, maximum, or both stds are used.

--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -60,12 +60,10 @@ workflows:
     - {jobs: ['build'], project: 'cudax', ctk: ['curr'], std: 'all', cxx: ['gcc', 'clang'], cpu: 'arm64'}
     - {jobs: ['test'],  project: 'cudax', ctk: ['curr'], std: 20,    cxx: ['gcc', 'clang', 'msvc'], gpu: 'rtx2080'}
     # Python and c/parallel jobs:
-    - {jobs: ['build_cuda_cccl', 'build_cuda_cooperative', 'build_cuda_parallel'], project: 'python', py_version: '3.10'}
-    - {jobs: ['build_cuda_cccl', 'build_cuda_cooperative', 'build_cuda_parallel'], project: 'python', py_version: '3.12'}
-    - {jobs: ['build_cuda_cccl', 'build_cuda_cooperative', 'build_cuda_parallel'], project: 'python', py_version: '3.13'}
-    - {jobs: ['test_cuda_cccl', 'test_cuda_cooperative', 'test_cuda_parallel'], project: 'python', gpu: 'rtxa6000', py_version: '3.10'}
-    - {jobs: ['test_cuda_cccl', 'test_cuda_cooperative', 'test_cuda_parallel'], project: 'python', gpu: 'rtxa6000', py_version: '3.12'}
-    - {jobs: ['test_cuda_cccl', 'test_cuda_cooperative', 'test_cuda_parallel'], project: 'python', gpu: 'rtxa6000', py_version: '3.13'}
+    - {jobs: ['test'], project: ['cccl_c_parallel'], gpu: 'rtx2080'}
+    ## TODO: Python test jobs cannot be run on consumer cards unless the runners have at least
+    ## the same version of CUDA as the build jobs (forward compatibility does not work on consumer cards).
+    - {jobs: ['test'], project: 'python', py_version: ['3.10', '3.13'], gpu: 'rtxa6000'}
     # cccl-infra:
     - {jobs: ['infra'], project: 'cccl', ctk: '12.0', cxx: ['gcc12', 'clang14'], gpu: 'rtx2080'}
     - {jobs: ['infra'], project: 'cccl', ctk: 'curr', cxx: ['gcc',   'clang'],   gpu: 'rtx2080'}

--- a/ci/pyenv_helper.sh
+++ b/ci/pyenv_helper.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+setup_python_env() {
+    local py_version=$1
+
+    # check if pyenv is installed
+    if ! command -v pyenv &> /dev/null; then
+        rm -f /pyenv
+        curl -fsSL https://pyenv.run | bash
+        echo "Installing pyenv"
+    fi
+
+    # Always set up pyenv environment
+    export PYENV_ROOT="$HOME/.pyenv"
+    [[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"
+    eval "$(pyenv init - bash)"
+
+    # Using pyenv, install the Python version
+    echo $py_version
+    which pyenv
+    PYENV_DEBUG=1 pyenv install -v "${py_version}"
+    echo "Done installing pyenv"
+    pyenv local "${py_version}"
+}

--- a/ci/pyenv_helper.sh
+++ b/ci/pyenv_helper.sh
@@ -7,7 +7,6 @@ setup_python_env() {
     if ! command -v pyenv &> /dev/null; then
         rm -f /pyenv
         curl -fsSL https://pyenv.run | bash
-        echo "Installing pyenv"
     fi
 
     # Always set up pyenv environment
@@ -16,9 +15,6 @@ setup_python_env() {
     eval "$(pyenv init - bash)"
 
     # Using pyenv, install the Python version
-    echo $py_version
-    which pyenv
     PYENV_DEBUG=1 pyenv install -v "${py_version}"
-    echo "Done installing pyenv"
     pyenv local "${py_version}"
 }

--- a/ci/test_cuda_cccl_python.sh
+++ b/ci/test_cuda_cccl_python.sh
@@ -1,15 +1,19 @@
 #!/bin/bash
 
 set -euo pipefail
+source "$(dirname "$0")/pyenv_helper.sh"
 
-source "$(dirname "$0")/build_common.sh"
+# Get the Python version from the command line arguments -py-version=3.10
+py_version=${2#*=}
+echo "Python version: ${py_version}"
 
-print_environment_details
+# Setup Python environment
+setup_python_env "${py_version}"
 
-fail_if_no_gpu
+# Install cuda_cccl
+CUDA_CCCL_WHEEL_PATH="$(ls /home/coder/cccl/wheelhouse/cuda_cccl-*.whl)"
+python -m pip install "${CUDA_CCCL_WHEEL_PATH}[test]"
 
-source "test_python_common.sh"
-
-list_environment
-
-run_tests "cuda_cccl"
+# Run tests
+cd "/home/coder/cccl/python/cuda_cccl/tests/"
+python -m pytest -n auto -v

--- a/ci/test_cuda_cooperative_python.sh
+++ b/ci/test_cuda_cooperative_python.sh
@@ -1,15 +1,23 @@
 #!/bin/bash
 
 set -euo pipefail
+source "$(dirname "$0")/pyenv_helper.sh"
 
-source "$(dirname "$0")/build_common.sh"
+# Get the Python version from the command line arguments -py-version=3.10
+py_version=${2#*=}
+echo "Python version: ${py_version}"
 
-print_environment_details
+# Setup Python environment
+setup_python_env "${py_version}"
 
-fail_if_no_gpu
+# Install cuda_cccl
+CUDA_CCCL_WHEEL_PATH="$(ls /home/coder/cccl/wheelhouse/cuda_cccl-*.whl)"
+python -m pip install "${CUDA_CCCL_WHEEL_PATH}"
 
-source "test_python_common.sh"
+# Install cuda_cooperative
+CUDA_COOPERATIVE_WHEEL_PATH="$(ls /home/coder/cccl/wheelhouse/cuda_cooperative-*.whl)"
+python -m pip install "${CUDA_COOPERATIVE_WHEEL_PATH}[test]"
 
-list_environment
-
-run_tests "cuda_cooperative"
+# Run tests
+cd "/home/coder/cccl/python/cuda_cooperative/tests/"
+python -m pytest -n auto -v

--- a/ci/test_cuda_parallel_python.sh
+++ b/ci/test_cuda_parallel_python.sh
@@ -1,15 +1,23 @@
 #!/bin/bash
 
 set -euo pipefail
+source "$(dirname "$0")/pyenv_helper.sh"
 
-source "$(dirname "$0")/build_common.sh"
+# Get the Python version from the command line arguments -py-version=3.10
+py_version=${2#*=}
+echo "Python version: ${py_version}"
 
-print_environment_details
+# Setup Python environment
+setup_python_env "${py_version}"
 
-fail_if_no_gpu
+# Install cuda_cccl
+CUDA_CCCL_WHEEL_PATH="$(ls /home/coder/cccl/wheelhouse/cuda_cccl-*.whl)"
+python -m pip install "${CUDA_CCCL_WHEEL_PATH}"
 
-source "test_python_common.sh"
+# Install cuda_parallel
+CUDA_PARALLEL_WHEEL_PATH="$(ls /home/coder/cccl/wheelhouse/cuda_parallel-*.whl)"
+python -m pip install "${CUDA_PARALLEL_WHEEL_PATH}[test]"
 
-list_environment
-
-run_tests "cuda_parallel"
+# Run tests
+cd "/home/coder/cccl/python/cuda_parallel/tests/"
+python -m pytest -n auto -v

--- a/python/cuda_parallel/pyproject.toml
+++ b/python/cuda_parallel/pyproject.toml
@@ -51,9 +51,6 @@ source-dir = "."
 version = ">=1.11"
 make-fallback = true
 
-[tool.scikit-build.wheel]
-py-api = "py3"
-
 [tool.scikit-build.wheel.packages]
 "cuda" = "cuda"
 "cuda/parallel" = "cuda/parallel"


### PR DESCRIPTION
Closes #2149 (doesn't use `cibuildwheel` though)

Note to reviewers: This PR may be easier to review commit-by-commit. Once it's approved, I'll remove the job matrix override and run al the jobs. The full matrix [does run successfully](https://github.com/NVIDIA/cccl/pull/4679#issuecomment-2874394407), but while iterating and addressing reviews I'd prefer to keep the override.

## Overview

This PR modifies and extends our Python testing workflow, by having build jobs that build `cuda_{cccl, cooperative, parallel}` wheels; and corresponding test jobs that install those wheels and run the corresponding package tests. Wheels are stored and communicated between jobs as GitHub artifacts.

The infrastructure introduced in this PR will be used to build automation that will let us build, test and deploy wheels to PyPI at release time. That is work for a subsequent PR.

## Details

### Enabling Docker-in-Docker

As noted in https://github.com/NVIDIA/cccl/issues/2149#issuecomment-2848014196, `cuda_parallel` in particular needs to be built inside a container. That container needs to be launched from within the CCCL devcontainer which all CI commands are currently invoked from. To support this, I've enabled [Docker outside of Docker](https://github.com/devcontainers/features/tree/main/src/docker-outside-of-docker) in the CCCL devcontainers - hence the changes to all the files in `.devcontainer/`.

@trxcllnt regarding these updates.

### Extended job Matrix

Previously, we ran a single Python job for each library - which both installed and ran tests for that library, for a specific CUDA and Python version. This PR increases the Python test matrix size by testing _two_ Python versions (3.10 and 3.13). The idea is to test at least the lowest and highest supported Python version - however, I could not get builds for 3.9 working as one of our dependencies, [pynvjitlink](https://pypi.org/project/pynvjitlink-cu12/) does not have a recent build for Python 3.9.

@alliepiper, @cryos regarding job matrix changes.
@bdice: would RAPIDS be open to publishing 3.9 wheels built against newer CTK for `pynvjitlink`? 

### Uploading/Downloading wheel artifacts

As mentioned above, the build jobs build and upload wheels as artifacts, which are subsequently pulled by test jobs. To support this, I added two new steps to the PR workflow ("Download Wheels" and "Upload Wheels").

* Both run unconditionally, where I suppose it would be nice if they ran only for Python jobs.
  - Further, test jobs don't need to run the "Upload Wheels" step, and build jobs don't need to run the "Download Wheels" step.

cc: @alliepiper regarding the above.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
