### PR TITLE
Add `cuda::device::warp_match_all`

### DIFF
--- a/docs/libcudacxx/extended_api/warp.rst
+++ b/docs/libcudacxx/extended_api/warp.rst
@@ -37,3 +37,8 @@ Warp
      - Warp shuffle from original lane index xor mask
      - CCCL 3.0.0
      - CUDA 13.0
+
+   * - :ref:`warp_match_all <libcudacxx-extended-api-warp-warp-match-all>`
+     - Check if all lanes have the same value
+     - CCCL 3.1.0
+     - CUDA 13.1

--- a/docs/libcudacxx/extended_api/warp/warp_match_all.rst
+++ b/docs/libcudacxx/extended_api/warp/warp_match_all.rst
@@ -1,0 +1,65 @@
+.. _libcudacxx-extended-api-warp-warp-match-all:
+
+Warp Match All
+==============
+
+``warp_match_all``:
+
+.. code:: cuda
+
+    template <typename T>
+    [[nodiscard]] __device__ bool
+    warp_match_all(const T& data, uint32_t lane_mask = 0xFFFFFFFF)
+
+The functionality provides a generalized and safe alternative to CUDA warp match all intrinsic ``__match_all_sync``.
+The function allows to exchange data of any data size, including raw arrays, pointers, and structs.
+
+**Parameters**
+
+- ``data``: data to exchange.
+- ``lane_mask``: mask of the active lanes
+
+**Return value**
+
+- ``true`` if all lanes in the ``lane_mask`` have the same value for ``data``. ``false`` otherwise
+
+**Preconditions**
+
+- ``lane_mask`` must be a subset of the active mask and be non-zero
+
+**Performance considerations**
+
+- The function calls the PTX instruction ``match.sync`` :math:`ceil\left(\frac{sizeof(data)}{4}\right)` times.
+
+**References**
+
+- `CUDA match_all Intrinsics <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#warp-match-functions>`_
+- `PTX match.sync instruction <https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#parallel-synchronization-and-communication-instructions-match-sync>`_
+
+Example
+-------
+
+.. code:: cuda
+
+    #include <cuda/std/array>
+    #include <cuda/std/cassert>
+    #include <cuda/warp>
+
+    struct MyStruct {
+        double x;
+        int    y;
+    };
+
+    __global__ void warp_match_kernel() {
+        assert(cuda::device::warp_match_all(2));
+        assert(cuda::device::warp_match_all(MyStruct{1.0, 3}));
+        assert(!cuda::device::warp_match_all(threadIdx.x));
+    }
+
+    int main() {
+        warp_match_kernel<<<1, 32>>>();
+        cudaDeviceSynchronize();
+        return 0;
+    }
+
+`See it on Godbolt 🔗 <https://godbolt.org/z/MYv7jMsss>`_

--- a/docs/libcudacxx/extended_api/warp/warp_shuffle.rst
+++ b/docs/libcudacxx/extended_api/warp/warp_shuffle.rst
@@ -107,7 +107,7 @@ The functions allow to exchange data of any data size, including raw arrays, poi
 
 **Preconditions**
 
-- ``lane_mask`` must be a subset of the active mask
+- ``lane_mask`` must be a subset of the active mask and be non-zero
 - The destination lane must be a member of the ``lane_mask``
 - ``delta`` and ``xor_mask`` must be less than ``Width``. Modulo behavior is allowed for ``src_lane``
 - All lanes must have the same value for ``lane_mask``, ``delta`` and ``xor_mask``

