### PR TITLE
rename `cudax::uninit` to `cudax::no_init` for better readability

### DIFF
--- a/cudax/examples/async_buffer_add.cu
+++ b/cudax/examples/async_buffer_add.cu
@@ -56,10 +56,10 @@ int main()
   // An environment we use to pass all necessary information to the containers
   cudax::env_t<cuda::mr::device_accessible> env{cudax::device_memory_resource{}, stream};
 
-  // Allocate the two inputs and output, but do not zero initialize via `cudax::uninit`
-  cudax::async_device_buffer<float> A{env, numElements, cudax::uninit};
-  cudax::async_device_buffer<float> B{env, numElements, cudax::uninit};
-  cudax::async_device_buffer<float> C{env, numElements, cudax::uninit};
+  // Allocate the two inputs and output, but do not zero initialize via `cudax::no_init`
+  cudax::async_device_buffer<float> A{env, numElements, cudax::no_init};
+  cudax::async_device_buffer<float> B{env, numElements, cudax::no_init};
+  cudax::async_device_buffer<float> C{env, numElements, cudax::no_init};
 
   // Fill both vectors on stream using a random number generator
   thrust::generate(policy, A.begin(), A.end(), generator{42});

--- a/cudax/include/cuda/experimental/__container/async_buffer.cuh
+++ b/cudax/include/cuda/experimental/__container/async_buffer.cuh
@@ -272,7 +272,7 @@ public:
   //! @param __env The environment providing the needed information
   //! @note No memory is allocated.
   _CCCL_HIDE_FROM_ABI async_buffer(const __env_t& __env)
-      : async_buffer(__env, 0, ::cuda::experimental::uninit)
+      : async_buffer(__env, 0, ::cuda::experimental::no_init)
   {}
 
   //! @brief Constructs a async_buffer of size \p __size using a memory resource and value-initializes \p __size
@@ -281,7 +281,7 @@ public:
   //! @param __size The size of the async_buffer. Defaults to zero
   //! @note If `__size == 0` then no memory is allocated.
   _CCCL_HIDE_FROM_ABI explicit async_buffer(const __env_t& __env, const size_type __size)
-      : async_buffer(__env, __size, ::cuda::experimental::uninit)
+      : async_buffer(__env, __size, ::cuda::experimental::no_init)
   {
     this->__value_initialize_n(__unwrapped_begin(), __size);
   }
@@ -293,7 +293,7 @@ public:
   //! @param __value The value all elements are copied from.
   //! @note If `__size == 0` then no memory is allocated.
   _CCCL_HIDE_FROM_ABI explicit async_buffer(const __env_t& __env, const size_type __size, const _Tp& __value)
-      : async_buffer(__env, __size, ::cuda::experimental::uninit)
+      : async_buffer(__env, __size, ::cuda::experimental::no_init)
   {
     this->__fill_n(__unwrapped_begin(), __size, __value);
   }
@@ -304,7 +304,8 @@ public:
   //! @warning This constructor does *NOT* initialize any elements. It is the user's responsibility to ensure that the
   //! elements within `[vec.begin(), vec.end())` are properly initialized, e.g with `cuda::std::uninitialized_copy`.
   //! At the destruction of the \c async_buffer all elements in the range `[vec.begin(), vec.end())` will be destroyed.
-  _CCCL_HIDE_FROM_ABI explicit async_buffer(const __env_t& __env, const size_type __size, ::cuda::experimental::uninit_t)
+  _CCCL_HIDE_FROM_ABI explicit async_buffer(
+    const __env_t& __env, const size_type __size, ::cuda::experimental::no_init_t)
       : __buf_(::cuda::experimental::get_memory_resource(__env), ::cuda::experimental::get_stream(__env), __size)
   {}
 
@@ -317,7 +318,7 @@ public:
   _CCCL_TEMPLATE(class _Iter)
   _CCCL_REQUIRES(_CUDA_VSTD::__is_cpp17_forward_iterator<_Iter>::value)
   _CCCL_HIDE_FROM_ABI async_buffer(const __env_t& __env, _Iter __first, _Iter __last)
-      : async_buffer(__env, static_cast<size_type>(_CUDA_VSTD::distance(__first, __last)), ::cuda::experimental::uninit)
+      : async_buffer(__env, static_cast<size_type>(_CUDA_VSTD::distance(__first, __last)), ::cuda::experimental::no_init)
   {
     this->__copy_cross<_Iter>(__first, __last, __unwrapped_begin(), __buf_.size());
   }
@@ -327,7 +328,7 @@ public:
   //! @param __ilist The initializer_list being copied into the async_buffer.
   //! @note If `__ilist.size() == 0` then no memory is allocated
   _CCCL_HIDE_FROM_ABI async_buffer(const __env_t& __env, _CUDA_VSTD::initializer_list<_Tp> __ilist)
