### PR TITLE
move `forwarding_query` to `cuda/std/__execution/env.h`

### DIFF
--- a/cudax/include/cuda/experimental/__execution/fwd.cuh
+++ b/cudax/include/cuda/experimental/__execution/fwd.cuh
@@ -134,7 +134,6 @@ struct sync_wait_t;
 struct start_detached_t;
 
 // queries:
-struct forwarding_query_t;
 struct get_allocator_t;
 struct get_stop_token_t;
 struct get_scheduler_t;

--- a/cudax/include/cuda/experimental/__execution/queries.cuh
+++ b/cudax/include/cuda/experimental/__execution/queries.cuh
@@ -41,26 +41,10 @@ _CCCL_SUPPRESS_DEPRECATED_POP
 
 namespace cuda::experimental::execution
 {
+using _CUDA_STD_EXEC::__forwarding_query;
 using _CUDA_STD_EXEC::__queryable_with;
-
-//////////////////////////////////////////////////////////////////////////////////////////
-// forwarding_query_t
-_CCCL_GLOBAL_CONSTANT struct forwarding_query_t
-{
-  template <class _Tag>
-  [[nodiscard]] _CCCL_API constexpr auto operator()(_Tag) const noexcept -> bool
-  {
-    if constexpr (__queryable_with<_Tag, forwarding_query_t>)
-    {
-      static_assert(noexcept(_Tag().query(*this)));
-      return _Tag().query(*this);
-    }
-    return _CUDA_VSTD::derived_from<_Tag, forwarding_query_t>;
-  }
-} forwarding_query{};
-
-template <class _Tag>
-_CCCL_CONCEPT __forwarding_query = _CCCL_REQUIRES_EXPR((_Tag))(forwarding_query(_Tag{}));
+using _CUDA_STD_EXEC::forwarding_query;
+using _CUDA_STD_EXEC::forwarding_query_t;
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // get_allocator

--- a/cudax/include/cuda/experimental/__stream/get_stream.cuh
+++ b/cudax/include/cuda/experimental/__stream/get_stream.cuh
@@ -24,10 +24,10 @@
 #include <cuda/std/__concepts/concept_macros.h>
 #include <cuda/std/__concepts/convertible_to.h>
 #include <cuda/std/__cuda/api_wrapper.h>
+#include <cuda/std/__execution/env.h>
 #include <cuda/std/__type_traits/is_convertible.h>
 #include <cuda/stream_ref>
 
-#include <cuda/experimental/__execution/queries.cuh>
 #include <cuda/experimental/__stream/stream.cuh>
 
 #include <cuda_runtime_api.h>
@@ -83,7 +83,7 @@ struct get_stream_t
     return __env.query(*this);
   }
 
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI static constexpr auto query(execution::forwarding_query_t) noexcept -> bool
+  [[nodiscard]] _CCCL_HIDE_FROM_ABI static constexpr auto query(_CUDA_STD_EXEC::forwarding_query_t) noexcept -> bool
   {
     return true;
   }

--- a/libcudacxx/include/cuda/std/__execution/env.h
+++ b/libcudacxx/include/cuda/std/__execution/env.h
@@ -22,6 +22,7 @@
 #endif // no system header
 
 #include <cuda/std/__concepts/concept_macros.h>
+#include <cuda/std/__concepts/derived_from.h>
 #include <cuda/std/__functional/reference_wrapper.h>
 #include <cuda/std/__tuple_dir/ignore.h>
 #include <cuda/std/__type_traits/enable_if.h>
@@ -366,6 +367,25 @@ _CCCL_GLOBAL_CONSTANT get_env_t get_env{};
 
 template <class _Ty>
 using env_of_t _CCCL_NODEBUG_ALIAS = decltype(get_env(declval<_Ty>()));
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// forwarding_query_t
+_CCCL_GLOBAL_CONSTANT struct forwarding_query_t
+{
+  template <class _Tag>
+  [[nodiscard]] _CCCL_API constexpr auto operator()(_Tag) const noexcept -> bool
+  {
+    if constexpr (__queryable_with<_Tag, forwarding_query_t>)
+    {
+      static_assert(noexcept(_Tag().query(*this)));
+      return _Tag().query(*this);
+    }
+    return _CUDA_VSTD::derived_from<_Tag, forwarding_query_t>;
+  }
+} forwarding_query{};
+
+template <class _Tag>
+_CCCL_CONCEPT __forwarding_query = _CCCL_REQUIRES_EXPR((_Tag))(forwarding_query(_Tag{}));
 
 _LIBCUDACXX_END_NAMESPACE_EXECUTION
 


### PR DESCRIPTION
## Description

#4737 needs a non-experimental `forwarding_query_t` definition. this PR moves its definition from cudax into `<cuda/std/__execution/env.h>`.