### PR TITLE
disable execution space warnings for all of µstdex's generic facilities

### DIFF
--- a/cudax/include/cuda/experimental/__execution/apply_sender.cuh
+++ b/cudax/include/cuda/experimental/__execution/apply_sender.cuh
@@ -61,6 +61,7 @@ public:
   //! @note This function is `constexpr` and `noexcept` if the underlying domain's
   //! `apply_sender` is `noexcept`.
   //! @throws Any exception thrown by the underlying domain's `apply_sender`.
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _Domain, class _Tag, class _Sndr, class... _Args>
   _CCCL_TRIVIAL_API constexpr auto operator()(_Domain, _Tag, _Sndr&& __sndr, _Args&&... __args) const
     noexcept(noexcept(__apply_domain_t<_Domain, _Tag, _Sndr, _Args...>{}.apply_sender(

--- a/cudax/include/cuda/experimental/__execution/completion_signatures.cuh
+++ b/cudax/include/cuda/experimental/__execution/completion_signatures.cuh
@@ -159,12 +159,14 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT completion_signatures
     }
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _Fn>
   _CCCL_API constexpr auto apply(_Fn __fn) const -> _CUDA_VSTD::__call_result_t<_Fn, _Sigs*...>
   {
     return __fn(static_cast<_Sigs*>(nullptr)...);
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _Fn>
   [[nodiscard]]
   _CCCL_API constexpr auto filter(_Fn __fn) const -> __concat_completion_signatures_t<__completion_if<_Fn, _Sigs>...>
@@ -190,6 +192,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT completion_signatures
     }
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _Transform, class _Reduce>
   [[nodiscard]]
   _CCCL_API constexpr auto transform_reduce(_Transform __transform, _Reduce __reduce) const
@@ -414,6 +417,7 @@ inline constexpr bool __has_get_completion_signatures<_Sndr, _Env> =
 struct _COULD_NOT_DETERMINE_COMPLETION_SIGNATURES_FOR_THIS_SENDER
 {};
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _Sndr, class... _Env>
 _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto __get_completion_signatures_helper()
 {
@@ -725,12 +729,14 @@ struct __decay_transform
 template <class _Fn, class... _As>
 using __meta_call_result_t _CCCL_NODEBUG_ALIAS = decltype(declval<_Fn>().template operator()<_As...>());
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _Ay, class... _As, class _Fn>
 _CCCL_TRIVIAL_API constexpr auto __transform_expr(const _Fn& __fn) -> __meta_call_result_t<const _Fn&, _Ay, _As...>
 {
   return __fn.template operator()<_Ay, _As...>();
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _Fn>
 _CCCL_TRIVIAL_API constexpr auto __transform_expr(const _Fn& __fn) -> __call_result_t<const _Fn&>
 {

--- a/cudax/include/cuda/experimental/__execution/conditional.cuh
+++ b/cudax/include/cuda/experimental/__execution/conditional.cuh
@@ -131,6 +131,7 @@ private:
       execution::start(__op_);
     }
 
+    _CCCL_EXEC_CHECK_DISABLE
     template <class... _As>
     _CCCL_API void set_value(_As&&... __as) noexcept
     {

--- a/cudax/include/cuda/experimental/__execution/cpos.cuh
+++ b/cudax/include/cuda/experimental/__execution/cpos.cuh
@@ -52,6 +52,7 @@ struct __completion_tag
 
 struct set_value_t : __completion_tag<__value>
 {
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _Rcvr, class... _Ts>
   _CCCL_TRIVIAL_API auto operator()(_Rcvr&& __rcvr, _Ts&&... __ts) const noexcept
     -> decltype(static_cast<_Rcvr&&>(__rcvr).set_value(static_cast<_Ts&&>(__ts)...))
@@ -65,6 +66,7 @@ struct set_value_t : __completion_tag<__value>
 
 struct set_error_t : __completion_tag<__error>
 {
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _Rcvr, class _Ey>
   _CCCL_TRIVIAL_API auto operator()(_Rcvr&& __rcvr, _Ey&& __e) const noexcept
     -> decltype(static_cast<_Rcvr&&>(__rcvr).set_error(static_cast<_Ey&&>(__e)))
@@ -78,6 +80,7 @@ struct set_error_t : __completion_tag<__error>
 
 struct set_stopped_t : __completion_tag<__stopped>
 {
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _Rcvr>
   _CCCL_TRIVIAL_API auto operator()(_Rcvr&& __rcvr) const noexcept
     -> decltype(static_cast<_Rcvr&&>(__rcvr).set_stopped())
@@ -90,6 +93,7 @@ struct set_stopped_t : __completion_tag<__stopped>
 
 struct start_t
 {
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _OpState>
   _CCCL_TRIVIAL_API auto operator()(_OpState& __opstate) const noexcept -> decltype(__opstate.start())
   {
@@ -109,6 +113,7 @@ struct connect_t
     return transform_sender(_Domain{}, static_cast<_Sndr&&>(__sndr), get_env(__rcvr));
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Sndr, class _Rcvr)
   _CCCL_REQUIRES((!__has_sender_transform<_Sndr, env_of_t<_Rcvr>>) )
   _CCCL_TRIVIAL_API constexpr auto operator()(_Sndr&& __sndr, _Rcvr __rcvr) const
@@ -117,6 +122,7 @@ struct connect_t
     return static_cast<_Sndr&&>(__sndr).connect(static_cast<_Rcvr&&>(__rcvr));
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Sndr, class _Rcvr)
   _CCCL_REQUIRES(__has_sender_transform<_Sndr, env_of_t<_Rcvr>>)
   _CCCL_TRIVIAL_API constexpr auto operator()(_Sndr&& __sndr, _Rcvr __rcvr) const
@@ -128,6 +134,7 @@ struct connect_t
 
 struct schedule_t
 {
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _Sch>
   _CCCL_TRIVIAL_API auto operator()(_Sch&& __sch) const noexcept -> decltype(declval<_Sch>().schedule())
   {

--- a/cudax/include/cuda/experimental/__execution/just_from.cuh
+++ b/cudax/include/cuda/experimental/__execution/just_from.cuh
@@ -93,6 +93,7 @@ private:
   {
     using operation_state_concept _CCCL_NODEBUG_ALIAS = operation_state_t;
 
+    _CCCL_EXEC_CHECK_DISABLE
     _CCCL_API void start() & noexcept
     {
       static_cast<_Fn&&>(__fn_)(__complete_fn<_Rcvr>{__rcvr_});

--- a/cudax/include/cuda/experimental/__execution/queries.cuh
+++ b/cudax/include/cuda/experimental/__execution/queries.cuh
@@ -46,6 +46,7 @@ using _CUDA_STD_EXEC::__queryable_with;
 // get_allocator
 _CCCL_GLOBAL_CONSTANT struct get_allocator_t
 {
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _Env>
   _CCCL_API auto operator()(const _Env& __env) const noexcept
   {
@@ -65,6 +66,7 @@ _CCCL_GLOBAL_CONSTANT struct get_allocator_t
 // get_stop_token
 _CCCL_GLOBAL_CONSTANT struct get_stop_token_t
 {
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _Env>
   _CCCL_API auto operator()(const _Env& __env) const noexcept
   {
@@ -88,6 +90,7 @@ using stop_token_of_t _CCCL_NODEBUG_ALIAS = __decay_t<__call_result_t<get_stop_t
 template <class _Tag>
 struct get_completion_scheduler_t
 {
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Env)
   _CCCL_REQUIRES(__queryable_with<_Env, get_completion_scheduler_t>)
   _CCCL_API auto operator()(const _Env& __env) const noexcept
@@ -109,6 +112,7 @@ using __completion_scheduler_of_t _CCCL_NODEBUG_ALIAS =
 // get_scheduler
 _CCCL_GLOBAL_CONSTANT struct get_scheduler_t
 {
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Env)
   _CCCL_REQUIRES(__queryable_with<_Env, get_scheduler_t>)
   _CCCL_API auto operator()(const _Env& __env) const noexcept
@@ -126,6 +130,7 @@ using __scheduler_of_t _CCCL_NODEBUG_ALIAS = __decay_t<__call_result_t<get_sched
 // get_delegation_scheduler
 _CCCL_GLOBAL_CONSTANT struct get_delegation_scheduler_t
 {
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Env)
   _CCCL_REQUIRES(__queryable_with<_Env, get_delegation_scheduler_t>)
   _CCCL_API auto operator()(const _Env& __env) const noexcept
@@ -147,6 +152,7 @@ enum class forward_progress_guarantee
 
 _CCCL_GLOBAL_CONSTANT struct get_forward_progress_guarantee_t
 {
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _Sch>
   _CCCL_API auto operator()(const _Sch& __sch) const noexcept
   {
@@ -166,6 +172,7 @@ _CCCL_GLOBAL_CONSTANT struct get_forward_progress_guarantee_t
 // get_domain
 _CCCL_GLOBAL_CONSTANT struct get_domain_t
 {
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _Env>
   _CCCL_API constexpr auto operator()(const _Env& __env) const noexcept
   {

--- a/cudax/include/cuda/experimental/__execution/rcvr_ref.cuh
+++ b/cudax/include/cuda/experimental/__execution/rcvr_ref.cuh
@@ -34,18 +34,21 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __rcvr_ref
   using receiver_concept _CCCL_NODEBUG_ALIAS = receiver_t;
   _Rcvr& __rcvr_;
 
+  _CCCL_EXEC_CHECK_DISABLE
   template <class... _As>
   _CCCL_TRIVIAL_API void set_value(_As&&... __as) noexcept
   {
     static_cast<_Rcvr&&>(__rcvr_).set_value(static_cast<_As&&>(__as)...);
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _Error>
   _CCCL_TRIVIAL_API void set_error(_Error&& __err) noexcept
   {
     static_cast<_Rcvr&&>(__rcvr_).set_error(static_cast<_Error&&>(__err));
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TRIVIAL_API void set_stopped() noexcept
   {
     static_cast<_Rcvr&&>(__rcvr_).set_stopped();

--- a/cudax/include/cuda/experimental/__execution/rcvr_with_env.cuh
+++ b/cudax/include/cuda/experimental/__execution/rcvr_with_env.cuh
@@ -49,6 +49,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __rcvr_with_env_t : _Rcvr
     template <class _Query>
     using __1st_env_t _CCCL_NODEBUG_ALIAS = decltype(__env_t::__get_1st<_Query>(declval<const __env_t&>()));
 
+    _CCCL_EXEC_CHECK_DISABLE
     template <class _Query>
     _CCCL_TRIVIAL_API constexpr auto query(_Query) const
       noexcept(__nothrow_queryable_with<__1st_env_t<_Query>, _Query>) //

--- a/cudax/include/cuda/experimental/__execution/read_env.cuh
+++ b/cudax/include/cuda/experimental/__execution/read_env.cuh
@@ -56,6 +56,7 @@ private:
 
     _CCCL_IMMOVABLE_OPSTATE(__opstate_t);
 
+    _CCCL_EXEC_CHECK_DISABLE
     _CCCL_API void start() noexcept
     {
       // If the query invocation is noexcept, call it directly. Otherwise,

--- a/cudax/include/cuda/experimental/__execution/then.cuh
+++ b/cudax/include/cuda/experimental/__execution/then.cuh
@@ -120,6 +120,7 @@ private:
       execution::start(__opstate_);
     }
 
+    _CCCL_EXEC_CHECK_DISABLE
     template <bool _CanThrow = false, class... _Ts>
     _CCCL_API void __set(_Ts&&... __ts) noexcept(!_CanThrow)
     {

--- a/cudax/include/cuda/experimental/__execution/transform_sender.cuh
+++ b/cudax/include/cuda/experimental/__execution/transform_sender.cuh
@@ -91,6 +91,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT transform_sender_t
     return static_cast<_Sndr&&>(__sndr);
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Self = transform_sender_t, class _Domain, class _Sndr, class... _Env)
   _CCCL_REQUIRES((__get_transform_strategy<_Self, _Domain, _Sndr, _Env...>().__strategy_ == __strategy::__transform))
   _CCCL_TRIVIAL_API constexpr auto operator()(_Domain, _Sndr&& __sndr, const _Env&... __env) const
@@ -100,6 +101,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT transform_sender_t
     return __dom_t{}.transform_sender(static_cast<_Sndr&&>(__sndr), __env...);
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Self = transform_sender_t, class _Domain, class _Sndr, class... _Env)
   _CCCL_REQUIRES((__get_transform_strategy<_Self, _Domain, _Sndr, _Env...>().__strategy_
                   == __strategy::__transform_recurse))

--- a/cudax/include/cuda/experimental/__execution/utility.cuh
+++ b/cudax/include/cuda/experimental/__execution/utility.cuh
@@ -81,6 +81,7 @@ _CCCL_API constexpr auto __index_of() noexcept -> size_t
   return execution::__find_pos(__same, __same + sizeof...(_Ts));
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _Ty, class _Uy = _Ty>
 _CCCL_API constexpr auto __exchange(_Ty& __obj, _Uy&& __new_value) noexcept -> _Ty
 {
@@ -94,6 +95,7 @@ _CCCL_API constexpr auto __exchange(_Ty& __obj, _Uy&& __new_value) noexcept -> _
   return old_value;
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _Ty>
 _CCCL_API constexpr void __swap(_Ty& __left, _Ty& __right) noexcept
 {
@@ -107,6 +109,7 @@ _CCCL_API constexpr void __swap(_Ty& __left, _Ty& __right) noexcept
   __right   = static_cast<_Ty&&>(__tmp);
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _Ty>
 _CCCL_API constexpr auto __decay_copy(_Ty&& __ty) noexcept(__nothrow_decay_copyable<_Ty>) -> _CUDA_VSTD::decay_t<_Ty>
 {

--- a/cudax/include/cuda/experimental/__execution/variant.cuh
+++ b/cudax/include/cuda/experimental/__execution/variant.cuh
@@ -95,6 +95,7 @@ public:
     return __index_;
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _Ty, class... _As>
   _CCCL_API auto __emplace(_As&&... __as) //
     noexcept(__nothrow_constructible<_Ty, _As...>) -> _Ty&
@@ -108,6 +109,7 @@ public:
     return *_CUDA_VSTD::launder(__value);
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   template <size_t _Ny, class... _As>
   _CCCL_API auto __emplace_at(_As&&... __as) //
     noexcept(__nothrow_constructible<__at<_Ny>, _As...>) -> __at<_Ny>&
@@ -120,6 +122,7 @@ public:
     return *_CUDA_VSTD::launder(__value);
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _Fn, class... _As>
   _CCCL_API auto __emplace_from(_Fn&& __fn, _As&&... __as) //
     noexcept(__nothrow_callable<_Fn, _As...>) -> __call_result_t<_Fn, _As...>&
@@ -134,6 +137,7 @@ public:
     return *_CUDA_VSTD::launder(__value);
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _Fn, class _Self, class... _As>
   _CCCL_API static void __visit(_Fn&& __fn, _Self&& __self, _As&&... __as) //
     noexcept((__nothrow_callable<_Fn, _As..., __copy_cvref_t<_Self, _Ts>> && ...))

--- a/cudax/include/cuda/experimental/__execution/visit.cuh
+++ b/cudax/include/cuda/experimental/__execution/visit.cuh
@@ -21,6 +21,7 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/std/__tuple_dir/ignore.h>
 #include <cuda/std/__type_traits/copy_cvref.h>
 
 #include <cuda/experimental/__execution/type_traits.cuh>
@@ -60,6 +61,7 @@ inline constexpr size_t structured_binding_size<_Sndr const&> = structured_bindi
 // C++26, structured binding can introduce a pack.
 struct _CCCL_TYPE_VISIBILITY_DEFAULT visit_t
 {
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _Visitor, class _CvSndr, class _Context>
     requires(static_cast<int>(structured_binding_size<_CvSndr>) >= 2)
   _CCCL_TRIVIAL_API constexpr auto operator()(_Visitor& __visitor, _CvSndr&& __sndr, _Context& __context) const
@@ -76,16 +78,27 @@ template <size_t _Arity>
 struct __sender_type_cannot_be_used_to_initialize_a_structured_binding;
 
 template <size_t _Arity>
-extern __sender_type_cannot_be_used_to_initialize_a_structured_binding<_Arity> __unpack;
+struct __unpack
+{
+  // This is to generate a compile-time error if the sender type cannot be used to
+  // initialize a structured binding.
+  auto operator()(_CUDA_VSTD::__ignore_t,
+                  __sender_type_cannot_be_used_to_initialize_a_structured_binding<_Arity>,
+                  _CUDA_VSTD::__ignore_t) const -> void;
+};
 
-#  define _CCCL_UNPACK_SENDER(_Arity)                                                                             \
-    template <>                                                                                                   \
-    [[maybe_unused]]                                                                                              \
-    _CCCL_GLOBAL_CONSTANT auto __unpack<2 + _Arity> =                                                             \
-      [](auto& __visitor, auto&& __sndr, auto& __context) -> decltype(auto) {                                     \
-      using _Sndr _CCCL_NODEBUG_ALIAS                                  = decltype(__sndr);                        \
-      auto&& [__tag, __data _CCCL_PP_REPEAT(_Arity, _CCCL_BIND_CHILD)] = static_cast<_Sndr&&>(__sndr);            \
-      return __visitor(__context, __tag, _CCCL_FWD_LIKE(_Sndr, __data) _CCCL_PP_REPEAT(_Arity, _CCCL_FWD_CHILD)); \
+#  define _CCCL_UNPACK_SENDER(_Arity)                                                                               \
+    template <>                                                                                                     \
+    struct __unpack<2 + _Arity>                                                                                     \
+    {                                                                                                               \
+      _CCCL_EXEC_CHECK_DISABLE                                                                                      \
+      template <class _Visitor, class _Sndr, class _Context>                                                        \
+      _CCCL_API constexpr auto operator()(_Visitor& __visitor, _Sndr&& __sndr, _Context& __context) const           \
+        -> decltype(auto)                                                                                           \
+      {                                                                                                             \
+        auto&& [__tag, __data _CCCL_PP_REPEAT(_Arity, _CCCL_BIND_CHILD)] = static_cast<_Sndr&&>(__sndr);            \
+        return __visitor(__context, __tag, _CCCL_FWD_LIKE(_Sndr, __data) _CCCL_PP_REPEAT(_Arity, _CCCL_FWD_CHILD)); \
+      }                                                                                                             \
     }
 
 _CCCL_UNPACK_SENDER(0);
@@ -105,12 +118,12 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT visit_t
     -> decltype(auto)
   {
     // This `if constexpr` shouldn't be needed given the `requires` clause above. It is
-    // here because nvcc 12.0 have a bug where the full signature of the function template
+    // here because nvcc 12.0 has a bug where the full signature of the function template
     // -- including the return type -- is instantiated before the `requires` clause is
     // checked.
     if constexpr (static_cast<int>(structured_binding_size<_Sndr>) >= 2)
     {
-      return __unpack<structured_binding_size<_Sndr>>(__visitor, static_cast<_Sndr&&>(__sndr), __context);
+      return __unpack<structured_binding_size<_Sndr>>{}(__visitor, static_cast<_Sndr&&>(__sndr), __context);
     }
   }
 };

--- a/cudax/include/cuda/experimental/__stream/get_stream.cuh
+++ b/cudax/include/cuda/experimental/__stream/get_stream.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -55,14 +55,16 @@ _CCCL_CONCEPT __has_query_get_stream = _CCCL_REQUIRES_EXPR((_Env), const _Env& _
 //! @brief `get_stream` is a customization point object that queries a type `T` for an associated stream
 struct get_stream_t
 {
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(__convertible_to_stream_ref<_Tp>)
   [[nodiscard]] _CCCL_HIDE_FROM_ABI constexpr ::cuda::stream_ref operator()(const _Tp& __t) const
     noexcept(noexcept(static_cast<::cuda::stream_ref>(__t)))
   {
     return static_cast<::cuda::stream_ref>(__t);
-  } // namespace __get_stream
+  }
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(__has_member_get_stream<_Tp>)
   [[nodiscard]] _CCCL_HIDE_FROM_ABI constexpr ::cuda::stream_ref operator()(const _Tp& __t) const
@@ -71,6 +73,7 @@ struct get_stream_t
     return __t.get_stream();
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Env)
   _CCCL_REQUIRES(__has_query_get_stream<_Env>)
   [[nodiscard]] _CCCL_HIDE_FROM_ABI constexpr ::cuda::stream_ref operator()(const _Env& __env) const noexcept


### PR DESCRIPTION
## Description

µstdex has a lot of `__host__`/`__device__` functions that call member functions of user-defined types. if those member functions are not _also_ `__host__`/`__device__`, this will generate a possibly bogus warning or error.

this pr changes µstdex to suppress the execution space warning for any `__host__`/`__device__` function that might end up calling a host- or device-only function.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
