### PR TITLE
make it possible to get the status code from a `cuda_error` exception object

### DIFF
--- a/libcudacxx/include/cuda/std/__exception/cuda_error.h
+++ b/libcudacxx/include/cuda/std/__exception/cuda_error.h
@@ -42,6 +42,12 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_CUDA
 
+#if _CCCL_HAS_CTK()
+using __cuda_error_t = ::cudaError_t;
+#else
+using __cuda_error_t = int;
+#endif
+
 #if _CCCL_HAS_EXCEPTIONS()
 
 namespace __detail
@@ -77,11 +83,6 @@ static char* __format_cuda_error(
   return __msg_buffer.__buffer;
 }
 
-#  if _CCCL_HAS_CTK()
-using __cuda_error_t = ::cudaError_t;
-#  else
-using __cuda_error_t = int;
-#  endif
 } // namespace __detail
 
 /**
@@ -90,7 +91,7 @@ using __cuda_error_t = int;
 class cuda_error : public ::std::runtime_error
 {
 public:
-  cuda_error(const __detail::__cuda_error_t __status,
+  cuda_error(const __cuda_error_t __status,
              const char* __msg,
              const char* __api                    = nullptr,
              _CUDA_VSTD::source_location __loc    = _CUDA_VSTD::source_location::current(),
@@ -99,17 +100,17 @@ public:
       , __status_(__status)
   {}
 
-  auto status() const noexcept -> __detail::__cuda_error_t
+  auto status() const noexcept -> __cuda_error_t
   {
     return __status_;
   }
 
 private:
-  __detail::__cuda_error_t __status_;
+  __cuda_error_t __status_;
 };
 
 [[noreturn]] _LIBCUDACXX_HIDE_FROM_ABI void __throw_cuda_error(
-  [[maybe_unused]] const __detail::__cuda_error_t __status,
+  [[maybe_unused]] const __cuda_error_t __status,
   [[maybe_unused]] const char* __msg,
   [[maybe_unused]] const char* __api                 = nullptr,
   [[maybe_unused]] _CUDA_VSTD::source_location __loc = _CUDA_VSTD::source_location::current())
@@ -123,7 +124,7 @@ class cuda_error
 {
 public:
   _LIBCUDACXX_HIDE_FROM_ABI cuda_error(
-    const __detail::__cuda_error_t,
+    const __cuda_error_t,
     const char*,
     const char*                 = nullptr,
     _CUDA_VSTD::source_location = _CUDA_VSTD::source_location::current()) noexcept
@@ -131,7 +132,7 @@ public:
 };
 
 [[noreturn]] _LIBCUDACXX_HIDE_FROM_ABI void __throw_cuda_error(
-  const __detail::__cuda_error_t,
+  const __cuda_error_t,
   const char*,
   const char*                 = nullptr,
   _CUDA_VSTD::source_location = _CUDA_VSTD::source_location::current())

--- a/libcudacxx/include/cuda/std/__exception/cuda_error.h
+++ b/libcudacxx/include/cuda/std/__exception/cuda_error.h
@@ -67,7 +67,7 @@ static char* __format_cuda_error(
     __loc.line(),
     __api ? __api : "",
     __api ? " " : "",
-#  if _CCCL_HAS_CUDA_COMPILER()
+#  if _CCCL_HAS_CTK()
     ::cudaGetErrorString(::cudaError_t(__status)),
 #  else
     "cudaError",
@@ -76,6 +76,12 @@ static char* __format_cuda_error(
     __msg);
   return __msg_buffer.__buffer;
 }
+
+#  if _CCCL_HAS_CTK()
+using __cuda_error_t = ::cudaError_t;
+#  else
+using __cuda_error_t = int;
+#  endif
 } // namespace __detail
 
 /**
@@ -84,7 +90,7 @@ static char* __format_cuda_error(
 class cuda_error : public ::std::runtime_error
 {
 public:
-  cuda_error(const int __status,
+  cuda_error(const __detail::__cuda_error_t __status,
              const char* __msg,
              const char* __api                    = nullptr,
              _CUDA_VSTD::source_location __loc    = _CUDA_VSTD::source_location::current(),
@@ -93,17 +99,17 @@ public:
       , __status_(__status)
   {}
 
-  auto status() const noexcept -> cudaError_t
+  auto status() const noexcept -> __detail::__cuda_error_t
   {
-    return static_cast<cudaError_t>(__status_);
+    return __status_;
   }
 
 private:
-  int __status_;
+  __detail::__cuda_error_t __status_;
 };
 
 [[noreturn]] _LIBCUDACXX_HIDE_FROM_ABI void __throw_cuda_error(
-  [[maybe_unused]] const int __status,
+  [[maybe_unused]] const __detail::__cuda_error_t __status,
   [[maybe_unused]] const char* __msg,
   [[maybe_unused]] const char* __api                 = nullptr,
   [[maybe_unused]] _CUDA_VSTD::source_location __loc = _CUDA_VSTD::source_location::current())
@@ -117,7 +123,7 @@ class cuda_error
 {
 public:
   _LIBCUDACXX_HIDE_FROM_ABI cuda_error(
-    const int,
+    const __detail::__cuda_error_t,
     const char*,
     const char*                 = nullptr,
     _CUDA_VSTD::source_location = _CUDA_VSTD::source_location::current()) noexcept
@@ -125,7 +131,10 @@ public:
 };
 
 [[noreturn]] _LIBCUDACXX_HIDE_FROM_ABI void __throw_cuda_error(
-  const int, const char*, const char* = nullptr, _CUDA_VSTD::source_location = _CUDA_VSTD::source_location::current())
+  const __detail::__cuda_error_t,
+  const char*,
+  const char*                 = nullptr,
+  _CUDA_VSTD::source_location = _CUDA_VSTD::source_location::current())
 {
   _CUDA_VSTD_NOVERSION::terminate();
 }

--- a/libcudacxx/include/cuda/std/__exception/cuda_error.h
+++ b/libcudacxx/include/cuda/std/__exception/cuda_error.h
@@ -90,7 +90,16 @@ public:
              _CUDA_VSTD::source_location __loc    = _CUDA_VSTD::source_location::current(),
              __detail::__msg_storage __msg_buffer = {}) noexcept
       : ::std::runtime_error(__detail::__format_cuda_error(__msg_buffer, __status, __msg, __api, __loc))
+      , __status_(__status)
   {}
+
+  auto status() const noexcept -> cudaError_t
+  {
+    return static_cast<cudaError_t>(__status_);
+  }
+
+private:
+  int __status_;
 };
 
 [[noreturn]] _LIBCUDACXX_HIDE_FROM_ABI void __throw_cuda_error(

--- a/libcudacxx/include/cuda/std/__exception/cuda_error.h
+++ b/libcudacxx/include/cuda/std/__exception/cuda_error.h
@@ -100,7 +100,7 @@ public:
       , __status_(__status)
   {}
 
-  auto status() const noexcept -> __cuda_error_t
+  [[nodiscard]] auto status() const noexcept -> __cuda_error_t
   {
     return __status_;
   }


### PR DESCRIPTION
## Description

the cudax apis throw `cuda_error` on errors. for the sake of interfacing with legacy code, there should be a way to convert the `cuda_error` object into the `cudaError_t` status code.
