### PR TITLE
Install suggested build environment for pyenv

### DIFF
--- a/ci/pyenv_helper.sh
+++ b/ci/pyenv_helper.sh
@@ -17,6 +17,7 @@ setup_python_env() {
             libbz2-dev libreadline-dev libsqlite3-dev curl git \
             libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
         elif [ "$ID" = "rocky" ]; then
+            # we're inside the rockylinux container, sudo not required/available
             dnf install -y make patch zlib-devel bzip2 bzip2-devel readline-devel \
             sqlite sqlite-devel openssl-devel tk-devel libffi-devel xz-devel libuuid-devel \
             gdbm-libs libnsl2

--- a/ci/pyenv_helper.sh
+++ b/ci/pyenv_helper.sh
@@ -13,7 +13,7 @@ setup_python_env() {
     if [ -f /etc/os-release ]; then
         source /etc/os-release
         if [ "$ID" = "ubuntu" ]; then
-            apt update; apt install -y make libssl-dev zlib1g-dev \
+            sudo apt update; sudo apt install -y make libssl-dev zlib1g-dev \
             libbz2-dev libreadline-dev libsqlite3-dev curl git \
             libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
         elif [ "$ID" = "rocky" ]; then

--- a/ci/pyenv_helper.sh
+++ b/ci/pyenv_helper.sh
@@ -13,11 +13,11 @@ setup_python_env() {
     if [ -f /etc/os-release ]; then
         source /etc/os-release
         if [ "$ID" = "ubuntu" ]; then
-            sudo apt update; sudo apt install -y make libssl-dev zlib1g-dev \
+            apt update; apt install -y make libssl-dev zlib1g-dev \
             libbz2-dev libreadline-dev libsqlite3-dev curl git \
             libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
         elif [ "$ID" = "rocky" ]; then
-            sudo dnf install -y make patch zlib-devel bzip2 bzip2-devel readline-devel \
+            dnf install -y make patch zlib-devel bzip2 bzip2-devel readline-devel \
             sqlite sqlite-devel openssl-devel tk-devel libffi-devel xz-devel libuuid-devel \
             gdbm-libs libnsl2
         else

--- a/ci/pyenv_helper.sh
+++ b/ci/pyenv_helper.sh
@@ -9,6 +9,23 @@ setup_python_env() {
         curl -fsSL https://pyenv.run | bash
     fi
 
+    # Install the build dependencies, check /etc/os-release to see if we are on ubuntu or rocky
+    if [ -f /etc/os-release ]; then
+        source /etc/os-release
+        if [ "$ID" = "ubuntu" ]; then
+            sudo apt update; sudo apt install -y make libssl-dev zlib1g-dev \
+            libbz2-dev libreadline-dev libsqlite3-dev curl git \
+            libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
+        elif [ "$ID" = "rocky" ]; then
+            sudo dnf install -y make patch zlib-devel bzip2 bzip2-devel readline-devel \
+            sqlite sqlite-devel openssl-devel tk-devel libffi-devel xz-devel libuuid-devel \
+            gdbm-libs libnsl2
+        else
+            echo "Unsupported Linux distribution"
+            exit 1
+        fi
+    fi
+
     # Always set up pyenv environment
     export PYENV_ROOT="$HOME/.pyenv"
     [[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"


### PR DESCRIPTION
## Description

Sometimes, the `pyenv` setup (part of Python jobs) fails due to `curl` errors when downloading `readline` ([example](https://github.com/NVIDIA/cccl/actions/runs/15173806338/job/42669987033?pr=4735)).

This PR aims to address that by ensuring `readline` (and several of the other [recommended dependencies](https://github.com/pyenv/pyenv/wiki#suggested-build-environment)) is available before `pyenv` runs, via the system-specific package manager.

Testing locally, this does prevent `pyenv` from attempting to download the `readline` dependency.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
