### PR TITLE
Fully qualify calls in `cuda::` and `cuda::device::` namespaces

### DIFF
--- a/libcudacxx/include/cuda/__annotated_ptr/access_property.h
+++ b/libcudacxx/include/cuda/__annotated_ptr/access_property.h
@@ -52,27 +52,27 @@ public:
   struct persisting
   {
 #if _CCCL_HAS_CTK()
-    [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr operator cudaAccessProperty() const noexcept
+    [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr operator ::cudaAccessProperty() const noexcept
     {
-      return cudaAccessProperty::cudaAccessPropertyPersisting;
+      return ::cudaAccessProperty::cudaAccessPropertyPersisting;
     }
 #endif // _CCCL_HAS_CTK()
   };
   struct streaming
   {
 #if _CCCL_HAS_CTK()
-    [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr operator cudaAccessProperty() const noexcept
+    [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr operator ::cudaAccessProperty() const noexcept
     {
-      return cudaAccessProperty::cudaAccessPropertyStreaming;
+      return ::cudaAccessProperty::cudaAccessPropertyStreaming;
     }
 #endif // _CCCL_HAS_CTK()
   };
   struct normal
   {
 #if _CCCL_HAS_CTK()
-    [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr operator cudaAccessProperty() const noexcept
+    [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr operator ::cudaAccessProperty() const noexcept
     {
-      return cudaAccessProperty::cudaAccessPropertyNormal;
+      return ::cudaAccessProperty::cudaAccessPropertyNormal;
     }
 #endif // _CCCL_HAS_CTK()
   };

--- a/libcudacxx/include/cuda/__annotated_ptr/annotated_ptr.h
+++ b/libcudacxx/include/cuda/__annotated_ptr/annotated_ptr.h
@@ -75,7 +75,7 @@ public:
     {
       if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
       {
-        NV_IF_TARGET(NV_IS_DEVICE, (_CCCL_ASSERT(__isShared((void*) __p), "__p must be shared");))
+        NV_IF_TARGET(NV_IS_DEVICE, (_CCCL_ASSERT(::__isShared((void*) __p), "__p must be shared");))
       }
     }
     else
@@ -83,7 +83,7 @@ public:
       _CCCL_ASSERT(__p != nullptr, "__p must not be null");
       if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
       {
-        NV_IF_TARGET(NV_IS_DEVICE, (_CCCL_ASSERT(__isGlobal((void*) __p), "__p must be global");))
+        NV_IF_TARGET(NV_IS_DEVICE, (_CCCL_ASSERT(::__isGlobal((void*) __p), "__p must be global");))
       }
     }
   }
@@ -98,7 +98,7 @@ public:
     static_assert(__is_global_access_property_v<_RuntimeProperty>,
                   "This method requires RuntimeProperty=global|normal|streaming|persisting|access_property");
     _CCCL_ASSERT(__p != nullptr, "__p must not be null");
-    NV_IF_TARGET(NV_IS_DEVICE, (_CCCL_ASSERT(__isGlobal((void*) __p), "__p must be global");))
+    NV_IF_TARGET(NV_IS_DEVICE, (_CCCL_ASSERT(::__isGlobal((void*) __p), "__p must be global");))
   }
 
   // cannot be constexpr because of get()

--- a/libcudacxx/include/cuda/__annotated_ptr/apply_access_property.h
+++ b/libcudacxx/include/cuda/__annotated_ptr/apply_access_property.h
@@ -38,7 +38,7 @@ _LIBCUDACXX_HIDE_FROM_ABI void apply_access_property(
     NV_PROVIDES_SM_80,
     (_CCCL_ASSERT(__ptr != nullptr, "null pointer");
      auto __ptr1 = const_cast<void*>(__ptr);
-     if (!__isGlobal(__ptr1))
+     if (!::__isGlobal(__ptr1))
      {
        return;
      }
@@ -63,7 +63,7 @@ _LIBCUDACXX_HIDE_FROM_ABI void apply_access_property(
     NV_PROVIDES_SM_80,
     (_CCCL_ASSERT(__ptr != nullptr, "null pointer");
      auto __ptr1 = const_cast<void*>(__ptr);
-     if (!__isGlobal(__ptr1))
+     if (!::__isGlobal(__ptr1))
      {
        return;
      }

--- a/libcudacxx/include/cuda/__annotated_ptr/associate_access_property.h
+++ b/libcudacxx/include/cuda/__annotated_ptr/associate_access_property.h
@@ -61,13 +61,13 @@ __associate_address_space(void* __ptr, [[maybe_unused]] _Property __prop)
 {
   if constexpr (_CUDA_VSTD::is_same_v<_Property, access_property::shared>)
   {
-    [[maybe_unused]] bool __b = __isShared(__ptr);
+    [[maybe_unused]] bool __b = ::__isShared(__ptr);
     _CCCL_ASSERT(__b, "");
     _CCCL_ASSUME(__b);
   }
   else if constexpr (__is_global_access_property_v<_Property>)
   {
-    [[maybe_unused]] bool __b = __isGlobal(__ptr);
+    [[maybe_unused]] bool __b = ::__isGlobal(__ptr);
     _CCCL_ASSERT(__b, "");
     _CCCL_ASSUME(__b);
   }
@@ -80,7 +80,7 @@ __associate_address_space(void* __ptr, [[maybe_unused]] _Property __prop)
 
 _CCCL_HIDE_FROM_ABI _CCCL_DEVICE void* __associate_raw_descriptor(void* __ptr, [[maybe_unused]] uint64_t __prop)
 {
-  NV_IF_TARGET(NV_PROVIDES_SM_80, (return __nv_associate_access_property(__ptr, __prop);))
+  NV_IF_TARGET(NV_PROVIDES_SM_80, (return ::__nv_associate_access_property(__ptr, __prop);))
   return __ptr;
 }
 
@@ -91,7 +91,7 @@ template <typename _Property>
   if constexpr (!_CUDA_VSTD::is_same_v<_Property, access_property::shared>)
   {
     [[maybe_unused]] auto __raw_prop = static_cast<uint64_t>(access_property{__prop});
-    return __associate_raw_descriptor(__ptr, __raw_prop);
+    return ::cuda::__associate_raw_descriptor(__ptr, __raw_prop);
   }
   return __ptr;
 }

--- a/libcudacxx/include/cuda/__annotated_ptr/createpolicy.h
+++ b/libcudacxx/include/cuda/__annotated_ptr/createpolicy.h
@@ -176,16 +176,16 @@ template <typename T = void>
 [[nodiscard]] _CCCL_CONST _CCCL_HIDE_FROM_ABI _CCCL_DEVICE uint64_t __createpolicy_range(
   __l2_evict_t __primary, __l2_evict_t __secondary, const void* __ptr, uint32_t __primary_size, uint32_t __total_size)
 {
-  _CCCL_ASSERT(__isGlobal(__ptr), "ptr must be global");
+  _CCCL_ASSERT(::__isGlobal(__ptr), "ptr must be global");
   _CCCL_ASSERT(__primary_size > 0, "primary_size  must be greater than zero");
   _CCCL_ASSERT(__primary_size <= __total_size, "primary_size must be less than or equal to total_size");
   _CCCL_ASSERT(__secondary == __l2_evict_t::_L2_Evict_First || __secondary == __l2_evict_t::_L2_Evict_Unchanged,
                "secondary policy must be evict_first or evict_unchanged");
-  [[maybe_unused]] auto __gmem_ptr = __cvta_generic_to_global(__ptr);
+  [[maybe_unused]] auto __gmem_ptr = ::__cvta_generic_to_global(__ptr);
   NV_IF_ELSE_TARGET(
     NV_PROVIDES_SM_80,
     (return ::cuda::__createpolicy_range_ptx(__primary, __secondary, __gmem_ptr, __primary_size, __total_size);),
-    (__createpolicy_is_not_supported_before_SM_80(); return 0;))
+    (::cuda::__createpolicy_is_not_supported_before_SM_80(); return 0;))
 }
 
 template <typename T = void>
@@ -197,7 +197,7 @@ __createpolicy_fraction(__l2_evict_t __primary, __l2_evict_t __secondary, float 
                "secondary policy must be evict_first or evict_unchanged");
   NV_IF_ELSE_TARGET(NV_PROVIDES_SM_80,
                     (return ::cuda::__createpolicy_fraction_ptx(__primary, __secondary, __fraction);),
-                    (__createpolicy_is_not_supported_before_SM_80(); return 0;))
+                    (::cuda::__createpolicy_is_not_supported_before_SM_80(); return 0;))
 }
 
 #endif // _CCCL_HAS_CUDA_COMPILER()

--- a/libcudacxx/include/cuda/__barrier/barrier_arrive_tx.h
+++ b/libcudacxx/include/cuda/__barrier/barrier_arrive_tx.h
@@ -43,7 +43,8 @@ extern "C" _CCCL_DEVICE void __cuda_ptx_barrier_arrive_tx_is_not_supported_befor
   _CUDA_VSTD::ptrdiff_t __arrive_count_update,
   _CUDA_VSTD::ptrdiff_t __transaction_count_update)
 {
-  _CCCL_ASSERT(__isShared(barrier_native_handle(__b)), "Barrier must be located in local shared memory.");
+  _CCCL_ASSERT(::__isShared(_CUDA_DEVICE::barrier_native_handle(__b)),
+               "Barrier must be located in local shared memory.");
   _CCCL_ASSERT(1 <= __arrive_count_update, "Arrival count update must be at least one.");
   _CCCL_ASSERT(__arrive_count_update <= (1 << 20) - 1, "Arrival count update cannot exceed 2^20 - 1.");
   _CCCL_ASSERT(__transaction_count_update >= 0, "Transaction count update must be non-negative.");
@@ -63,7 +64,8 @@ extern "C" _CCCL_DEVICE void __cuda_ptx_barrier_arrive_tx_is_not_supported_befor
     NV_PROVIDES_SM_90,
     (
 
-      auto __native_handle = barrier_native_handle(__b); auto __bh = __cvta_generic_to_shared(__native_handle);
+      auto __native_handle = _CUDA_DEVICE::barrier_native_handle(__b);
+      auto __bh            = ::__cvta_generic_to_shared(__native_handle);
       if (__arrive_count_update == 1) {
         __token = _CUDA_VPTX::mbarrier_arrive_expect_tx(
           _CUDA_VPTX::sem_release,
@@ -84,7 +86,7 @@ extern "C" _CCCL_DEVICE void __cuda_ptx_barrier_arrive_tx_is_not_supported_befor
           __native_handle,
           __arrive_count_update);
       }),
-    (__cuda_ptx_barrier_arrive_tx_is_not_supported_before_SM_90__();));
+    (_CUDA_DEVICE::__cuda_ptx_barrier_arrive_tx_is_not_supported_before_SM_90__();));
   return __token;
 }
 

--- a/libcudacxx/include/cuda/__barrier/barrier_block_scope.h
+++ b/libcudacxx/include/cuda/__barrier/barrier_block_scope.h
@@ -58,8 +58,7 @@ class barrier<thread_scope_block, _CUDA_VSTD::__empty_completion> : public __blo
   using __barrier_base = _CUDA_VSTD::__barrier_base<_CUDA_VSTD::__empty_completion, thread_scope_block>;
   __barrier_base __barrier;
 
-  _CCCL_DEVICE friend inline _CUDA_VSTD::uint64_t*
-  device::_LIBCUDACXX_ABI_NAMESPACE::barrier_native_handle(barrier<thread_scope_block>& b);
+  _CCCL_DEVICE friend inline _CUDA_VSTD::uint64_t* _CUDA_DEVICE::barrier_native_handle(barrier<thread_scope_block>& b);
 
   template <typename _Barrier>
   friend class _CUDA_VSTD::__barrier_poll_tester_phase;
@@ -86,15 +85,15 @@ public:
     NV_DISPATCH_TARGET(
       NV_PROVIDES_SM_90,
       (
-        if (__isShared(&__barrier)) {
+        if (::__isShared(&__barrier)) {
           asm volatile("mbarrier.inval.shared.b64 [%0];" ::"r"(static_cast<_CUDA_VSTD::uint32_t>(
-            __cvta_generic_to_shared(&__barrier)))
+            ::__cvta_generic_to_shared(&__barrier)))
                        : "memory");
-        } else if (__isClusterShared(&__barrier)) { __trap(); }),
+        } else if (::__isClusterShared(&__barrier)) { ::__trap(); }),
       NV_PROVIDES_SM_80,
