### PR TITLE
port the `let_value` tests over from stdexec

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -22,6 +22,29 @@ CompileFlags:
 
 ---
 
+# For __cccl/epilogue.h, force-include prologue.h to avoid spurious errors
+If:
+  PathMatch: ".*libcudacxx/include/cuda/std/__cccl/epilogue[.]h"
+
+CompileFlags:
+  Add:
+  - -include
+  - cuda/std/__cccl/prologue.h
+  - -Wno-unknown-pragmas
+
+---
+
+# For __cccl/visibility.h, pretend the file has been included from <cuda/__cccl_config>
+If:
+  PathMatch: ".*libcudacxx/include/cuda/std/__cccl/visibility[.]h"
+
+CompileFlags:
+  Add:
+  - -D_CUDA__CCCL_CONFIG
+
+---
+
+# For __execution/epilogue.cuh, force-include prologue.cuh to avoid spurious errors
 If:
   PathMatch: ".*cudax/include/cuda/experimental/__execution/epilogue[.]cuh"
 
@@ -41,6 +64,7 @@ CompileFlags:
     - -x
     - cuda
     - -Wno-unknown-cuda-version
+    - -Wno-pragma-system-header-outside-header
     - --no-cuda-version-check
     # report all errors
     - "-ferror-limit=0"

--- a/cudax/include/cuda/experimental/__execution/completion_signatures.cuh
+++ b/cudax/include/cuda/experimental/__execution/completion_signatures.cuh
@@ -41,6 +41,9 @@
 // include this last:
 #include <cuda/experimental/__execution/prologue.cuh>
 
+_CCCL_DIAG_PUSH
+_CCCL_DIAG_SUPPRESS_GCC("-Wunused-but-set-parameter")
+
 namespace cuda::experimental::execution
 {
 using _CUDA_VSTD::__type_list;
@@ -180,15 +183,20 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT completion_signatures
   {
     if constexpr (_Tag() == set_value)
     {
-      return __partitioned::template __value_types<__type_function<set_value_t>::__call, completion_signatures>();
+      using __result_t =
+        typename __partitioned::template __value_types<__type_function<set_value_t>::__call, completion_signatures>;
+      return __result_t{};
     }
     else if constexpr (_Tag() == set_error)
     {
-      return __partitioned::template __error_types<completion_signatures, __type_function<set_error_t>::__call>();
+      using __result_t =
+        typename __partitioned::template __error_types<completion_signatures, __type_function<set_error_t>::__call>;
+      return __result_t{};
     }
     else
     {
-      return __partitioned::template __stopped_types<completion_signatures>();
+      using __result_t = typename __partitioned::template __stopped_types<completion_signatures>;
+      return __result_t{};
     }
   }
 
@@ -352,13 +360,13 @@ template <class... _Sndr>
 template <class... What, class... Values>
 [[nodiscard]] _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto invalid_completion_signature([[maybe_unused]] Values... values)
 {
-  return _ERROR<What...>();
+  return _ERROR<What...>{};
 }
 
 template <class... _Sndr>
 [[nodiscard]] _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto __dependent_sender() -> __dependent_sender_error<_Sndr...>
 {
-  return __dependent_sender_error<_Sndr...>();
+  return __dependent_sender_error<_Sndr...>{};
 }
 
 #endif // ^^^ no constexpr exceptions ^^^
@@ -843,7 +851,7 @@ _CCCL_API constexpr auto transform_completion_signatures(
 #if _CCCL_HAS_EXCEPTIONS()
 _CCCL_API inline constexpr auto __eptr_completion() noexcept
 {
-  return completion_signatures<set_error_t(::std::exception_ptr)>();
+  return completion_signatures<set_error_t(::std::exception_ptr)>{};
 }
 #else // ^^^ _CCCL_HAS_EXCEPTIONS() ^^^ / vvv !_CCCL_HAS_EXCEPTIONS() vvv
 _CCCL_API inline constexpr auto __eptr_completion() noexcept
@@ -893,6 +901,8 @@ _CCCL_API constexpr auto __is_dependent_sender() noexcept -> bool
 #endif
 
 } // namespace cuda::experimental::execution
+
+_CCCL_DIAG_POP
 
 #include <cuda/experimental/__execution/epilogue.cuh>
 

--- a/cudax/include/cuda/experimental/__execution/cpos.cuh
+++ b/cudax/include/cuda/experimental/__execution/cpos.cuh
@@ -106,6 +106,7 @@ struct start_t
 // connect
 struct connect_t
 {
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _Sndr, class _Rcvr, class _Domain = domain_for_t<_Sndr, env_of_t<_Rcvr>>>
   _CCCL_TRIVIAL_API static constexpr auto __do_transform(_Sndr&& __sndr, _Rcvr __rcvr) noexcept(
     noexcept(transform_sender(_Domain{}, declval<_Sndr>(), get_env(__rcvr)))) -> decltype(auto)
@@ -136,7 +137,7 @@ struct schedule_t
 {
   _CCCL_EXEC_CHECK_DISABLE
   template <class _Sch>
-  _CCCL_TRIVIAL_API auto operator()(_Sch&& __sch) const noexcept -> decltype(declval<_Sch>().schedule())
+  _CCCL_TRIVIAL_API auto operator()(_Sch&& __sch) const noexcept
   {
     static_assert(noexcept(static_cast<_Sch&&>(__sch).schedule()));
     return static_cast<_Sch&&>(__sch).schedule();

--- a/cudax/include/cuda/experimental/__execution/domain.cuh
+++ b/cudax/include/cuda/experimental/__execution/domain.cuh
@@ -22,6 +22,7 @@
 #endif // no system header
 
 #include <cuda/std/__execution/env.h>
+#include <cuda/std/__type_traits/is_nothrow_move_constructible.h>
 
 #include <cuda/experimental/__detail/utility.cuh>
 #include <cuda/experimental/__execution/fwd.cuh>
@@ -30,9 +31,11 @@
 
 namespace cuda::experimental::execution
 {
+// NOLINTBEGIN(misc-unused-using-decls)
 using _CUDA_STD_EXEC::__query_result_t;
 using _CUDA_STD_EXEC::__queryable_with;
 using _CUDA_STD_EXEC::env_of_t;
+// NOLINTEND(misc-unused-using-decls)
 
 template <class _DomainOrTag, class... _Args>
 using __apply_sender_result_t _CCCL_NODEBUG_ALIAS = decltype(_DomainOrTag{}.apply_sender(declval<_Args>()...));
@@ -82,16 +85,21 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT default_domain
   }
 
   //! @overload
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _Sndr>
-  _CCCL_TRIVIAL_API static constexpr auto transform_sender(_Sndr&& __sndr) noexcept -> _Sndr&&
+  _CCCL_TRIVIAL_API static constexpr auto
+  transform_sender(_Sndr&& __sndr) noexcept(_CUDA_VSTD::is_nothrow_move_constructible_v<_Sndr>) -> _Sndr
   {
     // FUTURE TODO: add a transform for the split sender once we have a split sender
     return static_cast<_Sndr&&>(__sndr);
   }
 
   //! @overload
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _Sndr>
-  _CCCL_TRIVIAL_API static constexpr auto transform_sender(_Sndr&& __sndr, _CUDA_VSTD::__ignore_t) noexcept -> _Sndr&&
+  _CCCL_TRIVIAL_API static constexpr auto
+  transform_sender(_Sndr&& __sndr, _CUDA_VSTD::__ignore_t) noexcept(_CUDA_VSTD::is_nothrow_move_constructible_v<_Sndr>)
+    -> _Sndr
   {
     return static_cast<_Sndr&&>(__sndr);
   }

--- a/cudax/include/cuda/experimental/__execution/domain.cuh
+++ b/cudax/include/cuda/experimental/__execution/domain.cuh
@@ -62,6 +62,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT default_domain
   //! @param __sndr The sender to which the operation is applied.
   //! @param __args Additional arguments for the operation.
   //! @return The result of applying the sender operation.
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _Tag, class _Sndr, class... _Args>
   _CCCL_TRIVIAL_API static constexpr auto apply_sender(_Tag, _Sndr&& __sndr, _Args&&... __args) noexcept(noexcept(
     _Tag{}.apply_sender(declval<_Sndr>(), declval<_Args>()...))) -> __apply_sender_result_t<_Tag, _Sndr, _Args...>
@@ -76,6 +77,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT default_domain
   //! @param __sndr The sender to be transformed.
   //! @param __env The environment used for the transformation.
   //! @return The result of transforming the sender with the given environment.
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _Sndr, class _Env>
   _CCCL_TRIVIAL_API static constexpr auto transform_sender(_Sndr&& __sndr, const _Env& __env) noexcept(
     noexcept(tag_of_t<_Sndr>{}.transform_sender(static_cast<_Sndr&&>(__sndr), __env)))

--- a/cudax/include/cuda/experimental/__execution/let_value.cuh
+++ b/cudax/include/cuda/experimental/__execution/let_value.cuh
@@ -137,7 +137,7 @@ private:
             // Call the function with the results and connect the resulting
             // sender, storing the operation state in __opstate2_.
             auto& __next_op = __opstate2_.__emplace_from(
-              execution::connect, _CUDA_VSTD::__apply(static_cast<_Fn&&>(__fn_), __tupl), __rcvr_ref{__rcvr_});
+              execution::connect, _CUDA_VSTD::__apply(static_cast<_Fn&&>(__fn_), __tupl), __rcvr_ref<_Rcvr>{__rcvr_});
             execution::start(__next_op);
           }),
           _CUDAX_CATCH(...) //
@@ -219,6 +219,61 @@ private:
     }
   };
 
