### PR TITLE
de-duplication, reuse, naming conventions, and copyrights

### DIFF
--- a/cudax/examples/vector.cuh
+++ b/cudax/examples/vector.cuh
@@ -59,11 +59,11 @@ public:
   }
 
 private:
-  void sync_host_to_device([[maybe_unused]] ::cuda::stream_ref __str, detail::__param_kind __p) const
+  void sync_host_to_device([[maybe_unused]] ::cuda::stream_ref __str, __detail::__param_kind __p) const
   {
     if (__dirty_)
     {
-      if (__p == detail::__param_kind::_out)
+      if (__p == __detail::__param_kind::_out)
       {
         // There's no need to copy the data from host to device if the data is
         // only going to be written to. We can just allocate the device memory.
@@ -78,9 +78,9 @@ private:
     }
   }
 
-  void sync_device_to_host(::cuda::stream_ref __str, detail::__param_kind __p) const
+  void sync_device_to_host(::cuda::stream_ref __str, __detail::__param_kind __p) const
   {
-    if (__p != detail::__param_kind::_in)
+    if (__p != __detail::__param_kind::_in)
     {
       // TODO: use a memcpy async here
       __str.sync(); // wait for the kernel to finish executing
@@ -88,10 +88,10 @@ private:
     }
   }
 
-  template <detail::__param_kind _Kind>
-  class __action //: private detail::__immovable
+  template <__detail::__param_kind _Kind>
+  class __action //: private __detail::__immovable
   {
-    using __cv_vector = ::cuda::std::__maybe_const<_Kind == detail::__param_kind::_in, vector>;
+    using __cv_vector = ::cuda::std::__maybe_const<_Kind == __detail::__param_kind::_in, vector>;
 
   public:
     explicit __action(::cuda::stream_ref __str, __cv_vector& __v) noexcept
@@ -118,21 +118,21 @@ private:
     __cv_vector& __v_;
   };
 
-  [[nodiscard]] friend __action<detail::__param_kind::_inout>
+  [[nodiscard]] friend __action<__detail::__param_kind::_inout>
   __cudax_launch_transform(::cuda::stream_ref __str, vector& __v) noexcept
   {
-    return __action<detail::__param_kind::_inout>{__str, __v};
+    return __action<__detail::__param_kind::_inout>{__str, __v};
   }
 
-  [[nodiscard]] friend __action<detail::__param_kind::_in>
+  [[nodiscard]] friend __action<__detail::__param_kind::_in>
   __cudax_launch_transform(::cuda::stream_ref __str, const vector& __v) noexcept
   {
-    return __action<detail::__param_kind::_in>{__str, __v};
+    return __action<__detail::__param_kind::_in>{__str, __v};
   }
 
-  template <detail::__param_kind _Kind>
+  template <__detail::__param_kind _Kind>
   [[nodiscard]] friend __action<_Kind>
-  __cudax_launch_transform(::cuda::stream_ref __str, detail::__box<vector, _Kind> __b) noexcept
+  __cudax_launch_transform(::cuda::stream_ref __str, __detail::__box<vector, _Kind> __b) noexcept
   {
     return __action<_Kind>{__str, __b.__val};
   }

--- a/cudax/include/cuda/experimental/__algorithm/common.cuh
+++ b/cudax/include/cuda/experimental/__algorithm/common.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/cudax/include/cuda/experimental/__algorithm/copy.cuh
+++ b/cudax/include/cuda/experimental/__algorithm/copy.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/cudax/include/cuda/experimental/__algorithm/fill.cuh
+++ b/cudax/include/cuda/experimental/__algorithm/fill.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/cudax/include/cuda/experimental/__container/heterogeneous_iterator.cuh
+++ b/cudax/include/cuda/experimental/__container/heterogeneous_iterator.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/cudax/include/cuda/experimental/__container/uninitialized_async_buffer.cuh
+++ b/cudax/include/cuda/experimental/__container/uninitialized_async_buffer.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/cudax/include/cuda/experimental/__container/uninitialized_buffer.cuh
+++ b/cudax/include/cuda/experimental/__container/uninitialized_buffer.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/cudax/include/cuda/experimental/__detail/utility.cuh
+++ b/cudax/include/cuda/experimental/__detail/utility.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -27,17 +27,9 @@
 
 namespace cuda::experimental
 {
-namespace detail
-{
-// This is a helper type that can be used to ignore function arguments.
-struct [[maybe_unused]] __ignore
-{
-  _CCCL_HIDE_FROM_ABI __ignore() = default;
-
-  template <typename... _Args>
-  _CCCL_HOST_DEVICE constexpr __ignore(_Args&&...) noexcept
-  {}
-};
+// NOLINTBEGIN(misc-unused-using-decls)
+using _CUDA_VSTD::declval;
+// NOLINTEND(misc-unused-using-decls)
 
 // Classes can inherit from this type to become immovable.
 struct __immovable
@@ -52,17 +44,13 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __inherit : _Types...
 {};
 
 template <class _Type, template <class...> class _Template>
-inline constexpr bool __is_specialization_of = false;
+inline constexpr bool __is_specialization_of_v = false;
 
 template <template <class...> class _Template, class... _Args>
-inline constexpr bool __is_specialization_of<_Template<_Args...>, _Template> = true;
-
-} // namespace detail
+inline constexpr bool __is_specialization_of_v<_Template<_Args...>, _Template> = true;
 
 template <class _Tp>
 using __identity_t _CCCL_NODEBUG_ALIAS = _Tp;
-
-using _CUDA_VSTD::declval;
 
 struct no_init_t
 {

--- a/cudax/include/cuda/experimental/__device/all_devices.cuh
+++ b/cudax/include/cuda/experimental/__device/all_devices.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -33,7 +33,7 @@
 
 namespace cuda::experimental
 {
-namespace detail
+namespace __detail
 {
 //! @brief A random-access range of all available CUDA devices
 class all_devices
@@ -157,7 +157,7 @@ inline const ::std::vector<device>& all_devices::__devices()
   }();
   return __devices;
 }
-} // namespace detail
+} // namespace __detail
 
 //! @brief A range of all available CUDA devices
 //!
@@ -196,7 +196,7 @@ inline const ::std::vector<device>& all_devices::__devices()
 //! @sa
 //! * device
 //! * device_ref
-inline constexpr detail::all_devices devices{};
+inline constexpr __detail::all_devices devices{};
 
 inline const arch_traits_t& device_ref::get_arch_traits() const
 {

--- a/cudax/include/cuda/experimental/__device/arch_traits.cuh
+++ b/cudax/include/cuda/experimental/__device/arch_traits.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -31,7 +31,7 @@
 namespace cuda::experimental
 {
 
-namespace detail
+namespace __detail
 {
 struct arch_common_traits
 {
@@ -102,9 +102,9 @@ struct arch_common_traits
   // Maximum number of 32-bit registers available to a thread
   static constexpr int max_registers_per_thread = 255;
 };
-} // namespace detail
+} // namespace __detail
 
-struct arch_traits_t : public detail::arch_common_traits
+struct arch_traits_t : public __detail::arch_common_traits
 {
   // Major compute capability version number
   int compute_capability_major;
@@ -153,7 +153,7 @@ struct arch_traits_t : public detail::arch_common_traits
   bool tma_supported;
 };
 
-namespace detail
+namespace __detail
 {
 
 inline constexpr arch_traits_t sm_600_traits = []() constexpr {
@@ -165,7 +165,7 @@ inline constexpr arch_traits_t sm_600_traits = []() constexpr {
   __traits.max_blocks_per_multiprocessor        = 32;
   __traits.max_threads_per_multiprocessor       = 2048;
   __traits.max_warps_per_multiprocessor =
-    __traits.max_threads_per_multiprocessor / detail::arch_common_traits::warp_size;
+    __traits.max_threads_per_multiprocessor / __detail::arch_common_traits::warp_size;
   __traits.reserved_shared_memory_per_block  = 0;
   __traits.max_shared_memory_per_block_optin = 48 * 1024;
 
@@ -187,7 +187,7 @@ inline constexpr arch_traits_t sm_610_traits = []() constexpr {
   __traits.max_blocks_per_multiprocessor        = 32;
   __traits.max_threads_per_multiprocessor       = 2048;
   __traits.max_warps_per_multiprocessor =
-    __traits.max_threads_per_multiprocessor / detail::arch_common_traits::warp_size;
+    __traits.max_threads_per_multiprocessor / __detail::arch_common_traits::warp_size;
   __traits.reserved_shared_memory_per_block  = 0;
   __traits.max_shared_memory_per_block_optin = 48 * 1024;
 
@@ -209,7 +209,7 @@ inline constexpr arch_traits_t sm_700_traits = []() constexpr {
   __traits.max_blocks_per_multiprocessor        = 32;
   __traits.max_threads_per_multiprocessor       = 2048;
   __traits.max_warps_per_multiprocessor =
-    __traits.max_threads_per_multiprocessor / detail::arch_common_traits::warp_size;
+    __traits.max_threads_per_multiprocessor / __detail::arch_common_traits::warp_size;
   __traits.reserved_shared_memory_per_block = 0;
   __traits.max_shared_memory_per_block_optin =
     __traits.max_shared_memory_per_multiprocessor - __traits.reserved_shared_memory_per_block;
@@ -232,7 +232,7 @@ inline constexpr arch_traits_t sm_750_traits = []() constexpr {
   __traits.max_blocks_per_multiprocessor        = 16;
   __traits.max_threads_per_multiprocessor       = 1024;
   __traits.max_warps_per_multiprocessor =
-    __traits.max_threads_per_multiprocessor / detail::arch_common_traits::warp_size;
+    __traits.max_threads_per_multiprocessor / __detail::arch_common_traits::warp_size;
   __traits.reserved_shared_memory_per_block = 0;
   __traits.max_shared_memory_per_block_optin =
     __traits.max_shared_memory_per_multiprocessor - __traits.reserved_shared_memory_per_block;
@@ -255,7 +255,7 @@ inline constexpr arch_traits_t sm_800_traits = []() constexpr {
   __traits.max_blocks_per_multiprocessor        = 32;
   __traits.max_threads_per_multiprocessor       = 2048;
   __traits.max_warps_per_multiprocessor =
-    __traits.max_threads_per_multiprocessor / detail::arch_common_traits::warp_size;
+    __traits.max_threads_per_multiprocessor / __detail::arch_common_traits::warp_size;
   __traits.reserved_shared_memory_per_block = 1024;
   __traits.max_shared_memory_per_block_optin =
     __traits.max_shared_memory_per_multiprocessor - __traits.reserved_shared_memory_per_block;
@@ -278,7 +278,7 @@ inline constexpr arch_traits_t sm_860_traits = []() constexpr {
   __traits.max_blocks_per_multiprocessor        = 16;
   __traits.max_threads_per_multiprocessor       = 1536;
   __traits.max_warps_per_multiprocessor =
-    __traits.max_threads_per_multiprocessor / detail::arch_common_traits::warp_size;
+    __traits.max_threads_per_multiprocessor / __detail::arch_common_traits::warp_size;
   __traits.reserved_shared_memory_per_block = 1024;
   __traits.max_shared_memory_per_block_optin =
     __traits.max_shared_memory_per_multiprocessor - __traits.reserved_shared_memory_per_block;
@@ -301,7 +301,7 @@ inline constexpr arch_traits_t sm_890_traits = []() constexpr {
   __traits.max_blocks_per_multiprocessor        = 24;
   __traits.max_threads_per_multiprocessor       = 1536;
   __traits.max_warps_per_multiprocessor =
-    __traits.max_threads_per_multiprocessor / detail::arch_common_traits::warp_size;
+    __traits.max_threads_per_multiprocessor / __detail::arch_common_traits::warp_size;
   __traits.reserved_shared_memory_per_block = 1024;
   __traits.max_shared_memory_per_block_optin =
     __traits.max_shared_memory_per_multiprocessor - __traits.reserved_shared_memory_per_block;
@@ -324,7 +324,7 @@ inline constexpr arch_traits_t sm_900_traits = []() constexpr {
   __traits.max_blocks_per_multiprocessor        = 32;
   __traits.max_threads_per_multiprocessor       = 2048;
   __traits.max_warps_per_multiprocessor =
-    __traits.max_threads_per_multiprocessor / detail::arch_common_traits::warp_size;
+    __traits.max_threads_per_multiprocessor / __detail::arch_common_traits::warp_size;
   __traits.reserved_shared_memory_per_block = 1024;
   __traits.max_shared_memory_per_block_optin =
     __traits.max_shared_memory_per_multiprocessor - __traits.reserved_shared_memory_per_block;
@@ -347,7 +347,7 @@ inline constexpr arch_traits_t sm_1000_traits = []() constexpr {
   __traits.max_blocks_per_multiprocessor        = 32;
   __traits.max_threads_per_multiprocessor       = 2048;
   __traits.max_warps_per_multiprocessor =
-    __traits.max_threads_per_multiprocessor / detail::arch_common_traits::warp_size;
+    __traits.max_threads_per_multiprocessor / __detail::arch_common_traits::warp_size;
   __traits.reserved_shared_memory_per_block = 1024;
   __traits.max_shared_memory_per_block_optin =
     __traits.max_shared_memory_per_multiprocessor - __traits.reserved_shared_memory_per_block;
@@ -363,7 +363,7 @@ inline constexpr arch_traits_t sm_1000_traits = []() constexpr {
 
 inline constexpr unsigned int __highest_known_arch = 1000;
 
-} // namespace detail
+} // namespace __detail
 
 //! @brief Retrieve architecture traits of the specified architecture
 //!
@@ -376,23 +376,23 @@ _CCCL_HOST_DEVICE inline constexpr arch_traits_t arch_traits(unsigned int __sm_v
   switch (__sm_version)
   {
     case 600:
-      return detail::sm_600_traits;
+      return __detail::sm_600_traits;
     case 610:
-      return detail::sm_610_traits;
+      return __detail::sm_610_traits;
     case 700:
-      return detail::sm_700_traits;
+      return __detail::sm_700_traits;
     case 750:
-      return detail::sm_750_traits;
+      return __detail::sm_750_traits;
     case 800:
-      return detail::sm_800_traits;
+      return __detail::sm_800_traits;
     case 860:
-      return detail::sm_860_traits;
+      return __detail::sm_860_traits;
     case 890:
-      return detail::sm_890_traits;
+      return __detail::sm_890_traits;
     case 900:
-      return detail::sm_900_traits;
+      return __detail::sm_900_traits;
     case 1000:
-      return detail::sm_1000_traits;
+      return __detail::sm_1000_traits;
     default:
       __throw_cuda_error(cudaErrorInvalidValue, "Traits requested for an unknown architecture");
       break;
@@ -401,7 +401,7 @@ _CCCL_HOST_DEVICE inline constexpr arch_traits_t arch_traits(unsigned int __sm_v
 
 //! @brief Type representing a CUDA device architecture. It provides traits from arch_traits_t in form of static members
 template <unsigned int __SmVersion>
-struct arch : public detail::arch_common_traits
+struct arch : public __detail::arch_common_traits
 {
 private:
   static constexpr arch_traits_t __traits = arch_traits(__SmVersion);
@@ -441,7 +441,7 @@ _CCCL_DEVICE constexpr inline arch_traits_t current_arch()
 #endif
 }
 
-namespace detail
+namespace __detail
 {
 [[nodiscard]] inline constexpr arch_traits_t __arch_traits_might_be_unknown(int __device, unsigned int __arch)
 {
@@ -457,12 +457,12 @@ namespace detail
     __traits.compute_capability_minor = (__arch / 10) % 10;
     __traits.compute_capability       = __arch;
     __traits.max_shared_memory_per_multiprocessor =
-      detail::__device_attrs::max_shared_memory_per_multiprocessor(__device);
-    __traits.max_blocks_per_multiprocessor  = detail::__device_attrs::max_blocks_per_multiprocessor(__device);
-    __traits.max_threads_per_multiprocessor = detail::__device_attrs::max_threads_per_multiprocessor(__device);
+      __detail::__device_attrs::max_shared_memory_per_multiprocessor(__device);
+    __traits.max_blocks_per_multiprocessor  = __detail::__device_attrs::max_blocks_per_multiprocessor(__device);
+    __traits.max_threads_per_multiprocessor = __detail::__device_attrs::max_threads_per_multiprocessor(__device);
     __traits.max_warps_per_multiprocessor =
-      __traits.max_threads_per_multiprocessor / detail::arch_common_traits::warp_size;
-    __traits.reserved_shared_memory_per_block = detail::__device_attrs::reserved_shared_memory_per_block(__device);
+      __traits.max_threads_per_multiprocessor / __detail::arch_common_traits::warp_size;
+    __traits.reserved_shared_memory_per_block = __detail::__device_attrs::reserved_shared_memory_per_block(__device);
     __traits.max_shared_memory_per_block_optin =
       __traits.max_shared_memory_per_multiprocessor - __traits.reserved_shared_memory_per_block;
 
@@ -474,7 +474,7 @@ namespace detail
     return __traits;
   }
 }
-} // namespace detail
+} // namespace __detail
 
 } // namespace cuda::experimental
 

--- a/cudax/include/cuda/experimental/__device/attributes.cuh
+++ b/cudax/include/cuda/experimental/__device/attributes.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -31,7 +31,7 @@
 namespace cuda::experimental
 {
 
-namespace detail
+namespace __detail
 {
 
 template <::cudaDeviceAttr _Attr, typename _Type>
@@ -242,459 +242,460 @@ struct __dev_attr<::cudaDevAttrNumaConfig> //
 struct __device_attrs
 {
   // Maximum number of threads per block
-  using max_threads_per_block_t = detail::__dev_attr<::cudaDevAttrMaxThreadsPerBlock>;
+  using max_threads_per_block_t = __detail::__dev_attr<::cudaDevAttrMaxThreadsPerBlock>;
   static constexpr max_threads_per_block_t max_threads_per_block{};
 
   // Maximum x-dimension of a block
-  using max_block_dim_x_t = detail::__dev_attr<::cudaDevAttrMaxBlockDimX>;
+  using max_block_dim_x_t = __detail::__dev_attr<::cudaDevAttrMaxBlockDimX>;
   static constexpr max_block_dim_x_t max_block_dim_x{};
 
   // Maximum y-dimension of a block
-  using max_block_dim_y_t = detail::__dev_attr<::cudaDevAttrMaxBlockDimY>;
+  using max_block_dim_y_t = __detail::__dev_attr<::cudaDevAttrMaxBlockDimY>;
   static constexpr max_block_dim_y_t max_block_dim_y{};
 
   // Maximum z-dimension of a block
-  using max_block_dim_z_t = detail::__dev_attr<::cudaDevAttrMaxBlockDimZ>;
+  using max_block_dim_z_t = __detail::__dev_attr<::cudaDevAttrMaxBlockDimZ>;
   static constexpr max_block_dim_z_t max_block_dim_z{};
 
   // Maximum x-dimension of a grid
-  using max_grid_dim_x_t = detail::__dev_attr<::cudaDevAttrMaxGridDimX>;
+  using max_grid_dim_x_t = __detail::__dev_attr<::cudaDevAttrMaxGridDimX>;
   static constexpr max_grid_dim_x_t max_grid_dim_x{};
 
   // Maximum y-dimension of a grid
-  using max_grid_dim_y_t = detail::__dev_attr<::cudaDevAttrMaxGridDimY>;
+  using max_grid_dim_y_t = __detail::__dev_attr<::cudaDevAttrMaxGridDimY>;
   static constexpr max_grid_dim_y_t max_grid_dim_y{};
 
   // Maximum z-dimension of a grid
-  using max_grid_dim_z_t = detail::__dev_attr<::cudaDevAttrMaxGridDimZ>;
+  using max_grid_dim_z_t = __detail::__dev_attr<::cudaDevAttrMaxGridDimZ>;
   static constexpr max_grid_dim_z_t max_grid_dim_z{};
 
   // Maximum amount of shared memory available to a thread block in bytes
-  using max_shared_memory_per_block_t = detail::__dev_attr<::cudaDevAttrMaxSharedMemoryPerBlock>;
+  using max_shared_memory_per_block_t = __detail::__dev_attr<::cudaDevAttrMaxSharedMemoryPerBlock>;
   static constexpr max_shared_memory_per_block_t max_shared_memory_per_block{};
 
   // Memory available on device for __constant__ variables in a CUDA C kernel in bytes
-  using total_constant_memory_t = detail::__dev_attr<::cudaDevAttrTotalConstantMemory>;
+  using total_constant_memory_t = __detail::__dev_attr<::cudaDevAttrTotalConstantMemory>;
   static constexpr total_constant_memory_t total_constant_memory{};
 
   // Warp size in threads
-  using warp_size_t = detail::__dev_attr<::cudaDevAttrWarpSize>;
+  using warp_size_t = __detail::__dev_attr<::cudaDevAttrWarpSize>;
   static constexpr warp_size_t warp_size{};
 
   // Maximum pitch in bytes allowed by the memory copy functions that involve
   // memory regions allocated through cudaMallocPitch()
-  using max_pitch_t = detail::__dev_attr<::cudaDevAttrMaxPitch>;
+  using max_pitch_t = __detail::__dev_attr<::cudaDevAttrMaxPitch>;
   static constexpr max_pitch_t max_pitch{};
 
   // Maximum 1D texture width
-  using max_texture_1d_width_t = detail::__dev_attr<::cudaDevAttrMaxTexture1DWidth>;
+  using max_texture_1d_width_t = __detail::__dev_attr<::cudaDevAttrMaxTexture1DWidth>;
   static constexpr max_texture_1d_width_t max_texture_1d_width{};
 
   // Maximum width for a 1D texture bound to linear memory
-  using max_texture_1d_linear_width_t = detail::__dev_attr<::cudaDevAttrMaxTexture1DLinearWidth>;
+  using max_texture_1d_linear_width_t = __detail::__dev_attr<::cudaDevAttrMaxTexture1DLinearWidth>;
   static constexpr max_texture_1d_linear_width_t max_texture_1d_linear_width{};
 
   // Maximum mipmapped 1D texture width
-  using max_texture_1d_mipmapped_width_t = detail::__dev_attr<::cudaDevAttrMaxTexture1DMipmappedWidth>;
+  using max_texture_1d_mipmapped_width_t = __detail::__dev_attr<::cudaDevAttrMaxTexture1DMipmappedWidth>;
   static constexpr max_texture_1d_mipmapped_width_t max_texture_1d_mipmapped_width{};
 
   // Maximum 2D texture width
-  using max_texture_2d_width_t = detail::__dev_attr<::cudaDevAttrMaxTexture2DWidth>;
+  using max_texture_2d_width_t = __detail::__dev_attr<::cudaDevAttrMaxTexture2DWidth>;
   static constexpr max_texture_2d_width_t max_texture_2d_width{};
 
   // Maximum 2D texture height
-  using max_texture_2d_height_t = detail::__dev_attr<::cudaDevAttrMaxTexture2DHeight>;
+  using max_texture_2d_height_t = __detail::__dev_attr<::cudaDevAttrMaxTexture2DHeight>;
   static constexpr max_texture_2d_height_t max_texture_2d_height{};
 
   // Maximum width for a 2D texture bound to linear memory
-  using max_texture_2d_linear_width_t = detail::__dev_attr<::cudaDevAttrMaxTexture2DLinearWidth>;
+  using max_texture_2d_linear_width_t = __detail::__dev_attr<::cudaDevAttrMaxTexture2DLinearWidth>;
   static constexpr max_texture_2d_linear_width_t max_texture_2d_linear_width{};
 
   // Maximum height for a 2D texture bound to linear memory
-  using max_texture_2d_linear_height_t = detail::__dev_attr<::cudaDevAttrMaxTexture2DLinearHeight>;
+  using max_texture_2d_linear_height_t = __detail::__dev_attr<::cudaDevAttrMaxTexture2DLinearHeight>;
   static constexpr max_texture_2d_linear_height_t max_texture_2d_linear_height{};
 
   // Maximum pitch in bytes for a 2D texture bound to linear memory
-  using max_texture_2d_linear_pitch_t = detail::__dev_attr<::cudaDevAttrMaxTexture2DLinearPitch>;
+  using max_texture_2d_linear_pitch_t = __detail::__dev_attr<::cudaDevAttrMaxTexture2DLinearPitch>;
   static constexpr max_texture_2d_linear_pitch_t max_texture_2d_linear_pitch{};
 
   // Maximum mipmapped 2D texture width
-  using max_texture_2d_mipmapped_width_t = detail::__dev_attr<::cudaDevAttrMaxTexture2DMipmappedWidth>;
+  using max_texture_2d_mipmapped_width_t = __detail::__dev_attr<::cudaDevAttrMaxTexture2DMipmappedWidth>;
   static constexpr max_texture_2d_mipmapped_width_t max_texture_2d_mipmapped_width{};
 
   // Maximum mipmapped 2D texture height
-  using max_texture_2d_mipmapped_height_t = detail::__dev_attr<::cudaDevAttrMaxTexture2DMipmappedHeight>;
+  using max_texture_2d_mipmapped_height_t = __detail::__dev_attr<::cudaDevAttrMaxTexture2DMipmappedHeight>;
   static constexpr max_texture_2d_mipmapped_height_t max_texture_2d_mipmapped_height{};
 
   // Maximum 3D texture width
-  using max_texture_3d_width_t = detail::__dev_attr<::cudaDevAttrMaxTexture3DWidth>;
+  using max_texture_3d_width_t = __detail::__dev_attr<::cudaDevAttrMaxTexture3DWidth>;
   static constexpr max_texture_3d_width_t max_texture_3d_width{};
 
   // Maximum 3D texture height
-  using max_texture_3d_height_t = detail::__dev_attr<::cudaDevAttrMaxTexture3DHeight>;
+  using max_texture_3d_height_t = __detail::__dev_attr<::cudaDevAttrMaxTexture3DHeight>;
   static constexpr max_texture_3d_height_t max_texture_3d_height{};
 
   // Maximum 3D texture depth
-  using max_texture_3d_depth_t = detail::__dev_attr<::cudaDevAttrMaxTexture3DDepth>;
+  using max_texture_3d_depth_t = __detail::__dev_attr<::cudaDevAttrMaxTexture3DDepth>;
   static constexpr max_texture_3d_depth_t max_texture_3d_depth{};
 
   // Alternate maximum 3D texture width, 0 if no alternate maximum 3D texture size is supported
-  using max_texture_3d_width_alt_t = detail::__dev_attr<::cudaDevAttrMaxTexture3DWidthAlt>;
+  using max_texture_3d_width_alt_t = __detail::__dev_attr<::cudaDevAttrMaxTexture3DWidthAlt>;
   static constexpr max_texture_3d_width_alt_t max_texture_3d_width_alt{};
 
   // Alternate maximum 3D texture height, 0 if no alternate maximum 3D texture size is supported
-  using max_texture_3d_height_alt_t = detail::__dev_attr<::cudaDevAttrMaxTexture3DHeightAlt>;
+  using max_texture_3d_height_alt_t = __detail::__dev_attr<::cudaDevAttrMaxTexture3DHeightAlt>;
   static constexpr max_texture_3d_height_alt_t max_texture_3d_height_alt{};
 
   // Alternate maximum 3D texture depth, 0 if no alternate maximum 3D texture size is supported
-  using max_texture_3d_depth_alt_t = detail::__dev_attr<::cudaDevAttrMaxTexture3DDepthAlt>;
+  using max_texture_3d_depth_alt_t = __detail::__dev_attr<::cudaDevAttrMaxTexture3DDepthAlt>;
   static constexpr max_texture_3d_depth_alt_t max_texture_3d_depth_alt{};
 
   // Maximum cubemap texture width or height
-  using max_texture_cubemap_width_t = detail::__dev_attr<::cudaDevAttrMaxTextureCubemapWidth>;
+  using max_texture_cubemap_width_t = __detail::__dev_attr<::cudaDevAttrMaxTextureCubemapWidth>;
   static constexpr max_texture_cubemap_width_t max_texture_cubemap_width{};
 
   // Maximum 1D layered texture width
-  using max_texture_1d_layered_width_t = detail::__dev_attr<::cudaDevAttrMaxTexture1DLayeredWidth>;
+  using max_texture_1d_layered_width_t = __detail::__dev_attr<::cudaDevAttrMaxTexture1DLayeredWidth>;
   static constexpr max_texture_1d_layered_width_t max_texture_1d_layered_width{};
 
   // Maximum layers in a 1D layered texture
-  using max_texture_1d_layered_layers_t = detail::__dev_attr<::cudaDevAttrMaxTexture1DLayeredLayers>;
+  using max_texture_1d_layered_layers_t = __detail::__dev_attr<::cudaDevAttrMaxTexture1DLayeredLayers>;
   static constexpr max_texture_1d_layered_layers_t max_texture_1d_layered_layers{};
 
   // Maximum 2D layered texture width
-  using max_texture_2d_layered_width_t = detail::__dev_attr<::cudaDevAttrMaxTexture2DLayeredWidth>;
+  using max_texture_2d_layered_width_t = __detail::__dev_attr<::cudaDevAttrMaxTexture2DLayeredWidth>;
   static constexpr max_texture_2d_layered_width_t max_texture_2d_layered_width{};
 
   // Maximum 2D layered texture height
-  using max_texture_2d_layered_height_t = detail::__dev_attr<::cudaDevAttrMaxTexture2DLayeredHeight>;
+  using max_texture_2d_layered_height_t = __detail::__dev_attr<::cudaDevAttrMaxTexture2DLayeredHeight>;
   static constexpr max_texture_2d_layered_height_t max_texture_2d_layered_height{};
 
   // Maximum layers in a 2D layered texture
-  using max_texture_2d_layered_layers_t = detail::__dev_attr<::cudaDevAttrMaxTexture2DLayeredLayers>;
+  using max_texture_2d_layered_layers_t = __detail::__dev_attr<::cudaDevAttrMaxTexture2DLayeredLayers>;
   static constexpr max_texture_2d_layered_layers_t max_texture_2d_layered_layers{};
 
   // Maximum cubemap layered texture width or height
-  using max_texture_cubemap_layered_width_t = detail::__dev_attr<::cudaDevAttrMaxTextureCubemapLayeredWidth>;
+  using max_texture_cubemap_layered_width_t = __detail::__dev_attr<::cudaDevAttrMaxTextureCubemapLayeredWidth>;
   static constexpr max_texture_cubemap_layered_width_t max_texture_cubemap_layered_width{};
 
   // Maximum layers in a cubemap layered texture
-  using max_texture_cubemap_layered_layers_t = detail::__dev_attr<::cudaDevAttrMaxTextureCubemapLayeredLayers>;
+  using max_texture_cubemap_layered_layers_t = __detail::__dev_attr<::cudaDevAttrMaxTextureCubemapLayeredLayers>;
   static constexpr max_texture_cubemap_layered_layers_t max_texture_cubemap_layered_layers{};
 
   // Maximum 1D surface width
-  using max_surface_1d_width_t = detail::__dev_attr<::cudaDevAttrMaxSurface1DWidth>;
+  using max_surface_1d_width_t = __detail::__dev_attr<::cudaDevAttrMaxSurface1DWidth>;
   static constexpr max_surface_1d_width_t max_surface_1d_width{};
 
   // Maximum 2D surface width
-  using max_surface_2d_width_t = detail::__dev_attr<::cudaDevAttrMaxSurface2DWidth>;
+  using max_surface_2d_width_t = __detail::__dev_attr<::cudaDevAttrMaxSurface2DWidth>;
   static constexpr max_surface_2d_width_t max_surface_2d_width{};
 
   // Maximum 2D surface height
-  using max_surface_2d_height_t = detail::__dev_attr<::cudaDevAttrMaxSurface2DHeight>;
+  using max_surface_2d_height_t = __detail::__dev_attr<::cudaDevAttrMaxSurface2DHeight>;
   static constexpr max_surface_2d_height_t max_surface_2d_height{};
 
   // Maximum 3D surface width
-  using max_surface_3d_width_t = detail::__dev_attr<::cudaDevAttrMaxSurface3DWidth>;
+  using max_surface_3d_width_t = __detail::__dev_attr<::cudaDevAttrMaxSurface3DWidth>;
   static constexpr max_surface_3d_width_t max_surface_3d_width{};
 
   // Maximum 3D surface height
-  using max_surface_3d_height_t = detail::__dev_attr<::cudaDevAttrMaxSurface3DHeight>;
+  using max_surface_3d_height_t = __detail::__dev_attr<::cudaDevAttrMaxSurface3DHeight>;
   static constexpr max_surface_3d_height_t max_surface_3d_height{};
 
   // Maximum 3D surface depth
-  using max_surface_3d_depth_t = detail::__dev_attr<::cudaDevAttrMaxSurface3DDepth>;
+  using max_surface_3d_depth_t = __detail::__dev_attr<::cudaDevAttrMaxSurface3DDepth>;
   static constexpr max_surface_3d_depth_t max_surface_3d_depth{};
 
   // Maximum 1D layered surface width
-  using max_surface_1d_layered_width_t = detail::__dev_attr<::cudaDevAttrMaxSurface1DLayeredWidth>;
+  using max_surface_1d_layered_width_t = __detail::__dev_attr<::cudaDevAttrMaxSurface1DLayeredWidth>;
   static constexpr max_surface_1d_layered_width_t max_surface_1d_layered_width{};
 
   // Maximum layers in a 1D layered surface
-  using max_surface_1d_layered_layers_t = detail::__dev_attr<::cudaDevAttrMaxSurface1DLayeredLayers>;
+  using max_surface_1d_layered_layers_t = __detail::__dev_attr<::cudaDevAttrMaxSurface1DLayeredLayers>;
   static constexpr max_surface_1d_layered_layers_t max_surface_1d_layered_layers{};
 
   // Maximum 2D layered surface width
-  using max_surface_2d_layered_width_t = detail::__dev_attr<::cudaDevAttrMaxSurface2DLayeredWidth>;
+  using max_surface_2d_layered_width_t = __detail::__dev_attr<::cudaDevAttrMaxSurface2DLayeredWidth>;
   static constexpr max_surface_2d_layered_width_t max_surface_2d_layered_width{};
 
   // Maximum 2D layered surface height
-  using max_surface_2d_layered_height_t = detail::__dev_attr<::cudaDevAttrMaxSurface2DLayeredHeight>;
+  using max_surface_2d_layered_height_t = __detail::__dev_attr<::cudaDevAttrMaxSurface2DLayeredHeight>;
   static constexpr max_surface_2d_layered_height_t max_surface_2d_layered_height{};
 
   // Maximum layers in a 2D layered surface
-  using max_surface_2d_layered_layers_t = detail::__dev_attr<::cudaDevAttrMaxSurface2DLayeredLayers>;
+  using max_surface_2d_layered_layers_t = __detail::__dev_attr<::cudaDevAttrMaxSurface2DLayeredLayers>;
   static constexpr max_surface_2d_layered_layers_t max_surface_2d_layered_layers{};
 
   // Maximum cubemap surface width
-  using max_surface_cubemap_width_t = detail::__dev_attr<::cudaDevAttrMaxSurfaceCubemapWidth>;
+  using max_surface_cubemap_width_t = __detail::__dev_attr<::cudaDevAttrMaxSurfaceCubemapWidth>;
   static constexpr max_surface_cubemap_width_t max_surface_cubemap_width{};
 
   // Maximum cubemap layered surface width
-  using max_surface_cubemap_layered_width_t = detail::__dev_attr<::cudaDevAttrMaxSurfaceCubemapLayeredWidth>;
+  using max_surface_cubemap_layered_width_t = __detail::__dev_attr<::cudaDevAttrMaxSurfaceCubemapLayeredWidth>;
   static constexpr max_surface_cubemap_layered_width_t max_surface_cubemap_layered_width{};
 
   // Maximum layers in a cubemap layered surface
-  using max_surface_cubemap_layered_layers_t = detail::__dev_attr<::cudaDevAttrMaxSurfaceCubemapLayeredLayers>;
+  using max_surface_cubemap_layered_layers_t = __detail::__dev_attr<::cudaDevAttrMaxSurfaceCubemapLayeredLayers>;
   static constexpr max_surface_cubemap_layered_layers_t max_surface_cubemap_layered_layers{};
 
   // Maximum number of 32-bit registers available to a thread block
-  using max_registers_per_block_t = detail::__dev_attr<::cudaDevAttrMaxRegistersPerBlock>;
+  using max_registers_per_block_t = __detail::__dev_attr<::cudaDevAttrMaxRegistersPerBlock>;
   static constexpr max_registers_per_block_t max_registers_per_block{};
 
   // Peak clock frequency in kilohertz
-  using clock_rate_t = detail::__dev_attr<::cudaDevAttrClockRate>;
+  using clock_rate_t = __detail::__dev_attr<::cudaDevAttrClockRate>;
   static constexpr clock_rate_t clock_rate{};
 
   // Alignment requirement; texture base addresses aligned to textureAlign bytes
   // do not need an offset applied to texture fetches
-  using texture_alignment_t = detail::__dev_attr<::cudaDevAttrTextureAlignment>;
+  using texture_alignment_t = __detail::__dev_attr<::cudaDevAttrTextureAlignment>;
   static constexpr texture_alignment_t texture_alignment{};
 
   // Pitch alignment requirement for 2D texture references bound to pitched memory
-  using texture_pitch_alignment_t = detail::__dev_attr<::cudaDevAttrTexturePitchAlignment>;
+  using texture_pitch_alignment_t = __detail::__dev_attr<::cudaDevAttrTexturePitchAlignment>;
   static constexpr texture_pitch_alignment_t texture_pitch_alignment{};
 
   // true if the device can concurrently copy memory between host and device
   // while executing a kernel, or false if not
-  using gpu_overlap_t = detail::__dev_attr<::cudaDevAttrGpuOverlap>;
+  using gpu_overlap_t = __detail::__dev_attr<::cudaDevAttrGpuOverlap>;
   static constexpr gpu_overlap_t gpu_overlap{};
 
   // Number of multiprocessors on the device
-  using multiprocessor_count_t = detail::__dev_attr<::cudaDevAttrMultiProcessorCount>;
+  using multiprocessor_count_t = __detail::__dev_attr<::cudaDevAttrMultiProcessorCount>;
   static constexpr multiprocessor_count_t multiprocessor_count{};
 
   // true if there is a run time limit for kernels executed on the device, or
   // false if not
-  using kernel_exec_timeout_t = detail::__dev_attr<::cudaDevAttrKernelExecTimeout>;
+  using kernel_exec_timeout_t = __detail::__dev_attr<::cudaDevAttrKernelExecTimeout>;
   static constexpr kernel_exec_timeout_t kernel_exec_timeout{};
 
   // true if the device is integrated with the memory subsystem, or false if not
-  using integrated_t = detail::__dev_attr<::cudaDevAttrIntegrated>;
+  using integrated_t = __detail::__dev_attr<::cudaDevAttrIntegrated>;
   static constexpr integrated_t integrated{};
 
   // true if the device can map host memory into CUDA address space
-  using can_map_host_memory_t = detail::__dev_attr<::cudaDevAttrCanMapHostMemory>;
+  using can_map_host_memory_t = __detail::__dev_attr<::cudaDevAttrCanMapHostMemory>;
   static constexpr can_map_host_memory_t can_map_host_memory{};
 
   // Compute mode is the compute mode that the device is currently in.
-  using compute_mode_t = detail::__dev_attr<::cudaDevAttrComputeMode>;
+  using compute_mode_t = __detail::__dev_attr<::cudaDevAttrComputeMode>;
   static constexpr compute_mode_t compute_mode{};
 
   // true if the device supports executing multiple kernels within the same
   // context simultaneously, or false if not. It is not guaranteed that multiple
   // kernels will be resident on the device concurrently so this feature should
   // not be relied upon for correctness.
-  using concurrent_kernels_t = detail::__dev_attr<::cudaDevAttrConcurrentKernels>;
+  using concurrent_kernels_t = __detail::__dev_attr<::cudaDevAttrConcurrentKernels>;
   static constexpr concurrent_kernels_t concurrent_kernels{};
 
   // true if error correction is enabled on the device, 0 if error correction is
   // disabled or not supported by the device
-  using ecc_enabled_t = detail::__dev_attr<::cudaDevAttrEccEnabled>;
+  using ecc_enabled_t = __detail::__dev_attr<::cudaDevAttrEccEnabled>;
   static constexpr ecc_enabled_t ecc_enabled{};
 
   // PCI bus identifier of the device
-  using pci_bus_id_t = detail::__dev_attr<::cudaDevAttrPciBusId>;
+  using pci_bus_id_t = __detail::__dev_attr<::cudaDevAttrPciBusId>;
   static constexpr pci_bus_id_t pci_bus_id{};
 
   // PCI device (also known as slot) identifier of the device
-  using pci_device_id_t = detail::__dev_attr<::cudaDevAttrPciDeviceId>;
+  using pci_device_id_t = __detail::__dev_attr<::cudaDevAttrPciDeviceId>;
   static constexpr pci_device_id_t pci_device_id{};
 
   // true if the device is using a TCC driver. TCC is only available on Tesla
   // hardware running Windows Vista or later.
-  using tcc_driver_t = detail::__dev_attr<::cudaDevAttrTccDriver>;
+  using tcc_driver_t = __detail::__dev_attr<::cudaDevAttrTccDriver>;
   static constexpr tcc_driver_t tcc_driver{};
 
   // Peak memory clock frequency in kilohertz
-  using memory_clock_rate_t = detail::__dev_attr<::cudaDevAttrMemoryClockRate>;
+  using memory_clock_rate_t = __detail::__dev_attr<::cudaDevAttrMemoryClockRate>;
   static constexpr memory_clock_rate_t memory_clock_rate{};
 
   // Global memory bus width in bits
-  using global_memory_bus_width_t = detail::__dev_attr<::cudaDevAttrGlobalMemoryBusWidth>;
+  using global_memory_bus_width_t = __detail::__dev_attr<::cudaDevAttrGlobalMemoryBusWidth>;
   static constexpr global_memory_bus_width_t global_memory_bus_width{};
 
   // Size of L2 cache in bytes. 0 if the device doesn't have L2 cache.
-  using l2_cache_size_t = detail::__dev_attr<::cudaDevAttrL2CacheSize>;
+  using l2_cache_size_t = __detail::__dev_attr<::cudaDevAttrL2CacheSize>;
   static constexpr l2_cache_size_t l2_cache_size{};
 
   // Maximum resident threads per multiprocessor
-  using max_threads_per_multiprocessor_t = detail::__dev_attr<::cudaDevAttrMaxThreadsPerMultiProcessor>;
+  using max_threads_per_multiprocessor_t = __detail::__dev_attr<::cudaDevAttrMaxThreadsPerMultiProcessor>;
   static constexpr max_threads_per_multiprocessor_t max_threads_per_multiprocessor{};
 
   // true if the device shares a unified address space with the host, or false
   // if not
-  using unified_addressing_t = detail::__dev_attr<::cudaDevAttrUnifiedAddressing>;
+  using unified_addressing_t = __detail::__dev_attr<::cudaDevAttrUnifiedAddressing>;
   static constexpr unified_addressing_t unified_addressing{};
 
   // Major compute capability version number
-  using compute_capability_major_t = detail::__dev_attr<::cudaDevAttrComputeCapabilityMajor>;
+  using compute_capability_major_t = __detail::__dev_attr<::cudaDevAttrComputeCapabilityMajor>;
   static constexpr compute_capability_major_t compute_capability_major{};
 
   // Minor compute capability version number
-  using compute_capability_minor_t = detail::__dev_attr<::cudaDevAttrComputeCapabilityMinor>;
+  using compute_capability_minor_t = __detail::__dev_attr<::cudaDevAttrComputeCapabilityMinor>;
   static constexpr compute_capability_minor_t compute_capability_minor{};
 
   // true if the device supports stream priorities, or false if not
-  using stream_priorities_supported_t = detail::__dev_attr<::cudaDevAttrStreamPrioritiesSupported>;
+  using stream_priorities_supported_t = __detail::__dev_attr<::cudaDevAttrStreamPrioritiesSupported>;
   static constexpr stream_priorities_supported_t stream_priorities_supported{};
 
   // true if device supports caching globals in L1 cache, false if not
-  using global_l1_cache_supported_t = detail::__dev_attr<::cudaDevAttrGlobalL1CacheSupported>;
+  using global_l1_cache_supported_t = __detail::__dev_attr<::cudaDevAttrGlobalL1CacheSupported>;
   static constexpr global_l1_cache_supported_t global_l1_cache_supported{};
 
   // true if device supports caching locals in L1 cache, false if not
-  using local_l1_cache_supported_t = detail::__dev_attr<::cudaDevAttrLocalL1CacheSupported>;
+  using local_l1_cache_supported_t = __detail::__dev_attr<::cudaDevAttrLocalL1CacheSupported>;
   static constexpr local_l1_cache_supported_t local_l1_cache_supported{};
 
   // Maximum amount of shared memory available to a multiprocessor in bytes;
   // this amount is shared by all thread blocks simultaneously resident on a
   // multiprocessor
-  using max_shared_memory_per_multiprocessor_t = detail::__dev_attr<::cudaDevAttrMaxSharedMemoryPerMultiprocessor>;
+  using max_shared_memory_per_multiprocessor_t = __detail::__dev_attr<::cudaDevAttrMaxSharedMemoryPerMultiprocessor>;
   static constexpr max_shared_memory_per_multiprocessor_t max_shared_memory_per_multiprocessor{};
 
   // Maximum number of 32-bit registers available to a multiprocessor; this
   // number is shared by all thread blocks simultaneously resident on a
   // multiprocessor
-  using max_registers_per_multiprocessor_t = detail::__dev_attr<::cudaDevAttrMaxRegistersPerMultiprocessor>;
+  using max_registers_per_multiprocessor_t = __detail::__dev_attr<::cudaDevAttrMaxRegistersPerMultiprocessor>;
   static constexpr max_registers_per_multiprocessor_t max_registers_per_multiprocessor{};
 
   // true if device supports allocating managed memory, false if not
-  using managed_memory_t = detail::__dev_attr<::cudaDevAttrManagedMemory>;
+  using managed_memory_t = __detail::__dev_attr<::cudaDevAttrManagedMemory>;
   static constexpr managed_memory_t managed_memory{};
 
   // true if device is on a multi-GPU board, false if not
-  using is_multi_gpu_board_t = detail::__dev_attr<::cudaDevAttrIsMultiGpuBoard>;
+  using is_multi_gpu_board_t = __detail::__dev_attr<::cudaDevAttrIsMultiGpuBoard>;
   static constexpr is_multi_gpu_board_t is_multi_gpu_board{};
 
   // Unique identifier for a group of devices on the same multi-GPU board
-  using multi_gpu_board_group_id_t = detail::__dev_attr<::cudaDevAttrMultiGpuBoardGroupID>;
+  using multi_gpu_board_group_id_t = __detail::__dev_attr<::cudaDevAttrMultiGpuBoardGroupID>;
   static constexpr multi_gpu_board_group_id_t multi_gpu_board_group_id{};
 
   // true if the link between the device and the host supports native atomic
   // operations
-  using host_native_atomic_supported_t = detail::__dev_attr<::cudaDevAttrHostNativeAtomicSupported>;
+  using host_native_atomic_supported_t = __detail::__dev_attr<::cudaDevAttrHostNativeAtomicSupported>;
   static constexpr host_native_atomic_supported_t host_native_atomic_supported{};
 
   // Ratio of single precision performance (in floating-point operations per
   // second) to double precision performance
-  using single_to_double_precision_perf_ratio_t = detail::__dev_attr<::cudaDevAttrSingleToDoublePrecisionPerfRatio>;
+  using single_to_double_precision_perf_ratio_t = __detail::__dev_attr<::cudaDevAttrSingleToDoublePrecisionPerfRatio>;
   static constexpr single_to_double_precision_perf_ratio_t single_to_double_precision_perf_ratio{};
 
   // true if the device supports coherently accessing pageable memory without
   // calling cudaHostRegister on it, and false otherwise
-  using pageable_memory_access_t = detail::__dev_attr<::cudaDevAttrPageableMemoryAccess>;
+  using pageable_memory_access_t = __detail::__dev_attr<::cudaDevAttrPageableMemoryAccess>;
   static constexpr pageable_memory_access_t pageable_memory_access{};
 
   // true if the device can coherently access managed memory concurrently with
   // the CPU, and false otherwise
-  using concurrent_managed_access_t = detail::__dev_attr<::cudaDevAttrConcurrentManagedAccess>;
+  using concurrent_managed_access_t = __detail::__dev_attr<::cudaDevAttrConcurrentManagedAccess>;
   static constexpr concurrent_managed_access_t concurrent_managed_access{};
 
   // true if the device supports Compute Preemption, false if not
-  using compute_preemption_supported_t = detail::__dev_attr<::cudaDevAttrComputePreemptionSupported>;
+  using compute_preemption_supported_t = __detail::__dev_attr<::cudaDevAttrComputePreemptionSupported>;
   static constexpr compute_preemption_supported_t compute_preemption_supported{};
 
   // true if the device can access host registered memory at the same virtual
   // address as the CPU, and false otherwise
-  using can_use_host_pointer_for_registered_mem_t = detail::__dev_attr<::cudaDevAttrCanUseHostPointerForRegisteredMem>;
+  using can_use_host_pointer_for_registered_mem_t =
+    __detail::__dev_attr<::cudaDevAttrCanUseHostPointerForRegisteredMem>;
   static constexpr can_use_host_pointer_for_registered_mem_t can_use_host_pointer_for_registered_mem{};
 
   // true if the device supports launching cooperative kernels via
   // cudaLaunchCooperativeKernel, and false otherwise
-  using cooperative_launch_t = detail::__dev_attr<::cudaDevAttrCooperativeLaunch>;
+  using cooperative_launch_t = __detail::__dev_attr<::cudaDevAttrCooperativeLaunch>;
   static constexpr cooperative_launch_t cooperative_launch{};
 
   // true if the device supports flushing of outstanding remote writes, and
   // false otherwise
-  using can_flush_remote_writes_t = detail::__dev_attr<::cudaDevAttrCanFlushRemoteWrites>;
+  using can_flush_remote_writes_t = __detail::__dev_attr<::cudaDevAttrCanFlushRemoteWrites>;
   static constexpr can_flush_remote_writes_t can_flush_remote_writes{};
 
   // true if the device supports host memory registration via cudaHostRegister,
   // and false otherwise
-  using host_register_supported_t = detail::__dev_attr<::cudaDevAttrHostRegisterSupported>;
+  using host_register_supported_t = __detail::__dev_attr<::cudaDevAttrHostRegisterSupported>;
   static constexpr host_register_supported_t host_register_supported{};
 
   // true if the device accesses pageable memory via the host's page tables, and
   // false otherwise
   using pageable_memory_access_uses_host_page_tables_t =
-    detail::__dev_attr<::cudaDevAttrPageableMemoryAccessUsesHostPageTables>;
+    __detail::__dev_attr<::cudaDevAttrPageableMemoryAccessUsesHostPageTables>;
   static constexpr pageable_memory_access_uses_host_page_tables_t pageable_memory_access_uses_host_page_tables{};
 
   // true if the host can directly access managed memory on the device without
   // migration, and false otherwise
-  using direct_managed_mem_access_from_host_t = detail::__dev_attr<::cudaDevAttrDirectManagedMemAccessFromHost>;
+  using direct_managed_mem_access_from_host_t = __detail::__dev_attr<::cudaDevAttrDirectManagedMemAccessFromHost>;
   static constexpr direct_managed_mem_access_from_host_t direct_managed_mem_access_from_host{};
 
   // Maximum per block shared memory size on the device. This value can be opted
   // into when using dynamic_shared_memory with NonPortableSize set to true
-  using max_shared_memory_per_block_optin_t = detail::__dev_attr<::cudaDevAttrMaxSharedMemoryPerBlockOptin>;
+  using max_shared_memory_per_block_optin_t = __detail::__dev_attr<::cudaDevAttrMaxSharedMemoryPerBlockOptin>;
   static constexpr max_shared_memory_per_block_optin_t max_shared_memory_per_block_optin{};
 
   // Maximum number of thread blocks that can reside on a multiprocessor
-  using max_blocks_per_multiprocessor_t = detail::__dev_attr<::cudaDevAttrMaxBlocksPerMultiprocessor>;
+  using max_blocks_per_multiprocessor_t = __detail::__dev_attr<::cudaDevAttrMaxBlocksPerMultiprocessor>;
   static constexpr max_blocks_per_multiprocessor_t max_blocks_per_multiprocessor{};
 
   // Maximum L2 persisting lines capacity setting in bytes
-  using max_persisting_l2_cache_size_t = detail::__dev_attr<::cudaDevAttrMaxPersistingL2CacheSize>;
+  using max_persisting_l2_cache_size_t = __detail::__dev_attr<::cudaDevAttrMaxPersistingL2CacheSize>;
   static constexpr max_persisting_l2_cache_size_t max_persisting_l2_cache_size{};
 
   // Maximum value of cudaAccessPolicyWindow::num_bytes
-  using max_access_policy_window_size_t = detail::__dev_attr<::cudaDevAttrMaxAccessPolicyWindowSize>;
+  using max_access_policy_window_size_t = __detail::__dev_attr<::cudaDevAttrMaxAccessPolicyWindowSize>;
   static constexpr max_access_policy_window_size_t max_access_policy_window_size{};
 
   // Shared memory reserved by CUDA driver per block in bytes
-  using reserved_shared_memory_per_block_t = detail::__dev_attr<::cudaDevAttrReservedSharedMemoryPerBlock>;
+  using reserved_shared_memory_per_block_t = __detail::__dev_attr<::cudaDevAttrReservedSharedMemoryPerBlock>;
   static constexpr reserved_shared_memory_per_block_t reserved_shared_memory_per_block{};
 
   // true if the device supports sparse CUDA arrays and sparse CUDA mipmapped arrays.
-  using sparse_cuda_array_supported_t = detail::__dev_attr<::cudaDevAttrSparseCudaArraySupported>;
+  using sparse_cuda_array_supported_t = __detail::__dev_attr<::cudaDevAttrSparseCudaArraySupported>;
   static constexpr sparse_cuda_array_supported_t sparse_cuda_array_supported{};
 
   // Device supports using the cudaHostRegister flag cudaHostRegisterReadOnly to
   // register memory that must be mapped as read-only to the GPU
-  using host_register_read_only_supported_t = detail::__dev_attr<::cudaDevAttrHostRegisterReadOnlySupported>;
+  using host_register_read_only_supported_t = __detail::__dev_attr<::cudaDevAttrHostRegisterReadOnlySupported>;
   static constexpr host_register_read_only_supported_t host_register_read_only_supported{};
 
   // true if the device supports using the cudaMallocAsync and cudaMemPool
   // family of APIs, and false otherwise
-  using memory_pools_supported_t = detail::__dev_attr<::cudaDevAttrMemoryPoolsSupported>;
+  using memory_pools_supported_t = __detail::__dev_attr<::cudaDevAttrMemoryPoolsSupported>;
   static constexpr memory_pools_supported_t memory_pools_supported{};
 
   // true if the device supports GPUDirect RDMA APIs, and false otherwise
-  using gpu_direct_rdma_supported_t = detail::__dev_attr<::cudaDevAttrGPUDirectRDMASupported>;
+  using gpu_direct_rdma_supported_t = __detail::__dev_attr<::cudaDevAttrGPUDirectRDMASupported>;
   static constexpr gpu_direct_rdma_supported_t gpu_direct_rdma_supported{};
 
   // bitmask to be interpreted according to the
   // cudaFlushGPUDirectRDMAWritesOptions enum
-  using gpu_direct_rdma_flush_writes_options_t = detail::__dev_attr<::cudaDevAttrGPUDirectRDMAFlushWritesOptions>;
+  using gpu_direct_rdma_flush_writes_options_t = __detail::__dev_attr<::cudaDevAttrGPUDirectRDMAFlushWritesOptions>;
   static constexpr gpu_direct_rdma_flush_writes_options_t gpu_direct_rdma_flush_writes_options{};
 
   // see the cudaGPUDirectRDMAWritesOrdering enum for numerical values
-  using gpu_direct_rdma_writes_ordering_t = detail::__dev_attr<::cudaDevAttrGPUDirectRDMAWritesOrdering>;
+  using gpu_direct_rdma_writes_ordering_t = __detail::__dev_attr<::cudaDevAttrGPUDirectRDMAWritesOrdering>;
   static constexpr gpu_direct_rdma_writes_ordering_t gpu_direct_rdma_writes_ordering{};
 
   // Bitmask of handle types supported with mempool based IPC
-  using memory_pool_supported_handle_types_t = detail::__dev_attr<::cudaDevAttrMemoryPoolSupportedHandleTypes>;
+  using memory_pool_supported_handle_types_t = __detail::__dev_attr<::cudaDevAttrMemoryPoolSupportedHandleTypes>;
   static constexpr memory_pool_supported_handle_types_t memory_pool_supported_handle_types{};
 
   // true if the device supports deferred mapping CUDA arrays and CUDA mipmapped
   // arrays.
-  using deferred_mapping_cuda_array_supported_t = detail::__dev_attr<::cudaDevAttrDeferredMappingCudaArraySupported>;
+  using deferred_mapping_cuda_array_supported_t = __detail::__dev_attr<::cudaDevAttrDeferredMappingCudaArraySupported>;
   static constexpr deferred_mapping_cuda_array_supported_t deferred_mapping_cuda_array_supported{};
 
   // true if the device supports IPC Events, false otherwise.
-  using ipc_event_support_t = detail::__dev_attr<::cudaDevAttrIpcEventSupport>;
+  using ipc_event_support_t = __detail::__dev_attr<::cudaDevAttrIpcEventSupport>;
   static constexpr ipc_event_support_t ipc_event_support{};
 
 #if CUDART_VERSION >= 12020
 
   // NUMA configuration of a device: value is of type cudaDeviceNumaConfig enum
-  using numa_config_t = detail::__dev_attr<::cudaDevAttrNumaConfig>;
+  using numa_config_t = __detail::__dev_attr<::cudaDevAttrNumaConfig>;
   static constexpr numa_config_t numa_config{};
 
   // NUMA node ID of the GPU memory
-  using numa_id_t = detail::__dev_attr<::cudaDevAttrNumaId>;
+  using numa_id_t = __detail::__dev_attr<::cudaDevAttrNumaId>;
   static constexpr numa_id_t numa_id{};
 
 #endif // CUDART_VERSION >= 12020
@@ -711,7 +712,7 @@ struct __device_attrs
   static constexpr compute_capability_t compute_capability{};
 };
 
-} // namespace detail
+} // namespace __detail
 
 } // namespace cuda::experimental
 

--- a/cudax/include/cuda/experimental/__device/device.cuh
+++ b/cudax/include/cuda/experimental/__device/device.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -35,7 +35,7 @@
 
 namespace cuda::experimental
 {
-namespace detail
+namespace __detail
 {
 //! @brief A proxy object used to in-place construct a `device` object from an
 //! integer ID. Used in __detail/all_devices.cuh.
@@ -47,7 +47,7 @@ struct __emplace_device
 
   [[nodiscard]] constexpr const __emplace_device* operator->() const;
 };
-} // namespace detail
+} // namespace __detail
 
 // This is the element type of the the global `devices` array. In the future, we
 // can cache device properties here.
@@ -56,7 +56,7 @@ struct __emplace_device
 class device : public device_ref
 {
 public:
-  using attrs = detail::__device_attrs;
+  using attrs = __detail::__device_attrs;
 
   //! @brief For a given attribute, returns the type of the attribute value.
   //!
@@ -68,13 +68,13 @@ public:
   //!
   //! @sa device::attrs
   template <::cudaDeviceAttr _Attr>
-  using attr_result_t = typename detail::__dev_attr<_Attr>::type;
+  using attr_result_t = typename __detail::__dev_attr<_Attr>::type;
 
 #ifndef _CCCL_DOXYGEN_INVOKED // Do not document
 #  if _CCCL_COMPILER(MSVC)
   // When __EDG__ is defined, std::construct_at will not permit constructing
   // a device object from an __emplace_device object. This is a workaround.
-  device(detail::__emplace_device __ed)
+  device(__detail::__emplace_device __ed)
       : device(__ed.__id_)
   {}
 #  endif
@@ -94,8 +94,8 @@ public:
   CUcontext get_primary_context() const
   {
     ::std::call_once(__init_once, [this]() {
-      __device      = detail::driver::deviceGet(__id_);
-      __primary_ctx = detail::driver::primaryCtxRetain(__device);
+      __device      = __detail::driver::deviceGet(__id_);
+      __primary_ctx = __detail::driver::primaryCtxRetain(__device);
     });
     _CCCL_ASSERT(__primary_ctx != nullptr, "cuda::experimental::attr_result_t::primary_context failed to get context");
     return __primary_ctx;
@@ -105,7 +105,7 @@ public:
   {
     if (__primary_ctx)
     {
-      detail::driver::primaryCtxRelease(__device);
+      __detail::driver::primaryCtxRelease(__device);
     }
   }
 
@@ -114,7 +114,7 @@ private:
   // properties here.
 
   friend class device_ref;
-  friend struct detail::__emplace_device;
+  friend struct __detail::__emplace_device;
 
   mutable CUcontext __primary_ctx = nullptr;
   mutable CUdevice __device{};
@@ -127,7 +127,7 @@ private:
 
   explicit device(int __id)
       : device_ref(__id)
-      , __traits(detail::__arch_traits_might_be_unknown(__id, attrs::compute_capability(__id)))
+      , __traits(__detail::__arch_traits_might_be_unknown(__id, attrs::compute_capability(__id)))
   {}
 
   // `device` objects are not movable or copyable.
@@ -145,7 +145,7 @@ private:
 #endif // _CCCL_STD_VER <= 2017
 };
 
-namespace detail
+namespace __detail
 {
 [[nodiscard]] inline __emplace_device::operator device() const
 {
@@ -156,7 +156,7 @@ namespace detail
 {
   return this;
 }
-} // namespace detail
+} // namespace __detail
 
 } // namespace cuda::experimental
 

--- a/cudax/include/cuda/experimental/__device/device_ref.cuh
+++ b/cudax/include/cuda/experimental/__device/device_ref.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -35,11 +35,11 @@ namespace cuda::experimental
 class device;
 struct arch_traits_t;
 
-namespace detail
+namespace __detail
 {
 template <::cudaDeviceAttr _Attr>
 struct __dev_attr;
-} // namespace detail
+} // namespace __detail
 
 //! @brief A non-owning representation of a CUDA device
 class device_ref
@@ -110,7 +110,7 @@ public:
   template <::cudaDeviceAttr _Attr>
   [[nodiscard]] auto attr() const
   {
-    return attr(detail::__dev_attr<_Attr>());
+    return attr(__detail::__dev_attr<_Attr>());
   }
 
   //! @brief Retrieve string with the name of this device.
@@ -122,7 +122,7 @@ public:
     ::std::string __name(256, 0);
 
     // For some reason there is no separate name query in CUDA runtime
-    detail::driver::getName(__name.data(), __max_name_length, get());
+    __detail::driver::getName(__name.data(), __max_name_length, get());
     return __name;
   }
 

--- a/cudax/include/cuda/experimental/__device/logical_device.cuh
+++ b/cudax/include/cuda/experimental/__device/logical_device.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/cudax/include/cuda/experimental/__event/event.cuh
+++ b/cudax/include/cuda/experimental/__event/event.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -90,7 +90,7 @@ public:
     {
       // Needs to call driver API in case current device is not set, runtime version would set dev 0 current
       // Alternative would be to store the device and push/pop here
-      [[maybe_unused]] auto __status = detail::driver::eventDestroy(__event_);
+      [[maybe_unused]] auto __status = __detail::driver::eventDestroy(__event_);
     }
   }
 

--- a/cudax/include/cuda/experimental/__event/event_ref.cuh
+++ b/cudax/include/cuda/experimental/__event/event_ref.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -79,7 +79,7 @@ public:
     _CCCL_ASSERT(__event_ != nullptr, "cuda::experimental::event_ref::record no event set");
     _CCCL_ASSERT(__stream.get() != nullptr, "cuda::experimental::event_ref::record invalid stream passed");
     // Need to use driver API, cudaEventRecord will push dev 0 if stack is empty
-    detail::driver::eventRecord(__event_, __stream.get());
+    __detail::driver::eventRecord(__event_, __stream.get());
   }
 
   //! @brief Synchronizes the event

--- a/cudax/include/cuda/experimental/__event/timed_event.cuh
+++ b/cudax/include/cuda/experimental/__event/timed_event.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/cudax/include/cuda/experimental/__execution/atomic_intrusive_queue.cuh
+++ b/cudax/include/cuda/experimental/__execution/atomic_intrusive_queue.cuh
@@ -8,8 +8,8 @@
 //                         Copyright (c) 2023 Maikel Nadolski
 //===----------------------------------------------------------------------===//
 
-#ifndef __CUDAX_ASYNC_DETAIL_ATOMIC_INTRUSIVE_QUEUE
-#define __CUDAX_ASYNC_DETAIL_ATOMIC_INTRUSIVE_QUEUE
+#ifndef __CUDAX_EXECUTION_ATOMIC_INTRUSIVE_QUEUE
+#define __CUDAX_EXECUTION_ATOMIC_INTRUSIVE_QUEUE
 
 #include <cuda/std/detail/__config>
 
@@ -82,4 +82,4 @@ private:
 
 #include <cuda/experimental/__execution/epilogue.cuh>
 
-#endif // __CUDAX_ASYNC_DETAIL_ATOMIC_INTRUSIVE_QUEUE
+#endif // __CUDAX_EXECUTION_ATOMIC_INTRUSIVE_QUEUE

--- a/cudax/include/cuda/experimental/__execution/completion_signatures.cuh
+++ b/cudax/include/cuda/experimental/__execution/completion_signatures.cuh
@@ -101,10 +101,10 @@ _CCCL_GLOBAL_CONSTANT __concat_completion_signatures_fn concat_completion_signat
 #if defined(__cpp_constexpr_exceptions) // C++26, https://wg21.link/p3068
 template <class... What, class... Values>
 [[noreturn, nodiscard]] constexpr completion_signatures<> invalid_completion_signature(Values... values);
-#else
+#else // ^^^ constexpr exceptions ^^^ / vvv no constexpr exceptions vvv
 template <class... What, class... Values>
 [[nodiscard]] _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto invalid_completion_signature(Values... values);
-#endif
+#endif // ^^^ no constexpr exceptions ^^^
 
 struct _IN_COMPLETION_SIGNATURES_APPLY;
 struct _IN_COMPLETION_SIGNATURES_TRANSFORM_REDUCE;
@@ -899,14 +899,14 @@ catch (...)
 {
   return false; // different kind of exception was thrown; not a dependent sender
 }
-#else
+#else // ^^^ constexpr exceptions ^^^ / vvv no constexpr exceptions vvv
 template <class _Sndr>
 [[nodiscard]] _CCCL_API _CCCL_CONSTEVAL auto __is_dependent_sender() noexcept -> bool
 {
   using _Completions _CCCL_NODEBUG_ALIAS = decltype(get_completion_signatures<_Sndr>());
   return _CUDA_VSTD::is_base_of_v<dependent_sender_error, _Completions>;
 }
-#endif
+#endif // ^^^ no constexpr exceptions ^^^
 
 } // namespace cuda::experimental::execution
 
@@ -914,4 +914,4 @@ _CCCL_DIAG_POP
 
 #include <cuda/experimental/__execution/epilogue.cuh>
 
-#endif
+#endif // _CUDAX_EXECUTION_COMPLETION_SIGNATURES_H

--- a/cudax/include/cuda/experimental/__execution/concepts.cuh
+++ b/cudax/include/cuda/experimental/__execution/concepts.cuh
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CUDAX_ASYNC_DETAIL_CONCEPTS
-#define __CUDAX_ASYNC_DETAIL_CONCEPTS
+#ifndef __CUDAX_EXECUTION_CONCEPTS
+#define __CUDAX_EXECUTION_CONCEPTS
 
 #include <cuda/std/detail/__config>
 
@@ -150,4 +150,4 @@ _CCCL_CONCEPT dependent_sender = //
 
 #include <cuda/experimental/__execution/epilogue.cuh>
 
-#endif // __CUDAX_ASYNC_DETAIL_CONCEPTS
+#endif // __CUDAX_EXECUTION_CONCEPTS

--- a/cudax/include/cuda/experimental/__execution/conditional.cuh
+++ b/cudax/include/cuda/experimental/__execution/conditional.cuh
@@ -291,4 +291,4 @@ _CCCL_GLOBAL_CONSTANT conditional_t conditional{};
 
 #include <cuda/experimental/__execution/epilogue.cuh>
 
-#endif
+#endif // __CUDAX_EXECUTION_CONDITIONAL

--- a/cudax/include/cuda/experimental/__execution/conditional.cuh
+++ b/cudax/include/cuda/experimental/__execution/conditional.cuh
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CUDAX_ASYNC_DETAIL_CONDITIONAL
-#define __CUDAX_ASYNC_DETAIL_CONDITIONAL
+#ifndef __CUDAX_EXECUTION_CONDITIONAL
+#define __CUDAX_EXECUTION_CONDITIONAL
 
 #include <cuda/std/detail/__config>
 
@@ -96,8 +96,8 @@ private:
       else
       {
         return concat_completion_signatures(
-          get_completion_signatures<__call_result_t<_Then, __just_from_t<_As...>>, _Env...>(),
-          get_completion_signatures<__call_result_t<_Else, __just_from_t<_As...>>, _Env...>());
+          get_completion_signatures<_CUDA_VSTD::__call_result_t<_Then, __just_from_t<_As...>>, _Env...>(),
+          get_completion_signatures<_CUDA_VSTD::__call_result_t<_Else, __just_from_t<_As...>>, _Env...>());
       }
     }
   };
@@ -112,8 +112,8 @@ private:
     template <class... _As>
     using __opstate_t _CCCL_NODEBUG_ALIAS = //
       _CUDA_VSTD::__type_list< //
-        connect_result_t<__call_result_t<_Then, __just_from_t<_As...>>, __rcvr_ref<_Rcvr>>,
-        connect_result_t<__call_result_t<_Else, __just_from_t<_As...>>, __rcvr_ref<_Rcvr>>>;
+        connect_result_t<_CUDA_VSTD::__call_result_t<_Then, __just_from_t<_As...>>, __rcvr_ref<_Rcvr>>,
+        connect_result_t<_CUDA_VSTD::__call_result_t<_Else, __just_from_t<_As...>>, __rcvr_ref<_Rcvr>>>;
 
     using __next_ops_variant_t _CCCL_NODEBUG_ALIAS = //
       __value_types<completion_signatures_of_t<_Sndr, __env_t>, __opstate_t, __type_concat_into_quote<__variant>::__call>;

--- a/cudax/include/cuda/experimental/__execution/continues_on.cuh
+++ b/cudax/include/cuda/experimental/__execution/continues_on.cuh
@@ -87,4 +87,4 @@ _CCCL_GLOBAL_CONSTANT continues_on_t continues_on{};
 
 #include <cuda/experimental/__execution/epilogue.cuh>
 
-#endif
+#endif // __CUDAX_EXECUTION_CONTINUES_ON

--- a/cudax/include/cuda/experimental/__execution/continues_on.cuh
+++ b/cudax/include/cuda/experimental/__execution/continues_on.cuh
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CUDAX_ASYNC_DETAIL_CONTINUES_ON
-#define __CUDAX_ASYNC_DETAIL_CONTINUES_ON
+#ifndef __CUDAX_EXECUTION_CONTINUES_ON
+#define __CUDAX_EXECUTION_CONTINUES_ON
 
 #include <cuda/std/detail/__config>
 
@@ -43,7 +43,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT continues_on_t
     // _Sndr is a (possibly cvref-qualified) instance of continues_on_t::__sndr_t
     auto&& [__tag, __sch, __child] = static_cast<_Sndr&&>(__sndr);
     // By default, continues_on(sndr, sch) lowers to schedule_from(sch, sndr) in connect:
-    return schedule_from(__sch, static_cast<__copy_cvref_t<_Sndr&&, decltype(__child)>>(__child));
+    return schedule_from(__sch, static_cast<_CUDA_VSTD::__copy_cvref_t<_Sndr&&, decltype(__child)>>(__child));
   }
 
   template <class _Sndr, class _Sch>

--- a/cudax/include/cuda/experimental/__execution/cpos.cuh
+++ b/cudax/include/cuda/experimental/__execution/cpos.cuh
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CUDAX_ASYNC_DETAIL_CPOS
-#define __CUDAX_ASYNC_DETAIL_CPOS
+#ifndef __CUDAX_EXECUTION_CPOS
+#define __CUDAX_EXECUTION_CPOS
 
 #include <cuda/std/detail/__config>
 

--- a/cudax/include/cuda/experimental/__execution/cpos.cuh
+++ b/cudax/include/cuda/experimental/__execution/cpos.cuh
@@ -163,4 +163,4 @@ inline constexpr bool __nothrow_connectable = noexcept(connect(declval<_Sndr>(),
 
 #include <cuda/experimental/__execution/epilogue.cuh>
 
-#endif
+#endif // __CUDAX_EXECUTION_CPOS

--- a/cudax/include/cuda/experimental/__execution/domain.cuh
+++ b/cudax/include/cuda/experimental/__execution/domain.cuh
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CUDAX_ASYNC_DETAIL_DOMAIN
-#define __CUDAX_ASYNC_DETAIL_DOMAIN
+#ifndef __CUDAX_EXECUTION_DOMAIN
+#define __CUDAX_EXECUTION_DOMAIN
 
 #include <cuda/std/detail/__config>
 
@@ -22,6 +22,7 @@
 #endif // no system header
 
 #include <cuda/std/__execution/env.h>
+#include <cuda/std/__tuple_dir/ignore.h>
 #include <cuda/std/__type_traits/is_nothrow_move_constructible.h>
 
 #include <cuda/experimental/__detail/utility.cuh>
@@ -89,8 +90,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT default_domain
   //! @overload
   _CCCL_EXEC_CHECK_DISABLE
   template <class _Sndr>
-  _CCCL_TRIVIAL_API static constexpr auto
-  transform_sender(_Sndr&& __sndr) noexcept(_CUDA_VSTD::is_nothrow_move_constructible_v<_Sndr>) -> _Sndr
+  _CCCL_TRIVIAL_API static constexpr auto transform_sender(_Sndr&& __sndr) noexcept(__nothrow_movable<_Sndr>) -> _Sndr
   {
     // FUTURE TODO: add a transform for the split sender once we have a split sender
     return static_cast<_Sndr&&>(__sndr);
@@ -100,8 +100,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT default_domain
   _CCCL_EXEC_CHECK_DISABLE
   template <class _Sndr>
   _CCCL_TRIVIAL_API static constexpr auto
-  transform_sender(_Sndr&& __sndr, _CUDA_VSTD::__ignore_t) noexcept(_CUDA_VSTD::is_nothrow_move_constructible_v<_Sndr>)
-    -> _Sndr
+  transform_sender(_Sndr&& __sndr, _CUDA_VSTD::__ignore_t) noexcept(__nothrow_movable<_Sndr>) -> _Sndr
   {
     return static_cast<_Sndr&&>(__sndr);
   }
@@ -152,4 +151,4 @@ using domain_for_t _CCCL_NODEBUG_ALIAS =
 
 #include <cuda/experimental/__execution/epilogue.cuh>
 
-#endif // __CUDAX_ASYNC_DETAIL_DOMAIN
+#endif // __CUDAX_EXECUTION_DOMAIN

--- a/cudax/include/cuda/experimental/__execution/env.cuh
+++ b/cudax/include/cuda/experimental/__execution/env.cuh
@@ -73,8 +73,8 @@ namespace __detail
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __fwd_env_fn
 {
   template <class _Env>
-  [[nodiscard]] _CCCL_TRIVIAL_API constexpr auto operator()(_Env&& __env) const
-    noexcept(_CUDA_VSTD::is_nothrow_move_constructible_v<_Env>) -> __fwd_env_<_Env>
+  [[nodiscard]] _CCCL_TRIVIAL_API constexpr auto operator()(_Env&& __env) const noexcept(__nothrow_movable<_Env>)
+    -> __fwd_env_<_Env>
   {
     return __fwd_env_<_Env>{static_cast<_Env&&>(__env)};
   }
@@ -116,7 +116,7 @@ private:
   using __stream_ref = stream_ref;
 
   __resource __mr_                      = device_memory_resource{};
-  __stream_ref __stream_                = detail::__invalid_stream;
+  __stream_ref __stream_                = __detail::__invalid_stream;
   execution::execution_policy __policy_ = execution::execution_policy::invalid_execution_policy;
 
 public:
@@ -130,7 +130,7 @@ public:
   //! @param __policy The execution_policy passed in
   _CCCL_HIDE_FROM_ABI
   env_t(__resource __mr,
-        __stream_ref __stream                = detail::__invalid_stream,
+        __stream_ref __stream                = __detail::__invalid_stream,
         execution::execution_policy __policy = execution::execution_policy::invalid_execution_policy) noexcept
       : __mr_(_CUDA_VSTD::move(__mr))
       , __stream_(__stream)

--- a/cudax/include/cuda/experimental/__execution/exception.cuh
+++ b/cudax/include/cuda/experimental/__execution/exception.cuh
@@ -43,4 +43,4 @@
 #  define _CUDAX_NOEXCEPT_EXPR(...) noexcept(__VA_ARGS__)
 #endif // ^^^ !_CCCL_DEVICE_COMPILATION() || _CCCL_CUDA_COMPILER(NVHPC) ^^^
 
-#endif
+#endif // __CUDAX_EXECUTION_EXCEPTION

--- a/cudax/include/cuda/experimental/__execution/exception.cuh
+++ b/cudax/include/cuda/experimental/__execution/exception.cuh
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CUDAX_ASYNC_DETAIL_EXCEPTION
-#define __CUDAX_ASYNC_DETAIL_EXCEPTION
+#ifndef __CUDAX_EXECUTION_EXCEPTION
+#define __CUDAX_EXECUTION_EXCEPTION
 
 #include <cuda/std/detail/__config>
 

--- a/cudax/include/cuda/experimental/__execution/fwd.cuh
+++ b/cudax/include/cuda/experimental/__execution/fwd.cuh
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CUDAX_ASYNC_DETAIL_FWD
-#define __CUDAX_ASYNC_DETAIL_FWD
+#ifndef __CUDAX_EXECUTION_FWD
+#define __CUDAX_EXECUTION_FWD
 
 #include <cuda/std/detail/__config>
 
@@ -26,13 +26,24 @@
 #include <cuda/std/__type_traits/type_list.h>
 
 #include <cuda/experimental/__detail/utility.cuh>
-#include <cuda/experimental/__execution/meta.cuh>
+#include <cuda/experimental/__execution/type_traits.cuh>
 #include <cuda/experimental/__execution/visit.cuh>
 
 #include <cuda/experimental/__execution/prologue.cuh>
 
-namespace cuda::experimental::execution
+namespace cuda::experimental
 {
+// so we can refer to the cuda::experimental::__detail namespace below
+namespace __detail
+{
+}
+namespace execution
+{
+namespace __detail
+{
+using namespace cuda::experimental::__detail; // // NOLINT(misc-unused-using-decls)
+} // namespace __detail
+
 struct _CCCL_TYPE_VISIBILITY_DEFAULT receiver_t
 {};
 
@@ -55,13 +66,13 @@ template <class _Ty>
 using __scheduler_concept_t _CCCL_NODEBUG_ALIAS = typename _CUDA_VSTD::remove_reference_t<_Ty>::scheduler_concept;
 
 template <class _Ty>
-inline constexpr bool __is_sender = __type_valid_v<__sender_concept_t, _Ty>;
+inline constexpr bool __is_sender = __is_instantiable_with_v<__sender_concept_t, _Ty>;
 
 template <class _Ty>
-inline constexpr bool __is_receiver = __type_valid_v<__receiver_concept_t, _Ty>;
+inline constexpr bool __is_receiver = __is_instantiable_with_v<__receiver_concept_t, _Ty>;
 
 template <class _Ty>
-inline constexpr bool __is_scheduler = __type_valid_v<__scheduler_concept_t, _Ty>;
+inline constexpr bool __is_scheduler = __is_instantiable_with_v<__scheduler_concept_t, _Ty>;
 
 struct stream_domain;
 struct dependent_sender_error;
@@ -171,7 +182,8 @@ extern __fn_t<set_error_t>* __set_tag<__error, _Void>;
 template <class _Void>
 extern __fn_t<set_stopped_t>* __set_tag<__stopped, _Void>;
 } // namespace __detail
-} // namespace cuda::experimental::execution
+} // namespace execution
+} // namespace cuda::experimental
 
 #include <cuda/experimental/__execution/epilogue.cuh>
 

--- a/cudax/include/cuda/experimental/__execution/fwd.cuh
+++ b/cudax/include/cuda/experimental/__execution/fwd.cuh
@@ -194,4 +194,4 @@ extern __fn_t<set_stopped_t>* __set_tag<__stopped, _Void>;
 
 #include <cuda/experimental/__execution/epilogue.cuh>
 
-#endif
+#endif // __CUDAX_EXECUTION_FWD

--- a/cudax/include/cuda/experimental/__execution/intrusive_queue.cuh
+++ b/cudax/include/cuda/experimental/__execution/intrusive_queue.cuh
@@ -8,8 +8,8 @@
 //                         Copyright (c) 2021-2022 Facebook, Inc & AFFILIATES.
 //===----------------------------------------------------------------------===//
 
-#ifndef __CUDAX_ASYNC_DETAIL_INTRUSIVE_QUEUE
-#define __CUDAX_ASYNC_DETAIL_INTRUSIVE_QUEUE
+#ifndef __CUDAX_EXECUTION_INTRUSIVE_QUEUE
+#define __CUDAX_EXECUTION_INTRUSIVE_QUEUE
 
 #include <cuda/std/detail/__config>
 
@@ -293,4 +293,4 @@ private:
 
 #include <cuda/experimental/__execution/epilogue.cuh>
 
-#endif // __CUDAX_ASYNC_DETAIL_INTRUSIVE_QUEUE
+#endif // __CUDAX_EXECUTION_INTRUSIVE_QUEUE

--- a/cudax/include/cuda/experimental/__execution/just.cuh
+++ b/cudax/include/cuda/experimental/__execution/just.cuh
@@ -71,7 +71,7 @@ private:
     // escapes. So for gcc, we let this operation state be movable.
     // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=98995
     _CCCL_IMMOVABLE_OPSTATE(__opstate_t);
-#endif
+#endif // !_CCCL_COMPILER(GCC)
 
     _CCCL_API void start() & noexcept
     {
@@ -143,4 +143,4 @@ _CCCL_GLOBAL_CONSTANT auto just_stopped = just_stopped_t{};
 
 #include <cuda/experimental/__execution/epilogue.cuh>
 
-#endif
+#endif // __CUDAX_EXECUTION_JUST

--- a/cudax/include/cuda/experimental/__execution/just.cuh
+++ b/cudax/include/cuda/experimental/__execution/just.cuh
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CUDAX_ASYNC_DETAIL_JUST
-#define __CUDAX_ASYNC_DETAIL_JUST
+#ifndef __CUDAX_EXECUTION_JUST
+#define __CUDAX_EXECUTION_JUST
 
 #include <cuda/std/detail/__config>
 
@@ -36,7 +36,7 @@ namespace cuda::experimental::execution
 namespace __detail
 {
 template <__disposition_t, class _Void = void>
-extern __undefined<_Void> __just_tag;
+extern _CUDA_VSTD::__undefined<_Void> __just_tag;
 template <class _Void>
 extern __fn_t<just_t>* __just_tag<__value, _Void>;
 template <class _Void>

--- a/cudax/include/cuda/experimental/__execution/just_from.cuh
+++ b/cudax/include/cuda/experimental/__execution/just_from.cuh
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CUDAX_ASYNC_DETAIL_JUST_FROM
-#define __CUDAX_ASYNC_DETAIL_JUST_FROM
+#ifndef __CUDAX_EXECUTION_JUST_FROM
+#define __CUDAX_EXECUTION_JUST_FROM
 
 #include <cuda/std/detail/__config>
 
@@ -38,7 +38,7 @@ namespace cuda::experimental::execution
 namespace __detail
 {
 template <__disposition_t, class _Void = void>
-extern __undefined<_Void> __just_from_tag;
+extern _CUDA_VSTD::__undefined<_Void> __just_from_tag;
 template <class _Void>
 extern __fn_t<just_from_t>* __just_from_tag<__value, _Void>;
 template <class _Void>
@@ -123,7 +123,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __just_from_t<_Disposition>::__sndr_t
   template <class _Self, class...>
   [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL auto get_completion_signatures() noexcept
   {
-    return __call_result_t<_Fn, __probe_fn>{};
+    return _CUDA_VSTD::__call_result_t<_Fn, __probe_fn>{};
   }
 
   template <class _Rcvr>
@@ -145,7 +145,7 @@ template <__disposition_t _Disposition>
 template <class _Fn>
 _CCCL_TRIVIAL_API constexpr auto __just_from_t<_Disposition>::operator()(_Fn __fn) const noexcept -> __sndr_t<_Fn>
 {
-  using __completions _CCCL_NODEBUG_ALIAS = __call_result_t<_Fn, __probe_fn>;
+  using __completions _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::__call_result_t<_Fn, __probe_fn>;
   static_assert(__valid_completion_signatures<__completions>,
                 "The function passed to just_from must return an instance of a specialization of "
                 "completion_signatures<>.");

--- a/cudax/include/cuda/experimental/__execution/just_from.cuh
+++ b/cudax/include/cuda/experimental/__execution/just_from.cuh
@@ -167,4 +167,4 @@ _CCCL_GLOBAL_CONSTANT auto just_stopped_from = just_stopped_from_t{};
 
 #include <cuda/experimental/__execution/epilogue.cuh>
 
-#endif
+#endif // __CUDAX_EXECUTION_JUST_FROM

--- a/cudax/include/cuda/experimental/__execution/lazy.cuh
+++ b/cudax/include/cuda/experimental/__execution/lazy.cuh
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CUDAX_ASYNC_DETAIL_LAZY
-#define __CUDAX_ASYNC_DETAIL_LAZY
+#ifndef __CUDAX_EXECUTION_LAZY
+#define __CUDAX_EXECUTION_LAZY
 
 #include <cuda/std/detail/__config>
 
@@ -90,7 +90,7 @@ struct __lazy_tupl<_CUDA_VSTD::index_sequence<>>
 {
   template <class _Fn, class _Self, class... _Us>
   _CCCL_TRIVIAL_API static auto __apply(_Fn&& __fn, _Self&&, _Us&&... __us) //
-    noexcept(__nothrow_callable<_Fn, _Us...>) -> __call_result_t<_Fn, _Us...>
+    noexcept(__nothrow_callable<_Fn, _Us...>) -> _CUDA_VSTD::__call_result_t<_Fn, _Us...>
   {
     return static_cast<_Fn&&>(__fn)(static_cast<_Us&&>(__us)...);
   }
@@ -127,11 +127,12 @@ struct __lazy_tupl<_CUDA_VSTD::index_sequence<_Idx...>, _Ts...> : __detail::__la
 
   template <class _Fn, class _Self, class... _Us>
   _CCCL_TRIVIAL_API static auto __apply(_Fn&& __fn, _Self&& __self, _Us&&... __us) //
-    noexcept(__nothrow_callable<_Fn, _Us..., __copy_cvref_t<_Self, _Ts>...>)
-      -> __call_result_t<_Fn, _Us..., __copy_cvref_t<_Self, _Ts>...>
+    noexcept(__nothrow_callable<_Fn, _Us..., _CUDA_VSTD::__copy_cvref_t<_Self, _Ts>...>)
+      -> _CUDA_VSTD::__call_result_t<_Fn, _Us..., _CUDA_VSTD::__copy_cvref_t<_Self, _Ts>...>
   {
-    return static_cast<_Fn&&>(__fn)(
-      static_cast<_Us&&>(__us)..., static_cast<__copy_cvref_t<_Self, _Ts>&&>(*__self.template __get<_Idx, _Ts>())...);
+    return static_cast<_Fn&&>(
+      __fn)(static_cast<_Us&&>(__us)...,
+            static_cast<_CUDA_VSTD::__copy_cvref_t<_Self, _Ts>&&>(*__self.template __get<_Idx, _Ts>())...);
   }
 
   bool __engaged_[sizeof...(_Ts)] = {};
@@ -153,7 +154,7 @@ using __lazy_tuple _CCCL_NODEBUG_ALIAS = __lazy_tupl<_CUDA_VSTD::make_index_sequ
 #endif
 
 template <class... _Ts>
-using __decayed_lazy_tuple _CCCL_NODEBUG_ALIAS = __lazy_tuple<__decay_t<_Ts>...>;
+using __decayed_lazy_tuple _CCCL_NODEBUG_ALIAS = __lazy_tuple<_CUDA_VSTD::decay_t<_Ts>...>;
 
 } // namespace cuda::experimental::execution
 

--- a/cudax/include/cuda/experimental/__execution/lazy.cuh
+++ b/cudax/include/cuda/experimental/__execution/lazy.cuh
@@ -148,10 +148,10 @@ struct __mk_lazy_tuple_
 
 template <class... _Ts>
 using __lazy_tuple _CCCL_NODEBUG_ALIAS = typename __mk_lazy_tuple_<_Ts...>::type;
-#else
+#else // ^^^^ _CCCL_COMPILER(MSVC) ^^^ / vvv !_CCCL_COMPILER(MSVC) vvv
 template <class... _Ts>
 using __lazy_tuple _CCCL_NODEBUG_ALIAS = __lazy_tupl<_CUDA_VSTD::make_index_sequence<sizeof...(_Ts)>, _Ts...>;
-#endif
+#endif // !_CCCL_COMPILER(MSVC)
 
 template <class... _Ts>
 using __decayed_lazy_tuple _CCCL_NODEBUG_ALIAS = __lazy_tuple<_CUDA_VSTD::decay_t<_Ts>...>;
@@ -160,4 +160,4 @@ using __decayed_lazy_tuple _CCCL_NODEBUG_ALIAS = __lazy_tuple<_CUDA_VSTD::decay_
 
 #include <cuda/experimental/__execution/epilogue.cuh>
 
-#endif
+#endif // __CUDAX_EXECUTION_LAZY

--- a/cudax/include/cuda/experimental/__execution/let_value.cuh
+++ b/cudax/include/cuda/experimental/__execution/let_value.cuh
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CUDAX_ASYNC_DETAIL_LET_VALUE
-#define __CUDAX_ASYNC_DETAIL_LET_VALUE
+#ifndef __CUDAX_EXECUTION_LET_VALUE
+#define __CUDAX_EXECUTION_LET_VALUE
 
 #include <cuda/std/detail/__config>
 
@@ -49,7 +49,7 @@ struct _FUNCTION_MUST_RETURN_A_SENDER;
 namespace __detail
 {
 template <__disposition_t, class _Void = void>
-extern __undefined<_Void> __let_tag;
+extern _CUDA_VSTD::__undefined<_Void> __let_tag;
 template <class _Void>
 extern __fn_t<let_value_t>* __let_tag<__value, _Void>;
 template <class _Void>
@@ -82,7 +82,8 @@ private:
   struct __opstate_fn
   {
     template <class... _As>
-    using __call _CCCL_NODEBUG_ALIAS = connect_result_t<__call_result_t<_Fn, __decay_t<_As>&...>, __rcvr_ref<_Rcvr>>;
+    using __call _CCCL_NODEBUG_ALIAS =
+      connect_result_t<_CUDA_VSTD::__call_result_t<_Fn, _CUDA_VSTD::decay_t<_As>&...>, __rcvr_ref<_Rcvr>>;
   };
 
   /// @brief Computes the type of a variant of operation states to hold
@@ -378,14 +379,14 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __let_t<_Disposition>::__closure_t
   _Fn __fn_;
 
   template <class _Sndr>
-  _CCCL_TRIVIAL_API auto operator()(_Sndr __sndr) const -> __call_result_t<_LetTag, _Sndr, _Fn>
+  _CCCL_TRIVIAL_API auto operator()(_Sndr __sndr) const -> _CUDA_VSTD::__call_result_t<_LetTag, _Sndr, _Fn>
   {
     return _LetTag()(static_cast<_Sndr&&>(__sndr), __fn_);
   }
 
   template <class _Sndr>
   _CCCL_TRIVIAL_API friend auto operator|(_Sndr __sndr, const __closure_t& __self)
-    -> __call_result_t<_LetTag, _Sndr, _Fn>
+    -> _CUDA_VSTD::__call_result_t<_LetTag, _Sndr, _Fn>
   {
     return _LetTag()(static_cast<_Sndr&&>(__sndr), __self.__fn_);
   }

--- a/cudax/include/cuda/experimental/__execution/let_value.cuh
+++ b/cudax/include/cuda/experimental/__execution/let_value.cuh
@@ -428,4 +428,4 @@ _CCCL_GLOBAL_CONSTANT auto let_stopped = let_stopped_t{};
 
 #include <cuda/experimental/__execution/epilogue.cuh>
 
-#endif
+#endif // __CUDAX_EXECUTION_LET_VALUE

--- a/cudax/include/cuda/experimental/__execution/meta.cuh
+++ b/cudax/include/cuda/experimental/__execution/meta.cuh
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CUDAX_ASYNC_DETAIL_META
-#define __CUDAX_ASYNC_DETAIL_META
+#ifndef __CUDAX_EXECUTION_META
+#define __CUDAX_EXECUTION_META
 
 #include <cuda/std/detail/__config>
 
@@ -26,6 +26,8 @@
 #include <cuda/std/__type_traits/is_valid_expansion.h>
 #include <cuda/std/__type_traits/type_list.h>
 
+#include <cuda/experimental/__detail/utility.cuh>
+
 #if __cpp_lib_three_way_comparison
 #  include <compare> // IWYU pragma: keep
 #endif
@@ -40,12 +42,6 @@ namespace cuda::experimental::execution
 {
 template <class _Ret, class... _Args>
 using __fn_t _CCCL_NODEBUG_ALIAS = _Ret(_Args...);
-
-template <class _Ty>
-auto declval() noexcept -> _Ty&&;
-
-template <size_t... _Vals>
-struct __moffsets;
 
 // The following must be left undefined
 template <class...>
@@ -150,9 +146,6 @@ inline constexpr bool __type_contains_error =
 template <class... _Ts>
 using __type_find_error _CCCL_NODEBUG_ALIAS = decltype(+(declval<_Ts&>(), ..., declval<_ERROR<_UNKNOWN>&>()));
 
-template <template <class...> class _Fn, class... _Ts>
-inline constexpr bool __type_valid_v = _CUDA_VSTD::_IsValidExpansion<_Fn, _Ts...>::value;
-
 template <bool _Error>
 struct __type_self_or_error_with_
 {
@@ -229,7 +222,7 @@ struct __type_try_quote<_Fn, _Default>
 {
   template <class... _Ts>
   using __call _CCCL_NODEBUG_ALIAS =
-    typename _CUDA_VSTD::conditional_t<__type_valid_v<_Fn, _Ts...>, //
+    typename _CUDA_VSTD::conditional_t<_CUDA_VSTD::_IsValidExpansion<_Fn, _Ts...>::value, //
                                        __type_try_quote<_Fn>,
                                        _CUDA_VSTD::__type_always<_Default>>::template __call<_Ts...>;
 };
@@ -284,13 +277,6 @@ struct __type_self_or
 {
   template <class _Uy = _Ty>
   using __call _CCCL_NODEBUG_ALIAS = _Uy;
-};
-
-template <class _Ret>
-struct __type_quote_function
-{
-  template <class... _Args>
-  using __call _CCCL_NODEBUG_ALIAS = _Ret(_Args...);
 };
 } // namespace cuda::experimental::execution
 

--- a/cudax/include/cuda/experimental/__execution/meta.cuh
+++ b/cudax/include/cuda/experimental/__execution/meta.cuh
@@ -284,4 +284,4 @@ _CCCL_DIAG_POP
 
 #include <cuda/experimental/__execution/epilogue.cuh>
 
-#endif
+#endif // __CUDAX_EXECUTION_META

--- a/cudax/include/cuda/experimental/__execution/policy.cuh
+++ b/cudax/include/cuda/experimental/__execution/policy.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/cudax/include/cuda/experimental/__execution/queries.cuh
+++ b/cudax/include/cuda/experimental/__execution/queries.cuh
@@ -41,10 +41,12 @@ _CCCL_SUPPRESS_DEPRECATED_POP
 
 namespace cuda::experimental::execution
 {
+// NOLINTBEGIN(misc-unused-using-decls)
 using _CUDA_STD_EXEC::__forwarding_query;
 using _CUDA_STD_EXEC::__queryable_with;
 using _CUDA_STD_EXEC::forwarding_query;
 using _CUDA_STD_EXEC::forwarding_query_t;
+// NOLINTEND(misc-unused-using-decls)
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // get_allocator
@@ -225,4 +227,4 @@ using __domain_of_t _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::__call_result_t<get_domain
 
 #include <cuda/experimental/__execution/epilogue.cuh>
 
-#endif
+#endif // __CUDAX_EXECUTION_QUERIES

--- a/cudax/include/cuda/experimental/__execution/queries.cuh
+++ b/cudax/include/cuda/experimental/__execution/queries.cuh
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CUDAX_ASYNC_DETAIL_QUERIES
-#define __CUDAX_ASYNC_DETAIL_QUERIES
+#ifndef __CUDAX_EXECUTION_QUERIES
+#define __CUDAX_EXECUTION_QUERIES
 
 #include <cuda/std/detail/__config>
 
@@ -97,7 +97,7 @@ _CCCL_GLOBAL_CONSTANT struct get_stop_token_t
 } get_stop_token{};
 
 template <class _Ty>
-using stop_token_of_t _CCCL_NODEBUG_ALIAS = __decay_t<__call_result_t<get_stop_token_t, _Ty>>;
+using stop_token_of_t _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::decay_t<_CUDA_VSTD::__call_result_t<get_stop_token_t, _Ty>>;
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // get_completion_scheduler
@@ -125,7 +125,7 @@ _CCCL_GLOBAL_CONSTANT get_completion_scheduler_t<_Tag> get_completion_scheduler{
 
 template <class _Env, class _Tag = set_value_t>
 using __completion_scheduler_of_t _CCCL_NODEBUG_ALIAS =
-  __decay_t<__call_result_t<get_completion_scheduler_t<_Tag>, _Env>>;
+  _CUDA_VSTD::decay_t<_CUDA_VSTD::__call_result_t<get_completion_scheduler_t<_Tag>, _Env>>;
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // get_scheduler
@@ -148,7 +148,7 @@ _CCCL_GLOBAL_CONSTANT struct get_scheduler_t
 } get_scheduler{};
 
 template <class _Env>
-using __scheduler_of_t _CCCL_NODEBUG_ALIAS = __decay_t<__call_result_t<get_scheduler_t, _Env>>;
+using __scheduler_of_t _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::decay_t<_CUDA_VSTD::__call_result_t<get_scheduler_t, _Env>>;
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // get_delegation_scheduler
@@ -219,7 +219,7 @@ _CCCL_GLOBAL_CONSTANT struct get_domain_t
 } get_domain{};
 
 template <class _Env>
-using __domain_of_t _CCCL_NODEBUG_ALIAS = __call_result_t<get_domain_t, _Env>;
+using __domain_of_t _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::__call_result_t<get_domain_t, _Env>;
 
 } // namespace cuda::experimental::execution
 

--- a/cudax/include/cuda/experimental/__execution/rcvr_ref.cuh
+++ b/cudax/include/cuda/experimental/__execution/rcvr_ref.cuh
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CUDAX_ASYNC_DETAIL_RCVR_REF
-#define __CUDAX_ASYNC_DETAIL_RCVR_REF
+#ifndef __CUDAX_EXECUTION_RCVR_REF
+#define __CUDAX_EXECUTION_RCVR_REF
 
 #include <cuda/std/detail/__config>
 
@@ -66,4 +66,4 @@ _CCCL_HOST_DEVICE __rcvr_ref(_Rcvr&) -> __rcvr_ref<_Rcvr>;
 
 #include <cuda/experimental/__execution/epilogue.cuh>
 
-#endif // __CUDAX_ASYNC_DETAIL_RCVR_REF
+#endif // __CUDAX_EXECUTION_RCVR_REF

--- a/cudax/include/cuda/experimental/__execution/rcvr_with_env.cuh
+++ b/cudax/include/cuda/experimental/__execution/rcvr_with_env.cuh
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CUDAX_ASYNC_DETAIL_RCVR_WITH_ENV
-#define __CUDAX_ASYNC_DETAIL_RCVR_WITH_ENV
+#ifndef __CUDAX_EXECUTION_RCVR_WITH_ENV
+#define __CUDAX_EXECUTION_RCVR_WITH_ENV
 
 #include <cuda/std/detail/__config>
 

--- a/cudax/include/cuda/experimental/__execution/rcvr_with_env.cuh
+++ b/cudax/include/cuda/experimental/__execution/rcvr_with_env.cuh
@@ -91,4 +91,4 @@ __rcvr_with_env_t(_Rcvr, _Env) -> __rcvr_with_env_t<_Rcvr, _Env>;
 
 #include <cuda/experimental/__execution/epilogue.cuh>
 
-#endif
+#endif // __CUDAX_EXECUTION_RCVR_WITH_ENV

--- a/cudax/include/cuda/experimental/__execution/read_env.cuh
+++ b/cudax/include/cuda/experimental/__execution/read_env.cuh
@@ -153,4 +153,4 @@ _CCCL_GLOBAL_CONSTANT read_env_t read_env{};
 
 #include <cuda/experimental/__execution/epilogue.cuh>
 
-#endif
+#endif // __CUDAX_EXECUTION_READ_ENV

--- a/cudax/include/cuda/experimental/__execution/read_env.cuh
+++ b/cudax/include/cuda/experimental/__execution/read_env.cuh
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CUDAX_ASYNC_DETAIL_READ_ENV
-#define __CUDAX_ASYNC_DETAIL_READ_ENV
+#ifndef __CUDAX_EXECUTION_READ_ENV
+#define __CUDAX_EXECUTION_READ_ENV
 
 #include <cuda/std/detail/__config>
 
@@ -111,7 +111,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT read_env_t::__sndr_t
                                           _WITH_QUERY(_Query),
                                           _WITH_ENVIRONMENT(_Env)>();
     }
-    else if constexpr (_CUDA_VSTD::is_void_v<__call_result_t<_Query, _Env>>)
+    else if constexpr (_CUDA_VSTD::is_void_v<_CUDA_VSTD::__call_result_t<_Query, _Env>>)
     {
       return invalid_completion_signature<_WHERE(_IN_ALGORITHM, read_env_t),
                                           _WHAT(_THE_CURRENT_ENVIRONMENT_RETURNED_VOID_FOR_THIS_QUERY),
@@ -120,11 +120,12 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT read_env_t::__sndr_t
     }
     else if constexpr (__nothrow_callable<_Query, _Env>)
     {
-      return completion_signatures<set_value_t(__call_result_t<_Query, _Env>)>{};
+      return completion_signatures<set_value_t(_CUDA_VSTD::__call_result_t<_Query, _Env>)>{};
     }
     else
     {
-      return completion_signatures<set_value_t(__call_result_t<_Query, _Env>), set_error_t(::std::exception_ptr)>{};
+      return completion_signatures<set_value_t(_CUDA_VSTD::__call_result_t<_Query, _Env>),
+                                   set_error_t(::std::exception_ptr)>{};
     }
 
     _CCCL_UNREACHABLE();

--- a/cudax/include/cuda/experimental/__execution/run_loop.cuh
+++ b/cudax/include/cuda/experimental/__execution/run_loop.cuh
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CUDAX_ASYNC_DETAIL_RUN_LOOP
-#define __CUDAX_ASYNC_DETAIL_RUN_LOOP
+#ifndef __CUDAX_EXECUTION_RUN_LOOP
+#define __CUDAX_EXECUTION_RUN_LOOP
 
 #include <cuda/std/detail/__config>
 
@@ -21,10 +21,12 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/experimental/__detail/utility.cuh>
 #include <cuda/experimental/__execution/atomic_intrusive_queue.cuh>
 #include <cuda/experimental/__execution/completion_signatures.cuh>
 #include <cuda/experimental/__execution/env.cuh>
 #include <cuda/experimental/__execution/exception.cuh>
+#include <cuda/experimental/__execution/fwd.cuh>
 #include <cuda/experimental/__execution/queries.cuh>
 #include <cuda/experimental/__execution/utility.cuh>
 
@@ -240,4 +242,4 @@ private:
 
 #include <cuda/experimental/__execution/epilogue.cuh>
 
-#endif // __CUDAX_ASYNC_DETAIL_RUN_LOOP
+#endif // __CUDAX_EXECUTION_RUN_LOOP

--- a/cudax/include/cuda/experimental/__execution/schedule_from.cuh
+++ b/cudax/include/cuda/experimental/__execution/schedule_from.cuh
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CUDAX_ASYNC_DETAIL_SCHEDULE_FROM
-#define __CUDAX_ASYNC_DETAIL_SCHEDULE_FROM
+#ifndef __CUDAX_EXECUTION_SCHEDULE_FROM
+#define __CUDAX_EXECUTION_SCHEDULE_FROM
 
 #include <cuda/std/detail/__config>
 
@@ -58,11 +58,11 @@ struct __decay_args
     }
     else if constexpr (!__nothrow_decay_copyable<_Ts...>)
     {
-      return completion_signatures<_Tag(__decay_t<_Ts>...), set_error_t(::std::exception_ptr)>{};
+      return completion_signatures<_Tag(_CUDA_VSTD::decay_t<_Ts>...), set_error_t(::std::exception_ptr)>{};
     }
     else
     {
-      return completion_signatures<_Tag(__decay_t<_Ts>...)>{};
+      return completion_signatures<_Tag(_CUDA_VSTD::decay_t<_Ts>...)>{};
     }
   }
 };
@@ -136,10 +136,10 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT schedule_from_t
 {
 private:
   template <class... _As>
-  using __set_value_tuple_t _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::__tuple<set_value_t, __decay_t<_As>...>;
+  using __set_value_tuple_t _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::__tuple<set_value_t, _CUDA_VSTD::decay_t<_As>...>;
 
   template <class _Error>
-  using __set_error_tuple_t _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::__tuple<set_error_t, __decay_t<_Error>>;
+  using __set_error_tuple_t _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::__tuple<set_error_t, _CUDA_VSTD::decay_t<_Error>>;
 
   using __set_stopped_tuple_t _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::__tuple<set_stopped_t>;
 
@@ -162,7 +162,7 @@ private:
     template <class _Tag, class... _As>
     _CCCL_API void __set_result(_Tag, _As&&... __as) noexcept
     {
-      using __tupl_t _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::__tuple<_Tag, __decay_t<_As>...>;
+      using __tupl_t _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::__tuple<_Tag, _CUDA_VSTD::decay_t<_As>...>;
       if constexpr (__nothrow_decay_copyable<_As...>)
       {
         __result_.template __emplace<__tupl_t>(_Tag(), static_cast<_As&&>(__as)...);
@@ -296,4 +296,4 @@ _CCCL_GLOBAL_CONSTANT schedule_from_t schedule_from{};
 
 #include <cuda/experimental/__execution/epilogue.cuh>
 
-#endif // __CUDAX_ASYNC_DETAIL_SCHEDULE_FROM
+#endif // __CUDAX_EXECUTION_SCHEDULE_FROM

--- a/cudax/include/cuda/experimental/__execution/sequence.cuh
+++ b/cudax/include/cuda/experimental/__execution/sequence.cuh
@@ -172,4 +172,4 @@ _CCCL_GLOBAL_CONSTANT sequence_t sequence{};
 
 #include <cuda/experimental/__execution/epilogue.cuh>
 
-#endif
+#endif // __CUDAX_EXECUTION_SEQUENCE

--- a/cudax/include/cuda/experimental/__execution/sequence.cuh
+++ b/cudax/include/cuda/experimental/__execution/sequence.cuh
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CUDAX_ASYNC_DETAIL_SEQUENCE
-#define __CUDAX_ASYNC_DETAIL_SEQUENCE
+#ifndef __CUDAX_EXECUTION_SEQUENCE
+#define __CUDAX_EXECUTION_SEQUENCE
 
 #include <cuda/std/detail/__config>
 
@@ -22,6 +22,7 @@
 #endif // no system header
 
 #include <cuda/std/__cccl/unreachable.h>
+#include <cuda/std/__tuple_dir/ignore.h>
 
 #include <cuda/experimental/__execution/completion_signatures.cuh>
 #include <cuda/experimental/__execution/cpos.cuh>
@@ -150,7 +151,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT sequence_t::__sndr_t
   }
 
   _CCCL_NO_UNIQUE_ADDRESS sequence_t __tag_;
-  _CCCL_NO_UNIQUE_ADDRESS __ignore __ign_;
+  _CCCL_NO_UNIQUE_ADDRESS _CUDA_VSTD::__ignore_t __ign_;
   __sndr1_t __sndr1_;
   __sndr2_t __sndr2_;
 };

--- a/cudax/include/cuda/experimental/__execution/start_detached.cuh
+++ b/cudax/include/cuda/experimental/__execution/start_detached.cuh
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CUDAX_ASYNC_DETAIL_START_DETACHED
-#define __CUDAX_ASYNC_DETAIL_START_DETACHED
+#ifndef __CUDAX_EXECUTION_START_DETACHED
+#define __CUDAX_EXECUTION_START_DETACHED
 
 #include <cuda/std/detail/__config>
 

--- a/cudax/include/cuda/experimental/__execution/start_detached.cuh
+++ b/cudax/include/cuda/experimental/__execution/start_detached.cuh
@@ -108,4 +108,4 @@ _CCCL_GLOBAL_CONSTANT start_detached_t start_detached{};
 
 #include <cuda/experimental/__execution/epilogue.cuh>
 
-#endif
+#endif // __CUDAX_EXECUTION_START_DETACHED

--- a/cudax/include/cuda/experimental/__execution/starts_on.cuh
+++ b/cudax/include/cuda/experimental/__execution/starts_on.cuh
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CUDAX_ASYNC_DETAIL_STARTS_ON
-#define __CUDAX_ASYNC_DETAIL_STARTS_ON
+#ifndef __CUDAX_EXECUTION_STARTS_ON
+#define __CUDAX_EXECUTION_STARTS_ON
 
 #include <cuda/std/detail/__config>
 
@@ -108,7 +108,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT starts_on_t::__sndr_t
   [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL auto get_completion_signatures()
   {
     using __sch_sndr _CCCL_NODEBUG_ALIAS   = schedule_result_t<_Sch>;
-    using __child_sndr _CCCL_NODEBUG_ALIAS = __copy_cvref_t<_Self, _Sndr>;
+    using __child_sndr _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::__copy_cvref_t<_Self, _Sndr>;
     _CUDAX_LET_COMPLETIONS(
       auto(__sndr_completions) = execution::get_completion_signatures<__child_sndr, __env_t<_Env>...>())
     {

--- a/cudax/include/cuda/experimental/__execution/starts_on.cuh
+++ b/cudax/include/cuda/experimental/__execution/starts_on.cuh
@@ -156,4 +156,4 @@ _CCCL_GLOBAL_CONSTANT starts_on_t starts_on{};
 
 #include <cuda/experimental/__execution/epilogue.cuh>
 
-#endif
+#endif // __CUDAX_EXECUTION_STARTS_ON

--- a/cudax/include/cuda/experimental/__execution/stop_token.cuh
+++ b/cudax/include/cuda/experimental/__execution/stop_token.cuh
@@ -477,4 +477,4 @@ using stop_callback_for_t _CCCL_NODEBUG_ALIAS = typename _Token::template callba
 
 #include <cuda/experimental/__execution/epilogue.cuh>
 
-#endif
+#endif // __CUDAX_EXECUTION_STOP_TOKEN

--- a/cudax/include/cuda/experimental/__execution/stop_token.cuh
+++ b/cudax/include/cuda/experimental/__execution/stop_token.cuh
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CUDAX_ASYNC_DETAIL_STOP_TOKEN
-#define __CUDAX_ASYNC_DETAIL_STOP_TOKEN
+#ifndef __CUDAX_EXECUTION_STOP_TOKEN
+#define __CUDAX_EXECUTION_STOP_TOKEN
 
 #include <cuda/std/detail/__config>
 
@@ -22,6 +22,7 @@
 #endif // no system header
 
 #include <cuda/std/__thread/threading_support.h>
+#include <cuda/std/__tuple_dir/ignore.h>
 #include <cuda/std/__type_traits/is_nothrow_constructible.h>
 #include <cuda/std/atomic>
 
@@ -108,7 +109,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT never_stop_token
 private:
   struct __callback_type
   {
-    _CCCL_API explicit __callback_type(never_stop_token, __ignore) noexcept {}
+    _CCCL_API explicit __callback_type(never_stop_token, _CUDA_VSTD::__ignore_t) noexcept {}
   };
 
 public:
@@ -253,7 +254,7 @@ class _CCCL_TYPE_VISIBILITY_DEFAULT inplace_stop_callback : __stok::__inplace_st
 public:
   template <class _Fun2>
   _CCCL_API explicit inplace_stop_callback(inplace_stop_token __token,
-                                           _Fun2&& __fun) noexcept(_CUDA_VSTD::is_nothrow_constructible_v<_Fun, _Fun2>)
+                                           _Fun2&& __fun) noexcept(__nothrow_constructible<_Fun, _Fun2>)
       : __stok::__inplace_stop_callback_base(__token.__source_, &inplace_stop_callback::__execute_impl)
       , __fun(static_cast<_Fun2&&>(__fun))
   {

--- a/cudax/include/cuda/experimental/__execution/sync_wait.cuh
+++ b/cudax/include/cuda/experimental/__execution/sync_wait.cuh
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CUDAX_ASYNC_DETAIL_SYNC_WAIT
-#define __CUDAX_ASYNC_DETAIL_SYNC_WAIT
+#ifndef __CUDAX_EXECUTION_SYNC_WAIT
+#define __CUDAX_EXECUTION_SYNC_WAIT
 
 #include <cuda/std/detail/__config>
 
@@ -111,7 +111,7 @@ private:
           }), //
           _CUDAX_CATCH(...) //
           ({ //
-            if constexpr (!_CUDA_VSTD::is_nothrow_constructible_v<_Values, _As...>)
+            if constexpr (!__nothrow_constructible<_Values, _As...>)
             {
               __state_->__errors_.__emplace(::std::current_exception());
             }
@@ -272,4 +272,4 @@ _CCCL_GLOBAL_CONSTANT sync_wait_t sync_wait{};
 
 #include <cuda/experimental/__execution/epilogue.cuh>
 
-#endif // __CUDAX_ASYNC_DETAIL_SYNC_WAIT
+#endif // __CUDAX_EXECUTION_SYNC_WAIT

--- a/cudax/include/cuda/experimental/__execution/then.cuh
+++ b/cudax/include/cuda/experimental/__execution/then.cuh
@@ -340,4 +340,4 @@ _CCCL_GLOBAL_CONSTANT auto upon_stopped = upon_stopped_t{};
 
 #include <cuda/experimental/__execution/epilogue.cuh>
 
-#endif
+#endif // __CUDAX_EXECUTION_THEN

--- a/cudax/include/cuda/experimental/__execution/then.cuh
+++ b/cudax/include/cuda/experimental/__execution/then.cuh
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CUDAX_ASYNC_DETAIL_THEN
-#define __CUDAX_ASYNC_DETAIL_THEN
+#ifndef __CUDAX_EXECUTION_THEN
+#define __CUDAX_EXECUTION_THEN
 
 #include <cuda/std/detail/__config>
 
@@ -46,7 +46,7 @@ namespace cuda::experimental::execution
 namespace __detail
 {
 template <__disposition_t, class _Void = void>
-extern __undefined<_Void> __upon_tag;
+extern _CUDA_VSTD::__undefined<_Void> __upon_tag;
 template <class _Void>
 extern __fn_t<then_t>* __upon_tag<__value, _Void>;
 template <class _Void>
@@ -90,7 +90,8 @@ using __completion_ _CCCL_NODEBUG_ALIAS =
   _CUDA_VSTD::__type_call1<__completion_fn<_CUDA_VSTD::is_same_v<_Result, void>, _Nothrow>, _Result>;
 
 template <class _Fn, class... _Ts>
-using __completion _CCCL_NODEBUG_ALIAS = __completion_<__call_result_t<_Fn, _Ts...>, __nothrow_callable<_Fn, _Ts...>>;
+using __completion _CCCL_NODEBUG_ALIAS =
+  __completion_<_CUDA_VSTD::__call_result_t<_Fn, _Ts...>, __nothrow_callable<_Fn, _Ts...>>;
 } // namespace __upon
 
 template <__disposition_t _Disposition>
@@ -126,7 +127,7 @@ private:
     {
       if constexpr (_CanThrow || __nothrow_callable<_Fn, _Ts...>)
       {
-        if constexpr (_CUDA_VSTD::is_same_v<void, __call_result_t<_Fn, _Ts...>>)
+        if constexpr (_CUDA_VSTD::is_same_v<void, _CUDA_VSTD::__call_result_t<_Fn, _Ts...>>)
         {
           static_cast<_Fn&&>(__fn_)(static_cast<_Ts&&>(__ts)...);
           execution::set_value(static_cast<_Rcvr&&>(__rcvr_));
@@ -289,14 +290,14 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __upon_t<_Disposition>::__closure_t
   _Fn __fn_;
 
   template <class _Sndr>
-  _CCCL_TRIVIAL_API auto operator()(_Sndr __sndr) -> __call_result_t<_UponTag, _Sndr, _Fn>
+  _CCCL_TRIVIAL_API auto operator()(_Sndr __sndr) -> _CUDA_VSTD::__call_result_t<_UponTag, _Sndr, _Fn>
   {
     return _UponTag()(static_cast<_Sndr&&>(__sndr), static_cast<_Fn&&>(__fn_));
   }
 
   template <class _Sndr>
   _CCCL_TRIVIAL_API friend auto operator|(_Sndr __sndr, __closure_t&& __self) //
-    -> __call_result_t<_UponTag, _Sndr, _Fn>
+    -> _CUDA_VSTD::__call_result_t<_UponTag, _Sndr, _Fn>
   {
     return _UponTag()(static_cast<_Sndr&&>(__sndr), static_cast<_Fn&&>(__self.__fn_));
   }

--- a/cudax/include/cuda/experimental/__execution/thread.cuh
+++ b/cudax/include/cuda/experimental/__execution/thread.cuh
@@ -84,4 +84,4 @@ inline _CCCL_API void __this_thread_yield() noexcept
 
 #include <cuda/experimental/__execution/epilogue.cuh>
 
-#endif
+#endif // __CUDAX_EXECUTION_THREAD

--- a/cudax/include/cuda/experimental/__execution/thread.cuh
+++ b/cudax/include/cuda/experimental/__execution/thread.cuh
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CUDAX_ASYNC_DETAIL_THREAD
-#define __CUDAX_ASYNC_DETAIL_THREAD
+#ifndef __CUDAX_EXECUTION_THREAD
+#define __CUDAX_EXECUTION_THREAD
 
 #include <cuda/std/detail/__config>
 

--- a/cudax/include/cuda/experimental/__execution/thread_context.cuh
+++ b/cudax/include/cuda/experimental/__execution/thread_context.cuh
@@ -68,4 +68,4 @@ private:
 
 #endif // _CCCL_HOST_COMPILATION()
 
-#endif
+#endif // __CUDAX_EXECUTION_THREAD_CONTEXT

--- a/cudax/include/cuda/experimental/__execution/thread_context.cuh
+++ b/cudax/include/cuda/experimental/__execution/thread_context.cuh
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CUDAX_ASYNC_DETAIL_THREAD_CONTEXT
-#define __CUDAX_ASYNC_DETAIL_THREAD_CONTEXT
+#ifndef __CUDAX_EXECUTION_THREAD_CONTEXT
+#define __CUDAX_EXECUTION_THREAD_CONTEXT
 
 #include <cuda/std/detail/__config>
 

--- a/cudax/include/cuda/experimental/__execution/transform_sender.cuh
+++ b/cudax/include/cuda/experimental/__execution/transform_sender.cuh
@@ -89,7 +89,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT transform_sender_t
   _CCCL_TEMPLATE(class _Self = transform_sender_t, class _Domain, class _Sndr, class... _Env)
   _CCCL_REQUIRES((__get_transform_strategy<_Self, _Domain, _Sndr, _Env...>().__strategy_ == __strategy::__passthru))
   _CCCL_TRIVIAL_API constexpr auto operator()(_Domain, _Sndr&& __sndr, const _Env&...) const
-    noexcept(_CUDA_VSTD::is_nothrow_move_constructible_v<_Sndr>) -> _Sndr
+    noexcept(__nothrow_movable<_Sndr>) -> _Sndr
   {
     return static_cast<_Sndr&&>(__sndr);
   }

--- a/cudax/include/cuda/experimental/__execution/type_traits.cuh
+++ b/cudax/include/cuda/experimental/__execution/type_traits.cuh
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CUDAX_ASYNC_DETAIL_TYPE_TRAITS
-#define __CUDAX_ASYNC_DETAIL_TYPE_TRAITS
+#ifndef __CUDAX_EXECUTION_TYPE_TRAITS
+#define __CUDAX_EXECUTION_TYPE_TRAITS
 
 #include <cuda/std/detail/__config>
 
@@ -24,8 +24,13 @@
 #include <cuda/std/__type_traits/copy_cvref.h>
 #include <cuda/std/__type_traits/decay.h>
 #include <cuda/std/__type_traits/enable_if.h>
-#include <cuda/std/__type_traits/remove_reference.h>
-#include <cuda/std/__type_traits/type_list.h>
+#include <cuda/std/__type_traits/integral_constant.h>
+#include <cuda/std/__type_traits/is_callable.h>
+#include <cuda/std/__type_traits/is_constructible.h>
+#include <cuda/std/__type_traits/is_nothrow_constructible.h>
+#include <cuda/std/__type_traits/is_nothrow_copy_constructible.h>
+#include <cuda/std/__type_traits/is_nothrow_move_constructible.h>
+#include <cuda/std/__type_traits/is_valid_expansion.h>
 
 #include <cuda/experimental/__execution/meta.cuh>
 
@@ -33,45 +38,20 @@
 
 namespace cuda::experimental::execution
 {
+template <template <class...> class _Fn, class... _Ts>
+inline constexpr bool __is_instantiable_with_v = _CUDA_VSTD::_IsValidExpansion<_Fn, _Ts...>::value;
 
-//////////////////////////////////////////////////////////////////////////////////////////////////
-// __decay_t: An efficient implementation for ::std::decay
-#if defined(_CCCL_BUILTIN_DECAY)
-
-template <class _Ty>
-using __decay_t _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_DECAY(_Ty);
-
-#else // ^^^ _CCCL_BUILTIN_DECAY ^^^ / vvv !_CCCL_BUILTIN_DECAY vvv
-
-template <class _Ty>
-using __decay_t _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::decay_t<_Ty>;
-
-#endif // _CCCL_BUILTIN_DECAY
-
-//////////////////////////////////////////////////////////////////////////////////////////////////
-// __copy_cvref_t: For copying cvref from one type to another
-// TODO: This is a temporary implementation. We should merge this file and meta.cuh
-// with the facilities in <cuda/std/__type_traits/type_list.h>.
 template <class _Ty>
 using __cref_t _CCCL_NODEBUG_ALIAS = _Ty const&;
 
 using __cp _CCCL_NODEBUG_ALIAS    = _CUDA_VSTD::__type_self;
 using __cpclr _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::__type_quote1<__cref_t>;
 
-template <class _From, class _To>
-using __copy_cvref_t _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::__copy_cvref_t<_From, _To>;
-
-template <class _Fn, class... _As>
-using __call_result_t _CCCL_NODEBUG_ALIAS = decltype(declval<_Fn>()(declval<_As>()...));
-
-template <class _Fn, class... _As>
-inline constexpr bool __callable = __type_valid_v<__call_result_t, _Fn, _As...>;
-
 template <class _Ty>
-using __decay_copyable_ _CCCL_NODEBUG_ALIAS = decltype(__decay_t<_Ty>(declval<_Ty>()));
+using __decay_copyable_ _CCCL_NODEBUG_ALIAS = decltype(_CUDA_VSTD::decay_t<_Ty>(declval<_Ty>()));
 
 template <class... _As>
-inline constexpr bool __decay_copyable = (__type_valid_v<__decay_copyable_, _As> && ...);
+inline constexpr bool __decay_copyable = (_CUDA_VSTD::is_constructible_v<_CUDA_VSTD::decay_t<_As>, _As> && ...);
 
 #if _CCCL_DEVICE_COMPILATION() && !_CCCL_CUDA_COMPILER(NVHPC)
 template <class _Fn, class... _As>
@@ -91,34 +71,20 @@ inline constexpr bool __nothrow_copyable = true;
 #else // ^^^ _CCCL_DEVICE_COMPILATION() && !_CCCL_CUDA_COMPILER(NVHPC) ^^^ /
       // vvv !_CCCL_DEVICE_COMPILATION() || _CCCL_CUDA_COMPILER(NVHPC) vvv
 template <class _Fn, class... _As>
-using __nothrow_callable_ _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::enable_if_t<noexcept(declval<_Fn>()(declval<_As>()...))>;
-
-template <class _Fn, class... _As>
-inline constexpr bool __nothrow_callable = __type_valid_v<__nothrow_callable_, _Fn, _As...>;
+inline constexpr bool __nothrow_callable = _CUDA_VSTD::__is_nothrow_callable_v<_Fn, _As...>;
 
 template <class _Ty, class... _As>
-using __nothrow_constructible_ _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::enable_if_t<noexcept(_Ty{declval<_As>()...})>;
-
-template <class _Ty, class... _As>
-inline constexpr bool __nothrow_constructible = __type_valid_v<__nothrow_constructible_, _Ty, _As...>;
-
-template <class _Ty>
-using __nothrow_decay_copyable_ _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::enable_if_t<noexcept(__decay_t<_Ty>(declval<_Ty>()))>;
+inline constexpr bool __nothrow_constructible = _CUDA_VSTD::is_nothrow_constructible_v<_Ty, _As...>;
 
 template <class... _As>
-inline constexpr bool __nothrow_decay_copyable = (__type_valid_v<__nothrow_decay_copyable_, _As> && ...);
-
-template <class _Ty>
-using __nothrow_movable_ _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::enable_if_t<noexcept(_Ty(declval<_Ty>()))>;
+inline constexpr bool __nothrow_decay_copyable =
+  (_CUDA_VSTD::is_nothrow_constructible_v<_CUDA_VSTD::decay_t<_As>, _As> && ...);
 
 template <class... _As>
-inline constexpr bool __nothrow_movable = (__type_valid_v<__nothrow_movable_, _As> && ...);
-
-template <class _Ty>
-using __nothrow_copyable_ _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::enable_if_t<noexcept(_Ty(declval<const _Ty&>()))>;
+inline constexpr bool __nothrow_movable = (_CUDA_VSTD::is_nothrow_move_constructible_v<_As> && ...);
 
 template <class... _As>
-inline constexpr bool __nothrow_copyable = (__type_valid_v<__nothrow_copyable_, _As> && ...);
+inline constexpr bool __nothrow_copyable = (_CUDA_VSTD::is_nothrow_copy_constructible_v<_As> && ...);
 #endif // ^^^ !_CCCL_DEVICE_COMPILATION() || _CCCL_CUDA_COMPILER(NVHPC) ^^^
 
 template <class... _As>

--- a/cudax/include/cuda/experimental/__execution/type_traits.cuh
+++ b/cudax/include/cuda/experimental/__execution/type_traits.cuh
@@ -93,4 +93,4 @@ using __nothrow_decay_copyable_t _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::bool_constant
 
 #include <cuda/experimental/__execution/epilogue.cuh>
 
-#endif
+#endif // __CUDAX_EXECUTION_TYPE_TRAITS

--- a/cudax/include/cuda/experimental/__execution/utility.cuh
+++ b/cudax/include/cuda/experimental/__execution/utility.cuh
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CUDAX_ASYNC_DETAIL_UTILITY
-#define __CUDAX_ASYNC_DETAIL_UTILITY
+#ifndef __CUDAX_EXECUTION_UTILITY
+#define __CUDAX_EXECUTION_UTILITY
 
 #include <cuda/std/detail/__config>
 
@@ -21,9 +21,9 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/std/__tuple_dir/ignore.h>
 #include <cuda/std/__type_traits/decay.h>
 #include <cuda/std/__type_traits/is_same.h>
+#include <cuda/std/__type_traits/type_list.h>
 #include <cuda/std/initializer_list>
 
 #include <cuda/experimental/__detail/utility.cuh>
@@ -35,10 +35,6 @@
 namespace cuda::experimental::execution
 {
 _CCCL_GLOBAL_CONSTANT size_t __npos = static_cast<size_t>(-1);
-
-using __ignore _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::__ignore_t; // NOLINT: misc-unused-using-decls
-using _CUDA_VSTD::__undefined; // NOLINT: misc-unused-using-decls
-using experimental::detail::__immovable; // NOLINT: misc-unused-using-decls
 
 struct __empty
 {};

--- a/cudax/include/cuda/experimental/__execution/utility.cuh
+++ b/cudax/include/cuda/experimental/__execution/utility.cuh
@@ -175,7 +175,7 @@ using __zip _CCCL_NODEBUG_ALIAS = _Type;
 template <class _Id>
 using __unzip _CCCL_NODEBUG_ALIAS = _Id;
 
-#else
+#else // ^^^ _CCCL_COMPILER(CLANG, <, 12) ^^^ / vvv !_CCCL_COMPILER(CLANG, <, 12) vvv
 
 template <class _Type, size_t _Val = execution::__next<_Type>(0)>
 using __zip _CCCL_NODEBUG_ALIAS = __slot<_Val>;
@@ -183,7 +183,7 @@ using __zip _CCCL_NODEBUG_ALIAS = __slot<_Val>;
 template <class _Id>
 using __unzip _CCCL_NODEBUG_ALIAS = decltype(__slot_allocated(_Id())());
 
-#endif
+#endif // ^^^ !_CCCL_COMPILER(CLANG, <, 12) ^^^
 
 // burn the first slot
 using __ignore_this_typedef [[maybe_unused]] = __zip<void>;
@@ -196,4 +196,4 @@ _CCCL_DIAG_POP
 
 #include <cuda/experimental/__execution/epilogue.cuh>
 
-#endif
+#endif // __CUDAX_EXECUTION_UTILITY

--- a/cudax/include/cuda/experimental/__execution/variant.cuh
+++ b/cudax/include/cuda/experimental/__execution/variant.cuh
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CUDAX_ASYNC_DETAIL_VARIANT
-#define __CUDAX_ASYNC_DETAIL_VARIANT
+#ifndef __CUDAX_EXECUTION_VARIANT
+#define __CUDAX_EXECUTION_VARIANT
 
 #include <cuda/std/detail/__config>
 
@@ -139,9 +139,9 @@ public:
   _CCCL_EXEC_CHECK_DISABLE
   template <class _Fn, class... _As>
   _CCCL_API auto __emplace_from(_Fn&& __fn, _As&&... __as) //
-    noexcept(__nothrow_callable<_Fn, _As...>) -> __call_result_t<_Fn, _As...>&
+    noexcept(__nothrow_callable<_Fn, _As...>) -> _CUDA_VSTD::__call_result_t<_Fn, _As...>&
   {
-    using __result_t _CCCL_NODEBUG_ALIAS = __call_result_t<_Fn, _As...>;
+    using __result_t _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::__call_result_t<_Fn, _As...>;
     constexpr size_t __new_index         = execution::__index_of<__result_t, _Ts...>();
     static_assert(__new_index != __npos, "_Type not in variant");
 
@@ -154,7 +154,7 @@ public:
   _CCCL_EXEC_CHECK_DISABLE
   template <class _Fn, class _Self, class... _As>
   _CCCL_API static void __visit(_Fn&& __fn, _Self&& __self, _As&&... __as) //
-    noexcept((__nothrow_callable<_Fn, _As..., __copy_cvref_t<_Self, _Ts>> && ...))
+    noexcept((__nothrow_callable<_Fn, _As..., _CUDA_VSTD::__copy_cvref_t<_Self, _Ts>> && ...))
   {
     // make this local in case destroying the sub-object destroys *this
     const auto index = __self.__index_;
@@ -203,7 +203,7 @@ using __variant _CCCL_NODEBUG_ALIAS = __variant_impl<_CUDA_VSTD::make_index_sequ
 #endif
 
 template <class... _Ts>
-using __decayed_variant _CCCL_NODEBUG_ALIAS = __variant<__decay_t<_Ts>...>;
+using __decayed_variant _CCCL_NODEBUG_ALIAS = __variant<_CUDA_VSTD::decay_t<_Ts>...>;
 } // namespace cuda::experimental::execution
 
 #include <cuda/experimental/__execution/epilogue.cuh>

--- a/cudax/include/cuda/experimental/__execution/variant.cuh
+++ b/cudax/include/cuda/experimental/__execution/variant.cuh
@@ -197,10 +197,10 @@ struct __mk_variant_
 
 template <class... _Ts>
 using __variant _CCCL_NODEBUG_ALIAS = typename __mk_variant_<_Ts...>::type;
-#else
+#else // ^^^ _CCCL_COMPILER(MSVC) ^^^ / vvv !_CCCL_COMPILER(MSVC) vvv
 template <class... _Ts>
 using __variant _CCCL_NODEBUG_ALIAS = __variant_impl<_CUDA_VSTD::make_index_sequence<sizeof...(_Ts)>, _Ts...>;
-#endif
+#endif // ^^^ !_CCCL_COMPILER(MSVC) ^^^
 
 template <class... _Ts>
 using __decayed_variant _CCCL_NODEBUG_ALIAS = __variant<_CUDA_VSTD::decay_t<_Ts>...>;
@@ -208,4 +208,4 @@ using __decayed_variant _CCCL_NODEBUG_ALIAS = __variant<_CUDA_VSTD::decay_t<_Ts>
 
 #include <cuda/experimental/__execution/epilogue.cuh>
 
-#endif
+#endif // __CUDAX_EXECUTION_VARIANT

--- a/cudax/include/cuda/experimental/__execution/visit.cuh
+++ b/cudax/include/cuda/experimental/__execution/visit.cuh
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CUDAX_ASYNC_DETAIL_VISIT
-#define __CUDAX_ASYNC_DETAIL_VISIT
+#ifndef __CUDAX_EXECUTION_VISIT
+#define __CUDAX_EXECUTION_VISIT
 
 #include <cuda/std/detail/__config>
 
@@ -141,4 +141,4 @@ _CCCL_GLOBAL_CONSTANT visit_t visit{};
 
 #include <cuda/experimental/__execution/epilogue.cuh>
 
-#endif // __CUDAX_ASYNC_DETAIL_VISIT
+#endif // __CUDAX_EXECUTION_VISIT

--- a/cudax/include/cuda/experimental/__execution/when_all.cuh
+++ b/cudax/include/cuda/experimental/__execution/when_all.cuh
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CUDAX_ASYNC_DETAIL_WHEN_ALL
-#define __CUDAX_ASYNC_DETAIL_WHEN_ALL
+#ifndef __CUDAX_EXECUTION_WHEN_ALL
+#define __CUDAX_EXECUTION_WHEN_ALL
 
 #include <cuda/std/detail/__config>
 
@@ -213,13 +213,13 @@ private:
         // without worry.
         if constexpr (__nothrow_decay_copyable<_Error>)
         {
-          __errors_.template __emplace<__decay_t<_Error>>(static_cast<_Error&&>(__err));
+          __errors_.template __emplace<_CUDA_VSTD::decay_t<_Error>>(static_cast<_Error&&>(__err));
         }
         else
         {
           _CUDAX_TRY( //
             ({ //
-              __errors_.template __emplace<__decay_t<_Error>>(static_cast<_Error&&>(__err));
+              __errors_.template __emplace<_CUDA_VSTD::decay_t<_Error>>(static_cast<_Error&&>(__err));
             }),
             _CUDAX_CATCH(...) //
             ({ //
@@ -318,7 +318,8 @@ private:
     struct __connect_subs_fn
     {
       template <class... _CvSndrs>
-      _CCCL_API auto operator()(__state_t& __state, __ignore, __ignore, _CvSndrs&&... __sndrs_) const
+      _CCCL_API auto
+      operator()(__state_t& __state, _CUDA_VSTD::__ignore_t, _CUDA_VSTD::__ignore_t, _CvSndrs&&... __sndrs_) const
       {
         using __state_ref_t _CCCL_NODEBUG_ALIAS = __zip<__state_t>;
         // When there are no offsets, the when_all sender has no value
@@ -455,15 +456,16 @@ _CCCL_DIAG_POP
 
 // The sender for when_all
 template <class... _Sndrs>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT when_all_t::__sndr_t : _CUDA_VSTD::__tuple<when_all_t, __ignore, _Sndrs...>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT when_all_t::__sndr_t
+    : _CUDA_VSTD::__tuple<when_all_t, _CUDA_VSTD::__ignore_t, _Sndrs...>
 {
   using sender_concept _CCCL_NODEBUG_ALIAS = sender_t;
-  using __sndrs_t _CCCL_NODEBUG_ALIAS      = _CUDA_VSTD::__tuple<when_all_t, __ignore, _Sndrs...>;
+  using __sndrs_t _CCCL_NODEBUG_ALIAS      = _CUDA_VSTD::__tuple<when_all_t, _CUDA_VSTD::__ignore_t, _Sndrs...>;
 
   template <class _Self, class... _Env>
   [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL auto __get_completions_and_offsets()
   {
-    return __merge_completions(__child_completions<__copy_cvref_t<_Self, _Sndrs>, _Env...>()...);
+    return __merge_completions(__child_completions<_CUDA_VSTD::__copy_cvref_t<_Self, _Sndrs>, _Env...>()...);
   }
 
   template <class _Self, class... _Env>
@@ -506,9 +508,9 @@ _CCCL_TRIVIAL_API constexpr auto when_all_t::operator()(_Sndrs... __sndrs) const
   {
     return __sndr_t{};
   }
-  else if constexpr (!__type_valid_v<_CUDA_VSTD::common_type_t, domain_for_t<_Sndrs>...>)
+  else if constexpr (!__is_instantiable_with_v<_CUDA_VSTD::common_type_t, domain_for_t<_Sndrs>...>)
   {
-    static_assert(__type_valid_v<_CUDA_VSTD::common_type_t, domain_for_t<_Sndrs>...>,
+    static_assert(__is_instantiable_with_v<_CUDA_VSTD::common_type_t, domain_for_t<_Sndrs>...>,
                   "when_all: all child senders must have the same domain");
   }
   else

--- a/cudax/include/cuda/experimental/__execution/when_all.cuh
+++ b/cudax/include/cuda/experimental/__execution/when_all.cuh
@@ -534,4 +534,4 @@ _CCCL_GLOBAL_CONSTANT when_all_t when_all{};
 
 #include <cuda/experimental/__execution/epilogue.cuh>
 
-#endif
+#endif // __CUDAX_EXECUTION_WHEN_ALL

--- a/cudax/include/cuda/experimental/__execution/write_env.cuh
+++ b/cudax/include/cuda/experimental/__execution/write_env.cuh
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CUDAX_ASYNC_DETAIL_WRITE_ENV
-#define __CUDAX_ASYNC_DETAIL_WRITE_ENV
+#ifndef __CUDAX_EXECUTION_WRITE_ENV
+#define __CUDAX_EXECUTION_WRITE_ENV
 
 #include <cuda/std/detail/__config>
 
@@ -78,7 +78,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT write_env_t::__sndr_t
   template <class _Self, class... _Env2>
   [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL auto get_completion_signatures()
   {
-    using _Child _CCCL_NODEBUG_ALIAS = __copy_cvref_t<_Self, _Sndr>;
+    using _Child _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::__copy_cvref_t<_Self, _Sndr>;
     return execution::get_completion_signatures<_Child, env<const _Env&, __fwd_env_t<_Env2>>...>();
   }
 

--- a/cudax/include/cuda/experimental/__execution/write_env.cuh
+++ b/cudax/include/cuda/experimental/__execution/write_env.cuh
@@ -121,4 +121,4 @@ _CCCL_GLOBAL_CONSTANT __write_env_t write_env{};
 
 #include <cuda/experimental/__execution/epilogue.cuh>
 
-#endif
+#endif // __CUDAX_EXECUTION_WRITE_ENV

--- a/cudax/include/cuda/experimental/__green_context/green_ctx.cuh
+++ b/cudax/include/cuda/experimental/__green_context/green_ctx.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -44,9 +44,9 @@ struct green_context
       : __dev_id(__device.get())
   {
     // TODO get CUdevice from device
-    auto __dev_handle = detail::driver::deviceGet(__dev_id);
-    __green_ctx       = detail::driver::greenCtxCreate(__dev_handle);
-    __transformed     = detail::driver::ctxFromGreenCtx(__green_ctx);
+    auto __dev_handle = __detail::driver::deviceGet(__dev_id);
+    __green_ctx       = __detail::driver::greenCtxCreate(__dev_handle);
+    __transformed     = __detail::driver::ctxFromGreenCtx(__green_ctx);
   }
 
   green_context(const green_context&)            = delete;
@@ -56,10 +56,10 @@ struct green_context
   [[nodiscard]] static green_context from_native_handle(CUgreenCtx __gctx)
   {
     int __id;
-    CUcontext __transformed = detail::driver::ctxFromGreenCtx(__gctx);
-    detail::driver::ctxPush(__transformed);
+    CUcontext __transformed = __detail::driver::ctxFromGreenCtx(__gctx);
+    __detail::driver::ctxPush(__transformed);
     _CCCL_TRY_CUDA_API(cudaGetDevice, "Failed to get device ordinal from a green context", &__id);
-    detail::driver::ctxPop();
+    __detail::driver::ctxPop();
     return green_context(__id, __gctx, __transformed);
   }
 
@@ -74,7 +74,7 @@ struct green_context
   {
     if (__green_ctx)
     {
-      [[maybe_unused]] cudaError_t __status = detail::driver::greenCtxDestroy(__green_ctx);
+      [[maybe_unused]] cudaError_t __status = __detail::driver::greenCtxDestroy(__green_ctx);
     }
   }
 

--- a/cudax/include/cuda/experimental/__hierarchy/dimensions.cuh
+++ b/cudax/include/cuda/experimental/__hierarchy/dimensions.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -88,7 +88,7 @@ struct hierarchy_query_result : public dimensions<T, Extents...>
   }
 };
 
-namespace detail
+namespace __detail
 {
 template <typename OpType>
 [[nodiscard]] _CCCL_HOST_DEVICE constexpr size_t merge_extents(size_t e1, size_t e2)
@@ -154,7 +154,7 @@ template <typename TyTrunc, typename Index, typename Dims>
   return (static_cast<TyTrunc>(index.extent(2)) * dims.extent(1) + index.extent(1)) * dims.extent(0) + index.extent(0);
 }
 
-} // namespace detail
+} // namespace __detail
 } // namespace cuda::experimental
 #endif // _CCCL_STD_VER >= 2017
 

--- a/cudax/include/cuda/experimental/__hierarchy/hierarchy_dimensions.cuh
+++ b/cudax/include/cuda/experimental/__hierarchy/hierarchy_dimensions.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -40,7 +40,7 @@ struct unknown_unit : public hierarchy_level
 };
 */
 
-namespace detail
+namespace __detail
 {
 template <typename _Level>
 [[nodiscard]] _CCCL_API constexpr auto __as_level(_Level __l) noexcept -> _Level
@@ -53,7 +53,7 @@ template <typename _LevelFn>
 {
   return {};
 }
-} // namespace detail
+} // namespace __detail
 
 template <class _Level>
 using __level_type_of = typename _Level::level_type;
@@ -61,7 +61,7 @@ using __level_type_of = typename _Level::level_type;
 template <typename BottomUnit = thread_level, typename... Levels>
 struct hierarchy_dimensions;
 
-namespace detail
+namespace __detail
 {
 // Function to sometimes convince the compiler something is a constexpr and not really accessing runtime storage
 // Mostly a work around for what was addressed in P2280 (c++23) by leveraging the argumentless constructor of extents
@@ -118,23 +118,23 @@ struct get_level_helper
     _CCCL_UNREACHABLE();
   }
 };
-} // namespace detail
+} // namespace __detail
 
 template <typename QueryLevel, typename Hierarchy>
-inline constexpr bool has_level = detail::has_level_helper<QueryLevel, ::cuda::std::remove_cvref_t<Hierarchy>>::value;
+inline constexpr bool has_level = __detail::has_level_helper<QueryLevel, ::cuda::std::remove_cvref_t<Hierarchy>>::value;
 
 template <typename QueryLevel, typename Hierarchy>
 inline constexpr bool has_level_or_unit =
-  detail::has_level_helper<QueryLevel, ::cuda::std::remove_cvref_t<Hierarchy>>::value
-  || detail::has_unit<QueryLevel, ::cuda::std::remove_cvref_t<Hierarchy>>::value;
+  __detail::has_level_helper<QueryLevel, ::cuda::std::remove_cvref_t<Hierarchy>>::value
+  || __detail::has_unit<QueryLevel, ::cuda::std::remove_cvref_t<Hierarchy>>::value;
 
-namespace detail
+namespace __detail
 {
 template <typename... Levels>
 struct can_stack_checker
 {
   template <typename... LevelsShifted>
-  using can_stack = ::cuda::std::__fold_and<detail::can_rhs_stack_on_lhs<LevelsShifted, Levels>...>;
+  using can_stack = ::cuda::std::__fold_and<__detail::can_rhs_stack_on_lhs<LevelsShifted, Levels>...>;
 };
 
 template <typename LUnit, typename L1, typename... Levels>
@@ -321,19 +321,19 @@ struct rank_helper
     if constexpr (sizeof...(Levels) == 0)
     {
       auto hinted_index = static_index_hint(ltop.dims, dims_helper<BottomUnit, TopLevel>::index());
-      return detail::index_to_linear<typename TopLevel::product_type>(hinted_index, ltop.dims);
+      return __detail::index_to_linear<typename TopLevel::product_type>(hinted_index, ltop.dims);
     }
     else
     {
       using Unit        = ::cuda::std::__type_index_c<0, __level_type_of<Levels>...>;
       auto hinted_index = static_index_hint(ltop.dims, dims_helper<Unit, TopLevel>::index());
-      auto level_rank   = detail::index_to_linear<typename TopLevel::product_type>(hinted_index, ltop.dims);
+      auto level_rank   = __detail::index_to_linear<typename TopLevel::product_type>(hinted_index, ltop.dims);
       return level_rank * dims_to_count(hierarchy_extents_helper<BottomUnit>()(levels...))
            + rank_helper<BottomUnit>()(levels...);
     }
   }
 };
-} // namespace detail
+} // namespace __detail
 
 // Artificial empty hierarchy to make it possible for the config type to be empty,
 // seems easier than checking everywhere in hierarchy APIs if its not empty.
@@ -420,8 +420,8 @@ private:
   {
     static_assert(has_level<Level, hierarchy_dimensions<BottomUnit, Levels...>>);
     static_assert(has_level_or_unit<Unit, hierarchy_dimensions<BottomUnit, Levels...>>);
-    static_assert(detail::legal_unit_for_level<Unit, Level>);
-    return ::cuda::std::apply(detail::get_levels_range<Level, Unit, Levels...>, levels);
+    static_assert(__detail::legal_unit_for_level<Unit, Level>);
+    return ::cuda::std::apply(__detail::get_levels_range<Level, Unit, Levels...>, levels);
   }
 
   // TODO is this useful enough to expose?
@@ -447,7 +447,7 @@ public:
 
   template <typename Unit, typename Level>
   using extents_type = decltype(::cuda::std::apply(
-    ::cuda::std::declval<detail::hierarchy_extents_helper<Unit>>(),
+    ::cuda::std::declval<__detail::hierarchy_extents_helper<Unit>>(),
     hierarchy_dimensions::levels_range_static<Unit, Level>(::cuda::std::declval<::cuda::std::tuple<Levels...>>())));
 
   /**
@@ -520,7 +520,7 @@ public:
   _CCCL_API constexpr auto extents(const Unit& = Unit(), const Level& = Level()) const noexcept
   {
     auto selected = levels_range<Unit, Level>();
-    return detail::convert_to_query_result(::cuda::std::apply(detail::hierarchy_extents_helper<Unit>{}, selected));
+    return __detail::convert_to_query_result(::cuda::std::apply(__detail::hierarchy_extents_helper<Unit>{}, selected));
   }
 
   // template <typename Unit, typename Level>
@@ -561,7 +561,7 @@ public:
   template <typename Unit = BottomUnit, typename Level = __level_type_of<::cuda::std::__type_index_c<0, Levels...>>>
   _CCCL_API constexpr auto count(const Unit& = Unit(), const Level& = Level()) const noexcept
   {
-    return detail::dims_to_count(extents<Unit, Level>());
+    return __detail::dims_to_count(extents<Unit, Level>());
   }
 
   // TODO static extents?
@@ -600,7 +600,7 @@ public:
   {
     if constexpr (extents_type<Unit, Level>::rank_dynamic() == 0)
     {
-      return detail::dims_to_count(extents_type<Unit, Level>());
+      return __detail::dims_to_count(extents_type<Unit, Level>());
     }
     else
     {
@@ -651,7 +651,7 @@ public:
   _CCCL_DEVICE constexpr auto index(const Unit& = Unit(), const Level& = Level()) const noexcept
   {
     auto selected = levels_range<Unit, Level>();
-    return detail::convert_to_query_result(::cuda::std::apply(detail::index_helper<Unit>{}, selected));
+    return __detail::convert_to_query_result(::cuda::std::apply(__detail::index_helper<Unit>{}, selected));
   }
 
   /**
@@ -693,7 +693,7 @@ public:
   _CCCL_DEVICE constexpr auto rank(const Unit& = Unit(), const Level& = Level()) const noexcept
   {
     auto selected = levels_range<Unit, Level>();
-    return ::cuda::std::apply(detail::rank_helper<Unit>{}, selected);
+    return ::cuda::std::apply(__detail::rank_helper<Unit>{}, selected);
   }
 
   /**
@@ -722,7 +722,7 @@ public:
   {
     static_assert(has_level<Level, hierarchy_dimensions<BottomUnit, Levels...>>);
 
-    return ::cuda::std::apply(detail::get_level_helper<Level>{}, levels);
+    return ::cuda::std::apply(__detail::get_level_helper<Level>{}, levels);
   }
 
   //! @brief Returns a new hierarchy with combined levels of this and the other supplied hierarchy
@@ -742,7 +742,7 @@ public:
     using this_bottom_level  = __level_type_of<::cuda::std::__type_index_c<sizeof...(Levels) - 1, Levels...>>;
     using other_top_level    = __level_type_of<::cuda::std::__type_index_c<0, OtherLevels...>>;
     using other_bottom_level = __level_type_of<::cuda::std::__type_index_c<sizeof...(OtherLevels) - 1, OtherLevels...>>;
-    if constexpr (detail::can_rhs_stack_on_lhs<other_top_level, this_bottom_level>)
+    if constexpr (__detail::can_rhs_stack_on_lhs<other_top_level, this_bottom_level>)
     {
       // Easily stackable case, example this is (grid), other is (cluster, block)
       return ::cuda::std::apply(fragment_helper<OtherUnit>(), ::cuda::std::tuple_cat(levels, other.levels));
@@ -763,7 +763,7 @@ public:
     }
     else
     {
-      if constexpr (detail::can_rhs_stack_on_lhs<this_top_level, other_bottom_level>)
+      if constexpr (__detail::can_rhs_stack_on_lhs<this_top_level, other_bottom_level>)
       {
         // Easily stackable case again, just reversed
         return ::cuda::std::apply(fragment_helper<BottomUnit>(), ::cuda::std::tuple_cat(other.levels, levels));
@@ -859,7 +859,7 @@ constexpr auto _CCCL_HOST get_launch_dimensions(const hierarchy_dimensions<Level
 template <typename LUnit = void, typename L1, typename... Levels>
 constexpr auto make_hierarchy(L1 l1, Levels... ls) noexcept
 {
-  return detail::__make_hierarchy<LUnit>()(detail::__as_level(l1), detail::__as_level(ls)...);
+  return __detail::__make_hierarchy<LUnit>()(__detail::__as_level(l1), __detail::__as_level(ls)...);
 }
 
 /**
@@ -887,21 +887,21 @@ constexpr auto make_hierarchy(L1 l1, Levels... ls) noexcept
 template <typename NewLevel, typename Unit, typename... Levels>
 constexpr auto hierarchy_add_level(const hierarchy_dimensions<Unit, Levels...>& hierarchy, NewLevel lnew)
 {
-  auto new_level     = detail::__as_level(lnew);
+  auto new_level     = __detail::__as_level(lnew);
   using AddedLevel   = decltype(new_level);
   using top_level    = __level_type_of<::cuda::std::__type_index_c<0, Levels...>>;
   using bottom_level = __level_type_of<::cuda::std::__type_index_c<sizeof...(Levels) - 1, Levels...>>;
 
-  if constexpr (detail::can_rhs_stack_on_lhs<top_level, __level_type_of<AddedLevel>>)
+  if constexpr (__detail::can_rhs_stack_on_lhs<top_level, __level_type_of<AddedLevel>>)
   {
     return hierarchy_dimensions<Unit, AddedLevel, Levels...>(
       ::cuda::std::tuple_cat(::cuda::std::make_tuple(new_level), hierarchy.levels));
   }
   else
   {
-    static_assert(detail::can_rhs_stack_on_lhs<__level_type_of<AddedLevel>, bottom_level>,
+    static_assert(__detail::can_rhs_stack_on_lhs<__level_type_of<AddedLevel>, bottom_level>,
                   "Not supported order of levels in hierarchy");
-    using NewUnit = detail::__default_unit_below<__level_type_of<AddedLevel>>;
+    using NewUnit = __detail::__default_unit_below<__level_type_of<AddedLevel>>;
     return hierarchy_dimensions<NewUnit, Levels..., AddedLevel>(
       ::cuda::std::tuple_cat(hierarchy.levels, ::cuda::std::make_tuple(new_level)));
   }

--- a/cudax/include/cuda/experimental/__hierarchy/hierarchy_levels.cuh
+++ b/cudax/include/cuda/experimental/__hierarchy/hierarchy_levels.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -38,7 +38,7 @@ template <typename Unit, typename Level>
 _CCCL_DEVICE auto extents(const Unit& = Unit(), const Level& = Level());
 } // namespace hierarchy
 
-namespace detail
+namespace __detail
 {
 template <typename Level>
 struct dimensions_query;
@@ -71,7 +71,7 @@ struct dimensions_query
   }
 };
 
-} // namespace detail
+} // namespace __detail
 
 // Struct to represent levels allowed below or above a certain level,
 //  used for hierarchy sorting, validation and for hierarchy traversal
@@ -81,7 +81,7 @@ struct allowed_levels
   using default_unit = ::cuda::std::__type_index_c<0, Levels..., void>;
 };
 
-namespace detail
+namespace __detail
 {
 template <typename LevelType>
 using __default_unit_below = typename LevelType::allowed_below::default_unit;
@@ -103,7 +103,7 @@ inline constexpr bool legal_unit_for_level =
 
 template <typename Unit>
 inline constexpr bool legal_unit_for_level<Unit, void> = false;
-} // namespace detail
+} // namespace __detail
 
 // Base type for all hierarchy levels
 struct hierarchy_level
@@ -130,7 +130,7 @@ struct thread_level;
  */
 struct grid_level
     : public hierarchy_level
-    , public detail::dimensions_query<grid_level>
+    , public __detail::dimensions_query<grid_level>
 {
   using product_type  = unsigned long long;
   using allowed_above = allowed_levels<>;
@@ -148,7 +148,7 @@ _CCCL_GLOBAL_CONSTANT grid_level grid;
  */
 struct cluster_level
     : public hierarchy_level
-    , public detail::dimensions_query<cluster_level>
+    , public __detail::dimensions_query<cluster_level>
 {
   using product_type  = unsigned int;
   using allowed_above = allowed_levels<grid_level>;
@@ -166,7 +166,7 @@ _CCCL_GLOBAL_CONSTANT cluster_level cluster;
  */
 struct block_level
     : public hierarchy_level
-    , public detail::dimensions_query<block_level>
+    , public __detail::dimensions_query<block_level>
 {
   using product_type  = unsigned int;
   using allowed_above = allowed_levels<grid_level, cluster_level>;
@@ -184,7 +184,7 @@ _CCCL_GLOBAL_CONSTANT block_level block;
  */
 struct thread_level
     : public hierarchy_level
-    , public detail::dimensions_query<thread_level>
+    , public __detail::dimensions_query<thread_level>
 {
   using product_type  = unsigned int;
   using allowed_above = allowed_levels<block_level>;
@@ -197,7 +197,7 @@ constexpr bool is_core_cuda_hierarchy_level =
   ::cuda::std::is_same_v<Level, grid_level> || ::cuda::std::is_same_v<Level, cluster_level>
   || ::cuda::std::is_same_v<Level, block_level> || ::cuda::std::is_same_v<Level, thread_level>;
 
-namespace detail
+namespace __detail
 {
 
 template <typename Unit, typename Level>
@@ -284,7 +284,7 @@ template <typename Unit, typename Level>
   }
   else
   {
-    using SplitLevel = detail::__default_unit_below<Level>;
+    using SplitLevel = __detail::__default_unit_below<Level>;
     return dims_product<typename Level::product_type>(
       extents_impl<SplitLevel, Level>(), extents_impl<Unit, SplitLevel>());
   }
@@ -294,20 +294,20 @@ template <typename Unit, typename Level>
 template <typename Unit, typename Level>
 /* [[nodiscard]] */ _CCCL_DEVICE auto index_impl()
 {
-  if constexpr (::cuda::std::is_same_v<Unit, Level> || detail::can_rhs_stack_on_lhs<Unit, Level>)
+  if constexpr (::cuda::std::is_same_v<Unit, Level> || __detail::can_rhs_stack_on_lhs<Unit, Level>)
   {
     return dim3_to_dims(dims_helper<Unit, Level>::index());
   }
   else
   {
-    using SplitLevel = detail::__default_unit_below<Level>;
+    using SplitLevel = __detail::__default_unit_below<Level>;
     return dims_sum<typename Level::product_type>(
       dims_product<typename Level::product_type>(index_impl<SplitLevel, Level>(), extents_impl<Unit, SplitLevel>()),
       index_impl<Unit, SplitLevel>());
   }
   _CCCL_UNREACHABLE();
 }
-} // namespace detail
+} // namespace __detail
 
 namespace hierarchy
 {
@@ -347,8 +347,8 @@ namespace hierarchy
 template <typename Unit, typename Level>
 _CCCL_DEVICE auto count(const Unit&, const Level&)
 {
-  static_assert(detail::legal_unit_for_level<Unit, Level>);
-  auto d = detail::extents_impl<Unit, Level>();
+  static_assert(__detail::legal_unit_for_level<Unit, Level>);
+  auto d = __detail::extents_impl<Unit, Level>();
   return d.extent(0) * d.extent(1) * d.extent(2);
 }
 
@@ -388,17 +388,17 @@ _CCCL_DEVICE auto count(const Unit&, const Level&)
 template <typename Unit, typename Level>
 _CCCL_DEVICE auto rank(const Unit&, const Level&)
 {
-  static_assert(detail::legal_unit_for_level<Unit, Level>);
-  if constexpr (detail::can_rhs_stack_on_lhs<Unit, Level>)
+  static_assert(__detail::legal_unit_for_level<Unit, Level>);
+  if constexpr (__detail::can_rhs_stack_on_lhs<Unit, Level>)
   {
-    return detail::index_to_linear<typename Level::product_type>(
-      detail::index_impl<Unit, Level>(), detail::extents_impl<Unit, Level>());
+    return __detail::index_to_linear<typename Level::product_type>(
+      __detail::index_impl<Unit, Level>(), __detail::extents_impl<Unit, Level>());
   }
   else
   {
     /* Its interesting that there is a need for else here, but using the above in all cases would result in
         a different numbering scheme, where adjacent ranks in lower level would not be adjacent in this level */
-    using SplitLevel = detail::__default_unit_below<Level>;
+    using SplitLevel = __detail::__default_unit_below<Level>;
     return rank<SplitLevel, Level>() * count<Unit, SplitLevel>() + rank<Unit, SplitLevel>();
   }
 }
@@ -443,8 +443,8 @@ _CCCL_DEVICE auto rank(const Unit&, const Level&)
 template <typename Unit, typename Level>
 _CCCL_DEVICE auto extents(const Unit&, const Level&)
 {
-  static_assert(detail::legal_unit_for_level<Unit, Level>);
-  return hierarchy_query_result(detail::extents_impl<Unit, Level>());
+  static_assert(__detail::legal_unit_for_level<Unit, Level>);
+  return hierarchy_query_result(__detail::extents_impl<Unit, Level>());
 }
 
 /**
@@ -487,8 +487,8 @@ _CCCL_DEVICE auto extents(const Unit&, const Level&)
 template <typename Unit, typename Level>
 _CCCL_DEVICE auto index(const Unit&, const Level&)
 {
-  static_assert(detail::legal_unit_for_level<Unit, Level>);
-  return hierarchy_query_result(detail::index_impl<Unit, Level>());
+  static_assert(__detail::legal_unit_for_level<Unit, Level>);
+  return hierarchy_query_result(__detail::index_impl<Unit, Level>());
 }
 } // namespace hierarchy
 } // namespace cuda::experimental

--- a/cudax/include/cuda/experimental/__hierarchy/level_dimensions.cuh
+++ b/cudax/include/cuda/experimental/__hierarchy/level_dimensions.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -22,7 +22,7 @@
 namespace cuda::experimental
 {
 
-namespace detail
+namespace __detail
 {
 
 /* Keeping it around in case issues like https://github.com/NVIDIA/cccl/issues/522
@@ -77,7 +77,7 @@ struct dimensions_handler<::cuda::std::integral_constant<Dims, Val>>
     return dimensions<dimensions_index_type, size_t(d), 1, 1>();
   }
 };
-} // namespace detail
+} // namespace __detail
 
 /**
  * @brief Type representing dimensions of a level in a thread hierarchy.
@@ -166,8 +166,8 @@ _CCCL_HOST_DEVICE constexpr auto grid_dims() noexcept
 template <typename T>
 _CCCL_HOST_DEVICE constexpr auto grid_dims(T t) noexcept
 {
-  static_assert(detail::dimensions_handler<T>::is_type_supported);
-  auto dims = detail::dimensions_handler<T>::translate(t);
+  static_assert(__detail::dimensions_handler<T>::is_type_supported);
+  auto dims = __detail::dimensions_handler<T>::translate(t);
   return level_dimensions<grid_level, decltype(dims)>(dims);
 }
 
@@ -190,8 +190,8 @@ _CCCL_HOST_DEVICE constexpr auto cluster_dims() noexcept
 template <typename T>
 _CCCL_HOST_DEVICE constexpr auto cluster_dims(T t) noexcept
 {
-  static_assert(detail::dimensions_handler<T>::is_type_supported);
-  auto dims = detail::dimensions_handler<T>::translate(t);
+  static_assert(__detail::dimensions_handler<T>::is_type_supported);
+  auto dims = __detail::dimensions_handler<T>::translate(t);
   return level_dimensions<cluster_level, decltype(dims)>(dims);
 }
 
@@ -214,8 +214,8 @@ _CCCL_HOST_DEVICE constexpr auto block_dims() noexcept
 template <typename T>
 _CCCL_HOST_DEVICE constexpr auto block_dims(T t) noexcept
 {
-  static_assert(detail::dimensions_handler<T>::is_type_supported);
-  auto dims = detail::dimensions_handler<T>::translate(t);
+  static_assert(__detail::dimensions_handler<T>::is_type_supported);
+  auto dims = __detail::dimensions_handler<T>::translate(t);
   return level_dimensions<block_level, decltype(dims)>(dims);
 }
 

--- a/cudax/include/cuda/experimental/__launch/configuration.cuh
+++ b/cudax/include/cuda/experimental/__launch/configuration.cuh
@@ -126,8 +126,8 @@ inline constexpr bool no_duplicate_options<Option, Rest...> =
  */
 struct cooperative_launch : public __detail::launch_option
 {
-  static constexpr bool needs_attribute_space      = true;
-  static constexpr bool is_relevant_on_device      = true;
+  static constexpr bool needs_attribute_space        = true;
+  static constexpr bool is_relevant_on_device        = true;
   static constexpr __detail::launch_option_kind kind = __detail::launch_option_kind::cooperative_launch;
 
   constexpr cooperative_launch() = default;
@@ -201,9 +201,9 @@ private:
 template <typename Content, std::size_t Extent = 1, bool NonPortableSize = false>
 struct dynamic_shared_memory_option : public __detail::launch_option
 {
-  using content_type                               = Content;
-  static constexpr std::size_t extent              = Extent;
-  static constexpr bool is_relevant_on_device      = true;
+  using content_type                                 = Content;
+  static constexpr std::size_t extent                = Extent;
+  static constexpr bool is_relevant_on_device        = true;
   static constexpr __detail::launch_option_kind kind = __detail::launch_option_kind::dynamic_shared_memory;
   const std::size_t size;
 
@@ -290,8 +290,8 @@ dynamic_shared_memory(std::size_t count) noexcept
  */
 struct launch_priority : public __detail::launch_option
 {
-  static constexpr bool needs_attribute_space      = true;
-  static constexpr bool is_relevant_on_dpevice     = false;
+  static constexpr bool needs_attribute_space        = true;
+  static constexpr bool is_relevant_on_dpevice       = false;
   static constexpr __detail::launch_option_kind kind = __detail::launch_option_kind::launch_priority;
   int priority;
 

--- a/cudax/include/cuda/experimental/__launch/configuration.cuh
+++ b/cudax/include/cuda/experimental/__launch/configuration.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -26,7 +26,7 @@ namespace cuda::experimental
 template <typename Dimensions, typename... Options>
 struct kernel_config;
 
-namespace detail
+namespace __detail
 {
 struct launch_option
 {
@@ -55,7 +55,7 @@ enum class launch_option_kind
 struct option_not_found
 {};
 
-template <detail::launch_option_kind Kind>
+template <__detail::launch_option_kind Kind>
 struct find_option_in_tuple_impl
 {
   template <typename Option, typename... Options>
@@ -77,7 +77,7 @@ struct find_option_in_tuple_impl
   }
 };
 
-template <detail::launch_option_kind Kind, typename... Options>
+template <__detail::launch_option_kind Kind, typename... Options>
 _CCCL_DEVICE auto& find_option_in_tuple(const ::cuda::std::tuple<Options...>& tuple)
 {
   return ::cuda::std::apply(find_option_in_tuple_impl<Kind>(), tuple);
@@ -93,7 +93,7 @@ template <typename Option, typename... Rest>
 inline constexpr bool no_duplicate_options<Option, Rest...> =
   !__option_present_in_list<Option, Rest...> && no_duplicate_options<Rest...>;
 
-} // namespace detail
+} // namespace __detail
 
 /**
  * @brief Launch option enabling cooperative launch
@@ -124,16 +124,16 @@ inline constexpr bool no_duplicate_options<Option, Rest...> =
  * }
  * @endcode
  */
-struct cooperative_launch : public detail::launch_option
+struct cooperative_launch : public __detail::launch_option
 {
   static constexpr bool needs_attribute_space      = true;
   static constexpr bool is_relevant_on_device      = true;
-  static constexpr detail::launch_option_kind kind = detail::launch_option_kind::cooperative_launch;
+  static constexpr __detail::launch_option_kind kind = __detail::launch_option_kind::cooperative_launch;
 
   constexpr cooperative_launch() = default;
 
   template <typename Dimensions, typename... Options>
-  friend cudaError_t detail::apply_kernel_config(
+  friend cudaError_t __detail::apply_kernel_config(
     const kernel_config<Dimensions, Options...>& config, cudaLaunchConfig_t& cuda_config, void* kernel) noexcept;
 
 private:
@@ -199,12 +199,12 @@ private:
  *  Needs to be enabled to exceed the portable limit of 48kB of shared memory per block
  */
 template <typename Content, std::size_t Extent = 1, bool NonPortableSize = false>
-struct dynamic_shared_memory_option : public detail::launch_option
+struct dynamic_shared_memory_option : public __detail::launch_option
 {
   using content_type                               = Content;
   static constexpr std::size_t extent              = Extent;
   static constexpr bool is_relevant_on_device      = true;
-  static constexpr detail::launch_option_kind kind = detail::launch_option_kind::dynamic_shared_memory;
+  static constexpr __detail::launch_option_kind kind = __detail::launch_option_kind::dynamic_shared_memory;
   const std::size_t size;
 
   constexpr dynamic_shared_memory_option(std::size_t set_size) noexcept
@@ -212,7 +212,7 @@ struct dynamic_shared_memory_option : public detail::launch_option
   {}
 
   template <typename Dimensions, typename... Options>
-  friend cudaError_t detail::apply_kernel_config(
+  friend cudaError_t __detail::apply_kernel_config(
     const kernel_config<Dimensions, Options...>& config, cudaLaunchConfig_t& cuda_config, void* kernel) noexcept;
 
 private:
@@ -288,11 +288,11 @@ dynamic_shared_memory(std::size_t count) noexcept
  * More about stream priorities and valid values can be found in the CUDA programming guide
  * `here <https://docs.nvidia.com/cuda/cuda-c-programming-guide/#stream-priorities>`_
  */
-struct launch_priority : public detail::launch_option
+struct launch_priority : public __detail::launch_option
 {
   static constexpr bool needs_attribute_space      = true;
   static constexpr bool is_relevant_on_dpevice     = false;
-  static constexpr detail::launch_option_kind kind = detail::launch_option_kind::launch_priority;
+  static constexpr __detail::launch_option_kind kind = __detail::launch_option_kind::launch_priority;
   int priority;
 
   launch_priority(int p) noexcept
@@ -300,7 +300,7 @@ struct launch_priority : public detail::launch_option
   {}
 
   template <typename Dimensions, typename... Options>
-  friend cudaError_t detail::apply_kernel_config(
+  friend cudaError_t __detail::apply_kernel_config(
     const kernel_config<Dimensions, Options...>& config, cudaLaunchConfig_t& cuda_config, void* kernel) noexcept;
 
 private:
@@ -336,7 +336,7 @@ struct __filter_options
   [[nodiscard]] auto operator()(const _Options&... __options)
   {
     return ::cuda::std::tuple_cat(
-      __option_or_empty<!detail::__option_present_in_list<_Options, _OptionsToFilter...>>(__options)...);
+      __option_or_empty<!__detail::__option_present_in_list<_Options, _OptionsToFilter...>>(__options)...);
   }
 };
 
@@ -371,8 +371,8 @@ struct kernel_config
   Dimensions dims;
   ::cuda::std::tuple<Options...> options;
 
-  static_assert(::cuda::std::_And<::cuda::std::is_base_of<detail::launch_option, Options>...>::value);
-  static_assert(detail::no_duplicate_options<Options...>);
+  static_assert(::cuda::std::_And<::cuda::std::is_base_of<__detail::launch_option, Options>...>::value);
+  static_assert(__detail::no_duplicate_options<Options...>);
 
   constexpr kernel_config(const Dimensions& dims, const Options&... opts)
       : dims(dims)
@@ -477,7 +477,7 @@ auto __make_config_from_tuple(const _Dimensions& __dims, const ::cuda::std::tupl
 template <typename Dimensions,
           typename... Options,
           typename Option,
-          typename = ::cuda::std::enable_if_t<::cuda::std::is_base_of_v<detail::launch_option, Option>>>
+          typename = ::cuda::std::enable_if_t<::cuda::std::is_base_of_v<__detail::launch_option, Option>>>
 [[nodiscard]] constexpr auto
 operator&(const kernel_config<Dimensions, Options...>& config, const Option& option) noexcept
 {
@@ -486,7 +486,7 @@ operator&(const kernel_config<Dimensions, Options...>& config, const Option& opt
 
 template <typename... Levels,
           typename Option,
-          typename = ::cuda::std::enable_if_t<::cuda::std::is_base_of_v<detail::launch_option, Option>>>
+          typename = ::cuda::std::enable_if_t<::cuda::std::is_base_of_v<__detail::launch_option, Option>>>
 [[nodiscard]] constexpr auto operator&(const hierarchy_dimensions<Levels...>& dims, const Option& option) noexcept
 {
   return kernel_config(dims, option);
@@ -554,9 +554,9 @@ template <typename... Prev, typename Arg, typename... Rest>
 [[nodiscard]] constexpr auto
 __process_config_args(const ::cuda::std::tuple<Prev...>& previous, const Arg& arg, const Rest&... rest)
 {
-  if constexpr (::cuda::std::is_base_of_v<detail::launch_option, Arg>)
+  if constexpr (::cuda::std::is_base_of_v<__detail::launch_option, Arg>)
   {
-    static_assert((::cuda::std::is_base_of_v<detail::launch_option, Rest> && ...),
+    static_assert((::cuda::std::is_base_of_v<__detail::launch_option, Rest> && ...),
                   "Hierarchy levels and launch options can't be mixed");
     if constexpr (sizeof...(Prev) == 0)
     {
@@ -579,7 +579,7 @@ template <typename... Args>
   return __process_config_args(::cuda::std::make_tuple(), args...);
 }
 
-namespace detail
+namespace __detail
 {
 
 template <typename Dimensions, typename... Options>
@@ -615,7 +615,7 @@ template <typename Dimensions, typename... Options>
 
   return &dynamic_smem[0];
 }
-} // namespace detail
+} // namespace __detail
 
 // Might consider cutting this one due to being a potential trap with missing & in auto& var = dynamic_smem_ref(...);
 /**
@@ -628,13 +628,13 @@ template <typename Dimensions, typename... Options>
 template <typename Dimensions, typename... Options>
 _CCCL_DEVICE auto& dynamic_smem_ref(const kernel_config<Dimensions, Options...>& config) noexcept
 {
-  auto& option      = detail::find_option_in_tuple<detail::launch_option_kind::dynamic_shared_memory>(config.options);
+  auto& option = __detail::find_option_in_tuple<__detail::launch_option_kind::dynamic_shared_memory>(config.options);
   using option_type = ::cuda::std::remove_reference_t<decltype(option)>;
-  static_assert(!::cuda::std::is_same_v<option_type, detail::option_not_found>,
+  static_assert(!::cuda::std::is_same_v<option_type, __detail::option_not_found>,
                 "Dynamic shared memory option not found in the kernel configuration");
   static_assert(option_type::extent == 1, "Usable only on dynamic shared memory with a single element");
 
-  return *reinterpret_cast<typename option_type::content_type*>(detail::get_smem_ptr());
+  return *reinterpret_cast<typename option_type::content_type*>(__detail::get_smem_ptr());
 }
 
 /**
@@ -648,13 +648,13 @@ _CCCL_DEVICE auto& dynamic_smem_ref(const kernel_config<Dimensions, Options...>&
 template <typename Dimensions, typename... Options>
 _CCCL_DEVICE auto dynamic_smem_span(const kernel_config<Dimensions, Options...>& config) noexcept
 {
-  auto& option      = detail::find_option_in_tuple<detail::launch_option_kind::dynamic_shared_memory>(config.options);
+  auto& option = __detail::find_option_in_tuple<__detail::launch_option_kind::dynamic_shared_memory>(config.options);
   using option_type = ::cuda::std::remove_reference_t<decltype(option)>;
-  static_assert(!::cuda::std::is_same_v<option_type, detail::option_not_found>,
+  static_assert(!::cuda::std::is_same_v<option_type, __detail::option_not_found>,
                 "Dynamic shared memory option not found in the kernel configuration");
 
   return cuda::std::span<typename option_type::content_type, option_type::extent>(
-    reinterpret_cast<typename option_type::content_type*>(detail::get_smem_ptr()), option.size);
+    reinterpret_cast<typename option_type::content_type*>(__detail::get_smem_ptr()), option.size);
 }
 
 } // namespace cuda::experimental

--- a/cudax/include/cuda/experimental/__launch/launch_transform.cuh
+++ b/cudax/include/cuda/experimental/__launch/launch_transform.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/cudax/include/cuda/experimental/__launch/param_kind.cuh
+++ b/cudax/include/cuda/experimental/__launch/param_kind.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -29,7 +29,7 @@
 
 namespace cuda::experimental
 {
-namespace detail
+namespace __detail
 {
 enum class __param_kind : unsigned
 {
@@ -76,11 +76,11 @@ struct __inout_t
   }
 };
 
-} // namespace detail
+} // namespace __detail
 
-_CCCL_GLOBAL_CONSTANT detail::__in_t in{};
-_CCCL_GLOBAL_CONSTANT detail::__out_t out{};
-_CCCL_GLOBAL_CONSTANT detail::__inout_t inout{};
+_CCCL_GLOBAL_CONSTANT __detail::__in_t in{};
+_CCCL_GLOBAL_CONSTANT __detail::__out_t out{};
+_CCCL_GLOBAL_CONSTANT __detail::__inout_t inout{};
 
 } // namespace cuda::experimental
 

--- a/cudax/include/cuda/experimental/__memory_resource/any_resource.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/any_resource.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/cudax/include/cuda/experimental/__memory_resource/device_memory_pool.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/device_memory_pool.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/cudax/include/cuda/experimental/__memory_resource/device_memory_resource.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/device_memory_resource.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/cudax/include/cuda/experimental/__memory_resource/managed_memory_resource.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/managed_memory_resource.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/cudax/include/cuda/experimental/__memory_resource/pinned_memory_resource.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/pinned_memory_resource.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/cudax/include/cuda/experimental/__memory_resource/properties.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/properties.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/cudax/include/cuda/experimental/__memory_resource/resource.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/resource.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/cudax/include/cuda/experimental/__memory_resource/shared_resource.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/shared_resource.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/cudax/include/cuda/experimental/__stream/internal_streams.cuh
+++ b/cudax/include/cuda/experimental/__stream/internal_streams.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/cudax/include/cuda/experimental/__stream/stream.cuh
+++ b/cudax/include/cuda/experimental/__stream/stream.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -47,7 +47,7 @@ struct stream : stream_ref
   //!
   //! @throws cuda_error if stream creation fails
   explicit stream(device_ref __dev, int __priority = default_priority)
-      : stream_ref(detail::__invalid_stream)
+      : stream_ref(__detail::__invalid_stream)
   {
     [[maybe_unused]] __ensure_current_device __dev_setter(__dev);
     _CCCL_TRY_CUDA_API(
@@ -60,7 +60,7 @@ struct stream : stream_ref
   //!
   //! @throws cuda_error if stream creation fails
   explicit stream(::cuda::experimental::logical_device __dev, int __priority = default_priority)
-      : stream_ref(detail::__invalid_stream)
+      : stream_ref(__detail::__invalid_stream)
   {
     [[maybe_unused]] __ensure_current_device __dev_setter(__dev);
     _CCCL_TRY_CUDA_API(
@@ -79,7 +79,7 @@ struct stream : stream_ref
   //! @post `stream()` returns an invalid stream handle
   // Can't be constexpr because __invalid_stream isn't
   explicit stream(no_init_t) noexcept
-      : stream_ref(detail::__invalid_stream)
+      : stream_ref(__detail::__invalid_stream)
   {}
 
   //! @brief Move-construct a new `stream` object
@@ -88,7 +88,7 @@ struct stream : stream_ref
   //!
   //! @post `__other` is in moved-from state.
   stream(stream&& __other) noexcept
-      : stream(_CUDA_VSTD::exchange(__other.__stream, detail::__invalid_stream))
+      : stream(_CUDA_VSTD::exchange(__other.__stream, __detail::__invalid_stream))
   {}
 
   stream(const stream&) = delete;
@@ -98,11 +98,11 @@ struct stream : stream_ref
   //! @note If the stream fails to be destroyed, the error is silently ignored.
   ~stream()
   {
-    if (__stream != detail::__invalid_stream)
+    if (__stream != __detail::__invalid_stream)
     {
       // Needs to call driver API in case current device is not set, runtime version would set dev 0 current
       // Alternative would be to store the device and push/pop here
-      [[maybe_unused]] auto status = detail::driver::streamDestroy(__stream);
+      [[maybe_unused]] auto status = __detail::driver::streamDestroy(__stream);
     }
   }
 
@@ -145,7 +145,7 @@ struct stream : stream_ref
   //! @post The stream object is in a moved-from state.
   [[nodiscard]] ::cudaStream_t release()
   {
-    return _CUDA_VSTD::exchange(__stream, detail::__invalid_stream);
+    return _CUDA_VSTD::exchange(__stream, __detail::__invalid_stream);
   }
 
 private:

--- a/cudax/include/cuda/experimental/__stream/stream_ref.cuh
+++ b/cudax/include/cuda/experimental/__stream/stream_ref.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -35,12 +35,12 @@
 namespace cuda::experimental
 {
 
-namespace detail
+namespace __detail
 {
 // 0 is a valid stream in CUDA, so we need some other invalid stream representation
 // Can't make it constexpr, because cudaStream_t is a pointer type
 static const ::cudaStream_t __invalid_stream = reinterpret_cast<cudaStream_t>(~0ULL);
-} // namespace detail
+} // namespace __detail
 
 //! @brief A non-owning wrapper for cudaStream_t.
 struct stream_ref : ::cuda::stream_ref
@@ -110,7 +110,7 @@ struct stream_ref : ::cuda::stream_ref
   {
     _CCCL_ASSERT(__ev.get() != nullptr, "cuda::experimental::stream_ref::wait invalid event passed");
     // Need to use driver API, cudaStreamWaitEvent would push dev 0 if stack was empty
-    detail::driver::streamWaitEvent(get(), __ev.get());
+    __detail::driver::streamWaitEvent(get(), __ev.get());
   }
 
   //! @brief Make all future work submitted into this stream depend on completion of all work from the specified
@@ -123,7 +123,7 @@ struct stream_ref : ::cuda::stream_ref
   {
     // TODO consider an optimization to not create an event every time and instead have one persistent event or one
     // per stream
-    _CCCL_ASSERT(__stream != detail::__invalid_stream, "cuda::experimental::stream_ref::wait invalid stream passed");
+    _CCCL_ASSERT(__stream != __detail::__invalid_stream, "cuda::experimental::stream_ref::wait invalid stream passed");
     if (*this != __other)
     {
       event __tmp(__other);
@@ -140,12 +140,12 @@ struct stream_ref : ::cuda::stream_ref
     CUcontext __stream_ctx;
     ::cuda::experimental::logical_device::kinds __ctx_kind = ::cuda::experimental::logical_device::kinds::device;
 #if CUDART_VERSION >= 12050
-    if (detail::driver::getVersion() >= 12050)
+    if (__detail::driver::getVersion() >= 12050)
     {
-      auto __ctx = detail::driver::streamGetCtx_v2(__stream);
-      if (__ctx.__ctx_kind == detail::driver::__ctx_from_stream::__kind::__green)
+      auto __ctx = __detail::driver::streamGetCtx_v2(__stream);
+      if (__ctx.__ctx_kind == __detail::driver::__ctx_from_stream::__kind::__green)
       {
-        __stream_ctx = detail::driver::ctxFromGreenCtx(__ctx.__ctx_ptr.__green);
+        __stream_ctx = __detail::driver::ctxFromGreenCtx(__ctx.__ctx_ptr.__green);
         __ctx_kind   = ::cuda::experimental::logical_device::kinds::green_context;
       }
       else
@@ -157,7 +157,7 @@ struct stream_ref : ::cuda::stream_ref
     else
 #endif // CUDART_VERSION >= 12050
     {
-      __stream_ctx = detail::driver::streamGetCtx(__stream);
+      __stream_ctx = __detail::driver::streamGetCtx(__stream);
       __ctx_kind   = ::cuda::experimental::logical_device::kinds::device;
     }
     // Because the stream can come from_native_handle, we can't just loop over devices comparing contexts,

--- a/cudax/include/cuda/experimental/__utility/basic_any.cuh
+++ b/cudax/include/cuda/experimental/__utility/basic_any.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/cudax/include/cuda/experimental/__utility/basic_any/access.cuh
+++ b/cudax/include/cuda/experimental/__utility/basic_any/access.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -50,7 +50,7 @@ struct __basic_any_access
   _CCCL_TRIVIAL_HOST_API static auto __cast_to(_SrcCvAny&& __from, basic_any<_DstInterface>& __to) noexcept(
     noexcept(__to.__convert_from(static_cast<_SrcCvAny&&>(__from)))) -> void
   {
-    static_assert(detail::__is_specialization_of<_CUDA_VSTD::remove_cvref_t<_SrcCvAny>, basic_any>);
+    static_assert(__is_specialization_of_v<_CUDA_VSTD::remove_cvref_t<_SrcCvAny>, basic_any>);
     __to.__convert_from(static_cast<_SrcCvAny&&>(__from));
   }
 
@@ -59,7 +59,7 @@ struct __basic_any_access
   _CCCL_TRIVIAL_HOST_API static auto
   __cast_to(_SrcCvAny* __from, basic_any<_DstInterface>& __to) noexcept(noexcept(__to.__convert_from(__from))) -> void
   {
-    static_assert(detail::__is_specialization_of<_CUDA_VSTD::remove_const_t<_SrcCvAny>, basic_any>);
+    static_assert(__is_specialization_of_v<_CUDA_VSTD::remove_const_t<_SrcCvAny>, basic_any>);
     __to.__convert_from(__from);
   }
 

--- a/cudax/include/cuda/experimental/__utility/basic_any/any_cast.cuh
+++ b/cudax/include/cuda/experimental/__utility/basic_any/any_cast.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/cudax/include/cuda/experimental/__utility/basic_any/basic_any_base.cuh
+++ b/cudax/include/cuda/experimental/__utility/basic_any/basic_any_base.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/cudax/include/cuda/experimental/__utility/basic_any/basic_any_from.cuh
+++ b/cudax/include/cuda/experimental/__utility/basic_any/basic_any_from.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/cudax/include/cuda/experimental/__utility/basic_any/basic_any_fwd.cuh
+++ b/cudax/include/cuda/experimental/__utility/basic_any/basic_any_fwd.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/cudax/include/cuda/experimental/__utility/basic_any/basic_any_ptr.cuh
+++ b/cudax/include/cuda/experimental/__utility/basic_any/basic_any_ptr.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/cudax/include/cuda/experimental/__utility/basic_any/basic_any_ref.cuh
+++ b/cudax/include/cuda/experimental/__utility/basic_any/basic_any_ref.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/cudax/include/cuda/experimental/__utility/basic_any/basic_any_value.cuh
+++ b/cudax/include/cuda/experimental/__utility/basic_any/basic_any_value.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/cudax/include/cuda/experimental/__utility/basic_any/conversions.cuh
+++ b/cudax/include/cuda/experimental/__utility/basic_any/conversions.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/cudax/include/cuda/experimental/__utility/basic_any/dynamic_any_cast.cuh
+++ b/cudax/include/cuda/experimental/__utility/basic_any/dynamic_any_cast.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/cudax/include/cuda/experimental/__utility/basic_any/interfaces.cuh
+++ b/cudax/include/cuda/experimental/__utility/basic_any/interfaces.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -293,7 +293,7 @@ struct __make_interface_fn
 {
   static_assert(_CUDA_VSTD::is_class_v<_Super>, "expected a class type");
   template <class... _Interfaces>
-  using __call _CCCL_NODEBUG_ALIAS = detail::__inherit<__rebind_interface<_Interfaces, _Super>...>;
+  using __call _CCCL_NODEBUG_ALIAS = __inherit<__rebind_interface<_Interfaces, _Super>...>;
 };
 
 // Given an interface `_I<>`, let `_Bs<>...` be the list of types consisting

--- a/cudax/include/cuda/experimental/__utility/basic_any/iset.cuh
+++ b/cudax/include/cuda/experimental/__utility/basic_any/iset.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -52,7 +52,7 @@ struct __iset : __iset_<_Interfaces...>::template __interface_<>
 template <class _Interface>
 using __iset_flatten _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::__as_type_list<
   _CUDA_VSTD::
-    conditional_t<detail::__is_specialization_of<_Interface, __iset>, _Interface, _CUDA_VSTD::__type_list<_Interface>>>;
+    conditional_t<__is_specialization_of_v<_Interface, __iset>, _Interface, _CUDA_VSTD::__type_list<_Interface>>>;
 
 // flatten all sets into one, remove duplicates, and sort the elements.
 // TODO: sort!

--- a/cudax/include/cuda/experimental/__utility/basic_any/overrides.cuh
+++ b/cudax/include/cuda/experimental/__utility/basic_any/overrides.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -21,6 +21,7 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/std/__tuple_dir/ignore.h>
 #include <cuda/std/__type_traits/is_const.h>
 
 #include <cuda/experimental/__utility/basic_any/basic_any_fwd.cuh>
@@ -53,7 +54,7 @@ struct overrides_for<__iset<_Interfaces...>>
 template <>
 struct overrides_for<iunknown>
 {
-  using __vtable _CCCL_NODEBUG_ALIAS = detail::__ignore; // no vtable, rtti is added explicitly in __vtable_tuple
+  using __vtable _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::__ignore_t; // no vtable, rtti is added explicitly in __vtable_tuple
   using __vptr_t _CCCL_NODEBUG_ALIAS = __rtti const*;
 };
 

--- a/cudax/include/cuda/experimental/__utility/basic_any/rtti.cuh
+++ b/cudax/include/cuda/experimental/__utility/basic_any/rtti.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -68,7 +68,7 @@ struct bad_any_cast : ::std::bad_cast
 #endif // !_CCCL_HAS_EXCEPTIONS()
 }
 
-struct __rtti_base : detail::__immovable
+struct __rtti_base : __immovable
 {
   _CCCL_HOST_API constexpr __rtti_base(
     __vtable_kind __kind, uint16_t __nbr_interfaces, _CUDA_VSTD::__type_info_ref __self) noexcept

--- a/cudax/include/cuda/experimental/__utility/basic_any/semiregular.cuh
+++ b/cudax/include/cuda/experimental/__utility/basic_any/semiregular.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/cudax/include/cuda/experimental/__utility/basic_any/storage.cuh
+++ b/cudax/include/cuda/experimental/__utility/basic_any/storage.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -22,6 +22,7 @@
 #endif // no system header
 
 #include <cuda/std/__algorithm/max.h>
+#include <cuda/std/__tuple_dir/ignore.h>
 #include <cuda/std/__type_traits/is_nothrow_move_constructible.h>
 #include <cuda/std/__utility/swap.h>
 
@@ -61,7 +62,8 @@ template <class _Tp, class _Up, class _Vp = decltype(true ? __identity_t<_Tp*>()
   return static_cast<_Vp>(__lhs) == static_cast<_Vp>(__rhs);
 }
 
-[[nodiscard]] _CCCL_TRIVIAL_HOST_API constexpr auto __ptr_eq(detail::__ignore, detail::__ignore) noexcept -> bool
+[[nodiscard]] _CCCL_TRIVIAL_HOST_API constexpr auto __ptr_eq(_CUDA_VSTD::__ignore_t, _CUDA_VSTD::__ignore_t) noexcept
+  -> bool
 {
   return false;
 }

--- a/cudax/include/cuda/experimental/__utility/basic_any/tagged_ptr.cuh
+++ b/cudax/include/cuda/experimental/__utility/basic_any/tagged_ptr.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/cudax/include/cuda/experimental/__utility/basic_any/virtcall.cuh
+++ b/cudax/include/cuda/experimental/__utility/basic_any/virtcall.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/cudax/include/cuda/experimental/__utility/basic_any/virtual_functions.cuh
+++ b/cudax/include/cuda/experimental/__utility/basic_any/virtual_functions.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/cudax/include/cuda/experimental/__utility/basic_any/virtual_ptrs.cuh
+++ b/cudax/include/cuda/experimental/__utility/basic_any/virtual_ptrs.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/cudax/include/cuda/experimental/__utility/basic_any/virtual_tables.cuh
+++ b/cudax/include/cuda/experimental/__utility/basic_any/virtual_tables.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/cudax/include/cuda/experimental/__utility/driver_api.cuh
+++ b/cudax/include/cuda/experimental/__utility/driver_api.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -24,7 +24,7 @@
 #define CUDAX_GET_DRIVER_FUNCTION_VERSIONED(function_name, versioned_fn_name, version) \
   reinterpret_cast<decltype(versioned_fn_name)*>(get_driver_entry_point(#function_name, version))
 
-namespace cuda::experimental::detail::driver
+namespace cuda::experimental::__detail::driver
 {
 //! @brief Get a driver function pointer for a given API name and optionally specific CUDA version
 //!
@@ -232,7 +232,7 @@ inline CUcontext ctxFromGreenCtx(CUgreenCtx green_ctx)
   return result;
 }
 #endif // CUDART_VERSION >= 12050
-} // namespace cuda::experimental::detail::driver
+} // namespace cuda::experimental::__detail::driver
 
 #undef CUDAX_GET_DRIVER_FUNCTION
 

--- a/cudax/include/cuda/experimental/__utility/ensure_current_device.cuh
+++ b/cudax/include/cuda/experimental/__utility/ensure_current_device.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -50,7 +50,7 @@ struct [[maybe_unused]] __ensure_current_device
   explicit __ensure_current_device(device_ref __new_device)
   {
     auto __ctx = devices[__new_device.get()].get_primary_context();
-    detail::driver::ctxPush(__ctx);
+    __detail::driver::ctxPush(__ctx);
   }
 
   //! @brief Construct a new `__ensure_current_device` object and switch to the specified
@@ -64,14 +64,14 @@ struct [[maybe_unused]] __ensure_current_device
   //! @throws cuda_error if the device switch fails
   explicit __ensure_current_device(logical_device __new_device)
   {
-    detail::driver::ctxPush(__new_device.get_context());
+    __detail::driver::ctxPush(__new_device.get_context());
   }
 
   // Doesn't really fit into the type description, we might consider changing it once
   // green ctx design is more finalized
   explicit __ensure_current_device(CUcontext __ctx)
   {
-    detail::driver::ctxPush(__ctx);
+    __detail::driver::ctxPush(__ctx);
   }
 
   //! @brief Construct a new `__ensure_current_device` object and switch to the device
@@ -82,8 +82,8 @@ struct [[maybe_unused]] __ensure_current_device
   //! @throws cuda_error if the device switch fails
   explicit __ensure_current_device(stream_ref __stream)
   {
-    auto __ctx = detail::driver::streamGetCtx(__stream.get());
-    detail::driver::ctxPush(__ctx);
+    auto __ctx = __detail::driver::streamGetCtx(__stream.get());
+    __detail::driver::ctxPush(__ctx);
   }
 
   __ensure_current_device(__ensure_current_device&&)                 = delete;
@@ -99,7 +99,7 @@ struct [[maybe_unused]] __ensure_current_device
   ~__ensure_current_device() noexcept(false)
   {
     // TODO would it make sense to assert here that we pushed and popped the same thing?
-    detail::driver::ctxPop();
+    __detail::driver::ctxPop();
   }
 };
 } // namespace cuda::experimental

--- a/cudax/include/cuda/experimental/__utility/select_execution_space.cuh
+++ b/cudax/include/cuda/experimental/__utility/select_execution_space.cuh
@@ -3,7 +3,7 @@
 // Part of the CUDA Toolkit, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/cudax/include/cuda/experimental/algorithm.cuh
+++ b/cudax/include/cuda/experimental/algorithm.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/cudax/include/cuda/experimental/container.cuh
+++ b/cudax/include/cuda/experimental/container.cuh
@@ -3,7 +3,7 @@
 // Part of the CUDA Toolkit, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/cudax/include/cuda/experimental/device.cuh
+++ b/cudax/include/cuda/experimental/device.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/cudax/include/cuda/experimental/event.cuh
+++ b/cudax/include/cuda/experimental/event.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/cudax/include/cuda/experimental/green_context.cuh
+++ b/cudax/include/cuda/experimental/green_context.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/cudax/include/cuda/experimental/hierarchy.cuh
+++ b/cudax/include/cuda/experimental/hierarchy.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/cudax/include/cuda/experimental/launch.cuh
+++ b/cudax/include/cuda/experimental/launch.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/cudax/include/cuda/experimental/memory_resource.cuh
+++ b/cudax/include/cuda/experimental/memory_resource.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/cudax/include/cuda/experimental/stream.cuh
+++ b/cudax/include/cuda/experimental/stream.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/cudax/include/cuda/experimental/version.cuh
+++ b/cudax/include/cuda/experimental/version.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/cudax/test/common/utility.cuh
+++ b/cudax/test/common/utility.cuh
@@ -125,11 +125,11 @@ struct empty_kernel
 
 inline int count_driver_stack()
 {
-  if (cudax::detail::driver::ctxGetCurrent() != nullptr)
+  if (cudax::__detail::driver::ctxGetCurrent() != nullptr)
   {
-    auto ctx    = cudax::detail::driver::ctxPop();
+    auto ctx    = cudax::__detail::driver::ctxPop();
     auto result = 1 + count_driver_stack();
-    cudax::detail::driver::ctxPush(ctx);
+    cudax::__detail::driver::ctxPush(ctx);
     return result;
   }
   else
@@ -140,15 +140,15 @@ inline int count_driver_stack()
 
 inline void empty_driver_stack()
 {
-  while (cudax::detail::driver::ctxGetCurrent() != nullptr)
+  while (cudax::__detail::driver::ctxGetCurrent() != nullptr)
   {
-    cudax::detail::driver::ctxPop();
+    cudax::__detail::driver::ctxPop();
   }
 }
 
 inline int cuda_driver_version()
 {
-  return cudax::detail::driver::getVersion();
+  return cudax::__detail::driver::getVersion();
 }
 
 } // namespace test

--- a/cudax/test/execution/common/error_scheduler.cuh
+++ b/cudax/test/execution/common/error_scheduler.cuh
@@ -35,7 +35,7 @@ private:
   };
 
   template <class Rcvr>
-  struct opstate_t : cudax_async::__immovable
+  struct opstate_t : cudax::__immovable
   {
     using operation_state_concept = cudax_async::operation_state_t;
 

--- a/cudax/test/execution/common/impulse_scheduler.cuh
+++ b/cudax/test/execution/common/impulse_scheduler.cuh
@@ -53,7 +53,7 @@ private:
   std::shared_ptr<data_t> data_{};
 
   template <class Rcvr>
-  struct opstate_t : cudax_async::__immovable
+  struct opstate_t : cudax::__immovable
   {
     using operation_state_concept = cudax_async::operation_state_t;
 

--- a/cudax/test/execution/common/inline_scheduler.cuh
+++ b/cudax/test/execution/common/inline_scheduler.cuh
@@ -30,7 +30,7 @@ private:
   };
 
   template <class Rcvr>
-  struct opstate_t : cudax_async::__immovable
+  struct opstate_t : cudax::__immovable
   {
     using operation_state_concept = cudax_async::operation_state_t;
 

--- a/cudax/test/execution/common/stopped_scheduler.cuh
+++ b/cudax/test/execution/common/stopped_scheduler.cuh
@@ -34,7 +34,7 @@ private:
   };
 
   template <class Rcvr>
-  struct opstate_t : cudax_async::__immovable
+  struct opstate_t : cudax::__immovable
   {
     using operation_state_concept = cudax_async::operation_state_t;
 

--- a/cudax/test/execution/env.cu
+++ b/cudax/test/execution/env.cu
@@ -55,7 +55,7 @@ C2H_TEST("env_t is queryable for all properties we want", "[execution, env]")
 C2H_TEST("env_t is default constructible", "[execution, env]")
 {
   env_t env;
-  CHECK(env.query(cuda::get_stream) == ::cuda::experimental::detail::__invalid_stream);
+  CHECK(env.query(cuda::get_stream) == ::cuda::experimental::__detail::__invalid_stream);
   CHECK(env.query(cudax::execution::get_execution_policy)
         == cudax::execution::execution_policy::invalid_execution_policy);
   CHECK(env.query(cuda::mr::get_memory_resource) == cudax::device_memory_resource{});
@@ -68,7 +68,7 @@ C2H_TEST("env_t is constructible from an any_resource", "[execution, env]")
   SECTION("Passing an any_resource")
   {
     env_t env{mr};
-    CHECK(env.query(cuda::get_stream) == ::cuda::experimental::detail::__invalid_stream);
+    CHECK(env.query(cuda::get_stream) == ::cuda::experimental::__detail::__invalid_stream);
     CHECK(env.query(cudax::execution::get_execution_policy)
           == cudax::execution::execution_policy::invalid_execution_policy);
     CHECK(env.query(cuda::mr::get_memory_resource) == mr);
@@ -100,7 +100,7 @@ C2H_TEST("env_t is constructible from an any_resource passed as an rvalue", "[ex
   SECTION("Passing an any_resource")
   {
     env_t env{cudax::any_async_resource<cuda::mr::device_accessible>{test_resource{}}};
-    CHECK(env.query(cuda::get_stream) == ::cuda::experimental::detail::__invalid_stream);
+    CHECK(env.query(cuda::get_stream) == ::cuda::experimental::__detail::__invalid_stream);
     CHECK(env.query(cudax::execution::get_execution_policy)
           == cudax::execution::execution_policy::invalid_execution_policy);
     CHECK(env.query(cuda::mr::get_memory_resource)
@@ -139,7 +139,7 @@ C2H_TEST("env_t is constructible from a resource", "[execution, env]")
   SECTION("Passing an any_resource")
   {
     env_t env{mr};
-    CHECK(env.query(cuda::get_stream) == ::cuda::experimental::detail::__invalid_stream);
+    CHECK(env.query(cuda::get_stream) == ::cuda::experimental::__detail::__invalid_stream);
     CHECK(env.query(cudax::execution::get_execution_policy)
           == cudax::execution::execution_policy::invalid_execution_policy);
     CHECK(env.query(cuda::mr::get_memory_resource) == mr);
@@ -171,7 +171,7 @@ C2H_TEST("env_t is constructible from a resource passed as an rvalue", "[executi
   SECTION("Passing an any_resource")
   {
     env_t env{test_resource{}};
-    CHECK(env.query(cuda::get_stream) == ::cuda::experimental::detail::__invalid_stream);
+    CHECK(env.query(cuda::get_stream) == ::cuda::experimental::__detail::__invalid_stream);
     CHECK(env.query(cudax::execution::get_execution_policy)
           == cudax::execution::execution_policy::invalid_execution_policy);
     CHECK(env.query(cuda::mr::get_memory_resource) == test_resource{});

--- a/cudax/test/execution/test_when_all.cu
+++ b/cudax/test/execution/test_when_all.cu
@@ -8,14 +8,16 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <cuda/std/__tuple_dir/ignore.h>
+
 #include <cuda/experimental/execution.cuh>
 
 #include "common/checked_receiver.cuh"
 #include "common/error_scheduler.cuh"
-#include "common/impulse_scheduler.cuh"
+#include "common/impulse_scheduler.cuh" // IWYU pragma: keep
 #include "common/stopped_scheduler.cuh"
 #include "common/utility.cuh"
-#include "testing.cuh"
+#include "testing.cuh" // IWYU pragma: keep
 
 namespace
 {
@@ -197,7 +199,7 @@ struct just_ref
     return cudax_async::completion_signatures<cudax_async::set_value_t(Ts & ...)>{};
   }
 
-  _CCCL_HOST_DEVICE just_ref connect(cudax_async::__ignore) const
+  _CCCL_HOST_DEVICE just_ref connect(cuda::std::__ignore_t) const
   {
     return {};
   }

--- a/cudax/test/utility/basic_any.cu
+++ b/cudax/test/utility/basic_any.cu
@@ -16,7 +16,7 @@
 
 #undef interface
 
-using immovable = cudax::detail::__immovable;
+using immovable = cudax::__immovable;
 
 struct TestCounters
 {

--- a/cudax/test/utility/driver_api.cu
+++ b/cudax/test/utility/driver_api.cu
@@ -14,7 +14,7 @@
 
 C2H_TEST("Call each driver api", "[utility]")
 {
-  namespace driver = cuda::experimental::detail::driver;
+  namespace driver = cuda::experimental::__detail::driver;
   cudaStream_t stream;
   // Assumes the ctx stack was empty or had one ctx, should be the case unless some other
   // test leaves 2+ ctxs on the stack

--- a/cudax/test/utility/ensure_current_device.cu
+++ b/cudax/test/utility/ensure_current_device.cu
@@ -15,7 +15,7 @@
 
 #include <utility.cuh>
 
-namespace driver = cuda::experimental::detail::driver;
+namespace driver = cuda::experimental::__detail::driver;
 
 void recursive_check_device_setter(int id)
 {


### PR DESCRIPTION
## Description

low-priority clean-ups of the cudax code.

* we have both a `detail` namespace and a `__detail` namespace. settle on `__detail`.
* it is no longer 2024. update the copyright notices
* some utilities in `__execution/meta.cuh` and `__execution/utility.cuh` were duplicating functionality in `cuda::std`. eliminate the duplication.
* a few identifier renames to be more idiomatic; e.g., `__is_specialization_of` -> `__is_specialization_of_v`.
* the include guards macros for the `execution::` stuff never got updated when the files moved out of `__async/`. update their names to correspond with their current location in the directory hierarchy.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