--- a/libcudacxx/include/cuda/__warp/warp_match_all.h
+++ b/libcudacxx/include/cuda/__warp/warp_match_all.h
@@ -1,0 +1,63 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPO__RATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA___WARP_WARP_MATCH_H
+#define _CUDA___WARP_WARP_MATCH_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/__cmath/ceil_div.h>
+#include <cuda/std/__memory/addressof.h>
+#include <cuda/std/__type_traits/remove_cv.h>
+#include <cuda/std/cstdint>
+
+#if __cccl_ptx_isa >= 600
+
+#  include <cuda/std/__cccl/prologue.h>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_CUDA_DEVICE
+
+extern "C" _CCCL_DEVICE void __cuda__match_all_sync_is_not_supported_before_SM_70__();
+
+template <typename _Tp, typename _Up = _CUDA_VSTD::remove_cv_t<_Tp>>
+[[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_DEVICE bool warp_match_all(const _Tp& __data, uint32_t __lane_mask = 0xFFFFFFFF)
+{
+  constexpr int __ratio = ::cuda::ceil_div(sizeof(_Up), sizeof(uint32_t));
+  _CCCL_ASSERT((__lane_mask & __activemask()) == __lane_mask, "lane mask must be a subset of the active mask");
+  _CCCL_ASSERT(__lane_mask != 0, "lane_mask must be non-zero");
+  uint32_t __array[__ratio];
+  ::memcpy(__array, _CUDA_VSTD::addressof(__data), sizeof(_Up));
+  bool __ret = true;
+  _CCCL_PRAGMA_UNROLL_FULL()
+  for (int i = 0; i < __ratio; ++i)
+  {
+    int __pred = false;
+    NV_IF_ELSE_TARGET(NV_PROVIDES_SM_70,
+                      (__match_all_sync(__lane_mask, __array[i], &__pred);),
+                      (__cuda__match_all_sync_is_not_supported_before_SM_70__();));
+    __ret = __ret && __pred;
+  }
+  return __ret;
+}
+
+_LIBCUDACXX_END_NAMESPACE_CUDA_DEVICE
+
+#  include <cuda/std/__cccl/epilogue.h>
+
+#endif // __cccl_ptx_isa >= 600
+#endif // _CUDA___WARP_WARP_MATCH_H

--- a/libcudacxx/include/cuda/__warp/warp_shuffle.h
+++ b/libcudacxx/include/cuda/__warp/warp_shuffle.h
@@ -22,16 +22,16 @@
 #endif // no system header
 
 #include <cuda/__cmath/ceil_div.h>
+#include <cuda/__cmath/pow2.h>
 #include <cuda/__ptx/instructions/get_sreg.h>
 #include <cuda/__ptx/instructions/shfl_sync.h>
-#include <cuda/std/__bit/has_single_bit.h>
 #include <cuda/std/__concepts/concept_macros.h>
 #include <cuda/std/__memory/addressof.h>
 #include <cuda/std/__type_traits/enable_if.h>
 #include <cuda/std/__type_traits/integral_constant.h>
 #include <cuda/std/__type_traits/is_pointer.h>
 #include <cuda/std/__type_traits/is_void.h>
-#include <cuda/std/__type_traits/remove_cvref.h>
+#include <cuda/std/__type_traits/remove_cv.h>
 #include <cuda/std/cstdint>
 
 #if __cccl_ptx_isa >= 600
@@ -48,7 +48,7 @@ struct warp_shuffle_result
 
   template <typename _Up = _Tp>
   [[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_DEVICE
-  operator cuda::std::enable_if_t<!cuda::std::is_array_v<_Up>, _Up>() const
+  operator _CUDA_VSTD::enable_if_t<!_CUDA_VSTD::is_array_v<_Up>, _Up>() const
   {
     return data;
   }
@@ -62,8 +62,9 @@ template <int _Width = 32, typename _Tp, typename _Up = _CUDA_VSTD::remove_cv_t<
   constexpr bool __is_void_ptr = _CUDA_VSTD::is_same_v<_Up, void*> || _CUDA_VSTD::is_same_v<_Up, const void*>;
   static_assert(!_CUDA_VSTD::is_pointer_v<_Up> || __is_void_ptr,
                 "non-void pointers are not allowed to prevent bug-prone code");
-  static_assert(_CUDA_VSTD::has_single_bit(uint32_t{_Width}) && _Width >= 1 && _Width <= __warp_size,
+  static_assert(::cuda::is_power_of_two(_Width) && _Width >= 1 && _Width <= __warp_size,
                 "_Width must be a power of 2 and less or equal to the warp size");
+  _CCCL_ASSERT(__lane_mask != 0, "lane_mask must be non-zero");
   if constexpr (_Width == 1)
   {
     return warp_shuffle_result<_Up>{__data, true};
@@ -74,8 +75,7 @@ template <int _Width = 32, typename _Tp, typename _Up = _CUDA_VSTD::remove_cv_t<
     auto __clamp_segmask  = (_Width - 1u) | ((__warp_size - _Width) << 8);
     bool __pred;
     uint32_t __array[__ratio];
-    _CUDA_VSTD::memcpy(
-      static_cast<void*>(__array), static_cast<const void*>(_CUDA_VSTD::addressof(__data)), sizeof(_Up));
+    ::memcpy(__array, _CUDA_VSTD::addressof(__data), sizeof(_Up));
 
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int i = 0; i < __ratio; ++i)
@@ -84,8 +84,7 @@ template <int _Width = 32, typename _Tp, typename _Up = _CUDA_VSTD::remove_cv_t<
     }
     warp_shuffle_result<_Up> __result;
     __result.pred = __pred;
-    _CUDA_VSTD::memcpy(
-      static_cast<void*>(_CUDA_VSTD::addressof(__result.data)), static_cast<void*>(__array), sizeof(_Up));
+    ::memcpy(_CUDA_VSTD::addressof(__result.data), __array, sizeof(_Up));
     return __result;
   }
 }
@@ -105,12 +104,12 @@ template <int _Width = 32, typename _Tp, typename _Up = _CUDA_VSTD::remove_cv_t<
   constexpr bool __is_void_ptr = _CUDA_VSTD::is_same_v<_Up, void*> || _CUDA_VSTD::is_same_v<_Up, const void*>;
   static_assert(!_CUDA_VSTD::is_pointer_v<_Up> || __is_void_ptr,
                 "non-void pointers are not allowed to prevent bug-prone code");
-  static_assert(_CUDA_VSTD::has_single_bit(uint32_t{_Width}) && _Width >= 1 && _Width <= __warp_size,
+  static_assert(::cuda::is_power_of_two(_Width) && _Width >= 1 && _Width <= __warp_size,
                 "_Width must be a power of 2 and less or equal to the warp size");
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_70,
-    ([[maybe_unused]] int __pred1;
-     _CCCL_ASSERT(__match_all_sync(__activemask(), __delta, &__pred1), "all active lanes must have the same delta");))
+  _CCCL_ASSERT(__lane_mask != 0, "lane_mask must be non-zero");
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
+               (_CCCL_ASSERT(::cuda::device::warp_match_all(__delta, __activemask()),
+                             "all active lanes must have the same delta");))
   if constexpr (_Width == 1)
   {
     _CCCL_ASSERT(__delta == 0, "delta must be 0 when Width == 1");
@@ -123,8 +122,7 @@ template <int _Width = 32, typename _Tp, typename _Up = _CUDA_VSTD::remove_cv_t<
     auto __clamp_segmask  = (__warp_size - _Width) << 8;
     bool __pred;
     uint32_t __array[__ratio];
-    _CUDA_VSTD::memcpy(
-      static_cast<void*>(__array), static_cast<const void*>(_CUDA_VSTD::addressof(__data)), sizeof(_Up));
+    ::memcpy(__array, _CUDA_VSTD::addressof(__data), sizeof(_Up));
 
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int i = 0; i < __ratio; ++i)
@@ -133,8 +131,7 @@ template <int _Width = 32, typename _Tp, typename _Up = _CUDA_VSTD::remove_cv_t<
     }
     warp_shuffle_result<_Up> __result;
     __result.pred = __pred;