+  template <class _Fn>
+  struct __domain_transform_fn
+  {
+    template <class... _Ts>
+    _CCCL_API auto operator()(_SetTag (*)(_Ts...)) const
+    {
+      using __result_t _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::__call_result_t<_Fn, _CUDA_VSTD::decay_t<_Ts>&...>;
+      // ask the result sender if it knows where it will complete:
+      if constexpr (__queryable_with<env_of_t<__result_t>, get_domain_t>)
+      {
+        return __query_result_t<env_of_t<__result_t>, get_domain_t>{};
+      }
+      else
+      {
+        return __nil{};
+      }
+    }
+  };
+
+  struct __domain_reduce_fn
+  {
+    template <class... _Domains>
+    _CCCL_API auto operator()(_Domains...) const
+    {
+      if constexpr (_CUDA_VSTD::_IsValidExpansion<_CUDA_VSTD::common_type_t, _Domains...>::value)
+      {
+        return _CUDA_VSTD::common_type_t<_Domains...>{};
+      }
+      else
+      {
+        return __nil{};
+      }
+    }
+  };
+
+  template <class _Sndr, class _Fn>
+  _CCCL_API static constexpr auto __get_completion_domain() noexcept
+  {
+    // we can know the completion domain for non-dependent senders
+    using __completions = completion_signatures_of_t<_Sndr>;
+    if constexpr (__valid_completion_signatures<__completions>)
+    {
+      auto __dom =
+        __completions().select(_SetTag()).transform_reduce(__domain_transform_fn<_Fn>(), __domain_reduce_fn());
+      return __dom;
+    }
+    else
+    {
+      return __nil();
+    }
+  }
+
+  template <class _Sndr, class _Fn>
+  using __completion_domain_of_t _CCCL_NODEBUG_ALIAS = decltype(__get_completion_domain<_Sndr, _Fn>());
+
 public:
   /// @brief The `let_(value|error|stopped)` sender.
   /// @tparam _Sndr The predecessor sender.
