### PR TITLE
factor common code out of `schedule_from` and `continues_on`

### DIFF
--- a/cudax/include/cuda/experimental/__execution/completion_signatures.cuh
+++ b/cudax/include/cuda/experimental/__execution/completion_signatures.cuh
@@ -88,7 +88,7 @@ using __concat_completion_signatures_t _CCCL_NODEBUG_ALIAS =
 struct __concat_completion_signatures_fn
 {
   template <class... _Sigs>
-  _CCCL_TRIVIAL_API constexpr auto operator()(const _Sigs&...) const noexcept
+  _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto operator()(const _Sigs&...) const noexcept
     -> __concat_completion_signatures_t<_Sigs...>
   {
     return {};
@@ -114,7 +114,7 @@ using __completion_if _CCCL_NODEBUG_ALIAS =
   _CUDA_VSTD::_If<_CUDA_VSTD::__is_callable_v<_Fn, _Sig*>, completion_signatures<_Sig>, completion_signatures<>>;
 
 template <class _Fn, class _Sig>
-_CCCL_API constexpr auto __filer_one(_Fn __fn, _Sig* __sig) -> __completion_if<_Fn, _Sig>
+_CCCL_API _CCCL_CONSTEVAL auto __filer_one(_Fn __fn, _Sig* __sig) -> __completion_if<_Fn, _Sig>
 {
   if constexpr (_CUDA_VSTD::__is_callable_v<_Fn, _Sig*>)
   {
@@ -146,7 +146,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT completion_signatures
 
   template <class _Tag>
   [[nodiscard]]
-  _CCCL_API constexpr auto count(_Tag) const noexcept -> size_t
+  _CCCL_API _CCCL_CONSTEVAL auto count(_Tag) const noexcept -> size_t
   {
     if constexpr (_Tag() == set_value)
     {
@@ -164,7 +164,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT completion_signatures
 
   _CCCL_EXEC_CHECK_DISABLE
   template <class _Fn>
-  _CCCL_API constexpr auto apply(_Fn __fn) const -> _CUDA_VSTD::__call_result_t<_Fn, _Sigs*...>
+  _CCCL_API _CCCL_CONSTEVAL auto apply(_Fn __fn) const -> _CUDA_VSTD::__call_result_t<_Fn, _Sigs*...>
   {
     return __fn(static_cast<_Sigs*>(nullptr)...);
   }
@@ -172,14 +172,15 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT completion_signatures
   _CCCL_EXEC_CHECK_DISABLE
   template <class _Fn>
   [[nodiscard]]
-  _CCCL_API constexpr auto filter(_Fn __fn) const -> __concat_completion_signatures_t<__completion_if<_Fn, _Sigs>...>
+  _CCCL_API _CCCL_CONSTEVAL auto filter(_Fn __fn) const
+    -> __concat_completion_signatures_t<__completion_if<_Fn, _Sigs>...>
   {
     return concat_completion_signatures(execution::__filer_one(__fn, static_cast<_Sigs*>(nullptr))...);
   }
 
   template <class _Tag>
   [[nodiscard]]
-  _CCCL_API constexpr auto select(_Tag) const noexcept
+  _CCCL_API _CCCL_CONSTEVAL auto select(_Tag) const noexcept
   {
     if constexpr (_Tag() == set_value)
     {
@@ -203,7 +204,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT completion_signatures
   _CCCL_EXEC_CHECK_DISABLE
   template <class _Transform, class _Reduce>
   [[nodiscard]]
-  _CCCL_API constexpr auto transform_reduce(_Transform __transform, _Reduce __reduce) const
+  _CCCL_API _CCCL_CONSTEVAL auto transform_reduce(_Transform __transform, _Reduce __reduce) const
     -> _CUDA_VSTD::__call_result_t<_Reduce, _CUDA_VSTD::__call_result_t<_Transform, _Sigs*>...>
   {
     return __reduce(__transform(static_cast<_Sigs*>(nullptr))...);
@@ -211,7 +212,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT completion_signatures
 
   template <class... _OtherSigs>
   [[nodiscard]]
-  _CCCL_API constexpr auto operator+(completion_signatures<_OtherSigs...> __other) const noexcept
+  _CCCL_API _CCCL_CONSTEVAL auto operator+(completion_signatures<_OtherSigs...> __other) const noexcept
   {
     if constexpr (sizeof...(_OtherSigs) == 0) // short-circuit some common cases
     {
@@ -229,13 +230,13 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT completion_signatures
   }
 };
 
-completion_signatures() -> completion_signatures<>;
+_CCCL_HOST_DEVICE completion_signatures() -> completion_signatures<>;
 
 template <class _Ty>
 _CCCL_CONCEPT __valid_completion_signatures = detail::__is_specialization_of<_Ty, completion_signatures>;
 
 template <class... _Sigs>
-_CCCL_API constexpr void __assert_valid_completion_signatures(completion_signatures<_Sigs...>)
+_CCCL_API _CCCL_CONSTEVAL void __assert_valid_completion_signatures(completion_signatures<_Sigs...>)
 {}
 
 template <class _Derived>
@@ -243,7 +244,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __compile_time_error // : ::std::exception
 {
   _CCCL_HIDE_FROM_ABI __compile_time_error() = default;
 
-  auto what() const noexcept -> const char* // override
+  [[nodiscard]] auto what() const noexcept -> const char* // override
   {
     return _CCCL_TYPEID(_Derived*).name();
   }
@@ -264,7 +265,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __sender_type_check_failure //
 
 struct _CCCL_TYPE_VISIBILITY_DEFAULT dependent_sender_error // : ::std::exception
 {
-  _CCCL_TRIVIAL_API char const* what() const noexcept // override
+  [[nodiscard]] _CCCL_TRIVIAL_API auto what() const noexcept -> char const* // override
   {
     return what_;
   }
@@ -339,7 +340,7 @@ template <class... What, class... Values>
 template <class... _Sndr>
 [[noreturn, nodiscard]] _CCCL_API consteval auto __dependent_sender() -> completion_signatures<>
 {
-  throw __dependent_sender_error<_Sndr...>();
+  throw __dependent_sender_error<_Sndr...>{};
 }
 
 #else // ^^^ constexpr exceptions ^^^ / vvv no constexpr exceptions vvv
@@ -427,7 +428,7 @@ struct _COULD_NOT_DETERMINE_COMPLETION_SIGNATURES_FOR_THIS_SENDER
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _Sndr, class... _Env>
-_CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto __get_completion_signatures_helper()
+[[nodiscard]] _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto __get_completion_signatures_helper()
 {
   if constexpr (__has_get_completion_signatures<_Sndr, _Env...>)
   {
@@ -455,7 +456,7 @@ _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto __get_completion_signatures_helper()
 }
 
 template <class _Sndr, class... _Env>
-_CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto get_completion_signatures()
+[[nodiscard]] _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto get_completion_signatures()
 {
   static_assert(sizeof...(_Env) <= 1, "At most one environment is allowed.");
   if constexpr (0 == sizeof...(_Env))
@@ -476,7 +477,7 @@ _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto get_completion_signatures()
 }
 
 template <class _Parent, class _Child, class... _Env>
-_CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto get_child_completion_signatures()
+[[nodiscard]] _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto get_child_completion_signatures()
 {
   return get_completion_signatures<__copy_cvref_t<_Parent, _Child>, __fwd_env_t<_Env>...>();
 }
@@ -612,7 +613,7 @@ using __make_completion_signatures_t _CCCL_NODEBUG_ALIAS =
   decltype(execution::__make_unique(execution::__normalize(static_cast<_Sigs*>(nullptr))...));
 
 template <class... _ExplicitSigs, class... _DeducedSigs>
-_CCCL_TRIVIAL_API constexpr auto make_completion_signatures(_DeducedSigs*...) noexcept
+[[nodiscard]] _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto make_completion_signatures(_DeducedSigs*...) noexcept
   -> __make_completion_signatures_t<_ExplicitSigs..., _DeducedSigs...>
 {
   return {};
@@ -623,13 +624,13 @@ extern const completion_signatures<>& __empty_completion_signatures;
 
 struct __concat_completion_signatures_helper
 {
-  _CCCL_TRIVIAL_API constexpr auto operator()() const noexcept -> completion_signatures<> (*)()
+  _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto operator()() const noexcept -> completion_signatures<> (*)()
   {
     return nullptr;
   }
 
   template <class... _Sigs>
-  _CCCL_TRIVIAL_API constexpr auto operator()(const completion_signatures<_Sigs...>&) const noexcept
+  _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto operator()(const completion_signatures<_Sigs...>&) const noexcept
     -> __make_completion_signatures_t<_Sigs...> (*)()
   {
     return nullptr;
@@ -641,7 +642,7 @@ struct __concat_completion_signatures_helper
             class... _Cs,
             class... _Ds,
             class... _Rest>
-  _CCCL_TRIVIAL_API constexpr auto operator()(
+  _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto operator()(
     const completion_signatures<_As...>&,
     const completion_signatures<_Bs...>&,
     const completion_signatures<_Cs...>& = __empty_completion_signatures,
@@ -654,7 +655,7 @@ struct __concat_completion_signatures_helper
   }
 
   template <class _Ap, class _Bp = __ignore, class _Cp = __ignore, class _Dp = __ignore, class... _Rest>
-  _CCCL_TRIVIAL_API constexpr auto
+  _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto
   operator()(const _Ap&, const _Bp& = {}, const _Cp& = {}, const _Dp& = {}, const _Rest&...) const noexcept
   {
     if constexpr (!__valid_completion_signatures<_Ap>)
@@ -704,7 +705,7 @@ template <class _Tag>
 struct __default_transform_fn
 {
   template <class... _Ts>
-  _CCCL_TRIVIAL_API constexpr auto operator()() const noexcept -> completion_signatures<_Tag(_Ts...)>
+  _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto operator()() const noexcept -> completion_signatures<_Tag(_Ts...)>
   {
     return {};
   }
@@ -713,7 +714,7 @@ struct __default_transform_fn
 struct __swallow_transform
 {
   template <class... _Ts>
-  _CCCL_TRIVIAL_API constexpr auto operator()() const noexcept -> completion_signatures<>
+  _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto operator()() const noexcept -> completion_signatures<>
   {
     return {};
   }
@@ -723,7 +724,7 @@ template <class _Tag>
 struct __decay_transform
 {
   template <class... _Ts>
-  _CCCL_TRIVIAL_API constexpr auto operator()() const noexcept
+  _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto operator()() const noexcept
     -> completion_signatures<_Tag(_CUDA_VSTD::decay_t<_Ts>...)>
   {
     return {};
@@ -735,14 +736,15 @@ using __meta_call_result_t _CCCL_NODEBUG_ALIAS = decltype(declval<_Fn>().templat
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _Ay, class... _As, class _Fn>
-_CCCL_TRIVIAL_API constexpr auto __transform_expr(const _Fn& __fn) -> __meta_call_result_t<const _Fn&, _Ay, _As...>
+[[nodiscard]] _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto __transform_expr(const _Fn& __fn)
+  -> __meta_call_result_t<const _Fn&, _Ay, _As...>
 {
   return __fn.template operator()<_Ay, _As...>();
 }
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _Fn>
-_CCCL_TRIVIAL_API constexpr auto __transform_expr(const _Fn& __fn) -> __call_result_t<const _Fn&>
+[[nodiscard]] _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto __transform_expr(const _Fn& __fn) -> __call_result_t<const _Fn&>
 {
   return __fn();
 }
@@ -756,7 +758,7 @@ struct _COULD_NOT_CALL_THE_TRANSFORM_FUNCTION_WITH_THE_GIVEN_TEMPLATE_ARGUMENTS;
 
 // transform_completion_signatures:
 template <class... _As, class _Fn>
-_CCCL_API constexpr auto __apply_transform(const _Fn& __fn)
+[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL auto __apply_transform(const _Fn& __fn)
 {
   if constexpr (__type_valid_v<__transform_expr_t, _Fn, _As...>)
   {
@@ -794,7 +796,7 @@ struct __transform_one
   _StoppedFn __stopped_fn;
 
   template <class _Tag, class... _Ts>
-  _CCCL_API constexpr auto operator()(_Tag (*)(_Ts...)) const
+  [[nodiscard]] _CCCL_API _CCCL_CONSTEVAL auto operator()(_Tag (*)(_Ts...)) const
   {
     if constexpr (_Tag() == set_value)
     {
@@ -817,7 +819,7 @@ struct __transform_all_fn
   _TransformOne __tfx1;
 
   template <class... _Sigs>
-  _CCCL_API constexpr auto operator()(_Sigs*... __sigs) const
+  [[nodiscard]] _CCCL_API _CCCL_CONSTEVAL auto operator()(_Sigs*... __sigs) const
   {
     return concat_completion_signatures(__tfx1(__sigs)...);
   }
@@ -831,16 +833,16 @@ template <class _Completions,
           class _ErrorFn   = __default_transform_fn<set_error_t>,
           class _StoppedFn = __default_transform_fn<set_stopped_t>,
           class _ExtraSigs = completion_signatures<>>
-_CCCL_API constexpr auto transform_completion_signatures(
+_CCCL_API _CCCL_CONSTEVAL auto transform_completion_signatures(
   _Completions, //
   _ValueFn __value_fn     = {},
   _ErrorFn __error_fn     = {},
   _StoppedFn __stopped_fn = {},
   _ExtraSigs              = {})
 {
-  _CUDAX_LET_COMPLETIONS(auto(__completions) = _Completions())
+  _CUDAX_LET_COMPLETIONS(auto(__completions) = _Completions{})
   {
-    _CUDAX_LET_COMPLETIONS(auto(__extra) = _ExtraSigs())
+    _CUDAX_LET_COMPLETIONS(auto(__extra) = _ExtraSigs{})
     {
       __transform_one<_ValueFn, _ErrorFn, _StoppedFn> __tfx1{__value_fn, __error_fn, __stopped_fn};
       return concat_completion_signatures(__completions.apply(__transform_all_fn{__tfx1}), __extra);
@@ -849,19 +851,19 @@ _CCCL_API constexpr auto transform_completion_signatures(
 }
 
 #if _CCCL_HAS_EXCEPTIONS()
-_CCCL_API inline constexpr auto __eptr_completion() noexcept
+[[nodiscard]] _CCCL_API inline _CCCL_CONSTEVAL auto __eptr_completion() noexcept
 {
   return completion_signatures<set_error_t(::std::exception_ptr)>{};
 }
 #else // ^^^ _CCCL_HAS_EXCEPTIONS() ^^^ / vvv !_CCCL_HAS_EXCEPTIONS() vvv
-_CCCL_API inline constexpr auto __eptr_completion() noexcept
+[[nodiscard]] _CCCL_API inline _CCCL_CONSTEVAL auto __eptr_completion() noexcept
 {
   return completion_signatures{};
 }
 #endif // !_CCCL_HAS_EXCEPTIONS()
 
 template <bool _PotentiallyThrowing>
-_CCCL_API constexpr auto __eptr_completion_if() noexcept
+[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL auto __eptr_completion_if() noexcept
 {
   if constexpr (_PotentiallyThrowing)
   {
@@ -877,7 +879,7 @@ _CCCL_API constexpr auto __eptr_completion_if() noexcept
 // When asked for its completions without an envitonment, a dependent sender
 // will throw an exception of a type derived from `dependent_sender_error`.
 template <class _Sndr>
-_CCCL_API constexpr bool __is_dependent_sender() noexcept
+[[nodiscard]] _CCCL_API consteval bool __is_dependent_sender() noexcept
 try
 {
   (void) get_completion_signatures<_Sndr>();
@@ -893,7 +895,7 @@ catch (...)
 }
 #else
 template <class _Sndr>
-_CCCL_API constexpr auto __is_dependent_sender() noexcept -> bool
+[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL auto __is_dependent_sender() noexcept -> bool
 {
   using _Completions _CCCL_NODEBUG_ALIAS = decltype(get_completion_signatures<_Sndr>());
   return _CUDA_VSTD::is_base_of_v<dependent_sender_error, _Completions>;

--- a/cudax/include/cuda/experimental/__execution/concepts.cuh
+++ b/cudax/include/cuda/experimental/__execution/concepts.cuh
@@ -106,7 +106,7 @@ inline constexpr bool enable_sender = __enable_sender<_Sndr>();
 template <class... _Env>
 struct __completions_tester
 {
-  template <class _Sndr, bool EnableIfConstexpr = (get_completion_signatures<_Sndr, _Env...>(), true)>
+  template <class _Sndr, bool EnableIfConstexpr = ((void) get_completion_signatures<_Sndr, _Env...>(), true)>
   _CCCL_API static constexpr auto __is_valid(int) -> bool
   {
     return __valid_completion_signatures<completion_signatures_of_t<_Sndr, _Env...>>;

--- a/cudax/include/cuda/experimental/__execution/conditional.cuh
+++ b/cudax/include/cuda/experimental/__execution/conditional.cuh
@@ -77,7 +77,7 @@ private:
   struct __either_sig_fn
   {
     template <class... _As>
-    _CCCL_API constexpr auto operator()() const
+    [[nodiscard]] _CCCL_API _CCCL_CONSTEVAL auto operator()() const
     {
       if constexpr (!_CUDA_VSTD::__is_callable_v<_Pred, _As&...>)
       {
@@ -203,7 +203,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT conditional_t::__sndr_t<conditional_t::__cl
   _Sndr __sndr_;
 
   template <class _Self, class... _Env>
-  _CCCL_API static constexpr auto get_completion_signatures()
+  [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL auto get_completion_signatures()
   {
     _CUDAX_LET_COMPLETIONS(auto(__child_completions) = get_child_completion_signatures<_Self, _Sndr, _Env...>())
     {

--- a/cudax/include/cuda/experimental/__execution/just.cuh
+++ b/cudax/include/cuda/experimental/__execution/just.cuh
@@ -98,9 +98,9 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __just_t<_Disposition>::__sndr_t
   using sender_concept _CCCL_NODEBUG_ALIAS = sender_t;
 
   template <class _Self, class... _Env>
-  _CCCL_API static constexpr auto get_completion_signatures() noexcept
+  [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL auto get_completion_signatures() noexcept
   {
-    return completion_signatures<_SetTag(_Ts...)>();
+    return completion_signatures<_SetTag(_Ts...)>{};
   }
 
   template <class _Rcvr>

--- a/cudax/include/cuda/experimental/__execution/just_from.cuh
+++ b/cudax/include/cuda/experimental/__execution/just_from.cuh
@@ -121,7 +121,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __just_from_t<_Disposition>::__sndr_t
   _Fn __fn_;
 
   template <class _Self, class...>
-  _CCCL_API static constexpr auto get_completion_signatures() noexcept
+  [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL auto get_completion_signatures() noexcept
   {
     return __call_result_t<_Fn, __probe_fn>{};
   }

--- a/cudax/include/cuda/experimental/__execution/let_value.cuh
+++ b/cudax/include/cuda/experimental/__execution/let_value.cuh
@@ -186,7 +186,7 @@ private:
   struct __transform_args_fn
   {
     template <class... _Ts>
-    _CCCL_API constexpr auto operator()() const
+    [[nodiscard]] _CCCL_API _CCCL_CONSTEVAL auto operator()() const
     {
       if constexpr (!__decay_copyable<_Ts...>)
       {
@@ -223,7 +223,7 @@ private:
   struct __domain_transform_fn
   {
     template <class... _Ts>
-    _CCCL_API auto operator()(_SetTag (*)(_Ts...)) const
+    [[nodiscard]] _CCCL_API _CCCL_CONSTEVAL auto operator()(_SetTag (*)(_Ts...)) const
     {
       using __result_t _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::__call_result_t<_Fn, _CUDA_VSTD::decay_t<_Ts>&...>;
       // ask the result sender if it knows where it will complete:
@@ -241,7 +241,7 @@ private:
   struct __domain_reduce_fn
   {
     template <class... _Domains>
-    _CCCL_API auto operator()(_Domains...) const
+    [[nodiscard]] _CCCL_API _CCCL_CONSTEVAL auto operator()(_Domains...) const
     {
       if constexpr (_CUDA_VSTD::_IsValidExpansion<_CUDA_VSTD::common_type_t, _Domains...>::value)
       {
@@ -255,15 +255,13 @@ private:
   };
 
   template <class _Sndr, class _Fn>
-  _CCCL_API static constexpr auto __get_completion_domain() noexcept
+  [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL auto __get_completion_domain() noexcept
   {
     // we can know the completion domain for non-dependent senders
     using __completions = completion_signatures_of_t<_Sndr>;
     if constexpr (__valid_completion_signatures<__completions>)
     {
-      auto __dom =
-        __completions().select(_SetTag()).transform_reduce(__domain_transform_fn<_Fn>(), __domain_reduce_fn());
-      return __dom;
+      return __completions{}.select(_SetTag()).transform_reduce(__domain_transform_fn<_Fn>{}, __domain_reduce_fn{});
     }
     else
     {
@@ -324,7 +322,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __let_t<_Disposition>::__sndr_t
   };
 
   template <class _Self, class... _Env>
-  _CCCL_API static constexpr auto get_completion_signatures()
+  [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL auto get_completion_signatures()
   {
     _CUDAX_LET_COMPLETIONS(auto(__child_completions) = get_child_completion_signatures<_Self, _Sndr, _Env...>())
     {

--- a/cudax/include/cuda/experimental/__execution/read_env.cuh
+++ b/cudax/include/cuda/experimental/__execution/read_env.cuh
@@ -102,7 +102,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT read_env_t::__sndr_t
   _CCCL_NO_UNIQUE_ADDRESS _Query __query;
 
   template <class _Self, class _Env>
-  _CCCL_API static constexpr auto get_completion_signatures()
+  [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL auto get_completion_signatures()
   {
     if constexpr (!_CUDA_VSTD::__is_callable_v<_Query, _Env>)
     {

--- a/cudax/include/cuda/experimental/__execution/run_loop.cuh
+++ b/cudax/include/cuda/experimental/__execution/run_loop.cuh
@@ -132,12 +132,12 @@ public:
       }
 
       template <class _Self>
-      _CCCL_API static constexpr auto get_completion_signatures() noexcept
+      [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL auto get_completion_signatures() noexcept
       {
 #if _CCCL_HAS_EXCEPTIONS()
-        return completion_signatures<set_value_t(), set_error_t(::std::exception_ptr), set_stopped_t()>();
+        return completion_signatures<set_value_t(), set_error_t(::std::exception_ptr), set_stopped_t()>{};
 #else // ^^^ _CCCL_HAS_EXCEPTIONS() ^^^ / vvv !_CCCL_HAS_EXCEPTIONS() vvv
-        return completion_signatures<set_value_t(), set_stopped_t()>();
+        return completion_signatures<set_value_t(), set_stopped_t()>{};
 #endif // !_CCCL_HAS_EXCEPTIONS()
       }
 

--- a/cudax/include/cuda/experimental/__execution/schedule_from.cuh
+++ b/cudax/include/cuda/experimental/__execution/schedule_from.cuh
@@ -48,7 +48,7 @@ template <class _Tag>
 struct __decay_args
 {
   template <class... _Ts>
-  _CCCL_TRIVIAL_API constexpr auto operator()() const noexcept
+  [[nodiscard]] _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto operator()() const noexcept
   {
     if constexpr (!__decay_copyable<_Ts...>)
     {
@@ -102,7 +102,7 @@ struct __transfer_sndr_t
   };
 
   template <class _Self, class... _Env>
-  [[nodiscard]] _CCCL_API static constexpr auto get_completion_signatures()
+  [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL auto get_completion_signatures()
   {
     _CUDAX_LET_COMPLETIONS(auto(__child_completions) = get_child_completion_signatures<_Self, _Sndr, _Env...>())
     {
@@ -111,7 +111,7 @@ struct __transfer_sndr_t
       {
         // The scheduler contributes error and stopped completions.
         return concat_completion_signatures(
-          transform_completion_signatures(__sch_completions, __swallow_transform()),
+          transform_completion_signatures(__sch_completions, __swallow_transform{}),
           transform_completion_signatures(
             __child_completions, __decay_args<set_value_t>{}, __decay_args<set_error_t>{}));
       }
@@ -263,37 +263,30 @@ private:
 
 public:
   template <class _Sndr, class _Sch>
-  struct _CCCL_TYPE_VISIBILITY_DEFAULT __sndr_t;
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __sndr_t : __detail::__transfer_sndr_t<schedule_from_t, _Sch, _Sndr>
+  {
+    template <class _Rcvr>
+    [[nodiscard]] _CCCL_API auto connect(_Rcvr __rcvr) && -> __opstate_t<_Rcvr, _Sndr, _Sch>
+    {
+      return {static_cast<_Sndr&&>(this->__sndr_), this->__sch_, static_cast<_Rcvr&&>(__rcvr)};
+    }
+
+    template <class _Rcvr>
+    [[nodiscard]] _CCCL_API auto connect(_Rcvr __rcvr) const& -> __opstate_t<_Rcvr, const _Sndr&, _Sch>
+    {
+      return {this->__sndr_, this->__sch_, static_cast<_Rcvr&&>(__rcvr)};
+    }
+  };
 
   template <class _Sch, class _Sndr>
-  _CCCL_TRIVIAL_API constexpr auto operator()(_Sch __sch, _Sndr __sndr) const;
-};
-
-template <class _Sndr, class _Sch>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT schedule_from_t::__sndr_t
-    : __detail::__transfer_sndr_t<schedule_from_t, _Sch, _Sndr>
-{
-  template <class _Rcvr>
-  [[nodiscard]] _CCCL_API auto connect(_Rcvr __rcvr) && -> __opstate_t<_Rcvr, _Sndr, _Sch>
+  [[nodiscard]] _CCCL_TRIVIAL_API constexpr auto operator()(_Sch __sch, _Sndr __sndr) const
   {
-    return {static_cast<_Sndr&&>(this->__sndr_), this->__sch_, static_cast<_Rcvr&&>(__rcvr)};
-  }
-
-  template <class _Rcvr>
-  [[nodiscard]] _CCCL_API auto connect(_Rcvr __rcvr) const& -> __opstate_t<_Rcvr, const _Sndr&, _Sch>
-  {
-    return {this->__sndr_, this->__sch_, static_cast<_Rcvr&&>(__rcvr)};
+    static_assert(__is_sender<_Sndr>);
+    static_assert(__is_scheduler<_Sch>);
+    // schedule_from always dispatches based on the domain of the scheduler
+    return transform_sender(get_domain(__sch), __sndr_t<_Sndr, _Sch>{{{}, __sch, static_cast<_Sndr&&>(__sndr)}});
   }
 };
-
-template <class _Sch, class _Sndr>
-[[nodiscard]] _CCCL_TRIVIAL_API constexpr auto schedule_from_t::operator()(_Sch __sch, _Sndr __sndr) const
-{
-  static_assert(__is_sender<_Sndr>);
-  static_assert(__is_scheduler<_Sch>);
-  // schedule_from always dispatches based on the domain of the scheduler
-  return transform_sender(get_domain(__sch), __sndr_t<_Sndr, _Sch>{{{}, __sch, static_cast<_Sndr&&>(__sndr)}});
-}
 
 template <class _Sndr, class _Sch>
 inline constexpr size_t structured_binding_size<schedule_from_t::__sndr_t<_Sndr, _Sch>> = 3;

--- a/cudax/include/cuda/experimental/__execution/schedule_from.cuh
+++ b/cudax/include/cuda/experimental/__execution/schedule_from.cuh
@@ -22,6 +22,7 @@
 #endif // no system header
 
 #include <cuda/std/__cccl/unreachable.h>
+#include <cuda/std/__concepts/same_as.h>
 #include <cuda/std/__type_traits/conditional.h>
 #include <cuda/std/__utility/pod_tuple.h>
 
@@ -41,6 +42,96 @@
 
 namespace cuda::experimental::execution
 {
+namespace __detail
+{
+template <class _Tag>
+struct __decay_args
+{
+  template <class... _Ts>
+  _CCCL_TRIVIAL_API constexpr auto operator()() const noexcept
+  {
+    if constexpr (!__decay_copyable<_Ts...>)
+    {
+      return invalid_completion_signature<_WHERE(_IN_ALGORITHM, schedule_from_t),
+                                          _WHAT(_ARGUMENTS_ARE_NOT_DECAY_COPYABLE),
+                                          _WITH_ARGUMENTS(_Ts...)>();
+    }
+    else if constexpr (!__nothrow_decay_copyable<_Ts...>)
+    {
+      return completion_signatures<_Tag(__decay_t<_Ts>...), set_error_t(::std::exception_ptr)>{};
+    }
+    else
+    {
+      return completion_signatures<_Tag(__decay_t<_Ts>...)>{};
+    }
+  }
+};
+
+// A base class for both schedule_from_t::__sndr_t and continues_on_t::__sndr_t
+template <class _Tag, class _Sch, class _Sndr>
+struct __transfer_sndr_t
+{
+  using sender_concept = sender_t;
+
+  // see SCHED-ATTRS here: https://eel.is/c++draft/exec#snd.expos-6
+  struct __attrs_t
+  {
+    template <class _SetTag>
+    _CCCL_API auto query(get_completion_scheduler_t<_SetTag>) const = delete;
+
+    _CCCL_API auto query(get_completion_scheduler_t<set_value_t>) const noexcept -> _Sch
+    {
+      return __self_->__sch_;
+    }
+
+    // Returns the domain on which the schedule_from/continues_on sender will complete:
+    [[nodiscard]] _CCCL_API static constexpr auto query(get_domain_t) noexcept
+    {
+      return _CUDA_VSTD::__call_result_t<get_domain_t, _Sch>{};
+    }
+
+    _CCCL_TEMPLATE(class _Query)
+    _CCCL_REQUIRES(__forwarding_query<_Query> _CCCL_AND __queryable_with<env_of_t<_Sndr>, _Query>)
+    [[nodiscard]] _CCCL_API auto query(_Query) const noexcept(__nothrow_queryable_with<env_of_t<_Sndr>, _Query>)
+      -> __query_result_t<env_of_t<_Sndr>, _Query>
+    {
+      return execution::get_env(__self_->__sndr_).query(_Query{});
+    }
+
+    const __transfer_sndr_t* __self_;
+  };
+
+  template <class _Self, class... _Env>
+  [[nodiscard]] _CCCL_API static constexpr auto get_completion_signatures()
+  {
+    _CUDAX_LET_COMPLETIONS(auto(__child_completions) = get_child_completion_signatures<_Self, _Sndr, _Env...>())
+    {
+      _CUDAX_LET_COMPLETIONS(
+        auto(__sch_completions) = execution::get_completion_signatures<schedule_result_t<_Sch>, _Env...>())
+      {
+        // The scheduler contributes error and stopped completions.
+        return concat_completion_signatures(
+          transform_completion_signatures(__sch_completions, __swallow_transform()),
+          transform_completion_signatures(
+            __child_completions, __decay_args<set_value_t>{}, __decay_args<set_error_t>{}));
+      }
+    }
+
+    _CCCL_UNREACHABLE();
+  }
+
+  [[nodiscard]] _CCCL_API auto get_env() const noexcept -> __attrs_t
+  {
+    return __attrs_t{this};
+  }
+
+  _CCCL_NO_UNIQUE_ADDRESS _Tag __tag_;
+  _Sch __sch_;
+  _Sndr __sndr_;
+};
+
+} // namespace __detail
+
 struct _CCCL_TYPE_VISIBILITY_DEFAULT schedule_from_t
 {
 private:
@@ -178,92 +269,20 @@ public:
   _CCCL_TRIVIAL_API constexpr auto operator()(_Sch __sch, _Sndr __sndr) const;
 };
 
-template <class _Tag>
-struct __decay_args
-{
-  template <class... _Ts>
-  _CCCL_TRIVIAL_API constexpr auto operator()() const noexcept
-  {
-    if constexpr (!__decay_copyable<_Ts...>)
-    {
-      return invalid_completion_signature<_WHERE(_IN_ALGORITHM, schedule_from_t),
-                                          _WHAT(_ARGUMENTS_ARE_NOT_DECAY_COPYABLE),
-                                          _WITH_ARGUMENTS(_Ts...)>();
-    }
-    else if constexpr (!__nothrow_decay_copyable<_Ts...>)
-    {
-      return completion_signatures<_Tag(__decay_t<_Ts>...), set_error_t(::std::exception_ptr)>{};
-    }
-    else
-    {
-      return completion_signatures<_Tag(__decay_t<_Ts>...)>{};
-    }
-  }
-};
-
 template <class _Sndr, class _Sch>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT schedule_from_t::__sndr_t
+    : __detail::__transfer_sndr_t<schedule_from_t, _Sch, _Sndr>
 {
-  using sender_concept _CCCL_NODEBUG_ALIAS = sender_t;
-  _CCCL_NO_UNIQUE_ADDRESS schedule_from_t __tag_;
-  _Sch __sch_;
-  _Sndr __sndr_;
-
-  struct _CCCL_TYPE_VISIBILITY_DEFAULT __attrs_t
-  {
-    template <class _SetTag>
-    _CCCL_API auto query(get_completion_scheduler_t<_SetTag>) const = delete;
-
-    [[nodiscard]] _CCCL_API auto query(get_completion_scheduler_t<set_value_t>) const noexcept -> _Sch
-    {
-      return __sndr_->__sch_;
-    }
-
-    _CCCL_TEMPLATE(class _Query)
-    _CCCL_REQUIRES(__forwarding_query<_Query> _CCCL_AND __queryable_with<env_of_t<_Sndr>, _Query>)
-    [[nodiscard]] _CCCL_API auto query(_Query) const noexcept(__nothrow_queryable_with<env_of_t<_Sndr>, _Query>)
-      -> __query_result_t<env_of_t<_Sndr>, _Query>
-    {
-      return execution::get_env(__sndr_->__sndr_).query(_Query{});
-    }
-
-    const __sndr_t* __sndr_;
-  };
-
-  template <class _Self, class... _Env>
-  [[nodiscard]] _CCCL_API static constexpr auto get_completion_signatures()
-  {
-    _CUDAX_LET_COMPLETIONS(auto(__child_completions) = get_child_completion_signatures<_Self, _Sndr, _Env...>())
-    {
-      _CUDAX_LET_COMPLETIONS(
-        auto(__sch_completions) = execution::get_completion_signatures<schedule_result_t<_Sch>, _Env...>())
-      {
-        // The scheduler contributes error and stopped completions.
-        return concat_completion_signatures(
-          transform_completion_signatures(__sch_completions, __swallow_transform()),
-          transform_completion_signatures(
-            __child_completions, __decay_args<set_value_t>{}, __decay_args<set_error_t>{}));
-      }
-    }
-
-    _CCCL_UNREACHABLE();
-  }
-
   template <class _Rcvr>
   [[nodiscard]] _CCCL_API auto connect(_Rcvr __rcvr) && -> __opstate_t<_Rcvr, _Sndr, _Sch>
   {
-    return {static_cast<_Sndr&&>(__sndr_), __sch_, static_cast<_Rcvr&&>(__rcvr)};
+    return {static_cast<_Sndr&&>(this->__sndr_), this->__sch_, static_cast<_Rcvr&&>(__rcvr)};
   }
 
   template <class _Rcvr>
   [[nodiscard]] _CCCL_API auto connect(_Rcvr __rcvr) const& -> __opstate_t<_Rcvr, const _Sndr&, _Sch>
   {
-    return {__sndr_, __sch_, static_cast<_Rcvr&&>(__rcvr)};
-  }
-
-  [[nodiscard]] _CCCL_API auto get_env() const noexcept -> __attrs_t
-  {
-    return __attrs_t{this};
+    return {this->__sndr_, this->__sch_, static_cast<_Rcvr&&>(__rcvr)};
   }
 };
 
@@ -272,8 +291,8 @@ template <class _Sch, class _Sndr>
 {
   static_assert(__is_sender<_Sndr>);
   static_assert(__is_scheduler<_Sch>);
-  using __dom_t _CCCL_NODEBUG_ALIAS = __domain_of_t<_Sch>; // see [exec.schedule.from]
-  return transform_sender(__dom_t{}, __sndr_t<_Sndr, _Sch>{{}, __sch, static_cast<_Sndr&&>(__sndr)});
+  // schedule_from always dispatches based on the domain of the scheduler
+  return transform_sender(get_domain(__sch), __sndr_t<_Sndr, _Sch>{{{}, __sch, static_cast<_Sndr&&>(__sndr)}});
 }
 
 template <class _Sndr, class _Sch>

--- a/cudax/include/cuda/experimental/__execution/sequence.cuh
+++ b/cudax/include/cuda/experimental/__execution/sequence.cuh
@@ -116,14 +116,14 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT sequence_t::__sndr_t
   using __sndr2_t _CCCL_NODEBUG_ALIAS      = _Sndr2;
 
   template <class _Self, class... _Env>
-  _CCCL_API static constexpr auto get_completion_signatures()
+  [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL auto get_completion_signatures()
   {
     _CUDAX_LET_COMPLETIONS(auto(__completions1) = get_child_completion_signatures<_Self, _Sndr1, _Env...>())
     {
       _CUDAX_LET_COMPLETIONS(auto(__completions2) = get_child_completion_signatures<_Self, _Sndr2, _Env...>())
       {
         // ignore the first sender's value completions
-        return __completions2 + transform_completion_signatures(__completions1, __swallow_transform());
+        return __completions2 + transform_completion_signatures(__completions1, __swallow_transform{});
       }
     }
 

--- a/cudax/include/cuda/experimental/__execution/starts_on.cuh
+++ b/cudax/include/cuda/experimental/__execution/starts_on.cuh
@@ -105,7 +105,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT starts_on_t::__sndr_t
   using __env_t _CCCL_NODEBUG_ALIAS = env<__sch_env_t<_Sch>, __fwd_env_t<_Env>>;
 
   template <class _Self, class... _Env>
-  _CCCL_API static constexpr auto get_completion_signatures()
+  [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL auto get_completion_signatures()
   {
     using __sch_sndr _CCCL_NODEBUG_ALIAS   = schedule_result_t<_Sch>;
     using __child_sndr _CCCL_NODEBUG_ALIAS = __copy_cvref_t<_Self, _Sndr>;
@@ -115,7 +115,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT starts_on_t::__sndr_t
       _CUDAX_LET_COMPLETIONS(
         auto(__sch_completions) = execution::get_completion_signatures<__sch_sndr, __fwd_env_t<_Env>...>())
       {
-        return __sndr_completions + transform_completion_signatures(__sch_completions, __swallow_transform());
+        return __sndr_completions + transform_completion_signatures(__sch_completions, __swallow_transform{});
       }
     }
 

--- a/cudax/include/cuda/experimental/__execution/then.cuh
+++ b/cudax/include/cuda/experimental/__execution/then.cuh
@@ -194,11 +194,11 @@ private:
   struct __transform_args_fn
   {
     template <class... _Ts>
-    _CCCL_API constexpr auto operator()() const
+    [[nodiscard]] _CCCL_API _CCCL_CONSTEVAL auto operator()() const
     {
       if constexpr (_CUDA_VSTD::__is_callable_v<_Fn, _Ts...>)
       {
-        return __upon::__completion<_Fn, _Ts...>();
+        return __upon::__completion<_Fn, _Ts...>{};
       }
       else
       {
@@ -234,7 +234,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __upon_t<_Disposition>::__sndr_t
   _Sndr __sndr_;
 
   template <class _Self, class... _Env>
-  _CCCL_API static constexpr auto get_completion_signatures()
+  [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL auto get_completion_signatures()
   {
     _CUDAX_LET_COMPLETIONS(auto(__child_completions) = get_child_completion_signatures<_Self, _Sndr, _Env...>())
     {

--- a/cudax/include/cuda/experimental/__execution/variant.cuh
+++ b/cudax/include/cuda/experimental/__execution/variant.cuh
@@ -23,6 +23,7 @@
 
 #include <cuda/std/__memory/construct_at.h>
 #include <cuda/std/__new/launder.h>
+#include <cuda/std/__type_traits/decay.h>
 #include <cuda/std/__utility/integer_sequence.h>
 
 #include <cuda/experimental/__execution/meta.cuh>
@@ -100,6 +101,12 @@ public:
   [[nodiscard]] _CCCL_TRIVIAL_API size_t __index() const noexcept
   {
     return __index_;
+  }
+
+  template <class _Ty>
+  _CCCL_API auto __emplace(_Ty&& __value) noexcept(__nothrow_decay_copyable<_Ty>) -> _CUDA_VSTD::decay_t<_Ty>&
+  {
+    return __emplace<_CUDA_VSTD::decay_t<_Ty>, _Ty>(static_cast<_Ty&&>(__value));
   }
 
   _CCCL_EXEC_CHECK_DISABLE

--- a/cudax/include/cuda/experimental/__execution/when_all.cuh
+++ b/cudax/include/cuda/experimental/__execution/when_all.cuh
@@ -67,12 +67,12 @@ private:
   // Returns the completion signatures of a child sender. Throws an exception if
   // the child sender has more than one set_value completion signature.
   template <class _Child, class... _Env>
-  _CCCL_API static constexpr auto __child_completions();
+  [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL auto __child_completions();
 
   // Merges the completion signatures of the child senders into a single set of
   // completion signatures for the when_all sender.
   template <class... _Completions>
-  _CCCL_API static constexpr auto __merge_completions(_Completions...);
+  [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL auto __merge_completions(_Completions...);
 
   /// The receivers connected to the when_all's sub-operations expose this as
   /// their environment. Its `get_stop_token` query returns the token from
@@ -388,7 +388,7 @@ public:
 };
 
 template <class _Child, class... _Env>
-_CCCL_API constexpr auto when_all_t::__child_completions()
+[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL auto when_all_t::__child_completions()
 {
   using __env_t _CCCL_NODEBUG_ALIAS = prop<get_stop_token_t, inplace_stop_token>;
   _CUDAX_LET_COMPLETIONS(auto(__completions) = get_completion_signatures<_Child, env<__env_t, __fwd_env_t<_Env>>...>())
@@ -410,15 +410,15 @@ _CCCL_DIAG_PUSH
 _CCCL_DIAG_SUPPRESS_GCC("-Wunused-value")
 
 template <class... _Completions>
-_CCCL_API constexpr auto when_all_t::__merge_completions(_Completions... __cs)
+[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL auto when_all_t::__merge_completions(_Completions... __cs)
 {
   // Use _CUDAX_LET_COMPLETIONS to ensure all completions are valid:
   _CUDAX_LET_COMPLETIONS(auto(__tmp) = (completion_signatures{}, ..., __cs)) // NB: uses overloaded comma operator
   {
     _CUDA_VSTD::ignore           = __tmp; // silence unused variable warning
     auto __non_value_completions = concat_completion_signatures(
-      completion_signatures<set_stopped_t()>(),
-      transform_completion_signatures(__cs, __swallow_transform(), __decay_transform<set_error_t>())...);
+      completion_signatures<set_stopped_t()>{},
+      transform_completion_signatures(__cs, __swallow_transform{}, __decay_transform<set_error_t>{})...);
 
     if constexpr (((0 == __cs.count(set_value)) || ...))
     {
@@ -461,13 +461,13 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT when_all_t::__sndr_t : _CUDA_VSTD::__tuple<
   using __sndrs_t _CCCL_NODEBUG_ALIAS      = _CUDA_VSTD::__tuple<when_all_t, __ignore, _Sndrs...>;
 
   template <class _Self, class... _Env>
-  _CCCL_API static constexpr auto __get_completions_and_offsets()
+  [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL auto __get_completions_and_offsets()
   {
     return __merge_completions(__child_completions<__copy_cvref_t<_Self, _Sndrs>, _Env...>()...);
   }
 
   template <class _Self, class... _Env>
-  _CCCL_API static constexpr auto get_completion_signatures()
+  [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL auto get_completion_signatures()
   {
     return __get_completions_and_offsets<_Self, _Env...>().first;
   }

--- a/cudax/include/cuda/experimental/__execution/write_env.cuh
+++ b/cudax/include/cuda/experimental/__execution/write_env.cuh
@@ -76,7 +76,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT write_env_t::__sndr_t
   using sender_concept _CCCL_NODEBUG_ALIAS = sender_t;
 
   template <class _Self, class... _Env2>
-  _CCCL_API static constexpr auto get_completion_signatures()
+  [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL auto get_completion_signatures()
   {
     using _Child _CCCL_NODEBUG_ALIAS = __copy_cvref_t<_Self, _Sndr>;
     return execution::get_completion_signatures<_Child, env<const _Env&, __fwd_env_t<_Env2>>...>();

--- a/libcudacxx/include/cuda/std/__memory/construct_at.h
+++ b/libcudacxx/include/cuda/std/__memory/construct_at.h
@@ -181,6 +181,7 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr void __destroy_at(_Tp* __loc)
   }
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _ForwardIterator>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _ForwardIterator __destroy(_ForwardIterator __first, _ForwardIterator __last)
 {
@@ -191,6 +192,7 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr _ForwardIterator __destroy(_ForwardIterator 
   return __first;
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _BidirectionalIterator>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _BidirectionalIterator
 __reverse_destroy(_BidirectionalIterator __first, _BidirectionalIterator __last)
@@ -203,6 +205,7 @@ __reverse_destroy(_BidirectionalIterator __first, _BidirectionalIterator __last)
   return __last;
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _Tp>
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX20 void destroy_at(_Tp* __loc)
 {
@@ -227,6 +230,7 @@ _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX20 void destroy(_ForwardIterator __
   (void) _CUDA_VSTD::__destroy(_CUDA_VSTD::move(__first), _CUDA_VSTD::move(__last));
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _ForwardIterator, class _Size>
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX20 _ForwardIterator destroy_n(_ForwardIterator __first, _Size __n)
 {


### PR DESCRIPTION
## Description

this is mostly a simple refactor. `continues_on` and `schedule_from` are very similar, and much of their implementation can be factored out into a common base class.

the one functional change is to add the `get_domain` query to the environments of the `continues_on`/`schedule_from` senders. it is not strictly necessary -- the right domain will be inferred from the completion scheduler -- but explicit is better than implicit (tm).

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
