### PR TITLE
[STF] Ensure we generate CUDA graphs which always have the same topology

### DIFF
--- a/cudax/include/cuda/experimental/__stf/graph/internal/event_types.cuh
+++ b/cudax/include/cuda/experimental/__stf/graph/internal/event_types.cuh
@@ -46,10 +46,27 @@ protected:
     assert(node);
   }
 
+  // Remove duplicate entries from a vector.
+  //
+  // We could use sort and unique, but that could change the order of the nodes
+  // in the result, so that we would generate graphs with a topology that
+  // changes across multiple calls, where the update method would fail.
+  // Instead, we only append nodes to the result vector if they were not seen
+  // before.
   void remove_duplicates(::std::vector<cudaGraphNode_t>& nodes)
   {
-    ::std::sort(nodes.begin(), nodes.end());
-    nodes.erase(::std::unique(nodes.begin(), nodes.end()), nodes.end()); // Remove duplicates
+    ::std::unordered_set<cudaGraphNode_t> seen;
+    ::std::vector<cudaGraphNode_t> result;
+
+    for (cudaGraphNode_t node : nodes)
+    {
+      if (seen.insert(node).second)
+      {
+        result.push_back(node); // First time we've seen this node
+      }
+    }
+
+    ::std::swap(nodes, result);
   }
 
   bool factorize(backend_ctx_untyped& bctx, reserved::event_vector& events) override

--- a/cudax/include/cuda/experimental/__stf/internal/async_prereq.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/async_prereq.cuh
@@ -32,7 +32,6 @@
 #include <cuda/experimental/__stf/utility/scope_guard.cuh>
 #include <cuda/experimental/__stf/utility/threads.cuh>
 #include <cuda/experimental/__stf/utility/unique_id.cuh>
-#include <cuda/experimental/__stf/utility/unstable_unique.cuh>
 
 #include <algorithm>
 #include <atomic>
@@ -218,6 +217,12 @@ public:
 
     // nvtx_range r("optimize");
 
+    // This is a list of shared_ptr to events, we want to sort by events
+    // ID, not by addresses of the ptr
+    ::std::sort(payload.begin(), payload.end(), [](auto& a, auto& b) {
+      return *a < *b;
+    });
+
     // All items will have the same (derived) event type as the type of the front element.
     // If the type of the event does not implement a factorize method, a
     // false value is returned (eg. with cudaGraphs)
@@ -225,12 +230,8 @@ public:
 
     if (!factorized)
     {
-      // This is a list of shared_ptr to events, we want to sort by events
-      // ID, not by addresses of the ptr
-      ::std::sort(payload.begin(), payload.end(), [](auto& a, auto& b) {
-        return *a < *b;
-      });
-      auto new_end = unstable_unique(payload.begin(), payload.end(), [](auto& a, auto& b) {
+      // Note that the list was already sorted above so we can call unique directly
+      auto new_end = ::std::unique(payload.begin(), payload.end(), [](auto& a, auto& b) {
         return *a == *b;
       });
       // Erase the "undefined" elements at the end of the container


### PR DESCRIPTION
Some algorithms may reorder the edges in a CUDA graph, resulting in different topologies for the same code, and therefore prevent to update executable graphs.

## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes <!-- Link issue here -->

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
