### PR TITLE
Increase bytes in flight for B200 to 64KiB

### DIFF
--- a/cub/cub/device/dispatch/tuning/tuning_transform.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_transform.cuh
@@ -135,10 +135,19 @@ _CCCL_HOST_DEVICE constexpr auto bulk_copy_smem_for_tile_size(int tile_size, int
 
 _CCCL_HOST_DEVICE constexpr int arch_to_min_bytes_in_flight(int sm_arch)
 {
-  // TODO(bgruber): use if-else in C++14 for better readability
-  return sm_arch >= 900 ? 48 * 1024 // 32 for H100, 48 for H200
-       : sm_arch >= 800 ? 16 * 1024 // A100
-                        : 12 * 1024; // V100 and below
+  if (sm_arch >= 1000)
+  {
+    return 64 * 1024; // B200
+  }
+  if (sm_arch >= 900)
+  {
+    return 48 * 1024; // 32 for H100, 48 for H200
+  }
+  if (sm_arch >= 800)
+  {
+    return 16 * 1024; // A100
+  }
+  return 12 * 1024; // V100 and below
 }
 
 template <typename PolicyT, typename = void>


### PR DESCRIPTION
This causes some slowdowns in compute-heavier kernels because thread blocks tend to process more items, but larger and memory-bound workloads improve.

```
# mul

## [0] NVIDIA B200

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |       Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|------------|---------|----------|
|   I8    |      I32      |      2^16      |   6.323 us |      10.46% |   6.924 us |      14.13% |   0.601 us |   9.51% |   SAME   |
|   I8    |      I32      |      2^20      |   7.034 us |      12.44% |   7.834 us |       6.06% |   0.801 us |  11.38% |   SLOW   |
|   I8    |      I32      |      2^24      |  14.263 us |       2.51% |  14.362 us |       3.65% |   0.100 us |   0.70% |   SAME   |
|   I8    |      I32      |      2^28      | 120.427 us |       0.52% | 116.486 us |       0.32% |  -3.940 us |  -3.27% |   FAST   |
|   I8    |      I64      |      2^16      |   6.459 us |      10.35% |   7.320 us |      11.44% |   0.860 us |  13.32% |   SLOW   |
|   I8    |      I64      |      2^20      |   7.713 us |       8.90% |   7.932 us |       4.79% |   0.218 us |   2.83% |   SAME   |
|   I8    |      I64      |      2^24      |  14.363 us |       3.39% |  14.457 us |       4.10% |   0.094 us |   0.65% |   SAME   |
|   I8    |      I64      |      2^28      | 123.617 us |       0.76% | 118.643 us |       0.20% |  -4.974 us |  -4.02% |   FAST   |
|   I16   |      I32      |      2^16      |   6.316 us |       8.89% |   6.397 us |      10.17% |   0.082 us |   1.30% |   SAME   |
|   I16   |      I32      |      2^20      |   7.310 us |      12.31% |   7.274 us |      11.76% |  -0.037 us |  -0.50% |   SAME   |
|   I16   |      I32      |      2^24      |  18.292 us |       1.81% |  17.658 us |       4.64% |  -0.635 us |  -3.47% |   FAST   |
|   I16   |      I32      |      2^28      | 192.487 us |       0.06% | 178.249 us |       0.35% | -14.238 us |  -7.40% |   FAST   |
|   I16   |      I64      |      2^16      |   6.359 us |       9.31% |   6.397 us |      10.05% |   0.038 us |   0.60% |   SAME   |
|   I16   |      I64      |      2^20      |   7.138 us |      12.52% |   7.242 us |      11.57% |   0.104 us |   1.45% |   SAME   |
|   I16   |      I64      |      2^24      |  18.644 us |       3.62% |  18.009 us |       3.61% |  -0.635 us |  -3.40% |   SAME   |
|   I16   |      I64      |      2^28      | 198.093 us |       0.42% | 184.167 us |       0.15% | -13.926 us |  -7.03% |   FAST   |
|   F32   |      I32      |      2^16      |   5.972 us |       5.04% |   5.890 us |       5.81% |  -0.082 us |  -1.38% |   SAME   |
|   F32   |      I32      |      2^20      |   7.641 us |       9.72% |   7.604 us |       9.53% |  -0.037 us |  -0.48% |   SAME   |
|   F32   |      I32      |      2^24      |  26.421 us |       1.41% |  25.917 us |       2.96% |  -0.504 us |  -1.91% |   FAST   |
|   F32   |      I32      |      2^28      | 313.233 us |       0.07% | 313.479 us |       0.35% |   0.246 us |   0.08% |   SLOW   |
|   F32   |      I64      |      2^16      |   5.972 us |       5.11% |   5.899 us |       5.82% |  -0.073 us |  -1.22% |   SAME   |
|   F32   |      I64      |      2^20      |   7.604 us |      10.08% |   7.623 us |       9.36% |   0.020 us |   0.26% |   SAME   |
|   F32   |      I64      |      2^24      |  26.434 us |       1.18% |  26.163 us |       2.53% |  -0.271 us |  -1.02% |   SAME   |
|   F32   |      I64      |      2^28      | 313.410 us |       0.17% | 313.383 us |       0.32% |  -0.027 us |  -0.01% |   SAME   |
|   F64   |      I32      |      2^16      |   5.977 us |       5.08% |   5.934 us |       5.50% |  -0.043 us |  -0.72% |   SAME   |
|   F64   |      I32      |      2^20      |   8.342 us |       6.90% |   8.442 us |       7.79% |   0.101 us |   1.21% |   SAME   |
|   F64   |      I32      |      2^24      |  45.005 us |       1.19% |  45.634 us |       2.12% |   0.629 us |   1.40% |   SLOW   |
|   F64   |      I32      |      2^28      | 607.764 us |       0.24% | 620.682 us |       0.21% |  12.919 us |   2.13% |   SLOW   |
|   F64   |      I64      |      2^16      |   5.940 us |       5.25% |   5.915 us |       5.47% |  -0.026 us |  -0.43% |   SAME   |
|   F64   |      I64      |      2^20      |   8.381 us |       7.21% |   8.508 us |       8.11% |   0.127 us |   1.52% |   SAME   |
|   F64   |      I64      |      2^24      |  45.140 us |       1.56% |  45.766 us |       2.10% |   0.626 us |   1.39% |   SAME   |
|   F64   |      I64      |      2^28      | 608.190 us |       0.10% | 620.716 us |       0.23% |  12.527 us |   2.06% |   SLOW   |
|  I128   |      I32      |      2^16      |   5.974 us |       5.02% |   5.945 us |       5.48% |  -0.029 us |  -0.48% |   SAME   |
|  I128   |      I32      |      2^20      |  10.868 us |       7.34% |  10.854 us |       7.03% |  -0.015 us |  -0.13% |   SAME   |
|  I128   |      I32      |      2^24      |  83.778 us |       0.81% |  83.695 us |       0.88% |  -0.084 us |  -0.10% |   SAME   |
|  I128   |      I32      |      2^28      |   1.236 ms |       0.15% |   1.236 ms |       0.15% |   0.235 us |   0.02% |   SAME   |
|  I128   |      I64      |      2^16      |   6.120 us |       8.42% |   6.072 us |       9.42% |  -0.049 us |  -0.79% |   SAME   |
|  I128   |      I64      |      2^20      |  10.850 us |       7.36% |  10.900 us |       7.15% |   0.050 us |   0.46% |   SAME   |
|  I128   |      I64      |      2^24      |  83.906 us |       0.75% |  83.891 us |       0.75% |  -0.014 us |  -0.02% |   SAME   |
|  I128   |      I64      |      2^28      |   1.236 ms |       0.15% |   1.236 ms |       0.15% |   0.087 us |   0.01% |   SAME   |

# add

## [0] NVIDIA B200

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |       Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|------------|---------|----------|
|   I8    |      I32      |      2^16      |   7.515 us |      11.11% |   7.843 us |       7.88% |   0.328 us |   4.36% |   SAME   |
|   I8    |      I32      |      2^20      |   8.000 us |       3.92% |   7.973 us |       4.81% |  -0.026 us |  -0.33% |   SAME   |
|   I8    |      I32      |      2^24      |  18.156 us |       2.85% |  17.889 us |       3.97% |  -0.267 us |  -1.47% |   SAME   |
|   I8    |      I32      |      2^28      | 169.325 us |       0.52% | 155.798 us |       0.43% | -13.526 us |  -7.99% |   FAST   |
|   I8    |      I64      |      2^16      |   7.330 us |      11.82% |   7.314 us |      11.59% |  -0.015 us |  -0.21% |   SAME   |
|   I8    |      I64      |      2^20      |   8.000 us |       3.94% |   7.935 us |       4.37% |  -0.065 us |  -0.82% |   SAME   |
|   I8    |      I64      |      2^24      |  18.195 us |       2.33% |  16.942 us |       4.61% |  -1.253 us |  -6.89% |   FAST   |
|   I8    |      I64      |      2^28      | 167.809 us |       0.18% | 154.435 us |       0.63% | -13.374 us |  -7.97% |   FAST   |
|   I16   |      I32      |      2^16      |   6.423 us |       9.79% |   6.509 us |      10.72% |   0.086 us |   1.34% |   SAME   |
|   I16   |      I32      |      2^20      |   7.988 us |       4.28% |   7.831 us |       6.48% |  -0.156 us |  -1.96% |   SAME   |
|   I16   |      I32      |      2^24      |  25.384 us |       3.57% |  23.637 us |       3.70% |  -1.747 us |  -6.88% |   FAST   |
|   I16   |      I32      |      2^28      | 295.083 us |       0.22% | 259.554 us |       0.32% | -35.529 us | -12.04% |   FAST   |
|   I16   |      I64      |      2^16      |   6.165 us |       7.85% |   6.442 us |      10.21% |   0.277 us |   4.49% |   SAME   |
|   I16   |      I64      |      2^20      |   7.944 us |       4.97% |   7.926 us |       4.48% |  -0.018 us |  -0.22% |   SAME   |
|   I16   |      I64      |      2^24      |  25.420 us |       3.48% |  23.871 us |       3.37% |  -1.549 us |  -6.10% |   FAST   |
|   I16   |      I64      |      2^28      | 296.932 us |       0.14% | 264.213 us |       0.21% | -32.719 us | -11.02% |   FAST   |
|   F32   |      I32      |      2^16      |   5.989 us |       4.87% |   5.926 us |       5.70% |  -0.063 us |  -1.05% |   SAME   |
|   F32   |      I32      |      2^20      |   8.101 us |       4.78% |   8.027 us |       4.35% |  -0.074 us |  -0.91% |   SAME   |
|   F32   |      I32      |      2^24      |  39.782 us |       2.30% |  36.653 us |       0.98% |  -3.129 us |  -7.86% |   FAST   |
|   F32   |      I32      |      2^28      | 497.651 us |       0.01% | 454.537 us |       0.05% | -43.114 us |  -8.66% |   FAST   |
|   F32   |      I64      |      2^16      |   5.966 us |       5.13% |   5.952 us |       5.73% |  -0.014 us |  -0.23% |   SAME   |
|   F32   |      I64      |      2^20      |   8.109 us |       4.93% |   7.997 us |       4.90% |  -0.112 us |  -1.38% |   SAME   |
|   F32   |      I64      |      2^24      |  40.189 us |       2.10% |  36.665 us |       1.09% |  -3.523 us |  -8.77% |   FAST   |
|   F32   |      I64      |      2^28      | 501.664 us |       0.05% | 454.998 us |       0.18% | -46.666 us |  -9.30% |   FAST   |
|   F64   |      I32      |      2^16      |   6.003 us |       4.87% |   5.937 us |       5.59% |  -0.066 us |  -1.10% |   SAME   |
|   F64   |      I32      |      2^20      |  10.050 us |       3.08% |  10.020 us |       3.52% |  -0.030 us |  -0.30% |   SAME   |
|   F64   |      I32      |      2^24      |  65.357 us |       0.74% |  65.332 us |       0.75% |  -0.025 us |  -0.04% |   SAME   |
|   F64   |      I32      |      2^28      | 905.274 us |       0.19% | 905.178 us |       0.18% |  -0.096 us |  -0.01% |   SAME   |
|   F64   |      I64      |      2^16      |   5.960 us |       5.65% |   5.920 us |       6.17% |  -0.039 us |  -0.66% |   SAME   |
|   F64   |      I64      |      2^20      |  10.058 us |       3.50% |   9.993 us |       3.78% |  -0.065 us |  -0.64% |   SAME   |
|   F64   |      I64      |      2^24      |  65.436 us |       0.72% |  65.446 us |       0.72% |   0.011 us |   0.02% |   SAME   |
|   F64   |      I64      |      2^28      | 903.772 us |       0.19% | 903.640 us |       0.20% |  -0.132 us |  -0.01% |   SAME   |
|  I128   |      I32      |      2^16      |   6.031 us |       6.30% |   5.995 us |       6.29% |  -0.036 us |  -0.60% |   SAME   |
|  I128   |      I32      |      2^20      |  14.151 us |       2.42% |  14.105 us |       2.52% |  -0.045 us |  -0.32% |   SAME   |
|  I128   |      I32      |      2^24      | 120.746 us |       0.38% | 120.694 us |       0.42% |  -0.052 us |  -0.04% |   SAME   |
|  I128   |      I32      |      2^28      |   1.808 ms |       0.12% |   1.807 ms |       0.11% |  -0.036 us |  -0.00% |   SAME   |
|  I128   |      I64      |      2^16      |   6.263 us |      11.75% |   6.212 us |      11.00% |  -0.051 us |  -0.82% |   SAME   |
|  I128   |      I64      |      2^20      |  14.124 us |       2.36% |  14.100 us |       2.58% |  -0.024 us |  -0.17% |   SAME   |
|  I128   |      I64      |      2^24      | 120.784 us |       0.40% | 120.816 us |       0.43% |   0.032 us |   0.03% |   SAME   |
|  I128   |      I64      |      2^28      |   1.807 ms |       0.11% |   1.806 ms |       0.11% |  -0.173 us |  -0.01% |   SAME   |

# triad

## [0] NVIDIA B200

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |       Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|------------|---------|----------|
|   I8    |      I32      |      2^16      |   6.792 us |      13.67% |   7.156 us |      12.52% |   0.364 us |   5.35% |   SAME   |
|   I8    |      I32      |      2^20      |   7.975 us |       4.71% |   7.985 us |       3.88% |   0.010 us |   0.12% |   SAME   |
|   I8    |      I32      |      2^24      |  18.264 us |       1.64% |  17.904 us |       3.85% |  -0.360 us |  -1.97% |   FAST   |
|   I8    |      I32      |      2^28      | 167.994 us |       0.32% | 155.541 us |       0.15% | -12.453 us |  -7.41% |   FAST   |
|   I8    |      I64      |      2^16      |   6.420 us |      10.04% |   6.797 us |      11.99% |   0.377 us |   5.87% |   SAME   |
|   I8    |      I64      |      2^20      |   7.972 us |       3.98% |   7.937 us |       4.29% |  -0.035 us |  -0.44% |   SAME   |
|   I8    |      I64      |      2^24      |  18.217 us |       1.83% |  16.977 us |       4.76% |  -1.240 us |  -6.81% |   FAST   |
|   I8    |      I64      |      2^28      | 167.172 us |       0.55% | 153.768 us |       0.45% | -13.404 us |  -8.02% |   FAST   |
|   I16   |      I32      |      2^16      |   6.169 us |       7.55% |   6.350 us |       9.64% |   0.181 us |   2.94% |   SAME   |
|   I16   |      I32      |      2^20      |   7.901 us |       5.78% |   7.888 us |       5.83% |  -0.014 us |  -0.17% |   SAME   |
|   I16   |      I32      |      2^24      |  26.379 us |       1.67% |  24.163 us |       2.65% |  -2.216 us |  -8.40% |   FAST   |
|   I16   |      I32      |      2^28      | 290.921 us |       0.21% | 256.020 us |       0.20% | -34.901 us | -12.00% |   FAST   |
|   I16   |      I64      |      2^16      |   6.228 us |       8.43% |   6.398 us |      10.43% |   0.170 us |   2.73% |   SAME   |
|   I16   |      I64      |      2^20      |   7.932 us |       5.64% |   7.884 us |       6.14% |  -0.049 us |  -0.61% |   SAME   |
|   I16   |      I64      |      2^24      |  26.162 us |       2.57% |  23.839 us |       3.42% |  -2.324 us |  -8.88% |   FAST   |
|   I16   |      I64      |      2^28      | 292.801 us |       0.14% | 261.332 us |       0.36% | -31.469 us | -10.75% |   FAST   |
|   F32   |      I32      |      2^16      |   6.011 us |       5.23% |   5.956 us |       6.07% |  -0.056 us |  -0.93% |   SAME   |
|   F32   |      I32      |      2^20      |   8.070 us |       4.31% |   8.043 us |       4.58% |  -0.027 us |  -0.33% |   SAME   |
|   F32   |      I32      |      2^24      |  40.243 us |       2.10% |  36.648 us |       0.94% |  -3.595 us |  -8.93% |   FAST   |
|   F32   |      I32      |      2^28      | 493.444 us |       0.05% | 454.119 us |       0.17% | -39.326 us |  -7.97% |   FAST   |
|   F32   |      I64      |      2^16      |   5.948 us |       5.33% |   5.921 us |       5.61% |  -0.027 us |  -0.45% |   SAME   |
|   F32   |      I64      |      2^20      |   8.039 us |       4.37% |   7.979 us |       4.41% |  -0.060 us |  -0.75% |   SAME   |
|   F32   |      I64      |      2^24      |  40.718 us |       1.04% |  36.678 us |       1.18% |  -4.040 us |  -9.92% |   FAST   |
|   F32   |      I64      |      2^28      | 497.526 us |       0.05% | 454.533 us |       0.04% | -42.993 us |  -8.64% |   FAST   |
|   F64   |      I32      |      2^16      |   5.988 us |       5.12% |   5.933 us |       6.23% |  -0.055 us |  -0.92% |   SAME   |
|   F64   |      I32      |      2^20      |  10.203 us |       4.33% |  10.169 us |       4.68% |  -0.034 us |  -0.33% |   SAME   |
|   F64   |      I32      |      2^24      |  64.312 us |       1.48% |  64.341 us |       1.41% |   0.030 us |   0.05% |   SAME   |
|   F64   |      I32      |      2^28      | 903.830 us |       0.26% | 904.122 us |       0.26% |   0.292 us |   0.03% |   SAME   |
|   F64   |      I64      |      2^16      |   5.955 us |       5.13% |   5.926 us |       5.41% |  -0.028 us |  -0.47% |   SAME   |
|   F64   |      I64      |      2^20      |  10.177 us |       4.43% |  10.200 us |       4.69% |   0.024 us |   0.23% |   SAME   |
|   F64   |      I64      |      2^24      |  65.065 us |       1.08% |  65.054 us |       1.14% |  -0.010 us |  -0.02% |   SAME   |
|   F64   |      I64      |      2^28      | 902.253 us |       0.31% | 902.451 us |       0.32% |   0.198 us |   0.02% |   SAME   |
|  I128   |      I32      |      2^16      |   6.064 us |       5.38% |   6.031 us |       6.96% |  -0.033 us |  -0.55% |   SAME   |
|  I128   |      I32      |      2^20      |  14.155 us |       2.23% |  14.079 us |       2.41% |  -0.076 us |  -0.54% |   SAME   |
|  I128   |      I32      |      2^24      | 120.641 us |       0.27% | 120.620 us |       0.34% |  -0.021 us |  -0.02% |   SAME   |
|  I128   |      I32      |      2^28      |   1.810 ms |       0.16% |   1.810 ms |       0.16% |   0.291 us |   0.02% |   SAME   |
|  I128   |      I64      |      2^16      |   6.235 us |      11.17% |   6.270 us |      12.27% |   0.035 us |   0.56% |   SAME   |
|  I128   |      I64      |      2^20      |  14.129 us |       2.44% |  14.109 us |       2.52% |  -0.020 us |  -0.14% |   SAME   |
|  I128   |      I64      |      2^24      | 120.718 us |       0.33% | 120.665 us |       0.34% |  -0.052 us |  -0.04% |   SAME   |
|  I128   |      I64      |      2^28      |   1.808 ms |       0.17% |   1.808 ms |       0.17% |   0.071 us |   0.00% |   SAME   |

# nstream

## [0] NVIDIA B200

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |  OverwriteInput  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |        Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------------|------------|-------------|------------|-------------|-------------|---------|----------|
|   I8    |      I32      |      2^16      |        1         |   6.964 us |      13.74% |   7.499 us |      11.01% |    0.535 us |   7.68% |   SAME   |
|   I8    |      I32      |      2^20      |        1         |   7.997 us |       4.42% |   7.945 us |       4.29% |   -0.052 us |  -0.66% |   SAME   |
|   I8    |      I32      |      2^24      |        1         |  21.821 us |       3.87% |  20.321 us |       1.98% |   -1.500 us |  -6.87% |   FAST   |
|   I8    |      I32      |      2^28      |        1         | 227.291 us |       0.14% | 197.746 us |       0.48% |  -29.545 us | -13.00% |   FAST   |
|   I8    |      I64      |      2^16      |        1         |   7.180 us |      12.55% |   7.573 us |      10.18% |    0.392 us |   5.47% |   SAME   |
|   I8    |      I64      |      2^20      |        1         |   8.001 us |       3.81% |   7.979 us |       4.36% |   -0.022 us |  -0.28% |   SAME   |
|   I8    |      I64      |      2^24      |        1         |  22.281 us |       1.92% |  20.371 us |       2.31% |   -1.910 us |  -8.57% |   FAST   |
|   I8    |      I64      |      2^28      |        1         | 223.209 us |       0.17% | 198.918 us |       0.37% |  -24.291 us | -10.88% |   FAST   |
|   I16   |      I32      |      2^16      |        1         |   6.462 us |      10.30% |   6.689 us |      11.98% |    0.227 us |   3.51% |   SAME   |
|   I16   |      I32      |      2^20      |        1         |   8.001 us |       4.05% |   8.015 us |       5.03% |    0.014 us |   0.17% |   SAME   |
|   I16   |      I32      |      2^24      |        1         |  32.910 us |       1.90% |  29.796 us |       3.07% |   -3.114 us |  -9.46% |   FAST   |
|   I16   |      I32      |      2^28      |        1         | 414.979 us |       0.23% | 356.742 us |       0.24% |  -58.237 us | -14.03% |   FAST   |
|   I16   |      I64      |      2^16      |        1         |   6.712 us |      12.56% |   7.429 us |      11.12% |    0.718 us |  10.69% |   SAME   |
|   I16   |      I64      |      2^20      |        1         |   8.202 us |       5.97% |   8.098 us |       6.15% |   -0.104 us |  -1.26% |   SAME   |
|   I16   |      I64      |      2^24      |        1         |  31.674 us |       2.92% |  29.127 us |       2.78% |   -2.547 us |  -8.04% |   FAST   |
|   I16   |      I64      |      2^28      |        1         | 366.326 us |       0.16% | 327.917 us |       0.25% |  -38.409 us | -10.48% |   FAST   |
|   F32   |      I32      |      2^16      |        1         |   6.026 us |       5.23% |   6.072 us |       6.89% |    0.046 us |   0.77% |   SAME   |
|   F32   |      I32      |      2^20      |        1         |   9.213 us |       9.65% |   8.899 us |       9.09% |   -0.314 us |  -3.41% |   SAME   |
|   F32   |      I32      |      2^24      |        1         |  51.642 us |       1.47% |  47.126 us |       1.18% |   -4.516 us |  -8.74% |   FAST   |
|   F32   |      I32      |      2^28      |        1         | 681.474 us |       0.12% | 604.084 us |       0.06% |  -77.390 us | -11.36% |   FAST   |
|   F32   |      I64      |      2^16      |        1         |   6.030 us |       5.43% |   6.077 us |       7.26% |    0.047 us |   0.77% |   SAME   |
|   F32   |      I64      |      2^20      |        1         |   9.301 us |       9.46% |   8.952 us |       9.07% |   -0.349 us |  -3.75% |   SAME   |
|   F32   |      I64      |      2^24      |        1         |  52.400 us |       1.65% |  47.243 us |       1.40% |   -5.157 us |  -9.84% |   FAST   |
|   F32   |      I64      |      2^28      |        1         | 687.121 us |       0.14% | 605.186 us |       0.16% |  -81.935 us | -11.92% |   FAST   |
|   F64   |      I32      |      2^16      |        1         |   6.022 us |       5.39% |   5.990 us |       6.45% |   -0.032 us |  -0.54% |   SAME   |
|   F64   |      I32      |      2^20      |        1         |  12.108 us |       2.50% |  12.021 us |       3.11% |   -0.087 us |  -0.72% |   SAME   |
|   F64   |      I32      |      2^24      |        1         |  92.078 us |       0.45% |  84.389 us |       1.00% |   -7.689 us |  -8.35% |   FAST   |
|   F64   |      I32      |      2^28      |        1         |   1.329 ms |       0.02% |   1.185 ms |       0.08% | -143.849 us | -10.82% |   FAST   |
|   F64   |      I64      |      2^16      |        1         |   6.030 us |       5.33% |   6.031 us |       6.95% |    0.001 us |   0.02% |   SAME   |
|   F64   |      I64      |      2^20      |        1         |  12.095 us |       2.56% |  12.034 us |       2.82% |   -0.060 us |  -0.50% |   SAME   |
|   F64   |      I64      |      2^24      |        1         |  92.685 us |       0.85% |  84.564 us |       1.09% |   -8.121 us |  -8.76% |   FAST   |
|   F64   |      I64      |      2^28      |        1         |   1.339 ms |       0.07% |   1.185 ms |       0.07% | -153.496 us | -11.47% |   FAST   |
|  I128   |      I32      |      2^16      |        1         |   6.267 us |       8.49% |   6.303 us |       9.56% |    0.037 us |   0.58% |   SAME   |
|  I128   |      I32      |      2^20      |        1         |  16.652 us |       3.96% |  16.691 us |       4.18% |    0.039 us |   0.23% |   SAME   |
|  I128   |      I32      |      2^24      |        1         | 157.184 us |       0.48% | 157.258 us |       0.44% |    0.075 us |   0.05% |   SAME   |
|  I128   |      I32      |      2^28      |        1         |   2.359 ms |       0.05% |   2.359 ms |       0.05% |    0.115 us |   0.00% |   SAME   |
|  I128   |      I64      |      2^16      |        1         |   6.606 us |      12.85% |   6.649 us |      12.85% |    0.043 us |   0.65% |   SAME   |
|  I128   |      I64      |      2^20      |        1         |  16.701 us |       4.31% |  16.671 us |       4.11% |   -0.030 us |  -0.18% |   SAME   |
|  I128   |      I64      |      2^24      |        1         | 157.273 us |       0.44% | 157.254 us |       0.43% |   -0.019 us |  -0.01% |   SAME   |
|  I128   |      I64      |      2^28      |        1         |   2.359 ms |       0.05% |   2.359 ms |       0.05% |    0.074 us |   0.00% |   SAME   |

# compare_complex

## [0] NVIDIA B200

|  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------------|----------------|------------|-------------|------------|-------------|-----------|---------|----------|
|      I32      |      2^16      |   6.120 us |       6.60% |   6.160 us |       7.89% |  0.041 us |   0.67% |   SAME   |
|      I32      |      2^20      |  12.120 us |       2.86% |  12.105 us |       3.26% | -0.015 us |  -0.13% |   SAME   |
|      I32      |      2^24      |  96.076 us |       0.37% |  96.049 us |       0.35% | -0.028 us |  -0.03% |   SAME   |
|      I32      |      2^28      |   1.419 ms |       0.05% |   1.419 ms |       0.06% | -0.011 us |  -0.00% |   SAME   |
|      I64      |      2^16      |   6.226 us |       8.16% |   6.228 us |       8.53% |  0.003 us |   0.04% |   SAME   |
|      I64      |      2^20      |  12.187 us |       2.88% |  12.168 us |       3.56% | -0.020 us |  -0.16% |   SAME   |
|      I64      |      2^24      | 100.040 us |       0.52% |  99.976 us |       0.56% | -0.065 us |  -0.06% |   SAME   |
|      I64      |      2^28      |   1.468 ms |       0.04% |   1.468 ms |       0.07% | -0.058 us |  -0.00% |   SAME   |

# fibonacci

## [0] NVIDIA B200

|  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |       Diff |   %Diff |  Status  |
|---------------|----------------|------------|-------------|------------|-------------|------------|---------|----------|
|      I32      |      2^16      |   7.251 us |      12.56% |   7.960 us |       4.16% |   0.709 us |   9.78% |   SLOW   |
|      I32      |      2^20      |  12.695 us |       5.69% |  12.636 us |       5.37% |  -0.059 us |  -0.46% |   SAME   |
|      I32      |      2^24      |  92.051 us |       0.40% |  90.762 us |       0.89% |  -1.290 us |  -1.40% |   FAST   |
|      I32      |      2^28      |   1.359 ms |       0.07% |   1.333 ms |       0.06% | -25.471 us |  -1.87% |   FAST   |
|      I64      |      2^16      |   7.158 us |      12.58% |   7.755 us |       8.26% |   0.597 us |   8.34% |   SLOW   |
|      I64      |      2^20      |  12.228 us |       3.48% |  12.236 us |       3.50% |   0.008 us |   0.07% |   SAME   |
|      I64      |      2^24      |  87.837 us |       0.38% |  85.848 us |       0.43% |  -1.989 us |  -2.26% |   FAST   |
|      I64      |      2^28      |   1.286 ms |       0.05% |   1.255 ms |       0.08% | -31.724 us |  -2.47% |   FAST   |

# heavy

## [0] NVIDIA B200

|  Heaviness{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |         Diff |   %Diff |  Status  |
|-----------------|----------------|------------|-------------|------------|-------------|--------------|---------|----------|
|       32        |      2^16      |   8.293 us |       6.24% |   9.981 us |       3.41% |     1.687 us |  20.35% |   SLOW   |
|       32        |      2^20      |  20.252 us |       1.58% |  22.361 us |       1.72% |     2.110 us |  10.42% |   SLOW   |
|       32        |      2^24      | 212.647 us |       0.27% | 212.833 us |       0.19% |     0.185 us |   0.09% |   SAME   |
|       32        |      2^28      |   3.278 ms |       0.03% |   3.273 ms |       0.02% |    -5.340 us |  -0.16% |   FAST   |
|       64        |      2^16      |  15.621 us |       5.49% |  18.679 us |       3.36% |     3.058 us |  19.57% |   SLOW   |
|       64        |      2^20      |  34.211 us |       2.25% |  34.986 us |       1.77% |     0.775 us |   2.27% |   SLOW   |
|       64        |      2^24      | 403.252 us |       0.08% | 403.237 us |       0.13% |    -0.016 us |  -0.00% |   SAME   |
|       64        |      2^28      |   6.259 ms |       0.02% |   6.243 ms |       0.02% |   -15.446 us |  -0.25% |   FAST   |
|       128       |      2^16      |  43.343 us |       1.61% |  43.251 us |       1.49% |    -0.091 us |  -0.21% |   SAME   |
|       128       |      2^20      |  65.320 us |       0.52% |  65.289 us |       0.52% |    -0.030 us |  -0.05% |   SAME   |
|       128       |      2^24      | 766.941 us |       0.13% | 766.984 us |       0.12% |     0.043 us |   0.01% |   SAME   |
|       128       |      2^28      |  11.890 ms |       0.01% |  11.890 ms |       0.01% |    -0.375 us |  -0.00% |   SAME   |
|       256       |      2^16      | 118.502 us |       2.14% | 150.730 us |       1.75% |    32.229 us |  27.20% |   SLOW   |
|       256       |      2^20      |   1.018 ms |       0.35% | 977.242 us |       0.36% |   -40.336 us |  -3.96% |   FAST   |
|       256       |      2^24      |  16.249 ms |       0.17% |  15.996 ms |       0.16% |  -252.935 us |  -1.56% |   FAST   |
|       256       |      2^28      | 265.510 ms |       0.03% | 260.275 ms |       0.03% | -5235.492 us |  -1.97% |   FAST   |

# Summary

- Total Matches: 192
  - Pass    (diff <= min_noise): 125
  - Unknown (infinite noise):    0
  - Failure (diff > min_noise):  67
```