### PR TITLE
Remove Apple paths from libcu++

### DIFF
--- a/libcudacxx/include/cuda/std/__thread/threading_support_pthread.h
+++ b/libcudacxx/include/cuda/std/__thread/threading_support_pthread.h
@@ -29,9 +29,6 @@
 #  include <pthread.h>
 #  include <sched.h>
 #  include <semaphore.h>
-#  if defined(__APPLE__)
-#    include <dispatch/dispatch.h>
-#  endif // __APPLE__
 #  if defined(__linux__)
 #    include <unistd.h>
 
@@ -56,13 +53,8 @@ using __cccl_condvar_t = pthread_cond_t;
 #  define _LIBCUDACXX_CONDVAR_INITIALIZER PTHREAD_COND_INITIALIZER
 
 // Semaphore
-#  if defined(__APPLE__)
-using __cccl_semaphore_t = dispatch_semaphore_t;
-#    define _LIBCUDACXX_SEMAPHORE_MAX numeric_limits<long>::max()
-#  else // ^^^ __APPLE__ ^^^ / vvv !__APPLE__ vvv
 using __cccl_semaphore_t = sem_t;
-#    define _LIBCUDACXX_SEMAPHORE_MAX SEM_VALUE_MAX
-#  endif // !__APPLE__
+#  define _LIBCUDACXX_SEMAPHORE_MAX SEM_VALUE_MAX
 
 // Execute once
 using __cccl_exec_once_flag = pthread_once_t;
@@ -103,37 +95,6 @@ _LIBCUDACXX_HIDE_FROM_ABI __cccl_timespec_t __cccl_to_timespec(const _CUDA_VSTD:
 }
 
 // Semaphore
