### PR TITLE
Refactor `<cuda/std/ratio>`

### DIFF
--- a/libcudacxx/include/cuda/std/detail/libcxx/include/chrono
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/chrono
@@ -1043,15 +1043,15 @@ template <class _Rep, class _Period>
 class _CCCL_TYPE_VISIBILITY_DEFAULT duration
 {
   static_assert(!__is_duration<_Rep>::value, "A duration representation can not be a duration");
-  static_assert(__is_ratio<_Period>::value, "Second template parameter of duration must be a std::ratio");
+  static_assert(__is_ratio_v<_Period>, "Second template parameter of duration must be a std::ratio");
   static_assert(_Period::num > 0, "duration period must be positive");
 
   template <class _R1, class _R2>
   struct __no_overflow
   {
   private:
-    static const intmax_t __gcd_n1_n2 = __static_gcd<_R1::num, _R2::num>::value;
-    static const intmax_t __gcd_d1_d2 = __static_gcd<_R1::den, _R2::den>::value;
+    static const intmax_t __gcd_n1_n2 = _CUDA_VSTD::__cccl_ratio_gcd(_R1::num, _R2::num);
+    static const intmax_t __gcd_d1_d2 = _CUDA_VSTD::__cccl_ratio_gcd(_R1::den, _R2::den);
     static const intmax_t __n1        = _R1::num / __gcd_n1_n2;
     static const intmax_t __d1        = _R1::den / __gcd_d1_d2;
     static const intmax_t __n2        = _R2::num / __gcd_n1_n2;

--- a/libcudacxx/include/cuda/std/ratio
+++ b/libcudacxx/include/cuda/std/ratio
@@ -21,7 +21,10 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/std/__cstdlib/abs.h>
+#include <cuda/std/__limits/numeric_limits.h>
 #include <cuda/std/__type_traits/integral_constant.h>
+#include <cuda/std/__utility/swap.h>
 #include <cuda/std/climits>
 #include <cuda/std/cstdint>
 
@@ -29,194 +32,59 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-// __static_gcd
+inline constexpr intmax_t __cccl_ratio_nan = numeric_limits<intmax_t>::min();
+inline constexpr intmax_t __cccl_ratio_max = numeric_limits<intmax_t>::max();
+inline constexpr intmax_t __cccl_ratio_min = -__cccl_ratio_max;
 
-template <intmax_t _Xp, intmax_t _Yp>
-struct __static_gcd
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr intmax_t __cccl_ratio_gcd(intmax_t __x, intmax_t __y) noexcept
 {
-  static const intmax_t value = __static_gcd<_Yp, _Xp % _Yp>::value;
+  return (__y == 0) ? ((__x == 0) ? 1 : __x) : _CUDA_VSTD::__cccl_ratio_gcd(__y, __x % __y);
+}
+
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr intmax_t __cccl_ratio_lcm(intmax_t __x, intmax_t __y) noexcept
+{
+  return __x / _CUDA_VSTD::__cccl_ratio_gcd(__x, __y) * __y;
+}
+
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr int __cccl_ratio_sign(intmax_t __x) noexcept
+{
+  return (__x == 0) ? 0 : ((__x < 0) ? -1 : 1);
+}
+
+struct __ratio_values
+{
+  intmax_t __num;
+  intmax_t __den;
 };
 
-template <intmax_t _Xp>
-struct __static_gcd<_Xp, 0>
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr __ratio_values __cccl_ratio_reduce(__ratio_values __v) noexcept
 {
-  static const intmax_t value = _Xp;
-};
+  const auto __na  = _CUDA_VSTD::abs(__v.__num);
+  const auto __da  = _CUDA_VSTD::abs(__v.__den);
+  const auto __s   = _CUDA_VSTD::__cccl_ratio_sign(__v.__num) * _CUDA_VSTD::__cccl_ratio_sign(__v.__den);
+  const auto __gcd = _CUDA_VSTD::__cccl_ratio_gcd(__na, __da);
 
-template <>
-struct __static_gcd<0, 0>
-{
-  static const intmax_t value = 1;
-};
-
-// __static_lcm
-
-template <intmax_t _Xp, intmax_t _Yp>
-struct __static_lcm
-{
-  static const intmax_t value = _Xp / __static_gcd<_Xp, _Yp>::value * _Yp;
-};
-
-template <intmax_t _Xp>
-struct __static_abs
-{
-  static const intmax_t value = _Xp < 0 ? -_Xp : _Xp;
-};
-
-template <intmax_t _Xp>
-struct __static_sign
-{
-  static const intmax_t value = _Xp == 0 ? 0 : (_Xp < 0 ? -1 : 1);
-};
-
-template <intmax_t _Xp, intmax_t _Yp, intmax_t = __static_sign<_Yp>::value>
-class __ll_add;
-
-template <intmax_t _Xp, intmax_t _Yp>
-class __ll_add<_Xp, _Yp, 1>
-{
-  static const intmax_t min = (1LL << (sizeof(intmax_t) * CHAR_BIT - 1)) + 1;
-  static const intmax_t max = -min;
-
-  static_assert(_Xp <= max - _Yp, "overflow in __ll_add");
-
-public:
-  static const intmax_t value = _Xp + _Yp;
-};
-
-template <intmax_t _Xp, intmax_t _Yp>
-class __ll_add<_Xp, _Yp, 0>
-{
-public:
-  static const intmax_t value = _Xp;
-};
-
-template <intmax_t _Xp, intmax_t _Yp>
-class __ll_add<_Xp, _Yp, -1>
-{
-  static const intmax_t min = (1LL << (sizeof(intmax_t) * CHAR_BIT - 1)) + 1;
-  static const intmax_t max = -min;
-
-  static_assert(min - _Yp <= _Xp, "overflow in __ll_add");
-
-public:
-  static const intmax_t value = _Xp + _Yp;
-};
-
-template <intmax_t _Xp, intmax_t _Yp, intmax_t = __static_sign<_Yp>::value>
-class __ll_sub;
-
-template <intmax_t _Xp, intmax_t _Yp>
-class __ll_sub<_Xp, _Yp, 1>
-{
-  static const intmax_t min = (1LL << (sizeof(intmax_t) * CHAR_BIT - 1)) + 1;
-  static const intmax_t max = -min;
-
-  static_assert(min + _Yp <= _Xp, "overflow in __ll_sub");
-
-public:
-  static const intmax_t value = _Xp - _Yp;
-};
-
-template <intmax_t _Xp, intmax_t _Yp>
-class __ll_sub<_Xp, _Yp, 0>
-{
-public:
-  static const intmax_t value = _Xp;
-};
-
-template <intmax_t _Xp, intmax_t _Yp>
-class __ll_sub<_Xp, _Yp, -1>
-{
-  static const intmax_t min = (1LL << (sizeof(intmax_t) * CHAR_BIT - 1)) + 1;
-  static const intmax_t max = -min;
-
-  static_assert(_Xp <= max + _Yp, "overflow in __ll_sub");
-
-public:
-  static const intmax_t value = _Xp - _Yp;
-};
-
-template <intmax_t _Xp, intmax_t _Yp>
-class __ll_mul
-{
-  static const intmax_t nan   = (1LL << (sizeof(intmax_t) * CHAR_BIT - 1));
-  static const intmax_t min   = nan + 1;
-  static const intmax_t max   = -min;
-  static const intmax_t __a_x = __static_abs<_Xp>::value;
-  static const intmax_t __a_y = __static_abs<_Yp>::value;
-
-  static_assert(_Xp != nan && _Yp != nan && __a_x <= max / __a_y, "overflow in __ll_mul");
-
-public:
-  static const intmax_t value = _Xp * _Yp;
-};
-
-template <intmax_t _Yp>
-class __ll_mul<0, _Yp>
-{
-public:
-  static const intmax_t value = 0;
-};
-
-template <intmax_t _Xp>
-class __ll_mul<_Xp, 0>
-{
-public:
-  static const intmax_t value = 0;
-};
-
-template <>
-class __ll_mul<0, 0>
-{
-public:
-  static const intmax_t value = 0;
-};
-
-// Not actually used but left here in case needed in future maintenance
-template <intmax_t _Xp, intmax_t _Yp>
-class __ll_div
-{
-  static const intmax_t nan = (1LL << (sizeof(intmax_t) * CHAR_BIT - 1));
-  static const intmax_t min = nan + 1;
-  static const intmax_t max = -min;
-
-  static_assert(_Xp != nan && _Yp != nan && _Yp != 0, "overflow in __ll_div");
-
-public:
-  static const intmax_t value = _Xp / _Yp;
-};
+  return {__s * __na / __gcd, __da / __gcd};
+}
 
 template <intmax_t _Num, intmax_t _Den = 1>
 class _CCCL_TYPE_VISIBILITY_DEFAULT ratio
 {
-  static_assert(__static_abs<_Num>::value >= 0, "ratio numerator is out of range");
-  static_assert(_Den != 0, "ratio divide by 0");
-  static_assert(__static_abs<_Den>::value > 0, "ratio denominator is out of range");
-  static constexpr intmax_t __na  = __static_abs<_Num>::value;
-  static constexpr intmax_t __da  = __static_abs<_Den>::value;
-  static constexpr intmax_t __s   = __static_sign<_Num>::value * __static_sign<_Den>::value;
-  static constexpr intmax_t __gcd = __static_gcd<__na, __da>::value;
+  static_assert(_Num != __cccl_ratio_nan, "invalid ratio numerator value");
+  static_assert(_Den != __cccl_ratio_nan && _Den != 0, "invalid ratio denominator value");
 
 public:
-  static constexpr intmax_t num = __s * __na / __gcd;
-  static constexpr intmax_t den = __da / __gcd;
+  static constexpr intmax_t num = _CUDA_VSTD::__cccl_ratio_reduce({_Num, _Den}).__num;
+  static constexpr intmax_t den = _CUDA_VSTD::__cccl_ratio_reduce({_Num, _Den}).__den;
 
   using type = ratio<num, den>;
 };
 
-template <intmax_t _Num, intmax_t _Den>
-constexpr intmax_t ratio<_Num, _Den>::num;
-
-template <intmax_t _Num, intmax_t _Den>
-constexpr intmax_t ratio<_Num, _Den>::den;
-
 template <class _Tp>
-struct __is_ratio : false_type
-{};
+inline constexpr bool __is_ratio_v = false;
+
 template <intmax_t _Num, intmax_t _Den>
-struct __is_ratio<ratio<_Num, _Den>> : true_type
-{};
+inline constexpr bool __is_ratio_v<ratio<_Num, _Den>> = true;
 
 using atto  = ratio<1LL, 1000000000000000000LL>;
 using femto = ratio<1LL, 1000000000000000LL>;
@@ -235,180 +103,208 @@ using tera  = ratio<1000000000000LL, 1LL>;
 using peta  = ratio<1000000000000000LL, 1LL>;
 using exa   = ratio<1000000000000000000LL, 1LL>;
 
-template <class _R1, class _R2>
-struct __ratio_multiply
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr intmax_t __cccl_ratio_mul_ll(intmax_t __lhs, intmax_t __rhs) noexcept
 {
-  // private:
-  static const intmax_t __gcd_n1_d2 = __static_gcd<_R1::num, _R2::den>::value;
-  static const intmax_t __gcd_d1_n2 = __static_gcd<_R1::den, _R2::num>::value;
+  _CCCL_VERIFY(__lhs != __cccl_ratio_nan, "invalid multiplication numerator value");
+  _CCCL_VERIFY(__rhs != __cccl_ratio_nan, "invalid multiplication denominator value");
+  if (__lhs == 0 || __rhs == 0)
+  {
+    return 0;
+  }
+  const auto __lhs_abs = _CUDA_VSTD::abs(__lhs);
+  const auto __rhs_abs = _CUDA_VSTD::abs(__rhs);
+  _CCCL_VERIFY(__lhs_abs <= __cccl_ratio_max / __rhs_abs, "ratio multiplication overflow");
+  return __lhs * __rhs;
+}
 
-public:
-  using type = typename ratio<__ll_mul<_R1::num / __gcd_n1_d2, _R2::num / __gcd_d1_n2>::value,
-                              __ll_mul<_R2::den / __gcd_n1_d2, _R1::den / __gcd_d1_n2>::value>::type;
-};
-
-template <class _R1, class _R2>
-using ratio_multiply = typename __ratio_multiply<_R1, _R2>::type;
-
-template <class _R1, class _R2>
-struct __ratio_divide
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr __ratio_values
+__cccl_ratio_mul(__ratio_values __lhs, __ratio_values __rhs) noexcept
 {
-  // private:
-  static const intmax_t __gcd_n1_n2 = __static_gcd<_R1::num, _R2::num>::value;
-  static const intmax_t __gcd_d1_d2 = __static_gcd<_R1::den, _R2::den>::value;
+  const auto __gcd_n1_d2 = _CUDA_VSTD::__cccl_ratio_gcd(__lhs.__num, __lhs.__den);
+  const auto __gcd_d1_n2 = _CUDA_VSTD::__cccl_ratio_gcd(__lhs.__den, __rhs.__num);
 
-public:
-  using type = typename ratio<__ll_mul<_R1::num / __gcd_n1_n2, _R2::den / __gcd_d1_d2>::value,
-                              __ll_mul<_R2::num / __gcd_n1_n2, _R1::den / __gcd_d1_d2>::value>::type;
-};
+  __lhs.__num /= __gcd_n1_d2;
+  __rhs.__num /= __gcd_d1_n2;
+  __lhs.__den /= __gcd_n1_d2;
+  __rhs.__den /= __gcd_d1_n2;
+
+  const auto __num = _CUDA_VSTD::__cccl_ratio_mul_ll(__lhs.__num, __rhs.__num);
+  const auto __den = _CUDA_VSTD::__cccl_ratio_mul_ll(__lhs.__den, __rhs.__den);
+
+  return _CUDA_VSTD::__cccl_ratio_reduce({__num, __den});
+}
 
 template <class _R1, class _R2>