-      (if (__isShared(&__barrier)) {
+      (if (::__isShared(&__barrier)) {
         asm volatile("mbarrier.inval.shared.b64 [%0];" ::"r"(static_cast<_CUDA_VSTD::uint32_t>(
-          __cvta_generic_to_shared(&__barrier)))
+          ::__cvta_generic_to_shared(&__barrier)))
                      : "memory");
       }))
   }
@@ -105,19 +104,19 @@ public:
     NV_DISPATCH_TARGET(
       NV_PROVIDES_SM_90,
       (
-        if (__isShared(&__b->__barrier)) {
+        if (::__isShared(&__b->__barrier)) {
           asm volatile("mbarrier.init.shared.b64 [%0], %1;" ::"r"(
-                         static_cast<_CUDA_VSTD::uint32_t>(__cvta_generic_to_shared(&__b->__barrier))),
+                         static_cast<_CUDA_VSTD::uint32_t>(::__cvta_generic_to_shared(&__b->__barrier))),
                        "r"(static_cast<_CUDA_VSTD::uint32_t>(__expected))
                        : "memory");
-        } else if (__isClusterShared(&__b->__barrier)) { __trap(); } else {
+        } else if (::__isClusterShared(&__b->__barrier)) { ::__trap(); } else {
           new (&__b->__barrier) __barrier_base(__expected);
         }),
       NV_PROVIDES_SM_80,
       (
-        if (__isShared(&__b->__barrier)) {
+        if (::__isShared(&__b->__barrier)) {
           asm volatile("mbarrier.init.shared.b64 [%0], %1;" ::"r"(
-                         static_cast<_CUDA_VSTD::uint32_t>(__cvta_generic_to_shared(&__b->__barrier))),
+                         static_cast<_CUDA_VSTD::uint32_t>(::__cvta_generic_to_shared(&__b->__barrier))),
                        "r"(static_cast<_CUDA_VSTD::uint32_t>(__expected))
                        : "memory");
         } else { new (&__b->__barrier) __barrier_base(__expected); }),
@@ -132,9 +131,9 @@ public:
     NV_DISPATCH_TARGET(
       NV_PROVIDES_SM_90,
       (
-        if (!__isClusterShared(&__barrier)) { return __barrier.arrive(__update); } else if (!__isShared(&__barrier)) {
-          __trap();
-        }
+        if (!::__isClusterShared(&__barrier)) {
+          return __barrier.arrive(__update);
+        } else if (!::__isShared(&__barrier)) { ::__trap(); }
         // Cannot use cuda::device::barrier_native_handle here, as it is
         // only defined for block-scope barriers. This barrier may be a
         // non-block scoped barrier.
@@ -142,7 +141,7 @@ public:
         __token   = _CUDA_VPTX::mbarrier_arrive(__bh, __update);),
       NV_PROVIDES_SM_80,
       (
-        if (!__isShared(&__barrier)) {
+        if (!::__isShared(&__barrier)) {
           return __barrier.arrive(__update);
         } auto __bh = reinterpret_cast<_CUDA_VSTD::uint64_t*>(&__barrier);
         // Need 2 instructions, can't finish barrier with arrive > 1
@@ -150,22 +149,22 @@ public:
           _CUDA_VPTX::mbarrier_arrive(__bh);),
       NV_PROVIDES_SM_70,
       (
-        if (!__isShared(&__barrier)) { return __barrier.arrive(__update); }
+        if (!::__isShared(&__barrier)) { return __barrier.arrive(__update); }
 
-        unsigned int __mask    = __activemask();
-        unsigned int __activeA = __match_any_sync(__mask, __update);
-        unsigned int __activeB = __match_any_sync(__mask, reinterpret_cast<_CUDA_VSTD::uintptr_t>(&__barrier));
+        unsigned int __mask    = ::__activemask();
+        unsigned int __activeA = ::__match_any_sync(__mask, __update);
+        unsigned int __activeB = ::__match_any_sync(__mask, reinterpret_cast<_CUDA_VSTD::uintptr_t>(&__barrier));
         unsigned int __active  = __activeA & __activeB;
-        int __inc              = __popc(__active) * __update;
+        int __inc              = ::__popc(__active) * __update;
 
         unsigned __laneid;
         asm("mov.u32 %0, %%laneid;" : "=r"(__laneid));
-        int __leader = __ffs(__active) - 1;
+        int __leader = ::__ffs(__active) - 1;
         // All threads in mask synchronize here, establishing cummulativity to the __leader:
-        __syncwarp(__mask);
+        ::__syncwarp(__mask);
         if (__leader == static_cast<int>(__laneid)) {
           __token = __barrier.arrive(__inc);
-        } __token = __shfl_sync(__active, __token, __leader);),
+        } __token = ::__shfl_sync(__active, __token, __leader);),
       NV_IS_HOST,
       (__token = __barrier.arrive(__update);))
     return __token;
@@ -177,12 +176,13 @@ private:
     int32_t __ready = 0;
     NV_DISPATCH_TARGET(
       NV_PROVIDES_SM_80,
-      (asm volatile("{\n\t"
-                    ".reg .pred p;\n\t"
-                    "mbarrier.test_wait.shared.b64 p, [%1], %2;\n\t"
-                    "selp.b32 %0, 1, 0, p;\n\t"
-                    "}" : "=r"(__ready) : "r"(static_cast<_CUDA_VSTD::uint32_t>(__cvta_generic_to_shared(&__barrier))),
-                    "l"(__token) : "memory");))
+      (asm volatile(
+         "{\n\t"
+         ".reg .pred p;\n\t"
+         "mbarrier.test_wait.shared.b64 p, [%1], %2;\n\t"
+         "selp.b32 %0, 1, 0, p;\n\t"
+         "}" : "=r"(__ready) : "r"(static_cast<_CUDA_VSTD::uint32_t>(::__cvta_generic_to_shared(&__barrier))),
+         "l"(__token) : "memory");))
     return __ready;
   }
 
