### PR TITLE
test the return value of `forwarding_query(Tag{})` in the `__forwarding_query` concept

### DIFF
--- a/libcudacxx/include/cuda/std/__execution/env.h
+++ b/libcudacxx/include/cuda/std/__execution/env.h
@@ -391,7 +391,7 @@ _CCCL_GLOBAL_CONSTANT struct forwarding_query_t
 } forwarding_query{};
 
 template <class _Tag>
-_CCCL_CONCEPT __forwarding_query = _CCCL_REQUIRES_EXPR((_Tag))(forwarding_query(_Tag{}));
+_CCCL_CONCEPT __forwarding_query = forwarding_query(_Tag{});
 
 _LIBCUDACXX_END_NAMESPACE_EXECUTION
 


### PR DESCRIPTION
## Description

gcc-9 found a bug in my code! [This build failure](https://github.com/NVIDIA/cccl/actions/runs/15152759398/job/42601790181) in CI flags the fact that the return value of the `forwarding_query(_Tag{})` query was being ignored. this PR fixes the \`__forwarding_query\` concept to actually require that `forwarding_query(_Tag{})` returns `true`.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