@@ -242,9 +297,31 @@ template <class _Sndr, class _Fn>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __let_t<_Disposition>::__sndr_t
 {
   using sender_concept _CCCL_NODEBUG_ALIAS = sender_t;
-  _CCCL_NO_UNIQUE_ADDRESS _LetTag __tag_;
-  _Fn __fn_;
-  _Sndr __sndr_;
+
+  struct __attrs_t
+  {
+    template <class _SetTag>
+    _CCCL_API auto query(get_completion_scheduler_t<_SetTag>) const = delete;
+
+    // Returns the domain on which the let sender will complete:
+    _CCCL_TEMPLATE(class _Sndr2 = _Sndr)
+    _CCCL_REQUIRES((!_CUDA_VSTD::same_as<__completion_domain_of_t<_Sndr2, _Fn>, __nil>) )
+    [[nodiscard]] _CCCL_API static constexpr auto query(get_domain_t) noexcept -> __completion_domain_of_t<_Sndr2, _Fn>
+    {
+      return {};
+    }
+
+    _CCCL_TEMPLATE(class _Query)
+    _CCCL_REQUIRES(__forwarding_query<_Query> _CCCL_AND(!_CUDA_VSTD::same_as<_Query, get_domain_t>)
+                     _CCCL_AND __queryable_with<env_of_t<_Sndr>, _Query>)
+    [[nodiscard]] _CCCL_API auto query(_Query) const noexcept(__nothrow_queryable_with<env_of_t<_Sndr>, _Query>)
+      -> __query_result_t<env_of_t<_Sndr>, _Query>
+    {
+      return execution::get_env(__self_->__sndr_).query(_Query{});
+    }
+
+    const __sndr_t* __self_;
+  };
 
   template <class _Self, class... _Env>
   _CCCL_API static constexpr auto get_completion_signatures()
@@ -285,10 +362,14 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __let_t<_Disposition>::__sndr_t
     return __opstate_t<_Rcvr, const _Sndr&, _Fn>(__sndr_, __fn_, static_cast<_Rcvr&&>(__rcvr));
   }
 
-  [[nodiscard]] _CCCL_API auto get_env() const noexcept -> __fwd_env_t<env_of_t<_Sndr>>
+  [[nodiscard]] _CCCL_API auto get_env() const noexcept -> __attrs_t
   {
-    return __fwd_env(execution::get_env(__sndr_));
+    return __attrs_t{this};
   }
+
+  _CCCL_NO_UNIQUE_ADDRESS _LetTag __tag_;
+  _Fn __fn_;
+  _Sndr __sndr_;
 };
 
 template <__disposition_t _Disposition>

--- a/cudax/include/cuda/experimental/__execution/rcvr_ref.cuh
+++ b/cudax/include/cuda/experimental/__execution/rcvr_ref.cuh
@@ -61,7 +61,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __rcvr_ref
 };
 
 template <class _Rcvr>
-__rcvr_ref(_Rcvr&) -> __rcvr_ref<_Rcvr>;
+_CCCL_HOST_DEVICE __rcvr_ref(_Rcvr&) -> __rcvr_ref<_Rcvr>;
 } // namespace cuda::experimental::execution
 
 #include <cuda/experimental/__execution/epilogue.cuh>

--- a/cudax/include/cuda/experimental/__execution/transform_sender.cuh
+++ b/cudax/include/cuda/experimental/__execution/transform_sender.cuh
@@ -22,6 +22,7 @@
 #endif // no system header
 
 #include <cuda/std/__type_traits/conditional.h>
+#include <cuda/std/__type_traits/is_nothrow_move_constructible.h>
 #include <cuda/std/__type_traits/is_valid_expansion.h>
 
 #include <cuda/experimental/__detail/utility.cuh>
@@ -66,7 +67,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT transform_sender_t
     else
     {
       using __dom2_t _CCCL_NODEBUG_ALIAS = __transform_domain_t<domain_for_t<__result_t, _Env...>, __result_t, _Env...>;
-      using __result2_t _CCCL_NODEBUG_ALIAS = __transform_sender_result_t<__dom2_t, _Sndr, _Env...>;
+      using __result2_t _CCCL_NODEBUG_ALIAS = __transform_sender_result_t<__dom2_t, __result_t, _Env...>;
 
       if constexpr (_CUDA_VSTD::_IsSame<__result2_t&&, __result_t&&>::value)
       {
@@ -84,9 +85,11 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT transform_sender_t
     }
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Self = transform_sender_t, class _Domain, class _Sndr, class... _Env)
   _CCCL_REQUIRES((__get_transform_strategy<_Self, _Domain, _Sndr, _Env...>().__strategy_ == __strategy::__passthru))
-  _CCCL_TRIVIAL_API constexpr auto operator()(_Domain, _Sndr&& __sndr, const _Env&...) const noexcept -> _Sndr&&
+  _CCCL_TRIVIAL_API constexpr auto operator()(_Domain, _Sndr&& __sndr, const _Env&...) const
+    noexcept(_CUDA_VSTD::is_nothrow_move_constructible_v<_Sndr>) -> _Sndr
   {
     return static_cast<_Sndr&&>(__sndr);
   }

--- a/cudax/test/CMakeLists.txt
+++ b/cudax/test/CMakeLists.txt
@@ -85,6 +85,7 @@ foreach(cn_target IN LISTS cudax_TARGETS)
     execution/test_continues_on.cu
     execution/test_just.cu
     execution/test_sequence.cu
+    execution/test_let_value.cu
     execution/test_visit.cu
     execution/test_when_all.cu
   )