@@ -192,20 +192,20 @@ private:
     NV_DISPATCH_TARGET(
       NV_PROVIDES_SM_90,
       (
-        int32_t __ready = 0; if (!__isClusterShared(&__barrier)) {
+        int32_t __ready = 0; if (!::__isClusterShared(&__barrier)) {
           return _CUDA_VSTD::__call_try_wait(__barrier, _CUDA_VSTD::move(__token));
-        } else if (!__isShared(&__barrier)) {
-          __trap();
+        } else if (!::__isShared(&__barrier)) {
+          ::__trap();
         } asm volatile("{\n\t"
                        ".reg .pred p;\n\t"
                        "mbarrier.try_wait.shared.b64 p, [%1], %2;\n\t"
                        "selp.b32 %0, 1, 0, p;\n\t"
                        "}" : "=r"(__ready) : "r"(
-                         static_cast<_CUDA_VSTD::uint32_t>(__cvta_generic_to_shared(&__barrier))),
+                         static_cast<_CUDA_VSTD::uint32_t>(::__cvta_generic_to_shared(&__barrier))),
                        "l"(__token) : "memory");
         return __ready;),
       NV_PROVIDES_SM_80,
-      (if (!__isShared(&__barrier)) {
+      (if (!::__isShared(&__barrier)) {
         return _CUDA_VSTD::__call_try_wait(__barrier, _CUDA_VSTD::move(__token));
       } return __test_wait_sm_80(__token);),
       NV_ANY_TARGET,
@@ -224,10 +224,10 @@ private:
       NV_PROVIDES_SM_90,
       (
         int32_t __ready = 0;
-        if (!__isClusterShared(&__barrier)) {
+        if (!::__isClusterShared(&__barrier)) {
           return _CUDA_VSTD::__cccl_thread_poll_with_backoff(
             _CUDA_VSTD::__barrier_poll_tester_phase<barrier>(this, _CUDA_VSTD::move(__token)), __nanosec);
-        } else if (!__isShared(&__barrier)) { __trap(); }
+        } else if (!::__isShared(&__barrier)) { ::__trap(); }
 
         _CUDA_VSTD::chrono::high_resolution_clock::time_point const __start =
           _CUDA_VSTD::chrono::high_resolution_clock::now();
@@ -241,7 +241,7 @@ private:
             "selp.b32 %0, 1, 0, p;\n\t"
             "}"
             : "=r"(__ready)
-            : "r"(static_cast<_CUDA_VSTD::uint32_t>(__cvta_generic_to_shared(&__barrier))),
+            : "r"(static_cast<_CUDA_VSTD::uint32_t>(::__cvta_generic_to_shared(&__barrier))),
               "l"(__token),
               "r"(__wait_nsec)
             : "memory");
@@ -251,7 +251,7 @@ private:
       NV_PROVIDES_SM_80,
       (
         bool __ready = 0;
-        if (!__isShared(&__barrier)) {
+        if (!::__isShared(&__barrier)) {
           return _CUDA_VSTD::__cccl_thread_poll_with_backoff(
             _CUDA_VSTD::__barrier_poll_tester_phase<barrier>(this, _CUDA_VSTD::move(__token)), __nanosec);
         }
@@ -277,7 +277,7 @@ private:
                     ".reg .pred %%p;"
                     "mbarrier.test_wait.parity.shared.b64 %%p, [%1], %2;"
                     "selp.u16 %0, 1, 0, %%p;"
-                    "}" : "=h"(__ready) : "r"(static_cast<uint32_t>(__cvta_generic_to_shared(&__barrier))),
+                    "}" : "=h"(__ready) : "r"(static_cast<uint32_t>(::__cvta_generic_to_shared(&__barrier))),
                     "r"(static_cast<uint32_t>(__phase_parity)) : "memory");))
     return __ready;
   }
@@ -287,16 +287,17 @@ private:
     NV_DISPATCH_TARGET(
       NV_PROVIDES_SM_90,
       (
-        if (!__isClusterShared(&__barrier)) {
+        if (!::__isClusterShared(&__barrier)) {
           return _CUDA_VSTD::__call_try_wait_parity(__barrier, __phase_parity);
-        } else if (!__isShared(&__barrier)) { __trap(); } int32_t __ready = 0;
+        } else if (!::__isShared(&__barrier)) { ::__trap(); } int32_t __ready = 0;
 
-        asm volatile("{\n\t"
-                     ".reg .pred p;\n\t"
-                     "mbarrier.try_wait.parity.shared.b64 p, [%1], %2;\n\t"
-                     "selp.b32 %0, 1, 0, p;\n\t"
-                     "}" : "=r"(__ready) : "r"(static_cast<_CUDA_VSTD::uint32_t>(__cvta_generic_to_shared(&__barrier))),
-                     "r"(static_cast<_CUDA_VSTD::uint32_t>(__phase_parity)) :);
+        asm volatile(
+          "{\n\t"
+          ".reg .pred p;\n\t"
+          "mbarrier.try_wait.parity.shared.b64 p, [%1], %2;\n\t"
+          "selp.b32 %0, 1, 0, p;\n\t"
+          "}" : "=r"(__ready) : "r"(static_cast<_CUDA_VSTD::uint32_t>(::__cvta_generic_to_shared(&__barrier))),
+          "r"(static_cast<_CUDA_VSTD::uint32_t>(__phase_parity)) :);
 
         return __ready;),
       NV_PROVIDES_SM_80,
@@ -318,10 +319,10 @@ private:
       NV_PROVIDES_SM_90,
       (
         int32_t __ready = 0;
-        if (!__isClusterShared(&__barrier)) {
+        if (!::__isClusterShared(&__barrier)) {
           return _CUDA_VSTD::__cccl_thread_poll_with_backoff(
             _CUDA_VSTD::__barrier_poll_tester_parity<barrier>(this, __phase_parity), __nanosec);
-        } else if (!__isShared(&__barrier)) { __trap(); }
+        } else if (!::__isShared(&__barrier)) { ::__trap(); }
 
         _CUDA_VSTD::chrono::high_resolution_clock::time_point const __start =
           _CUDA_VSTD::chrono::high_resolution_clock::now();
@@ -335,7 +336,7 @@ private:
             "selp.b32 %0, 1, 0, p;\n\t"
             "}"
             : "=r"(__ready)
-            : "r"(static_cast<_CUDA_VSTD::uint32_t>(__cvta_generic_to_shared(&__barrier))),
+            : "r"(static_cast<_CUDA_VSTD::uint32_t>(::__cvta_generic_to_shared(&__barrier))),
               "r"(static_cast<_CUDA_VSTD::uint32_t>(__phase_parity)),
               "r"(__wait_nsec)
             : "memory");
@@ -387,22 +388,22 @@ public:
     NV_DISPATCH_TARGET(
       NV_PROVIDES_SM_90,
       (
-        if (!__isClusterShared(&__barrier)) { return __barrier.arrive_and_drop(); } else if (!__isShared(&__barrier)) {
-          __trap();
-        }
+        if (!::__isClusterShared(&__barrier)) {
+          return __barrier.arrive_and_drop();
+        } else if (!::__isShared(&__barrier)) { ::__trap(); }
 
         asm volatile("mbarrier.arrive_drop.shared.b64 _, [%0];" ::"r"(
-          static_cast<_CUDA_VSTD::uint32_t>(__cvta_generic_to_shared(&__barrier))) : "memory");),
+          static_cast<_CUDA_VSTD::uint32_t>(::__cvta_generic_to_shared(&__barrier))) : "memory");),
       NV_PROVIDES_SM_80,
       (
         // Fallback to slowpath on device
-        if (!__isShared(&__barrier)) {
+        if (!::__isShared(&__barrier)) {
           __barrier.arrive_and_drop();
           return;
         }
 
         asm volatile("mbarrier.arrive_drop.shared.b64 _, [%0];" ::"r"(
-          static_cast<_CUDA_VSTD::uint32_t>(__cvta_generic_to_shared(&__barrier))) : "memory");),
+          static_cast<_CUDA_VSTD::uint32_t>(::__cvta_generic_to_shared(&__barrier))) : "memory");),
       NV_ANY_TARGET,
       (
         // Fallback to slowpath on device

--- a/libcudacxx/include/cuda/__barrier/barrier_expect_tx.h
+++ b/libcudacxx/include/cuda/__barrier/barrier_expect_tx.h
@@ -40,7 +40,8 @@ extern "C" _CCCL_DEVICE void __cuda_ptx_barrier_expect_tx_is_not_supported_befor
 _CCCL_DEVICE inline void
 barrier_expect_tx(barrier<thread_scope_block>& __b, _CUDA_VSTD::ptrdiff_t __transaction_count_update)
 {
-  _CCCL_ASSERT(__isShared(barrier_native_handle(__b)), "Barrier must be located in local shared memory.");
+  _CCCL_ASSERT(::__isShared(_CUDA_DEVICE::barrier_native_handle(__b)),
+               "Barrier must be located in local shared memory.");
   _CCCL_ASSERT(__transaction_count_update >= 0, "Transaction count update must be non-negative.");
   // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#contents-of-the-mbarrier-object
   _CCCL_ASSERT(__transaction_count_update <= (1 << 20) - 1, "Transaction count update cannot exceed 2^20 - 1.");
@@ -55,10 +56,10 @@ barrier_expect_tx(barrier<thread_scope_block>& __b, _CUDA_VSTD::ptrdiff_t __tran
   // On architectures pre-sm90, arrive_tx is not supported.
   NV_IF_ELSE_TARGET(
     NV_PROVIDES_SM_90,
-    (auto __bh = __cvta_generic_to_shared(barrier_native_handle(__b));
+    (auto __bh = ::__cvta_generic_to_shared(_CUDA_DEVICE::barrier_native_handle(__b));
      asm("mbarrier.expect_tx.relaxed.cta.shared::cta.b64 [%0], %1;" : : "r"(static_cast<_CUDA_VSTD::uint32_t>(__bh)),
          "r"(static_cast<_CUDA_VSTD::uint32_t>(__transaction_count_update)) : "memory");),
-    (__cuda_ptx_barrier_expect_tx_is_not_supported_before_SM_90__();));
+    (_CUDA_DEVICE::__cuda_ptx_barrier_expect_tx_is_not_supported_before_SM_90__();));
 }
 
 _LIBCUDACXX_END_NAMESPACE_CUDA_DEVICE

--- a/libcudacxx/include/cuda/__bit/bit_reverse.h
+++ b/libcudacxx/include/cuda/__bit/bit_reverse.h
@@ -77,19 +77,19 @@ template <typename _Tp>
 #  endif // _CCCL_HAS_INT128()
   if constexpr (sizeof(_Tp) == sizeof(uint64_t))
   {
-    NV_IF_TARGET(NV_IS_DEVICE, (return __brevll(__value);))
+    NV_IF_TARGET(NV_IS_DEVICE, (return ::__brevll(__value);))
   }
   else if constexpr (sizeof(_Tp) == sizeof(uint32_t))
   {
-    NV_IF_TARGET(NV_IS_DEVICE, (return __brev(__value);))
+    NV_IF_TARGET(NV_IS_DEVICE, (return ::__brev(__value);))
   }
   else if constexpr (sizeof(_Tp) == sizeof(uint16_t))
   {
-    NV_IF_TARGET(NV_IS_DEVICE, (return __brev(static_cast<uint32_t>(__value) << 16);))
+    NV_IF_TARGET(NV_IS_DEVICE, (return ::__brev(static_cast<uint32_t>(__value) << 16);))
   }
   else
   {
-    NV_IF_TARGET(NV_IS_DEVICE, (return __brev(static_cast<uint32_t>(__value) << 24);))
+    NV_IF_TARGET(NV_IS_DEVICE, (return ::__brev(static_cast<uint32_t>(__value) << 24);))
   }
   _CCCL_UNREACHABLE();
 }

--- a/libcudacxx/include/cuda/__cmath/ilog.h
+++ b/libcudacxx/include/cuda/__cmath/ilog.h
@@ -153,35 +153,35 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr int ilog10(_Tp __t) noexcept
   auto __log10_approx                 = static_cast<int>(__log2);
   if constexpr (sizeof(_Tp) <= sizeof(uint32_t))
   {
-    _CCCL_ASSERT(__log10_approx < int{_CUDA_VSTD::size(__power_of_10_32bit())}, "out of bounds");
+    _CCCL_ASSERT(__log10_approx < int{_CUDA_VSTD::size(::cuda::__power_of_10_32bit())}, "out of bounds");
     if constexpr (_CUDA_VSTD::is_same_v<_Tp, uint32_t>)
     {
       // don't replace +1 with >= because wraparound behavior is needed here
-      __log10_approx += static_cast<uint32_t>(__t) + 1 > __power_of_10_32bit()[__log10_approx];
+      __log10_approx += static_cast<uint32_t>(__t) + 1 > ::cuda::__power_of_10_32bit()[__log10_approx];
     }
     else
     {
-      __log10_approx += static_cast<uint32_t>(__t) >= __power_of_10_32bit()[__log10_approx];
+      __log10_approx += static_cast<uint32_t>(__t) >= ::cuda::__power_of_10_32bit()[__log10_approx];
     }
   }
   else if constexpr (sizeof(_Tp) == sizeof(uint64_t))
   {
-    _CCCL_ASSERT(__log10_approx < int{_CUDA_VSTD::size(__power_of_10_64bit())}, "out of bounds");
+    _CCCL_ASSERT(__log10_approx < int{_CUDA_VSTD::size(::cuda::__power_of_10_64bit())}, "out of bounds");
     // +1 is not needed here
-    __log10_approx += static_cast<uint64_t>(__t) >= __power_of_10_64bit()[__log10_approx];
+    __log10_approx += static_cast<uint64_t>(__t) >= ::cuda::__power_of_10_64bit()[__log10_approx];
   }
 #if _CCCL_HAS_INT128()
   else
   {
-    _CCCL_ASSERT(__log10_approx < int{_CUDA_VSTD::size(__power_of_10_128bit())}, "out of bounds");
+    _CCCL_ASSERT(__log10_approx < int{_CUDA_VSTD::size(::cuda::__power_of_10_128bit())}, "out of bounds");
     if constexpr (_CUDA_VSTD::is_same_v<_Tp, __uint128_t>)
     {
       // don't replace +1 with >= because wraparound behavior is needed here
-      __log10_approx += static_cast<__uint128_t>(__t) + 1 > __power_of_10_128bit()[__log10_approx];
+      __log10_approx += static_cast<__uint128_t>(__t) + 1 > ::cuda::__power_of_10_128bit()[__log10_approx];
     }
     else
     {
-      __log10_approx += static_cast<__uint128_t>(__t) >= __power_of_10_128bit()[__log10_approx];
+      __log10_approx += static_cast<__uint128_t>(__t) >= ::cuda::__power_of_10_128bit()[__log10_approx];
     }
   }
 #endif // _CCCL_HAS_INT128()

--- a/libcudacxx/include/cuda/__functional/for_each_canceled.h
+++ b/libcudacxx/include/cuda/__functional/for_each_canceled.h
@@ -92,7 +92,7 @@ __for_each_canceled_block_sm100(dim3 __block_idx, bool __is_leader, __UnaryFunct
   // Initialize barrier and kick-start try_cancel pipeline:
   if (__is_leader)
   {
-    auto __leader_mask = __activemask();
+    auto __leader_mask = ::__activemask();
     asm volatile(
       "{\n\t"
       ".reg .pred p;\n\t"
@@ -105,8 +105,8 @@ __for_each_canceled_block_sm100(dim3 __block_idx, bool __is_leader, __UnaryFunct
       "@p mbarrier.arrive.expect_tx.relaxed.cta.shared::cta.b64 _, [%1], 16;\n\t"
       "}"
       :
-      : "r"((int) __cvta_generic_to_shared(&__result)),
-        "r"((int) __cvta_generic_to_shared(&__barrier)),
+      : "r"((int) ::__cvta_generic_to_shared(&__result)),
+        "r"((int) ::__cvta_generic_to_shared(&__barrier)),
         "r"(__leader_mask)
       : "memory");
   }
@@ -124,11 +124,11 @@ __for_each_canceled_block_sm100(dim3 __block_idx, bool __is_leader, __UnaryFunct
         "@!p bra waitLoop;\n\t"
         "}"
         :
-        : "r"((int) __cvta_generic_to_shared(&__barrier)), "r"((unsigned) __phase)
+        : "r"((int) ::__cvta_generic_to_shared(&__barrier)), "r"((unsigned) __phase)
         : "memory");
       __phase = !__phase;
     }
-    __syncthreads(); // All threads of prior thread block have "exited".
+    ::__syncthreads(); // All threads of prior thread block have "exited".
     // Note: this syncthreads provides the .acquire.cta fence preventing
     // the next query operations from being re-ordered above the poll loop.
     {
@@ -163,13 +163,13 @@ __for_each_canceled_block_sm100(dim3 __block_idx, bool __is_leader, __UnaryFunct
 
     // Wait for all threads to read __result before issuing next async op.
     // generic->generic synchronization
-    __syncthreads();
+    ::__syncthreads();
     // TODO: only control-warp requires sync, other warps can arrive
     // TODO: double-buffering results+barrier pairs using phase to avoids this sync
 
     if (__is_leader)
     {
-      auto __leader_mask = __activemask();
+      auto __leader_mask = ::__activemask();
       asm volatile(
         "{\n\t"
         ".reg .pred p;\n\t"
@@ -183,8 +183,8 @@ __for_each_canceled_block_sm100(dim3 __block_idx, bool __is_leader, __UnaryFunct
         "@p mbarrier.arrive.expect_tx.relaxed.cta.shared::cta.b64 _, [%1], 16;\n\t"
         "}"
         :
-        : "r"((int) __cvta_generic_to_shared(&__result)),
-          "r"((int) __cvta_generic_to_shared(&__barrier)),
+        : "r"((int) ::__cvta_generic_to_shared(&__result)),
+          "r"((int) ::__cvta_generic_to_shared(&__barrier)),
           "r"(__leader_mask)
         : "memory");
     }

--- a/libcudacxx/include/cuda/__memcpy_async/cp_async_bulk_shared_global.h
+++ b/libcudacxx/include/cuda/__memcpy_async/cp_async_bulk_shared_global.h
@@ -47,7 +47,7 @@ inline _CCCL_DEVICE void __cp_async_bulk_shared_global(
                       _CUDA_VPTX::cp_async_bulk(
                         _CUDA_VPTX::space_cluster, _CUDA_VPTX::space_global, __dest, __src, __size, __bar_handle);
                     }),
-                    (__cuda_ptx_cp_async_bulk_shared_global_is_not_supported_before_SM_90__();));
+                    (::cuda::__cuda_ptx_cp_async_bulk_shared_global_is_not_supported_before_SM_90__();));
 }
 
 _LIBCUDACXX_END_NAMESPACE_CUDA

--- a/libcudacxx/include/cuda/__memcpy_async/cp_async_shared_global.h
+++ b/libcudacxx/include/cuda/__memcpy_async/cp_async_shared_global.h
@@ -48,10 +48,10 @@ inline _CCCL_DEVICE void __cp_async_shared_global(char* __dest, const char* __sr
   NV_IF_ELSE_TARGET(
     NV_PROVIDES_SM_80,
     (asm volatile("cp.async.ca.shared.global [%0], [%1], %2, %2;" : : "r"(
-                    static_cast<_CUDA_VSTD::uint32_t>(__cvta_generic_to_shared(__dest))),
-                  "l"(static_cast<_CUDA_VSTD::uint64_t>(__cvta_generic_to_global(__src))),
+                    static_cast<_CUDA_VSTD::uint32_t>(::__cvta_generic_to_shared(__dest))),
+                  "l"(static_cast<_CUDA_VSTD::uint64_t>(::__cvta_generic_to_global(__src))),
                   "n"(_Copy_size) : "memory");),
-    (__cuda_ptx_cp_async_shared_global_is_not_supported_before_SM_80__();));
+    (::cuda::__cuda_ptx_cp_async_shared_global_is_not_supported_before_SM_80__();));
 }
 
 template <>