-using ratio_divide = typename __ratio_divide<_R1, _R2>::type;
+using ratio_multiply = ratio<_CUDA_VSTD::__cccl_ratio_mul({_R1::num, _R1::den}, {_R2::num, _R2::den}).__num,
+                             _CUDA_VSTD::__cccl_ratio_mul({_R1::num, _R1::den}, {_R2::num, _R2::den}).__den>;
 
 template <class _R1, class _R2>
-struct __ratio_add
+using ratio_divide = ratio<_CUDA_VSTD::__cccl_ratio_mul({_R1::num, _R1::den}, {_R2::den, _R2::num}).__num,
+                           _CUDA_VSTD::__cccl_ratio_mul({_R1::num, _R1::den}, {_R2::den, _R2::num}).__den>;
+
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr intmax_t __cccl_ratio_add_ll(intmax_t __lhs, intmax_t __rhs) noexcept
 {
-  // private:
-  static const intmax_t __gcd_n1_n2 = __static_gcd<_R1::num, _R2::num>::value;
-  static const intmax_t __gcd_d1_d2 = __static_gcd<_R1::den, _R2::den>::value;
+  if (__rhs > 0)
+  {
+    _CCCL_VERIFY(__lhs <= __cccl_ratio_max - __rhs, "ratio addition overflow");
+    return __lhs + __rhs;
+  }
+  else if (__rhs < 0)
+  {
+    _CCCL_VERIFY(__lhs >= __cccl_ratio_min - __rhs, "ratio addition overflow");
+    return __lhs + __rhs;
+  }
+  else
+  {
+    return __lhs;
+  }
+}
 