-#  if defined(__APPLE__)
-
-_LIBCUDACXX_HIDE_FROM_ABI bool __cccl_semaphore_init(__cccl_semaphore_t* __sem, int __init)
-{
-  return (*__sem = dispatch_semaphore_create(__init)) != nullptr;
-}
-
-_LIBCUDACXX_HIDE_FROM_ABI bool __cccl_semaphore_destroy(__cccl_semaphore_t* __sem)
-{
-  dispatch_release(*__sem);
-  return true;
-}
-
-_LIBCUDACXX_HIDE_FROM_ABI bool __cccl_semaphore_post(__cccl_semaphore_t* __sem)
-{
-  dispatch_semaphore_signal(*__sem);
-  return true;
-}
-
-_LIBCUDACXX_HIDE_FROM_ABI bool __cccl_semaphore_wait(__cccl_semaphore_t* __sem)
-{
-  return dispatch_semaphore_wait(*__sem, DISPATCH_TIME_FOREVER) == 0;
-}
-
-_LIBCUDACXX_HIDE_FROM_ABI bool
-__cccl_semaphore_wait_timed(__cccl_semaphore_t* __sem, _CUDA_VSTD::chrono::nanoseconds const& __ns)
-{
-  return dispatch_semaphore_wait(*__sem, dispatch_time(DISPATCH_TIME_NOW, __ns.count())) == 0;
-}
-
-#  else // ^^^ __APPLE__ ^^^ / vvv !__APPLE__ vvv
 
 _LIBCUDACXX_HIDE_FROM_ABI bool __cccl_semaphore_init(__cccl_semaphore_t* __sem, int __init)
 {
@@ -161,8 +122,6 @@ __cccl_semaphore_wait_timed(__cccl_semaphore_t* __sem, _CUDA_VSTD::chrono::nanos
   __cccl_timespec_t __ts = __cccl_to_timespec(__ns);
   return sem_timedwait(__sem, &__ts) == 0;
 }
-
-#  endif // !__APPLE__
 
 _LIBCUDACXX_HIDE_FROM_ABI void __cccl_thread_yield()
 {

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__config
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__config
@@ -130,8 +130,7 @@ extern "C++" {
 
 #  if !defined(_LIBCUDACXX_HAS_THREAD_API_PTHREAD) && !defined(_LIBCUDACXX_HAS_THREAD_API_WIN32) \
     && !defined(_LIBCUDACXX_HAS_THREAD_API_EXTERNAL)
-#    if defined(__linux__) || defined(__GNU__) || defined(__APPLE__) \
-      || (defined(__MINGW32__) && _CCCL_HAS_INCLUDE(<pthread.h>))
+#    if defined(__linux__) || defined(__GNU__) || (defined(__MINGW32__) && _CCCL_HAS_INCLUDE(<pthread.h>))
 #      define _LIBCUDACXX_HAS_THREAD_API_PTHREAD
 #    elif defined(_WIN32)
 #      define _LIBCUDACXX_HAS_THREAD_API_WIN32

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/atomic_copyable.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/atomic_copyable.pass.cpp
@@ -9,10 +9,6 @@
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 
-// NOTE: atomic<> of a TriviallyCopyable class is wrongly rejected by older
-// clang versions. It was fixed right before the llvm 3.5 release. See PR18097.
-// XFAIL: apple-clang-6.0, clang-3.4, clang-3.3
-
 // <cuda/std/atomic>
 
 #include <cuda/atomic>

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/non_trivial.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/non_trivial.pass.cpp
@@ -9,10 +9,6 @@
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 
-// NOTE: atomic<> of a TriviallyCopyable class is wrongly rejected by older
-// clang versions. It was fixed right before the llvm 3.5 release. See PR18097.
-// XFAIL: apple-clang-6.0, clang-3.4, clang-3.3
-
 // <cuda/std/atomic>
 
 // template <class T>

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/trivially_copyable.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/trivially_copyable.pass.cpp
@@ -9,10 +9,6 @@
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 
-// NOTE: atomic<> of a TriviallyCopyable class is wrongly rejected by older
-// clang versions. It was fixed right before the llvm 3.5 release. See PR18097.
-// XFAIL: apple-clang-6.0, clang-3.4, clang-3.3
-
 // <cuda/std/atomic>
 
 // template <class T>

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/ctor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/ctor.pass.cpp
@@ -9,10 +9,6 @@
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 
-// NOTE: atomic<> of a TriviallyCopyable class is wrongly rejected by older
-// clang versions. It was fixed right before the llvm 3.5 release. See PR18097.
-// XFAIL: apple-clang-6.0, clang-3.4, clang-3.3
-
 // <cuda/std/atomic>
 
 // constexpr atomic<T>::atomic(T value)

--- a/libcudacxx/test/libcudacxx/std/iterators/stream.iterators/istream.iterator/istream.iterator.cons/default.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/stream.iterators/istream.iterator/istream.iterator.cons/default.pass.cpp
@@ -7,10 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// Usage of is_trivially_constructible is broken with these compilers.
-// See https://bugs.llvm.org/show_bug.cgi?id=31016
-// XFAIL: clang-3.7, apple-clang-7 && c++17
-
 // <cuda/std/iterator>
 
 // class istream_iterator

--- a/libcudacxx/test/libcudacxx/std/language.support/support.types/byteops/enum_direct_init.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.types/byteops/enum_direct_init.pass.cpp
@@ -10,11 +10,6 @@
 
 #include <test_macros.h>
 
-// The following compilers don't like "cuda::std::byte b1{1}"
-// XFAIL: clang-3.5, clang-3.6, clang-3.7, clang-3.8
-// XFAIL: apple-clang-6, apple-clang-7, apple-clang-8.0
-// UNSUPPORTED: gcc-6
-
 int main(int, char**)
 {
   constexpr cuda::std::byte b{42};

--- a/libcudacxx/test/libcudacxx/std/utilities/meta/meta.rel/is_base_of_union.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/meta/meta.rel/is_base_of_union.pass.cpp
@@ -14,14 +14,6 @@
 
 #include "test_macros.h"
 
-//  Clang before v9 and apple-clang up to and including v11 do not
-//  report that unions are never base classes - nor can they have bases.
-//  See https://reviews.llvm.org/D61858
-// XFAIL: apple-clang-6.0, apple-clang-7.0, apple-clang-8.0
-// XFAIL: apple-clang-9.0, apple-clang-9.1, apple-clang-10.0, apple-clang-11.0.0
-// XFAIL: clang-3.3, clang-3.4, clang-3.5, clang-3.6, clang-3.7, clang-3.8, clang-3.9
-// XFAIL: clang-4.0, clang-5.0, clang-6.0, clang-7.0, clang-7.1, clang-8.0
-
 template <class T, class U>
 __host__ __device__ void test_is_base_of()
 {

--- a/libcudacxx/test/libcudacxx/std/utilities/meta/meta.unary/meta.unary.prop/has_unique_object_representations.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/meta/meta.unary/meta.unary.prop/has_unique_object_representations.pass.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: clang-3, clang-4, clang-5, apple-clang, gcc-5, gcc-6, msvc-19
+// UNSUPPORTED: msvc-19
 
 // type_traits
 

--- a/libcudacxx/test/libcudacxx/std/utilities/meta/meta.unary/meta.unary.prop/is_constructible.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/meta/meta.unary/meta.unary.prop/is_constructible.pass.cpp
@@ -7,8 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // type_traits
-// XFAIL: apple-clang-6.0
-//  The Apple-6 compiler gets is_constructible<void ()> wrong.
 
 // template <class T, class... Args>
 //   struct is_constructible;

--- a/libcudacxx/test/libcudacxx/std/utilities/meta/meta.unary/meta.unary.prop/is_trivially_copyable_volatile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/meta/meta.unary/meta.unary.prop/is_trivially_copyable_volatile.pass.cpp
@@ -12,8 +12,7 @@
 
 // These compilers have not implemented Core 2094 which makes volatile
 // qualified types trivially copyable.
-// XFAIL: clang-3, clang-4, apple-clang-6, apple-clang-7, apple-clang-8, apple-clang-9.0
-// XFAIL: gcc-4.8, gcc-5, gcc-6, gcc-7, gcc-8, gcc-9
+// XFAIL: gcc-7, gcc-8, gcc-9
 
 // When we marked this XFAIL for MSVC, QA reported that it unexpectedly passed.
 // When we stopped marking it XFAIL for MSVC, QA reported that it unexpectedly

--- a/libcudacxx/test/libcudacxx/std/utilities/meta/meta.unary/meta.unary.prop/is_trivially_destructible.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/meta/meta.unary/meta.unary.prop/is_trivially_destructible.pass.cpp
@@ -5,7 +5,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: apple-clang-9
 
 // type_traits
 

--- a/libcudacxx/test/libcudacxx/std/utilities/time/time.cal/time.cal.day/time.cal.day.nonmembers/literals.fail.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/time/time.cal/time.cal.day/time.cal.day.nonmembers/literals.fail.cpp
@@ -6,8 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 // UNSUPPORTED: c++17
-// UNSUPPORTED: clang-5, clang-6
-// UNSUPPORTED: apple-clang-6, apple-clang-7, apple-clang-8, apple-clang-9, apple-clang-10
 
 // <chrono>
 // class day;

--- a/libcudacxx/test/libcudacxx/std/utilities/time/time.cal/time.cal.day/time.cal.day.nonmembers/literals.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/time/time.cal/time.cal.day/time.cal.day.nonmembers/literals.pass.cpp
@@ -6,9 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 // UNSUPPORTED: c++17
-// UNSUPPORTED: clang-5, clang-6, clang-7
-// UNSUPPORTED: apple-clang-6, apple-clang-7, apple-clang-8, apple-clang-9
-// UNSUPPORTED: apple-clang-10.0.0
 
 // <chrono>
 // class day;

--- a/libcudacxx/test/libcudacxx/std/utilities/time/time.cal/time.cal.year/time.cal.year.nonmembers/literals.fail.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/time/time.cal/time.cal.year/time.cal.year.nonmembers/literals.fail.cpp
@@ -6,8 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 // UNSUPPORTED: c++17
-// UNSUPPORTED: clang-5, clang-6
-// UNSUPPORTED: apple-clang-6, apple-clang-7, apple-clang-8, apple-clang-9, apple-clang-10
 
 // <chrono>
 // class year;

--- a/libcudacxx/test/libcudacxx/std/utilities/time/time.cal/time.cal.year/time.cal.year.nonmembers/literals.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/time/time.cal/time.cal.year/time.cal.year.nonmembers/literals.pass.cpp
@@ -6,9 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 // UNSUPPORTED: c++17
-// UNSUPPORTED: clang-5, clang-6, clang-7
-// UNSUPPORTED: apple-clang-6, apple-clang-7, apple-clang-8, apple-clang-9
-// UNSUPPORTED: apple-clang-10.0.0
 
 // <chrono>
 // class year;

--- a/libcudacxx/test/libcudacxx/std/utilities/time/time.clock/time.clock.hires/consistency.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/time/time.clock/time.clock.hires/consistency.pass.cpp
@@ -10,12 +10,6 @@
 // violation because Clock::is_steady is defined in both the dylib and this TU.
 // UNSUPPORTED: asan
 
-// Starting with C++17, Clock::is_steady is inlined (but not before LLVM-3.9!),
-// but before C++17 it requires the symbol to be present in the dylib, which
-// is only shipped starting with macosx10.9.
-// XFAIL: with_system_cxx_lib=macosx10.7 && (c++98 || c++03 || c++11 || c++14 || apple-clang-7 || apple-clang-8.0)
-// XFAIL: with_system_cxx_lib=macosx10.8 && (c++98 || c++03 || c++11 || c++14 || apple-clang-7 || apple-clang-8.0)
-
 // <cuda/std/chrono>
 
 // high_resolution_clock

--- a/libcudacxx/test/libcudacxx/std/utilities/time/time.clock/time.clock.system/consistency.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/time/time.clock/time.clock.system/consistency.pass.cpp
@@ -10,12 +10,6 @@
 // violation because Clock::is_steady is defined in both the dylib and this TU.
 // UNSUPPORTED: asan
 
-// Starting with C++17, Clock::is_steady is inlined (but not before LLVM-3.9!),
-// but before C++17 it requires the symbol to be present in the dylib, which
-// is only shipped starting with macosx10.9.
-// XFAIL: with_system_cxx_lib=macosx10.7 && (c++98 || c++03 || c++11 || c++14 || apple-clang-7 || apple-clang-8.0)
-// XFAIL: with_system_cxx_lib=macosx10.8 && (c++98 || c++03 || c++11 || c++14 || apple-clang-7 || apple-clang-8.0)
-
 // <cuda/std/chrono>
 
 // system_clock

--- a/libcudacxx/test/libcudacxx/std/utilities/time/time.hms/hhmmss.fail.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/time/time.hms/hhmmss.fail.cpp
@@ -6,7 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: apple-clang-9
 // <chrono>
 
 // template <class Duration> class hh_mm_ss;

--- a/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.cnstr/deduct.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.tuple/tuple.cnstr/deduct.pass.cpp
@@ -7,17 +7,12 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: libcpp-no-deduction-guides
-// UNSUPPORTED: apple-clang-9
 // UNSUPPORTED: msvc
-// UNSUPPORTED: nvcc-10.3, nvcc-11.0, nvcc-11.1, nvcc-11.2, nvcc-11.3, nvcc-11.4
 
 // GCC's implementation of class template deduction is still immature and runs
 // into issues with libc++. However GCC accepts this code when compiling
 // against libstdc++.
-// XFAIL: gcc-5, gcc-6, gcc-7, gcc-10
-
-// Currently broken with Clang + NVCC.
-// XFAIL: clang-6, clang-7
+// XFAIL: gcc-7, gcc-10
 
 // <cuda/std/tuple>
 

--- a/libcudacxx/test/support/filesystem_test_helper.h
+++ b/libcudacxx/test/support/filesystem_test_helper.h
@@ -225,14 +225,12 @@ struct scoped_test_env
 
   // OS X and FreeBSD doesn't support socket files so we shouldn't even
   // allow tests to call this unguarded.
-#  if !defined(__APPLE__)
   std::string create_socket(std::string file)
   {
     file = sanitize_path(std::move(file));
     fs_helper_run(fs_make_cmd("create_socket", file));
     return file;
   }
-#  endif
 
   fs::path const test_root;
 


### PR DESCRIPTION
Apple is not a supported platform.

I've also removed some other unsupported compiler constraints from the tests.