### PR TITLE
Fix cuda.coop limitation preventing user-defined types when items_per_thread > 1 in block scan module.

### DIFF
--- a/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_scan.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_scan.py
@@ -104,7 +104,7 @@ from cuda.cooperative.experimental._typing import (
 def scan(
     dtype: DtypeType,
     threads_per_block: DimType,
-    items_per_thread: int = 4,
+    items_per_thread: int,
     initial_value: Any = None,
     mode: Literal["exclusive", "inclusive"] = "exclusive",
     scan_op: ScanOpType = "+",
@@ -128,9 +128,8 @@ def scan(
         for a 2D or 3D block, respectively.
     :type  threads_per_block: DimType
 
-    :param items_per_thread: Optionally supplies the number of items
-        partitioned onto each thread.  Default is 4.  This parameter must be
-        greater than or equal to 1.
+    :param items_per_thread: Supplies the number of items partitioned onto
+        each thread.  This parameter must be greater than or equal to 1.
     :type  items_per_thread: int, optional
 
     :param initial_value: Optionally supplies the initial value to use for the
@@ -654,7 +653,7 @@ def scan(
 def exclusive_sum(
     dtype: DtypeType,
     threads_per_block: DimType,
-    items_per_thread: int = 4,
+    items_per_thread: int,
     prefix_op: Callable = None,
     algorithm: Literal["raking", "raking_memoize", "warp_scans"] = "raking",
     methods: dict = None,
@@ -699,9 +698,8 @@ def exclusive_sum(
         for a 2D or 3D block, respectively.
     :type  threads_per_block: DimType
 
-    :param items_per_thread: Optionally supplies the number of items
-        partitioned onto each thread.  Default is 4.  This parameter must be
-        greater than or equal to 1.
+    :param items_per_thread: Supplies the number of items partitioned onto
+        each thread.  This parameter must be greater than or equal to 1.
     :type  items_per_thread: int, optional
 
     :param prefix_op: Optionally supplies a callable that will be invoked by the
@@ -749,7 +747,7 @@ def exclusive_sum(
 def inclusive_sum(
     dtype: DtypeType,
     threads_per_block: DimType,
-    items_per_thread: int = 4,
+    items_per_thread: int,
     prefix_op: Callable = None,
     algorithm: Literal["raking", "raking_memoize", "warp_scans"] = "raking",
     methods: dict = None,
@@ -766,9 +764,8 @@ def inclusive_sum(
         for a 2D or 3D block, respectively.
     :type  threads_per_block: DimType
 
-    :param items_per_thread: Optionally supplies the number of items
-        partitioned onto each thread.  Default is 4.  This parameter must be
-        greater than or equal to 1.
+    :param items_per_thread: Supplies the number of items partitioned onto
+        each thread.  This parameter must be greater than or equal to 1.
     :type  items_per_thread: int, optional
 
     :param prefix_op: Optionally supplies a callable that will be invoked by the
@@ -814,8 +811,8 @@ def exclusive_scan(
     dtype: DtypeType,
     threads_per_block: DimType,
     scan_op: ScanOpType,
+    items_per_thread: int,
     initial_value: Any = None,
-    items_per_thread: int = 4,
     prefix_op: Callable = None,
     algorithm: Literal["raking", "raking_memoize", "warp_scans"] = "raking",
     methods: dict = None,
@@ -835,15 +832,14 @@ def exclusive_scan(
     :param scan_op: Supplies the scan operator to use for the block-wide scan.
     :type  scan_op: ScanOpType
 
+    :param items_per_thread: Supplies the number of items partitioned onto
+        each thread.  This parameter must be greater than or equal to 1.
+    :type  items_per_thread: int, optional
+
     :param initial_value: Optionally supplies the initial value to use for the
         block-wide scan.  If a non-None value is supplied, ``prefix_op`` must
         be *None*.
     :type  initial_value: Any, optional
-
-    :param items_per_thread: Optionally supplies the number of items
-        partitioned onto each thread.  Default is 4.  This parameter must be
-        greater than or equal to 1.
-    :type  items_per_thread: int, optional
 
     :param prefix_op: Optionally supplies a callable that will be invoked by
         the first warp of threads in a block with the block aggregate value;
@@ -907,8 +903,8 @@ def inclusive_scan(
     dtype: DtypeType,
     threads_per_block: DimType,
     scan_op: ScanOpType,
+    items_per_thread: int,
     initial_value: Any = None,
-    items_per_thread: int = 4,
     prefix_op: Callable = None,
     algorithm: Literal["raking", "raking_memoize", "warp_scans"] = "raking",
     methods: dict = None,
@@ -928,16 +924,15 @@ def inclusive_scan(
     :param scan_op: Supplies the scan operator to use for the block-wide scan.
     :type  scan_op: ScanOpType
 
+    :param items_per_thread: Supplies the number of items partitioned onto
+        each thread.  This parameter must be greater than or equal to 1.
+    :type  items_per_thread: int, optional
+
     :param initial_value: Optionally supplies the initial value to use for the
         block-wide scan.  If a non-None value is supplied, ``prefix_op`` must
         be *None*.  Only supported when ``items_per_thread > 1``; a
         ``ValueError`` will be raised if this is not the case.
     :type  initial_value: Any, optional
-
-    :param items_per_thread: Optionally supplies the number of items
-        partitioned onto each thread.  Default is 4.  This parameter must be
-        greater than or equal to 1.
-    :type  items_per_thread: int, optional
 
     :param prefix_op: Optionally supplies a callable that will be invoked by
         the first warp of threads in a block with the block aggregate value;

--- a/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_scan.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_scan.py
@@ -104,7 +104,7 @@ from cuda.cooperative.experimental._typing import (
 def scan(
     dtype: DtypeType,
     threads_per_block: DimType,
-    items_per_thread: int = 1,
+    items_per_thread: int = 4,
     initial_value: Any = None,
     mode: Literal["exclusive", "inclusive"] = "exclusive",
     scan_op: ScanOpType = "+",
@@ -128,8 +128,9 @@ def scan(
         for a 2D or 3D block, respectively.
     :type  threads_per_block: DimType
 
-    :param items_per_thread: Supplies the number of items partitioned onto each
-        thread.
+    :param items_per_thread: Optionally supplies the number of items
+        partitioned onto each thread.  Default is 4.  This parameter must be
+        greater than or equal to 1.
     :type  items_per_thread: int, optional
 
     :param initial_value: Optionally supplies the initial value to use for the
@@ -653,7 +654,7 @@ def scan(
 def exclusive_sum(
     dtype: DtypeType,
     threads_per_block: DimType,
-    items_per_thread: int = 1,
+    items_per_thread: int = 4,
     prefix_op: Callable = None,
     algorithm: Literal["raking", "raking_memoize", "warp_scans"] = "raking",
     methods: dict = None,
@@ -698,8 +699,9 @@ def exclusive_sum(
         for a 2D or 3D block, respectively.
     :type  threads_per_block: DimType
 
-    :param items_per_thread: Supplies the number of items partitioned onto each
-        thread.
+    :param items_per_thread: Optionally supplies the number of items
+        partitioned onto each thread.  Default is 4.  This parameter must be
+        greater than or equal to 1.
     :type  items_per_thread: int, optional
 
     :param prefix_op: Optionally supplies a callable that will be invoked by the
@@ -747,7 +749,7 @@ def exclusive_sum(
 def inclusive_sum(
     dtype: DtypeType,
     threads_per_block: DimType,
-    items_per_thread: int = 1,
+    items_per_thread: int = 4,
     prefix_op: Callable = None,
     algorithm: Literal["raking", "raking_memoize", "warp_scans"] = "raking",
     methods: dict = None,
@@ -764,8 +766,9 @@ def inclusive_sum(
         for a 2D or 3D block, respectively.
     :type  threads_per_block: DimType
 
-    :param items_per_thread: Supplies the number of items partitioned onto each
-        thread.
+    :param items_per_thread: Optionally supplies the number of items
+        partitioned onto each thread.  Default is 4.  This parameter must be
+        greater than or equal to 1.
     :type  items_per_thread: int, optional
 
     :param prefix_op: Optionally supplies a callable that will be invoked by the
@@ -812,7 +815,7 @@ def exclusive_scan(
     threads_per_block: DimType,
     scan_op: ScanOpType,
     initial_value: Any = None,
-    items_per_thread: int = 1,
+    items_per_thread: int = 4,
     prefix_op: Callable = None,
     algorithm: Literal["raking", "raking_memoize", "warp_scans"] = "raking",
     methods: dict = None,
@@ -838,7 +841,8 @@ def exclusive_scan(
     :type  initial_value: Any, optional
 
     :param items_per_thread: Optionally supplies the number of items
-        partitioned onto each thread.  Defaults to *1*.
+        partitioned onto each thread.  Default is 4.  This parameter must be
+        greater than or equal to 1.
     :type  items_per_thread: int, optional
 
     :param prefix_op: Optionally supplies a callable that will be invoked by
@@ -904,7 +908,7 @@ def inclusive_scan(
     threads_per_block: DimType,
     scan_op: ScanOpType,
     initial_value: Any = None,
-    items_per_thread: int = 1,
+    items_per_thread: int = 4,
     prefix_op: Callable = None,
     algorithm: Literal["raking", "raking_memoize", "warp_scans"] = "raking",
     methods: dict = None,
@@ -931,7 +935,8 @@ def inclusive_scan(
     :type  initial_value: Any, optional
 
     :param items_per_thread: Optionally supplies the number of items
-        partitioned onto each thread.  Defaults to *1*.
+        partitioned onto each thread.  Default is 4.  This parameter must be
+        greater than or equal to 1.
     :type  items_per_thread: int, optional
 
     :param prefix_op: Optionally supplies a callable that will be invoked by

--- a/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_scan.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_scan.py
@@ -156,17 +156,13 @@ def scan(
     :type  algorithm: Literal["raking", "raking_memoize", "warp_scans"], optional
 
     :param methods: Optionally supplies a dictionary of methods to use for
-        user-defined types.  The default is *None*.  Not supported if
-        ``items_per_thread > 1``.
+        user-defined types.  The default is *None*.
     :type  methods: dict, optional
 
     :raises ValueError: If ``algorithm`` is not one of the supported algorithms
         (``"raking"``, ``"raking_memoize"``, or ``"warp_scans"``).
 
     :raises ValueError: If ``items_per_thread`` is less than 1.
-
-    :raises ValueError: If ``items_per_thread`` is greater than 1 and ``methods``
-        is not *None* (i.e. a user-defined type is being used).
 
     :raises ValueError: If ``mode`` is not one of the supported modes
         (``"exclusive"`` or ``"inclusive"``).
@@ -218,12 +214,6 @@ def scan(
         cpp_function_name = f"{cpp_func_prefix}Sum"
     else:
         cpp_function_name = f"{cpp_func_prefix}Scan"
-
-    # If items_per_thread > 1, we need to check that methods is not None.
-    if items_per_thread > 1 and methods is not None:
-        raise ValueError(
-            "user-defined types are not supported for items_per_thread > 1"
-        )
 
     # An initial value is not supported for inclusive and exclusive sums.
     if initial_value is not None and scan_op.is_sum:

--- a/python/cuda_cooperative/tests/helpers.py
+++ b/python/cuda_cooperative/tests/helpers.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
@@ -14,6 +14,7 @@ from numba.core.extending import (
     type_callable,
     typeof_impl,
 )
+from numba.core.imputils import lower_constant
 
 NUMBA_TYPES_TO_NP = {
     types.int8: np.int8,
@@ -97,4 +98,12 @@ def impl_complex(context, builder, sig, args):
     state = cgutils.create_struct_proxy(typ)(context, builder)
     state.real = real
     state.imag = imag
+    return state._getvalue()
+
+
+@lower_constant(ComplexType)
+def lower_constant_complex(context, builder, typ, value):
+    state = cgutils.create_struct_proxy(typ)(context, builder)
+    state.real = context.get_constant(types.int32, value.real)
+    state.imag = context.get_constant(types.int32, value.imag)
     return state._getvalue()

--- a/python/cuda_cooperative/tests/test_block_scan.py
+++ b/python/cuda_cooperative/tests/test_block_scan.py
@@ -316,7 +316,7 @@ def test_block_scan_sum_invalid_algorithm(mode):
         sum_func = cudax.block.exclusive_sum
 
     with pytest.raises(ValueError):
-        sum_func(numba.int32, 128, algorithm="invalid_algorithm")
+        sum_func(numba.int32, 128, items_per_thread=1, algorithm="invalid_algorithm")
 
 
 @pytest.mark.parametrize("initial_value", [None, Complex(0, 0), Complex(1, 1)])
@@ -892,11 +892,13 @@ def test_inclusive_sum_alignment():
     block_scan1 = cudax.block.inclusive_sum(
         dtype=types.int32,
         threads_per_block=256,
+        items_per_thread=1,
     )
 
     block_scan2 = cudax.block.inclusive_sum(
         dtype=types.float64,
         threads_per_block=256,
+        items_per_thread=1,
     )
 
     assert block_scan1.temp_storage_alignment == 16

--- a/python/cuda_cooperative/tests/test_block_scan.py
+++ b/python/cuda_cooperative/tests/test_block_scan.py
@@ -602,7 +602,13 @@ def test_block_scan_invariants(mode):
                 "with items_per_thread == 1"
             ),
         ):
-            scan_func(numba.int32, 128, scan_op="*", initial_value=0)
+            scan_func(
+                dtype=numba.int32,
+                threads_per_block=128,
+                scan_op="*",
+                items_per_thread=1,
+                initial_value=0,
+            )
 
     # 2) For exclusive scans with items_per_thread=1 and a prefix callback,
     #    initial_value is invalid.
@@ -619,9 +625,10 @@ def test_block_scan_invariants(mode):
             ),
         ):
             scan_func(
-                numba.int32,
-                128,
+                dtype=numba.int32,
+                threads_per_block=128,
                 scan_op="*",
+                items_per_thread=1,
                 initial_value=0,
                 prefix_op=prefix_op,
             )
@@ -638,7 +645,12 @@ def test_block_scan_invariants(mode):
             "operator has been supplied"
         ),
     ):
-        scan_func(complex_type, 128, scan_op="+", items_per_thread=2)
+        scan_func(
+            dtype=complex_type,
+            threads_per_block=128,
+            scan_op="*",
+            items_per_thread=2,
+        )
 
 
 @pytest.mark.parametrize("T", [types.int32])

--- a/python/cuda_cooperative/tests/test_block_scan_api.py
+++ b/python/cuda_cooperative/tests/test_block_scan_api.py
@@ -55,11 +55,14 @@ def test_block_exclusive_sum():
 
 def test_block_exclusive_sum_single_input_per_thread():
     # example-begin exclusive-sum-single-input-per-thread
+    items_per_thread = 1
     threads_per_block = 128
 
     # Specialize exclusive sum for a 1D block of 128 threads.  Each thread
     # owns a single integer item.
-    block_exclusive_sum = cudax.block.exclusive_sum(numba.int32, threads_per_block)
+    block_exclusive_sum = cudax.block.exclusive_sum(
+        numba.int32, threads_per_block, items_per_thread
+    )
 
     # Link the exclusive sum to a CUDA kernel
     @cuda.jit(link=block_exclusive_sum.files)


### PR DESCRIPTION
Commits have been organized to ease review.  Underlying "bug" was fixed by adding a missing `lower_constant` for the `Complex` type we use in our tests of user-defined types.  `_block_scan.py` invariants and docstrings updated accordingly.

Additionally, now that there are no restrictions regarding items_per_thread > 1, I have changed the default from 1 to 4, such that we have a more optimal default out-of-the-box.

- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

This will close #4747 when merged.