--- a/cudax/test/execution/common/checked_receiver.cuh
+++ b/cudax/test/execution/common/checked_receiver.cuh
@@ -67,7 +67,7 @@ struct checked_value_receiver
 };
 
 template <class... Values>
-checked_value_receiver(Values...) -> checked_value_receiver<Values...>;
+_CCCL_HOST_DEVICE checked_value_receiver(Values...) -> checked_value_receiver<Values...>;
 
 template <class Error>
 struct checked_error_receiver
@@ -85,7 +85,10 @@ struct checked_error_receiver
   {
     if constexpr (_CUDA_VSTD::is_same_v<Error, Ty>)
     {
-      CUDAX_CHECK(ty == _error);
+      if (!_CUDA_VSTD::is_same_v<Error, ::std::exception_ptr>)
+      {
+        CUDAX_CHECK(ty == _error);
+      }
     }
     else
     {
@@ -102,7 +105,7 @@ struct checked_error_receiver
 };
 
 template <class Error>
-checked_error_receiver(Error) -> checked_error_receiver<Error>;
+_CCCL_HOST_DEVICE checked_error_receiver(Error) -> checked_error_receiver<Error>;
 
 struct checked_stopped_receiver
 {
@@ -122,5 +125,38 @@ struct checked_stopped_receiver
 
   _CCCL_HOST_DEVICE void set_stopped() && noexcept {}
 };
+
+template <class Ty>
+struct proxy_value_receiver
+{
+  using receiver_concept = cudax_async::receiver_t;
+
+  template <class... As>
+  _CCCL_HOST_DEVICE void set_value(As...) && noexcept
+  {
+    CUDAX_FAIL("expected a value completion; got a different value");
+  }
+
+  _CCCL_HOST_DEVICE void set_value(Ty value) && noexcept
+  {
+    _value = value;
+  }
+
+  template <class Error>
+  _CCCL_HOST_DEVICE void set_error(Error) && noexcept
+  {
+    CUDAX_FAIL("expected a value completion; got an error");
+  }
+
+  _CCCL_HOST_DEVICE void set_stopped() && noexcept
+  {
+    CUDAX_FAIL("expected a value completion; got stopped");
+  }
+
+  Ty& _value;
+};
+
+template <class Ty>
+_CCCL_HOST_DEVICE proxy_value_receiver(Ty&) -> proxy_value_receiver<Ty>;
 
 } // namespace

