### PR TITLE
Cuda parallel test add mark large

### DIFF
--- a/ci/test_cuda_parallel_python.sh
+++ b/ci/test_cuda_parallel_python.sh
@@ -20,4 +20,4 @@ python -m pip install "${CUDA_PARALLEL_WHEEL_PATH}[test]"
 
 # Run tests
 cd "/home/coder/cccl/python/cuda_parallel/tests/"
-python -m pytest -n auto -v
+python -m pytest -n auto -v -m "not large"

--- a/python/cuda_parallel/pyproject.toml
+++ b/python/cuda_parallel/pyproject.toml
@@ -76,4 +76,7 @@ extend = "../../pyproject.toml"
 known-first-party = ["cuda.parallel"]
 
 [tool.pytest.ini_options]
-markers = ["no_verify_sass: skip SASS verification check"]
+markers = [
+  "no_verify_sass: skip SASS verification check",
+  "large: tests requiring large device memory allocations",
+]

--- a/python/cuda_parallel/tests/test_radix_sort.py
+++ b/python/cuda_parallel/tests/test_radix_sort.py
@@ -12,6 +12,13 @@ import pytest
 
 import cuda.parallel.experimental.algorithms as algorithms
 
+
+def get_mark(dt, log_size):
+    if log_size < 20:
+        return tuple()
+    return pytest.mark.large
+
+
 DTYPE_LIST = [
     np.uint8,
     np.uint16,
@@ -27,7 +34,11 @@ DTYPE_LIST = [
 
 PROBLEM_SIZES = [2, 10, 20]
 
-DTYPE_SIZE = [(dt, 2**log_size) for dt in DTYPE_LIST for log_size in PROBLEM_SIZES]
+DTYPE_SIZE = [
+    pytest.param(dt, 2**log_size, marks=get_mark(dt, log_size))
+    for dt in DTYPE_LIST
+    for log_size in PROBLEM_SIZES
+]
 
 
 def random_array(size, dtype, max_value=None) -> np.typing.NDArray:
@@ -251,7 +262,7 @@ def test_radix_sort_pairs_double_buffer(dtype, num_items):
 
 # These tests take longer to execute so we reduce the number of test cases
 DTYPE_SIZE_BIT_WINDOW = [
-    (dt, 2**log_size)
+    pytest.param(dt, 2**log_size, marks=get_mark(dt, log_size))
     for dt in [np.uint8, np.int16, np.uint32, np.int64, np.float64]
     for log_size in [2, 24]
 ]

--- a/python/cuda_parallel/tests/test_reduce.py
+++ b/python/cuda_parallel/tests/test_reduce.py
@@ -31,8 +31,14 @@ def type_to_problem_sizes(dtype):
         raise ValueError("Unsupported dtype")
 
 
+def get_mark(dt, log_size):
+    if log_size + np.log2(np.dtype(dt).itemsize) < 21:
+        return tuple()
+    return pytest.mark.large
+
+
 dtype_size_pairs = [
-    (dt, 2**log_size)
+    pytest.param(dt, 2**log_size, marks=get_mark(dt, log_size))
     for dt in [np.uint8, np.uint16, np.uint32, np.uint64]
     for log_size in type_to_problem_sizes(dt)
 ]

--- a/python/cuda_parallel/tests/test_unique_by_key.py
+++ b/python/cuda_parallel/tests/test_unique_by_key.py
@@ -25,10 +25,19 @@ DTYPE_LIST = [
     np.float64,
 ]
 
+
+def get_mark(dt, log_size):
+    if log_size < 20:
+        return tuple()
+    return pytest.mark.large
+
+
 PROBLEM_SIZES = [2, 8, 16, 22]
 
 DTYPE_SIZE_PAIRS = [
-    (dt, 2**log_size) for dt in DTYPE_LIST for log_size in PROBLEM_SIZES
+    pytest.param(dt, 2**log_size, marks=get_mark(dt, log_size))
+    for dt in DTYPE_LIST
+    for log_size in PROBLEM_SIZES
 ]
 
 


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes #4722 

<!-- Provide a standalone description of changes in this PR. -->

This PR introduces `pytest.mark.large` to `cuda.parallel` test suite and marks tests allocating over ``2**20`` elements as large. CI script running project's test use `-m "not large"`. 

Verified that this helps by running ``CUDA_VISIBLE_DEVICES=1 pytest -s -n 6 -m "not large" tests``  locally, where device 1 is RTX A400 4GB consumer GPU card.

Of course, with a 64-core machine, ``CUDA_VISIBLE_DEVICES=1 pytest -s -n auto -m "not large" tests`` runs into out-of-memory issues.

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