@@ -62,10 +62,10 @@ inline _CCCL_DEVICE void __cp_async_shared_global<16>(char* __dest, const char* 
   NV_IF_ELSE_TARGET(
     NV_PROVIDES_SM_80,
     (asm volatile("cp.async.cg.shared.global [%0], [%1], %2, %2;" : : "r"(
-                    static_cast<_CUDA_VSTD::uint32_t>(__cvta_generic_to_shared(__dest))),
-                  "l"(static_cast<_CUDA_VSTD::uint64_t>(__cvta_generic_to_global(__src))),
+                    static_cast<_CUDA_VSTD::uint32_t>(::__cvta_generic_to_shared(__dest))),
+                  "l"(static_cast<_CUDA_VSTD::uint64_t>(::__cvta_generic_to_global(__src))),
                   "n"(16) : "memory");),
-    (__cuda_ptx_cp_async_shared_global_is_not_supported_before_SM_80__();));
+    (::cuda::__cuda_ptx_cp_async_shared_global_is_not_supported_before_SM_80__();));
 }
 
 template <size_t _Alignment, typename _Group>
@@ -85,7 +85,7 @@ __cp_async_shared_global_mechanism(_Group __g, char* __dest, const char* __src, 
   const int __stride     = __group_size * __copy_size;
   for (int __offset = __group_rank * __copy_size; __offset < static_cast<int>(__size); __offset += __stride)
   {
-    __cp_async_shared_global<__copy_size>(__dest + __offset, __src + __offset);
+    ::cuda::__cp_async_shared_global<__copy_size>(__dest + __offset, __src + __offset);
   }
 }
 

--- a/libcudacxx/include/cuda/__memcpy_async/dispatch_memcpy_async.h
+++ b/libcudacxx/include/cuda/__memcpy_async/dispatch_memcpy_async.h
@@ -57,7 +57,7 @@ template <_CUDA_VSTD::size_t _Align, typename _Group>
   _CUDA_VSTD::uint32_t __allowed_completions,
   _CUDA_VSTD::uint64_t* __bar_handle)
 {
-  __cp_async_fallback_mechanism<_Align>(__group, __dest_char, __src_char, __size);
+  ::cuda::__cp_async_fallback_mechanism<_Align>(__group, __dest_char, __src_char, __size);
   return __completion_mechanism::__sync;
 }
 
@@ -78,9 +78,9 @@ template <_CUDA_VSTD::size_t _Align, typename _Group>
      _CCCL_ASSERT(__can_use_complete_tx == (nullptr != __bar_handle),
                   "Pass non-null bar_handle if and only if can_use_complete_tx.");
      if constexpr (_Align >= 16) {
-       if (__can_use_complete_tx && __isShared(__bar_handle))
+       if (__can_use_complete_tx && ::__isShared(__bar_handle))
        {
-         __cp_async_bulk_shared_global(__group, __dest_char, __src_char, __size, __bar_handle);
+         ::cuda::__cp_async_bulk_shared_global(__group, __dest_char, __src_char, __size, __bar_handle);
          return __completion_mechanism::__mbarrier_complete_tx;
        }
      }
@@ -94,14 +94,14 @@ template <_CUDA_VSTD::size_t _Align, typename _Group>
       const bool __can_use_async_group = __allowed_completions & uint32_t(__completion_mechanism::__async_group);
       if (__can_use_async_group)
       {
-        __cp_async_shared_global_mechanism<_Align>(__group, __dest_char, __src_char, __size);
+        ::cuda::__cp_async_shared_global_mechanism<_Align>(__group, __dest_char, __src_char, __size);
         return __completion_mechanism::__async_group;
       }
     }
      // Fallthrough..
      ));
 
