### PR TITLE
Check `cuda::memcpy_async` preconditions

### DIFF
--- a/libcudacxx/include/cuda/__barrier/aligned_size.h
+++ b/libcudacxx/include/cuda/__barrier/aligned_size.h
@@ -21,6 +21,7 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/__cmath/pow2.h>
 #include <cuda/std/cstddef>
 
 #include <cuda/std/__cccl/prologue.h>
@@ -30,13 +31,18 @@ _LIBCUDACXX_BEGIN_NAMESPACE_CUDA
 template <_CUDA_VSTD::size_t _Alignment>
 struct aligned_size_t
 {
+  static_assert(::cuda::is_power_of_two(_Alignment), "alignment must be a power of two");
+
   static constexpr _CUDA_VSTD::size_t align = _Alignment;
   _CUDA_VSTD::size_t value;
 
-  _LIBCUDACXX_HIDE_FROM_ABI explicit constexpr aligned_size_t(size_t __s)
+  _LIBCUDACXX_HIDE_FROM_ABI explicit constexpr aligned_size_t(_CUDA_VSTD::size_t __s)
       : value(__s)
-  {}
-  _LIBCUDACXX_HIDE_FROM_ABI constexpr operator size_t() const
+  {
+    _CCCL_ASSERT(value % align == 0,
+                 "aligned_size_t must be constructed with a size that is a multiple of the alignment");
+  }
+  _LIBCUDACXX_HIDE_FROM_ABI constexpr operator _CUDA_VSTD::size_t() const
   {
     return value;
   }

--- a/libcudacxx/include/cuda/__memcpy_async/memcpy_async.h
+++ b/libcudacxx/include/cuda/__memcpy_async/memcpy_async.h
@@ -33,6 +33,7 @@
 #  include <cuda/std/__atomic/scopes.h>
 #  include <cuda/std/__type_traits/void_t.h>
 #  include <cuda/std/cstddef>
+#  include <cuda/std/cstdint>
 
 #  include <cuda/std/__cccl/prologue.h>
 
@@ -104,6 +105,10 @@ _LIBCUDACXX_HIDE_FROM_ABI async_contract_fulfillment memcpy_async(
   aligned_size_t<_Alignment> __size,
   barrier<_Sco, _CompF>& __barrier)
 {
+  _CCCL_ASSERT(reinterpret_cast<uintptr_t>(__destination) % _Alignment == 0,
+               "destination pointer must be aligned to the specified alignment");
+  _CCCL_ASSERT(reinterpret_cast<uintptr_t>(__source) % _Alignment == 0,
+               "source pointer must be aligned to the specified alignment");
   return __memcpy_async_barrier(__group, __destination, __source, __size, __barrier);
 }
 
@@ -145,6 +150,10 @@ _LIBCUDACXX_HIDE_FROM_ABI async_contract_fulfillment memcpy_async(
   aligned_size_t<_Alignment> __size,
   barrier<_Sco, _CompF>& __barrier)
 {
+  _CCCL_ASSERT(reinterpret_cast<uintptr_t>(__destination) % _Alignment == 0,
+               "destination pointer must be aligned to the specified alignment");
+  _CCCL_ASSERT(reinterpret_cast<uintptr_t>(__source) % _Alignment == 0,
+               "source pointer must be aligned to the specified alignment");
   return __memcpy_async_barrier(
     __group, reinterpret_cast<char*>(__destination), reinterpret_cast<char const*>(__source), __size, __barrier);
 }

--- a/libcudacxx/include/cuda/__memcpy_async/memcpy_async_tx.h
+++ b/libcudacxx/include/cuda/__memcpy_async/memcpy_async_tx.h
@@ -57,6 +57,11 @@ _CCCL_DEVICE inline async_contract_fulfillment memcpy_async_tx(
 #    endif
   static_assert(16 <= _Alignment, "mempcy_async_tx expects arguments to be at least 16 byte aligned.");
 
+  _CCCL_ASSERT(reinterpret_cast<uintptr_t>(__dest) % _Alignment == 0,
+               "destination pointer must be aligned to the specified alignment");
+  _CCCL_ASSERT(reinterpret_cast<uintptr_t>(__src) % _Alignment == 0,
+               "source pointer must be aligned to the specified alignment");
+
   _CCCL_ASSERT(__isShared(barrier_native_handle(__b)), "Barrier must be located in local shared memory.");
   _CCCL_ASSERT(__isShared(__dest), "dest must point to shared memory.");
   _CCCL_ASSERT(__isGlobal(__src), "src must point to global memory.");

--- a/libcudacxx/include/cuda/pipeline
+++ b/libcudacxx/include/cuda/pipeline
@@ -26,6 +26,7 @@
 #include <cuda/atomic>
 #include <cuda/barrier>
 #include <cuda/std/chrono>
+#include <cuda/std/cstdint>
 
 #include <cuda/std/__cccl/prologue.h>
 
@@ -499,7 +500,7 @@ _LIBCUDACXX_HIDE_FROM_ABI async_contract_fulfillment __memcpy_async_pipeline(
   _CUDA_VSTD::uint32_t __allowed_completions = _CUDA_VSTD::uint32_t(__completion_mechanism::__async_group);
 
   // Alignment: Use the maximum of the alignment of _Tp and that of a possible cuda::aligned_size_t.
-  constexpr _CUDA_VSTD::size_t __size_align = __get_size_align<_Size>::align;
+  constexpr _CUDA_VSTD::size_t __size_align = __get_size_align_v<_Size>;
   constexpr _CUDA_VSTD::size_t __align      = (alignof(_Tp) < __size_align) ? __size_align : alignof(_Tp);
   // Cast to char pointers. We don't need the type for alignment anymore and
   // erasing the types reduces the number of instantiations of down-stream
@@ -521,11 +522,7 @@ _LIBCUDACXX_HIDE_FROM_ABI async_contract_fulfillment memcpy_async(
   return __memcpy_async_pipeline(__group, __destination, __source, __size, __pipeline);
 }
 
-template <typename _Group,
-          class _Type,
-          std::size_t _Alignment,
-          thread_scope _Scope,
-          std::size_t _Larger_alignment = (alignof(_Type) > _Alignment) ? alignof(_Type) : _Alignment>
+template <typename _Group, class _Type, std::size_t _Alignment, thread_scope _Scope>
 _LIBCUDACXX_HIDE_FROM_ABI async_contract_fulfillment memcpy_async(
   _Group const& __group,
   _Type* __destination,
@@ -533,6 +530,10 @@ _LIBCUDACXX_HIDE_FROM_ABI async_contract_fulfillment memcpy_async(
   aligned_size_t<_Alignment> __size,
   pipeline<_Scope>& __pipeline)
 {
+  _CCCL_ASSERT(reinterpret_cast<uintptr_t>(__destination) % _Alignment == 0,
+               "destination pointer must be aligned to the specified alignment");
+  _CCCL_ASSERT(reinterpret_cast<uintptr_t>(__source) % _Alignment == 0,
+               "source pointer must be aligned to the specified alignment");
   return __memcpy_async_pipeline(__group, __destination, __source, __size, __pipeline);
 }
 
@@ -559,6 +560,10 @@ _LIBCUDACXX_HIDE_FROM_ABI async_contract_fulfillment memcpy_async(
   aligned_size_t<_Alignment> __size,
   pipeline<_Scope>& __pipeline)
 {
+  _CCCL_ASSERT(reinterpret_cast<uintptr_t>(__destination) % _Alignment == 0,
+               "destination pointer must be aligned to the specified alignment");
+  _CCCL_ASSERT(reinterpret_cast<uintptr_t>(__source) % _Alignment == 0,
+               "source pointer must be aligned to the specified alignment");
   return __memcpy_async_pipeline(
     __group, reinterpret_cast<char*>(__destination), reinterpret_cast<char const*>(__source), __size, __pipeline);
 }

--- a/libcudacxx/test/libcudacxx/cuda/barrier/aligned_size_t.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/barrier/aligned_size_t.pass.cpp
@@ -22,8 +22,8 @@
 __host__ __device__ constexpr bool test()
 {
   using aligned_t = cuda::aligned_size_t<1>;
-  static_assert(!cuda::std::is_default_constructible<aligned_t>::value, "");
-  static_assert(aligned_t::align == 1, "");
+  static_assert(!cuda::std::is_default_constructible<aligned_t>::value);
+  static_assert(aligned_t::align == 1);
   {
     const aligned_t aligned{42};
     assert(aligned.value == 42);
@@ -33,11 +33,11 @@ __host__ __device__ constexpr bool test()
 }
 
 // test C++11 differently
-static_assert(cuda::aligned_size_t<42>{1337}.value == 1337, "");
+static_assert(cuda::aligned_size_t<32>{1024}.value == 1024);
 
 int main(int, char**)
 {
   test();
-  static_assert(test(), "");
+  static_assert(test());
   return 0;
 }


### PR DESCRIPTION
The preconditions of `cuda::memcpy_async` are described in the documentation, however, they are not checked in the code.

This PR adds assert statements to `cuda::aligned_size_t` and `cuda::memcpy_async` checking the preconditions.
