### PR TITLE
Align bulk copies to 16 bytes on Blackwell

### DIFF
--- a/cub/benchmarks/bench/transform/common.h
+++ b/cub/benchmarks/bench/transform/common.h
@@ -38,7 +38,7 @@ struct policy_hub_t
     using algo_policy =
       ::cuda::std::_If<algorithm == cub::detail::transform::Algorithm::prefetch,
                        cub::detail::transform::prefetch_policy_t<TUNE_THREADS>,
-                       cub::detail::transform::async_copy_policy_t<TUNE_THREADS>>;
+                       cub::detail::transform::async_copy_policy_t<TUNE_THREADS, __CUDA_ARCH_LIST__ == 900 ? 128 : 16>>;
   };
 };
 #endif

--- a/cub/cub/device/dispatch/dispatch_transform.cuh
+++ b/cub/cub/device/dispatch/dispatch_transform.cuh
@@ -169,6 +169,7 @@ struct dispatch_t<StableAddress,
   RandomAccessIteratorOut out;
   Offset num_items;
   TransformOp op;
+  int bulk_copy_align;
   cudaStream_t stream;
   KernelSource kernel_source             = {};
   KernelLauncherFactory launcher_factory = {};
@@ -181,12 +182,11 @@ struct dispatch_t<StableAddress,
     ::cuda::std::
       tuple<THRUST_NS_QUALIFIER::cuda_cub::detail::triple_chevron, decltype(kernel_source.TransformKernel()), int>>
   {
-    using policy_t                    = typename ActivePolicy::algo_policy;
-    constexpr int block_dim           = policy_t::block_threads;
-    constexpr int bulk_copy_alignment = policy_t::bulk_copy_alignment;
-    static_assert(block_dim % bulk_copy_alignment == 0,
-                  "block_threads needs to be a multiple of bulk_copy_alignment (128)"); // then tile_size is a multiple
-                                                                                        // of 128-byte
+    using policy_t          = typename ActivePolicy::algo_policy;
+    constexpr int block_dim = policy_t::block_threads;
+    _CCCL_ASSERT_HOST(block_dim % bulk_copy_align == 0,
+                      "block_threads needs to be a multiple of bulk_copy_alignment"); // then tile_size is a multiple of
+                                                                                      // it
 
     auto determine_element_counts = [&]() -> cuda_expected<elem_counts> {
       const auto max_smem = get_max_shared_memory();
@@ -203,7 +203,7 @@ struct dispatch_t<StableAddress,
            ++elem_per_thread)
       {
         const int tile_size = block_dim * elem_per_thread;
-        const int smem_size = bulk_copy_smem_for_tile_size<RandomAccessIteratorsIn...>(tile_size, bulk_copy_alignment);
+        const int smem_size = bulk_copy_smem_for_tile_size<RandomAccessIteratorsIn...>(tile_size, bulk_copy_align);
         if (smem_size > *max_smem)
         {
           // assert should be prevented by smem check in policy
@@ -247,7 +247,7 @@ struct dispatch_t<StableAddress,
     }
     _CCCL_ASSERT_HOST(config->elem_per_thread > 0, "");
     _CCCL_ASSERT_HOST(config->tile_size > 0, "");
-    _CCCL_ASSERT_HOST(config->tile_size % bulk_copy_alignment == 0, "");
+    _CCCL_ASSERT_HOST(config->tile_size % bulk_copy_align == 0, "");
     _CCCL_ASSERT_HOST((sizeof...(RandomAccessIteratorsIn) == 0) != (config->smem_size != 0), ""); // logical xor
 
     const auto grid_dim = static_cast<unsigned int>(::cuda::ceil_div(num_items, Offset{config->tile_size}));
@@ -260,8 +260,7 @@ struct dispatch_t<StableAddress,
   template <typename ActivePolicy, size_t... Is>
   CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t invoke_ublkcp_algorithm(::cuda::std::index_sequence<Is...>)
   {
-    constexpr int bulk_copy_alignment = ActivePolicy::algo_policy::bulk_copy_alignment;
-    auto ret                          = configure_ublkcp_kernel<ActivePolicy>();
+    auto ret = configure_ublkcp_kernel<ActivePolicy>();
     if (!ret)
     {
       return ret.error();
@@ -274,7 +273,7 @@ struct dispatch_t<StableAddress,
       op,
       out,
       make_aligned_base_ptr_kernel_arg(
-        THRUST_NS_QUALIFIER::try_unwrap_contiguous_iterator(::cuda::std::get<Is>(in)), bulk_copy_alignment)...);
+        THRUST_NS_QUALIFIER::try_unwrap_contiguous_iterator(::cuda::std::get<Is>(in)), bulk_copy_align)...);
   }
 #endif // _CUB_HAS_TRANSFORM_UBLKCP
 
@@ -387,6 +386,7 @@ struct dispatch_t<StableAddress,
       ::cuda::std::move(out),
       num_items,
       ::cuda::std::move(op),
+      bulk_copy_alignment(ptx_version),
       stream,
       kernel_source,
       launcher_factory};