--- a/cudax/test/execution/test_conditional.cu
+++ b/cudax/test/execution/test_conditional.cu
@@ -1,18 +1,12 @@
-/*
- * Copyright (c) 2024 NVIDIA Corporation
- *
- * Licensed under the Apache License Version 2.0 with LLVM Exceptions
- * (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
- *
- *   https://llvm.org/LICENSE.txt
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
 
 // Include this first
 #include <cuda/experimental/execution.cuh>

--- a/cudax/test/execution/test_let_value.cu
+++ b/cudax/test/execution/test_let_value.cu
@@ -91,7 +91,7 @@ C2H_TEST("let_value can be used to produce values", "[adaptors][let_value]")
 
 C2H_TEST("let_value can be used to transform values", "[adaptors][let_value]")
 {
-  auto sndr = ex::just(13) | ex::let_value([] _CCCL_HOST_DEVICE(int& x) {
+  auto sndr = ex::just(13) | ex::let_value([](int& x) {
                 return ex::just(x + 4);
               });
   wait_for_value(std::move(sndr), 17);
@@ -99,7 +99,7 @@ C2H_TEST("let_value can be used to transform values", "[adaptors][let_value]")
 
 C2H_TEST("let_value can be used with multiple parameters", "[adaptors][let_value]")
 {
-  auto sndr = ex::just(3, 0.1415) | ex::let_value([] _CCCL_HOST_DEVICE(int& x, double y) {
+  auto sndr = ex::just(3, 0.1415) | ex::let_value([](int& x, double y) {
                 return ex::just(x + y);
               });
   wait_for_value(std::move(sndr), 3.1415); // NOLINT(modernize-use-std-numbers)
@@ -107,7 +107,7 @@ C2H_TEST("let_value can be used with multiple parameters", "[adaptors][let_value
 
 C2H_TEST("let_value can be used to change the sender", "[adaptors][let_value]")
 {
-  auto sndr = ex::just(13) | ex::let_value([] _CCCL_HOST_DEVICE(int& x) {
+  auto sndr = ex::just(13) | ex::let_value([](int& x) {
                 return ex::just_error(x + 4);
               });
   auto op   = ex::connect(std::move(sndr), checked_error_receiver{13 + 4});
@@ -179,7 +179,7 @@ C2H_TEST("let_value can throw, and set_error will be called", "[adaptors][let_va
 C2H_TEST("let_value can be used with just_error", "[adaptors][let_value]")
 {
   auto sndr = ex::just_error(std::string{"err"}) //
-            | ex::let_value([] _CCCL_HOST_DEVICE() {
+            | ex::let_value([]() {
                 return ex::just(17);
               });
   auto op = ex::connect(std::move(sndr), checked_error_receiver{std::string{"err"}});
@@ -188,7 +188,7 @@ C2H_TEST("let_value can be used with just_error", "[adaptors][let_value]")
 
 C2H_TEST("let_value can be used with just_stopped", "[adaptors][let_value]")
 {
-  auto sndr = ex::just_stopped() | ex::let_value([] _CCCL_HOST_DEVICE() {
+  auto sndr = ex::just_stopped() | ex::let_value([]() {
                 return ex::just(17);
               });
   auto op   = ex::connect(std::move(sndr), checked_stopped_receiver{});

--- a/cudax/test/execution/test_let_value.cu
+++ b/cudax/test/execution/test_let_value.cu
@@ -1,0 +1,461 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/experimental/execution.cuh>
+
+#include "common/checked_receiver.cuh"
+#include "common/error_scheduler.cuh"
+#include "common/impulse_scheduler.cuh" // IWYU pragma: keep
+#include "common/inline_scheduler.cuh"
+#include "common/stopped_scheduler.cuh"
+#include "common/utility.cuh"
+#include "testing.cuh" // IWYU pragma: keep
+
+namespace ex = cuda::experimental::execution;
+
+namespace
+{
+// Return a different sender when we invoke this custom defined let_value implementation
+struct let_value_test_domain
+{
+  _CCCL_TEMPLATE(class Sender)
+  _CCCL_REQUIRES(_CUDA_VSTD::same_as<ex::tag_of_t<Sender>, ex::let_value_t>)
+  static auto transform_sender(Sender&&)
+  {
+    return ex::just(std::string{"hallo"});
+  }
+};
+
+// C2H_TEST("let_value returns a sender", "[adaptors][let_value]")
+// {
+//   auto sndr = ex::let_value(ex::just(), [] {
+//     return ex::just();
+//   });
+//   static_assert(ex::sender<decltype(sndr)>);
+//   (void) sndr;
+// }
+
+// C2H_TEST("let_value with environment returns a sender", "[adaptors][let_value]")
+// {
+//   auto sndr = ex::let_value(ex::just(), [] {
+//     return ex::just();
+//   });
+//   static_assert(ex::sender_in<decltype(sndr), ex::env<>>);
+//   (void) sndr;
+// }
+
+C2H_TEST("let_value simple example", "[adaptors][let_value]")
+{
+  bool called{false};
+  auto sndr = ex::let_value(ex::just(), [&] {
+    called = true;
+    return ex::just();
+  });
+  auto op   = ex::connect(std::move(sndr), checked_value_receiver{});
+  ex::start(op);
+  // The receiver checks that it's called
+  // we also check that the function was invoked
+  CHECK(called);
+}
+
+C2H_TEST("let_value can be piped", "[adaptors][let_value]")
+{
+  auto sndr = ex::just() | ex::let_value([] {
+                return ex::just();
+              });
+  (void) sndr;
+}
+
+C2H_TEST("let_value returning void can we waited on", "[adaptors][let_value]")
+{
+  auto sndr = ex::just() | ex::let_value([] {
+                return ex::just();
+              });
+  ex::sync_wait(std::move(sndr));
+}
+
+C2H_TEST("let_value can be used to produce values", "[adaptors][let_value]")
+{
+  auto sndr = ex::just() | ex::let_value([] {
+                return ex::just(13);
+              });
+  wait_for_value(std::move(sndr), 13);
+}
+
+C2H_TEST("let_value can be used to transform values", "[adaptors][let_value]")
+{
+  auto sndr = ex::just(13) | ex::let_value([] _CCCL_HOST_DEVICE(int& x) {
+                return ex::just(x + 4);
+              });
+  wait_for_value(std::move(sndr), 17);
+}
+
+C2H_TEST("let_value can be used with multiple parameters", "[adaptors][let_value]")
+{
+  auto sndr = ex::just(3, 0.1415) | ex::let_value([] _CCCL_HOST_DEVICE(int& x, double y) {
+                return ex::just(x + y);
+              });
+  wait_for_value(std::move(sndr), 3.1415); // NOLINT(modernize-use-std-numbers)
+}
+
+C2H_TEST("let_value can be used to change the sender", "[adaptors][let_value]")
+{
+  auto sndr = ex::just(13) | ex::let_value([] _CCCL_HOST_DEVICE(int& x) {
+                return ex::just_error(x + 4);
+              });
+  auto op   = ex::connect(std::move(sndr), checked_error_receiver{13 + 4});
+  ex::start(op);
+}
+
+#if _CCCL_HOST_COMPILATION()
+
+auto is_prime(int x) -> bool
+{
+  if (x > 2 && (x % 2 == 0))
+  {
+    return false;
+  }
+  int d = 3;
+  while (d * d < x)
+  {
+    if (x % d == 0)
+    {
+      return false;
+    }
+    d += 2;
+  }
+  return true;
+}
+
+C2H_TEST("let_value can be used for composition", "[adaptors][let_value]")
+{
+  bool called1{false};
+  bool called2{false};
+  bool called3{false};
+  auto f1 = [&](int& x) {
+    called1 = true;
+    return ex::just(2 * x);
+  };
+  auto f2 = [&](int& x) {
+    called2 = true;
+    return ex::just(x + 3);
+  };
+  auto f3 = [&](int& x) {
+    called3 = true;
+    if (!is_prime(x))
+    {
+      throw std::logic_error("not prime");
+    }
+    return ex::just(x);
+  };
+  auto sndr = ex::just(13) //
+            | ex::let_value(f1) //
+            | ex::let_value(f2) //
+            | ex::let_value(f3) //
+    ;
+  wait_for_value(std::move(sndr), 29);
+  CHECK(called1);
+  CHECK(called2);
+  CHECK(called3);
+}
+
+C2H_TEST("let_value can throw, and set_error will be called", "[adaptors][let_value]")
+{
+  auto sndr = ex::just(13) //
+            | ex::let_value([](int&) -> decltype(ex::just(0)) {
+                throw std::logic_error{"err"};
+              });
+  auto op = ex::connect(std::move(sndr), checked_error_receiver{::std::exception_ptr{}});
+  ex::start(op);
+}
+
+C2H_TEST("let_value can be used with just_error", "[adaptors][let_value]")
+{
+  auto sndr = ex::just_error(std::string{"err"}) //
+            | ex::let_value([] _CCCL_HOST_DEVICE() {
+                return ex::just(17);
+              });
+  auto op = ex::connect(std::move(sndr), checked_error_receiver{std::string{"err"}});
+  ex::start(op);
+}
+
+C2H_TEST("let_value can be used with just_stopped", "[adaptors][let_value]")
+{
+  auto sndr = ex::just_stopped() | ex::let_value([] _CCCL_HOST_DEVICE() {
+                return ex::just(17);
+              });
+  auto op   = ex::connect(std::move(sndr), checked_stopped_receiver{});
+  ex::start(op);
+}
+
+C2H_TEST("let_value function is not called on error", "[adaptors][let_value]")
+{
+  bool called{false};
+  error_scheduler<int> sched{-1};
+  auto sndr = ex::just(13) //
+            | ex::continues_on(sched) //
+            | ex::let_value([&](int& x) {
+                called = true;
+                return ex::just(x + 5);
+              });
+  auto op = ex::connect(std::move(sndr), checked_error_receiver{-1});
+  ex::start(op);
+  CHECK_FALSE(called);
+}
+
+C2H_TEST("let_value function is not called when cancelled", "[adaptors][let_value]")
+{
+  bool called{false};
+  stopped_scheduler sched;
+  auto sndr = ex::just(13) //
+            | ex::continues_on(sched) //
+            | ex::let_value([&](int& x) {
+                called = true;
+                return ex::just(x + 5);
+              });
+  auto op = ex::connect(std::move(sndr), checked_stopped_receiver{});
+  ex::start(op);
+  CHECK_FALSE(called);
+}
+
+C2H_TEST("let_value exposes a parameter that is destructed when the main operation is destructed",
+         "[adaptors][let_value]")
+{
+  // Type that sets into a received boolean when the dtor is called
+  struct my_type
+  {
+    bool* p_called_{nullptr};
+
+    explicit my_type(bool* p_called)
+        : p_called_(p_called)
+    {}
+
+    my_type(my_type&& rhs)
+        : p_called_(rhs.p_called_)
+    {
+      rhs.p_called_ = nullptr;
+    }
+
+    auto operator=(my_type&& rhs) -> my_type&
+    {
+      if (p_called_)
+      {
+        *p_called_ = true;
+      }
+      p_called_     = rhs.p_called_;
+      rhs.p_called_ = nullptr;
+      return *this;
+    }
+
+    ~my_type()
+    {
+      if (p_called_)
+      {
+        *p_called_ = true;
+      }
+    }
+  };
+
+  bool param_destructed{false};
+  bool fun_called{false};
+  impulse_scheduler sched;
+
+  auto sndr = ex::just(my_type(&param_destructed)) //
+            | ex::let_value([&](const my_type&) {
+                CHECK_FALSE(param_destructed);
+                fun_called = true;
+                return ex::just(13) | ex::continues_on(sched);
+              });
+
+  {
+    int res{0};
+    auto op = ex::connect(std::move(sndr), proxy_value_receiver{res});
+    ex::start(op);
+    // The function is called immediately after starting the operation
+    CHECK(fun_called);
+    // As the returned sender didn't complete yet, the parameter must still be alive
+    CHECK_FALSE(param_destructed);
+    CHECK(res == 0);
+
+    // Now, tell the scheduler to execute the final operation
+    sched.start_next();
+
+    // The parameter is going to be destructed when the op is destructed; it should be valid now
+    CHECK_FALSE(param_destructed);
+    CHECK(res == 13);
+  }
+
+  // At this point everything can be destructed
+  CHECK(param_destructed);
+}
+
+// NOT YET SUPPORTED
+// C2H_TEST("let_value works when changing threads", "[adaptors][let_value]")
+// {
+//   exec::static_thread_pool pool{2};
+//   std::atomic<bool> called{false};
+//   {
+//     // lunch some work on the thread pool
+//     auto sndr = ex::transfer_just(pool.get_scheduler(), 7) //
+//              | ex::let_value([]_CCCL_HOST_DEVICE(int& x) {
+//                  return ex::just(x * 2 - 1);
+//                }) //
+//              | ex::then([&]_CCCL_HOST_DEVICE(int x) {
+//                  CHECK(x == 13);
+//                  called.store(true);
+//                });
+//     ex::start_detached(std::move(sndr));
+//   }
+//   // wait for the work to be executed, with timeout
+//   // perform a poor-man's sync
+//   // NOTE: it's a shame that the `join` method in static_thread_pool is not public
+//   for (int i = 0; i < 1000 && !called.load(); i++)
+//   {
+//     std::this_thread::sleep_for(1ms);
+//   }
+//   // the work should be executed
+//   REQUIRE(called);
+// }
+
+C2H_TEST("let_value has the values_type corresponding to the given values", "[adaptors][let_value]")
+{
+  check_value_types<types<int>>(ex::just() | ex::let_value([] {
+                                  return ex::just(7);
+                                }));
+  check_value_types<types<double>>(ex::just() | ex::let_value([] {
+                                     return ex::just(3.14);
+                                   }));
+  check_value_types<types<movable>>(ex::just() | ex::let_value([] {
+                                      return ex::just(movable{0});
+                                    }));
+}
+
+C2H_TEST("let_value keeps error_types from input sender", "[adaptors][let_value]")
+{
+  inline_scheduler sched1{};
+  error_scheduler sched2{::std::exception_ptr{}};
+  error_scheduler<int> sched3{43};
+
+  check_error_types<std::exception_ptr>( //
+    ex::just() | ex::continues_on(sched1) | ex::let_value([] {
+      return ex::just();
+    }));
+  check_error_types<std::exception_ptr>( //
+    ex::just() | ex::continues_on(sched2) | ex::let_value([] {
+      return ex::just();
+    }));
+  check_error_types<int, std::exception_ptr>( //
+    ex::just() | ex::continues_on(sched3) | ex::let_value([] {
+      return ex::just();
+    }));
+
+  // NOT YET SUPPORTED
+  // check_error_types<>( //
+  //   ex::just() | ex::continues_on(sched1) | ex::let_value([]_CCCL_HOST_DEVICE() noexcept {
+  //     return ex::just();
+  //   }));
+  // check_error_types<std::exception_ptr>( //
+  //   ex::just() | ex::continues_on(sched2) | ex::let_value([]_CCCL_HOST_DEVICE() noexcept {
+  //     return ex::just();
+  //   }));
+  // check_error_types<int>( //
+  //   ex::just() | ex::continues_on(sched3) | ex::let_value([]_CCCL_HOST_DEVICE() noexcept {
+  //     return ex::just();
+  //   }));
+}
+
+C2H_TEST("let_value keeps sends_stopped from input sender", "[adaptors][let_value]")
+{
+  inline_scheduler sched1{};
+  error_scheduler sched2{::std::exception_ptr{}};
+  stopped_scheduler sched3{};
+
+  check_sends_stopped<false>( //
+    ex::just() | ex::continues_on(sched1) | ex::let_value([] {
+      return ex::just();
+    }));
+  check_sends_stopped<true>( //
+    ex::just() | ex::continues_on(sched2) | ex::let_value([] {
+      return ex::just();
+    }));
+  check_sends_stopped<true>( //
+    ex::just() | ex::continues_on(sched3) | ex::let_value([] {
+      return ex::just();
+    }));
+}
+
+C2H_TEST("let_value can be customized", "[adaptors][let_value]")
+{
+  // The customization will return a different value
+  auto sndr = ex::just(std::string{"hello"}) | write_attrs(ex::prop{ex::get_domain, let_value_test_domain{}})
+            | ex::let_value([](std::string& x) {
+                return ex::just(x + ", world");
+              });
+  wait_for_value(std::move(sndr), std::string{"hallo"});
+}
+
+C2H_TEST("let_value can nest", "[adaptors][let_value]")
+{
+  auto work = ex::just(2) //
+            | ex::let_value([](int x) { //
+                return ex::just() //
+                     | ex::let_value([=] { //
+                         return ex::just(x);
+                       });
+              });
+  wait_for_value(std::move(work), 2);
+}
+
+// NOT YET SUPPORTED
+// struct bad_receiver
+// {
+//   using receiver_concept = ex::receiver_t;
+
+//   bad_receiver(bool& completed) noexcept
+//       : completed_{completed}
+//   {}
+
+//   bad_receiver(bad_receiver&& other) noexcept(false) // BAD!
+//       : completed_(other.completed_)
+//   {}
+
+//   void set_value() noexcept
+//   {
+//     completed_ = true;
+//   }
+
+//   bool& completed_;
+// };
+
+// C2H_TEST("let_value does not add std::exception_ptr even if the receiver is bad", "[adaptors][let_value]")
+// {
+//   auto sndr = ex::let_value(ex::just(), []_CCCL_HOST_DEVICE() noexcept {
+//     return ex::just();
+//   });
+//   check_error_types<>(sndr);
+//   bool completed{false};
+//   auto op = ex::connect(std::move(sndr), bad_receiver{completed}); // should compile
+//   ex::start(op);
+//   CHECK(completed);
+// }
+
+#endif // _CCCL_HOST_COMPILATION()
+
+C2H_TEST("let_value has the correct completion domain", "[adaptors][let_value]")
+{
+  auto attrs = ex::prop{ex::get_domain, let_value_test_domain{}};
+  auto sndr  = ex::just() | ex::let_value([=] {
+                return write_attrs(ex::just(), attrs);
+              });
+  auto dom   = ex::get_domain(ex::get_env(sndr));
+  static_assert(_CUDA_VSTD::is_same_v<decltype(dom), let_value_test_domain>);
+}
+
+} // namespace

--- a/cudax/test/execution/test_sequence.cu
+++ b/cudax/test/execution/test_sequence.cu
@@ -1,18 +1,12 @@
-/*
- * Copyright (c) 2024 NVIDIA Corporation
- *
- * Licensed under the Apache License Version 2.0 with LLVM Exceptions
- * (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
- *
- *   https://llvm.org/LICENSE.txt
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
 
 // Include this first
 #include <cuda/experimental/execution.cuh>

--- a/libcudacxx/include/cuda/std/__cccl/diagnostic.h
+++ b/libcudacxx/include/cuda/std/__cccl/diagnostic.h
@@ -124,23 +124,6 @@
 #  if !defined(_LIBCUDACXX_DISABLE_PRAGMA_MSVC_WARNING)
 #    define _CCCL_USE_PRAGMA_MSVC_WARNING
 #  endif // !_LIBCUDACXX_DISABLE_PRAGMA_MSVC_WARNING
-
-// https://github.com/microsoft/STL/blob/master/stl/inc/yvals_core.h#L353
-// warning C4100: 'quack': unreferenced formal parameter
-// warning C4127: conditional expression is constant
-// warning C4180: qualifier applied to function type has no meaning; ignored
-// warning C4197: 'purr': top-level volatile in cast is ignored
-// warning C4324: 'roar': structure was padded due to alignment specifier
-// warning C4455: literal suffix identifiers that do not start with an underscore are reserved
-// warning C4503: 'hum': decorated name length exceeded, name was truncated
-// warning C4522: 'woof' : multiple assignment operators specified
-// warning C4668: 'meow' is not defined as a preprocessor macro, replacing with '0' for '#if/#elif'
-// warning C4800: 'boo': forcing value to bool 'true' or 'false' (performance warning)
-// warning C4996: 'meow': was declared deprecated
-#  define _CCCL_MSVC_DISABLED_WARNINGS 4100 4127 4180 4197 4296 4324 4455 4503 4522 4668 4800 4996 /**/
-#  define _CCCL_MSVC_WARNINGS_PUSH \
-    _CCCL_PRAGMA(warning(push)) _CCCL_PRAGMA(warning(disable : _CCCL_MSVC_DISABLED_WARNINGS))
-#  define _CCCL_MSVC_WARNINGS_POP _CCCL_PRAGMA(warning(pop))
 #endif // !_CCCL_COMPILER(MSVC)
 
 #endif // __CCCL_DIAGNOSTIC_H