-public:
-  using type =
-    typename ratio_multiply<ratio<__gcd_n1_n2, _R1::den / __gcd_d1_d2>,
-                            ratio<__ll_add<__ll_mul<_R1::num / __gcd_n1_n2, _R2::den / __gcd_d1_d2>::value,
-                                           __ll_mul<_R2::num / __gcd_n1_n2, _R1::den / __gcd_d1_d2>::value>::value,
-                                  _R2::den>>::type;
-};
-
-template <class _R1, class _R2>
-using ratio_add = typename __ratio_add<_R1, _R2>::type;
-
-template <class _R1, class _R2>
-struct __ratio_subtract
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr __ratio_values
+__cccl_ratio_add(__ratio_values __lhs, __ratio_values __rhs) noexcept
 {
-  // private:
-  static const intmax_t __gcd_n1_n2 = __static_gcd<_R1::num, _R2::num>::value;
-  static const intmax_t __gcd_d1_d2 = __static_gcd<_R1::den, _R2::den>::value;
+  const auto __gcd_n1_n2 = _CUDA_VSTD::__cccl_ratio_gcd(__lhs.__num, __rhs.__num);
+  const auto __gcd_d1_d2 = _CUDA_VSTD::__cccl_ratio_gcd(__lhs.__den, __rhs.__den);
 
-public:
-  using type =
-    typename ratio_multiply<ratio<__gcd_n1_n2, _R1::den / __gcd_d1_d2>,
-                            ratio<__ll_sub<__ll_mul<_R1::num / __gcd_n1_n2, _R2::den / __gcd_d1_d2>::value,
-                                           __ll_mul<_R2::num / __gcd_n1_n2, _R1::den / __gcd_d1_d2>::value>::value,
-                                  _R2::den>>::type;
-};
+  const auto __tmp1 = _CUDA_VSTD::__cccl_ratio_mul_ll(__lhs.__num / __gcd_n1_n2, __rhs.__den / __gcd_d1_d2);
+  const auto __tmp2 = _CUDA_VSTD::__cccl_ratio_mul_ll(__rhs.__num / __gcd_n1_n2, __lhs.__den / __gcd_d1_d2);
 
