### PR TITLE
Introduce temp storage alignment awareness to cuda.cooperative.

### DIFF
--- a/python/cuda_cooperative/cuda/cooperative/experimental/_common.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/_common.py
@@ -6,7 +6,7 @@ import re
 import tempfile
 from collections import namedtuple
 from enum import Enum
-from typing import Union
+from typing import BinaryIO, Union
 
 import numba
 import numpy as np
@@ -47,7 +47,17 @@ class CudaSharedMemConfig(Enum):
         return f"cudaSharedMem{self.name}"
 
 
-def make_binary_tempfile(content, suffix):
+def make_binary_tempfile(content: bytes, suffix: str) -> BinaryIO:
+    """
+    Creates an unbuffered temporary binary file containing **content** and
+    ending with **suffix**.  The caller is responsible for closing the file.
+
+    :param content: Supplies the content to write to the temporary file.
+
+    :param suffix: Supplies the suffix for the temporary file.
+
+    :return: A binary file-like object representing the temporary file.
+    """
     tmp = tempfile.NamedTemporaryFile(mode="w+b", suffix=suffix, buffering=0)
     tmp.write(content)
     return tmp

--- a/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_load_store.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_load_store.py
@@ -121,7 +121,8 @@ def load(dtype, threads_per_block, items_per_thread=1, algorithm="direct"):
             make_binary_tempfile(ltoir, ".ltoir")
             for ltoir in specialization.get_lto_ir()
         ],
-        temp_storage_bytes=specialization.get_temp_storage_bytes(),
+        temp_storage_bytes=specialization.temp_storage_bytes,
+        temp_storage_alignment=specialization.temp_storage_alignment,
         algorithm=specialization,
     )
 
@@ -208,6 +209,7 @@ def store(dtype, threads_per_block, items_per_thread=1, algorithm="direct"):
             make_binary_tempfile(ltoir, ".ltoir")
             for ltoir in specialization.get_lto_ir()
         ],
-        temp_storage_bytes=specialization.get_temp_storage_bytes(),
+        temp_storage_bytes=specialization.temp_storage_bytes,
+        temp_storage_alignment=specialization.temp_storage_alignment,
         algorithm=specialization,
     )

--- a/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_merge_sort.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_merge_sort.py
@@ -119,6 +119,7 @@ def merge_sort_keys(
             make_binary_tempfile(ltoir, ".ltoir")
             for ltoir in specialization.get_lto_ir()
         ],
-        temp_storage_bytes=specialization.get_temp_storage_bytes(),
+        temp_storage_bytes=specialization.temp_storage_bytes,
+        temp_storage_alignment=specialization.temp_storage_alignment,
         algorithm=specialization,
     )

--- a/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_radix_sort.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_radix_sort.py
@@ -126,7 +126,8 @@ def _radix_sort(
             make_binary_tempfile(ltoir, ".ltoir")
             for ltoir in specialization.get_lto_ir()
         ],
-        temp_storage_bytes=specialization.get_temp_storage_bytes(),
+        temp_storage_bytes=specialization.temp_storage_bytes,
+        temp_storage_alignment=specialization.temp_storage_alignment,
         algorithm=specialization,
     )
 

--- a/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_reduce.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_reduce.py
@@ -164,7 +164,8 @@ def _reduce(
             make_binary_tempfile(ltoir, ".ltoir")
             for ltoir in specialization.get_lto_ir()
         ],
-        temp_storage_bytes=specialization.get_temp_storage_bytes(),
+        temp_storage_bytes=specialization.temp_storage_bytes,
+        temp_storage_alignment=specialization.temp_storage_alignment,
         algorithm=specialization,
     )
 

--- a/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_scan.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_scan.py
@@ -654,7 +654,8 @@ def scan(
             make_binary_tempfile(ltoir, ".ltoir")
             for ltoir in specialization.get_lto_ir()
         ],
-        temp_storage_bytes=specialization.get_temp_storage_bytes(),
+        temp_storage_bytes=specialization.temp_storage_bytes,
+        temp_storage_alignment=specialization.temp_storage_alignment,
         algorithm=specialization,
     )
 

