### PR TITLE
Use proper qualification in allocate.h

### DIFF
--- a/libcudacxx/include/cuda/std/__new/allocate.h
+++ b/libcudacxx/include/cuda/std/__new/allocate.h
@@ -76,13 +76,13 @@ using ::std::align_val_t;
 _LIBCUDACXX_HIDE_FROM_ABI void* __cccl_allocate(size_t __size, [[maybe_unused]] size_t __align)
 {
 #if _LIBCUDACXX_HAS_ALIGNED_ALLOCATION()
-  if (__is_overaligned_for_new(__align))
+  if (_CUDA_VSTD::__is_overaligned_for_new(__align))
   {
     const align_val_t __align_val = static_cast<align_val_t>(__align);
-    return __cccl_operator_new(__size, __align_val);
+    return _CUDA_VSTD::__cccl_operator_new(__size, __align_val);
   }
 #endif // _LIBCUDACXX_HAS_ALIGNED_ALLOCATION()
-  return __cccl_operator_new(__size);
+  return _CUDA_VSTD::__cccl_operator_new(__size);
 }
 
 template <class... _Args>
@@ -98,25 +98,25 @@ _LIBCUDACXX_HIDE_FROM_ABI void __do_deallocate_handle_size(void* __ptr, [[maybe_
 _LIBCUDACXX_HIDE_FROM_ABI void __cccl_deallocate(void* __ptr, size_t __size, [[maybe_unused]] size_t __align)
 {
 #if _LIBCUDACXX_HAS_ALIGNED_ALLOCATION()
-  if (__is_overaligned_for_new(__align))
+  if (_CUDA_VSTD::__is_overaligned_for_new(__align))
   {
     const align_val_t __align_val = static_cast<align_val_t>(__align);
-    return __do_deallocate_handle_size(__ptr, __size, __align_val);
+    return _CUDA_VSTD::__do_deallocate_handle_size(__ptr, __size, __align_val);
   }
 #endif // _LIBCUDACXX_HAS_ALIGNED_ALLOCATION()
-  return __do_deallocate_handle_size(__ptr, __size);
+  return _CUDA_VSTD::__do_deallocate_handle_size(__ptr, __size);
 }
 
 _LIBCUDACXX_HIDE_FROM_ABI void __cccl_deallocate_unsized(void* __ptr, [[maybe_unused]] size_t __align)
 {
 #if _LIBCUDACXX_HAS_ALIGNED_ALLOCATION()
-  if (__is_overaligned_for_new(__align))
+  if (_CUDA_VSTD::__is_overaligned_for_new(__align))
   {
     const align_val_t __align_val = static_cast<align_val_t>(__align);
-    return __cccl_operator_delete(__ptr, __align_val);
+    return _CUDA_VSTD::__cccl_operator_delete(__ptr, __align_val);
   }
 #endif // _LIBCUDACXX_HAS_ALIGNED_ALLOCATION()
-  return __cccl_operator_delete(__ptr);
+  return _CUDA_VSTD::__cccl_operator_delete(__ptr);
 }
 
 _LIBCUDACXX_END_NAMESPACE_STD


### PR DESCRIPTION
Fixes [BUG]: Ambiguous call to __do_deallocate_handle_size when compiling with clang and libc++ #4793
