### PR TITLE
Clear CUDA error state after a failure

### DIFF
--- a/cudax/include/cuda/experimental/__memory_resource/memory_pool_base.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/memory_pool_base.cuh
@@ -147,11 +147,9 @@ private:
         case ::cudaSuccess:
           break;
         case ::cudaErrorInvalidValue:
-          ::cudaGetLastError(); // Clear CUDA error state
           ::cuda::__throw_cuda_error(
             ::cudaErrorNotSupported, "Requested IPC memory handle type not supported on given device");
         default:
-          ::cudaGetLastError(); // Clear CUDA error state
           ::cuda::__throw_cuda_error(__status, "Failed to call cudaDeviceGetAttribute");
       }
     }

--- a/libcudacxx/include/cuda/__stream/stream_ref.h
+++ b/libcudacxx/include/cuda/__stream/stream_ref.h
@@ -130,7 +130,6 @@ public:
       case ::cudaSuccess:
         break;
       default:
-        ::cudaGetLastError(); // Clear CUDA error state
         ::cuda::__throw_cuda_error(__result, "Failed to query stream.");
     }
     return true;

--- a/libcudacxx/include/cuda/std/__cuda/api_wrapper.h
+++ b/libcudacxx/include/cuda/std/__cuda/api_wrapper.h
@@ -41,8 +41,8 @@
   do                                                                    \
   {                                                                     \
     [[maybe_unused]] const ::cudaError_t __status = _NAME(__VA_ARGS__); \
-    _CCCL_ASSERT(__status == cudaSuccess, _MSG);                        \
     ::cudaGetLastError(); /* clear CUDA error state */                  \
+    _CCCL_ASSERT(__status == cudaSuccess, _MSG);                        \
   } while (0)
 
 #define _CCCL_LOG_CUDA_API(_NAME, _MSG, ...)                                       \

--- a/libcudacxx/include/cuda/std/__cuda/api_wrapper.h
+++ b/libcudacxx/include/cuda/std/__cuda/api_wrapper.h
@@ -23,24 +23,27 @@
 
 #include <cuda/std/__exception/cuda_error.h>
 
-#define _CCCL_TRY_CUDA_API(_NAME, _MSG, ...)                \
-  {                                                         \
-    const ::cudaError_t __status = _NAME(__VA_ARGS__);      \
-    switch (__status)                                       \
-    {                                                       \
-      case ::cudaSuccess:                                   \
-        break;                                              \
-      default:                                              \
-        ::cudaGetLastError();                               \
-        ::cuda::__throw_cuda_error(__status, _MSG, #_NAME); \
-    }                                                       \
-  }
+#define _CCCL_TRY_CUDA_API(_NAME, _MSG, ...)                        \
+  do                                                                \
+  {                                                                 \
+    const ::cudaError_t __status = _NAME(__VA_ARGS__);              \
+    switch (__status)                                               \
+    {                                                               \
+      case ::cudaSuccess:                                           \
+        break;                                                      \
+      default:                                                      \
+        /* CUDA error state is cleared inside __throw_cuda_error */ \
+        ::cuda::__throw_cuda_error(__status, _MSG, #_NAME);         \
+    }                                                               \
+  } while (0)
 
 #define _CCCL_ASSERT_CUDA_API(_NAME, _MSG, ...)                         \
+  do                                                                    \
   {                                                                     \
     [[maybe_unused]] const ::cudaError_t __status = _NAME(__VA_ARGS__); \
     _CCCL_ASSERT(__status == cudaSuccess, _MSG);                        \
-  }
+    ::cudaGetLastError(); /* clear CUDA error state */                  \
+  } while (0)
 
 #define _CCCL_LOG_CUDA_API(_NAME, _MSG, ...)                                       \
   [&]() {                                                                          \
@@ -52,6 +55,7 @@
       ::fprintf(stderr, "%s\n", __msg_buffer.__buffer);                            \
       ::fflush(stderr);                                                            \
     }                                                                              \
+    ::cudaGetLastError(); /* clear CUDA error state */                             \
     return __status;                                                               \
   }()
 

--- a/libcudacxx/include/cuda/std/__exception/cuda_error.h
+++ b/libcudacxx/include/cuda/std/__exception/cuda_error.h
@@ -110,7 +110,8 @@ private:
   [[maybe_unused]] _CUDA_VSTD::source_location __loc = _CUDA_VSTD::source_location::current())
 {
   NV_IF_ELSE_TARGET(NV_IS_HOST,
-                    (throw ::cuda::cuda_error(__status, __msg, __api, __loc);), //
+                    (::cudaGetLastError(); // clear CUDA error state
+                     throw ::cuda::cuda_error(__status, __msg, __api, __loc);), //
                     (_CUDA_VSTD_NOVERSION::terminate();))
 }
 #else // ^^^ _CCCL_HAS_EXCEPTIONS() ^^^ / vvv !_CCCL_HAS_EXCEPTIONS() vvv


### PR DESCRIPTION
*"There was a question whether we should clear the cuda error here so that a user does not have to reach back to the cuda API"*

- @miscco, #4731

This PR adds call to `cudaGetLastError` to `_CCCL_XXX_CUDA_API` macros and `cuda::__throw_cuda_error` function, so we clear the CUDA error state after an internal failure.