### PR TITLE
install ca-certificates into devcontainer

### DIFF
--- a/.devcontainer/cccl-entrypoint.sh
+++ b/.devcontainer/cccl-entrypoint.sh
@@ -8,6 +8,8 @@ devcontainer-utils-post-create-command;
 devcontainer-utils-init-git;
 devcontainer-utils-post-attach-command;
 
+sudo apt-get update && sudo apt-get install -y ca-certificates
+
 cd /home/coder/cccl/
 
 # Check if docker CLI is available, and if not, install docker-outside-of-docker feature if specified in devcontainer.json


### PR DESCRIPTION
## Description

Many Python jobs hit this error:

```
curl: (60) SSL certificate problem: unable to get local issuer certificate
More details here: https://curl.se/docs/sslcerts.html

curl failed to verify the legitimacy of the server and therefore could not
establish a secure connection to it. To learn more about this situation and
how to fix it, please visit the web page mentioned above.
```

This is an attempt to fix that by installing `ca-certificates` in the devcontainer.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