-template <class _R1, class _R2>
-using ratio_subtract = typename __ratio_subtract<_R1, _R2>::type;
+  const __ratio_values __a{__gcd_n1_n2, __lhs.__den / __gcd_d1_d2};
+  const __ratio_values __b{_CUDA_VSTD::__cccl_ratio_add_ll(__tmp1, __tmp2), __rhs.__den};
 
-// ratio_equal
+  return _CUDA_VSTD::__cccl_ratio_mul(__a, {__b});
+}
 
 template <class _R1, class _R2>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT ratio_equal : public bool_constant<(_R1::num == _R2::num && _R1::den == _R2::den)>
-{};
+using ratio_add = ratio<_CUDA_VSTD::__cccl_ratio_add({_R1::num, _R1::den}, {_R2::num, _R2::den}).__num,
+                        _CUDA_VSTD::__cccl_ratio_add({_R1::num, _R1::den}, {_R2::num, _R2::den}).__den>;
+
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr intmax_t __cccl_ratio_sub_ll(intmax_t __lhs, intmax_t __rhs) noexcept
+{
+  if (__rhs > 0)
+  {
+    _CCCL_VERIFY(__lhs >= __cccl_ratio_min + __rhs, "ratio subtraction overflow");
+    return __lhs - __rhs;
+  }
+  else if (__rhs < 0)
+  {
+    _CCCL_VERIFY(__lhs <= __cccl_ratio_max + __rhs, "ratio subtraction overflow");
+    return __lhs - __rhs;
+  }
+  else
+  {
+    return __lhs;
+  }
+}
+
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr __ratio_values
+__cccl_ratio_sub(__ratio_values __lhs, __ratio_values __rhs) noexcept
+{
+  const auto __gcd_n1_n2 = _CUDA_VSTD::__cccl_ratio_gcd(__lhs.__num, __rhs.__num);
+  const auto __gcd_d1_d2 = _CUDA_VSTD::__cccl_ratio_gcd(__lhs.__den, __rhs.__den);
+
+  const auto __tmp1 = _CUDA_VSTD::__cccl_ratio_mul_ll(__lhs.__num / __gcd_n1_n2, __rhs.__den / __gcd_d1_d2);
+  const auto __tmp2 = _CUDA_VSTD::__cccl_ratio_mul_ll(__rhs.__num / __gcd_n1_n2, __lhs.__den / __gcd_d1_d2);
+
+  const __ratio_values __a{__gcd_n1_n2, __lhs.__den / __gcd_d1_d2};
+  const __ratio_values __b{_CUDA_VSTD::__cccl_ratio_sub_ll(__tmp1, __tmp2), __rhs.__den};
+
+  return _CUDA_VSTD::__cccl_ratio_mul(__a, {__b});
+}
 
 template <class _R1, class _R2>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT ratio_not_equal : public bool_constant<(!ratio_equal<_R1, _R2>::value)>