-      : async_buffer(__env, __ilist.size(), ::cuda::experimental::uninit)
+      : async_buffer(__env, __ilist.size(), ::cuda::experimental::no_init)
   {
     this->__copy_cross(__ilist.begin(), __ilist.end(), __unwrapped_begin(), __buf_.size());
   }
@@ -340,7 +341,7 @@ public:
   _CCCL_REQUIRES(__compatible_range<_Range> _CCCL_AND _CUDA_VRANGES::forward_range<_Range> _CCCL_AND
                    _CUDA_VRANGES::sized_range<_Range>)
   _CCCL_HIDE_FROM_ABI async_buffer(const __env_t& __env, _Range&& __range)
-      : async_buffer(__env, static_cast<size_type>(_CUDA_VRANGES::size(__range)), ::cuda::experimental::uninit)
+      : async_buffer(__env, static_cast<size_type>(_CUDA_VRANGES::size(__range)), ::cuda::experimental::no_init)
   {
     using _Iter = _CUDA_VRANGES::iterator_t<_Range>;
     this->__copy_cross<_Iter>(
@@ -355,7 +356,7 @@ public:
       : async_buffer(
           __env,
           static_cast<size_type>(_CUDA_VRANGES::distance(_CUDA_VRANGES::begin(__range), _CUDA_VRANGES::end(__range))),
-          ::cuda::experimental::uninit)
+          ::cuda::experimental::no_init)
   {
     using _Iter = _CUDA_VRANGES::iterator_t<_Range>;
     this->__copy_cross<_Iter>(
@@ -644,7 +645,7 @@ async_buffer<_Tp, _TargetProperties...> make_async_buffer(
   const async_buffer<_Tp, _SourceProperties...>& __source)
 {
   env_t<_TargetProperties...> __env{__mr, __stream};
-  async_buffer<_Tp, _TargetProperties...> __res{__env, __source.size(), uninit};
+  async_buffer<_Tp, _TargetProperties...> __res{__env, __source.size(), no_init};
 
   // We need some opt-out for the wait here, but I don't know how yet
   __stream.wait(__source.get_stream());

--- a/cudax/include/cuda/experimental/__detail/utility.cuh
+++ b/cudax/include/cuda/experimental/__detail/utility.cuh
@@ -64,12 +64,15 @@ using __identity_t _CCCL_NODEBUG_ALIAS = _Tp;
 
 using _CUDA_VSTD::declval;
 
-struct uninit_t
+struct no_init_t
 {
-  explicit uninit_t() = default;
+  explicit no_init_t() = default;
 };
 
-_CCCL_GLOBAL_CONSTANT uninit_t uninit{};
+_CCCL_GLOBAL_CONSTANT no_init_t no_init{};
+
+using uninit_t CCCL_DEPRECATED_BECAUSE("Use cuda::experimental::no_init_t instead") = no_init_t;
+_CCCL_GLOBAL_CONSTANT no_init_t uninit{};
 } // namespace cuda::experimental
 
 #include <cuda/std/__cccl/epilogue.h>

--- a/cudax/include/cuda/experimental/__event/event.cuh
+++ b/cudax/include/cuda/experimental/__event/event.cuh
@@ -65,7 +65,7 @@ public:
   //! @brief Construct a new `event` object into the moved-from state.
   //!
   //! @post `get()` returns `cudaEvent_t()`.
-  explicit constexpr event(uninit_t) noexcept
+  explicit constexpr event(no_init_t) noexcept
       : event_ref(::cudaEvent_t{})
   {}
 

--- a/cudax/include/cuda/experimental/__event/timed_event.cuh
+++ b/cudax/include/cuda/experimental/__event/timed_event.cuh
@@ -52,8 +52,8 @@ public:
   //! @brief Construct a new `timed_event` object into the moved-from state.
   //!
   //! @post `get()` returns `cudaEvent_t()`.
-  explicit constexpr timed_event(uninit_t) noexcept
-      : event(uninit)
+  explicit constexpr timed_event(no_init_t) noexcept
+      : event(no_init)
   {}
 
   timed_event(timed_event&&) noexcept            = default;

--- a/cudax/include/cuda/experimental/__launch/launch.cuh
+++ b/cudax/include/cuda/experimental/__launch/launch.cuh
@@ -43,7 +43,7 @@ template <typename Config, typename Kernel, typename... Args>
 [[nodiscard]] cudaError_t
 launch_impl(::cuda::stream_ref stream, Config conf, const Kernel& kernel_fn, const Args&... args)
 {
-  static_assert(!::cuda::std::is_same_v<decltype(conf.dims), uninit_t>,
+  static_assert(!::cuda::std::is_same_v<decltype(conf.dims), no_init_t>,
                 "Can't launch a configuration without hierarchy dimensions");
   cudaLaunchConfig_t config{};
   cudaError_t status                      = cudaSuccess;

--- a/cudax/include/cuda/experimental/__stream/stream.cuh
+++ b/cudax/include/cuda/experimental/__stream/stream.cuh
@@ -78,7 +78,7 @@ struct stream : stream_ref
   //!
   //! @post `stream()` returns an invalid stream handle
   // Can't be constexpr because __invalid_stream isn't
-  explicit stream(uninit_t) noexcept
+  explicit stream(no_init_t) noexcept
       : stream_ref(detail::__invalid_stream)
   {}
 

--- a/cudax/test/containers/async_buffer/iterators.cu
+++ b/cudax/test/containers/async_buffer/iterators.cu
@@ -95,7 +95,7 @@ C2H_TEST("cudax::async_buffer iterators", "[container][async_buffer]", test_type
 
   SECTION("cudax::async_buffer::begin/end with allocation")
   {
-    Buffer buf{env, 42, cudax::uninit}; // Note we do not care about the elements just the sizes
+    Buffer buf{env, 42, cudax::no_init}; // Note we do not care about the elements just the sizes
     // begin points to the element at data()
     CUDAX_CHECK(buf.begin() == iterator{buf.data()});
     CUDAX_CHECK(cuda::std::as_const(buf).begin() == const_iterator{buf.data()});
@@ -148,7 +148,7 @@ C2H_TEST("cudax::async_buffer iterators", "[container][async_buffer]", test_type
 
   SECTION("cudax::async_buffer::rbegin/rend with allocation")
   {
-    Buffer buf{env, 42, cudax::uninit}; // Note we do not care about the elements just the sizes
+    Buffer buf{env, 42, cudax::no_init}; // Note we do not care about the elements just the sizes
     // rbegin points to the element at data() + 42
     CUDAX_CHECK(buf.rbegin() == reverse_iterator{iterator{buf.data() + 42}});
     CUDAX_CHECK(cuda::std::as_const(buf).rbegin() == const_reverse_iterator{const_iterator{buf.data() + 42}});

--- a/cudax/test/containers/async_buffer/swap.cu
+++ b/cudax/test/containers/async_buffer/swap.cu
@@ -48,11 +48,11 @@ C2H_TEST("cudax::async_buffer swap", "[container][async_buffer]", test_types)
   STATIC_REQUIRE(noexcept(swap(cuda::std::declval<Buffer&>(), cuda::std::declval<Buffer&>())));
 
   // Note we do not care about the elements just the sizes
-  Buffer vec_small{env, 5, cudax::uninit};
+  Buffer vec_small{env, 5, cudax::no_init};
 
   SECTION("Can swap async_buffer")
   {
-    Buffer vec_large{env, 42, cudax::uninit};
+    Buffer vec_large{env, 42, cudax::no_init};
 
     CUDAX_CHECK(vec_large.size() == 42);
     CUDAX_CHECK(vec_small.size() == 5);
@@ -74,7 +74,7 @@ C2H_TEST("cudax::async_buffer swap", "[container][async_buffer]", test_types)
 
   SECTION("Can swap async_buffer without allocation")
   {
-    Buffer vec_no_allocation{env, 0, cudax::uninit};
+    Buffer vec_no_allocation{env, 0, cudax::no_init};
 
     CUDAX_CHECK(vec_no_allocation.size() == 0);
     CUDAX_CHECK(vec_small.size() == 5);

--- a/cudax/test/containers/async_buffer/transform.cu
+++ b/cudax/test/containers/async_buffer/transform.cu
@@ -100,12 +100,12 @@ C2H_TEST("DeviceTransform::Transform cudax::async_device_buffer", "[device][devi
   cudax::stream stream{};
   cudax::env_t<cuda::mr::device_accessible> env{cudax::device_memory_resource{}, stream};
 
-  cudax::async_device_buffer<type> a{env, num_items, cudax::uninit};
-  cudax::async_device_buffer<type> b{env, num_items, cudax::uninit};
+  cudax::async_device_buffer<type> a{env, num_items, cudax::no_init};
+  cudax::async_device_buffer<type> b{env, num_items, cudax::no_init};
   thrust::sequence(thrust::cuda::par_nosync.on(stream.get()), a.begin(), a.end());
   thrust::sequence(thrust::cuda::par_nosync.on(stream.get()), b.begin(), b.end());
 
-  cudax::async_device_buffer<type> result{env, num_items, cudax::uninit};
+  cudax::async_device_buffer<type> result{env, num_items, cudax::no_init};
 
   transform_many_with_alg<alg>(
     ::cuda::std::make_tuple(a.begin(), b.begin()), result.begin(), num_items, ::cuda::std::plus<type>{});


### PR DESCRIPTION
## Description

the people i've talked to on slack have agreed that `no_init` reads better than `uninit`.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