--- a/libcudacxx/include/cuda/std/__cccl/epilogue.h
+++ b/libcudacxx/include/cuda/std/__cccl/epilogue.h
@@ -18,11 +18,8 @@
 #endif
 #undef _CCCL_PROLOGUE_INCLUDED
 
-// msvc warnings pop
-
-#if _CCCL_COMPILER(MSVC)
-_CCCL_MSVC_WARNINGS_POP
-#endif // _CCCL_COMPILER(MSVC)
+// warnings pop
+_CCCL_DIAG_POP
 
 // __declspec modifiers
 

--- a/libcudacxx/include/cuda/std/__cccl/prologue.h
+++ b/libcudacxx/include/cuda/std/__cccl/prologue.h
@@ -247,10 +247,21 @@
 #  define _CCCL_POP_MACRO_interface
 #endif // defined(interface)
 
-// msvc warnings push
+_CCCL_DIAG_PUSH
 
-#if _CCCL_COMPILER(MSVC)
-_CCCL_MSVC_WARNINGS_PUSH
-#endif // _CCCL_COMPILER(MSVC)
+// disable some msvc warnings
+// https://github.com/microsoft/STL/blob/master/stl/inc/yvals_core.h#L353
+// warning C4100: 'quack': unreferenced formal parameter
+// warning C4127: conditional expression is constant
+// warning C4180: qualifier applied to function type has no meaning; ignored
+// warning C4197: 'purr': top-level volatile in cast is ignored
+// warning C4324: 'roar': structure was padded due to alignment specifier
+// warning C4455: literal suffix identifiers that do not start with an underscore are reserved
+// warning C4503: 'hum': decorated name length exceeded, name was truncated
+// warning C4522: 'woof' : multiple assignment operators specified
+// warning C4668: 'meow' is not defined as a preprocessor macro, replacing with '0' for '#if/#elif'
+// warning C4800: 'boo': forcing value to bool 'true' or 'false' (performance warning)
+// warning C4996: 'meow': was declared deprecated
+_CCCL_DIAG_SUPPRESS_MSVC(4100 4127 4180 4197 4296 4324 4455 4503 4522 4668 4800 4996)
 
 // NO include guards here (this file is included multiple times)