-{};
+using ratio_subtract = ratio<_CUDA_VSTD::__cccl_ratio_sub({_R1::num, _R1::den}, {_R2::num, _R2::den}).__num,
+                             _CUDA_VSTD::__cccl_ratio_sub({_R1::num, _R1::den}, {_R2::num, _R2::den}).__den>;
 
 // ratio_less
 
-template <class _R1,
-          class _R2,
-          bool _Odd    = false,
-          intmax_t _Q1 = _R1::num / _R1::den,
-          intmax_t _M1 = _R1::num % _R1::den,
-          intmax_t _Q2 = _R2::num / _R2::den,
-          intmax_t _M2 = _R2::num % _R2::den>
-struct __ratio_less1
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr bool
+__cccl_ratio_less_helper(__ratio_values __lhs, __ratio_values __rhs) noexcept
 {
-  static const bool value = _Odd ? _Q2 < _Q1 : _Q1 < _Q2;
-};
+  while (true)
+  {
+    const auto __lhs_div_res = __lhs.__num / __lhs.__den;
+    const auto __rhs_div_res = __rhs.__num / __rhs.__den;
+    if (__lhs_div_res != __rhs_div_res)
+    {
+      return __lhs_div_res < __rhs_div_res;
+    }
+    __lhs = {__lhs.__den, __lhs.__num % __lhs.__den};
+    __rhs = {__rhs.__den, __rhs.__num % __rhs.__den};
+    if (__lhs.__den == 0 || __rhs.__den == 0)
+    {
+      return __lhs.__den == 0 && __rhs.__den != 0;
+    }
+    _CUDA_VSTD::swap(__lhs, __rhs);
+  }
+  _CCCL_UNREACHABLE();
+}
 
