### PR TITLE
Add workflow to build and test all Python wheels 

### DIFF
--- a/.github/actions/workflow-run-job-linux/action.yml
+++ b/.github/actions/workflow-run-job-linux/action.yml
@@ -36,12 +36,11 @@ runs:
     - name: Checkout repo
       uses: actions/checkout@v4
       with:
-        path: ${{github.event.repository.name}}
         persist-credentials: false
     - name: Add NVCC problem matcher
       shell: bash --noprofile --norc -euo pipefail {0}
       run: |
-        echo "::add-matcher::${{github.event.repository.name}}/.github/problem-matchers/problem-matcher.json"
+        echo "::add-matcher::${{github.workspace}}/.github/problem-matchers/problem-matcher.json"
     - name: Get AWS credentials for sccache bucket
       uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -52,7 +51,7 @@ runs:
       uses: actions/download-artifact@v4
       with:
         name: wheelhouse-${{ inputs.producer_id || inputs.id }}
-        path: ${{github.event.repository.name}}/wheelhouse/
+        path: wheelhouse/
       continue-on-error: true
     - name: Run command # Do not change this step's name, it is checked in parse-job-times.py
       shell: bash --noprofile --norc -euo pipefail {0}
@@ -111,7 +110,7 @@ runs:
         chmod +x ci.sh
 
         # The devcontainer will mount this path to the home directory:
-        readonly aws_dir="${{github.event.repository.name}}/.aws"
+        readonly aws_dir="${{github.workspace}}/.aws"
         mkdir "${aws_dir}";
 
         cat <<EOF > "${aws_dir}/config"
@@ -144,7 +143,7 @@ runs:
 
         # Launch this container using the host's docker daemon
         set -x
-        ${{github.event.repository.name}}/.devcontainer/launch.sh \
+        ${{github.workspace}}/.devcontainer/launch.sh \
           --docker \
           --cuda ${{inputs.cuda}} \
           --host ${{inputs.host}} \
@@ -199,5 +198,5 @@ runs:
       uses: actions/upload-artifact@v4
       with:
         name: wheelhouse-${{inputs.id}}
-        path: ${{github.event.repository.name}}/wheelhouse/
+        path: wheelhouse/
         compression-level: 0

