### PR TITLE
Reenable `__APPLE__` for pthread detection.

### DIFF
--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__config
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__config
@@ -130,7 +130,8 @@ extern "C++" {
 
 #  if !defined(_LIBCUDACXX_HAS_THREAD_API_PTHREAD) && !defined(_LIBCUDACXX_HAS_THREAD_API_WIN32) \
     && !defined(_LIBCUDACXX_HAS_THREAD_API_EXTERNAL)
-#    if defined(__linux__) || defined(__GNU__) || (defined(__MINGW32__) && _CCCL_HAS_INCLUDE(<pthread.h>))
+#    if defined(__linux__) || defined(__GNU__) || defined(__APPLE__) \
+      || (defined(__MINGW32__) && _CCCL_HAS_INCLUDE(<pthread.h>))
 #      define _LIBCUDACXX_HAS_THREAD_API_PTHREAD
 #    elif defined(_WIN32)
 #      define _LIBCUDACXX_HAS_THREAD_API_WIN32


### PR DESCRIPTION
We do not suppport macOS officially, but I believe there is no harm in not breaking users relying on our libraries on that platform.

We will not bring back other code that was specific to macOS but that is an easy fix.

See https://github.com/NVIDIA/cccl/pull/4693#issuecomment-2906818181