### PR TITLE
Segmented reduce to reuse CUB's tuning policy

### DIFF
--- a/c/parallel/include/cccl/c/segmented_reduce.h
+++ b/c/parallel/include/cccl/c/segmented_reduce.h
@@ -30,6 +30,7 @@ typedef struct cccl_device_segmented_reduce_build_result_t
   CUlibrary library;
   uint64_t accumulator_size;
   CUkernel segmented_reduce_kernel;
+  void* runtime_policy;
 } cccl_device_segmented_reduce_build_result_t;
 
 // TODO return a union of nvtx/cuda/nvrtc errors or a string?

--- a/c/parallel/src/reduce.cu
+++ b/c/parallel/src/reduce.cu
@@ -175,7 +175,7 @@ CUresult cccl_device_reduce_build(
 
   try
   {
-    const char* name = "test";
+    const char* name = "device_reduce";
 
     const int cc                 = cc_major * 10 + cc_minor;
     const cccl_type_info accum_t = reduce::get_accumulator_type(op, input_it, init);
@@ -241,7 +241,7 @@ struct __align__({1}) storage_t {{
 
 #if false // CCCL_DEBUGGING_SWITCH
     fflush(stderr);
-    printf("\nCODE4NVRTC BEGIN\n%sCODE4NVRTC END\n", src.c_str());
+    printf("\nCODE4NVRTC BEGIN\n%sCODE4NVRTC END\n", final_src.c_str());
     fflush(stdout);
 #endif
 

--- a/c/parallel/src/segmented_reduce.cu
+++ b/c/parallel/src/segmented_reduce.cu
@@ -128,7 +128,10 @@ struct segmented_reduce_kernel_source
 };
 } // namespace segmented_reduce
 
-struct segmented_reduce_iterator_tag;
+struct segmented_reduce_input_iterator_tag;
+struct segmented_reduce_output_iterator_tag;
+struct segmented_reduce_start_offset_iterator_tag;
+struct segmented_reduce_end_offset_iterator_tag;
 struct segmented_reduce_operation_tag;
 
 CUresult cccl_device_segmented_reduce_build(
@@ -157,14 +160,17 @@ CUresult cccl_device_segmented_reduce_build(
     const auto accum_cpp         = cccl_type_enum_to_name(accum_t.type);
 
     const auto [input_iterator_name, input_iterator_src] =
-      get_specialization<segmented_reduce_iterator_tag>(template_id<input_iterator_traits>(), input_it);
+      get_specialization<segmented_reduce_input_iterator_tag>(template_id<input_iterator_traits>(), input_it);
 
-    const auto [output_iterator_name, output_iterator_src] =
-      get_specialization<segmented_reduce_iterator_tag>(template_id<output_iterator_traits>(), output_it, accum_t);
+    const auto [output_iterator_name, output_iterator_src] = get_specialization<segmented_reduce_output_iterator_tag>(
+      template_id<output_iterator_traits>(), output_it, accum_t);
+
     const auto [start_offset_iterator_name, start_offset_iterator_src] =
-      get_specialization<segmented_reduce_iterator_tag>(template_id<input_iterator_traits>(), start_offset_it);
+      get_specialization<segmented_reduce_start_offset_iterator_tag>(
+        template_id<input_iterator_traits>(), start_offset_it);
+
     const auto [end_offset_iterator_name, end_offset_iterator_src] =
-      get_specialization<segmented_reduce_iterator_tag>(template_id<input_iterator_traits>(), end_offset_it);
+      get_specialization<segmented_reduce_end_offset_iterator_tag>(template_id<input_iterator_traits>(), end_offset_it);
 
     const auto [op_name, op_src] =
       get_specialization<segmented_reduce_operation_tag>(template_id<binary_user_operation_traits>(), op, accum_t);


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes #4360

<!-- Provide a standalone description of changes in this PR. -->

This PR transitions `cccl_device_segmented_reduce` to reuse CUB's tuning policies, as well as use modern Jinja's template machinery to generate device code for iterators and operators.

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