--- a/cub/cub/device/dispatch/kernels/transform.cuh
+++ b/cub/cub/device/dispatch/kernels/transform.cuh
@@ -206,6 +206,8 @@ template <typename BulkCopyPolicy, typename Offset, typename F, typename RandomA
 _CCCL_DEVICE void transform_kernel_ublkcp(
   Offset num_items, int num_elem_per_thread, F f, RandomAccessIteratorOut out, aligned_base_ptr<InTs>... aligned_ptrs)
 {
+  constexpr int bulk_copy_alignment = BulkCopyPolicy::bulk_copy_alignment;
+
   __shared__ uint64_t bar;
   extern __shared__ char __align__(bulk_copy_alignment) smem[];
 

--- a/cub/cub/device/dispatch/kernels/transform.cuh
+++ b/cub/cub/device/dispatch/kernels/transform.cuh
@@ -202,27 +202,6 @@ _CCCL_DEVICE _CCCL_FORCEINLINE static bool elect_one()
   return threadIdx.x < 32 && static_cast<bool>(is_elected);
 }
 
-template <typename Offset, typename T>
-_CCCL_DEVICE void bulk_copy_tile_fallback(
-  int tile_size,
-  int tile_stride,
-  char* smem,
-  int& smem_offset,
-  Offset global_offset,
-  const aligned_base_ptr<T>& aligned_ptr)
-{
-  const T* src = aligned_ptr.ptr_to_elements() + global_offset;
-  T* dst       = reinterpret_cast<T*>(smem + smem_offset + aligned_ptr.head_padding);
-  _CCCL_ASSERT(reinterpret_cast<uintptr_t>(src) % alignof(T) == 0, "");
-  _CCCL_ASSERT(reinterpret_cast<uintptr_t>(dst) % alignof(T) == 0, "");
-
-  const int bytes_to_copy = static_cast<int>(sizeof(T)) * tile_size;
-  cooperative_groups::memcpy_async(cooperative_groups::this_thread_block(), dst, src, bytes_to_copy);
-
-  // add bulk_copy_alignment to make space for the next tile's head padding
-  smem_offset += static_cast<int>(sizeof(T)) * tile_stride + bulk_copy_alignment;
-}
-
 template <typename BulkCopyPolicy, typename Offset, typename F, typename RandomAccessIteratorOut, typename... InTs>
 _CCCL_DEVICE void transform_kernel_ublkcp(
   Offset num_items, int num_elem_per_thread, F f, RandomAccessIteratorOut out, aligned_base_ptr<InTs>... aligned_ptrs)

--- a/cub/test/catch2_test_device_transform.cu
+++ b/cub/test/catch2_test_device_transform.cu
@@ -38,7 +38,7 @@ struct policy_hub_for_alg
     using algo_policy =
       ::cuda::std::_If<Alg == Algorithm::prefetch,
                        cub::detail::transform::prefetch_policy_t<256>,
-                       cub::detail::transform::async_copy_policy_t<256>>;
+                       cub::detail::transform::async_copy_policy_t<256, 128>>;
   };
 };
 

--- a/cudax/test/containers/async_buffer/transform.cu
+++ b/cudax/test/containers/async_buffer/transform.cu
@@ -39,7 +39,7 @@ struct policy_hub_for_alg
     using algo_policy =
       ::cuda::std::_If<Alg == Algorithm::prefetch,
                        cub::detail::transform::prefetch_policy_t<256>,
-                       cub::detail::transform::async_copy_policy_t<256>>;
+                       cub::detail::transform::async_copy_policy_t<256, 128>>;
   };
 };
 


### PR DESCRIPTION
This PR replaces the global constant `bulk_copy_alignment` by a new value in the tuning policies.

