### PR TITLE
Port `thrust::discard_iterator`

### DIFF
--- a/libcudacxx/include/cuda/__iterator/discard_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/discard_iterator.h
@@ -73,7 +73,7 @@ private:
   {
     _CCCL_TEMPLATE(class _Tp)
     _CCCL_REQUIRES((!_CUDA_VSTD::is_same_v<_CUDA_VSTD::remove_cvref_t<_Tp>, __discard_proxy>) )
-    _LIBCUDACXX_HIDE_FROM_ABI constexpr __discard_proxy& operator=(_Tp&&) noexcept
+    _LIBCUDACXX_HIDE_FROM_ABI constexpr const __discard_proxy& operator=(_Tp&&) const noexcept
     {
       return *this;
     }
@@ -213,10 +213,7 @@ public:
     return *this;
   }
 
-  //! @brief Compares two \c discard_iterator \p __lhs and \p __rhs for equality
-  //! @param __lhs The left \c discard_iterator
-  //! @param __rhs The right \c discard_iterator
-  //! @return true if both iterators store the same index
+  //! @brief Compares two \c discard_iterator for equality by comparing their indices
   [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI friend constexpr bool
   operator==(const discard_iterator& __lhs, const discard_iterator& __rhs) noexcept
   {
@@ -224,10 +221,7 @@ public:
   }
 
 #if _CCCL_STD_VER <= 2017
-  //! @brief Compares two \c discard_iterator \p __lhs and \p __rhs for inequality
-  //! @param __lhs The left \c discard_iterator
-  //! @param __rhs The right \c discard_iterator
-  //! @return true if both iterators store different indexs
+  //! @brief Compares two \c discard_iterator for inequality by comparing their indices
   [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI friend constexpr bool
   operator!=(const discard_iterator& __lhs, const discard_iterator& __rhs) noexcept
   {
@@ -235,9 +229,7 @@ public:
   }
 #endif // _CCCL_STD_VER <= 2017
 
-  //! @brief Compares a \c discard_iterator \p __lhs with \p default_sentinel for equality
-  //! @param __lhs The left \c discard_iterator
-  //! @return true if the index of \p __lhs is zero
+  //! @brief Compares a \c discard_iterator with \p default_sentinel , true if the index of \p __lhs is zero
   [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI friend constexpr bool
   operator==(const discard_iterator& __lhs, _CUDA_VSTD::default_sentinel_t) noexcept
   {
@@ -245,27 +237,21 @@ public:
   }
 
 #if _CCCL_STD_VER <= 2017
-  //! @brief Compares a \c discard_iterator \p __rhs with \p default_sentinel for equality
-  //! @param __rhs The right \c discard_iterator
-  //! @return true if the index of \p __rhs is zero
+  //! @brief Compares a \c discard_iterator with \p default_sentinel , true if the index of \p __lhs is zero
   [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI friend constexpr bool
   operator==(_CUDA_VSTD::default_sentinel_t, const discard_iterator& __rhs) noexcept
   {
     return __rhs.__index_ == 0;
   }
 
-  //! @brief Compares a \c discard_iterator \p __rhs with \p default_sentinel for inequality
-  //! @param __lhs The right \c discard_iterator
-  //! @return true if the index of \p __lhs is not zero
+  //! @brief Compares a \c discard_iterator with \p default_sentinel , true if the index of \p __lhs is not zero
   [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI friend constexpr bool
   operator!=(const discard_iterator& __lhs, _CUDA_VSTD::default_sentinel_t) noexcept
   {
     return __lhs.__index_ != 0;
   }
 
-  //! @brief Compares a \c discard_iterator \p __rhs with \p default_sentinel for inequality
-  //! @param __rhs The right \c discard_iterator
-  //! @return true if the index of \p __rhs is not zero
+  //! @brief Compares a \c discard_iterator with \p default_sentinel , true if the index of \p __lhs is not zero
   [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI friend constexpr bool
   operator!=(_CUDA_VSTD::default_sentinel_t, const discard_iterator& __rhs) noexcept
   {
@@ -274,10 +260,7 @@ public:
 #endif // _CCCL_STD_VER <= 2017
 
 #if _LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
-  //! @brief Three-way-compares two \c discard_iterator \p __lhs and \p __rhs
-  //! @param __lhs The left \c discard_iterator
-  //! @param __rhs The right \c discard_iterator
-  //! @return the three-way ordering of the indexs stored by \p __lhs and \p __rhs
+  //! @brief Three-way-compares two \c discard_iterator by comparing their indices
   [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI friend constexpr strong_ordering
   operator<=>(const discard_iterator& __lhs, const discard_iterator& __rhs) noexcept
   {
@@ -285,40 +268,28 @@ public:
   }
 #endif // _LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
 
-  //! @brief Compares two \c discard_iterator \p __lhs and \p __rhs for less than
-  //! @param __lhs The left \c discard_iterator
-  //! @param __rhs The right \c discard_iterator
-  //! @return true if the index stored by \p __lhs compares less than the one stored by \p __rhs
+  //! @brief Compares two \c discard_iterator for less then by comparing their indices
   [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI friend constexpr bool
   operator<(const discard_iterator& __lhs, const discard_iterator& __rhs) noexcept
   {
     return __lhs.__index_ < __rhs.__index_;
   }
 
-  //! @brief Compares two \c discard_iterator \p __lhs and \p __rhs for less equal
-  //! @param __lhs The left \c discard_iterator
-  //! @param __rhs The right \c discard_iterator
-  //! @return true if the index stored by \p __lhs compares less equal the one stored by \p __rhs
+  //! @brief Compares two \c discard_iterator for less equal by comparing their indices
   [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI friend constexpr bool
   operator<=(const discard_iterator& __lhs, const discard_iterator& __rhs) noexcept
   {
     return __lhs.__index_ <= __rhs.__index_;
   }
 
-  //! @brief Compares two \c discard_iterator \p __lhs and \p __rhs for greater than
-  //! @param __lhs The left \c discard_iterator
-  //! @param __rhs The right \c discard_iterator
-  //! @return true if the index stored by \p __lhs compares less greater the one stored by \p __rhs
+  //! @brief Compares two \c discard_iterator for greater then by comparing their indices
   [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI friend constexpr bool
   operator>(const discard_iterator& __lhs, const discard_iterator& __rhs) noexcept
   {
     return __lhs.__index_ > __rhs.__index_;
   }
 
-  //! @brief Compares two \c discard_iterator \p __lhs and \p __rhs for greater equal
-  //! @param __lhs The left \c discard_iterator
-  //! @param __rhs The right \c discard_iterator
-  //! @return true if the index stored by \p __lhs compares greater equal the one stored by \p __rhs
+  //! @brief Compares two \c discard_iterator for greater equal by comparing their indices
   [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI friend constexpr bool
   operator>=(const discard_iterator& __lhs, const discard_iterator& __rhs) noexcept
   {

--- a/libcudacxx/include/cuda/__iterator/discard_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/discard_iterator.h
@@ -268,7 +268,7 @@ public:
   }
 #endif // _LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
 
-  //! @brief Compares two \c discard_iterator for less then by comparing their indices
+  //! @brief Compares two \c discard_iterator for less than by comparing their indices
   [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI friend constexpr bool
   operator<(const discard_iterator& __lhs, const discard_iterator& __rhs) noexcept
   {
@@ -282,7 +282,7 @@ public:
     return __lhs.__index_ <= __rhs.__index_;
   }
 
-  //! @brief Compares two \c discard_iterator for greater then by comparing their indices
+  //! @brief Compares two \c discard_iterator for greater than by comparing their indices
   [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI friend constexpr bool
   operator>(const discard_iterator& __lhs, const discard_iterator& __rhs) noexcept
   {

--- a/libcudacxx/include/cuda/__iterator/discard_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/discard_iterator.h
@@ -1,0 +1,359 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA___ITERATOR_DISCARD_ITERATOR_H
+#define _CUDA___ITERATOR_DISCARD_ITERATOR_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__iterator/concepts.h>
+#include <cuda/std/__iterator/default_sentinel.h>
+#include <cuda/std/__iterator/iterator_traits.h>
+#include <cuda/std/__type_traits/is_same.h>
+#include <cuda/std/__type_traits/remove_cvref.h>
+#include <cuda/std/cstdint>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_CUDA
+
+//! @brief \p discard_iterator is an iterator which represents a special kind of pointer that ignores values written to
+//! it upon dereference. This iterator is useful for ignoring the output of certain algorithms without wasting memory
+//! capacity or bandwidth. \p discard_iterator may also be used to count the size of an algorithm's output which may not
+//! be known a priori.
+//!
+//! The following code snippet demonstrates how to use \p discard_iterator to ignore one of the output ranges of
+//! reduce_by_key
+//!
+//! @code
+//! #include <cuda/iterator>
+//! #include <thrust/reduce.h>
+//! #include <thrust/device_vector.h>
+//!
+//! int main()
+//! {
+//!   thrust::device_vector<int> keys(7), values(7);
+//!
+//!   keys[0] = 1;
+//!   keys[1] = 3;
+//!   keys[2] = 3;
+//!   keys[3] = 3;
+//!   keys[4] = 2;
+//!   keys[5] = 2;
+//!   keys[6] = 1;
+//!
+//!   values[0] = 9;
+//!   values[1] = 8;
+//!   values[2] = 7;
+//!   values[3] = 6;
+//!   values[4] = 5;
+//!   values[5] = 4;
+//!   values[6] = 3;
+//!
+//!   thrust::device_vector<int> result(4);
+//!
+//!   // we are only interested in the reduced values
+//!   // use discard_iterator to ignore the output keys
+//!   thrust::reduce_by_key(keys.begin(), keys.end(),
+//!                         values.begin(),
+//!                         cuda::make_discard_iterator(),
+//!                         result.begin());
+//!
+//!   // result is now [9, 21, 9, 3]
+//!
+//!   return 0;
+//! }
+//! @endcode
+class discard_iterator
+{
+private:
+  _CUDA_VSTD::ptrdiff_t __counter_ = 0;
+
+  struct __discard_proxy
+  {
+    _CCCL_TEMPLATE(class _Tp)
+    _CCCL_REQUIRES((!_CUDA_VSTD::is_same_v<_CUDA_VSTD::remove_cvref_t<_Tp>, __discard_proxy>) )
+    _LIBCUDACXX_HIDE_FROM_ABI constexpr __discard_proxy& operator=(_Tp&&) noexcept
+    {
+      return *this;
+    }
+  };
+
+public:
+  using iterator_concept  = _CUDA_VSTD::random_access_iterator_tag;
+  using iterator_category = _CUDA_VSTD::random_access_iterator_tag;
+  using difference_type   = _CUDA_VSTD::ptrdiff_t;
+  using value_type        = void;
+  using pointer           = void*;
+  using reference         = void;
+
+  //! @brief Default constructs a \p discard_iterator with a value initialized counter
+  _CCCL_HIDE_FROM_ABI constexpr discard_iterator() = default;
+
+  //! @brief Constructs a \p discard_iterator with a given \p __counter
+  //! @param __counter The counter used for the discard iterator
+  _CCCL_TEMPLATE(class _Integer)
+  _CCCL_REQUIRES(_CUDA_VSTD::__integer_like<_Integer>)
+  _LIBCUDACXX_HIDE_FROM_ABI constexpr discard_iterator(_Integer __counter) noexcept
+      : __counter_(static_cast<_CUDA_VSTD::ptrdiff_t>(__counter))
+  {}
+
+  //! @brief Returns the stored counter
+  [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr difference_type count() const noexcept
+  {
+    return __counter_;
+  }
+
+  //! @brief Dereferences the \c discard_iterator returning a proxy that discards all values that are assigned to it
+  [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr __discard_proxy operator*() const noexcept
+  {
+    return {};
+  }
+
+  //! @brief Subscipts the \c discard_iterator returning a proxy that discards all values that are assigned to it
+  [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr __discard_proxy operator[](difference_type) const noexcept
+  {
+    return {};
+  }
+
+  //! @brief Increments the stored counter
+  _LIBCUDACXX_HIDE_FROM_ABI constexpr discard_iterator& operator++() noexcept
+  {
+    ++__counter_;
+    return *this;
+  }
+
+  //! @brief Increments the stored counter
+  _LIBCUDACXX_HIDE_FROM_ABI constexpr discard_iterator operator++(int) noexcept
+  {
+    discard_iterator __tmp = *this;
+    ++__counter_;
+    return __tmp;
+  }
+
+  //! @brief Decrements the stored counter
+  _LIBCUDACXX_HIDE_FROM_ABI constexpr discard_iterator& operator--() noexcept
+  {
+    --__counter_;
+    return *this;
+  }
+
+  //! @brief Decrements the stored counter
+  _LIBCUDACXX_HIDE_FROM_ABI constexpr discard_iterator operator--(int) noexcept
+  {
+    discard_iterator __tmp = *this;
+    --__counter_;
+    return __tmp;
+  }
+
+  //! @brief Returns a copy of this \c discard_iterator advanced by \p __n
+  //! @param __n The number of elements to advance
+  [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr discard_iterator operator+(difference_type __n) const noexcept
+  {
+    return discard_iterator{__counter_ + __n};
+  }
+
+  //! @brief Returns a copy of \p __x advanced by \p __n
+  //! @param __n The number of elements to advance
+  //! @param __x The original \c discard_iterator
+  [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI friend constexpr discard_iterator
+  operator+(difference_type __n, const discard_iterator& __x) noexcept
+  {
+    return __x + __n;
+  }
+
+  //! @brief Advances this \c discard_iterator by \p __n
+  //! @param __n The number of elements to advance
+  _LIBCUDACXX_HIDE_FROM_ABI constexpr discard_iterator& operator+=(difference_type __n) noexcept
+  {
+    __counter_ += __n;
+    return *this;
+  }
+
+  //! @brief Returns a copy of this \c discard_iterator decremented by \p __n
+  //! @param __n The number of elements to decrement
+  [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr discard_iterator operator-(difference_type __n) const noexcept
+  {
+    return discard_iterator{__counter_ - __n};
+  }
+
+  //! @brief Returns the distance between \p __lhs and \p __rhs
+  //! @param __lhs The left \c discard_iterator
+  //! @param __rhs The right \c discard_iterator
+  //! @return __rhs.__counter_ - __lhs.__counter_
+  [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI friend constexpr difference_type
+  operator-(const discard_iterator& __lhs, const discard_iterator& __rhs) noexcept
+  {
+    return __rhs.__counter_ - __lhs.__counter_;
+  }
+
+  //! @brief Returns the distance between \p __lhs a \p default_sentinel
+  //! @param __lhs The left \c discard_iterator
+  //! @return -__lhs.__counter_
+  [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI friend constexpr difference_type
+  operator-(const discard_iterator& __lhs, _CUDA_VSTD::default_sentinel_t) noexcept
+  {
+    return static_cast<difference_type>(-__lhs.__counter_);
+  }
+
+  //! @brief Returns the distance between a \p default_sentinel and \p __rhs
+  //! @param __rhs The right \c discard_iterator
+  //! @return __rhs.__coutner_
+  [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI friend constexpr difference_type
+  operator-(_CUDA_VSTD::default_sentinel_t, const discard_iterator& __rhs) noexcept
+  {
+    return static_cast<difference_type>(__rhs.__counter_);
+  }
+
+  //! @brief Decrements the \c discard_iterator by \p __n
+  //! @param __n The number of elements to decrement
+  _LIBCUDACXX_HIDE_FROM_ABI constexpr discard_iterator& operator-=(difference_type __n) noexcept
+  {
+    __counter_ -= __n;
+    return *this;
+  }
+
+  //! @brief Compares two \c discard_iterator \p __lhs and \p __rhs for equality
+  //! @param __lhs The left \c discard_iterator
+  //! @param __rhs The right \c discard_iterator
+  //! @return true if both iterators store the same counter
+  [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI friend constexpr bool
+  operator==(const discard_iterator& __lhs, const discard_iterator& __rhs) noexcept
+  {
+    return __lhs.__counter_ == __rhs.__counter_;
+  }
+
+#if _CCCL_STD_VER <= 2017
+  //! @brief Compares two \c discard_iterator \p __lhs and \p __rhs for inequality
+  //! @param __lhs The left \c discard_iterator
+  //! @param __rhs The right \c discard_iterator
+  //! @return true if both iterators store different counters
+  [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI friend constexpr bool
+  operator!=(const discard_iterator& __lhs, const discard_iterator& __rhs) noexcept
+  {
+    return __lhs.__counter_ != __rhs.__counter_;
+  }
+#endif // _CCCL_STD_VER <= 2017
+
+  //! @brief Compares a \c discard_iterator \p __lhs with \p default_sentinel for equality
+  //! @param __lhs The left \c discard_iterator
+  //! @return true if the counter of \p __lhs is zero
+  [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI friend constexpr bool
+  operator==(const discard_iterator& __lhs, _CUDA_VSTD::default_sentinel_t) noexcept
+  {
+    return __lhs.__counter_ == 0;
+  }
+
+#if _CCCL_STD_VER <= 2017
+  //! @brief Compares a \c discard_iterator \p __rhs with \p default_sentinel for equality
+  //! @param __rhs The right \c discard_iterator
+  //! @return true if the counter of \p __rhs is zero
+  [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI friend constexpr bool
+  operator==(_CUDA_VSTD::default_sentinel_t, const discard_iterator& __rhs) noexcept
+  {
+    return __rhs.__counter_ == 0;
+  }
+
+  //! @brief Compares a \c discard_iterator \p __rhs with \p default_sentinel for inequality
+  //! @param __lhs The right \c discard_iterator
+  //! @return true if the counter of \p __lhs is not zero
+  [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI friend constexpr bool
+  operator!=(const discard_iterator& __lhs, _CUDA_VSTD::default_sentinel_t) noexcept
+  {
+    return __lhs.__counter_ != 0;
+  }
+
+  //! @brief Compares a \c discard_iterator \p __rhs with \p default_sentinel for inequality
+  //! @param __rhs The right \c discard_iterator
+  //! @return true if the counter of \p __rhs is not zero
+  [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI friend constexpr bool
+  operator!=(_CUDA_VSTD::default_sentinel_t, const discard_iterator& __rhs) noexcept
+  {
+    return __rhs.__counter_ != 0;
+  }
+#endif // _CCCL_STD_VER <= 2017
+
+#if _LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
+  //! @brief Three-way-compares two \c discard_iterator \p __lhs and \p __rhs
+  //! @param __lhs The left \c discard_iterator
+  //! @param __rhs The right \c discard_iterator
+  //! @return the three-way ordering of the counters stored by \p __lhs and \p __rhs
+  [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI friend constexpr strong_ordering
+  operator<=>(const discard_iterator& __lhs, const discard_iterator& __rhs) noexcept
+  {
+    return __lhs.__counter_ <=> __rhs.__counter_;
+  }
+#endif // _LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
+
+  //! @brief Compares two \c discard_iterator \p __lhs and \p __rhs for less than
+  //! @param __lhs The left \c discard_iterator
+  //! @param __rhs The right \c discard_iterator
+  //! @return true if the counter stored by \p __lhs compares less than the one stored by \p __rhs
+  [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI friend constexpr bool
+  operator<(const discard_iterator& __lhs, const discard_iterator& __rhs) noexcept
+  {
+    return __lhs.__counter_ < __rhs.__counter_;
+  }
+
+  //! @brief Compares two \c discard_iterator \p __lhs and \p __rhs for less equal
+  //! @param __lhs The left \c discard_iterator
+  //! @param __rhs The right \c discard_iterator
+  //! @return true if the counter stored by \p __lhs compares less equal the one stored by \p __rhs
+  [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI friend constexpr bool
+  operator<=(const discard_iterator& __lhs, const discard_iterator& __rhs) noexcept
+  {
+    return __lhs.__counter_ <= __rhs.__counter_;
+  }
+
+  //! @brief Compares two \c discard_iterator \p __lhs and \p __rhs for greater than
+  //! @param __lhs The left \c discard_iterator
+  //! @param __rhs The right \c discard_iterator
+  //! @return true if the counter stored by \p __lhs compares less greater the one stored by \p __rhs
+  [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI friend constexpr bool
+  operator>(const discard_iterator& __lhs, const discard_iterator& __rhs) noexcept
+  {
+    return __lhs.__counter_ > __rhs.__counter_;
+  }
+
+  //! @brief Compares two \c discard_iterator \p __lhs and \p __rhs for greater equal
+  //! @param __lhs The left \c discard_iterator
+  //! @param __rhs The right \c discard_iterator
+  //! @return true if the counter stored by \p __lhs compares greater equal the one stored by \p __rhs
+  [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI friend constexpr bool
+  operator>=(const discard_iterator& __lhs, const discard_iterator& __rhs) noexcept
+  {
+    return __lhs.__counter_ >= __rhs.__counter_;
+  }
+};
+
+//! @brief Creates a \p discard_iterator from an optional counter.
+//! @param __counter The index of the returned \p discard_iterator within a range. In the default case, the value of
+//! this parameter is \c 0.
+//! @return A new \p discard_iterator with \p __counter as the couner.
+_CCCL_TEMPLATE(class _Integer = _CUDA_VSTD::ptrdiff_t)
+_CCCL_REQUIRES(_CUDA_VSTD::__integer_like<_Integer>)
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr discard_iterator make_discard_iterator(_Integer __counter = 0)
+{
+  return discard_iterator{__counter};
+}
+
+_LIBCUDACXX_END_NAMESPACE_CUDA
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA___ITERATOR_DISCARD_ITERATOR_H

--- a/libcudacxx/include/cuda/iterator
+++ b/libcudacxx/include/cuda/iterator
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_ITERATOR
+#define _CUDA_ITERATOR
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/__iterator/discard_iterator.h>
+#include <cuda/std/iterator>
+
+#endif // _CUDA_ITERATOR

--- a/libcudacxx/include/cuda/std/__iterator/concepts.h
+++ b/libcudacxx/include/cuda/std/__iterator/concepts.h
@@ -79,12 +79,11 @@ using iter_common_reference_t = common_reference_t<iter_reference_t<_Tp>, iter_v
 // [iterator.concept.writable]
 template <class _Out, class _Tp>
 concept indirectly_writable = requires(_Out&& __o, _Tp&& __t) {
-  *__o                            = _CUDA_VSTD::forward<_Tp>(__t); // not required to be equality-preserving
-  *_CUDA_VSTD::forward<_Out>(__o) = _CUDA_VSTD::forward<_Tp>(__t); // not required to be equality-preserving
-  const_cast<const iter_reference_t<_Out>&&>(*__o) = _CUDA_VSTD::forward<_Tp>(__t); // not required to be
-                                                                                    // equality-preserving
-  const_cast<const iter_reference_t<_Out>&&>(*_CUDA_VSTD::forward<_Out>(__o)) =
-    _CUDA_VSTD::forward<_Tp>(__t); // not required to be equality-preserving
+  *__o                                             = static_cast<_Tp&&>(__t); // not required to be equality-preserving
+  *static_cast<_Out&&>(__o)                        = static_cast<_Tp&&>(__t); // not required to be equality-preserving
+  const_cast<const iter_reference_t<_Out>&&>(*__o) = static_cast<_Tp&&>(__t); // not required to be equality-preserving
+  const_cast<const iter_reference_t<_Out>&&>(*static_cast<_Out&&>(__o)) =
+    static_cast<_Tp&&>(__t); // not required to be equality-preserving
 };
 
 // [iterator.concept.winc]
@@ -142,7 +141,7 @@ concept input_iterator = input_or_output_iterator<_Ip> && indirectly_readable<_I
 template <class _Ip, class _Tp>
 concept output_iterator =
   input_or_output_iterator<_Ip> && indirectly_writable<_Ip, _Tp> && requires(_Ip __it, _Tp&& __t) {
-    *__it++ = _CUDA_VSTD::forward<_Tp>(__t); // not required to be equality-preserving
+    *__it++ = static_cast<_Tp&&>(__t); // not required to be equality-preserving
   };
 
 // [iterator.concept.forward]
@@ -278,19 +277,14 @@ _CCCL_CONCEPT indirectly_readable = _CCCL_FRAGMENT(__indirectly_readable_impl_, 
 template <class _Tp>
 using iter_common_reference_t =
   enable_if_t<indirectly_readable<_Tp>, common_reference_t<iter_reference_t<_Tp>, iter_value_t<_Tp>&>>;
+
 // [iterator.concept.writable]
 template <class _Out, class _Tp>
-_CCCL_CONCEPT_FRAGMENT(
-  __indirectly_writable_,
-  requires(_Out&& __o, _Tp&& __t)(
-    typename(decltype(*__o = _CUDA_VSTD::forward<_Tp>(__t))),
-    typename(decltype(*_CUDA_VSTD::forward<_Out>(__o) = _CUDA_VSTD::forward<_Tp>(__t))),
-    typename(decltype(const_cast<const iter_reference_t<_Out>&&>(*__o) = _CUDA_VSTD::forward<_Tp>(__t))),
-    typename(decltype(const_cast<const iter_reference_t<_Out>&&>(*_CUDA_VSTD::forward<_Out>(__o)) =
-                        _CUDA_VSTD::forward<_Tp>(__t)))));
-
-template <class _Out, class _Tp>
-_CCCL_CONCEPT indirectly_writable = _CCCL_FRAGMENT(__indirectly_writable_, _Out, _Tp);
+_CCCL_CONCEPT indirectly_writable = _CCCL_REQUIRES_EXPR((_Out, _Tp), _Out&& __o, _Tp&& __t)(
+  (*__o = static_cast<_Tp&&>(__t)),
+  (*static_cast<_Out&&>(__o) = static_cast<_Tp&&>(__t)),
+  (const_cast<const iter_reference_t<_Out>&&>(*__o) = static_cast<_Tp&&>(__t)),
+  (const_cast<const iter_reference_t<_Out>&&>(*static_cast<_Out&&>(__o)) = static_cast<_Tp&&>(__t)));
 
 // [iterator.concept.winc]
 template <class _Tp>
@@ -375,7 +369,7 @@ template <class _Ip, class _Tp>
 _CCCL_CONCEPT_FRAGMENT(__output_iterator_,
                        requires(_Ip __it, _Tp&& __t)(requires(input_or_output_iterator<_Ip>),
                                                      requires(indirectly_writable<_Ip, _Tp>),
-                                                     (*__it++ = _CUDA_VSTD::forward<_Tp>(__t))));
+                                                     (*__it++ = static_cast<_Tp&&>(__t))));
 
 template <class _Ip, class _Tp>
 _CCCL_CONCEPT output_iterator = _CCCL_FRAGMENT(__output_iterator_, _Ip, _Tp);

--- a/libcudacxx/test/libcudacxx/cuda/iterators/discard_iterator/compare.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/discard_iterator/compare.pass.cpp
@@ -1,0 +1,91 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// friend constexpr bool operator==(const discard_iterator& x, const discard_iterator& y);
+// friend constexpr bool operator==(const discard_iterator& x, default_sentinel_t);
+
+#include <cuda/iterator>
+#include <cuda/std/utility>
+
+#include "test_macros.h"
+
+__host__ __device__ constexpr bool test()
+{
+  const int offset1 = 3;
+  const int offset2 = 4;
+  cuda::discard_iterator iter1(offset1);
+  cuda::discard_iterator iter2(offset2);
+
+  // equality
+  assert(iter1 == iter1);
+  assert(iter1 != iter2);
+
+  assert(cuda::std::as_const(iter1) == iter1);
+  assert(iter1 != cuda::std::as_const(iter2));
+
+  assert(iter1 == cuda::std::as_const(iter1));
+  assert(cuda::std::as_const(iter1) != iter2);
+
+  assert(cuda::std::as_const(iter1) == cuda::std::as_const(iter1));
+  assert(cuda::std::as_const(iter1) != cuda::std::as_const(iter2));
+
+  // relation
+  assert(iter1 < iter2);
+  assert(iter1 <= iter2);
+  assert(iter2 > iter1);
+  assert(iter2 >= iter1);
+
+  assert(cuda::std::as_const(iter1) < iter2);
+  assert(cuda::std::as_const(iter1) <= iter2);
+  assert(cuda::std::as_const(iter2) > iter1);
+  assert(cuda::std::as_const(iter2) >= iter1);
+
+  assert(iter1 < cuda::std::as_const(iter2));
+  assert(iter1 <= cuda::std::as_const(iter2));
+  assert(iter2 > cuda::std::as_const(iter1));
+  assert(iter2 >= cuda::std::as_const(iter1));
+
+  assert(cuda::std::as_const(iter1) < cuda::std::as_const(iter2));
+  assert(cuda::std::as_const(iter1) <= cuda::std::as_const(iter2));
+  assert(cuda::std::as_const(iter2) > cuda::std::as_const(iter1));
+  assert(cuda::std::as_const(iter2) >= cuda::std::as_const(iter1));
+
+#if _LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
+  using cuda::std::strong_ordering::equal;
+  using cuda::std::strong_ordering::greater;
+  using cuda::std::strong_ordering::less;
+
+  assert(iter1 <=> iter1 == equal);
+  assert(iter2 <=> iter1 == greater);
+  assert(iter1 <=> iter2 == less);
+
+  assert(cuda::std::as_const(iter1) <=> iter1 == equal);
+  assert(cuda::std::as_const(iter2) <=> iter1 == greater);
+  assert(cuda::std::as_const(iter1) <=> iter2 == less);
+
+  assert(iter1 <=> cuda::std::as_const(iter1) == equal);
+  assert(iter2 <=> cuda::std::as_const(iter1) == greater);
+  assert(iter1 <=> cuda::std::as_const(iter2) == less);
+
+  assert(cuda::std::as_const(iter1) <=> cuda::std::as_const(iter1) == equal);
+  assert(cuda::std::as_const(iter2) <=> cuda::std::as_const(iter1) == greater);
+  assert(cuda::std::as_const(iter1) <=> cuda::std::as_const(iter2) == less);
+#endif // _LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/discard_iterator/count.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/discard_iterator/count.pass.cpp
@@ -1,0 +1,42 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// constexpr iter_difference_t<I> offset() const noexcept;
+
+#include <cuda/iterator>
+
+#include "test_iterators.h"
+#include "test_macros.h"
+
+__host__ __device__ constexpr bool test()
+{
+  {
+    const cuda::discard_iterator iter{};
+    assert(iter.count() == 0);
+    static_assert(cuda::std::is_same_v<decltype(iter.count()), cuda::std::ptrdiff_t>);
+  }
+
+  {
+    const cuda::std::ptrdiff_t count = 2;
+    cuda::discard_iterator iter(count);
+    assert(iter.count() == count);
+    static_assert(cuda::std::is_same_v<decltype(iter.count()), cuda::std::ptrdiff_t>);
+  }
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/discard_iterator/ctor.default.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/discard_iterator/ctor.default.pass.cpp
@@ -1,0 +1,36 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// constexpr discard_iterator()
+
+#include <cuda/iterator>
+#include <cuda/std/type_traits>
+
+#include "test_macros.h"
+
+__host__ __device__ constexpr bool test()
+{
+  [[maybe_unused]] cuda::discard_iterator iter{};
+
+  static_assert(cuda::std::is_copy_constructible_v<cuda::discard_iterator>);
+  static_assert(cuda::std::is_move_constructible_v<cuda::discard_iterator>);
+  static_assert(cuda::std::is_copy_assignable_v<cuda::discard_iterator>);
+  static_assert(cuda::std::is_move_assignable_v<cuda::discard_iterator>);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/discard_iterator/decrement.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/discard_iterator/decrement.pass.cpp
@@ -17,10 +17,10 @@
 
 __host__ __device__ constexpr bool test()
 {
-  const int counter = 3;
-  cuda::discard_iterator iter(counter);
-  assert(iter-- == cuda::discard_iterator(counter + 0));
-  assert(--iter == cuda::discard_iterator(counter - 2));
+  const int index = 3;
+  cuda::discard_iterator iter(index);
+  assert(iter-- == cuda::discard_iterator(index + 0));
+  assert(--iter == cuda::discard_iterator(index - 2));
 
   static_assert(cuda::std::is_same_v<decltype(iter--), cuda::discard_iterator>);
   static_assert(cuda::std::is_same_v<decltype(--iter), cuda::discard_iterator&>);

--- a/libcudacxx/test/libcudacxx/cuda/iterators/discard_iterator/decrement.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/discard_iterator/decrement.pass.cpp
@@ -1,0 +1,37 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// constexpr discard_iterator& operator--()
+// constexpr discard_iterator operator--(int)
+
+#include <cuda/iterator>
+
+#include "test_macros.h"
+
+__host__ __device__ constexpr bool test()
+{
+  const int counter = 3;
+  cuda::discard_iterator iter(counter);
+  assert(iter-- == cuda::discard_iterator(counter + 0));
+  assert(--iter == cuda::discard_iterator(counter - 2));
+
+  static_assert(cuda::std::is_same_v<decltype(iter--), cuda::discard_iterator>);
+  static_assert(cuda::std::is_same_v<decltype(--iter), cuda::discard_iterator&>);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/discard_iterator/deref.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/discard_iterator/deref.pass.cpp
@@ -19,14 +19,14 @@
 __host__ __device__ constexpr bool test()
 {
   {
-    const int counter = 2;
-    cuda::discard_iterator iter(counter);
+    const int index = 2;
+    cuda::discard_iterator iter(index);
     *iter = 42;
   }
 
   {
-    const int counter = 2;
-    const cuda::discard_iterator iter(counter);
+    const int index = 2;
+    const cuda::discard_iterator iter(index);
     *iter = 42;
   }
 

--- a/libcudacxx/test/libcudacxx/cuda/iterators/discard_iterator/deref.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/discard_iterator/deref.pass.cpp
@@ -1,0 +1,42 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// constexpr decltype(auto) operator*();
+// constexpr decltype(auto) operator*() const
+//   requires dereferenceable<const I>;
+
+#include <cuda/iterator>
+
+#include "test_macros.h"
+
+__host__ __device__ constexpr bool test()
+{
+  {
+    const int counter = 2;
+    cuda::discard_iterator iter(counter);
+    *iter = 42;
+  }
+
+  {
+    const int counter = 2;
+    const cuda::discard_iterator iter(counter);
+    *iter = 42;
+  }
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/discard_iterator/increment.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/discard_iterator/increment.pass.cpp
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// constexpr discard_iterator& operator++();
+// constexpr discard_iterator operator++(int);
+
+#include <cuda/iterator>
+
+#include "test_macros.h"
+
+__host__ __device__ constexpr bool test()
+{
+  const int counter = 2;
+  cuda::discard_iterator iter(counter);
+
+  assert(iter++ == cuda::discard_iterator(counter + 0));
+  assert(++iter == cuda::discard_iterator(counter + 2));
+
+  static_assert(cuda::std::is_same_v<decltype(iter++), cuda::discard_iterator>);
+  static_assert(cuda::std::is_same_v<decltype(++iter), cuda::discard_iterator&>);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/discard_iterator/increment.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/discard_iterator/increment.pass.cpp
@@ -17,11 +17,11 @@
 
 __host__ __device__ constexpr bool test()
 {
-  const int counter = 2;
-  cuda::discard_iterator iter(counter);
+  const int index = 2;
+  cuda::discard_iterator iter(index);
 
-  assert(iter++ == cuda::discard_iterator(counter + 0));
-  assert(++iter == cuda::discard_iterator(counter + 2));
+  assert(iter++ == cuda::discard_iterator(index + 0));
+  assert(++iter == cuda::discard_iterator(index + 2));
 
   static_assert(cuda::std::is_same_v<decltype(iter++), cuda::discard_iterator>);
   static_assert(cuda::std::is_same_v<decltype(++iter), cuda::discard_iterator&>);

--- a/libcudacxx/test/libcudacxx/cuda/iterators/discard_iterator/index.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/discard_iterator/index.pass.cpp
@@ -19,15 +19,15 @@ __host__ __device__ constexpr bool test()
 {
   {
     const cuda::discard_iterator iter{};
-    assert(iter.count() == 0);
-    static_assert(cuda::std::is_same_v<decltype(iter.count()), cuda::std::ptrdiff_t>);
+    assert(iter.index() == 0);
+    static_assert(cuda::std::is_same_v<decltype(iter.index()), cuda::std::ptrdiff_t>);
   }
 
   {
-    const cuda::std::ptrdiff_t count = 2;
-    cuda::discard_iterator iter(count);
-    assert(iter.count() == count);
-    static_assert(cuda::std::is_same_v<decltype(iter.count()), cuda::std::ptrdiff_t>);
+    const cuda::std::ptrdiff_t index = 2;
+    cuda::discard_iterator iter(index);
+    assert(iter.index() == index);
+    static_assert(cuda::std::is_same_v<decltype(iter.index()), cuda::std::ptrdiff_t>);
   }
 
   return true;

--- a/libcudacxx/test/libcudacxx/cuda/iterators/discard_iterator/iterator_traits.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/discard_iterator/iterator_traits.compile.pass.cpp
@@ -25,6 +25,8 @@ __host__ __device__ void test()
   static_assert(cuda::std::same_as<IterTraits::difference_type, cuda::std::ptrdiff_t>);
   static_assert(cuda::std::same_as<IterTraits::pointer, void*>);
   static_assert(cuda::std::same_as<IterTraits::reference, void>);
+  static_assert(cuda::std::input_or_output_iterator<cuda::discard_iterator>);
+  static_assert(cuda::std::output_iterator<cuda::discard_iterator, float>);
 }
 
 int main(int, char**)

--- a/libcudacxx/test/libcudacxx/cuda/iterators/discard_iterator/iterator_traits.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/discard_iterator/iterator_traits.compile.pass.cpp
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/iterator>
+
+#include "test_iterators.h"
+#include "test_macros.h"
+
+template <class>
+void print() = delete;
+
+__host__ __device__ void test()
+{
+  using IterTraits = cuda::std::iterator_traits<cuda::discard_iterator>;
+
+  static_assert(cuda::std::same_as<IterTraits::iterator_category, cuda::std::random_access_iterator_tag>);
+  static_assert(cuda::std::same_as<IterTraits::value_type, void>);
+  static_assert(cuda::std::same_as<IterTraits::difference_type, cuda::std::ptrdiff_t>);
+  static_assert(cuda::std::same_as<IterTraits::pointer, void*>);
+  static_assert(cuda::std::same_as<IterTraits::reference, void>);
+}
+
+int main(int, char**)
+{
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/discard_iterator/make_discard_iterator.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/discard_iterator/make_discard_iterator.pass.cpp
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// constexpr decltype(auto) operator*();
+// constexpr decltype(auto) operator*() const
+//   requires dereferenceable<const I>;
+
+#include <cuda/iterator>
+#include <cuda/std/type_traits>
+
+#include "test_macros.h"
+
+__host__ __device__ constexpr bool test()
+{
+  {
+    auto iter = cuda::make_discard_iterator();
+    static_assert(cuda::std::is_same_v<decltype(iter), cuda::discard_iterator>);
+    *iter = 42;
+  }
+
+  {
+    auto iter = cuda::make_discard_iterator(static_cast<short>(42));
+    static_assert(cuda::std::is_same_v<decltype(iter), cuda::discard_iterator>);
+    *iter = 42;
+  }
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/discard_iterator/member_types.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/discard_iterator/member_types.compile.pass.cpp
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// iterator_type, value_type, difference_type, iterator_concept, iterator_category
+
+#include <cuda/iterator>
+
+#include "test_iterators.h"
+#include "test_macros.h"
+
+__host__ __device__ void test()
+{
+  using Iter = cuda::discard_iterator;
+  static_assert(cuda::std::same_as<Iter::value_type, void>);
+  static_assert(cuda::std::same_as<Iter::pointer, void*>);
+  static_assert(cuda::std::same_as<Iter::difference_type, cuda::std::ptrdiff_t>);
+  static_assert(cuda::std::same_as<Iter::iterator_concept, cuda::std::random_access_iterator_tag>);
+  static_assert(cuda::std::same_as<Iter::iterator_category, cuda::std::random_access_iterator_tag>);
+}
+
+int main(int, char**)
+{
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/discard_iterator/minus.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/discard_iterator/minus.pass.cpp
@@ -1,0 +1,128 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// constexpr discard_iterator operator-(iter_difference_t<I> n) const;
+// friend constexpr iter_difference_t operator-(const discard_iterator& x, const discard_iterator& y)
+// constexpr discard_iterator& operator-=(iter_difference_t<I> n);
+// friend constexpr iter_difference_t<I> operator-(const discard_iterator& x, default_sentinel_t);
+// friend constexpr iter_difference_t<I> operator-(default_sentinel_t, const discard_iterator& y);
+
+#include <cuda/iterator>
+
+#include "test_iterators.h"
+#include "test_macros.h"
+
+template <class Iter>
+_CCCL_CONCEPT MinusEnabled = _CCCL_REQUIRES_EXPR((Iter), Iter& iter)((iter - 1));
+
+__host__ __device__ constexpr bool test()
+{
+  { // operator-(iter_difference_t<I> n)
+    {
+      const int counter = 3;
+      const int diff    = 2;
+      cuda::discard_iterator iter(counter);
+      assert(iter - diff == cuda::discard_iterator(counter - diff));
+      assert(iter - 0 == cuda::discard_iterator(counter));
+
+      static_assert(cuda::std::is_same_v<decltype(iter - 2), cuda::discard_iterator>);
+    }
+
+    {
+      const int counter = 3;
+      const int diff    = 2;
+      const cuda::discard_iterator iter(counter);
+      assert(iter - diff == cuda::discard_iterator(counter - diff));
+      assert(iter - 0 == cuda::discard_iterator(counter));
+
+      static_assert(cuda::std::is_same_v<decltype(iter - 2), cuda::discard_iterator>);
+    }
+  }
+
+  { // operator-(const discard_iterator& x, const discard_iterator& y)
+    {
+      const int counter1 = 4;
+      const int counter2 = 2;
+      cuda::discard_iterator iter1(counter1);
+      cuda::discard_iterator iter2(counter2);
+      assert(iter1 - iter2 == counter2 - counter1);
+      assert(iter2 - iter1 == counter1 - counter2);
+
+      static_assert(cuda::std::is_same_v<decltype(iter1 - iter2), cuda::std::ptrdiff_t>);
+    }
+
+    {
+      const int counter1 = 4;
+      const int counter2 = 2;
+      const cuda::discard_iterator iter1(counter1);
+      const cuda::discard_iterator iter2(counter2);
+      assert(iter1 - iter2 == counter2 - counter1);
+      assert(iter2 - iter1 == counter1 - counter2);
+
+      static_assert(cuda::std::is_same_v<decltype(iter1 - iter2), cuda::std::ptrdiff_t>);
+    }
+  }
+
+  { // operator-=(iter_difference_t<I> n)
+    const int counter = 3;
+    const int diff    = 2;
+    cuda::discard_iterator iter(counter);
+    assert((iter -= diff) == cuda::discard_iterator(1));
+    assert((iter -= 0) == cuda::discard_iterator(1));
+
+    static_assert(cuda::std::is_same_v<decltype(iter -= 2), cuda::discard_iterator&>);
+  }
+
+  { // operator-(const discard_iterator& x, default_sentinel_t)
+    {
+      const int counter = 3;
+      cuda::discard_iterator iter(counter);
+      assert((iter - cuda::std::default_sentinel) == -counter);
+
+      static_assert(cuda::std::is_same_v<decltype(iter - cuda::std::default_sentinel), cuda::std::ptrdiff_t>);
+    }
+
+    {
+      const int counter = 3;
+      const cuda::discard_iterator iter(counter);
+      assert((iter - cuda::std::default_sentinel) == -counter);
+
+      static_assert(cuda::std::is_same_v<decltype(iter - cuda::std::default_sentinel), cuda::std::ptrdiff_t>);
+    }
+  }
+
+  { // operator-(default_sentinel_t, const discard_iterator& y)
+    {
+      const int counter = 3;
+      cuda::discard_iterator iter(counter);
+      assert((cuda::std::default_sentinel - iter) == counter);
+
+      static_assert(cuda::std::is_same_v<decltype(cuda::std::default_sentinel - iter), cuda::std::ptrdiff_t>);
+    }
+
+    {
+      const int counter = 3;
+      const cuda::discard_iterator iter(counter);
+      assert((cuda::std::default_sentinel - iter) == counter);
+
+      static_assert(cuda::std::is_same_v<decltype(cuda::std::default_sentinel - iter), cuda::std::ptrdiff_t>);
+    }
+  }
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/discard_iterator/minus.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/discard_iterator/minus.pass.cpp
@@ -26,21 +26,21 @@ __host__ __device__ constexpr bool test()
 {
   { // operator-(iter_difference_t<I> n)
     {
-      const int counter = 3;
-      const int diff    = 2;
-      cuda::discard_iterator iter(counter);
-      assert(iter - diff == cuda::discard_iterator(counter - diff));
-      assert(iter - 0 == cuda::discard_iterator(counter));
+      const int index = 3;
+      const int diff  = 2;
+      cuda::discard_iterator iter(index);
+      assert(iter - diff == cuda::discard_iterator(index - diff));
+      assert(iter - 0 == cuda::discard_iterator(index));
 
       static_assert(cuda::std::is_same_v<decltype(iter - 2), cuda::discard_iterator>);
     }
 
     {
-      const int counter = 3;
-      const int diff    = 2;
-      const cuda::discard_iterator iter(counter);
-      assert(iter - diff == cuda::discard_iterator(counter - diff));
-      assert(iter - 0 == cuda::discard_iterator(counter));
+      const int index = 3;
+      const int diff  = 2;
+      const cuda::discard_iterator iter(index);
+      assert(iter - diff == cuda::discard_iterator(index - diff));
+      assert(iter - 0 == cuda::discard_iterator(index));
 
       static_assert(cuda::std::is_same_v<decltype(iter - 2), cuda::discard_iterator>);
     }
@@ -48,32 +48,32 @@ __host__ __device__ constexpr bool test()
 
   { // operator-(const discard_iterator& x, const discard_iterator& y)
     {
-      const int counter1 = 4;
-      const int counter2 = 2;
-      cuda::discard_iterator iter1(counter1);
-      cuda::discard_iterator iter2(counter2);
-      assert(iter1 - iter2 == counter2 - counter1);
-      assert(iter2 - iter1 == counter1 - counter2);
+      const int index1 = 4;
+      const int index2 = 2;
+      cuda::discard_iterator iter1(index1);
+      cuda::discard_iterator iter2(index2);
+      assert(iter1 - iter2 == index2 - index1);
+      assert(iter2 - iter1 == index1 - index2);
 
       static_assert(cuda::std::is_same_v<decltype(iter1 - iter2), cuda::std::ptrdiff_t>);
     }
 
     {
-      const int counter1 = 4;
-      const int counter2 = 2;
-      const cuda::discard_iterator iter1(counter1);
-      const cuda::discard_iterator iter2(counter2);
-      assert(iter1 - iter2 == counter2 - counter1);
-      assert(iter2 - iter1 == counter1 - counter2);
+      const int index1 = 4;
+      const int index2 = 2;
+      const cuda::discard_iterator iter1(index1);
+      const cuda::discard_iterator iter2(index2);
+      assert(iter1 - iter2 == index2 - index1);
+      assert(iter2 - iter1 == index1 - index2);
 
       static_assert(cuda::std::is_same_v<decltype(iter1 - iter2), cuda::std::ptrdiff_t>);
     }
   }
 
   { // operator-=(iter_difference_t<I> n)
-    const int counter = 3;
-    const int diff    = 2;
-    cuda::discard_iterator iter(counter);
+    const int index = 3;
+    const int diff  = 2;
+    cuda::discard_iterator iter(index);
     assert((iter -= diff) == cuda::discard_iterator(1));
     assert((iter -= 0) == cuda::discard_iterator(1));
 
@@ -82,17 +82,17 @@ __host__ __device__ constexpr bool test()
 
   { // operator-(const discard_iterator& x, default_sentinel_t)
     {
-      const int counter = 3;
-      cuda::discard_iterator iter(counter);
-      assert((iter - cuda::std::default_sentinel) == -counter);
+      const int index = 3;
+      cuda::discard_iterator iter(index);
+      assert((iter - cuda::std::default_sentinel) == -index);
 
       static_assert(cuda::std::is_same_v<decltype(iter - cuda::std::default_sentinel), cuda::std::ptrdiff_t>);
     }
 
     {
-      const int counter = 3;
-      const cuda::discard_iterator iter(counter);
-      assert((iter - cuda::std::default_sentinel) == -counter);
+      const int index = 3;
+      const cuda::discard_iterator iter(index);
+      assert((iter - cuda::std::default_sentinel) == -index);
 
       static_assert(cuda::std::is_same_v<decltype(iter - cuda::std::default_sentinel), cuda::std::ptrdiff_t>);
     }
@@ -100,17 +100,17 @@ __host__ __device__ constexpr bool test()
 
   { // operator-(default_sentinel_t, const discard_iterator& y)
     {
-      const int counter = 3;
-      cuda::discard_iterator iter(counter);
-      assert((cuda::std::default_sentinel - iter) == counter);
+      const int index = 3;
+      cuda::discard_iterator iter(index);
+      assert((cuda::std::default_sentinel - iter) == index);
 
       static_assert(cuda::std::is_same_v<decltype(cuda::std::default_sentinel - iter), cuda::std::ptrdiff_t>);
     }
 
     {
-      const int counter = 3;
-      const cuda::discard_iterator iter(counter);
-      assert((cuda::std::default_sentinel - iter) == counter);
+      const int index = 3;
+      const cuda::discard_iterator iter(index);
+      assert((cuda::std::default_sentinel - iter) == index);
 
       static_assert(cuda::std::is_same_v<decltype(cuda::std::default_sentinel - iter), cuda::std::ptrdiff_t>);
     }

--- a/libcudacxx/test/libcudacxx/cuda/iterators/discard_iterator/plus.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/discard_iterator/plus.pass.cpp
@@ -21,21 +21,21 @@ __host__ __device__ constexpr bool test()
 {
   { // operator+(iter_difference_t<I> n)
     {
-      const int counter = 2;
-      const int diff    = 3;
-      cuda::discard_iterator iter(counter);
-      assert(iter + diff == cuda::discard_iterator(counter + diff));
-      assert(iter + 0 == cuda::discard_iterator(counter));
+      const int index = 2;
+      const int diff  = 3;
+      cuda::discard_iterator iter(index);
+      assert(iter + diff == cuda::discard_iterator(index + diff));
+      assert(iter + 0 == cuda::discard_iterator(index));
 
       static_assert(cuda::std::is_same_v<decltype(iter + 2), cuda::discard_iterator>);
     }
 
     {
-      const int counter = 2;
-      const int diff    = 3;
-      const cuda::discard_iterator iter(counter);
-      assert(iter + diff == cuda::discard_iterator(counter + diff));
-      assert(iter + 0 == cuda::discard_iterator(counter));
+      const int index = 2;
+      const int diff  = 3;
+      const cuda::discard_iterator iter(index);
+      assert(iter + diff == cuda::discard_iterator(index + diff));
+      assert(iter + 0 == cuda::discard_iterator(index));
 
       static_assert(cuda::std::is_same_v<decltype(iter + 2), cuda::discard_iterator>);
     }
@@ -43,11 +43,11 @@ __host__ __device__ constexpr bool test()
 
   { // operator+(iter_difference_t<I> n, const discard_iterator& x)
     {
-      const int counter = 2;
-      const int diff    = 3;
-      cuda::discard_iterator iter(counter);
-      assert(diff + iter == cuda::discard_iterator(counter + diff));
-      assert(0 + iter == cuda::discard_iterator(counter));
+      const int index = 2;
+      const int diff  = 3;
+      cuda::discard_iterator iter(index);
+      assert(diff + iter == cuda::discard_iterator(index + diff));
+      assert(0 + iter == cuda::discard_iterator(index));
 
       static_assert(cuda::std::is_same_v<decltype(2 + iter), cuda::discard_iterator>);
     }
@@ -55,11 +55,11 @@ __host__ __device__ constexpr bool test()
 
   { // operator+=(iter_difference_t<I> n)
     {
-      const int counter = 2;
-      const int diff    = 3;
-      cuda::discard_iterator iter(counter);
-      assert((iter += 0) == cuda::discard_iterator(counter));
-      assert((iter += diff) == cuda::discard_iterator(counter + diff));
+      const int index = 2;
+      const int diff  = 3;
+      cuda::discard_iterator iter(index);
+      assert((iter += 0) == cuda::discard_iterator(index));
+      assert((iter += diff) == cuda::discard_iterator(index + diff));
 
       static_assert(cuda::std::is_same_v<decltype(iter += 2), cuda::discard_iterator&>);
     }

--- a/libcudacxx/test/libcudacxx/cuda/iterators/discard_iterator/plus.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/discard_iterator/plus.pass.cpp
@@ -1,0 +1,77 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// constexpr discard_iterator operator+(iter_difference_t<I> n) const;
+// friend constexpr discard_iterator operator+(iter_difference_t<I> n, const discard_iterator& x);
+// constexpr discard_iterator& operator+=(iter_difference_t<I> n);
+
+#include <cuda/iterator>
+
+#include "test_iterators.h"
+#include "test_macros.h"
+
+__host__ __device__ constexpr bool test()
+{
+  { // operator+(iter_difference_t<I> n)
+    {
+      const int counter = 2;
+      const int diff    = 3;
+      cuda::discard_iterator iter(counter);
+      assert(iter + diff == cuda::discard_iterator(counter + diff));
+      assert(iter + 0 == cuda::discard_iterator(counter));
+
+      static_assert(cuda::std::is_same_v<decltype(iter + 2), cuda::discard_iterator>);
+    }
+
+    {
+      const int counter = 2;
+      const int diff    = 3;
+      const cuda::discard_iterator iter(counter);
+      assert(iter + diff == cuda::discard_iterator(counter + diff));
+      assert(iter + 0 == cuda::discard_iterator(counter));
+
+      static_assert(cuda::std::is_same_v<decltype(iter + 2), cuda::discard_iterator>);
+    }
+  }
+
+  { // operator+(iter_difference_t<I> n, const discard_iterator& x)
+    {
+      const int counter = 2;
+      const int diff    = 3;
+      cuda::discard_iterator iter(counter);
+      assert(diff + iter == cuda::discard_iterator(counter + diff));
+      assert(0 + iter == cuda::discard_iterator(counter));
+
+      static_assert(cuda::std::is_same_v<decltype(2 + iter), cuda::discard_iterator>);
+    }
+  }
+
+  { // operator+=(iter_difference_t<I> n)
+    {
+      const int counter = 2;
+      const int diff    = 3;
+      cuda::discard_iterator iter(counter);
+      assert((iter += 0) == cuda::discard_iterator(counter));
+      assert((iter += diff) == cuda::discard_iterator(counter + diff));
+
+      static_assert(cuda::std::is_same_v<decltype(iter += 2), cuda::discard_iterator&>);
+    }
+  }
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/discard_iterator/subscript.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/discard_iterator/subscript.pass.cpp
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// constexpr decltype(auto) operator[](iter_difference_t<I> n) const;
+
+#include <cuda/iterator>
+
+#include "test_iterators.h"
+#include "test_macros.h"
+
+__host__ __device__ constexpr bool test()
+{
+  {
+    cuda::discard_iterator iter{};
+    iter[42] = 1337;
+  }
+
+  {
+    const cuda::discard_iterator iter{};
+    iter[42] = 1337;
+  }
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/alg.req.ind.copy/indirectly_copyable.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/alg.req.ind.copy/indirectly_copyable.compile.pass.cpp
@@ -35,7 +35,9 @@ static_assert(!cuda::std::indirectly_copyable<int*, const int*>, "");
 static_assert(!cuda::std::indirectly_copyable<const int*, const int*>, "");
 
 // Can copy from a pointer into an array but arrays aren't considered indirectly copyable-from.
+#if !TEST_COMPILER(MSVC) || TEST_STD_VER != 2017
 static_assert(cuda::std::indirectly_copyable<int*, int[2]>, "");
+#endif // !TEST_COMPILER(MSVC) || TEST_STD_VER != 2017
 static_assert(!cuda::std::indirectly_copyable<int[2], int*>, "");
 static_assert(!cuda::std::indirectly_copyable<int[2], int[2]>, "");
 static_assert(!cuda::std::indirectly_copyable<int (&)[2], int (&)[2]>, "");

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/alg.req.ind.copy/indirectly_copyable_storable.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/alg.req.ind.copy/indirectly_copyable_storable.compile.pass.cpp
@@ -37,7 +37,9 @@ static_assert(cuda::std::indirectly_copyable_storable<int*, int*>, "");
 static_assert(cuda::std::indirectly_copyable_storable<const int*, int*>, "");
 static_assert(!cuda::std::indirectly_copyable_storable<int*, const int*>, "");
 static_assert(!cuda::std::indirectly_copyable_storable<const int*, const int*>, "");
+#if !TEST_COMPILER(MSVC) || TEST_STD_VER != 2017
 static_assert(cuda::std::indirectly_copyable_storable<int*, int[2]>, "");
+#endif // !TEST_COMPILER(MSVC) || TEST_STD_VER != 2017
 static_assert(!cuda::std::indirectly_copyable_storable<int[2], int*>, "");
 static_assert(!cuda::std::indirectly_copyable_storable<MoveOnly*, MoveOnly*>, "");
 static_assert(!cuda::std::indirectly_copyable_storable<PointerTo<MoveOnly>, PointerTo<MoveOnly>>, "");

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/alg.req.ind.move/indirectly_movable.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/alg.req.ind.move/indirectly_movable.compile.pass.cpp
@@ -22,7 +22,9 @@ static_assert(!cuda::std::indirectly_movable<int*, const int*>, "");
 static_assert(cuda::std::indirectly_movable<const int*, int*>, "");
 
 // Can move from a pointer into an array but arrays aren't considered indirectly movable-from.
+#if !TEST_COMPILER(MSVC) || TEST_STD_VER != 2017
 static_assert(cuda::std::indirectly_movable<int*, int[2]>, "");
+#endif // !TEST_COMPILER(MSVC) || TEST_STD_VER != 2017
 static_assert(!cuda::std::indirectly_movable<int[2], int*>, "");
 static_assert(!cuda::std::indirectly_movable<int[2], int[2]>, "");
 static_assert(!cuda::std::indirectly_movable<int (&)[2], int (&)[2]>, "");

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/alg.req.ind.move/indirectly_movable_storable.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/alg.req.ind.move/indirectly_movable_storable.compile.pass.cpp
@@ -28,7 +28,9 @@ static_assert(cuda::std::indirectly_movable_storable<int*, int*>, "");
 static_assert(cuda::std::indirectly_movable_storable<const int*, int*>, "");
 static_assert(!cuda::std::indirectly_movable_storable<int*, const int*>, "");
 static_assert(!cuda::std::indirectly_movable_storable<const int*, const int*>, "");
+#if !TEST_COMPILER(MSVC) || TEST_STD_VER != 2017
 static_assert(cuda::std::indirectly_movable_storable<int*, int[2]>, "");
+#endif // !TEST_COMPILER(MSVC) || TEST_STD_VER != 2017
 static_assert(!cuda::std::indirectly_movable_storable<int[2], int*>, "");
 static_assert(cuda::std::indirectly_movable_storable<MoveOnly*, MoveOnly*>, "");
 static_assert(cuda::std::indirectly_movable_storable<PointerTo<MoveOnly>, PointerTo<MoveOnly>>, "");

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.cust/iterator.cust.swap/iter_swap.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.cust/iterator.cust.swap/iter_swap.pass.cpp
@@ -208,9 +208,11 @@ __host__ __device__ constexpr bool test()
   {
     move_tracker arr[2];
     cuda::std::ranges::iter_swap(cuda::std::begin(arr), cuda::std::begin(arr) + 1);
-    if (__builtin_is_constant_evaluated())
+    if (cuda::std::is_constant_evaluated())
     {
+#  if !TEST_COMPILER(MSVC) || TEST_STD_VER != 2017
       assert(arr[0].moves() == 1 && arr[1].moves() == 3);
+#  endif // !TEST_COMPILER(MSVC) || TEST_STD_VER != 2017
     }
     else
     {


### PR DESCRIPTION
This ports `thrust::discard_iterator` to namespace `cuda` and also gives it a bit of a modernization.