### PR TITLE
[CUDAX] Add in_place_type argument to pass-through constructor of shared resource

### DIFF
--- a/cudax/include/cuda/experimental/__memory_resource/shared_resource.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/shared_resource.cuh
@@ -224,9 +224,6 @@ struct shared_resource
     return get_property(__self.__control_block->__resource, _Property{});
   }
 
-  template <class _Res, class... _Args>
-  friend auto make_shared_resource(_Args&&... __args) -> shared_resource<_Res>;
-
 private:
   // Use a custom shared_ptr implementation because (a) we don't need to support weak_ptr so we only
   // need one pointer, not two, and (b) this implementation can work on device also.
@@ -237,14 +234,6 @@ private:
   };
 
   _Control_block* __control_block;
-
-  //! @brief Constructs a \c shared_resource referring to an object of type \c _Resource
-  //! that has been constructed with arguments \c __args. The \c _Resource object is
-  //! dynamically allocated with \c new.
-  //! @param __args The arguments to be passed to the \c _Resource constructor.
-  explicit shared_resource(_Control_block* __control_block)
-      : __control_block(__control_block)
-  {}
 };
 
 //! @rst

--- a/cudax/test/memory_resource/shared_resource.cu
+++ b/cudax/test/memory_resource/shared_resource.cu
@@ -61,7 +61,7 @@ TEMPLATE_TEST_CASE_METHOD(test_fixture, "shared_resource", "[container][resource
       CHECK(mr2 == mr4); // pointers compare equal, no call to TestResource::operator==
       CHECK(this->counts == expected);
 
-      cudax::shared_resource<TestResource> mr5{cudax::make_shared_resource<TestResource>(42, this)};
+      cudax::shared_resource<TestResource> mr5{cudax::make_shared_resource<TestResource>(TestResource{42, this})};
       ++expected.object_count;
       ++expected.move_count;
       CHECK(mr3 == mr5); // pointers are not equal, calls TestResource::operator==

--- a/cudax/test/memory_resource/shared_resource.cu
+++ b/cudax/test/memory_resource/shared_resource.cu
@@ -25,7 +25,7 @@ TEMPLATE_TEST_CASE_METHOD(test_fixture, "shared_resource", "[container][resource
     Counts expected{};
     CHECK(this->counts == expected);
     {
-      cudax::shared_resource<TestResource> mr{42, this};
+      auto mr = cudax::make_shared_resource<TestResource>(42, this);
       ++expected.object_count;
       CHECK(this->counts == expected);
     }
@@ -42,7 +42,7 @@ TEMPLATE_TEST_CASE_METHOD(test_fixture, "shared_resource", "[container][resource
     Counts expected{};
     CHECK(this->counts == expected);
     {
-      cudax::shared_resource<TestResource> mr{42, this};
+      auto mr = cudax::make_shared_resource<TestResource>(42, this);
       ++expected.object_count;
       CHECK(this->counts == expected);
 
@@ -51,15 +51,20 @@ TEMPLATE_TEST_CASE_METHOD(test_fixture, "shared_resource", "[container][resource
       CHECK(mr == mr2); // pointers compare equal, no call to TestResource::operator==
       CHECK(this->counts == expected);
 
-      auto mr3 = std::move(mr);
+      cudax::shared_resource<TestResource> mr3(mr);
       CHECK(this->counts == expected);
-      CHECK(mr2 == mr3); // pointers compare equal, no call to TestResource::operator==
+      CHECK(mr == mr3); // pointers compare equal, no call to TestResource::operator==
       CHECK(this->counts == expected);
 
-      cudax::shared_resource<TestResource> mr4{TestResource{42, this}};
+      auto mr4 = std::move(mr);
+      CHECK(this->counts == expected);
+      CHECK(mr2 == mr4); // pointers compare equal, no call to TestResource::operator==
+      CHECK(this->counts == expected);
+
+      cudax::shared_resource<TestResource> mr5{cudax::make_shared_resource<TestResource>(42, this)};
       ++expected.object_count;
       ++expected.move_count;
-      CHECK(mr3 == mr4); // pointers are not equal, calls TestResource::operator==
+      CHECK(mr3 == mr5); // pointers are not equal, calls TestResource::operator==
       ++expected.equal_to_count;
       CHECK(this->counts == expected);
     }
@@ -76,7 +81,7 @@ TEMPLATE_TEST_CASE_METHOD(test_fixture, "shared_resource", "[container][resource
     Counts expected{};
     CHECK(this->counts == expected);
     {
-      cudax::shared_resource<TestResource> mr{42, this};
+      auto mr = cudax::make_shared_resource<TestResource>(42, this);
       ++expected.object_count;
       CHECK(this->counts == expected);
 
@@ -101,7 +106,7 @@ TEMPLATE_TEST_CASE_METHOD(test_fixture, "shared_resource", "[container][resource
   {
     Counts expected{};
     {
-      cudax::shared_resource<TestResource> mr{42, this};
+      auto mr = cudax::make_shared_resource<TestResource>(42, this);
       ++expected.object_count;
       CHECK(this->counts == expected);
 
@@ -130,7 +135,7 @@ TEMPLATE_TEST_CASE_METHOD(test_fixture, "shared_resource", "[container][resource
     {
       bytes(42 * sizeof(int));
       cudax::uninitialized_buffer<int, cudax::host_accessible> buffer{
-        cudax::shared_resource<TestResource>(42, this), 42};
+        cudax::make_shared_resource<TestResource>(42, this), 42};
       ++expected.object_count;
       ++expected.allocate_count;
       CHECK(this->counts == expected);

--- a/cudax/test/memory_resource/shared_resource.cu
+++ b/cudax/test/memory_resource/shared_resource.cu
@@ -61,7 +61,7 @@ TEMPLATE_TEST_CASE_METHOD(test_fixture, "shared_resource", "[container][resource
       CHECK(mr2 == mr4); // pointers compare equal, no call to TestResource::operator==
       CHECK(this->counts == expected);
 
-      cudax::shared_resource mr5{cuda::std::in_place_type<TestResource>, 42, this};
+      cudax::shared_resource mr5{cuda::std::in_place_type<TestResource>, TestResource{42, this}};
       ++expected.object_count;
       ++expected.move_count;
       CHECK(mr4 == mr5); // pointers are not equal, calls TestResource::operator==

--- a/cudax/test/memory_resource/shared_resource.cu
+++ b/cudax/test/memory_resource/shared_resource.cu
@@ -25,7 +25,7 @@ TEMPLATE_TEST_CASE_METHOD(test_fixture, "shared_resource", "[container][resource
     Counts expected{};
     CHECK(this->counts == expected);
     {
-      auto mr = cudax::make_shared_resource<TestResource>(42, this);
+      cudax::shared_resource mr{cuda::std::in_place_type<TestResource>, 42, this};
       ++expected.object_count;
       CHECK(this->counts == expected);
     }
@@ -42,7 +42,7 @@ TEMPLATE_TEST_CASE_METHOD(test_fixture, "shared_resource", "[container][resource
     Counts expected{};
     CHECK(this->counts == expected);
     {
-      auto mr = cudax::make_shared_resource<TestResource>(42, this);
+      cudax::shared_resource mr{cuda::std::in_place_type<TestResource>, 42, this};
       ++expected.object_count;
       CHECK(this->counts == expected);
 
@@ -51,7 +51,7 @@ TEMPLATE_TEST_CASE_METHOD(test_fixture, "shared_resource", "[container][resource
       CHECK(mr == mr2); // pointers compare equal, no call to TestResource::operator==
       CHECK(this->counts == expected);
 
-      cudax::shared_resource<TestResource> mr3(mr);
+      cudax::shared_resource mr3{mr};
       CHECK(this->counts == expected);
       CHECK(mr == mr3); // pointers compare equal, no call to TestResource::operator==
       CHECK(this->counts == expected);
@@ -61,10 +61,10 @@ TEMPLATE_TEST_CASE_METHOD(test_fixture, "shared_resource", "[container][resource
       CHECK(mr2 == mr4); // pointers compare equal, no call to TestResource::operator==
       CHECK(this->counts == expected);
 
-      cudax::shared_resource<TestResource> mr5{cudax::make_shared_resource<TestResource>(TestResource{42, this})};
+      cudax::shared_resource mr5{cuda::std::in_place_type<TestResource>, 42, this};
       ++expected.object_count;
       ++expected.move_count;
-      CHECK(mr3 == mr5); // pointers are not equal, calls TestResource::operator==
+      CHECK(mr4 == mr5); // pointers are not equal, calls TestResource::operator==
       ++expected.equal_to_count;
       CHECK(this->counts == expected);
     }
@@ -81,7 +81,7 @@ TEMPLATE_TEST_CASE_METHOD(test_fixture, "shared_resource", "[container][resource
     Counts expected{};
     CHECK(this->counts == expected);
     {
-      auto mr = cudax::make_shared_resource<TestResource>(42, this);
+      cudax::shared_resource mr{cuda::std::in_place_type<TestResource>, 42, this};
       ++expected.object_count;
       CHECK(this->counts == expected);
 
@@ -106,7 +106,7 @@ TEMPLATE_TEST_CASE_METHOD(test_fixture, "shared_resource", "[container][resource
   {
     Counts expected{};
     {
-      auto mr = cudax::make_shared_resource<TestResource>(42, this);
+      cudax::shared_resource mr{cuda::std::in_place_type<TestResource>, 42, this};
       ++expected.object_count;
       CHECK(this->counts == expected);
 
@@ -135,7 +135,7 @@ TEMPLATE_TEST_CASE_METHOD(test_fixture, "shared_resource", "[container][resource
     {
       bytes(42 * sizeof(int));
       cudax::uninitialized_buffer<int, cudax::host_accessible> buffer{
-        cudax::make_shared_resource<TestResource>(42, this), 42};
+        cudax::shared_resource<TestResource>(cuda::std::in_place_type<TestResource>, 42, this), 42};
       ++expected.object_count;
       ++expected.allocate_count;
       CHECK(this->counts == expected);


### PR DESCRIPTION
Copy constructor of `shared_resource` doesn't work correctly right now, because for non-const argument the constructor that passed-through the arguments to the resource constructor is picked by overload resolution instead.

~~There might be a way to restrict that constructor to fix the overload resolution, but we already have `make_shared_resource` that does pretty much the same thing and avoids this issue. This PR proposes removal of the problematic pass-through constructor that will make the copy constructor work properly.~~
This PR adds `in_place_type` argument to the pass-through `shared_resource` constructor to avoid issues with overload resolution and enable CTAD.