-  __cp_async_fallback_mechanism<_Align>(__group, __dest_char, __src_char, __size);
+  ::cuda::__cp_async_fallback_mechanism<_Align>(__group, __dest_char, __src_char, __size);
   return __completion_mechanism::__sync;
 }
 
@@ -127,11 +127,11 @@ template <_CUDA_VSTD::size_t _Align, typename _Group>
       // 2) make sure none of the code paths can reach each other by "falling through".
       //
       // See nvbug 4074679 and also PR #478.
-      if (__isGlobal(__src_char) && __isShared(__dest_char)) {
-        return __dispatch_memcpy_async_global_to_shared<_Align>(
+      if (::__isGlobal(__src_char) && ::__isShared(__dest_char)) {
+        return ::cuda::__dispatch_memcpy_async_global_to_shared<_Align>(
           __group, __dest_char, __src_char, __size, __allowed_completions, __bar_handle);
       } else {
-        return __dispatch_memcpy_async_any_to_any<_Align>(
+        return ::cuda::__dispatch_memcpy_async_any_to_any<_Align>(
           __group, __dest_char, __src_char, __size, __allowed_completions, __bar_handle);
       }),
     (
@@ -151,7 +151,8 @@ template <_CUDA_VSTD::size_t _Align, typename _Group>
 {
   _CCCL_ASSERT(!(__allowed_completions & uint32_t(__completion_mechanism::__mbarrier_complete_tx)),
                "Cannot allow mbarrier_complete_tx completion mechanism when not passing a barrier. ");
-  return __dispatch_memcpy_async<_Align>(__group, __dest_char, __src_char, __size, __allowed_completions, nullptr);
+  return ::cuda::__dispatch_memcpy_async<_Align>(
+    __group, __dest_char, __src_char, __size, __allowed_completions, nullptr);
 }
 
 _LIBCUDACXX_END_NAMESPACE_CUDA

--- a/libcudacxx/include/cuda/__memcpy_async/is_local_smem_barrier.h
+++ b/libcudacxx/include/cuda/__memcpy_async/is_local_smem_barrier.h
@@ -39,7 +39,7 @@ template <thread_scope _Sco,
                            && _CCCL_TRAIT(_CUDA_VSTD::is_same, _CompF, _CUDA_VSTD::__empty_completion)>
 _LIBCUDACXX_HIDE_FROM_ABI bool __is_local_smem_barrier(barrier<_Sco, _CompF>& __barrier)
 {
-  NV_IF_ELSE_TARGET(NV_IS_DEVICE, (return _Is_mbarrier && __isShared(&__barrier);), (return false;));
+  NV_IF_ELSE_TARGET(NV_IS_DEVICE, (return _Is_mbarrier && ::__isShared(&__barrier);), (return false;));
 }
 
 _LIBCUDACXX_END_NAMESPACE_CUDA

--- a/libcudacxx/include/cuda/__memcpy_async/memcpy_async.h
+++ b/libcudacxx/include/cuda/__memcpy_async/memcpy_async.h
@@ -104,14 +104,14 @@ _LIBCUDACXX_HIDE_FROM_ABI async_contract_fulfillment memcpy_async(
   aligned_size_t<_Alignment> __size,
   barrier<_Sco, _CompF>& __barrier)
 {
-  return __memcpy_async_barrier(__group, __destination, __source, __size, __barrier);
+  return ::cuda::__memcpy_async_barrier(__group, __destination, __source, __size, __barrier);
 }
 
 template <class _Tp, typename _Size, thread_scope _Sco, typename _CompF>
 _LIBCUDACXX_HIDE_FROM_ABI async_contract_fulfillment
 memcpy_async(_Tp* __destination, _Tp const* __source, _Size __size, barrier<_Sco, _CompF>& __barrier)
 {
-  return __memcpy_async_barrier(__single_thread_group{}, __destination, __source, __size, __barrier);
+  return ::cuda::__memcpy_async_barrier(__single_thread_group{}, __destination, __source, __size, __barrier);
 }
 
 template <typename _Group, class _Tp, thread_scope _Sco, typename _CompF>
@@ -122,7 +122,7 @@ _LIBCUDACXX_HIDE_FROM_ABI async_contract_fulfillment memcpy_async(
   _CUDA_VSTD::size_t __size,
   barrier<_Sco, _CompF>& __barrier)
 {
-  return __memcpy_async_barrier(__group, __destination, __source, __size, __barrier);
+  return ::cuda::__memcpy_async_barrier(__group, __destination, __source, __size, __barrier);
 }
 
 template <typename _Group, thread_scope _Sco, typename _CompF>
@@ -133,7 +133,7 @@ _LIBCUDACXX_HIDE_FROM_ABI async_contract_fulfillment memcpy_async(
   _CUDA_VSTD::size_t __size,
   barrier<_Sco, _CompF>& __barrier)
 {
-  return __memcpy_async_barrier(
+  return ::cuda::__memcpy_async_barrier(
     __group, reinterpret_cast<char*>(__destination), reinterpret_cast<char const*>(__source), __size, __barrier);
 }
 
@@ -145,7 +145,7 @@ _LIBCUDACXX_HIDE_FROM_ABI async_contract_fulfillment memcpy_async(
   aligned_size_t<_Alignment> __size,
   barrier<_Sco, _CompF>& __barrier)
 {
-  return __memcpy_async_barrier(
+  return ::cuda::__memcpy_async_barrier(
     __group, reinterpret_cast<char*>(__destination), reinterpret_cast<char const*>(__source), __size, __barrier);
 }
 
@@ -153,7 +153,7 @@ template <typename _Size, thread_scope _Sco, typename _CompF>
 _LIBCUDACXX_HIDE_FROM_ABI async_contract_fulfillment
 memcpy_async(void* __destination, void const* __source, _Size __size, barrier<_Sco, _CompF>& __barrier)
 {
-  return __memcpy_async_barrier(
+  return ::cuda::__memcpy_async_barrier(
     __single_thread_group{},
     reinterpret_cast<char*>(__destination),
     reinterpret_cast<char const*>(__source),

--- a/libcudacxx/include/cuda/__memcpy_async/memcpy_async_barrier.h
+++ b/libcudacxx/include/cuda/__memcpy_async/memcpy_async_barrier.h
@@ -93,7 +93,7 @@ _LIBCUDACXX_HIDE_FROM_ABI async_contract_fulfillment __memcpy_async_barrier(
   // shared memory, supports the mbarrier_complete_tx mechanism in addition to
   // the async group mechanism.
   _CUDA_VSTD::uint32_t __allowed_completions =
-    __is_local_smem_barrier(__barrier)
+    ::cuda::__is_local_smem_barrier(__barrier)
       ? (_CUDA_VSTD::uint32_t(__completion_mechanism::__async_group)
          | _CUDA_VSTD::uint32_t(__completion_mechanism::__mbarrier_complete_tx))
       : _CUDA_VSTD::uint32_t(__completion_mechanism::__async_group);
@@ -110,10 +110,12 @@ _LIBCUDACXX_HIDE_FROM_ABI async_contract_fulfillment __memcpy_async_barrier(
   // 2. Issue actual copy instructions.
   _CUDA_VSTD::uint64_t* __bh = nullptr;
 #if __cccl_ptx_isa >= 800
-  NV_IF_TARGET(NV_PROVIDES_SM_90,
-               (__bh = __is_local_smem_barrier(__barrier) ? __try_get_barrier_handle(__barrier) : nullptr;))
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_90,
+    (__bh = ::cuda::__is_local_smem_barrier(__barrier) ? ::cuda::__try_get_barrier_handle(__barrier) : nullptr;))
 #endif // __cccl_ptx_isa >= 800
-  auto __cm = __dispatch_memcpy_async<__align>(__group, __dest_char, __src_char, __size, __allowed_completions, __bh);
+  auto __cm =
+    ::cuda::__dispatch_memcpy_async<__align>(__group, __dest_char, __src_char, __size, __allowed_completions, __bh);
 
   // 3. Synchronize barrier with copy instructions.
   return __memcpy_completion_impl::__defer(__cm, __group, __size, __barrier);

--- a/libcudacxx/include/cuda/__memcpy_async/memcpy_async_tx.h
+++ b/libcudacxx/include/cuda/__memcpy_async/memcpy_async_tx.h
@@ -57,21 +57,22 @@ _CCCL_DEVICE inline async_contract_fulfillment memcpy_async_tx(
 #    endif
   static_assert(16 <= _Alignment, "mempcy_async_tx expects arguments to be at least 16 byte aligned.");
 
-  _CCCL_ASSERT(__isShared(barrier_native_handle(__b)), "Barrier must be located in local shared memory.");
-  _CCCL_ASSERT(__isShared(__dest), "dest must point to shared memory.");
-  _CCCL_ASSERT(__isGlobal(__src), "src must point to global memory.");
+  _CCCL_ASSERT(::__isShared(_CUDA_DEVICE::barrier_native_handle(__b)),
+               "Barrier must be located in local shared memory.");
+  _CCCL_ASSERT(::__isShared(__dest), "dest must point to shared memory.");
+  _CCCL_ASSERT(::__isGlobal(__src), "src must point to global memory.");
 
   NV_IF_ELSE_TARGET(
     NV_PROVIDES_SM_90,
     (
-      if (__isShared(__dest) && __isGlobal(__src)) {
+      if (::__isShared(__dest) && ::__isGlobal(__src)) {
         _CUDA_VPTX::cp_async_bulk(
           _CUDA_VPTX::space_cluster,
           _CUDA_VPTX::space_global,
           __dest,
           __src,
           static_cast<uint32_t>(__size),
-          barrier_native_handle(__b));
+          _CUDA_DEVICE::barrier_native_handle(__b));
       } else {
         // memcpy_async_tx only supports copying from global to shared
         // or from shared to remote cluster dsmem. To copy to remote
@@ -79,7 +80,7 @@ _CCCL_DEVICE inline async_contract_fulfillment memcpy_async_tx(
         // is not yet implemented. So we trap in this case as well.
         _CCCL_UNREACHABLE();
       }),
-    (__cuda_ptx_memcpy_async_tx_is_not_supported_before_SM_90__();));
+    (_CUDA_DEVICE::__cuda_ptx_memcpy_async_tx_is_not_supported_before_SM_90__();));
 
   return async_contract_fulfillment::async;
 }

--- a/libcudacxx/include/cuda/__memcpy_async/memcpy_completion.h
+++ b/libcudacxx/include/cuda/__memcpy_async/memcpy_completion.h
@@ -61,7 +61,7 @@ struct __memcpy_completion_impl
     // In principle, this is the overload for shared memory barriers. However, a
     // block-scope barrier may also be located in global memory. Therefore, we
     // check if the barrier is a non-smem barrier and handle that separately.
-    if (!__is_local_smem_barrier(__barrier))
+    if (!::cuda::__is_local_smem_barrier(__barrier))
     {
       return __defer_non_smem_barrier(__cm, __group, __size, __barrier);
     }
@@ -76,10 +76,10 @@ struct __memcpy_completion_impl
             // Non-Blocking: unbalance barrier by 1, barrier will be
             // rebalanced when all thread-local cp.async instructions
             // have completed writing to shared memory.
-            _CUDA_VSTD::uint64_t* __bh = __try_get_barrier_handle(__barrier);
+            _CUDA_VSTD::uint64_t* __bh = ::cuda::__try_get_barrier_handle(__barrier);
 
             asm volatile("cp.async.mbarrier.arrive.shared.b64 [%0];" ::"r"(
-              static_cast<_CUDA_VSTD::uint32_t>(__cvta_generic_to_shared(__bh))) : "memory");));
+              static_cast<_CUDA_VSTD::uint32_t>(::__cvta_generic_to_shared(__bh))) : "memory");));
         return async_contract_fulfillment::async;
       case __completion_mechanism::__async_bulk_group:
         // This completion mechanism should not be used with a shared
@@ -92,7 +92,7 @@ struct __memcpy_completion_impl
         NV_IF_TARGET(NV_PROVIDES_SM_90,
                      (
                        // Only perform the expect_tx operation with the leader thread
-                       if (__group.thread_rank() == 0) { ::cuda::device::barrier_expect_tx(__barrier, __size); }));
+                       if (__group.thread_rank() == 0) { _CUDA_DEVICE::barrier_expect_tx(__barrier, __size); }));
 #endif // __cccl_ptx_isa >= 800
         return async_contract_fulfillment::async;
       case __completion_mechanism::__sync:

--- a/libcudacxx/include/cuda/__memcpy_async/try_get_barrier_handle.h
+++ b/libcudacxx/include/cuda/__memcpy_async/try_get_barrier_handle.h
@@ -48,7 +48,7 @@ __try_get_barrier_handle<::cuda::thread_scope_block, _CUDA_VSTD::__empty_complet
   [[maybe_unused]] barrier<thread_scope_block>& __barrier)
 {
   NV_DISPATCH_TARGET(
-    NV_IS_DEVICE, (return ::cuda::device::barrier_native_handle(__barrier);), NV_ANY_TARGET, (return nullptr;));
+    NV_IS_DEVICE, (return _CUDA_DEVICE::barrier_native_handle(__barrier);), NV_ANY_TARGET, (return nullptr;));
   _CCCL_UNREACHABLE();
 }
 