--- a/.github/workflows/build-and-test-python-wheels.yml
+++ b/.github/workflows/build-and-test-python-wheels.yml
@@ -1,0 +1,114 @@
+name: Build and Test Python Wheels
+
+on:
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash --noprofile --norc -euo pipefail {0}
+
+jobs:
+  build-cccl:
+    name: Build CCCL Wheels
+    uses: ./.github/workflows/run-ci-script.yml
+    with:
+      script-command: ci/build_cuda_cccl_python.sh -py-version ${{ matrix.python-version }}
+      python-version: ${{ matrix.python-version }}
+      upload-artifact: true
+      upload-artifact-name: wheel-cccl-${{ matrix.python-version }}
+      upload-artifact-path: wheelhouse/
+      runner: linux-amd64-cpu16
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11', '3.12', '3.13']
+    permissions:
+      id-token: write
+      contents: read
+
+  test-cccl:
+    name: Test CCCL Wheels
+    needs: build-cccl
+    uses: ./.github/workflows/run-ci-script.yml
+    with:
+      script-command: ci/test_cuda_cccl_python.sh -py-version ${{ matrix.python-version }}
+      python-version: ${{ matrix.python-version }}
+      needs-artifact: true
+      artifact-name: wheel-cccl-${{ matrix.python-version }}
+      artifact-path: wheelhouse/
+      runner: linux-amd64-cpu16
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11', '3.12', '3.13']
+    permissions:
+      id-token: write
+      contents: read
+
+  build-cooperative:
+    name: Build Cooperative Wheels
+    uses: ./.github/workflows/run-ci-script.yml
+    with:
+      script-command: ci/build_cuda_cooperative_python.sh -py-version ${{ matrix.python-version }}
+      python-version: ${{ matrix.python-version }}
+      upload-artifact: true
+      upload-artifact-name: wheel-cooperative-${{ matrix.python-version }}
+      upload-artifact-path: wheelhouse/
+      runner: linux-amd64-cpu16
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11', '3.12', '3.13']
+    permissions:
+      id-token: write
+      contents: read
+
+  test-cooperative:
+    name: Test Cooperative Wheels
+    needs: build-cooperative
+    uses: ./.github/workflows/run-ci-script.yml
+    with:
+      script-command: ci/test_cuda_cooperative_python.sh -py-version ${{ matrix.python-version }}
+      python-version: ${{ matrix.python-version }}
+      needs-artifact: true
+      artifact-name: wheel-cooperative-${{ matrix.python-version }}
+      artifact-path: wheelhouse/
+      runner: linux-amd64-gpu-rtxa6000-latest-1
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11', '3.12', '3.13']
+    permissions:
+      id-token: write
+      contents: read
+
+  build-parallel:
+    name: Build Parallel Wheels
+    uses: ./.github/workflows/run-ci-script.yml
+    with:
+      script-command: ci/build_cuda_parallel_python.sh -py-version ${{ matrix.python-version }}
+      python-version: ${{ matrix.python-version }}
+      upload-artifact: true
+      upload-artifact-name: wheel-parallel-${{ matrix.python-version }}
+      upload-artifact-path: wheelhouse/
+      runner: linux-amd64-cpu16
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11', '3.12', '3.13']
+    permissions:
+      id-token: write
+      contents: read
+
+  test-parallel:
+    name: Test Parallel Wheels
+    needs: build-parallel
+    uses: ./.github/workflows/run-ci-script.yml
+    with:
+      script-command: ci/test_cuda_parallel_python.sh -py-version ${{ matrix.python-version }}
+      python-version: ${{ matrix.python-version }}
+      needs-artifact: true
+      artifact-name: wheel-parallel-${{ matrix.python-version }}
+      artifact-path: wheelhouse/
+      runner: linux-amd64-gpu-rtxa6000-latest-1
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11', '3.12', '3.13']
+    permissions:
+      id-token: write
+      contents: read