--- a/libcudacxx/include/cuda/std/__cccl/visibility.h
+++ b/libcudacxx/include/cuda/std/__cccl/visibility.h
@@ -91,9 +91,15 @@
 // - `_CCCL_API` declares the function host/device and hides the symbol from the ABI
 // - `_CCCL_TRIVIAL_API` does the same while also inlining and hiding the function from
 //   debuggers
-#define _CCCL_API        _CCCL_HOST_DEVICE _CCCL_VISIBILITY_HIDDEN _CCCL_EXCLUDE_FROM_EXPLICIT_INSTANTIATION
-#define _CCCL_HOST_API   _CCCL_HOST _CCCL_VISIBILITY_HIDDEN _CCCL_EXCLUDE_FROM_EXPLICIT_INSTANTIATION
-#define _CCCL_DEVICE_API _CCCL_DEVICE _CCCL_VISIBILITY_HIDDEN _CCCL_EXCLUDE_FROM_EXPLICIT_INSTANTIATION
+#if _CCCL_COMPILER(NVHPC) // NVHPC has issues with visibility attributes on symbols with internal linkage
+#  define _CCCL_API        _CCCL_HOST_DEVICE
+#  define _CCCL_HOST_API   _CCCL_HOST
+#  define _CCCL_DEVICE_API _CCCL_DEVICE
+#else // ^^^ _CCCL_COMPILER(NVHPC) ^^^ / vvv !_CCCL_COMPILER(NVHPC) vvv
+#  define _CCCL_API        _CCCL_HOST_DEVICE _CCCL_VISIBILITY_HIDDEN _CCCL_EXCLUDE_FROM_EXPLICIT_INSTANTIATION
+#  define _CCCL_HOST_API   _CCCL_HOST _CCCL_VISIBILITY_HIDDEN _CCCL_EXCLUDE_FROM_EXPLICIT_INSTANTIATION
+#  define _CCCL_DEVICE_API _CCCL_DEVICE _CCCL_VISIBILITY_HIDDEN _CCCL_EXCLUDE_FROM_EXPLICIT_INSTANTIATION
+#endif // !_CCCL_COMPILER(NVHPC)
 
 // _CCCL_TRIVIAL_API force-inlines a function, marks its visibility as hidden, and causes
 // debuggers to skip it. This is useful for trivial internal functions that do dispatching

--- a/libcudacxx/include/cuda/std/__execution/env.h
+++ b/libcudacxx/include/cuda/std/__execution/env.h
@@ -391,7 +391,7 @@ _CCCL_GLOBAL_CONSTANT struct forwarding_query_t
 } forwarding_query{};
 
 template <class _Tag>
-_CCCL_CONCEPT __forwarding_query = _CCCL_REQUIRES_EXPR((_Tag))(forwarding_query(_Tag{}));
+_CCCL_CONCEPT __forwarding_query = forwarding_query(_Tag{});
 
 _LIBCUDACXX_END_NAMESPACE_EXECUTION
 


### PR DESCRIPTION
## Description

this PR adds tests for the \`let_value\` algorithm. it also fixes some problems the tests turned up. in particular, the reported domain of the `let_value(s,f)` sender was not considering the domain of the sender(s) returned from `f`.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
