### PR TITLE
Add missing ForceInclusive tag in exclusive.scan benchmark source

### DIFF
--- a/cub/benchmarks/bench/scan/exclusive/base.cuh
+++ b/cub/benchmarks/bench/scan/exclusive/base.cuh
@@ -96,9 +96,11 @@ static void basic(nvbench::state& state, nvbench::type_list<T, OffsetT>)
 
 #if !TUNE_BASE
   using policy_t   = policy_hub_t<accum_t>;
-  using dispatch_t = cub::DispatchScan<input_it_t, output_it_t, op_t, wrapped_init_t, offset_t, accum_t, policy_t>;
+  using dispatch_t = cub::
+    DispatchScan<input_it_t, output_it_t, op_t, wrapped_init_t, offset_t, accum_t, cub::ForceInclusive::No, policy_t>;
 #else
-  using dispatch_t = cub::DispatchScan<input_it_t, output_it_t, op_t, wrapped_init_t, offset_t, accum_t>;
+  using dispatch_t =
+    cub::DispatchScan<input_it_t, output_it_t, op_t, wrapped_init_t, offset_t, accum_t, cub::ForceInclusive::No>;
 #endif
 
   const auto elements = static_cast<std::size_t>(state.get_int64("Elements{io}"));


### PR DESCRIPTION
Fixes minor bug from missing `ForceInclusive::No` tag in `cub.exclusive.scan` benchmark that was added since #3739.

ping @bernhardmgruber 
