### PR TITLE
Fix define headers on libcucxx according to new path names

### DIFF
--- a/libcudacxx/include/cuda/__memcpy_async/completion_mechanism.h
+++ b/libcudacxx/include/cuda/__memcpy_async/completion_mechanism.h
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _CUDA___BARRIER_COMPLETION_MECHANISM_H
-#define _CUDA___BARRIER_COMPLETION_MECHANISM_H
+#ifndef _CUDA___MEMCPY_ASYNC_COMPLETION_MECHANISM_H
+#define _CUDA___MEMCPY_ASYNC_COMPLETION_MECHANISM_H
 
 #include <cuda/std/detail/__config>
 
@@ -44,4 +44,4 @@ _LIBCUDACXX_END_NAMESPACE_CUDA
 
 #include <cuda/std/__cccl/epilogue.h>
 
-#endif // _CUDA___BARRIER_COMPLETION_MECHANISM_H
+#endif // _CUDA___MEMCPY_ASYNC_COMPLETION_MECHANISM_H

--- a/libcudacxx/include/cuda/__memcpy_async/cp_async_bulk_shared_global.h
+++ b/libcudacxx/include/cuda/__memcpy_async/cp_async_bulk_shared_global.h
@@ -9,8 +9,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _CUDA_PTX__MEMCPY_ASYNC_CP_ASYNC_BULK_SHARED_GLOBAL_H_
-#define _CUDA_PTX__MEMCPY_ASYNC_CP_ASYNC_BULK_SHARED_GLOBAL_H_
+#ifndef _CUDA___MEMCPY_ASYNC_CP_ASYNC_BULK_SHARED_GLOBAL_H_
+#define _CUDA___MEMCPY_ASYNC_CP_ASYNC_BULK_SHARED_GLOBAL_H_
 
 #include <cuda/std/detail/__config>
 
@@ -57,4 +57,4 @@ _LIBCUDACXX_END_NAMESPACE_CUDA
 #  endif // __cccl_ptx_isa >= 800
 #endif // _CCCL_CUDA_COMPILER
 
-#endif // _CUDA_PTX__MEMCPY_ASYNC_CP_ASYNC_BULK_SHARED_GLOBAL_H_
+#endif // _CUDA___MEMCPY_ASYNC_CP_ASYNC_BULK_SHARED_GLOBAL_H_

--- a/libcudacxx/include/cuda/__memcpy_async/cp_async_fallback.h
+++ b/libcudacxx/include/cuda/__memcpy_async/cp_async_fallback.h
@@ -9,8 +9,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _CUDA_PTX__MEMCPY_ASYNC_CP_ASYNC_FALLBACK_H_
-#define _CUDA_PTX__MEMCPY_ASYNC_CP_ASYNC_FALLBACK_H_
+#ifndef _CUDA___MEMCPY_ASYNC_CP_ASYNC_FALLBACK_H_
+#define _CUDA___MEMCPY_ASYNC_CP_ASYNC_FALLBACK_H_
 
 #include <cuda/std/detail/__config>
 
@@ -69,4 +69,4 @@ _LIBCUDACXX_END_NAMESPACE_CUDA
 
 #include <cuda/std/__cccl/epilogue.h>
 
-#endif // _CUDA_PTX__MEMCPY_ASYNC_CP_ASYNC_FALLBACK_H_
+#endif // _CUDA___MEMCPY_ASYNC_CP_ASYNC_FALLBACK_H_

--- a/libcudacxx/include/cuda/__memcpy_async/cp_async_shared_global.h
+++ b/libcudacxx/include/cuda/__memcpy_async/cp_async_shared_global.h
@@ -9,8 +9,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _CUDA_PTX__MEMCPY_ASYNC_CP_ASYNC_SHARED_GLOBAL_H_
-#define _CUDA_PTX__MEMCPY_ASYNC_CP_ASYNC_SHARED_GLOBAL_H_
+#ifndef _CUDA___MEMCPY_ASYNC_CP_ASYNC_SHARED_GLOBAL_H_
+#define _CUDA___MEMCPY_ASYNC_CP_ASYNC_SHARED_GLOBAL_H_
 
 #include <cuda/std/detail/__config>
 
@@ -95,4 +95,4 @@ _LIBCUDACXX_END_NAMESPACE_CUDA
 
 #endif // _CCCL_CUDA_COMPILER
 
-#endif // _CUDA_PTX__MEMCPY_ASYNC_CP_ASYNC_SHARED_GLOBAL_H_
+#endif // _CUDA___MEMCPY_ASYNC_CP_ASYNC_SHARED_GLOBAL_H_

--- a/libcudacxx/include/cuda/__memcpy_async/dispatch_memcpy_async.h
+++ b/libcudacxx/include/cuda/__memcpy_async/dispatch_memcpy_async.h
@@ -9,8 +9,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _CUDA_PTX__MEMCPY_ASYNC_DISPATCH_MEMCPY_ASYNC_H_
-#define _CUDA_PTX__MEMCPY_ASYNC_DISPATCH_MEMCPY_ASYNC_H_
+#ifndef _CUDA___MEMCPY_ASYNC_DISPATCH_MEMCPY_ASYNC_H_
+#define _CUDA___MEMCPY_ASYNC_DISPATCH_MEMCPY_ASYNC_H_
 
 #include <cuda/std/detail/__config>
 
@@ -159,4 +159,4 @@ _LIBCUDACXX_END_NAMESPACE_CUDA
 
 #include <cuda/std/__cccl/epilogue.h>
 
-#endif // _CUDA_PTX__MEMCPY_ASYNC_DISPATCH_MEMCPY_ASYNC_H_
+#endif // _CUDA___MEMCPY_ASYNC_DISPATCH_MEMCPY_ASYNC_H_