-    _CUDA_VSTD::memcpy(
-      static_cast<void*>(_CUDA_VSTD::addressof(__result.data)), static_cast<void*>(__array), sizeof(_Up));
+    ::memcpy(_CUDA_VSTD::addressof(__result.data), __array, sizeof(_Up));
     return __result;
   }
 }
@@ -154,12 +151,12 @@ template <int _Width = 32, typename _Tp, typename _Up = _CUDA_VSTD::remove_cv_t<
   constexpr bool __is_void_ptr = _CUDA_VSTD::is_same_v<_Up, void*> || _CUDA_VSTD::is_same_v<_Up, const void*>;
   static_assert(!_CUDA_VSTD::is_pointer_v<_Up> || __is_void_ptr,
                 "non-void pointers are not allowed to prevent bug-prone code");
-  static_assert(_CUDA_VSTD::has_single_bit(uint32_t{_Width}) && _Width >= 1 && _Width <= __warp_size,
+  static_assert(::cuda::is_power_of_two(_Width) && _Width >= 1 && _Width <= __warp_size,
                 "_Width must be a power of 2 and less or equal to the warp size");
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_70,
-    ([[maybe_unused]] int __pred1;
-     _CCCL_ASSERT(__match_all_sync(__activemask(), __delta, &__pred1), "all active lanes must have the same delta");))
+  _CCCL_ASSERT(__lane_mask != 0, "lane_mask must be non-zero");
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
+               (_CCCL_ASSERT(::cuda::device::warp_match_all(__delta, __activemask()),
+                             "all active lanes must have the same delta");))
   if constexpr (_Width == 1)
   {
     _CCCL_ASSERT(__delta == 0, "delta must be 0 when Width == 1");
@@ -172,8 +169,7 @@ template <int _Width = 32, typename _Tp, typename _Up = _CUDA_VSTD::remove_cv_t<
     auto __clamp_segmask  = (_Width - 1u) | ((__warp_size - _Width) << 8);
     bool __pred;
     uint32_t __array[__ratio];
-    _CUDA_VSTD::memcpy(
-      static_cast<void*>(__array), static_cast<const void*>(_CUDA_VSTD::addressof(__data)), sizeof(_Up));
+    ::memcpy(__array, _CUDA_VSTD::addressof(__data), sizeof(_Up));
 
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int i = 0; i < __ratio; ++i)
@@ -182,8 +178,7 @@ template <int _Width = 32, typename _Tp, typename _Up = _CUDA_VSTD::remove_cv_t<
     }
     warp_shuffle_result<_Up> __result;
     __result.pred = __pred;