-template <class _R1, class _R2, bool _Odd, intmax_t _Qp>
-struct __ratio_less1<_R1, _R2, _Odd, _Qp, 0, _Qp, 0>
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr bool
+__cccl_ratio_less(__ratio_values __lhs, __ratio_values __rhs) noexcept
 {
-  static const bool value = false;
-};
+  const auto __lhs_sign = _CUDA_VSTD::__cccl_ratio_sign(__lhs.__num);
+  const auto __rhs_sign = _CUDA_VSTD::__cccl_ratio_sign(__rhs.__num);
 
-template <class _R1, class _R2, bool _Odd, intmax_t _Qp, intmax_t _M2>
-struct __ratio_less1<_R1, _R2, _Odd, _Qp, 0, _Qp, _M2>
-{
-  static const bool value = !_Odd;
-};
-
-template <class _R1, class _R2, bool _Odd, intmax_t _Qp, intmax_t _M1>
-struct __ratio_less1<_R1, _R2, _Odd, _Qp, _M1, _Qp, 0>
-{
-  static const bool value = _Odd;
-};
-
-template <class _R1, class _R2, bool _Odd, intmax_t _Qp, intmax_t _M1, intmax_t _M2>
-struct __ratio_less1<_R1, _R2, _Odd, _Qp, _M1, _Qp, _M2>
-{
-  static const bool value = __ratio_less1<ratio<_R1::den, _M1>, ratio<_R2::den, _M2>, !_Odd>::value;
-};
-
-template <class _R1,
-          class _R2,
-          intmax_t _S1 = __static_sign<_R1::num>::value,
-          intmax_t _S2 = __static_sign<_R2::num>::value>
-struct __ratio_less
-{
-  static const bool value = _S1 < _S2;
-};
-
-template <class _R1, class _R2>
-struct __ratio_less<_R1, _R2, 1LL, 1LL>
-{
-  static const bool value = __ratio_less1<_R1, _R2>::value;
-};
-
-template <class _R1, class _R2>
-struct __ratio_less<_R1, _R2, -1LL, -1LL>
-{
-  static const bool value = __ratio_less1<ratio<-_R2::num, _R2::den>, ratio<-_R1::num, _R1::den>>::value;
-};
-
-template <class _R1, class _R2>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT ratio_less : public bool_constant<(__ratio_less<_R1, _R2>::value)>
-{};
-
-template <class _R1, class _R2>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT ratio_less_equal : public bool_constant<(!ratio_less<_R2, _R1>::value)>
-{};
-
-template <class _R1, class _R2>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT ratio_greater : public bool_constant<(ratio_less<_R2, _R1>::value)>
-{};
-
-template <class _R1, class _R2>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT ratio_greater_equal : public bool_constant<(!ratio_less<_R1, _R2>::value)>
-{};
+  if (__lhs_sign == 1 && __rhs_sign == 1)
+  {
+    return _CUDA_VSTD::__cccl_ratio_less_helper(__lhs, __rhs);
+  }
+  if (__lhs_sign == -1 && __rhs_sign == -1)
+  {
+    return _CUDA_VSTD::__cccl_ratio_less_helper({-__rhs.__num, __rhs.__den}, {-__lhs.__num, __lhs.__den});
+  }
+  return __lhs_sign < __rhs_sign;
+}
 
 template <class _R1, class _R2>
 struct __ratio_gcd
 {
-  using type = ratio<__static_gcd<_R1::num, _R2::num>::value, __static_lcm<_R1::den, _R2::den>::value>;
+  using type =
+    ratio<_CUDA_VSTD::__cccl_ratio_gcd(_R1::num, _R2::num), _CUDA_VSTD::__cccl_ratio_lcm(_R1::den, _R2::den)>;
 };
 
 template <class _R1, class _R2>
