### PR TITLE
Port `thrust::transform_iterator` to cuda

### DIFF
--- a/libcudacxx/include/cuda/__iterator/transform_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/transform_iterator.h
@@ -215,10 +215,19 @@ public:
   }
 
   //! @brief Invokes the stored functor with the value pointed to by the stored iterator
+  _CCCL_TEMPLATE(class _Iter2 = _Iter)
+  _CCCL_REQUIRES(_CUDA_VSTD::regular_invocable<const _Fn&, _CUDA_VSTD::iter_reference_t<const _Iter2>>)
   [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr decltype(auto) operator*() const
-    noexcept(noexcept(_CUDA_VSTD::invoke(const_cast<_Fn&>(*__func_), *__current_)))
+    noexcept(noexcept(_CUDA_VSTD::invoke(*__func_, *__current_)))
   {
-    return _CUDA_VSTD::invoke(const_cast<_Fn&>(*__func_), *__current_);
+    return _CUDA_VSTD::invoke(*__func_, *__current_);
+  }
+
+  //! @brief Invokes the stored functor with the value pointed to by the stored iterator
+  [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr decltype(auto)
+  operator*() noexcept(noexcept(_CUDA_VSTD::invoke(*__func_, *__current_)))
+  {
+    return _CUDA_VSTD::invoke(*__func_, *__current_);
   }
 
   //! @brief Increments the stored iterator
@@ -289,11 +298,23 @@ public:
   //! @param __n The additional offset
   //! @returns _CUDA_VSTD::invoke(__func_, __current_[__n])
   _CCCL_TEMPLATE(class _Iter2 = _Iter)
-  _CCCL_REQUIRES(_CUDA_VSTD::random_access_iterator<_Iter2>)
+  _CCCL_REQUIRES(_CUDA_VSTD::random_access_iterator<_Iter2> _CCCL_AND
+                   _CUDA_VSTD::regular_invocable<const _Fn&, _CUDA_VSTD::iter_reference_t<const _Iter2>>)
   [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr decltype(auto) operator[](difference_type __n) const
-    noexcept(__transform_iterator_nothrow_subscript<_Fn, _Iter2>)
+    noexcept(__transform_iterator_nothrow_subscript<const _Fn, _Iter2>)
   {
-    return _CUDA_VSTD::invoke(const_cast<_Fn&>(*__func_), __current_[__n]);
+    return _CUDA_VSTD::invoke(*__func_, __current_[__n]);
+  }
+
+  //! @brief Subscripts the stored iterator by \p __n and applies the stored functor to the result
+  //! @param __n The additional offset
+  //! @returns _CUDA_VSTD::invoke(__func_, __current_[__n])
+  _CCCL_TEMPLATE(class _Iter2 = _Iter)
+  _CCCL_REQUIRES(_CUDA_VSTD::random_access_iterator<_Iter2>)
+  [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr decltype(auto)
+  operator[](difference_type __n) noexcept(__transform_iterator_nothrow_subscript<_Fn, _Iter2>)
+  {
+    return _CUDA_VSTD::invoke(*__func_, __current_[__n]);
   }
 
   //! @brief Compares two \c transform_iterator for equality, directly comparing the stored iterators

--- a/libcudacxx/include/cuda/__iterator/transform_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/transform_iterator.h
@@ -318,7 +318,7 @@ public:
   }
 #endif // _CCCL_STD_VER <= 2017
 
-  //! @brief Compares two \c transform_iterator for less then, directly comparing the stored iterators
+  //! @brief Compares two \c transform_iterator for less than, directly comparing the stored iterators
   template <class _Iter2 = _Iter>
   [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI friend constexpr auto
   operator<(const transform_iterator& __lhs, const transform_iterator& __rhs) noexcept(
@@ -328,7 +328,7 @@ public:
     return __lhs.__current_ < __rhs.__current_;
   }
 
-  //! @brief Compares two \c transform_iterator for greater then, directly comparing the stored iterators
+  //! @brief Compares two \c transform_iterator for greater than, directly comparing the stored iterators
   template <class _Iter2 = _Iter>
   [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI friend constexpr auto
   operator>(const transform_iterator& __lhs, const transform_iterator& __rhs) noexcept(

--- a/libcudacxx/include/cuda/__iterator/transform_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/transform_iterator.h
@@ -1,0 +1,501 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES
+//
+//===----------------------------------------------------------------------===//
+#ifndef _CUDA___ITERATOR_TRANSFORM_ITERATOR_H
+#define _CUDA___ITERATOR_TRANSFORM_ITERATOR_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#if _LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
+#  include <cuda/std/__compare/three_way_comparable.h>
+#endif // _LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
+#include <cuda/std/__concepts/constructible.h>
+#include <cuda/std/__concepts/derived_from.h>
+#include <cuda/std/__concepts/equality_comparable.h>
+#include <cuda/std/__concepts/invocable.h>
+#include <cuda/std/__functional/invoke.h>
+#include <cuda/std/__iterator/concepts.h>
+#include <cuda/std/__iterator/iterator_traits.h>
+#include <cuda/std/__ranges/concepts.h>
+#include <cuda/std/__ranges/movable_box.h>
+#include <cuda/std/__type_traits/conditional.h>
+#include <cuda/std/__type_traits/enable_if.h>
+#include <cuda/std/__type_traits/is_nothrow_default_constructible.h>
+#include <cuda/std/__type_traits/is_nothrow_move_constructible.h>
+#include <cuda/std/__type_traits/is_object.h>
+#include <cuda/std/__type_traits/is_reference.h>
+#include <cuda/std/__type_traits/remove_cvref.h>
+#include <cuda/std/__utility/forward.h>
+#include <cuda/std/__utility/move.h>
+
+#include <cuda/std/__cccl/prologue.h>
+
+// MSVC complains about [[msvc::no_unique_address]] prior to C++20 as a vendor extension
+_CCCL_DIAG_PUSH
+_CCCL_DIAG_SUPPRESS_MSVC(4848)
+
+_LIBCUDACXX_BEGIN_NAMESPACE_CUDA
+
+template <class, class, class = void>
+struct __transform_iterator_category_base
+{};
+
+template <class _Iter, class _Fn>
+struct __transform_iterator_category_base<_Iter, _Fn, _CUDA_VSTD::enable_if_t<_CUDA_VSTD::forward_iterator<_Iter>>>
+{
+  using _Cat = typename _CUDA_VSTD::iterator_traits<_Iter>::iterator_category;
+
+  using iterator_category = _CUDA_VSTD::conditional_t<
+    _CUDA_VSTD::is_reference_v<_CUDA_VSTD::invoke_result_t<_Fn&, _CUDA_VSTD::iter_reference_t<_Iter>>>,
+    _CUDA_VSTD::conditional_t<_CUDA_VSTD::derived_from<_Cat, _CUDA_VSTD::contiguous_iterator_tag>,
+                              _CUDA_VSTD::random_access_iterator_tag,
+                              _Cat>,
+    _CUDA_VSTD::input_iterator_tag>;
+};
+
+template <class _Fn, class _Iter, bool = _CUDA_VSTD::random_access_iterator<_Iter>>
+inline constexpr bool __transform_iterator_nothrow_subscript = false;
+
+template <class _Fn, class _Iter>
+inline constexpr bool __transform_iterator_nothrow_subscript<_Fn, _Iter, true> =
+  noexcept(_CUDA_VSTD::invoke(_CUDA_VSTD::declval<_Fn&>(), _CUDA_VSTD::declval<_Iter&>()[0]));
+
+//! \addtogroup iterators
+//! \{
+
+//!! \addtogroup fancyiterator Fancy Iterators
+//!  \ingroup iterators
+//!  \{
+
+//! @brief \p transform_iterator is an iterator which represents a pointer into a range of values after transformation
+//! by a function. This iterator is useful for creating a range filled with the result of applying an operation to
+//! another range without either explicitly storing it in memory, or explicitly executing the transformation. Using
+//! \p transform_iterator facilitates kernel fusion by deferring the execution of a transformation until the value is
+//! needed while saving both memory capacity and bandwidth.
+//!
+//! The following code snippet demonstrates how to create a \p transform_iterator which represents the result of
+//! \c sqrtf applied to the contents of a \p device_vector.
+//!
+//! @code
+//! #include <cuda/iterator>
+//! #include <thrust/device_vector.h>
+//!
+//! struct square_root
+//! {
+//!   __host__ __device__
+//!   float operator()(float x) const
+//!   {
+//!     return sqrtf(x);
+//!   }
+//! };
+//!
+//! int main()
+//! {
+//!   thrust::device_vector<float> v(4);
+//!   v[0] = 1.0f;
+//!   v[1] = 4.0f;
+//!   v[2] = 9.0f;
+//!   v[3] = 16.0f;
+//!
+//!   using FloatIterator = thrust::device_vector<float>::iterator;
+//!
+//!   cuda::transform_iterator iter(v.begin(), square_root{});
+//!
+//!   *iter;   // returns 1.0f
+//!   iter[0]; // returns 1.0f;
+//!   iter[1]; // returns 2.0f;
+//!   iter[2]; // returns 3.0f;
+//!   iter[3]; // returns 4.0f;
+//!
+//!   // iter[4] is an out-of-bounds error
+//! }
+//! @endcode
+//!
+//! This next example demonstrates how to use a \p transform_iterator with the \p thrust::reduce function to compute the
+//! sum of squares of a sequence. We will create temporary \p transform_iterators with the \p make_transform_iterator
+//! function in order to avoid explicitly specifying their type:
+//!
+//! @code
+//! #include <cuda/iterator>
+//! #include <thrust/device_vector.h>
+//! #include <thrust/reduce.h>
+//! #include <iostream>
+//!
+//! struct square
+//! {
+//!   __host__ __device__
+//!   float operator()(float x) const
+//!   {
+//!     return x * x;
+//!   }
+//! };
+//!
+//! int main()
+//! {
+//!   // initialize a device array
+//!   thrust::device_vector<float> v(4);
+//!   v[0] = 1.0f;
+//!   v[1] = 2.0f;
+//!   v[2] = 3.0f;
+//!   v[3] = 4.0f;
+//!
+//!   float sum_of_squares =
+//!    thrust::reduce(cuda::make_transform_iterator(v.begin(), square{}),
+//!                   cuda::make_transform_iterator(v.end(),   square{}));
+//!
+//!   std::cout << "sum of squares: " << sum_of_squares << std::endl;
+//!   return 0;
+//! }
+//! @endcode
+//!
+//! The following example illustrates how to use the third template argument to explicitly specify the return type of
+//! the function.
+//!
+//! @code
+//! #include <cuda/iterator>
+//! #include <thrust/device_vector.h>
+//!
+//! struct square_root
+//! {
+//!   __host__ __device__
+//!   float operator()(float x) const
+//!   {
+//!     return sqrtf(x);
+//!   }
+//! };
+//!
+//! int main()
+//! {
+//!   thrust::device_vector<float> v(4);
+//!   v[0] = 1.0f;
+//!   v[1] = 4.0f;
+//!   v[2] = 9.0f;
+//!   v[3] = 16.0f;
+//!
+//!   using FloatIterator = thrust::device_vector<float>::iterator;
+//!
+//!   // note: float result_type is specified explicitly
+//!   cuda::transform_iterator iter(v.begin(), square_root{});
+//!
+//!   *iter;   // returns 1.0f
+//!   iter[0]; // returns 1.0f;
+//!   iter[1]; // returns 2.0f;
+//!   iter[2]; // returns 3.0f;
+//!   iter[3]; // returns 4.0f;
+//!
+//!   // iter[4] is an out-of-bounds error
+//! }
+//! @endcode
+template <class _Iter, class _Fn>
+class transform_iterator : public __transform_iterator_category_base<_Iter, _Fn>
+{
+  static_assert(_CUDA_VSTD::is_object_v<_Fn>, "cuda::transform_iterator requires that _Fn is a function object");
+  static_assert(_CUDA_VSTD::regular_invocable<_Fn&, _CUDA_VSTD::iter_reference_t<_Iter>>,
+                "cuda::transform_iterator requires that _Fn is invocable with iter_reference_t<_Iter>");
+  static_assert(_CUDA_VSTD::regular_invocable<_Fn&, _CUDA_VSTD::iter_reference_t<_Iter>>,
+                "cuda::transform_iterator requires that the return type of _Fn is referenceable");
+
+public:
+  _CCCL_NO_UNIQUE_ADDRESS _Iter __current_;
+  _CCCL_NO_UNIQUE_ADDRESS _CUDA_VRANGES::__movable_box<_Fn> __func_;
+
+  using iterator_concept = _CUDA_VSTD::conditional_t<
+    _CUDA_VSTD::random_access_iterator<_Iter>,
+    _CUDA_VSTD::random_access_iterator_tag,
+    _CUDA_VSTD::conditional_t<_CUDA_VSTD::bidirectional_iterator<_Iter>,
+                              _CUDA_VSTD::bidirectional_iterator_tag,
+                              _CUDA_VSTD::conditional_t<_CUDA_VSTD::forward_iterator<_Iter>,
+                                                        _CUDA_VSTD::forward_iterator_tag,
+                                                        _CUDA_VSTD::input_iterator_tag>>>;
+  using value_type = _CUDA_VSTD::remove_cvref_t<_CUDA_VSTD::invoke_result_t<_Fn&, _CUDA_VSTD::iter_reference_t<_Iter>>>;
+  using difference_type = _CUDA_VSTD::iter_difference_t<_Iter>;
+
+  //! @brief Default constructs a \p transform_iterator with a value initialized iterator and functor
+#if !defined(_CCCL_NO_CONCEPTS)
+  _CCCL_HIDE_FROM_ABI transform_iterator()
+    requires _CUDA_VSTD::default_initializable<_Iter> && _CUDA_VSTD::default_initializable<_Fn>
+  = default;
+#else // ^^^ !_CCCL_NO_CONCEPTS ^^^ / vvv _CCCL_NO_CONCEPTS vvv
+  _CCCL_TEMPLATE(class _Iter2 = _Iter, class _Fn2 = _Fn)
+  _CCCL_REQUIRES(_CUDA_VSTD::default_initializable<_Iter2> _CCCL_AND _CUDA_VSTD::default_initializable<_Fn2>)
+  _LIBCUDACXX_HIDE_FROM_ABI constexpr transform_iterator() noexcept(
+    _CUDA_VSTD::is_nothrow_default_constructible_v<_Iter2> && _CUDA_VSTD::is_nothrow_default_constructible_v<_Fn2>)
+  {}
+#endif // _CCCL_NO_CONCEPTS
+
+  //! @brief Constructs a \p transform_iterator with a given \p __iter iterator and \p __func functor
+  //! @param __iter The iterator to transform
+  //! @param __func The functor to apply to the iterator
+  _LIBCUDACXX_HIDE_FROM_ABI constexpr transform_iterator(_Iter __current, _Fn __func_) noexcept(
+    _CUDA_VSTD::is_nothrow_move_constructible_v<_Iter> && _CUDA_VSTD::is_nothrow_move_constructible_v<_Fn>)
+      : __current_(_CUDA_VSTD::move(__current))
+      , __func_(_CUDA_VSTD::in_place, _CUDA_VSTD::move(__func_))
+  {}
+
+  //! @brief Returns a const reference to the iterator stored in this \p transform_iterator
+  [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr const _Iter& base() const& noexcept
+  {
+    return __current_;
+  }
+
+  //! @brief Extracts the iterator stored in this \p transform_iterator
+  [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr _Iter
+  base() && noexcept(_CUDA_VSTD::is_nothrow_move_constructible_v<_Iter>)
+  {
+    return _CUDA_VSTD::move(__current_);
+  }
+
+  //! @brief Invokes the stored functor with the value pointed to by the stored iterator
+  [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr decltype(auto) operator*() const
+    noexcept(noexcept(_CUDA_VSTD::invoke(const_cast<_Fn&>(*__func_), *__current_)))
+  {
+    return _CUDA_VSTD::invoke(const_cast<_Fn&>(*__func_), *__current_);
+  }
+
+  //! @brief Increments the stored iterator
+  _LIBCUDACXX_HIDE_FROM_ABI constexpr transform_iterator& operator++() noexcept(noexcept(++__current_))
+  {
+    ++__current_;
+    return *this;
+  }
+
+  //! @brief Increments the stored iterator
+  _LIBCUDACXX_HIDE_FROM_ABI constexpr auto operator++(int) noexcept(noexcept(++__current_))
+  {
+    if constexpr (_CUDA_VSTD::forward_iterator<_Iter>)
+    {
+      auto __tmp = *this;
+      ++*this;
+      return __tmp;
+    }
+    else
+    {
+      ++__current_;
+    }
+  }
+
+  //! @brief Decrements the stored iterator
+  _CCCL_TEMPLATE(class _Iter2 = _Iter)
+  _CCCL_REQUIRES(_CUDA_VSTD::bidirectional_iterator<_Iter2>)
+  _LIBCUDACXX_HIDE_FROM_ABI constexpr transform_iterator& operator--() noexcept(noexcept(--__current_))
+  {
+    --__current_;
+    return *this;
+  }
+
+  //! @brief Decrements the stored iterator
+  _CCCL_TEMPLATE(class _Iter2 = _Iter)
+  _CCCL_REQUIRES(_CUDA_VSTD::bidirectional_iterator<_Iter2>)
+  _LIBCUDACXX_HIDE_FROM_ABI constexpr transform_iterator
+  operator--(int) noexcept(_CUDA_VSTD::is_nothrow_copy_constructible_v<_Iter> && noexcept(--__current_))
+  {
+    auto __tmp = *this;
+    --*this;
+    return __tmp;
+  }
+
+  //! @brief Advances this \c transform_iterator by \p __n
+  //! @param __n The number of elements to advance
+  _CCCL_TEMPLATE(class _Iter2 = _Iter)
+  _CCCL_REQUIRES(_CUDA_VSTD::random_access_iterator<_Iter2>)
+  _LIBCUDACXX_HIDE_FROM_ABI constexpr transform_iterator&
+  operator+=(difference_type __n) noexcept(noexcept(__current_ += __n))
+  {
+    __current_ += __n;
+    return *this;
+  }
+
+  //! @brief Decrements this \c transform_iterator by \p __n
+  //! @param __n The number of elements to decrement
+  _CCCL_TEMPLATE(class _Iter2 = _Iter)
+  _CCCL_REQUIRES(_CUDA_VSTD::random_access_iterator<_Iter2>)
+  _LIBCUDACXX_HIDE_FROM_ABI constexpr transform_iterator&
+  operator-=(difference_type __n) noexcept(noexcept(__current_ -= __n))
+  {
+    __current_ -= __n;
+    return *this;
+  }
+
+  //! @brief Subscripts the stored iterator by \p __n and applies the stored functor to the result
+  //! @param __n The additional offset
+  //! @returns _CUDA_VSTD::invoke(__func_, __current_[__n])
+  _CCCL_TEMPLATE(class _Iter2 = _Iter)
+  _CCCL_REQUIRES(_CUDA_VSTD::random_access_iterator<_Iter2>)
+  [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr decltype(auto) operator[](difference_type __n) const
+    noexcept(__transform_iterator_nothrow_subscript<_Fn, _Iter2>)
+  {
+    return _CUDA_VSTD::invoke(const_cast<_Fn&>(*__func_), __current_[__n]);
+  }
+
+  //! @brief Compares two \c transform_iterator \p __lhs and \p __rhs for equality
+  //! @param __lhs The left \c transform_iterator
+  //! @param __rhs The right \c transform_iterator
+  //! @return true if the stored iterators compares equal
+  template <class _Iter2 = _Iter>
+  [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI friend constexpr auto
+  operator==(const transform_iterator& __lhs, const transform_iterator& __rhs) noexcept(
+    noexcept(_CUDA_VSTD::declval<const _Iter2&>() == _CUDA_VSTD::declval<const _Iter2&>()))
+    _CCCL_TRAILING_REQUIRES(bool)(_CUDA_VSTD::equality_comparable<_Iter2>)
+  {
+    return __lhs.__current_ == __rhs.__current_;
+  }
+
+#if _CCCL_STD_VER <= 2017
+  //! @brief Compares two \c transform_iterator \p __lhs and \p __rhs for inequality
+  //! @param __lhs The left \c transform_iterator
+  //! @param __rhs The right \c transform_iterator
+  //! @return true if the stored iterators do not compare equal
+  template <class _Iter2 = _Iter>
+  [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI friend constexpr auto
+  operator!=(const transform_iterator& __lhs, const transform_iterator& __rhs) noexcept(
+    noexcept(_CUDA_VSTD::declval<const _Iter2&>() != _CUDA_VSTD::declval<const _Iter2&>()))
+    _CCCL_TRAILING_REQUIRES(bool)(_CUDA_VSTD::equality_comparable<_Iter2>)
+  {
+    return __lhs.__current_ != __rhs.__current_;
+  }
+#endif // _CCCL_STD_VER <= 2017
+
+  //! @brief Compares two \c transform_iterator \p __lhs and \p __rhs for less than
+  //! @param __lhs The left \c transform_iterator
+  //! @param __rhs The right \c transform_iterator
+  //! @return true if the stored iterators compares less than
+  template <class _Iter2 = _Iter>
+  [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI friend constexpr auto
+  operator<(const transform_iterator& __lhs, const transform_iterator& __rhs) noexcept(
+    noexcept(_CUDA_VSTD::declval<const _Iter2&>() < _CUDA_VSTD::declval<const _Iter2&>()))
+    _CCCL_TRAILING_REQUIRES(bool)(_CUDA_VSTD::random_access_iterator<_Iter2>)
+  {
+    return __lhs.__current_ < __rhs.__current_;
+  }
+
+  //! @brief Compares two \c transform_iterator \p __lhs and \p __rhs for greater than
+  //! @param __lhs The left \c transform_iterator
+  //! @param __rhs The right \c transform_iterator
+  //! @return true if the stored iterators compares greater than
+  template <class _Iter2 = _Iter>
+  [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI friend constexpr auto
+  operator>(const transform_iterator& __lhs, const transform_iterator& __rhs) noexcept(
+    noexcept(_CUDA_VSTD::declval<const _Iter2&>() < _CUDA_VSTD::declval<const _Iter2&>()))
+    _CCCL_TRAILING_REQUIRES(bool)(_CUDA_VSTD::random_access_iterator<_Iter2>)
+  {
+    return __lhs.__current_ > __rhs.__current_;
+  }
+
+  //! @brief Compares two \c transform_iterator \p __lhs and \p __rhs for less equal
+  //! @param __lhs The left \c transform_iterator
+  //! @param __rhs The right \c transform_iterator
+  //! @return true if the stored iterators compares less equal
+  template <class _Iter2 = _Iter>
+  [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI friend constexpr auto
+  operator<=(const transform_iterator& __lhs, const transform_iterator& __rhs) noexcept(
+    noexcept(_CUDA_VSTD::declval<const _Iter2&>() < _CUDA_VSTD::declval<const _Iter2&>()))
+    _CCCL_TRAILING_REQUIRES(bool)(_CUDA_VSTD::random_access_iterator<_Iter2>)
+  {
+    return __lhs.__current_ <= __rhs.__current_;
+  }
+
+  //! @brief Compares two \c transform_iterator \p __lhs and \p __rhs for greater equal
+  //! @param __lhs The left \c transform_iterator
+  //! @param __rhs The right \c transform_iterator
+  //! @return true if the stored iterators compares greater equal
+  template <class _Iter2 = _Iter>
+  [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI friend constexpr auto
+  operator>=(const transform_iterator& __lhs, const transform_iterator& __rhs) noexcept(
+    noexcept(_CUDA_VSTD::declval<const _Iter2&>() < _CUDA_VSTD::declval<const _Iter2&>()))
+    _CCCL_TRAILING_REQUIRES(bool)(_CUDA_VSTD::random_access_iterator<_Iter2>)
+  {
+    return __lhs.__current_ >= __rhs.__current_;
+  }
+
+#if _LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
+  //! @brief Three-way-compares two \c transform_iterator \p __lhs and \p __rhs
+  //! @param __lhs The left \c transform_iterator
+  //! @param __rhs The right \c transform_iterator
+  //! @return The three-way ordering of stored iterators
+  template <class _Iter2 = _Iter>
+  [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI friend constexpr auto
+  operator<=>(const transform_iterator& __lhs, const transform_iterator& __rhs) noexcept(
+    noexcept(_CUDA_VSTD::declval<const _Iter2&>() <=> _CUDA_VSTD::declval<const _Iter2&>()))
+    _CCCL_TRAILING_REQUIRES(bool)(_CUDA_VSTD::random_access_iterator<_Iter2>&& _CUDA_VSTD::three_way_comparable<_Iter2>)
+  {
+    return __lhs.__current_ <=> __rhs.__current_;
+  }
+#endif // !_LIBCUDACXX_HAS_NO_SPACESHIP_OPERATOR
+
+  //! @brief Returns a copy of the \c transform_iterator \p __i advanced by \p __n
+  //! @param __i The \c transform_iterator to advance
+  //! @param __n The number of elements to advance
+  template <class _Iter2 = _Iter>
+  [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI friend constexpr auto
+  operator+(const transform_iterator& __i, difference_type __n)
+    _CCCL_TRAILING_REQUIRES(transform_iterator)(_CUDA_VSTD::random_access_iterator<_Iter2>)
+  {
+    return transform_iterator{__i.__current_ + __n, *__i.__func_};
+  }
+
+  //! @brief Returns a copy of the \c transform_iterator \p __i advanced by \p __n
+  //! @param __n The number of elements to advance
+  //! @param __i The \c transform_iterator to advance
+  template <class _Iter2 = _Iter>
+  [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI friend constexpr auto
+  operator+(difference_type __n, const transform_iterator& __i)
+    _CCCL_TRAILING_REQUIRES(transform_iterator)(_CUDA_VSTD::random_access_iterator<_Iter2>)
+  {
+    return transform_iterator{__i.__current_ + __n, *__i.__func_};
+  }
+
+  //! @brief Returns a copy of the the \c transform_iterator \p __i decremented by \p __n
+  //! @param __i The \c transform_iterator to decrement
+  //! @param __n The number of elements to decrement
+  template <class _Iter2 = _Iter>
+  [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI friend constexpr auto
+  operator-(const transform_iterator& __i, difference_type __n)
+    _CCCL_TRAILING_REQUIRES(transform_iterator)(_CUDA_VSTD::random_access_iterator<_Iter2>)
+  {
+    return transform_iterator{__i.__current_ - __n, *__i.__func_};
+  }
+
+  //! @brief Returns the distance between \p __lhs and \p __rhs
+  //! @param __lhs The left \c transform_iterator
+  //! @param __rhs The right \c transform_iterator
+  //! @return The distance between the stored iterators
+  template <class _Iter2 = _Iter>
+  [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI friend constexpr auto
+  operator-(const transform_iterator& __lhs, const transform_iterator& __rhs)
+    _CCCL_TRAILING_REQUIRES(difference_type)(_CUDA_VSTD::sized_sentinel_for<_Iter2, _Iter2>)
+  {
+    return __lhs.__current_ - __rhs.__current_;
+  }
+};
+
+//! @brief make_transform_iterator creates a \p transform_iterator from an \c _Iter and a \c _Fn.
+//!
+//! @param __iter The \c Iterator pointing to the input range of the newly created \p transform_iterator.
+//! @param __fun The \c _Fn used to transform the range pointed to by @param __iter in the newly created
+//! \p transform_iterator.
+//! @return A new \p transform_iterator which transforms the range at @param __iter by @param __fun.
+template <class _Iter, class _Fn>
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr auto make_transform_iterator(_Iter __iter, _Fn __fun)
+{
+  return transform_iterator<_Iter, _Fn>{__iter, __fun};
+}
+
+_LIBCUDACXX_END_NAMESPACE_CUDA
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA___ITERATOR_TRANSFORM_ITERATOR_H

--- a/libcudacxx/include/cuda/iterator
+++ b/libcudacxx/include/cuda/iterator
@@ -22,6 +22,7 @@
 #endif // no system header
 
 #include <cuda/__iterator/discard_iterator.h>
+#include <cuda/__iterator/transform_iterator.h>
 #include <cuda/std/iterator>
 
 #endif // _CUDA_ITERATOR

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/arithmetic.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/arithmetic.pass.cpp
@@ -1,0 +1,91 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// transform_iterator::operator{++,--,+=,-=}
+
+#include <cuda/iterator>
+#include <cuda/std/cassert>
+#include <cuda/std/utility>
+
+#include "test_iterators.h"
+#include "test_macros.h"
+#include "types.h"
+
+template <class Iter>
+_CCCL_CONCEPT can_decrement = _CCCL_REQUIRES_EXPR((Iter), Iter i)((--i));
+template <class Iter>
+_CCCL_CONCEPT can_post_decrement = _CCCL_REQUIRES_EXPR((Iter), Iter i)((i--));
+
+template <class Iter>
+_CCCL_CONCEPT can_plus_equal = _CCCL_REQUIRES_EXPR((Iter), Iter i)((i += 1));
+template <class Iter>
+_CCCL_CONCEPT can_minus_equal = _CCCL_REQUIRES_EXPR((Iter), Iter i)((i -= 1));
+
+template <class Iter>
+__host__ __device__ constexpr void test()
+{
+  int buffer[8] = {0, 1, 2, 3, 4, 5, 6, 7};
+
+  cuda::transform_iterator iter{Iter{buffer}, PlusOne{}};
+  assert((++iter).base() == Iter{buffer + 1});
+
+  if constexpr (cuda::std::forward_iterator<Iter>)
+  {
+    assert((iter++).base() == Iter{buffer + 1});
+  }
+  else
+  {
+    iter++;
+    static_assert(cuda::std::is_same_v<decltype(iter++), void>);
+  }
+  assert(iter.base() == Iter{buffer + 2});
+
+  if constexpr (cuda::std::bidirectional_iterator<Iter>)
+  {
+    assert((--iter).base() == Iter{buffer + 1});
+    assert((iter--).base() == Iter{buffer + 1});
+    assert(iter.base() == Iter{buffer});
+  }
+  else
+  {
+    static_assert(!can_decrement<Iter>);
+    static_assert(!can_post_decrement<Iter>);
+  }
+
+  if constexpr (cuda::std::random_access_iterator<Iter>)
+  {
+    assert((iter += 4).base() == Iter{buffer + 4});
+    assert((iter -= 3).base() == Iter{buffer + 1});
+  }
+  else
+  {
+    static_assert(!can_plus_equal<Iter>);
+    static_assert(!can_minus_equal<Iter>);
+  }
+}
+
+__host__ __device__ constexpr bool test()
+{
+  test<cpp17_input_iterator<int*>>();
+  test<forward_iterator<int*>>();
+  test<bidirectional_iterator<int*>>();
+  test<random_access_iterator<int*>>();
+  test<int*>();
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test(), "");
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/base.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/base.pass.cpp
@@ -1,0 +1,55 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// transform_iterator::base
+
+#include <cuda/iterator>
+#include <cuda/std/cassert>
+#include <cuda/std/type_traits>
+#include <cuda/std/utility>
+
+#include "test_iterators.h"
+#include "test_macros.h"
+#include "types.h"
+
+template <class Iter>
+__host__ __device__ constexpr void test()
+{
+  int buffer[8] = {0, 1, 2, 3, 4, 5, 6, 7};
+
+  cuda::transform_iterator iter{Iter{buffer}, PlusOne{}};
+  using transform_iter = decltype(iter);
+  static_assert(cuda::std::is_same_v<decltype(static_cast<transform_iter&>(iter).base()), Iter const&>);
+  static_assert(cuda::std::is_same_v<decltype(static_cast<transform_iter&&>(iter).base()), Iter>);
+  static_assert(cuda::std::is_same_v<decltype(static_cast<const transform_iter&>(iter).base()), Iter const&>);
+  static_assert(cuda::std::is_same_v<decltype(static_cast<const transform_iter&&>(iter).base()), Iter const&>);
+  static_assert(noexcept(iter.base()));
+  static_assert(
+    noexcept(static_cast<transform_iter&&>(iter).base()) == cuda::std::is_nothrow_move_constructible_v<Iter>);
+  assert(base(iter.base()) == buffer);
+  assert(base(cuda::std::move(iter).base()) == buffer);
+}
+
+__host__ __device__ constexpr bool test()
+{
+  test<cpp17_input_iterator<int*>>();
+  test<random_access_iterator<int*>>();
+  test<int*>();
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test(), "");
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/compare.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/compare.pass.cpp
@@ -1,0 +1,82 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// transform_iterator::operator{<,>,<=,>=,==,!=,<=>}
+
+#include <cuda/iterator>
+#if _LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
+#  include <cuda/std/compare>
+#endif // _LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
+
+#include "test_iterators.h"
+#include "test_macros.h"
+#include "types.h"
+
+template <class Iter>
+__host__ __device__ constexpr void test()
+{
+  int buffer[8] = {0, 1, 2, 3, 4, 5, 6, 7};
+
+  cuda::transform_iterator iter1{Iter{buffer}, PlusOne{}};
+  cuda::transform_iterator iter2{Iter{buffer + 4}, PlusOne{}};
+
+  assert(!(iter1 < iter1));
+  assert(iter1 < iter2);
+  assert(!(iter2 < iter1));
+  assert(iter1 <= iter1);
+  assert(iter1 <= iter2);
+  assert(!(iter2 <= iter1));
+  assert(!(iter1 > iter1));
+  assert(!(iter1 > iter2));
+  assert(iter2 > iter1);
+  assert(iter1 >= iter1);
+  assert(!(iter1 >= iter2));
+  assert(iter2 >= iter1);
+  assert(iter1 == iter1);
+  assert(!(iter1 == iter2));
+  assert(iter2 == iter2);
+  assert(!(iter1 != iter1));
+  assert(iter1 != iter2);
+  assert(!(iter2 != iter2));
+
+#if TEST_HAS_SPACESHIP()
+  // Test a new-school iterator with operator<=>; the transform iterator should also have operator<=>.
+  if constexpr (cuda::std::is_same_v<Iter, three_way_contiguous_iterator<int*>>)
+  {
+    static_assert(cuda::std::three_way_comparable<Iter>);
+    static_assert(cuda::std::three_way_comparable<decltype(iter1)>);
+
+    assert((iter1 <=> iter2) == cuda::std::strong_ordering::less);
+    assert((iter1 <=> iter1) == cuda::std::strong_ordering::equal);
+    assert((iter2 <=> iter1) == cuda::std::strong_ordering::greater);
+  }
+#endif // TEST_HAS_SPACESHIP()
+}
+
+__host__ __device__ constexpr bool test()
+{
+  test<random_access_iterator<int*>>();
+  test<contiguous_iterator<int*>>();
+  test<int*>();
+
+#if TEST_HAS_SPACESHIP()
+  test<three_way_contiguous_iterator<int*>>();
+#endif // TEST_HAS_SPACESHIP()
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test(), "");
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/ctor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/ctor.pass.cpp
@@ -1,0 +1,126 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// transform_iterator::transform_iterator();
+
+#include <cuda/iterator>
+#include <cuda/std/cassert>
+#include <cuda/std/concepts>
+
+#include "test_iterators.h"
+#include "test_macros.h"
+#include "types.h"
+
+struct NoDefaultInitIter
+{
+  int* ptr_;
+  typedef cuda::std::random_access_iterator_tag iterator_category;
+  typedef int value_type;
+  typedef cuda::std::ptrdiff_t difference_type;
+  typedef int* pointer;
+  typedef int& reference;
+  typedef NoDefaultInitIter self;
+
+  __host__ __device__ constexpr NoDefaultInitIter(int* ptr)
+      : ptr_(ptr)
+  {}
+
+  __host__ __device__ constexpr reference operator*() const;
+  __host__ __device__ constexpr pointer operator->() const;
+#if TEST_HAS_SPACESHIP()
+  __host__ __device__ constexpr auto operator<=>(const self&) const = default;
+#else // ^^^ TEST_HAS_SPACESHIP() ^^^ / vvv !TEST_HAS_SPACESHIP() vvv
+  __host__ __device__ constexpr bool operator<(const self&) const;
+  __host__ __device__ constexpr bool operator<=(const self&) const;
+  __host__ __device__ constexpr bool operator>(const self&) const;
+  __host__ __device__ constexpr bool operator>=(const self&) const;
+#endif // !TEST_HAS_SPACESHIP()
+
+  __host__ __device__ constexpr friend bool operator==(const self& lhs, const self& rhs)
+  {
+    return lhs.ptr_ == rhs.ptr_;
+  }
+#if TEST_STD_VER <= 2017
+  __host__ __device__ constexpr friend bool operator!=(const self& lhs, const self& rhs)
+  {
+    return lhs.ptr_ != rhs.ptr_;
+  }
+#endif // TEST_STD_VER <= 2017
+
+  __host__ __device__ constexpr self& operator++();
+  __host__ __device__ constexpr self operator++(int);
+
+  __host__ __device__ constexpr self& operator--();
+  __host__ __device__ constexpr self operator--(int);
+
+  __host__ __device__ constexpr self& operator+=(difference_type n);
+  __host__ __device__ constexpr self operator+(difference_type n) const;
+  __host__ __device__ constexpr friend self operator+(difference_type n, self x);
+
+  __host__ __device__ constexpr self& operator-=(difference_type n);
+  __host__ __device__ constexpr self operator-(difference_type n) const;
+  __host__ __device__ constexpr difference_type operator-(const self&) const;
+
+  __host__ __device__ constexpr reference operator[](difference_type n) const;
+};
+
+struct NoDefaultInitFunc
+{
+  int val_;
+
+  __host__ __device__ constexpr NoDefaultInitFunc(int val)
+      : val_(val)
+  {}
+
+  __host__ __device__ constexpr int operator()(int x) const
+  {
+    return x * val_;
+  }
+};
+
+template <class Iter, class Fn>
+__host__ __device__ constexpr void test(Fn fun)
+{
+  int buffer[8] = {0, 1, 2, 3, 4, 5, 6, 7};
+
+  { // default initialization
+    constexpr bool can_default_init = cuda::std::default_initializable<Iter> && cuda::std::default_initializable<Fn>;
+    static_assert(cuda::std::default_initializable<cuda::transform_iterator<Iter, Fn>> == can_default_init);
+    if constexpr (can_default_init)
+    {
+      [[maybe_unused]] cuda::transform_iterator<Iter, Fn> iter{};
+    }
+  }
+
+  { // construction from iter and functor
+    cuda::transform_iterator iter{Iter{buffer}, fun};
+    assert(iter.base() == Iter{buffer});
+  }
+}
+
+__host__ __device__ constexpr bool test()
+{
+  test<NoDefaultInitIter>(PlusOne{});
+  test<random_access_iterator<int*>>(PlusOne{});
+
+  NoDefaultInitFunc func{42};
+  test<NoDefaultInitIter>(func);
+  test<random_access_iterator<int*>>(func);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test(), "");
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/ctor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/ctor.pass.cpp
@@ -21,12 +21,12 @@
 struct NoDefaultInitIter
 {
   int* ptr_;
-  typedef cuda::std::random_access_iterator_tag iterator_category;
-  typedef int value_type;
-  typedef cuda::std::ptrdiff_t difference_type;
-  typedef int* pointer;
-  typedef int& reference;
-  typedef NoDefaultInitIter self;
+  using iterator_category = cuda::std::random_access_iterator_tag;
+  using value_type        = int;
+  using difference_type   = cuda::std::ptrdiff_t;
+  using pointer           = int*;
+  using reference         = int&;
+  using self              = NoDefaultInitIter;
 
   __host__ __device__ constexpr NoDefaultInitIter(int* ptr)
       : ptr_(ptr)

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/deref.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/deref.pass.cpp
@@ -1,0 +1,89 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// transform_iterator::operator*
+
+#include <cuda/iterator>
+#include <cuda/std/cassert>
+#include <cuda/std/type_traits>
+#include <cuda/std/utility>
+
+#include "test_iterators.h"
+#include "test_macros.h"
+#include "types.h"
+
+template <class Iter>
+__host__ __device__ constexpr void test()
+{
+  int buffer[8] = {0, 1, 2, 3, 4, 5, 6, 7};
+
+  {
+    cuda::transform_iterator iter{Iter{buffer}, PlusOne{}};
+    assert(*iter == 1);
+    assert(*buffer == 0);
+
+    static_assert(!noexcept(*iter));
+    static_assert(cuda::std::is_same_v<int, decltype(*iter)>);
+  }
+
+  {
+    cuda::transform_iterator iter{Iter{buffer}, PlusOneMutable{}};
+    assert(*iter == 1);
+    assert(*buffer == 0);
+
+    static_assert(!noexcept(*iter));
+    static_assert(cuda::std::is_same_v<int, decltype(*iter)>);
+  }
+
+  {
+    cuda::transform_iterator iter{Iter{buffer}, PlusOneNoexcept{}};
+    assert(*iter == 1);
+    assert(*buffer == 0);
+
+    static_assert(noexcept(*iter) == noexcept(*cuda::std::declval<Iter>()));
+    static_assert(cuda::std::is_same_v<int, decltype(*iter)>);
+  }
+
+  {
+    cuda::transform_iterator iter{Iter{buffer}, Increment{}};
+    assert(*iter == 1);
+    assert(*buffer == 1);
+
+    static_assert(!noexcept(*iter));
+    static_assert(cuda::std::is_same_v<int&, decltype(*iter)>);
+  }
+
+  {
+    cuda::transform_iterator iter{Iter{buffer}, IncrementRvalueRef{}};
+    assert(*iter == 2);
+    assert(*buffer == 2);
+
+    static_assert(!noexcept(*iter));
+    static_assert(cuda::std::is_same_v<int&&, decltype(*iter)>);
+  }
+}
+
+__host__ __device__ constexpr bool test()
+{
+  test<cpp17_input_iterator<int*>>();
+  test<forward_iterator<int*>>();
+  test<random_access_iterator<int*>>();
+  test<int*>();
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test(), "");
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/deref.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/deref.pass.cpp
@@ -27,6 +27,7 @@ __host__ __device__ constexpr void test()
   {
     cuda::transform_iterator iter{Iter{buffer}, PlusOne{}};
     assert(*iter == 1);
+    assert(*cuda::std::as_const(iter) == 1);
     assert(*buffer == 0);
 
     static_assert(!noexcept(*iter));
@@ -67,6 +68,17 @@ __host__ __device__ constexpr void test()
 
     static_assert(!noexcept(*iter));
     static_assert(cuda::std::is_same_v<int&&, decltype(*iter)>);
+  }
+
+  {
+    cuda::transform_iterator iter{Iter{buffer}, PlusWithMutableMember{3}};
+    assert(*iter == 5);
+    assert(*iter == 6);
+    assert(*iter == 7);
+    assert(*buffer == 2);
+
+    static_assert(noexcept(*iter) == noexcept(*cuda::std::declval<Iter>()));
+    static_assert(cuda::std::is_same_v<int, decltype(*iter)>);
   }
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/iter_move.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/iter_move.pass.cpp
@@ -1,0 +1,54 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// friend constexpr decltype(auto) iter_move(const iterator& i)
+//    noexcept(noexcept(invoke(i.parent_->fun_, *i.current_)))
+
+#include <cuda/iterator>
+#include <cuda/std/cassert>
+#include <cuda/std/type_traits>
+
+#include "test_iterators.h"
+#include "test_macros.h"
+#include "types.h"
+
+__host__ __device__ constexpr bool test()
+{
+  int buffer[8] = {0, 1, 2, 3, 4, 5, 6, 7};
+
+  {
+    cuda::transform_iterator iter{buffer, PlusOne{}};
+    static_assert(!noexcept(cuda::std::ranges::iter_move(iter)));
+
+    assert(cuda::std::ranges::iter_move(iter) == 1);
+    assert(cuda::std::ranges::iter_move(iter + 2) == 3);
+
+    static_assert(cuda::std::is_same_v<int, decltype(cuda::std::ranges::iter_move(iter))>);
+    static_assert(cuda::std::is_same_v<int, decltype(cuda::std::ranges::iter_move(cuda::std::move(iter)))>);
+  }
+
+  {
+    [[maybe_unused]] cuda::transform_iterator iter_noexcept{buffer, PlusOneNoexcept{}};
+    static_assert(noexcept(cuda::std::ranges::iter_move(iter_noexcept)));
+
+    [[maybe_unused]] cuda::transform_iterator iter_not_noexcept{buffer, PlusOneMutable{}};
+    static_assert(!noexcept(cuda::std::ranges::iter_move(iter_not_noexcept)));
+  }
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test(), "");
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/make_transform_iterator.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/make_transform_iterator.pass.cpp
@@ -1,0 +1,48 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// transform_iterator::operator*
+
+#include <cuda/iterator>
+#include <cuda/std/cassert>
+#include <cuda/std/type_traits>
+
+#include "test_iterators.h"
+#include "test_macros.h"
+#include "types.h"
+
+template <class Iter>
+__host__ __device__ constexpr void test()
+{
+  int buffer[8] = {0, 1, 2, 3, 4, 5, 6, 7};
+
+  {
+    auto iter = cuda::make_transform_iterator(Iter{buffer}, PlusOne{});
+    static_assert(cuda::std::is_same_v<decltype(iter), cuda::transform_iterator<Iter, PlusOne>>);
+  }
+}
+
+__host__ __device__ constexpr bool test()
+{
+  test<cpp17_input_iterator<int*>>();
+  test<forward_iterator<int*>>();
+  test<random_access_iterator<int*>>();
+  test<int*>();
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test(), "");
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/member_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/member_types.pass.cpp
@@ -1,0 +1,96 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/iterator>
+#include <cuda/std/cassert>
+#include <cuda/std/concepts>
+
+#include "test_iterators.h"
+#include "test_macros.h"
+#include "types.h"
+
+template <class Iter, class Fn>
+_CCCL_CONCEPT HasIterCategory =
+  _CCCL_REQUIRES_EXPR((Iter, Fn))(typename(typename cuda::transform_iterator<Iter, Fn>::iterator_category));
+
+__host__ __device__ constexpr bool test()
+{
+  {
+    // Member typedefs for contiguous iterator.
+    static_assert(
+      cuda::std::same_as<cuda::std::iterator_traits<int*>::iterator_concept, cuda::std::contiguous_iterator_tag>);
+    static_assert(
+      cuda::std::same_as<cuda::std::iterator_traits<int*>::iterator_category, cuda::std::random_access_iterator_tag>);
+
+    using TIter = cuda::transform_iterator<int*, Increment>;
+    static_assert(cuda::std::same_as<typename TIter::iterator_concept, cuda::std::random_access_iterator_tag>);
+    static_assert(cuda::std::same_as<typename TIter::iterator_category, cuda::std::random_access_iterator_tag>);
+    static_assert(cuda::std::same_as<typename TIter::value_type, int>);
+    static_assert(cuda::std::same_as<typename TIter::difference_type, cuda::std::ptrdiff_t>);
+  }
+  {
+    // Member typedefs for random access iterator.
+    using TIter = cuda::transform_iterator<random_access_iterator<int*>, Increment>;
+    static_assert(cuda::std::same_as<typename TIter::iterator_concept, cuda::std::random_access_iterator_tag>);
+    static_assert(cuda::std::same_as<typename TIter::iterator_category, cuda::std::random_access_iterator_tag>);
+    static_assert(cuda::std::same_as<typename TIter::value_type, int>);
+    static_assert(cuda::std::same_as<typename TIter::difference_type, cuda::std::ptrdiff_t>);
+  }
+  {
+    // Member typedefs for random access iterator, LWG3798 rvalue reference.
+    using TIter = cuda::transform_iterator<random_access_iterator<int*>, IncrementRvalueRef>;
+    static_assert(cuda::std::same_as<typename TIter::iterator_concept, cuda::std::random_access_iterator_tag>);
+    static_assert(cuda::std::same_as<typename TIter::iterator_category, cuda::std::random_access_iterator_tag>);
+    static_assert(cuda::std::same_as<typename TIter::value_type, int>);
+    static_assert(cuda::std::same_as<typename TIter::difference_type, cuda::std::ptrdiff_t>);
+  }
+  {
+    // Member typedefs for random access iterator/not-lvalue-ref.
+    using TIter = cuda::transform_iterator<random_access_iterator<int*>, PlusOneMutable>;
+    static_assert(cuda::std::same_as<typename TIter::iterator_concept, cuda::std::random_access_iterator_tag>);
+    static_assert(cuda::std::same_as<typename TIter::iterator_category, cuda::std::input_iterator_tag>);
+    static_assert(cuda::std::same_as<typename TIter::value_type, int>);
+    static_assert(cuda::std::same_as<typename TIter::difference_type, cuda::std::ptrdiff_t>);
+  }
+  {
+    // Member typedefs for bidirectional iterator.
+    using TIter = cuda::transform_iterator<bidirectional_iterator<int*>, Increment>;
+    static_assert(cuda::std::same_as<typename TIter::iterator_concept, cuda::std::bidirectional_iterator_tag>);
+    static_assert(cuda::std::same_as<typename TIter::iterator_category, cuda::std::bidirectional_iterator_tag>);
+    static_assert(cuda::std::same_as<typename TIter::value_type, int>);
+    static_assert(cuda::std::same_as<typename TIter::difference_type, cuda::std::ptrdiff_t>);
+  }
+  {
+    // Member typedefs for forward iterator.
+    using TIter = cuda::transform_iterator<forward_iterator<int*>, Increment>;
+    static_assert(cuda::std::same_as<typename TIter::iterator_concept, cuda::std::forward_iterator_tag>);
+    static_assert(cuda::std::same_as<typename TIter::iterator_category, cuda::std::forward_iterator_tag>);
+    static_assert(cuda::std::same_as<typename TIter::value_type, int>);
+    static_assert(cuda::std::same_as<typename TIter::difference_type, cuda::std::ptrdiff_t>);
+  }
+  {
+    // Member typedefs for input iterator.
+    using TIter = cuda::transform_iterator<cpp17_input_iterator<int*>, Increment>;
+    static_assert(cuda::std::same_as<typename TIter::iterator_concept, cuda::std::input_iterator_tag>);
+    static_assert(!HasIterCategory<cpp17_input_iterator<int*>, Increment>);
+    static_assert(cuda::std::same_as<typename TIter::value_type, int>);
+    static_assert(cuda::std::same_as<typename TIter::difference_type, cuda::std::ptrdiff_t>);
+  }
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test(), "");
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/plus_minus.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/plus_minus.pass.cpp
@@ -1,0 +1,65 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// transform_iterator::operator{+,-}
+
+#include <cuda/iterator>
+#include <cuda/std/cassert>
+
+#include "test_iterators.h"
+#include "test_macros.h"
+#include "types.h"
+
+template <class Iter>
+_CCCL_CONCEPT can_plus = _CCCL_REQUIRES_EXPR((Iter), Iter i)((i + 42), (42 + i));
+
+template <class Iter>
+_CCCL_CONCEPT can_minus = _CCCL_REQUIRES_EXPR((Iter), Iter i)((i - 42));
+
+template <class Iter>
+__host__ __device__ constexpr void test()
+{
+  if constexpr (cuda::std::random_access_iterator<Iter>)
+  {
+    int buffer[8] = {0, 1, 2, 3, 4, 5, 6, 7};
+
+    cuda::transform_iterator iter1{Iter{buffer + 4}, PlusOne{}};
+    cuda::transform_iterator iter2{Iter{buffer}, PlusOne{}};
+
+    assert((iter1 + 1).base() == Iter{buffer + 5});
+    assert((1 + iter1).base() == Iter{buffer + 5});
+    assert((iter1 - 1).base() == Iter{buffer + 3});
+    assert(iter1 - iter2 == 4);
+    assert((iter1 + 2) - 2 == iter1);
+    assert((iter1 - 2) + 2 == iter1);
+  }
+  else
+  {
+    static_assert(!can_plus<cuda::transform_iterator<Iter, PlusOne>>);
+    static_assert(!can_minus<cuda::transform_iterator<Iter, PlusOne>>);
+  }
+}
+
+__host__ __device__ constexpr bool test()
+{
+  test<cpp17_input_iterator<int*>>();
+  test<random_access_iterator<int*>>();
+  test<int*>();
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test(), "");
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/subscript.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/subscript.pass.cpp
@@ -1,0 +1,96 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// transform_iterator::operator[]
+
+#include <cuda/iterator>
+#include <cuda/std/cassert>
+
+#include "test_iterators.h"
+#include "test_macros.h"
+#include "types.h"
+
+template <class Iter>
+_CCCL_CONCEPT can_subscript = _CCCL_REQUIRES_EXPR((Iter), Iter i)((i[0]));
+
+template <class Iter>
+__host__ __device__ constexpr void test()
+{
+  if constexpr (cuda::std::random_access_iterator<Iter>)
+  {
+    int buffer[8] = {0, 1, 2, 3, 4, 5, 6, 7};
+
+    {
+      cuda::transform_iterator iter{Iter{buffer}, PlusOne{}};
+      assert(iter[4] == 5);
+      assert(buffer[4] == 4);
+
+      static_assert(!noexcept(iter[4]));
+      static_assert(cuda::std::is_same_v<int, decltype(iter[4])>);
+    }
+
+    {
+      cuda::transform_iterator iter{Iter{buffer}, PlusOneMutable{}};
+      assert(iter[4] == 5);
+      assert(buffer[4] == 4);
+
+      static_assert(!noexcept(iter[4]));
+      static_assert(cuda::std::is_same_v<int, decltype(iter[4])>);
+    }
+
+    {
+      cuda::transform_iterator iter{Iter{buffer}, PlusOneNoexcept{}};
+      assert(iter[4] == 5);
+      assert(buffer[4] == 4);
+
+      static_assert(noexcept(iter[4]) == noexcept(*cuda::std::declval<Iter>()));
+      static_assert(cuda::std::is_same_v<int, decltype(iter[4])>);
+    }
+
+    {
+      cuda::transform_iterator iter{Iter{buffer}, Increment{}};
+      assert(iter[4] == 5);
+      assert(buffer[4] == 5);
+
+      static_assert(!noexcept(iter[4]));
+      static_assert(cuda::std::is_same_v<int&, decltype(iter[4])>);
+    }
+
+    {
+      cuda::transform_iterator iter{Iter{buffer}, IncrementRvalueRef{}};
+      assert(iter[4] == 6);
+      assert(buffer[4] == 6);
+
+      static_assert(!noexcept(iter[4]));
+      static_assert(cuda::std::is_same_v<int&&, decltype(iter[4])>);
+    }
+  }
+  else
+  {
+    static_assert(!can_subscript<Iter>);
+  }
+}
+
+__host__ __device__ constexpr bool test()
+{
+  test<cpp17_input_iterator<int*>>();
+  test<random_access_iterator<int*>>();
+  test<int*>();
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test(), "");
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/subscript.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/subscript.pass.cpp
@@ -12,6 +12,7 @@
 
 #include <cuda/iterator>
 #include <cuda/std/cassert>
+#include <cuda/std/utility>
 
 #include "test_iterators.h"
 #include "test_macros.h"
@@ -84,13 +85,25 @@ __host__ __device__ constexpr bool test()
   test<random_access_iterator<int*>>();
   test<int*>();
 
+  { // Enjusre that we can assign through projections
+    using pair    = cuda::std::pair<int, int>;
+    pair buffer[] = {{0, -1}, {1, -1}, {2, -1}, {3, -1}, {4, -1}, {5, -1}, {6, -1}, {7, -1}};
+    cuda::transform_iterator iter{buffer, &cuda::std::pair<int, int>::second};
+    assert(iter[4] == -1);
+    iter[4] = 42;
+    assert(iter[4] == 42);
+
+    const pair expected{4, 42};
+    assert(buffer[4] == expected);
+  }
+
   return true;
 }
 
 int main(int, char**)
 {
   test();
-  static_assert(test(), "");
+  // static_assert(test(), "");
 
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/subscript.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/subscript.pass.cpp
@@ -31,6 +31,7 @@ __host__ __device__ constexpr void test()
     {
       cuda::transform_iterator iter{Iter{buffer}, PlusOne{}};
       assert(iter[4] == 5);
+      assert(cuda::std::as_const(iter)[4] == 5);
       assert(buffer[4] == 4);
 
       static_assert(!noexcept(iter[4]));
@@ -71,6 +72,17 @@ __host__ __device__ constexpr void test()
 
       static_assert(!noexcept(iter[4]));
       static_assert(cuda::std::is_same_v<int&&, decltype(iter[4])>);
+    }
+
+    {
+      cuda::transform_iterator iter{Iter{buffer}, PlusWithMutableMember{3}};
+      assert(iter[4] == 9);
+      assert(iter[4] == 10);
+      assert(iter[4] == 11);
+      assert(buffer[4] == 6);
+
+      static_assert(noexcept(iter[4]) == noexcept(*cuda::std::declval<Iter>()));
+      static_assert(cuda::std::is_same_v<int, decltype(iter[4])>);
     }
   }
   else

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/subscript.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/subscript.pass.cpp
@@ -85,10 +85,10 @@ __host__ __device__ constexpr bool test()
   test<random_access_iterator<int*>>();
   test<int*>();
 
-  { // Enjusre that we can assign through projections
+  { // Ensure that we can assign through projections
     using pair    = cuda::std::pair<int, int>;
     pair buffer[] = {{0, -1}, {1, -1}, {2, -1}, {3, -1}, {4, -1}, {5, -1}, {6, -1}, {7, -1}};
-    cuda::transform_iterator iter{buffer, &cuda::std::pair<int, int>::second};
+    cuda::transform_iterator iter{buffer, &pair::second};
     assert(iter[4] == -1);
     iter[4] = 42;
     assert(iter[4] == 42);
@@ -103,7 +103,7 @@ __host__ __device__ constexpr bool test()
 int main(int, char**)
 {
   test();
-  // static_assert(test(), "");
+  static_assert(test(), "");
 
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/subscript.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/subscript.pass.cpp
@@ -85,6 +85,9 @@ __host__ __device__ constexpr bool test()
   test<random_access_iterator<int*>>();
   test<int*>();
 
+#if TEST_COMPILER(MSVC)
+  if (!cuda::std::is_constant_evaluated()) // MSVC complains about a non constant expression in the assignment
+#endif // TEST_COMPILER(MSVC)
   { // Ensure that we can assign through projections
     using pair    = cuda::std::pair<int, int>;
     pair buffer[] = {{0, -1}, {1, -1}, {2, -1}, {3, -1}, {4, -1}, {5, -1}, {6, -1}, {7, -1}};

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/types.h
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/types.h
@@ -63,4 +63,16 @@ struct PlusOneNoexcept
   }
 };
 
+struct PlusWithMutableMember
+{
+  int val_ = 0;
+  __host__ __device__ constexpr PlusWithMutableMember(const int val) noexcept
+      : val_(val)
+  {}
+  __host__ __device__ constexpr int operator()(int x) noexcept
+  {
+    return x + val_++;
+  }
+};
+
 #endif // TEST_CUDA_TRANSFORM_ITERATOR_TYPES_H

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/types.h
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/types.h
@@ -1,0 +1,66 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TEST_CUDA_TRANSFORM_ITERATOR_TYPES_H
+#define TEST_CUDA_TRANSFORM_ITERATOR_TYPES_H
+
+#include <cuda/std/utility>
+
+#include "test_macros.h"
+
+struct TimesTwo
+{
+  __host__ __device__ constexpr int operator()(int x) const
+  {
+    return x * 2;
+  }
+};
+
+struct PlusOneMutable
+{
+  __host__ __device__ constexpr int operator()(int x)
+  {
+    return x + 1;
+  }
+};
+
+struct PlusOne
+{
+  __host__ __device__ constexpr int operator()(int x) const
+  {
+    return x + 1;
+  }
+};
+
+struct Increment
+{
+  __host__ __device__ constexpr int& operator()(int& x)
+  {
+    return ++x;
+  }
+};
+
+struct IncrementRvalueRef
+{
+  __host__ __device__ constexpr int&& operator()(int& x)
+  {
+    return cuda::std::move(++x);
+  }
+};
+
+struct PlusOneNoexcept
+{
+  __host__ __device__ constexpr int operator()(int x) noexcept
+  {
+    return x + 1;
+  }
+};
+
+#endif // TEST_CUDA_TRANSFORM_ITERATOR_TYPES_H


### PR DESCRIPTION
This ports `thrust::transform_iterator` over to namesapce cuda and also gives it a little overhaul