### PR TITLE
fix broken cudax build due to an invalid expression in `sync_wait` error path

### DIFF
--- a/cudax/include/cuda/experimental/__execution/variant.cuh
+++ b/cudax/include/cuda/experimental/__execution/variant.cuh
@@ -23,6 +23,7 @@
 
 #include <cuda/std/__memory/construct_at.h>
 #include <cuda/std/__new/launder.h>
+#include <cuda/std/__type_traits/decay.h>
 #include <cuda/std/__utility/integer_sequence.h>
 
 #include <cuda/experimental/__execution/meta.cuh>
@@ -100,6 +101,12 @@ public:
   [[nodiscard]] _CCCL_TRIVIAL_API size_t __index() const noexcept
   {
     return __index_;
+  }
+
+  template <class _Ty>
+  _CCCL_API auto __emplace(_Ty&& __value) noexcept(__nothrow_decay_copyable<_Ty>) -> _CUDA_VSTD::decay_t<_Ty>&
+  {
+    return __emplace<_CUDA_VSTD::decay_t<_Ty>, _Ty>(static_cast<_Ty&&>(__value));
   }
 
   _CCCL_EXEC_CHECK_DISABLE

--- a/libcudacxx/include/cuda/std/__memory/construct_at.h
+++ b/libcudacxx/include/cuda/std/__memory/construct_at.h
@@ -181,6 +181,7 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr void __destroy_at(_Tp* __loc)
   }
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _ForwardIterator>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _ForwardIterator __destroy(_ForwardIterator __first, _ForwardIterator __last)
 {
@@ -191,6 +192,7 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr _ForwardIterator __destroy(_ForwardIterator 
   return __first;
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _BidirectionalIterator>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _BidirectionalIterator
 __reverse_destroy(_BidirectionalIterator __first, _BidirectionalIterator __last)
@@ -203,6 +205,7 @@ __reverse_destroy(_BidirectionalIterator __first, _BidirectionalIterator __last)
   return __last;
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _Tp>
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX20 void destroy_at(_Tp* __loc)
 {
@@ -227,6 +230,7 @@ _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX20 void destroy(_ForwardIterator __
   (void) _CUDA_VSTD::__destroy(_CUDA_VSTD::move(__first), _CUDA_VSTD::move(__last));
 }
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _ForwardIterator, class _Size>
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX20 _ForwardIterator destroy_n(_ForwardIterator __first, _Size __n)
 {


### PR DESCRIPTION
## Description

pr #4734 changed `sync_wait` to no longer try to call `::std::make_exception_ptr` from device code. instead, the device code writes any error into a `__variant`, from where the host code will read and throw it.

unfortunately, in so doing it called an overload of `__variant::__emplace` that doesn't exist. somehow my tests were missing this, since it happens on an error path.

then pr #4771 added tests that exercise this code path. both prs passed CI. both of them together do not.

this pr adds the missing overload of `__variant::__emplace`.


## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