-    _CUDA_VSTD::memcpy(
-      static_cast<void*>(_CUDA_VSTD::addressof(__result.data)), static_cast<void*>(__array), sizeof(_Up));
+    ::memcpy(_CUDA_VSTD::addressof(__result.data), __array, sizeof(_Up));
     return __result;
   }
 }
@@ -203,11 +198,12 @@ template <int _Width = 32, typename _Tp, typename _Up = _CUDA_VSTD::remove_cv_t<
   constexpr bool __is_void_ptr = _CUDA_VSTD::is_same_v<_Up, void*> || _CUDA_VSTD::is_same_v<_Up, const void*>;
   static_assert(!_CUDA_VSTD::is_pointer_v<_Up> || __is_void_ptr,
                 "non-void pointers are not allowed to prevent bug-prone code");
-  static_assert(_CUDA_VSTD::has_single_bit(uint32_t{_Width}) && _Width >= 1 && _Width <= __warp_size,
+  static_assert(::cuda::is_power_of_two(_Width) && _Width >= 1 && _Width <= __warp_size,
                 "_Width must be a power of 2 and less or equal to the warp size");
+  _CCCL_ASSERT(__lane_mask != 0, "lane_mask must be non-zero");
   NV_IF_TARGET(NV_PROVIDES_SM_70,
-               ([[maybe_unused]] int __pred1; _CCCL_ASSERT(__match_all_sync(__activemask(), __xor_mask, &__pred1),
-                                                           "all active lanes must have the same delta");))
+               (_CCCL_ASSERT(::cuda::device::warp_match_all(__xor_mask, __activemask()),
+                             "all active lanes must have the same delta");))
   if constexpr (_Width == 1)
   {
     _CCCL_ASSERT(__xor_mask == 0, "delta must be 0 when Width == 1");
@@ -220,8 +216,7 @@ template <int _Width = 32, typename _Tp, typename _Up = _CUDA_VSTD::remove_cv_t<
     auto __clamp_segmask  = (_Width - 1u) | ((__warp_size - _Width) << 8);
     bool __pred;
     uint32_t __array[__ratio];
-    _CUDA_VSTD::memcpy(
-      static_cast<void*>(__array), static_cast<const void*>(_CUDA_VSTD::addressof(__data)), sizeof(_Up));
+    ::memcpy(__array, _CUDA_VSTD::addressof(__data), sizeof(_Up));
 
     _CCCL_PRAGMA_UNROLL_FULL()
     for (int i = 0; i < __ratio; ++i)
@@ -230,8 +225,7 @@ template <int _Width = 32, typename _Tp, typename _Up = _CUDA_VSTD::remove_cv_t<
     }
     warp_shuffle_result<_Up> __result;
     __result.pred = __pred;