--- a/libcudacxx/include/cuda/__ptx/instructions/shfl_sync.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/shfl_sync.h
@@ -89,9 +89,9 @@ _CCCL_DEVICE static inline void __shfl_sync_checks(
   }
   _CCCL_ASSERT((__clamp_segmask | 0b1111100011111) == 0b1111100011111,
                "clamp value + segmentation mask must use the bit positions [0:4] and [8:12]");
-  _CCCL_ASSERT((__lane_mask & __activemask()) == __lane_mask, "lane mask must be a subset of the active mask");
+  _CCCL_ASSERT((__lane_mask & ::__activemask()) == __lane_mask, "lane mask must be a subset of the active mask");
   NV_IF_TARGET(NV_PROVIDES_SM_70,
-               ([[maybe_unused]] int __pred; _CCCL_ASSERT(__match_all_sync(__activemask(), __lane_mask, &__pred),
+               ([[maybe_unused]] int __pred; _CCCL_ASSERT(::__match_all_sync(::__activemask(), __lane_mask, &__pred),
                                                           "all active lanes must have the same lane mask");))
   _CCCL_ASSERT(_CUDA_VPTX::__shfl_sync_dst_lane(__shfl_mode, __lane_idx_offset, __clamp_segmask) & __lane_mask,
                "the destination lane must be a member of the lane mask");
@@ -105,7 +105,7 @@ template <typename _Tp>
   _CUDA_VSTD::uint32_t __clamp_segmask,
   _CUDA_VSTD::uint32_t __lane_mask) noexcept
 {
-  __shfl_sync_checks(__dot_shfl_mode::__idx, __data, __lane_idx_offset, __clamp_segmask, __lane_mask);
+  _CUDA_VPTX::__shfl_sync_checks(__dot_shfl_mode::__idx, __data, __lane_idx_offset, __clamp_segmask, __lane_mask);
   auto __data1 = _CUDA_VSTD::bit_cast<_CUDA_VSTD::uint32_t>(__data);
   _CUDA_VSTD::int32_t __pred1;
   _CUDA_VSTD::uint32_t __ret;
@@ -128,7 +128,7 @@ template <typename _Tp>
   _CUDA_VSTD::uint32_t __clamp_segmask,
   _CUDA_VSTD::uint32_t __lane_mask) noexcept
 {
-  __shfl_sync_checks(__dot_shfl_mode::__idx, __data, __lane_idx_offset, __clamp_segmask, __lane_mask);
+  _CUDA_VPTX::__shfl_sync_checks(__dot_shfl_mode::__idx, __data, __lane_idx_offset, __clamp_segmask, __lane_mask);
   auto __data1 = _CUDA_VSTD::bit_cast<_CUDA_VSTD::uint32_t>(__data);
   _CUDA_VSTD::uint32_t __ret;
   asm volatile("{                                                      \n\t\t"
@@ -147,7 +147,7 @@ template <typename _Tp>
   _CUDA_VSTD::uint32_t __clamp_segmask,
   _CUDA_VSTD::uint32_t __lane_mask) noexcept
 {
-  __shfl_sync_checks(__dot_shfl_mode::__up, __data, __lane_idx_offset, __clamp_segmask, __lane_mask);
+  _CUDA_VPTX::__shfl_sync_checks(__dot_shfl_mode::__up, __data, __lane_idx_offset, __clamp_segmask, __lane_mask);
   auto __data1 = _CUDA_VSTD::bit_cast<_CUDA_VSTD::uint32_t>(__data);
   _CUDA_VSTD::int32_t __pred1;
   _CUDA_VSTD::uint32_t __ret;
@@ -170,7 +170,7 @@ template <typename _Tp>
   _CUDA_VSTD::uint32_t __clamp_segmask,
   _CUDA_VSTD::uint32_t __lane_mask) noexcept
 {
-  __shfl_sync_checks(__dot_shfl_mode::__up, __data, __lane_idx_offset, __clamp_segmask, __lane_mask);
+  _CUDA_VPTX::__shfl_sync_checks(__dot_shfl_mode::__up, __data, __lane_idx_offset, __clamp_segmask, __lane_mask);
   auto __data1 = _CUDA_VSTD::bit_cast<_CUDA_VSTD::uint32_t>(__data);
   _CUDA_VSTD::uint32_t __ret;
   asm volatile("{                                                      \n\t\t"
@@ -189,7 +189,7 @@ template <typename _Tp>
   _CUDA_VSTD::uint32_t __clamp_segmask,
   _CUDA_VSTD::uint32_t __lane_mask) noexcept
 {
-  __shfl_sync_checks(__dot_shfl_mode::__down, __data, __lane_idx_offset, __clamp_segmask, __lane_mask);
+  _CUDA_VPTX::__shfl_sync_checks(__dot_shfl_mode::__down, __data, __lane_idx_offset, __clamp_segmask, __lane_mask);
   auto __data1 = _CUDA_VSTD::bit_cast<_CUDA_VSTD::uint32_t>(__data);
   _CUDA_VSTD::int32_t __pred1;
   _CUDA_VSTD::uint32_t __ret;
@@ -212,7 +212,7 @@ template <typename _Tp>
   _CUDA_VSTD::uint32_t __clamp_segmask,
   _CUDA_VSTD::uint32_t __lane_mask) noexcept
 {
-  __shfl_sync_checks(__dot_shfl_mode::__down, __data, __lane_idx_offset, __clamp_segmask, __lane_mask);
+  _CUDA_VPTX::__shfl_sync_checks(__dot_shfl_mode::__down, __data, __lane_idx_offset, __clamp_segmask, __lane_mask);
   auto __data1 = _CUDA_VSTD::bit_cast<_CUDA_VSTD::uint32_t>(__data);
   _CUDA_VSTD::uint32_t __ret;
   asm volatile("{                                                      \n\t\t"
@@ -231,7 +231,7 @@ template <typename _Tp>
   _CUDA_VSTD::uint32_t __clamp_segmask,
   _CUDA_VSTD::uint32_t __lane_mask) noexcept
 {
-  __shfl_sync_checks(__dot_shfl_mode::__bfly, __data, __lane_idx_offset, __clamp_segmask, __lane_mask);
+  _CUDA_VPTX::__shfl_sync_checks(__dot_shfl_mode::__bfly, __data, __lane_idx_offset, __clamp_segmask, __lane_mask);
   auto __data1 = _CUDA_VSTD::bit_cast<_CUDA_VSTD::uint32_t>(__data);
   _CUDA_VSTD::int32_t __pred1;
   _CUDA_VSTD::uint32_t __ret;
@@ -254,7 +254,7 @@ template <typename _Tp>
   _CUDA_VSTD::uint32_t __clamp_segmask,
   _CUDA_VSTD::uint32_t __lane_mask) noexcept
 {
-  __shfl_sync_checks(__dot_shfl_mode::__bfly, __data, __lane_idx_offset, __clamp_segmask, __lane_mask);
+  _CUDA_VPTX::__shfl_sync_checks(__dot_shfl_mode::__bfly, __data, __lane_idx_offset, __clamp_segmask, __lane_mask);
   auto __data1 = _CUDA_VSTD::bit_cast<_CUDA_VSTD::uint32_t>(__data);
   _CUDA_VSTD::uint32_t __ret;
   asm volatile( //

--- a/libcudacxx/include/cuda/__ptx/ptx_helper_functions.h
+++ b/libcudacxx/include/cuda/__ptx/ptx_helper_functions.h
@@ -41,7 +41,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_CUDA_PTX
 inline _CCCL_DEVICE _CUDA_VSTD::uint32_t __as_ptr_smem(const void* __ptr)
 {
   // Consider adding debug asserts here.
-  return static_cast<_CUDA_VSTD::uint32_t>(__cvta_generic_to_shared(__ptr));
+  return static_cast<_CUDA_VSTD::uint32_t>(::__cvta_generic_to_shared(__ptr));
 }
 
 inline _CCCL_DEVICE _CUDA_VSTD::uint32_t __as_ptr_dsmem(const void* __ptr)
@@ -61,7 +61,7 @@ inline _CCCL_DEVICE _CUDA_VSTD::uint32_t __as_ptr_remote_dsmem(const void* __ptr
 inline _CCCL_DEVICE _CUDA_VSTD::uint64_t __as_ptr_gmem(const void* __ptr)
 {
   // Consider adding debug asserts here.
-  return static_cast<_CUDA_VSTD::uint64_t>(__cvta_generic_to_global(__ptr));
+  return static_cast<_CUDA_VSTD::uint64_t>(::__cvta_generic_to_global(__ptr));
 }
 
 /*************************************************************
@@ -73,7 +73,7 @@ template <typename _Tp>
 inline _CCCL_DEVICE _Tp* __from_ptr_smem(_CUDA_VSTD::size_t __ptr)
 {
   // Consider adding debug asserts here.
-  return reinterpret_cast<_Tp*>(__cvta_shared_to_generic(__ptr));
+  return reinterpret_cast<_Tp*>(::__cvta_shared_to_generic(__ptr));
 }
 
 template <typename _Tp>
@@ -94,7 +94,7 @@ template <typename _Tp>
 inline _CCCL_DEVICE _Tp* __from_ptr_gmem(_CUDA_VSTD::size_t __ptr)
 {
   // Consider adding debug asserts here.
-  return reinterpret_cast<_Tp*>(__cvta_global_to_generic(__ptr));
+  return reinterpret_cast<_Tp*>(::__cvta_global_to_generic(__ptr));
 }
 
 /*************************************************************

--- a/libcudacxx/include/cuda/__warp/warp_shuffle.h
+++ b/libcudacxx/include/cuda/__warp/warp_shuffle.h
@@ -94,7 +94,7 @@ template <int _Width, typename _Tp, typename _Up = _CUDA_VSTD::remove_cv_t<_Tp>>
 [[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_DEVICE warp_shuffle_result<_Up>
 warp_shuffle_idx(const _Tp& __data, int __src_lane, _CUDA_VSTD::integral_constant<int, _Width> __width)
 {
-  return ::cuda::device::warp_shuffle_idx(__data, __src_lane, 0xFFFFFFFF, __width);
+  return _CUDA_DEVICE::warp_shuffle_idx(__data, __src_lane, 0xFFFFFFFF, __width);
 }
 
 template <int _Width = 32, typename _Tp, typename _Up = _CUDA_VSTD::remove_cv_t<_Tp>>
@@ -107,10 +107,9 @@ template <int _Width = 32, typename _Tp, typename _Up = _CUDA_VSTD::remove_cv_t<
                 "non-void pointers are not allowed to prevent bug-prone code");
   static_assert(_CUDA_VSTD::has_single_bit(uint32_t{_Width}) && _Width >= 1 && _Width <= __warp_size,
                 "_Width must be a power of 2 and less or equal to the warp size");
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_70,
-    ([[maybe_unused]] int __pred1;
-     _CCCL_ASSERT(__match_all_sync(__activemask(), __delta, &__pred1), "all active lanes must have the same delta");))
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
+               ([[maybe_unused]] int __pred1; _CCCL_ASSERT(::__match_all_sync(::__activemask(), __delta, &__pred1),
+                                                           "all active lanes must have the same delta");))
   if constexpr (_Width == 1)
   {
     _CCCL_ASSERT(__delta == 0, "delta must be 0 when Width == 1");
@@ -143,7 +142,7 @@ template <int _Width, typename _Tp, typename _Up = _CUDA_VSTD::remove_cv_t<_Tp>>
 [[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_DEVICE warp_shuffle_result<_Up>
 warp_shuffle_up(const _Tp& __data, int __src_lane, _CUDA_VSTD::integral_constant<int, _Width> __width)
 {
-  return ::cuda::device::warp_shuffle_up(__data, __src_lane, 0xFFFFFFFF, __width);
+  return _CUDA_DEVICE::warp_shuffle_up(__data, __src_lane, 0xFFFFFFFF, __width);
 }
 
 template <int _Width = 32, typename _Tp, typename _Up = _CUDA_VSTD::remove_cv_t<_Tp>>
@@ -156,10 +155,9 @@ template <int _Width = 32, typename _Tp, typename _Up = _CUDA_VSTD::remove_cv_t<
                 "non-void pointers are not allowed to prevent bug-prone code");
   static_assert(_CUDA_VSTD::has_single_bit(uint32_t{_Width}) && _Width >= 1 && _Width <= __warp_size,
                 "_Width must be a power of 2 and less or equal to the warp size");
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_70,
-    ([[maybe_unused]] int __pred1;
-     _CCCL_ASSERT(__match_all_sync(__activemask(), __delta, &__pred1), "all active lanes must have the same delta");))
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
+               ([[maybe_unused]] int __pred1; _CCCL_ASSERT(::__match_all_sync(::__activemask(), __delta, &__pred1),
+                                                           "all active lanes must have the same delta");))
   if constexpr (_Width == 1)
   {
     _CCCL_ASSERT(__delta == 0, "delta must be 0 when Width == 1");
@@ -192,7 +190,7 @@ template <int _Width, typename _Tp, typename _Up = _CUDA_VSTD::remove_cv_t<_Tp>>
 [[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_DEVICE warp_shuffle_result<_Tp>
 warp_shuffle_down(const _Tp& __data, int __src_lane, _CUDA_VSTD::integral_constant<int, _Width> __width)
 {
-  return ::cuda::device::warp_shuffle_down(__data, __src_lane, 0xFFFFFFFF, __width);
+  return _CUDA_DEVICE::warp_shuffle_down(__data, __src_lane, 0xFFFFFFFF, __width);
 }
 
 template <int _Width = 32, typename _Tp, typename _Up = _CUDA_VSTD::remove_cv_t<_Tp>>
@@ -206,7 +204,7 @@ template <int _Width = 32, typename _Tp, typename _Up = _CUDA_VSTD::remove_cv_t<
   static_assert(_CUDA_VSTD::has_single_bit(uint32_t{_Width}) && _Width >= 1 && _Width <= __warp_size,
                 "_Width must be a power of 2 and less or equal to the warp size");
   NV_IF_TARGET(NV_PROVIDES_SM_70,
-               ([[maybe_unused]] int __pred1; _CCCL_ASSERT(__match_all_sync(__activemask(), __xor_mask, &__pred1),
+               ([[maybe_unused]] int __pred1; _CCCL_ASSERT(::__match_all_sync(::__activemask(), __xor_mask, &__pred1),
                                                            "all active lanes must have the same delta");))
   if constexpr (_Width == 1)
   {
@@ -240,7 +238,7 @@ template <int _Width, typename _Tp, typename _Up = _CUDA_VSTD::remove_cv_t<_Tp>>
 [[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_DEVICE warp_shuffle_result<_Up>
 warp_shuffle_xor(const _Tp& __data, int __src_lane, _CUDA_VSTD::integral_constant<int, _Width> __width)
 {
-  return ::cuda::device::warp_shuffle_xor(__data, __src_lane, 0xFFFFFFFF, __width);
+  return _CUDA_DEVICE::warp_shuffle_xor(__data, __src_lane, 0xFFFFFFFF, __width);
 }
 
 _LIBCUDACXX_END_NAMESPACE_CUDA_DEVICE

--- a/libcudacxx/include/cuda/barrier
+++ b/libcudacxx/include/cuda/barrier
@@ -73,8 +73,8 @@ inline _CCCL_DEVICE void cp_async_bulk_global_to_shared(
   void* __dest, const void* __src, _CUDA_VSTD::uint32_t __size, ::cuda::barrier<::cuda::thread_scope_block>& __bar)
 {
   _CCCL_ASSERT(__size % 16 == 0, "Size must be multiple of 16.");
-  _CCCL_ASSERT(__isShared(__dest), "Destination must be shared memory address.");
-  _CCCL_ASSERT(__isGlobal(__src), "Source must be global memory address.");
+  _CCCL_ASSERT(::__isShared(__dest), "Destination must be shared memory address.");
+  _CCCL_ASSERT(::__isGlobal(__src), "Source must be global memory address.");
 
   _CUDA_VPTX::cp_async_bulk(
     _CUDA_VPTX::space_cluster,
@@ -82,15 +82,15 @@ inline _CCCL_DEVICE void cp_async_bulk_global_to_shared(
     __dest,
     __src,
     __size,
-    ::cuda::device::barrier_native_handle(__bar));
+    _CUDA_DEVICE::barrier_native_handle(__bar));
 }
 
 // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#data-movement-and-conversion-instructions-cp-async-bulk
 inline _CCCL_DEVICE void cp_async_bulk_shared_to_global(void* __dest, const void* __src, _CUDA_VSTD::uint32_t __size)
 {
   _CCCL_ASSERT(__size % 16 == 0, "Size must be multiple of 16.");
-  _CCCL_ASSERT(__isGlobal(__dest), "Destination must be global memory address.");
-  _CCCL_ASSERT(__isShared(__src), "Source must be shared memory address.");
+  _CCCL_ASSERT(::__isGlobal(__dest), "Destination must be global memory address.");
+  _CCCL_ASSERT(::__isShared(__src), "Source must be shared memory address.");
 
   _CUDA_VPTX::cp_async_bulk(_CUDA_VPTX::space_global, _CUDA_VPTX::space_shared, __dest, __src, __size);
 }
@@ -107,7 +107,7 @@ inline _CCCL_DEVICE void cp_async_bulk_tensor_1d_global_to_shared(
     __dest,
     __tensor_map,
     __coords,
-    ::cuda::device::barrier_native_handle(__bar));
+    _CUDA_DEVICE::barrier_native_handle(__bar));
 }
 
 // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#data-movement-and-conversion-instructions-cp-async-bulk-tensor
@@ -122,7 +122,7 @@ inline _CCCL_DEVICE void cp_async_bulk_tensor_2d_global_to_shared(
     __dest,
     __tensor_map,
     __coords,
-    ::cuda::device::barrier_native_handle(__bar));
+    _CUDA_DEVICE::barrier_native_handle(__bar));
 }
 
 // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#data-movement-and-conversion-instructions-cp-async-bulk-tensor
@@ -142,7 +142,7 @@ inline _CCCL_DEVICE void cp_async_bulk_tensor_3d_global_to_shared(
     __dest,
     __tensor_map,
     __coords,
-    ::cuda::device::barrier_native_handle(__bar));
+    _CUDA_DEVICE::barrier_native_handle(__bar));
 }
 
 // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#data-movement-and-conversion-instructions-cp-async-bulk-tensor
@@ -163,7 +163,7 @@ inline _CCCL_DEVICE void cp_async_bulk_tensor_4d_global_to_shared(
     __dest,
     __tensor_map,
     __coords,
-    ::cuda::device::barrier_native_handle(__bar));
+    _CUDA_DEVICE::barrier_native_handle(__bar));
 }
 
 // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#data-movement-and-conversion-instructions-cp-async-bulk-tensor
@@ -185,7 +185,7 @@ inline _CCCL_DEVICE void cp_async_bulk_tensor_5d_global_to_shared(
     __dest,
     __tensor_map,
     __coords,
-    ::cuda::device::barrier_native_handle(__bar));
+    _CUDA_DEVICE::barrier_native_handle(__bar));
 }
 
 // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#data-movement-and-conversion-instructions-cp-async-bulk-tensor

--- a/libcudacxx/include/cuda/discard_memory
+++ b/libcudacxx/include/cuda/discard_memory
@@ -37,7 +37,7 @@ discard_memory([[maybe_unused]] volatile void* __ptr, [[maybe_unused]] size_t __
   NV_IF_TARGET(
     NV_PROVIDES_SM_80,
     (_CCCL_ASSERT(__ptr != nullptr, "null pointer passed to discard_memory");
-    if (!__isGlobal((void*) __ptr)) {
+    if (!::__isGlobal((void*) __ptr)) {
       return;
     }
     constexpr size_t __line_size = 128;

--- a/libcudacxx/include/cuda/pipeline
+++ b/libcudacxx/include/cuda/pipeline
@@ -113,10 +113,10 @@ public:
     NV_IF_TARGET(
       NV_IS_DEVICE,
       const uint32_t __match_mask =
-        __match_any_sync(__activemask(), reinterpret_cast<uintptr_t>(__shared_state_get_refcount()));
-      const uint32_t __elected_id = __ffs(__match_mask) - 1;
+        ::__match_any_sync(::__activemask(), reinterpret_cast<uintptr_t>(__shared_state_get_refcount()));
+      const uint32_t __elected_id = ::__ffs(__match_mask) - 1;
       __elected                   = (__pipeline_asm_helper::__lane_id() == __elected_id);
-      __sub_count                 = __popc(__match_mask);
+      __sub_count                 = ::__popc(__match_mask);
       , __elected = true;
       __sub_count = 1;)
     bool __released = false;
@@ -303,10 +303,10 @@ make_pipeline(const _Group& __group, pipeline_shared_state<_Scope, _Stages_count
     NV_IF_TARGET(
       NV_IS_DEVICE,
       const uint32_t __match_mask =
-        __match_any_sync(__activemask(), reinterpret_cast<uintptr_t>(&__shared_state->__refcount));
-      const uint32_t __elected_id = __ffs(__match_mask) - 1;
+        ::__match_any_sync(::__activemask(), reinterpret_cast<uintptr_t>(&__shared_state->__refcount));
+      const uint32_t __elected_id = ::__ffs(__match_mask) - 1;
       __elected                   = (__pipeline_asm_helper::__lane_id() == __elected_id);
-      __add_count                 = __popc(__match_mask);
+      __add_count                 = ::__popc(__match_mask);
       , __elected = true;
       __add_count = 1;)
     if (__elected)
@@ -375,7 +375,7 @@ public:
       if (__head == __tail) { return; }
 
       const uint8_t __prior = __head - __tail - 1;
-      device::__pipeline_consumer_wait(*this, __prior);
+      _CUDA_DEVICE::__pipeline_consumer_wait(*this, __prior);
       ++__tail;)
   }
 
@@ -433,31 +433,31 @@ _CCCL_DEVICE inline void __pipeline_consumer_wait(pipeline<thread_scope_thread>&
   switch (__prior)
   {
     case 0:
-      device::__pipeline_consumer_wait<0>(__pipeline);
+      _CUDA_DEVICE::__pipeline_consumer_wait<0>(__pipeline);
       break;
     case 1:
-      device::__pipeline_consumer_wait<1>(__pipeline);
+      _CUDA_DEVICE::__pipeline_consumer_wait<1>(__pipeline);
       break;
     case 2:
-      device::__pipeline_consumer_wait<2>(__pipeline);
+      _CUDA_DEVICE::__pipeline_consumer_wait<2>(__pipeline);
       break;
     case 3:
-      device::__pipeline_consumer_wait<3>(__pipeline);
+      _CUDA_DEVICE::__pipeline_consumer_wait<3>(__pipeline);
       break;
     case 4:
-      device::__pipeline_consumer_wait<4>(__pipeline);
+      _CUDA_DEVICE::__pipeline_consumer_wait<4>(__pipeline);
       break;
     case 5:
-      device::__pipeline_consumer_wait<5>(__pipeline);
+      _CUDA_DEVICE::__pipeline_consumer_wait<5>(__pipeline);
       break;
     case 6:
-      device::__pipeline_consumer_wait<6>(__pipeline);
+      _CUDA_DEVICE::__pipeline_consumer_wait<6>(__pipeline);
       break;
     case 7:
-      device::__pipeline_consumer_wait<7>(__pipeline);
+      _CUDA_DEVICE::__pipeline_consumer_wait<7>(__pipeline);
       break;
     default:
-      device::__pipeline_consumer_wait<8>(__pipeline);
+      _CUDA_DEVICE::__pipeline_consumer_wait<8>(__pipeline);
       break;
   }
 }
@@ -474,7 +474,7 @@ _LIBCUDACXX_HIDE_FROM_ABI pipeline<thread_scope_thread> make_pipeline()
 template <uint8_t _Prior>
 _LIBCUDACXX_HIDE_FROM_ABI void pipeline_consumer_wait_prior(pipeline<thread_scope_thread>& __pipeline)
 {
-  NV_IF_TARGET(NV_PROVIDES_SM_80, device::__pipeline_consumer_wait<_Prior>(__pipeline);
+  NV_IF_TARGET(NV_PROVIDES_SM_80, _CUDA_DEVICE::__pipeline_consumer_wait<_Prior>(__pipeline);
                __pipeline.__tail = __pipeline.__head - _Prior;)
 }
 
@@ -508,7 +508,7 @@ _LIBCUDACXX_HIDE_FROM_ABI async_contract_fulfillment __memcpy_async_pipeline(
   char const* __src_char = reinterpret_cast<char const*>(__source);
 
   // 2. Issue actual copy instructions.
-  auto __cm = __dispatch_memcpy_async<__align>(__group, __dest_char, __src_char, __size, __allowed_completions);
+  auto __cm = ::cuda::__dispatch_memcpy_async<__align>(__group, __dest_char, __src_char, __size, __allowed_completions);
 
   // 3. No need to synchronize with copy instructions.
   return __memcpy_completion_impl::__defer(__cm, __group, __size, __pipeline);
@@ -518,7 +518,7 @@ template <typename _Group, class _Type, thread_scope _Scope>
 _LIBCUDACXX_HIDE_FROM_ABI async_contract_fulfillment memcpy_async(
   _Group const& __group, _Type* __destination, _Type const* __source, std::size_t __size, pipeline<_Scope>& __pipeline)
 {
-  return __memcpy_async_pipeline(__group, __destination, __source, __size, __pipeline);
+  return ::cuda::__memcpy_async_pipeline(__group, __destination, __source, __size, __pipeline);
 }
 
 template <typename _Group,
@@ -533,21 +533,21 @@ _LIBCUDACXX_HIDE_FROM_ABI async_contract_fulfillment memcpy_async(
   aligned_size_t<_Alignment> __size,
   pipeline<_Scope>& __pipeline)
 {
-  return __memcpy_async_pipeline(__group, __destination, __source, __size, __pipeline);
+  return ::cuda::__memcpy_async_pipeline(__group, __destination, __source, __size, __pipeline);
 }
 
 template <class _Type, typename _Size, thread_scope _Scope>
 _LIBCUDACXX_HIDE_FROM_ABI async_contract_fulfillment
 memcpy_async(_Type* __destination, _Type const* __source, _Size __size, pipeline<_Scope>& __pipeline)
 {
-  return __memcpy_async_pipeline(__single_thread_group{}, __destination, __source, __size, __pipeline);
+  return ::cuda::__memcpy_async_pipeline(__single_thread_group{}, __destination, __source, __size, __pipeline);
 }
 
 template <typename _Group, thread_scope _Scope>
 _LIBCUDACXX_HIDE_FROM_ABI async_contract_fulfillment memcpy_async(
   _Group const& __group, void* __destination, void const* __source, std::size_t __size, pipeline<_Scope>& __pipeline)
 {
-  return __memcpy_async_pipeline(
+  return ::cuda::__memcpy_async_pipeline(
     __group, reinterpret_cast<char*>(__destination), reinterpret_cast<char const*>(__source), __size, __pipeline);
 }
 
@@ -559,7 +559,7 @@ _LIBCUDACXX_HIDE_FROM_ABI async_contract_fulfillment memcpy_async(
   aligned_size_t<_Alignment> __size,
   pipeline<_Scope>& __pipeline)
 {
-  return __memcpy_async_pipeline(
+  return ::cuda::__memcpy_async_pipeline(
     __group, reinterpret_cast<char*>(__destination), reinterpret_cast<char const*>(__source), __size, __pipeline);
 }
 
@@ -567,7 +567,7 @@ template <typename _Size, thread_scope _Scope>
 _LIBCUDACXX_HIDE_FROM_ABI async_contract_fulfillment
 memcpy_async(void* __destination, void const* __source, _Size __size, pipeline<_Scope>& __pipeline)
 {
-  return __memcpy_async_pipeline(
+  return ::cuda::__memcpy_async_pipeline(
     __single_thread_group{},
     reinterpret_cast<char*>(__destination),
     reinterpret_cast<char const*>(__source),


### PR DESCRIPTION
This PR adds missing full qualifications to calls in `cuda::` and `cuda::device::` namespaces