### PR TITLE
Add missing #pragma once to headers to prevent multiple inclusions

### DIFF
--- a/cub/benchmarks/bench/reduce/base.cuh
+++ b/cub/benchmarks/bench/reduce/base.cuh
@@ -25,6 +25,8 @@
  *
  ******************************************************************************/
 
+#pragma once
+
 #include <cub/device/device_reduce.cuh>
 
 #ifndef TUNE_BASE

--- a/cub/benchmarks/bench/scan/exclusive/base.cuh
+++ b/cub/benchmarks/bench/scan/exclusive/base.cuh
@@ -25,6 +25,8 @@
  *
  ******************************************************************************/
 
+#pragma once
+
 #include <cub/device/device_scan.cuh>
 
 #include <cuda/std/__functional/invoke.h>

--- a/cub/benchmarks/bench/segmented_reduce/base.cuh
+++ b/cub/benchmarks/bench/segmented_reduce/base.cuh
@@ -25,6 +25,8 @@
  *
  ******************************************************************************/
 
+#pragma once
+
 #include <cub/device/device_reduce.cuh>
 
 #ifndef TUNE_BASE

--- a/cub/cub/device/dispatch/dispatch_unique_by_key.cuh
+++ b/cub/cub/device/dispatch/dispatch_unique_by_key.cuh
@@ -32,6 +32,8 @@
  * items by key from sequences of data items residing within device-accessible memory.
  */
 
+#pragma once
+
 #include <cub/config.cuh>
 
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)

--- a/cudax/include/cuda/experimental/__execution/epilogue.cuh
+++ b/cudax/include/cuda/experimental/__execution/epilogue.cuh
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// IMPORTANT: This file intionally lacks a header guard.
+// IMPORTANT: This file intentionally lacks a header guard.
 
 #if !defined(_CUDAX_ASYNC_PROLOGUE_INCLUDED)
 #  error epilogue.cuh included without a prior inclusion of prologue.cuh


### PR DESCRIPTION
## Description

Closes #4773

This PR adds missing #pragma once to related cub headers to prevent multiple inclusions and fixes a typo in the comment.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