--- a/python/cuda_cooperative/cuda/cooperative/experimental/warp/_warp_merge_sort.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/warp/_warp_merge_sort.py
@@ -92,6 +92,7 @@ def merge_sort_keys(
             make_binary_tempfile(ltoir, ".ltoir")
             for ltoir in specialization.get_lto_ir(threads=threads_in_warp)
         ],
-        temp_storage_bytes=specialization.get_temp_storage_bytes(),
+        temp_storage_bytes=specialization.temp_storage_bytes,
+        temp_storage_alignment=specialization.temp_storage_alignment,
         algorithm=specialization,
     )

--- a/python/cuda_cooperative/cuda/cooperative/experimental/warp/_warp_reduce.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/warp/_warp_reduce.py
@@ -83,7 +83,8 @@ def reduce(dtype, binary_op, threads_in_warp=32, methods=None):
             make_binary_tempfile(ltoir, ".ltoir")
             for ltoir in specialization.get_lto_ir(threads=threads_in_warp)
         ],
-        temp_storage_bytes=specialization.get_temp_storage_bytes(),
+        temp_storage_bytes=specialization.temp_storage_bytes,
+        temp_storage_alignment=specialization.temp_storage_alignment,
         algorithm=specialization,
     )
 
@@ -146,6 +147,7 @@ def sum(dtype, threads_in_warp=32):
             make_binary_tempfile(ltoir, ".ltoir")
             for ltoir in specialization.get_lto_ir(threads=threads_in_warp)
         ],
-        temp_storage_bytes=specialization.get_temp_storage_bytes(),
+        temp_storage_bytes=specialization.temp_storage_bytes,
+        temp_storage_alignment=specialization.temp_storage_alignment,
         algorithm=specialization,
     )

--- a/python/cuda_cooperative/cuda/cooperative/experimental/warp/_warp_scan.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/warp/_warp_scan.py
@@ -72,6 +72,7 @@ def exclusive_sum(dtype, threads_in_warp=32):
             make_binary_tempfile(ltoir, ".ltoir")
             for ltoir in specialization.get_lto_ir(threads=threads_in_warp)
         ],
-        temp_storage_bytes=specialization.get_temp_storage_bytes(),
+        temp_storage_bytes=specialization.temp_storage_bytes,
+        temp_storage_alignment=specialization.temp_storage_alignment,
         algorithm=specialization,
     )

--- a/python/cuda_cooperative/tests/test_block_reduce.py
+++ b/python/cuda_cooperative/tests/test_block_reduce.py
@@ -635,3 +635,24 @@ def test_block_sum_invalid_algorithm():
             threads_per_block=128,
             algorithm="invalid_algorithm",
         )
+
+
+def test_sum_alignment():
+    sum1 = cudax.block.sum(
+        dtype=types.int32,
+        threads_per_block=256,
+    )
+
+    sum2 = cudax.block.sum(
+        dtype=types.float64,
+        threads_per_block=256,
+    )
+
+    sum3 = cudax.block.sum(
+        dtype=types.int8,
+        threads_per_block=256,
+    )
+
+    assert sum1.temp_storage_alignment == 4
+    assert sum2.temp_storage_alignment == 8
+    assert sum3.temp_storage_alignment == 1

--- a/python/cuda_cooperative/tests/test_block_scan.py
+++ b/python/cuda_cooperative/tests/test_block_scan.py
@@ -886,3 +886,18 @@ def test_block_scan_known_ops(
     sass = kernel.inspect_sass(sig)
     assert "LDL" not in sass
     assert "STL" not in sass
+
+
+def test_inclusive_sum_alignment():
+    block_scan1 = cudax.block.inclusive_sum(
+        dtype=types.int32,
+        threads_per_block=256,
+    )
+
+    block_scan2 = cudax.block.inclusive_sum(
+        dtype=types.float64,
+        threads_per_block=256,
+    )
+
+    assert block_scan1.temp_storage_alignment == 16
+    assert block_scan2.temp_storage_alignment == 16


### PR DESCRIPTION
This is a relatively simple PR that plumbs `temp_storage_alignment` in the same fashion as `temp_storage_bytes`.  Commits have been crafted to simplify review.

- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