--- a/libcudacxx/include/cuda/__memcpy_async/is_local_smem_barrier.h
+++ b/libcudacxx/include/cuda/__memcpy_async/is_local_smem_barrier.h
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _CUDA___BARRIER_IS_LOCAL_SMEM_BARRIER_H
-#define _CUDA___BARRIER_IS_LOCAL_SMEM_BARRIER_H
+#ifndef _CUDA___MEMCPY_ASYNC_IS_LOCAL_SMEM_BARRIER_H
+#define _CUDA___MEMCPY_ASYNC_IS_LOCAL_SMEM_BARRIER_H
 
 #include <cuda/std/detail/__config>
 
@@ -46,4 +46,4 @@ _LIBCUDACXX_END_NAMESPACE_CUDA
 
 #include <cuda/std/__cccl/epilogue.h>
 
-#endif // _CUDA___BARRIER_IS_LOCAL_SMEM_BARRIER_H
+#endif // _CUDA___MEMCPY_ASYNC_IS_LOCAL_SMEM_BARRIER_H

--- a/libcudacxx/include/cuda/__memcpy_async/memcpy_async.h
+++ b/libcudacxx/include/cuda/__memcpy_async/memcpy_async.h
@@ -9,8 +9,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _CUDA_PTX__MEMCPY_ASYNC_MEMCPY_ASYNC_H_
-#define _CUDA_PTX__MEMCPY_ASYNC_MEMCPY_ASYNC_H_
+#ifndef _CUDA___MEMCPY_ASYNC_MEMCPY_ASYNC_H_
+#define _CUDA___MEMCPY_ASYNC_MEMCPY_ASYNC_H_
 
 #include <cuda/std/detail/__config>
 
@@ -167,4 +167,4 @@ _LIBCUDACXX_END_NAMESPACE_CUDA
 
 #endif // _CCCL_CUDA_COMPILER
 
-#endif // _CUDA_PTX__MEMCPY_ASYNC_MEMCPY_ASYNC_H_
+#endif // _CUDA___MEMCPY_ASYNC_MEMCPY_ASYNC_H_

--- a/libcudacxx/include/cuda/__memcpy_async/memcpy_async_barrier.h
+++ b/libcudacxx/include/cuda/__memcpy_async/memcpy_async_barrier.h
@@ -9,8 +9,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _CUDA_PTX__MEMCPY_ASYNC_MEMCPY_ASYNC_BARRIER_H_
-#define _CUDA_PTX__MEMCPY_ASYNC_MEMCPY_ASYNC_BARRIER_H_
+#ifndef _CUDA___MEMCPY_ASYNC_MEMCPY_ASYNC_BARRIER_H_
+#define _CUDA___MEMCPY_ASYNC_MEMCPY_ASYNC_BARRIER_H_
 
 #include <cuda/std/detail/__config>
 
@@ -125,4 +125,4 @@ _LIBCUDACXX_END_NAMESPACE_CUDA
 
 #include <cuda/std/__cccl/epilogue.h>
 
-#endif // _CUDA_PTX__MEMCPY_ASYNC_MEMCPY_ASYNC_BARRIER_H_
+#endif // _CUDA___MEMCPY_ASYNC_MEMCPY_ASYNC_BARRIER_H_

--- a/libcudacxx/include/cuda/__memcpy_async/memcpy_async_tx.h
+++ b/libcudacxx/include/cuda/__memcpy_async/memcpy_async_tx.h
@@ -9,8 +9,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _CUDA_PTX__MEMCPY_ASYNC_MEMCPY_ASYNC_TX_H_
-#define _CUDA_PTX__MEMCPY_ASYNC_MEMCPY_ASYNC_TX_H_
+#ifndef _CUDA___MEMCPY_ASYNC_MEMCPY_ASYNC_TX_H_
+#define _CUDA___MEMCPY_ASYNC_MEMCPY_ASYNC_TX_H_
 
 #include <cuda/std/detail/__config>
 
@@ -92,4 +92,4 @@ _LIBCUDACXX_END_NAMESPACE_CUDA_DEVICE
 #  endif // __cccl_ptx_isa >= 800
 #endif // _CCCL_CUDA_COMPILER
 
-#endif // _CUDA_PTX__MEMCPY_ASYNC_MEMCPY_ASYNC_TX_H_
+#endif // _CUDA___MEMCPY_ASYNC_MEMCPY_ASYNC_TX_H_

--- a/libcudacxx/include/cuda/__memcpy_async/try_get_barrier_handle.h
+++ b/libcudacxx/include/cuda/__memcpy_async/try_get_barrier_handle.h
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _CUDA___BARRIER_TRY_GET_BARRIER_HANDLE_H
-#define _CUDA___BARRIER_TRY_GET_BARRIER_HANDLE_H
+#ifndef _CUDA___MEMCPY_ASYNC_TRY_GET_BARRIER_HANDLE_H
+#define _CUDA___MEMCPY_ASYNC_TRY_GET_BARRIER_HANDLE_H
 
 #include <cuda/std/detail/__config>
 
@@ -56,4 +56,4 @@ _LIBCUDACXX_END_NAMESPACE_CUDA
 
 #include <cuda/std/__cccl/epilogue.h>
 
-#endif // _CUDA___BARRIER_TRY_GET_BARRIER_HANDLE_H
+#endif // _CUDA___MEMCPY_ASYNC_TRY_GET_BARRIER_HANDLE_H


### PR DESCRIPTION
fixes some top `#define`s misnamings in libcucxx. ping @miscco 