-    _CUDA_VSTD::memcpy(
-      static_cast<void*>(_CUDA_VSTD::addressof(__result.data)), static_cast<void*>(__array), sizeof(_Up));
+    ::memcpy(_CUDA_VSTD::addressof(__result.data), __array, sizeof(_Up));
     return __result;
   }
 }

--- a/libcudacxx/include/cuda/warp
+++ b/libcudacxx/include/cuda/warp
@@ -21,6 +21,7 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/__warp/warp_match.h>
 #include <cuda/__warp/warp_shuffle.h>
 
 #endif // _CUDA_WARP

--- a/libcudacxx/test/libcudacxx/cuda/warp/warp_match.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/warp/warp_match.pass.cpp
@@ -1,0 +1,49 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the libcu++ Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+// UNSUPPORTED: pre-sm-70
+
+#include <cuda/std/array>
+#include <cuda/std/cassert>
+#include <cuda/std/cstdint>
+#include <cuda/std/type_traits>
+#include <cuda/warp>
+
+#include "test_macros.h"
+
+template <typename T>
+__device__ void test_types(T valueA = T{}, T valueB = T{1})
+{
+  for (int i = 1; i < 32; ++i)
+  {
+    auto mask = (1u << i) - 1;
+    assert(cuda::device::warp_match_all(valueA, mask));
+    auto value = threadIdx.x == 0 ? valueA : valueB;
+    assert(!cuda::device::warp_match_all(value, mask));
+  }
+}
+
+__global__ void test_kernel()
+{
+  test_types<uint8_t>();
+  test_types<uint16_t>();
+  test_types<uint32_t>();
+  test_types<uint64_t>();
+#if _CCCL_HAS_INT128()
+  test_types<__uint128_t>();
+#endif
+  test_types(char3{0, 0, 0}, char3{1, 1, 1});
+  using array_t = cuda::std::array<char, 6>;
+  test_types(array_t{0, 0, 0, 0, 0, 0}, array_t{1, 1, 1, 1, 1, 1});
+}
+
+int main(int, char**)
+{
+  NV_IF_TARGET(NV_IS_HOST, (test_kernel<<<1, 32>>>();))
+  return 0;
+}


### PR DESCRIPTION
## Description

Following the same idea of the existing utilities in [<cuda/warp>](https://nvidia.github.io/cccl/libcudacxx/extended_api/warp.html), this PR adds `cuda::device::warp_match_all` to check if a subset of lanes has the same value.
The function performs a bitwise comparison. We could raise a compile-time error if the data type overrides the `operator==`. On the other hand, this would prevent comparing types like `cuda::std::array`.
