### PR TITLE
fix two issues with `transform_sender`

### DIFF
--- a/cudax/include/cuda/experimental/__execution/cpos.cuh
+++ b/cudax/include/cuda/experimental/__execution/cpos.cuh
@@ -106,6 +106,7 @@ struct start_t
 // connect
 struct connect_t
 {
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _Sndr, class _Rcvr, class _Domain = domain_for_t<_Sndr, env_of_t<_Rcvr>>>
   _CCCL_TRIVIAL_API static constexpr auto __do_transform(_Sndr&& __sndr, _Rcvr __rcvr) noexcept(
     noexcept(transform_sender(_Domain{}, declval<_Sndr>(), get_env(__rcvr)))) -> decltype(auto)
@@ -136,7 +137,7 @@ struct schedule_t
 {
   _CCCL_EXEC_CHECK_DISABLE
   template <class _Sch>
-  _CCCL_TRIVIAL_API auto operator()(_Sch&& __sch) const noexcept -> decltype(declval<_Sch>().schedule())
+  _CCCL_TRIVIAL_API auto operator()(_Sch&& __sch) const noexcept
   {
     static_assert(noexcept(static_cast<_Sch&&>(__sch).schedule()));
     return static_cast<_Sch&&>(__sch).schedule();

--- a/cudax/include/cuda/experimental/__execution/domain.cuh
+++ b/cudax/include/cuda/experimental/__execution/domain.cuh
@@ -22,6 +22,7 @@
 #endif // no system header
 
 #include <cuda/std/__execution/env.h>
+#include <cuda/std/__type_traits/is_nothrow_move_constructible.h>
 
 #include <cuda/experimental/__detail/utility.cuh>
 #include <cuda/experimental/__execution/fwd.cuh>
@@ -30,9 +31,11 @@
 
 namespace cuda::experimental::execution
 {
+// NOLINTBEGIN(misc-unused-using-decls)
 using _CUDA_STD_EXEC::__query_result_t;
 using _CUDA_STD_EXEC::__queryable_with;
 using _CUDA_STD_EXEC::env_of_t;
+// NOLINTEND(misc-unused-using-decls)
 
 template <class _DomainOrTag, class... _Args>
 using __apply_sender_result_t _CCCL_NODEBUG_ALIAS = decltype(_DomainOrTag{}.apply_sender(declval<_Args>()...));
@@ -82,16 +85,21 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT default_domain
   }
 
   //! @overload
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _Sndr>
-  _CCCL_TRIVIAL_API static constexpr auto transform_sender(_Sndr&& __sndr) noexcept -> _Sndr&&
+  _CCCL_TRIVIAL_API static constexpr auto
+  transform_sender(_Sndr&& __sndr) noexcept(_CUDA_VSTD::is_nothrow_move_constructible_v<_Sndr>) -> _Sndr
   {
     // FUTURE TODO: add a transform for the split sender once we have a split sender
     return static_cast<_Sndr&&>(__sndr);
   }
 
   //! @overload
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _Sndr>
-  _CCCL_TRIVIAL_API static constexpr auto transform_sender(_Sndr&& __sndr, _CUDA_VSTD::__ignore_t) noexcept -> _Sndr&&
+  _CCCL_TRIVIAL_API static constexpr auto
+  transform_sender(_Sndr&& __sndr, _CUDA_VSTD::__ignore_t) noexcept(_CUDA_VSTD::is_nothrow_move_constructible_v<_Sndr>)
+    -> _Sndr
   {
     return static_cast<_Sndr&&>(__sndr);
   }

--- a/cudax/include/cuda/experimental/__execution/transform_sender.cuh
+++ b/cudax/include/cuda/experimental/__execution/transform_sender.cuh
@@ -22,6 +22,7 @@
 #endif // no system header
 
 #include <cuda/std/__type_traits/conditional.h>
+#include <cuda/std/__type_traits/is_nothrow_move_constructible.h>
 #include <cuda/std/__type_traits/is_valid_expansion.h>
 
 #include <cuda/experimental/__detail/utility.cuh>
@@ -66,7 +67,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT transform_sender_t
     else
     {
       using __dom2_t _CCCL_NODEBUG_ALIAS = __transform_domain_t<domain_for_t<__result_t, _Env...>, __result_t, _Env...>;
-      using __result2_t _CCCL_NODEBUG_ALIAS = __transform_sender_result_t<__dom2_t, _Sndr, _Env...>;
+      using __result2_t _CCCL_NODEBUG_ALIAS = __transform_sender_result_t<__dom2_t, __result_t, _Env...>;
 
       if constexpr (_CUDA_VSTD::_IsSame<__result2_t&&, __result_t&&>::value)
       {
@@ -84,9 +85,11 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT transform_sender_t
     }
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Self = transform_sender_t, class _Domain, class _Sndr, class... _Env)
   _CCCL_REQUIRES((__get_transform_strategy<_Self, _Domain, _Sndr, _Env...>().__strategy_ == __strategy::__passthru))
-  _CCCL_TRIVIAL_API constexpr auto operator()(_Domain, _Sndr&& __sndr, const _Env&...) const noexcept -> _Sndr&&
+  _CCCL_TRIVIAL_API constexpr auto operator()(_Domain, _Sndr&& __sndr, const _Env&...) const
+    noexcept(_CUDA_VSTD::is_nothrow_move_constructible_v<_Sndr>) -> _Sndr
   {
     return static_cast<_Sndr&&>(__sndr);
   }

--- a/libcudacxx/include/cuda/std/__execution/env.h
+++ b/libcudacxx/include/cuda/std/__execution/env.h
@@ -391,7 +391,7 @@ _CCCL_GLOBAL_CONSTANT struct forwarding_query_t
 } forwarding_query{};
 
 template <class _Tag>
-_CCCL_CONCEPT __forwarding_query = _CCCL_REQUIRES_EXPR((_Tag))(forwarding_query(_Tag{}));
+_CCCL_CONCEPT __forwarding_query = forwarding_query(_Tag{});
 
 _LIBCUDACXX_END_NAMESPACE_EXECUTION
 


### PR DESCRIPTION
## Description

* issue 1: `transform_sender` could return an rvalue reference to a local temporary.
* issue 2: the code for determining whether `transform_sender` should recurse or not was using the wrong sender type to make its determination.

this PR fixes both of these issues. in the next PR i will add tests for `let_value` that exercise this change.