-inline constexpr bool ratio_equal_v = ratio_equal<_R1, _R2>::value;
+inline constexpr bool ratio_equal_v = _R1::num == _R2::num && _R1::den == _R2::den;
 
 template <class _R1, class _R2>
-inline constexpr bool ratio_not_equal_v = ratio_not_equal<_R1, _R2>::value;
+inline constexpr bool ratio_not_equal_v = !ratio_equal_v<_R1, _R2>;
 
 template <class _R1, class _R2>
-inline constexpr bool ratio_less_v = ratio_less<_R1, _R2>::value;
+inline constexpr bool ratio_less_v = _CUDA_VSTD::__cccl_ratio_less({_R1::num, _R1::den}, {_R2::num, _R2::den});
 
 template <class _R1, class _R2>
-inline constexpr bool ratio_less_equal_v = ratio_less_equal<_R1, _R2>::value;
+inline constexpr bool ratio_less_equal_v = !ratio_less_v<_R2, _R1>;
 
 template <class _R1, class _R2>
-inline constexpr bool ratio_greater_v = ratio_greater<_R1, _R2>::value;
+inline constexpr bool ratio_greater_v = ratio_less_v<_R2, _R1>;
 
 template <class _R1, class _R2>
-inline constexpr bool ratio_greater_equal_v = ratio_greater_equal<_R1, _R2>::value;
+inline constexpr bool ratio_greater_equal_v = !ratio_less_v<_R1, _R2>;
+
+template <class _R1, class _R2>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT ratio_equal : bool_constant<ratio_equal_v<_R1, _R2>>
+{};
+
+template <class _R1, class _R2>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT ratio_not_equal : bool_constant<ratio_not_equal_v<_R1, _R2>>
+{};
+
+template <class _R1, class _R2>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT ratio_less : bool_constant<ratio_less_v<_R1, _R2>>
+{};
+
+template <class _R1, class _R2>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT ratio_less_equal : bool_constant<ratio_less_equal_v<_R1, _R2>>
+{};
+
+template <class _R1, class _R2>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT ratio_greater : bool_constant<ratio_greater_v<_R1, _R2>>
+{};
+
+template <class _R1, class _R2>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT ratio_greater_equal : bool_constant<ratio_greater_equal_v<_R1, _R2>>
+{};
 
 _LIBCUDACXX_END_NAMESPACE_STD
 


### PR DESCRIPTION
This PR refactors `<cuda/std/ratio>`, the goal is to reduce the number of `cuda::std::ratio` instantiations.