### PR TITLE
Disable NVTX tests for NVHPC in C++20

### DIFF
--- a/cub/test/CMakeLists.txt
+++ b/cub/test/CMakeLists.txt
@@ -33,6 +33,11 @@ file(GLOB_RECURSE test_srcs
   catch2_test_*.cu
 )
 
+# nvtx headers contain a variable named `module`, which breaks nvc++ as that is a keyword
+if ("NVHPC" STREQUAL "${CMAKE_CXX_COMPILER_ID}" AND NOT "${CMAKE_CXX_STANDARD}" MATCHES "17")
+  list(FILTER test_srcs EXCLUDE REGEX "test_nvtx*")
+endif()
+
 ## _cub_is_catch2_test
 #
 # If the test_src contains the substring "catch2_test_", `result_var` will


### PR DESCRIPTION
The nvtx headers contain a variable named `module` which nvc++ rejects as a c++20 keyword

I believe we got lucky with sccache thinking the file unchanged previously