--- a/.github/workflows/run-ci-script.yml
+++ b/.github/workflows/run-ci-script.yml
@@ -1,0 +1,133 @@
+name: Run CI Script
+
+on:
+  workflow_call:
+    inputs:
+      script-command:
+        required: true
+        type: string
+        description: 'The command to run in the CI script'
+      python-version:
+        required: true
+        type: string
+        description: 'Python version to use'
+      needs-artifact:
+        required: false
+        type: boolean
+        default: false
+        description: 'Whether to download the wheel artifact'
+      artifact-name:
+        required: false
+        type: string
+        description: 'Name of the artifact to download'
+      artifact-path:
+        required: false
+        type: string
+        description: 'Path to download the artifact to'
+      upload-artifact:
+        required: false
+        type: boolean
+        default: false
+        description: 'Whether to upload the wheel artifact'
+      upload-artifact-name:
+        required: false
+        type: string
+        description: 'Name for the uploaded artifact'
+      upload-artifact-path:
+        required: false
+        type: string
+        description: 'Path to upload the artifact from'
+      runner:
+        required: false
+        type: string
+        default: 'ubuntu-latest'
+        description: 'The runner to use for this job'
+
+jobs:
+  run-script:
+    name: Run CI Script
+    runs-on: ${{ inputs.runner }}
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Get AWS credentials for sccache bucket
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::279114543810:role/gha-oidc-NVIDIA
+          aws-region: us-east-2
+          role-duration-seconds: 43200 # 12 hours
+
+      - name: Download wheel artifact
+        if: ${{ inputs.needs-artifact }}
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: ${{ inputs.artifact-path }}
+          continue-on-error: true
+
+      - name: Create CI script
+        run: |
+          cat <<"EOF" > "$RUNNER_TEMP/ci.sh"
+          #! /usr/bin/env bash
+          set -eo pipefail
+
+          ${{ inputs.script-command }};
+          EOF
+
+          chmod +x "$RUNNER_TEMP/ci.sh"
+
+          mkdir -p .aws
+          cat <<EOF > .aws/config
+          [default]
+          bucket=rapids-sccache-devs
+          region=us-east-2
+          EOF
+
+          cat <<EOF > .aws/credentials
+          [default]
+          aws_access_key_id=$AWS_ACCESS_KEY_ID
+          aws_session_token=$AWS_SESSION_TOKEN
+          aws_secret_access_key=$AWS_SECRET_ACCESS_KEY
+          EOF
+
+          chmod 0600 .aws/credentials
+          chmod 0664 .aws/config
+
+      - name: Run script
+        env:
+          PYTHON_VERSION: ${{ inputs.python-version }}
+        run: |
+          ${{github.workspace}}/.devcontainer/launch.sh \
+            --docker \
+            --cuda 12.9 \
+            --host gcc13 \
+            --volume "$RUNNER_TEMP/ci.sh:/ci.sh" \
+            --env "CI=$CI" \
+            --env "AWS_ROLE_ARN=" \
+            --env "SCCACHE_IDLE_TIMEOUT=0" \
+            --env "GITHUB_ENV=$GITHUB_ENV" \
+            --env "GITHUB_SHA=$GITHUB_SHA" \
+            --env "GITHUB_PATH=$GITHUB_PATH" \
+            --env "GITHUB_OUTPUT=$GITHUB_OUTPUT" \
+            --env "GITHUB_ACTIONS=$GITHUB_ACTIONS" \
+            --env "GITHUB_REF_NAME=$GITHUB_REF_NAME" \
+            --env "GITHUB_WORKSPACE=$GITHUB_WORKSPACE" \
+            --env "GITHUB_REPOSITORY=$GITHUB_REPOSITORY" \
+            --env "GITHUB_STEP_SUMMARY=$GITHUB_STEP_SUMMARY" \
+            --env "HOST_WORKSPACE=${{github.workspace}}/" \
+            -- /ci.sh
+
+      - name: Upload wheel artifact
+        if: ${{ inputs.upload-artifact }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.upload-artifact-name }}
+          path: ${{ inputs.upload-artifact-path }}
+          retention-days: 1
+        continue-on-error: true

--- a/ci/build_cuda_parallel_python.sh
+++ b/ci/build_cuda_parallel_python.sh
@@ -5,7 +5,6 @@ set -euo pipefail
 py_version=${2#*=}
 echo "Docker socket: " $(ls /var/run/docker.sock)
 
-
 # cuda_parallel must be built in a container that can produce manylinux wheels,
 # and has the CUDA toolkit installed. We use the rapidsai/ci-wheel image for this.
 # These images don't come with a new enough version of gcc installed, so that
@@ -28,5 +27,5 @@ docker run --rm -i \
     python -m pip install patchelf auditwheel && \
     python --version && \
     python -m auditwheel repair cuda_parallel-*.whl --exclude libcuda.so.1 && \
-    mv cuda_cccl-*.whl /workspace/cccl/wheelhouse && \
-    mv wheelhouse/cuda_parallel-*.whl /workspace/cccl/wheelhouse/'
+    mv cuda_cccl-*.whl /workspace/wheelhouse && \
+    mv wheelhouse/cuda_parallel-*.whl /workspace/wheelhouse/'


### PR DESCRIPTION
## Description

Closes #4701

This PR adds a workflow with a `workflow_dispatch` trigger which will build and test wheels for `cuda_{cccl,cooperative,parallel}`, producing wheels as artifacts.

https://github.com/NVIDIA/cccl/actions/workflows/build-and-test-python-wheels.yml


## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