```
# mul

## [0] NVIDIA B200

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-----------|---------|----------|
|   I8    |      I32      |      2^16      |   6.365 us |      11.64% |   6.347 us |      10.63% | -0.019 us |  -0.29% |   SAME   |
|   I8    |      I32      |      2^20      |   7.050 us |      12.20% |   7.079 us |      12.49% |  0.030 us |   0.42% |   SAME   |
|   I8    |      I32      |      2^24      |  14.231 us |       2.52% |  14.271 us |       2.83% |  0.040 us |   0.28% |   SAME   |
|   I8    |      I32      |      2^28      | 120.491 us |       0.45% | 120.463 us |       0.49% | -0.027 us |  -0.02% |   SAME   |
|   I8    |      I64      |      2^16      |   6.472 us |      10.31% |   6.417 us |       9.88% | -0.054 us |  -0.84% |   SAME   |
|   I8    |      I64      |      2^20      |   7.657 us |       9.42% |   7.725 us |       9.17% |  0.068 us |   0.89% |   SAME   |
|   I8    |      I64      |      2^24      |  14.378 us |       3.73% |  14.349 us |       3.47% | -0.030 us |  -0.21% |   SAME   |
|   I8    |      I64      |      2^28      | 123.758 us |       0.79% | 123.882 us |       0.77% |  0.125 us |   0.10% |   SAME   |
|   I16   |      I32      |      2^16      |   6.295 us |       8.79% |   6.308 us |       8.92% |  0.013 us |   0.20% |   SAME   |
|   I16   |      I32      |      2^20      |   7.390 us |      11.47% |   7.237 us |      12.57% | -0.152 us |  -2.06% |   SAME   |
|   I16   |      I32      |      2^24      |  18.262 us |       2.18% |  18.244 us |       2.14% | -0.018 us |  -0.10% |   SAME   |
|   I16   |      I32      |      2^28      | 192.361 us |       0.15% | 192.839 us |       0.42% |  0.478 us |   0.25% |   SLOW   |
|   I16   |      I64      |      2^16      |   6.347 us |       9.43% |   6.401 us |       9.88% |  0.054 us |   0.85% |   SAME   |
|   I16   |      I64      |      2^20      |   7.171 us |      12.60% |   7.140 us |      12.17% | -0.032 us |  -0.44% |   SAME   |
|   I16   |      I64      |      2^24      |  18.564 us |       3.38% |  18.648 us |       3.73% |  0.083 us |   0.45% |   SAME   |
|   I16   |      I64      |      2^28      | 196.616 us |       0.26% | 198.224 us |       0.36% |  1.608 us |   0.82% |   SLOW   |
|   F32   |      I32      |      2^16      |   5.917 us |       5.75% |   5.926 us |       5.65% |  0.009 us |   0.15% |   SAME   |
|   F32   |      I32      |      2^20      |   7.562 us |      10.18% |   7.565 us |       9.81% |  0.003 us |   0.04% |   SAME   |
|   F32   |      I32      |      2^24      |  26.324 us |       1.68% |  26.396 us |       1.53% |  0.072 us |   0.27% |   SAME   |
|   F32   |      I32      |      2^28      | 313.237 us |       0.07% | 313.242 us |       0.08% |  0.005 us |   0.00% |   SAME   |
|   F32   |      I64      |      2^16      |   5.910 us |       5.48% |   5.937 us |       5.35% |  0.027 us |   0.45% |   SAME   |
|   F32   |      I64      |      2^20      |   7.611 us |       9.43% |   7.627 us |       9.59% |  0.016 us |   0.21% |   SAME   |
|   F32   |      I64      |      2^24      |  26.419 us |       1.25% |  26.387 us |       1.31% | -0.032 us |  -0.12% |   SAME   |
|   F32   |      I64      |      2^28      | 313.330 us |       0.15% | 313.601 us |       0.25% |  0.271 us |   0.09% |   SAME   |
|   F64   |      I32      |      2^16      |   5.944 us |       5.36% |   5.943 us |       5.41% | -0.001 us |  -0.02% |   SAME   |
|   F64   |      I32      |      2^20      |   8.396 us |       7.64% |   8.457 us |       8.05% |  0.061 us |   0.73% |   SAME   |
|   F64   |      I32      |      2^24      |  45.006 us |       1.28% |  44.958 us |       1.26% | -0.049 us |  -0.11% |   SAME   |
|   F64   |      I32      |      2^28      | 607.926 us |       0.34% | 608.020 us |       0.26% |  0.093 us |   0.02% |   SAME   |
|   F64   |      I64      |      2^16      |   5.943 us |       5.39% |   5.923 us |       5.49% | -0.020 us |  -0.33% |   SAME   |
|   F64   |      I64      |      2^20      |   8.508 us |       8.08% |   8.478 us |       7.92% | -0.030 us |  -0.36% |   SAME   |
|   F64   |      I64      |      2^24      |  45.152 us |       1.60% |  45.093 us |       1.52% | -0.059 us |  -0.13% |   SAME   |
|   F64   |      I64      |      2^28      | 608.256 us |       0.00% | 608.198 us |       0.12% | -0.058 us |  -0.01% |   FAST   |
|  I128   |      I32      |      2^16      |   5.919 us |       5.78% |   5.925 us |       5.73% |  0.007 us |   0.11% |   SAME   |
|  I128   |      I32      |      2^20      |  10.925 us |       7.43% |  10.924 us |       7.23% | -0.001 us |  -0.01% |   SAME   |
|  I128   |      I32      |      2^24      |  83.733 us |       0.84% |  83.745 us |       0.74% |  0.012 us |   0.01% |   SAME   |
|  I128   |      I32      |      2^28      |   1.236 ms |       0.15% |   1.236 ms |       0.14% |  0.119 us |   0.01% |   SAME   |
|  I128   |      I64      |      2^16      |   6.098 us |       9.37% |   6.104 us |       8.48% |  0.006 us |   0.10% |   SAME   |
|  I128   |      I64      |      2^20      |  10.937 us |       7.32% |  10.880 us |       7.36% | -0.057 us |  -0.52% |   SAME   |
|  I128   |      I64      |      2^24      |  83.870 us |       0.74% |  83.894 us |       0.72% |  0.025 us |   0.03% |   SAME   |
|  I128   |      I64      |      2^28      |   1.236 ms |       0.14% |   1.236 ms |       0.15% |  0.005 us |   0.00% |   SAME   |

# add

## [0] NVIDIA B200

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-----------|---------|----------|
|   I8    |      I32      |      2^16      |   7.519 us |      11.24% |   7.511 us |      11.18% | -0.008 us |  -0.11% |   SAME   |
|   I8    |      I32      |      2^20      |   7.973 us |       4.09% |   7.992 us |       4.18% |  0.018 us |   0.23% |   SAME   |
|   I8    |      I32      |      2^24      |  18.121 us |       2.84% |  18.067 us |       3.22% | -0.053 us |  -0.30% |   SAME   |
|   I8    |      I32      |      2^28      | 169.479 us |       0.46% | 169.507 us |       0.45% |  0.027 us |   0.02% |   SAME   |
|   I8    |      I64      |      2^16      |   7.361 us |      11.64% |   6.747 us |      11.80% | -0.614 us |  -8.34% |   SAME   |
|   I8    |      I64      |      2^20      |   7.963 us |       4.11% |   7.972 us |       4.19% |  0.010 us |   0.12% |   SAME   |
|   I8    |      I64      |      2^24      |  18.120 us |       2.45% |  18.186 us |       1.89% |  0.067 us |   0.37% |   SAME   |
|   I8    |      I64      |      2^28      | 167.820 us |       0.17% | 167.805 us |       0.17% | -0.015 us |  -0.01% |   SAME   |
|   I16   |      I32      |      2^16      |   6.387 us |       9.72% |   6.326 us |       9.47% | -0.061 us |  -0.96% |   SAME   |
|   I16   |      I32      |      2^20      |   7.956 us |       4.33% |   7.882 us |       5.65% | -0.074 us |  -0.94% |   SAME   |
|   I16   |      I32      |      2^24      |  25.422 us |       3.55% |  25.439 us |       3.57% |  0.016 us |   0.06% |   SAME   |
|   I16   |      I32      |      2^28      | 294.866 us |       0.14% | 295.330 us |       0.29% |  0.464 us |   0.16% |   SLOW   |
|   I16   |      I64      |      2^16      |   6.226 us |       9.07% |   6.157 us |       8.24% | -0.069 us |  -1.10% |   SAME   |
|   I16   |      I64      |      2^20      |   7.924 us |       4.79% |   7.933 us |       5.07% |  0.008 us |   0.11% |   SAME   |
|   I16   |      I64      |      2^24      |  25.558 us |       3.44% |  25.556 us |       3.47% | -0.002 us |  -0.01% |   SAME   |
|   I16   |      I64      |      2^28      | 296.742 us |       0.16% | 297.034 us |       0.21% |  0.292 us |   0.10% |   SAME   |
|   F32   |      I32      |      2^16      |   5.965 us |       5.57% |   5.972 us |       5.99% |  0.007 us |   0.12% |   SAME   |
|   F32   |      I32      |      2^20      |   8.120 us |       5.26% |   8.112 us |       5.42% | -0.008 us |  -0.10% |   SAME   |
|   F32   |      I32      |      2^24      |  39.856 us |       2.30% |  39.894 us |       2.21% |  0.038 us |   0.09% |   SAME   |
|   F32   |      I32      |      2^28      | 497.664 us |       0.00% | 497.573 us |       0.06% | -0.091 us |  -0.02% |   FAST   |
|   F32   |      I64      |      2^16      |   5.940 us |       5.84% |   5.950 us |       5.89% |  0.011 us |   0.18% |   SAME   |
|   F32   |      I64      |      2^20      |   8.089 us |       4.81% |   8.107 us |       5.32% |  0.018 us |   0.22% |   SAME   |
|   F32   |      I64      |      2^24      |  40.201 us |       1.99% |  40.225 us |       1.99% |  0.024 us |   0.06% |   SAME   |
|   F32   |      I64      |      2^28      | 501.645 us |       0.05% | 501.760 us |       0.00% |  0.115 us |   0.02% |   ????   |
|   F64   |      I32      |      2^16      |   5.957 us |       5.57% |   5.972 us |       5.83% |  0.015 us |   0.25% |   SAME   |
|   F64   |      I32      |      2^20      |  10.056 us |       3.42% |  10.021 us |       3.27% | -0.036 us |  -0.35% |   SAME   |
|   F64   |      I32      |      2^24      |  65.329 us |       0.80% |  65.316 us |       0.76% | -0.013 us |  -0.02% |   SAME   |
|   F64   |      I32      |      2^28      | 905.360 us |       0.19% | 905.139 us |       0.19% | -0.221 us |  -0.02% |   SAME   |
|   F64   |      I64      |      2^16      |   5.971 us |       5.38% |   5.930 us |       6.05% | -0.041 us |  -0.69% |   SAME   |
|   F64   |      I64      |      2^20      |  10.011 us |       3.82% |  10.037 us |       3.70% |  0.026 us |   0.26% |   SAME   |
|   F64   |      I64      |      2^24      |  65.449 us |       0.68% |  65.404 us |       0.68% | -0.046 us |  -0.07% |   SAME   |
|   F64   |      I64      |      2^28      | 903.884 us |       0.19% | 903.568 us |       0.19% | -0.316 us |  -0.03% |   SAME   |
|  I128   |      I32      |      2^16      |   6.028 us |       6.64% |   6.041 us |       6.34% |  0.012 us |   0.21% |   SAME   |
|  I128   |      I32      |      2^20      |  14.131 us |       2.49% |  14.132 us |       2.39% |  0.000 us |   0.00% |   SAME   |
|  I128   |      I32      |      2^24      | 120.751 us |       0.39% | 120.711 us |       0.36% | -0.040 us |  -0.03% |   SAME   |
|  I128   |      I32      |      2^28      |   1.808 ms |       0.12% |   1.808 ms |       0.11% |  0.076 us |   0.00% |   SAME   |
|  I128   |      I64      |      2^16      |   6.264 us |      11.57% |   6.260 us |      11.73% | -0.003 us |  -0.05% |   SAME   |
|  I128   |      I64      |      2^20      |  14.116 us |       2.51% |  14.137 us |       2.47% |  0.021 us |   0.15% |   SAME   |
|  I128   |      I64      |      2^24      | 120.764 us |       0.41% | 120.768 us |       0.39% |  0.004 us |   0.00% |   SAME   |
|  I128   |      I64      |      2^28      |   1.807 ms |       0.11% |   1.807 ms |       0.10% | -0.086 us |  -0.00% |   SAME   |

# triad

## [0] NVIDIA B200

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-----------|---------|----------|
|   I8    |      I32      |      2^16      |   6.806 us |      13.30% |   6.736 us |      13.47% | -0.069 us |  -1.02% |   SAME   |
|   I8    |      I32      |      2^20      |   7.931 us |       5.05% |   7.936 us |       5.56% |  0.005 us |   0.07% |   SAME   |
|   I8    |      I32      |      2^24      |  18.237 us |       1.93% |  18.207 us |       1.85% | -0.030 us |  -0.16% |   SAME   |
|   I8    |      I32      |      2^28      | 168.078 us |       0.41% | 168.152 us |       0.44% |  0.074 us |   0.04% |   SAME   |
|   I8    |      I64      |      2^16      |   6.456 us |      10.41% |   6.436 us |      10.10% | -0.020 us |  -0.31% |   SAME   |
|   I8    |      I64      |      2^20      |   7.934 us |       4.75% |   7.920 us |       4.52% | -0.014 us |  -0.17% |   SAME   |
|   I8    |      I64      |      2^24      |  18.215 us |       1.74% |  18.203 us |       1.87% | -0.012 us |  -0.06% |   SAME   |
|   I8    |      I64      |      2^28      | 167.289 us |       0.51% | 167.446 us |       0.44% |  0.157 us |   0.09% |   SAME   |
|   I16   |      I32      |      2^16      |   6.150 us |       8.13% |   6.198 us |       8.05% |  0.048 us |   0.78% |   SAME   |
|   I16   |      I32      |      2^20      |   7.908 us |       5.54% |   7.864 us |       6.18% | -0.044 us |  -0.56% |   SAME   |
|   I16   |      I32      |      2^24      |  26.339 us |       1.82% |  26.363 us |       1.76% |  0.024 us |   0.09% |   SAME   |
|   I16   |      I32      |      2^28      | 290.729 us |       0.12% | 291.081 us |       0.27% |  0.352 us |   0.12% |   SLOW   |
|   I16   |      I64      |      2^16      |   6.193 us |       8.55% |   6.196 us |       8.60% |  0.003 us |   0.06% |   SAME   |
|   I16   |      I64      |      2^20      |   7.859 us |       6.03% |   7.850 us |       6.56% | -0.009 us |  -0.12% |   SAME   |
|   I16   |      I64      |      2^24      |  26.105 us |       2.73% |  26.227 us |       2.28% |  0.123 us |   0.47% |   SAME   |
|   I16   |      I64      |      2^28      | 292.659 us |       0.14% | 292.898 us |       0.20% |  0.239 us |   0.08% |   SAME   |
|   F32   |      I32      |      2^16      |   5.976 us |       6.03% |   5.954 us |       5.32% | -0.021 us |  -0.35% |   SAME   |
|   F32   |      I32      |      2^20      |   8.069 us |       5.08% |   8.076 us |       4.95% |  0.007 us |   0.08% |   SAME   |
|   F32   |      I32      |      2^24      |  40.279 us |       2.02% |  40.276 us |       2.00% | -0.003 us |  -0.01% |   SAME   |
|   F32   |      I32      |      2^28      | 493.433 us |       0.06% | 493.456 us |       0.05% |  0.023 us |   0.00% |   SAME   |
|   F32   |      I64      |      2^16      |   5.945 us |       5.96% |   5.934 us |       5.65% | -0.011 us |  -0.18% |   SAME   |
|   F32   |      I64      |      2^20      |   8.054 us |       5.15% |   8.075 us |       5.24% |  0.021 us |   0.26% |   SAME   |
|   F32   |      I64      |      2^24      |  40.679 us |       1.04% |  40.659 us |       1.07% | -0.020 us |  -0.05% |   SAME   |
|   F32   |      I64      |      2^28      | 497.406 us |       0.10% | 497.511 us |       0.05% |  0.105 us |   0.02% |   SAME   |
|   F64   |      I32      |      2^16      |   5.957 us |       5.22% |   5.972 us |       5.55% |  0.016 us |   0.27% |   SAME   |
|   F64   |      I32      |      2^20      |  10.159 us |       4.57% |  10.170 us |       4.27% |  0.011 us |   0.11% |   SAME   |
|   F64   |      I32      |      2^24      |  64.372 us |       1.47% |  64.304 us |       1.43% | -0.068 us |  -0.11% |   SAME   |
|   F64   |      I32      |      2^28      | 904.113 us |       0.29% | 904.087 us |       0.27% | -0.026 us |  -0.00% |   SAME   |
|   F64   |      I64      |      2^16      |   5.976 us |       5.73% |   5.920 us |       5.89% | -0.057 us |  -0.95% |   SAME   |
|   F64   |      I64      |      2^20      |  10.208 us |       4.64% |  10.190 us |       4.41% | -0.019 us |  -0.18% |   SAME   |
|   F64   |      I64      |      2^24      |  65.086 us |       1.06% |  65.035 us |       1.06% | -0.050 us |  -0.08% |   SAME   |
|   F64   |      I64      |      2^28      | 902.430 us |       0.32% | 902.018 us |       0.31% | -0.411 us |  -0.05% |   SAME   |
|  I128   |      I32      |      2^16      |   6.043 us |       6.64% |   6.027 us |       6.07% | -0.017 us |  -0.27% |   SAME   |
|  I128   |      I32      |      2^20      |  14.170 us |       2.14% |  14.121 us |       2.35% | -0.048 us |  -0.34% |   SAME   |
|  I128   |      I32      |      2^24      | 120.595 us |       0.33% | 120.607 us |       0.31% |  0.013 us |   0.01% |   SAME   |
|  I128   |      I32      |      2^28      |   1.811 ms |       0.15% |   1.811 ms |       0.15% |  0.016 us |   0.00% |   SAME   |
|  I128   |      I64      |      2^16      |   6.258 us |      11.79% |   6.248 us |      11.27% | -0.010 us |  -0.17% |   SAME   |
|  I128   |      I64      |      2^20      |  14.125 us |       2.55% |  14.139 us |       2.25% |  0.014 us |   0.10% |   SAME   |
|  I128   |      I64      |      2^24      | 120.690 us |       0.32% | 120.684 us |       0.35% | -0.007 us |  -0.01% |   SAME   |
|  I128   |      I64      |      2^28      |   1.808 ms |       0.17% |   1.808 ms |       0.17% | -0.325 us |  -0.02% |   SAME   |

# nstream

## [0] NVIDIA B200

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |  OverwriteInput  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------------|------------|-------------|------------|-------------|-----------|---------|----------|
|   I8    |      I32      |      2^16      |        1         |   7.016 us |      13.37% |   6.929 us |      13.77% | -0.087 us |  -1.24% |   SAME   |
|   I8    |      I32      |      2^20      |        1         |   7.946 us |       4.58% |   8.051 us |       4.23% |  0.104 us |   1.31% |   SAME   |
|   I8    |      I32      |      2^24      |        1         |  21.901 us |       3.36% |  21.980 us |       3.45% |  0.079 us |   0.36% |   SAME   |
|   I8    |      I32      |      2^28      |        1         | 227.204 us |       0.10% | 227.255 us |       0.13% |  0.051 us |   0.02% |   SAME   |
|   I8    |      I64      |      2^16      |        1         |   7.176 us |      12.23% |   7.191 us |      12.41% |  0.016 us |   0.22% |   SAME   |
|   I8    |      I64      |      2^20      |        1         |   7.997 us |       3.90% |   7.971 us |       4.04% | -0.027 us |  -0.33% |   SAME   |
|   I8    |      I64      |      2^24      |        1         |  22.300 us |       1.75% |  22.278 us |       1.93% | -0.022 us |  -0.10% |   SAME   |
|   I8    |      I64      |      2^28      |        1         | 223.191 us |       0.17% | 223.231 us |       0.22% |  0.040 us |   0.02% |   SAME   |
|   I16   |      I32      |      2^16      |        1         |   6.528 us |      10.76% |   6.852 us |      12.42% |  0.324 us |   4.97% |   SAME   |
|   I16   |      I32      |      2^20      |        1         |   7.986 us |       4.15% |   8.038 us |       5.58% |  0.052 us |   0.65% |   SAME   |
|   I16   |      I32      |      2^24      |        1         |  32.833 us |       1.75% |  32.995 us |       1.99% |  0.162 us |   0.49% |   SAME   |
|   I16   |      I32      |      2^28      |        1         | 411.794 us |       0.16% | 415.024 us |       0.21% |  3.230 us |   0.78% |   SLOW   |
|   I16   |      I64      |      2^16      |        1         |   6.906 us |      12.64% |   6.869 us |      12.74% | -0.037 us |  -0.54% |   SAME   |
|   I16   |      I64      |      2^20      |        1         |   8.190 us |       6.33% |   8.151 us |       6.24% | -0.039 us |  -0.48% |   SAME   |
|   I16   |      I64      |      2^24      |        1         |  31.754 us |       2.84% |  31.826 us |       2.73% |  0.072 us |   0.23% |   SAME   |
|   I16   |      I64      |      2^28      |        1         | 364.562 us |       0.14% | 366.418 us |       0.15% |  1.856 us |   0.51% |   SLOW   |
|   F32   |      I32      |      2^16      |        1         |   6.021 us |       6.35% |   6.038 us |       6.52% |  0.016 us |   0.27% |   SAME   |
|   F32   |      I32      |      2^20      |        1         |   9.317 us |       8.79% |   9.263 us |       9.19% | -0.054 us |  -0.57% |   SAME   |
|   F32   |      I32      |      2^24      |        1         |  51.714 us |       1.53% |  51.751 us |       1.57% |  0.037 us |   0.07% |   SAME   |
|   F32   |      I32      |      2^28      |        1         | 679.955 us |       0.07% | 681.674 us |       0.09% |  1.719 us |   0.25% |   SLOW   |
|   F32   |      I64      |      2^16      |        1         |   6.019 us |       6.03% |   5.984 us |       6.17% | -0.035 us |  -0.58% |   SAME   |
|   F32   |      I64      |      2^20      |        1         |   9.305 us |       9.31% |   9.323 us |       9.25% |  0.018 us |   0.19% |   SAME   |
|   F32   |      I64      |      2^24      |        1         |  52.370 us |       1.64% |  52.415 us |       1.63% |  0.045 us |   0.09% |   SAME   |
|   F32   |      I64      |      2^28      |        1         | 685.991 us |       0.05% | 687.491 us |       0.12% |  1.500 us |   0.22% |   SLOW   |
|   F64   |      I32      |      2^16      |        1         |   5.991 us |       5.50% |   5.996 us |       5.92% |  0.005 us |   0.08% |   SAME   |
|   F64   |      I32      |      2^20      |        1         |  12.097 us |       2.54% |  12.066 us |       2.65% | -0.031 us |  -0.25% |   SAME   |
|   F64   |      I32      |      2^24      |        1         |  92.019 us |       0.38% |  92.064 us |       0.49% |  0.045 us |   0.05% |   SAME   |
|   F64   |      I32      |      2^28      |        1         |   1.328 ms |       0.07% |   1.329 ms |       0.03% |  1.276 us |   0.10% |   SLOW   |
|   F64   |      I64      |      2^16      |        1         |   5.991 us |       6.09% |   5.977 us |       6.15% | -0.014 us |  -0.23% |   SAME   |
|   F64   |      I64      |      2^20      |        1         |  12.057 us |       2.76% |  12.078 us |       2.56% |  0.021 us |   0.18% |   SAME   |
|   F64   |      I64      |      2^24      |        1         |  92.658 us |       0.81% |  92.796 us |       0.87% |  0.138 us |   0.15% |   SAME   |
|   F64   |      I64      |      2^28      |        1         |   1.337 ms |       0.02% |   1.339 ms |       0.05% |  1.754 us |   0.13% |   SLOW   |
|  I128   |      I32      |      2^16      |        1         |   6.264 us |       8.94% |   6.306 us |       9.38% |  0.042 us |   0.66% |   SAME   |
|  I128   |      I32      |      2^20      |        1         |  16.736 us |       4.33% |  16.676 us |       4.04% | -0.060 us |  -0.36% |   SAME   |
|  I128   |      I32      |      2^24      |        1         | 157.166 us |       0.51% | 157.204 us |       0.49% |  0.038 us |   0.02% |   SAME   |
|  I128   |      I32      |      2^28      |        1         |   2.359 ms |       0.05% |   2.359 ms |       0.05% |  0.071 us |   0.00% |   SAME   |
|  I128   |      I64      |      2^16      |        1         |   6.659 us |      13.14% |   6.663 us |      13.20% |  0.004 us |   0.06% |   SAME   |
|  I128   |      I64      |      2^20      |        1         |  16.720 us |       4.49% |  16.717 us |       4.20% | -0.003 us |  -0.02% |   SAME   |
|  I128   |      I64      |      2^24      |        1         | 157.240 us |       0.45% | 157.293 us |       0.45% |  0.053 us |   0.03% |   SAME   |
|  I128   |      I64      |      2^28      |        1         |   2.359 ms |       0.05% |   2.359 ms |       0.05% | -0.067 us |  -0.00% |   SAME   |

# compare_complex

## [0] NVIDIA B200

|  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------------|----------------|------------|-------------|------------|-------------|-----------|---------|----------|
|      I32      |      2^16      |   6.118 us |       6.98% |   6.162 us |       7.35% |  0.044 us |   0.72% |   SAME   |
|      I32      |      2^20      |  12.131 us |       2.69% |  12.150 us |       2.73% |  0.019 us |   0.16% |   SAME   |
|      I32      |      2^24      |  96.071 us |       0.38% |  96.096 us |       0.35% |  0.025 us |   0.03% |   SAME   |
|      I32      |      2^28      |   1.419 ms |       0.04% |   1.420 ms |       0.08% |  1.355 us |   0.10% |   SLOW   |
|      I64      |      2^16      |   6.204 us |       8.32% |   6.222 us |       7.94% |  0.018 us |   0.29% |   SAME   |
|      I64      |      2^20      |  12.199 us |       3.68% |  12.127 us |       2.89% | -0.072 us |  -0.59% |   SAME   |
|      I64      |      2^24      |  99.913 us |       0.66% | 100.096 us |       0.42% |  0.182 us |   0.18% |   SAME   |
|      I64      |      2^28      |   1.467 ms |       0.06% |   1.469 ms |       0.07% |  2.505 us |   0.17% |   SLOW   |

# fibonacci

## [0] NVIDIA B200

|  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------------|----------------|------------|-------------|------------|-------------|-----------|---------|----------|
|      I32      |      2^16      |   7.308 us |      11.77% |   7.334 us |      11.49% |  0.026 us |   0.36% |   SAME   |
|      I32      |      2^20      |  12.704 us |       5.79% |  12.692 us |       5.94% | -0.012 us |  -0.10% |   SAME   |
|      I32      |      2^24      |  92.040 us |       0.46% |  92.078 us |       0.48% |  0.038 us |   0.04% |   SAME   |
|      I32      |      2^28      |   1.360 ms |       0.05% |   1.360 ms |       0.07% |  0.248 us |   0.02% |   SAME   |
|      I64      |      2^16      |   7.188 us |      12.34% |   7.186 us |      12.19% | -0.003 us |  -0.04% |   SAME   |
|      I64      |      2^20      |  12.198 us |       3.57% |  12.208 us |       3.85% |  0.011 us |   0.09% |   SAME   |
|      I64      |      2^24      |  87.841 us |       0.38% |  87.817 us |       0.38% | -0.024 us |  -0.03% |   SAME   |
|      I64      |      2^28      |   1.287 ms |       0.08% |   1.288 ms |       0.08% |  0.172 us |   0.01% |   SAME   |

# heavy

## [0] NVIDIA B200

|  Heaviness{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|-----------------|----------------|------------|-------------|------------|-------------|-----------|---------|----------|
|       32        |      2^16      |   8.267 us |       6.40% |   8.283 us |       6.30% |  0.015 us |   0.19% |   SAME   |
|       32        |      2^20      |  20.239 us |       1.73% |  20.255 us |       1.68% |  0.016 us |   0.08% |   SAME   |
|       32        |      2^24      | 212.818 us |       0.21% | 212.830 us |       0.21% |  0.012 us |   0.01% |   SAME   |
|       32        |      2^28      |   3.281 ms |       0.02% |   3.281 ms |       0.04% |  0.377 us |   0.01% |   SAME   |
|       64        |      2^16      |  15.563 us |       5.63% |  15.530 us |       5.63% | -0.032 us |  -0.21% |   SAME   |
|       64        |      2^20      |  34.531 us |       1.29% |  34.531 us |       1.27% | -0.000 us |  -0.00% |   SAME   |
|       64        |      2^24      | 403.410 us |       0.13% | 403.401 us |       0.15% | -0.010 us |  -0.00% |   SAME   |
|       64        |      2^28      |   6.264 ms |       0.02% |   6.264 ms |       0.02% |  0.254 us |   0.00% |   SAME   |
|       128       |      2^16      |  43.366 us |       1.58% |  43.318 us |       1.58% | -0.048 us |  -0.11% |   SAME   |
|       128       |      2^20      |  65.460 us |       0.61% |  65.427 us |       0.63% | -0.033 us |  -0.05% |   SAME   |
|       128       |      2^24      | 766.472 us |       0.11% | 766.861 us |       0.12% |  0.389 us |   0.05% |   SAME   |
|       128       |      2^28      |  11.894 ms |       0.01% |  11.895 ms |       0.01% |  1.309 us |   0.01% |   SLOW   |
|       256       |      2^16      | 118.852 us |       2.05% | 118.529 us |       1.94% | -0.323 us |  -0.27% |   SAME   |
|       256       |      2^20      |   1.018 ms |       0.36% |   1.018 ms |       0.34% | -0.155 us |  -0.02% |   SAME   |
|       256       |      2^24      |  16.248 ms |       0.16% |  16.250 ms |       0.17% |  2.048 us |   0.01% |   SAME   |
|       256       |      2^28      | 265.515 ms |       0.04% | 265.544 ms |       0.03% | 28.941 us |   0.01% |   SAME   |

# Summary

- Total Matches: 192
  - Pass    (diff <= min_noise): 176
  - Unknown (infinite noise):    1
  - Failure (diff > min_noise):  15

```