### PR TITLE
Add `address_space` and `is_address_from` to `cuda::device::`

### DIFF
--- a/libcudacxx/include/cuda/__memory/address_space.h
+++ b/libcudacxx/include/cuda/__memory/address_space.h
@@ -1,0 +1,86 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA___MEMORY_ADDRESS_SPACE_H
+#define _CUDA___MEMORY_ADDRESS_SPACE_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#if _CCCL_CUDA_COMPILATION()
+
+#  include <cuda/std/__utility/to_underlying.h>
+
+#  include <nv/target>
+
+#  include <cuda/std/__cccl/prologue.h>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_CUDA_DEVICE
+
+enum class address_space
+{
+  global,
+  shared,
+  constant,
+  local,
+  grid_constant,
+  cluster_shared,
+  __max,
+};
+
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr bool __cccl_is_valid_address_space(address_space __space) noexcept
+{
+  const auto __v = _CUDA_VSTD::to_underlying(__space);
+  return __v >= 0 && __v < _CUDA_VSTD::to_underlying(address_space::__max);
+}
+
+[[nodiscard]] _CCCL_FORCEINLINE _CCCL_VISIBILITY_HIDDEN _CCCL_DEVICE bool
+is_address_from(address_space __space, const void* __ptr)
+{
+  _CCCL_ASSERT(__ptr != nullptr, "invalid pointer");
+  _CCCL_ASSERT(_CUDA_DEVICE::__cccl_is_valid_address_space(__space), "invalid address space");
+
+  switch (__space)
+  {
+    case address_space::global:
+      return ::__isGlobal(__ptr);
+    case address_space::shared:
+      return ::__isShared(__ptr);
+    case address_space::constant:
+      return ::__isConstant(__ptr);
+    case address_space::local:
+      return ::__isLocal(__ptr);
+    case address_space::grid_constant:
+#  if _CCCL_HAS_GRID_CONSTANT()
+      NV_IF_ELSE_TARGET(NV_PROVIDES_SM_70, (return ::__isGridConstant(__ptr);), (return false;))
+#  else // ^^^ _CCCL_HAS_GRID_CONSTANT() ^^^ / vvv !_CCCL_HAS_GRID_CONSTANT() vvv
+      return false;
+#  endif // ^^^ !_CCCL_HAS_GRID_CONSTANT() ^^^
+    case address_space::cluster_shared:
+      NV_IF_ELSE_TARGET(NV_PROVIDES_SM_90, (return ::__isClusterShared(__ptr);), (return false;))
+    default:
+      return false;
+  }
+}
+
+_LIBCUDACXX_END_NAMESPACE_CUDA_DEVICE
+
+#  include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CCCL_CUDA_COMPILATION()
+
+#endif // _CUDA___MEMORY_ADDRESS_SPACE_H

--- a/libcudacxx/include/cuda/memory
+++ b/libcudacxx/include/cuda/memory
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_MEMORY
+#define _CUDA_MEMORY
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/__memory/address_space.h>
+#include <cuda/std/memory>
+
+#endif // _CUDA_MEMORY

--- a/libcudacxx/include/cuda/std/__cccl/execution_space.h
+++ b/libcudacxx/include/cuda/std/__cccl/execution_space.h
@@ -50,8 +50,10 @@
 
 // Compile with NVCC compiler and only device code, Volta+  GPUs
 #if _CCCL_CUDA_COMPILER(NVCC) && _CCCL_PTX_ARCH() >= 700
-#  define _CCCL_GRID_CONSTANT __grid_constant__
+#  define _CCCL_HAS_GRID_CONSTANT() 1
+#  define _CCCL_GRID_CONSTANT       __grid_constant__
 #else // ^^^ _CCCL_CUDA_COMPILER(NVCC) ^^^ / vvv !_CCCL_CUDA_COMPILER(NVCC) vvv
+#  define _CCCL_HAS_GRID_CONSTANT() 0
 #  define _CCCL_GRID_CONSTANT
 #endif // _CCCL_CUDA_COMPILER(NVCC) && _CCCL_PTX_ARCH() >= 700
 

--- a/libcudacxx/test/libcudacxx/cuda/memory/is_address_from.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory/is_address_from.pass.cpp
@@ -1,0 +1,56 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/memory>
+
+using cuda::device::address_space;
+using cuda::device::is_address_from;
+
+template <address_space exp_space>
+__device__ void test_is_address_from(const void* ptr)
+{
+  assert(is_address_from(address_space::global, ptr) == (exp_space == address_space::global));
+  assert(is_address_from(address_space::shared, ptr) == (exp_space == address_space::shared));
+  assert(is_address_from(address_space::constant, ptr) == (exp_space == address_space::constant));
+  assert(is_address_from(address_space::local, ptr) == (exp_space == address_space::local));
+  assert(is_address_from(address_space::grid_constant, ptr) == (exp_space == address_space::grid_constant));
+  assert(is_address_from(address_space::cluster_shared, ptr) == (exp_space == address_space::cluster_shared));
+}
+
+struct MutableStruct
+{
+  mutable int v;
+};
+
+__device__ int global_var;
+__constant__ int constant_var;
+
+__global__ void test_kernel(const _CCCL_GRID_CONSTANT MutableStruct grid_constant_var)
+{
+  __shared__ int shared_var;
+  int local_var;
+
+  test_is_address_from<address_space::global>(&global_var);
+  test_is_address_from<address_space::shared>(&shared_var);
+  test_is_address_from<address_space::constant>(&constant_var);
+  test_is_address_from<address_space::local>(&local_var);
+
+  // __grid_constant__ address may come from other address spaces, so we test the variable address comes from the
+  // address_space::grid_constant
+  assert(is_address_from(address_space::grid_constant, &grid_constant_var) == _CCCL_HAS_GRID_CONSTANT());
+
+  // todo: test address_space::cluster_shared
+}
+
+int main(int, char**)
+{
+  NV_IF_TARGET(NV_IS_HOST, (test_kernel<<<1, 1>>>(MutableStruct{}); assert(cudaDeviceSynchronize() == cudaSuccess);))
+  return 0;
+}


### PR DESCRIPTION
This PR adds initial support for device address memory spaces and implements `cuda::device::is_address_from(mem_space, ptr)` function that should replace intrinsics like `__isGlobal` or `__isShared`.