### PR TITLE
Avoid plain `assert` in device code

### DIFF
--- a/cub/cub/thread/thread_reduce.cuh
+++ b/cub/cub/thread/thread_reduce.cuh
@@ -546,7 +546,7 @@ _CCCL_REQUIRES((!cub::internal::enable_generic_simd_reduction<Input, ReductionOp
 _CCCL_NODISCARD _CCCL_DEVICE _CCCL_FORCEINLINE auto
 ThreadReduceSimd(const Input& input, ReductionOp) -> ::cuda::std::remove_cvref_t<decltype(input[0])>
 {
-  assert(false);
+  _CCCL_VERIFY(false, "ThreadReduceSimd: Should never be reached");
   return input[0];
 }
 

--- a/cub/test/CMakeLists.txt
+++ b/cub/test/CMakeLists.txt
@@ -109,6 +109,11 @@ file(GLOB_RECURSE test_srcs
   catch2_test_*.cu
 )
 
+# nvtx headers contain a variable named `module`, which breaks nvc++ as that is a keyword
+if ("NVHPC" STREQUAL "${CMAKE_CXX_COMPILER_ID}" AND NOT "${CMAKE_CXX_STANDARD}" MATCHES "17")
+  list(FILTER test_srcs EXCLUDE REGEX "test_nvtx*")
+endif()
+
 ## _cub_is_catch2_test
 #
 # If the test_src contains the substring "catch2_test_", `result_var` will


### PR DESCRIPTION
This does not compile on all platforms due to windows falling back to `_wassert` which is not recognized by clang-cuda as a device function
