### PR TITLE
Check for `__cpp_xxx` value, not definition

### DIFF
--- a/cudax/include/cuda/experimental/__execution/completion_signatures.cuh
+++ b/cudax/include/cuda/experimental/__execution/completion_signatures.cuh
@@ -98,7 +98,7 @@ struct __concat_completion_signatures_fn
 
 _CCCL_GLOBAL_CONSTANT __concat_completion_signatures_fn concat_completion_signatures{};
 
-#if defined(__cpp_constexpr_exceptions) // C++26, https://wg21.link/p3068
+#if __cpp_constexpr_exceptions // C++26, https://wg21.link/p3068
 template <class... What, class... Values>
 [[noreturn, nodiscard]] constexpr completion_signatures<> invalid_completion_signature(Values... values);
 #else // ^^^ constexpr exceptions ^^^ / vvv no constexpr exceptions vvv
@@ -317,7 +317,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __dependent_sender_error : dependent_sender
 //   }
 //   else
 
-#if _CCCL_HAS_EXCEPTIONS() && defined(__cpp_constexpr_exceptions) // C++26, https://wg21.link/p3068
+#if _CCCL_HAS_EXCEPTIONS() && __cpp_constexpr_exceptions // C++26, https://wg21.link/p3068
 
 #  define _CUDAX_LET_COMPLETIONS(...)                  \
     if constexpr ([[maybe_unused]] __VA_ARGS__; false) \
@@ -881,7 +881,7 @@ template <bool _PotentiallyThrowing>
   }
 }
 
-#if _CCCL_HAS_EXCEPTIONS() && defined(__cpp_constexpr_exceptions) // C++26, https://wg21.link/p3068
+#if _CCCL_HAS_EXCEPTIONS() && __cpp_constexpr_exceptions // C++26, https://wg21.link/p3068
 // When asked for its completions without an envitonment, a dependent sender
 // will throw an exception of a type derived from `dependent_sender_error`.
 template <class _Sndr>

--- a/cudax/test/execution/common/utility.cuh
+++ b/cudax/test/execution/common/utility.cuh
@@ -19,7 +19,7 @@
 #include "testing.cuh" // IWYU pragma: keep
 
 // Workaround for https://github.com/llvm/llvm-project/issues/113087
-#if defined(__clang__) && defined(__cpp_lib_tuple_like)
+#if defined(__clang__) && __cpp_lib_tuple_like
 #  define C2H_CHECK_TUPLE(...) CHECK((__VA_ARGS__))
 #else
 #  define C2H_CHECK_TUPLE(...) CHECK(__VA_ARGS__)

--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -1317,8 +1317,7 @@
 
 // std::forward_like builtin
 // Leaving out MSVC for now because it is hard for forward-declare std::forward_like.
-#    if (_CCCL_COMPILER(CLANG, >=, 17) || _CCCL_COMPILER(GCC, >=, 15)) && defined(__cpp_lib_forward_like) \
-      && (__cpp_lib_forward_like >= 202217L)
+#    if (_CCCL_COMPILER(CLANG, >=, 17) || _CCCL_COMPILER(GCC, >=, 15)) && (__cpp_lib_forward_like >= 202217L)
 #      define _CCCL_HAS_BUILTIN_STD_FORWARD_LIKE() 1
 #    endif
 #  endif // defined(_GLIBCXX_VERSION) || defined(_LIBCXX_VERSION) || defined(_MSVC_STL_VERSION)

--- a/libcudacxx/include/cuda/std/__cccl/dialect.h
+++ b/libcudacxx/include/cuda/std/__cccl/dialect.h
@@ -87,9 +87,9 @@
 
 // Some compilers turn on pack indexing in pre-C++26 code. We want to use it if it is
 // available.
-#if !defined(__cpp_pack_indexing) || _CCCL_CUDA_COMPILER(NVCC) || _CCCL_COMPILER(CLANG, <, 20)
+#if !__cpp_pack_indexing || _CCCL_CUDA_COMPILER(NVCC) || _CCCL_COMPILER(CLANG, <, 20)
 #  define _CCCL_NO_PACK_INDEXING
-#endif // !defined(__cpp_pack_indexing) || _CCCL_CUDA_COMPILER(NVCC) || _CCCL_COMPILER(CLANG, <, 20)
+#endif // !__cpp_pack_indexing || _CCCL_CUDA_COMPILER(NVCC) || _CCCL_COMPILER(CLANG, <, 20)
 
 #if _CCCL_STD_VER <= 2017 || __cpp_consteval < 201811L
 #  define _CCCL_NO_CONSTEVAL

--- a/libcudacxx/include/cuda/std/__cccl/extended_data_types.h
+++ b/libcudacxx/include/cuda/std/__cccl/extended_data_types.h
@@ -117,11 +117,11 @@
  * char8_t
  **********************************************************************************************************************/
 
-#if _CCCL_STD_VER <= 2017 || !defined(__cpp_char8_t)
+#if _CCCL_STD_VER <= 2017 || !__cpp_char8_t
 #  define _CCCL_HAS_CHAR8_T() 0
 #else
 #  define _CCCL_HAS_CHAR8_T() 1
-#endif // _CCCL_STD_VER <= 2017 || !defined(__cpp_char8_t)
+#endif // _CCCL_STD_VER <= 2017 || !__cpp_char8_t
 
 // We currently do not support any of the STL wchar facilities
 #define _CCCL_HAS_WCHAR_T() 0

--- a/libcudacxx/include/cuda/std/__cccl/rtti.h
+++ b/libcudacxx/include/cuda/std/__cccl/rtti.h
@@ -43,7 +43,7 @@
 #      define _CCCL_NO_RTTI
 #    endif
 #  else
-#    if __GXX_RTTI == 0 && __cpp_rtti == 0
+#    if __GXX_RTTI == 0 && !__cpp_rtti
 #      define _CCCL_NO_RTTI
 #    endif
 #  endif
@@ -63,7 +63,7 @@
 #      define _CCCL_NO_TYPEID
 #    endif
 #  else
-#    if __GXX_RTTI == 0 && __cpp_rtti == 0
+#    if __GXX_RTTI == 0 && !__cpp_rtti
 #      define _CCCL_NO_TYPEID
 #    endif
 #  endif

--- a/libcudacxx/include/cuda/std/__expected/bad_expected_access.h
+++ b/libcudacxx/include/cuda/std/__expected/bad_expected_access.h
@@ -26,7 +26,7 @@
 #include <nv/target>
 
 #if _CCCL_HAS_EXCEPTIONS()
-#  ifdef __cpp_lib_expected
+#  if __cpp_lib_expected
 #    include <expected>
 #  else // ^^^ __cpp_lib_expected ^^^ / vvv !__cpp_lib_expected vvv
 #    include <exception>
@@ -39,7 +39,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 #if _CCCL_HAS_EXCEPTIONS()
 
-#  ifdef __cpp_lib_expected
+#  if __cpp_lib_expected
 
 using ::std::bad_expected_access;
 

--- a/libcudacxx/include/cuda/std/__memory/construct_at.h
+++ b/libcudacxx/include/cuda/std/__memory/construct_at.h
@@ -47,7 +47,7 @@
 #    include <memory>
 #  endif // _CCCL_COMPILER(NVRTC)
 
-#  ifndef __cpp_lib_constexpr_dynamic_alloc
+#  if !__cpp_lib_constexpr_dynamic_alloc
 namespace std
 {
 _CCCL_EXEC_CHECK_DISABLE

--- a/libcudacxx/include/cuda/std/__new/allocate.h
+++ b/libcudacxx/include/cuda/std/__new/allocate.h
@@ -28,7 +28,7 @@
 #  include <new> // for align_val_t
 #endif // _LIBCUDACXX_HAS_ALIGNED_ALLOCATION() !_CCCL_COMPILER(NVRTC)
 
-#if !defined(__cpp_sized_deallocation) || __cpp_sized_deallocation < 201309L
+#if __cpp_sized_deallocation < 201309L
 #  define _LIBCUDACXX_HAS_SIZED_DEALLOCATION() 0
 #else
 #  define _LIBCUDACXX_HAS_SIZED_DEALLOCATION() 1

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__config
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__config
@@ -226,8 +226,8 @@ extern "C++" {
 
 // We can only expose constexpr allocations if the compiler supports it
 // For now disable constexpr allocation support until we can actually use
-#  if 0 && defined(__cpp_constexpr_dynamic_alloc) && defined(__cpp_lib_constexpr_dynamic_alloc) \
-    && _CCCL_STD_VER >= 2020 && !_CCCL_COMPILER(NVRTC)
+#  if 0 && __cpp_constexpr_dynamic_alloc && __cpp_lib_constexpr_dynamic_alloc && _CCCL_STD_VER >= 2020 \
+    && !_CCCL_COMPILER(NVRTC)
 #    define _CCCL_HAS_CONSTEXPR_ALLOCATION
 #    define _CCCL_CONSTEXPR_CXX20_ALLOCATION constexpr
 #  else // ^^^ __cpp_constexpr_dynamic_alloc ^^^ / vvv !__cpp_constexpr_dynamic_alloc vvv

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/optional
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/optional
@@ -214,7 +214,7 @@ template<class T>
 #endif // _LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
 
 #if _CCCL_HAS_EXCEPTIONS()
-#  ifdef __cpp_lib_optional
+#  if __cpp_lib_optional
 #    include <optional>
 #  else // ^^^ __cpp_lib_optional ^^^ / vvv !__cpp_lib_optional vvv
 #    include <exception>
@@ -224,7 +224,7 @@ template<class T>
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD_NOVERSION
 
-#  ifdef __cpp_lib_optional
+#  if __cpp_lib_optional
 
 using ::std::bad_optional_access;
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/variant
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/variant
@@ -267,7 +267,7 @@ C++20
 #endif // _LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
 
 #if _CCCL_HAS_EXCEPTIONS()
-#  ifdef __cpp_lib_variant
+#  if __cpp_lib_variant
 #    include <variant>
 #  else // ^^^ __cpp_lib_variant ^^^ / vvv !__cpp_lib_variant vvv
 #    include <exception>
@@ -277,7 +277,7 @@ C++20
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD_NOVERSION
 
-#  ifdef __cpp_lib_variant
+#  if __cpp_lib_variant
 
 using ::std::bad_variant_access;
 

--- a/libcudacxx/include/cuda/std/version
+++ b/libcudacxx/include/cuda/std/version
@@ -51,7 +51,7 @@
 #define __cccl_lib_math_constants               201907L
 #if defined(_CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY) \
   && defined(_CCCL_BUILTIN_REFERENCE_CONVERTS_FROM_TEMPORARY)
-#  define __cpp_lib_reference_from_temporary 202202L
+#  define __cccl_lib_reference_from_temporary 202202L
 #endif // _CCCL_BUILTIN_REFERENCE_CONSTRUCTS_FROM_TEMPORARY && _CCCL_BUILTIN_REFERENCE_CONVERTS_FROM_TEMPORARY
 #define __cccl_lib_shift                        201806L
 #define __cccl_lib_to_address                   201711L
@@ -60,7 +60,7 @@
 #define __cccl_lib_transparent_operators        201210L
 #define __cccl_lib_transformation_trait_aliases 201304L
 #define __cccl_lib_tuple_element_t              201402L
-// #define __cpp_lib_tuple_like                    202311L // P2819R2 is implemented, but P2165R4 is not yet
+// #define __cccl_lib_tuple_like                    202311L // P2819R2 is implemented, but P2165R4 is not yet
 #define __cccl_lib_type_identity                 201806L
 #define __cccl_lib_type_trait_variable_templates 201510L
 #define __cccl_lib_unreachable                   202202L
@@ -86,7 +86,7 @@
 #define __cccl_lib_null_iterators 201304L
 #define __cccl_lib_optional       202110L
 #ifdef CCCL_ENABLE_OPTIONAL_REF
-#  define __cpp_lib_optional_ref 202602L
+#  define __cccl_lib_optional_ref 202602L
 #endif // CCCL_ENABLE_OPTIONAL_REF
 // # define __cccl_lib_quoted_string_io                     201304L
 #define __cccl_lib_result_of_sfinae            201210L
@@ -179,8 +179,7 @@
 // # define __cccl_lib_constexpr_utility                    201811L
 // # define __cccl_lib_constexpr_vector                     201907L
 // # define __cccl_lib_coroutine                            201902L
-#  if defined(__cpp_impl_destroying_delete) && __cpp_impl_destroying_delete >= 201806L \
-    && defined(__cpp_lib_destroying_delete)
+#  if __cpp_impl_destroying_delete >= 201806L && __cpp_lib_destroying_delete
 #    define __cccl_lib_destroying_delete 201806L
 #  endif
 // # define __cccl_lib_erase_if                             201811L

--- a/libcudacxx/test/libcudacxx/std/concepts/concepts.compare/concept.equalitycomparable/equality_comparable.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/concepts/concepts.compare/concept.equalitycomparable/equality_comparable.compile.pass.cpp
@@ -27,9 +27,9 @@ static_assert(equality_comparable<char const*>, "");
 static_assert(equality_comparable<char volatile*>, "");
 static_assert(equality_comparable<char const volatile*>, "");
 static_assert(equality_comparable<wchar_t&>, "");
-#if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
+#if _CCCL_HAS_CHAR8_T()
 static_assert(equality_comparable<char8_t const&>, "");
-#endif // TEST_STD_VER > 2017 && defined(__cpp_char8_t)
+#endif // _CCCL_HAS_CHAR8_T()
 static_assert(equality_comparable<char16_t volatile&>, "");
 static_assert(equality_comparable<char32_t const volatile&>, "");
 static_assert(equality_comparable<unsigned char&&>, "");

--- a/libcudacxx/test/libcudacxx/std/concepts/concepts.compare/concepts.totallyordered/totally_ordered.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/concepts/concepts.compare/concepts.totallyordered/totally_ordered.pass.cpp
@@ -58,9 +58,9 @@ static_assert(models_totally_ordered<char const*>(), "");
 static_assert(models_totally_ordered<char volatile*>(), "");
 static_assert(models_totally_ordered<char const volatile*>(), "");
 static_assert(models_totally_ordered<wchar_t&>(), "");
-#if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
+#if _CCCL_HAS_CHAR8_T()
 static_assert(models_totally_ordered<char8_t const&>(), "");
-#endif // TEST_STD_VER > 2017 && defined(__cpp_char8_t)
+#endif // _CCCL_HAS_CHAR8_T()
 static_assert(models_totally_ordered<char16_t volatile&>(), "");
 static_assert(models_totally_ordered<char32_t const volatile&>(), "");
 static_assert(models_totally_ordered<unsigned char&&>(), "");

--- a/libcudacxx/test/libcudacxx/std/concepts/concepts.lang/concepts.arithmetic/floating_point.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/concepts/concepts.lang/concepts.arithmetic/floating_point.pass.cpp
@@ -67,9 +67,9 @@ static_assert(!CheckFloatingPointQualifiers<unsigned long long>(), "");
 static_assert(!CheckFloatingPointQualifiers<wchar_t>(), "");
 static_assert(!CheckFloatingPointQualifiers<bool>(), "");
 static_assert(!CheckFloatingPointQualifiers<char>(), "");
-#if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
+#if _CCCL_HAS_CHAR8_T()
 static_assert(!CheckFloatingPointQualifiers<char8_t>(), "");
-#endif // TEST_STD_VER > 2017 && defined(__cpp_char8_t)
+#endif // _CCCL_HAS_CHAR8_T()
 static_assert(!CheckFloatingPointQualifiers<char16_t>(), "");
 static_assert(!CheckFloatingPointQualifiers<char32_t>(), "");
 static_assert(!floating_point<void>, "");

--- a/libcudacxx/test/libcudacxx/std/concepts/concepts.lang/concepts.arithmetic/integral.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/concepts/concepts.lang/concepts.arithmetic/integral.pass.cpp
@@ -70,9 +70,9 @@ static_assert(CheckIntegralQualifiers<__uint128_t>(), "");
 static_assert(CheckIntegralQualifiers<wchar_t>(), "");
 static_assert(CheckIntegralQualifiers<bool>(), "");
 static_assert(CheckIntegralQualifiers<char>(), "");
-#if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
+#if _CCCL_HAS_CHAR8_T()
 static_assert(CheckIntegralQualifiers<char8_t>(), "");
-#endif // TEST_STD_VER > 2017 && defined(__cpp_char8_t)
+#endif // _CCCL_HAS_CHAR8_T()
 static_assert(CheckIntegralQualifiers<char16_t>(), "");
 static_assert(CheckIntegralQualifiers<char32_t>(), "");
 

--- a/libcudacxx/test/libcudacxx/std/concepts/concepts.lang/concepts.arithmetic/signed_integral.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/concepts/concepts.lang/concepts.arithmetic/signed_integral.pass.cpp
@@ -59,9 +59,9 @@ static_assert(CheckSignedIntegralQualifiers<long long>(), "");
 static_assert(CheckSignedIntegralQualifiers<wchar_t>() == cuda::std::is_signed_v<wchar_t>, "");
 static_assert(CheckSignedIntegralQualifiers<bool>() == cuda::std::is_signed_v<bool>, "");
 static_assert(CheckSignedIntegralQualifiers<char>() == cuda::std::is_signed_v<char>, "");
-#if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
+#if _CCCL_HAS_CHAR8_T()
 static_assert(CheckSignedIntegralQualifiers<char8_t>() == cuda::std::is_signed_v<char8_t>, "");
-#endif // TEST_STD_VER > 2017 && defined(__cpp_char8_t)
+#endif // _CCCL_HAS_CHAR8_T()
 static_assert(CheckSignedIntegralQualifiers<char16_t>() == cuda::std::is_signed_v<char16_t>, "");
 static_assert(CheckSignedIntegralQualifiers<char32_t>() == cuda::std::is_signed_v<char32_t>, "");
 

--- a/libcudacxx/test/libcudacxx/std/concepts/concepts.lang/concepts.arithmetic/unsigned_integral.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/concepts/concepts.lang/concepts.arithmetic/unsigned_integral.pass.cpp
@@ -59,9 +59,9 @@ static_assert(CheckUnsignedIntegralQualifiers<unsigned long long>(), "");
 static_assert(CheckUnsignedIntegralQualifiers<wchar_t>() == !cuda::std::is_signed_v<wchar_t>, "");
 static_assert(CheckUnsignedIntegralQualifiers<bool>() == !cuda::std::is_signed_v<bool>, "");
 static_assert(CheckUnsignedIntegralQualifiers<char>() == !cuda::std::is_signed_v<char>, "");
-#if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
+#if _CCCL_HAS_CHAR8_T()
 static_assert(CheckUnsignedIntegralQualifiers<char8_t>() == !cuda::std::is_signed_v<char8_t>, "");
-#endif // TEST_STD_VER > 2017 && defined(__cpp_char8_t)
+#endif // _CCCL_HAS_CHAR8_T()
 static_assert(CheckUnsignedIntegralQualifiers<char16_t>() == !cuda::std::is_signed_v<char16_t>, "");
 static_assert(CheckUnsignedIntegralQualifiers<char32_t>() == !cuda::std::is_signed_v<char32_t>, "");
 

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/const_data_members.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/const_data_members.pass.cpp
@@ -89,9 +89,9 @@ int main(int, char**)
   test_type<signed char>();
   test_type<unsigned char>();
   test_type<wchar_t>();
-#if TEST_STD_VER >= 2020 && defined(__cpp_char8_t)
+#if _CCCL_HAS_CHAR8_T()
   test_type<char8_t>();
-#endif // TEST_STD_VER >= 2020 && defined(__cpp_char8_t)
+#endif // _CCCL_HAS_CHAR8_T()
   test_type<char16_t>();
   test_type<char32_t>();
   test_type<short>();

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/denorm_min.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/denorm_min.pass.cpp
@@ -34,9 +34,9 @@ int main(int, char**)
   test<signed char>(0);
   test<unsigned char>(0);
   test<wchar_t>(0);
-#if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
+#if _CCCL_HAS_CHAR8_T()
   test<char8_t>(0);
-#endif
+#endif // _CCCL_HAS_CHAR8_T()
   test<char16_t>(0);
   test<char32_t>(0);
   test<short>(0);

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/digits.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/digits.pass.cpp
@@ -31,9 +31,9 @@ int main(int, char**)
   test<signed char, 7>();
   test<unsigned char, 8>();
   test<wchar_t, cuda::std::numeric_limits<wchar_t>::is_signed ? sizeof(wchar_t) * 8 - 1 : sizeof(wchar_t) * 8>();
-#if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
+#if _CCCL_HAS_CHAR8_T()
   test<char8_t, 8>();
-#endif
+#endif // _CCCL_HAS_CHAR8_T()
   test<char16_t, 16>();
   test<char32_t, 32>();
   test<short, 15>();

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/digits10.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/digits10.pass.cpp
@@ -50,9 +50,9 @@ int main(int, char**)
   test<signed char>();
   test<unsigned char>();
   test<wchar_t>();
-#if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
+#if _CCCL_HAS_CHAR8_T()
   test<char8_t>();
-#endif
+#endif // _CCCL_HAS_CHAR8_T()
   test<char16_t>();
   test<char32_t>();
   test<short>();

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/epsilon.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/epsilon.pass.cpp
@@ -34,9 +34,9 @@ int main(int, char**)
   test<signed char>(0);
   test<unsigned char>(0);
   test<wchar_t>(0);
-#if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
+#if _CCCL_HAS_CHAR8_T()
   test<char8_t>(0);
-#endif
+#endif // _CCCL_HAS_CHAR8_T()
   test<char16_t>(0);
   test<char32_t>(0);
   test<short>(0);

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/has_denorm.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/has_denorm.pass.cpp
@@ -30,9 +30,9 @@ int main(int, char**)
   test<signed char, cuda::std::denorm_absent>();
   test<unsigned char, cuda::std::denorm_absent>();
   test<wchar_t, cuda::std::denorm_absent>();
-#if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
+#if _CCCL_HAS_CHAR8_T()
   test<char8_t, cuda::std::denorm_absent>();
-#endif
+#endif // _CCCL_HAS_CHAR8_T()
   test<char16_t, cuda::std::denorm_absent>();
   test<char32_t, cuda::std::denorm_absent>();
   test<short, cuda::std::denorm_absent>();

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/has_denorm_loss.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/has_denorm_loss.pass.cpp
@@ -30,9 +30,9 @@ int main(int, char**)
   test<signed char, false>();
   test<unsigned char, false>();
   test<wchar_t, false>();
-#if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
+#if _CCCL_HAS_CHAR8_T()
   test<char8_t, false>();
-#endif
+#endif // _CCCL_HAS_CHAR8_T()
   test<char16_t, false>();
   test<char32_t, false>();
   test<short, false>();

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/has_infinity.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/has_infinity.pass.cpp
@@ -30,9 +30,9 @@ int main(int, char**)
   test<signed char, false>();
   test<unsigned char, false>();
   test<wchar_t, false>();
-#if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
+#if _CCCL_HAS_CHAR8_T()
   test<char8_t, false>();
-#endif
+#endif // _CCCL_HAS_CHAR8_T()
   test<char16_t, false>();
   test<char32_t, false>();
   test<short, false>();

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/has_quiet_NaN.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/has_quiet_NaN.pass.cpp
@@ -30,9 +30,9 @@ int main(int, char**)
   test<signed char, false>();
   test<unsigned char, false>();
   test<wchar_t, false>();
-#if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
+#if _CCCL_HAS_CHAR8_T()
   test<char8_t, false>();
-#endif
+#endif // _CCCL_HAS_CHAR8_T()
   test<char16_t, false>();
   test<char32_t, false>();
   test<short, false>();

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/has_signaling_NaN.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/has_signaling_NaN.pass.cpp
@@ -30,9 +30,9 @@ int main(int, char**)
   test<signed char, false>();
   test<unsigned char, false>();
   test<wchar_t, false>();
-#if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
+#if _CCCL_HAS_CHAR8_T()
   test<char8_t, false>();
-#endif
+#endif // _CCCL_HAS_CHAR8_T()
   test<char16_t, false>();
   test<char32_t, false>();
   test<short, false>();

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/infinity.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/infinity.pass.cpp
@@ -46,9 +46,9 @@ int main(int, char**)
   test<signed char>(0);
   test<unsigned char>(0);
   test<wchar_t>(0);
-#if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
+#if _CCCL_HAS_CHAR8_T()
   test<char8_t>(0);
-#endif
+#endif // _CCCL_HAS_CHAR8_T()
   test<char16_t>(0);
   test<char32_t>(0);
   test<short>(0);

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/is_bounded.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/is_bounded.pass.cpp
@@ -30,9 +30,9 @@ int main(int, char**)
   test<signed char, true>();
   test<unsigned char, true>();
   test<wchar_t, true>();
-#if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
+#if _CCCL_HAS_CHAR8_T()
   test<char8_t, true>();
-#endif
+#endif // _CCCL_HAS_CHAR8_T()
   test<char16_t, true>();
   test<char32_t, true>();
   test<short, true>();

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/is_exact.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/is_exact.pass.cpp
@@ -30,9 +30,9 @@ int main(int, char**)
   test<signed char, true>();
   test<unsigned char, true>();
   test<wchar_t, true>();
-#if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
+#if _CCCL_HAS_CHAR8_T()
   test<char8_t, true>();
-#endif
+#endif // _CCCL_HAS_CHAR8_T()
   test<char16_t, true>();
   test<char32_t, true>();
   test<short, true>();

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/is_iec559.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/is_iec559.pass.cpp
@@ -30,9 +30,9 @@ int main(int, char**)
   test<signed char, false>();
   test<unsigned char, false>();
   test<wchar_t, false>();
-#if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
+#if _CCCL_HAS_CHAR8_T()
   test<char8_t, false>();
-#endif
+#endif // _CCCL_HAS_CHAR8_T()
   test<char16_t, false>();
   test<char32_t, false>();
   test<short, false>();

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/is_integer.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/is_integer.pass.cpp
@@ -30,9 +30,9 @@ int main(int, char**)
   test<signed char, true>();
   test<unsigned char, true>();
   test<wchar_t, true>();
-#if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
+#if _CCCL_HAS_CHAR8_T()
   test<char8_t, true>();
-#endif
+#endif // _CCCL_HAS_CHAR8_T()
   test<char16_t, true>();
   test<char32_t, true>();
   test<short, true>();

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/is_modulo.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/is_modulo.pass.cpp
@@ -30,9 +30,9 @@ int main(int, char**)
   test<signed char, false>();
   test<unsigned char, true>();
 //    test<wchar_t, false>(); // don't know
-#if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
+#if _CCCL_HAS_CHAR8_T()
   test<char8_t, true>();
-#endif
+#endif // _CCCL_HAS_CHAR8_T()
   test<char16_t, true>();
   test<char32_t, true>();
   test<short, false>();

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/is_signed.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/is_signed.pass.cpp
@@ -30,9 +30,9 @@ int main(int, char**)
   test<signed char, true>();
   test<unsigned char, false>();
   test<wchar_t, wchar_t(-1) < wchar_t(0)>();
-#if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
+#if _CCCL_HAS_CHAR8_T()
   test<char8_t, false>();
-#endif
+#endif // _CCCL_HAS_CHAR8_T()
   test<char16_t, false>();
   test<char32_t, false>();
   test<short, true>();

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/lowest.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/lowest.pass.cpp
@@ -43,9 +43,9 @@ int main(int, char**)
 #if !TEST_COMPILER(NVRTC)
   test<wchar_t>(WCHAR_MIN);
 #endif // !TEST_COMPILER(NVRTC)
-#if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
+#if _CCCL_HAS_CHAR8_T()
   test<char8_t>(0);
-#endif
+#endif // _CCCL_HAS_CHAR8_T()
   test<char16_t>(0);
   test<char32_t>(0);
   test<short>(SHRT_MIN);

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/max.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/max.pass.cpp
@@ -42,9 +42,9 @@ int main(int, char**)
   test<char>(CHAR_MAX);
   test<signed char>(SCHAR_MAX);
   test<unsigned char>(UCHAR_MAX);
-#if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
+#if _CCCL_HAS_CHAR8_T()
   test<char8_t>(UCHAR_MAX); // ??
-#endif
+#endif // _CCCL_HAS_CHAR8_T()
   test<char16_t>(USHRT_MAX);
   test<char32_t>(UINT_MAX);
   test<short>(SHRT_MAX);

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/max_digits10.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/max_digits10.pass.cpp
@@ -45,9 +45,9 @@ int main(int, char**)
   test<signed char>();
   test<unsigned char>();
   test<wchar_t>();
-#if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
+#if _CCCL_HAS_CHAR8_T()
   test<char8_t>();
-#endif
+#endif // _CCCL_HAS_CHAR8_T()
   test<char16_t>();
   test<char32_t>();
   test<short>();

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/max_exponent.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/max_exponent.pass.cpp
@@ -38,9 +38,9 @@ int main(int, char**)
   test<signed char>();
   test<unsigned char>();
   test<wchar_t>();
-#if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
+#if _CCCL_HAS_CHAR8_T()
   test<char8_t>();
-#endif
+#endif // _CCCL_HAS_CHAR8_T()
   test<char16_t>();
   test<char32_t>();
   test<short>();

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/max_exponent10.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/max_exponent10.pass.cpp
@@ -38,9 +38,9 @@ int main(int, char**)
   test<signed char>();
   test<unsigned char>();
   test<wchar_t>();
-#if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
+#if _CCCL_HAS_CHAR8_T()
   test<char8_t>();
-#endif
+#endif // _CCCL_HAS_CHAR8_T()
   test<char16_t>();
   test<char32_t>();
   test<short>();

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/min.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/min.pass.cpp
@@ -43,9 +43,9 @@ int main(int, char**)
   test<char>(CHAR_MIN);
   test<signed char>(SCHAR_MIN);
   test<unsigned char>(0);
-#if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
+#if _CCCL_HAS_CHAR8_T()
   test<char8_t>(0);
-#endif
+#endif // _CCCL_HAS_CHAR8_T()
   test<char16_t>(0);
   test<char32_t>(0);
   test<short>(SHRT_MIN);

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/min_exponent.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/min_exponent.pass.cpp
@@ -38,9 +38,9 @@ int main(int, char**)
   test<signed char>();
   test<unsigned char>();
   test<wchar_t>();
-#if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
+#if _CCCL_HAS_CHAR8_T()
   test<char8_t>();
-#endif
+#endif // _CCCL_HAS_CHAR8_T()
   test<char16_t>();
   test<char32_t>();
   test<short>();

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/min_exponent10.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/min_exponent10.pass.cpp
@@ -38,9 +38,9 @@ int main(int, char**)
   test<signed char>();
   test<unsigned char>();
   test<wchar_t>();
-#if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
+#if _CCCL_HAS_CHAR8_T()
   test<char8_t>();
-#endif
+#endif // _CCCL_HAS_CHAR8_T()
   test<char16_t>();
   test<char32_t>();
   test<short>();

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/quiet_NaN.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/quiet_NaN.pass.cpp
@@ -49,9 +49,9 @@ int main(int, char**)
   test<signed char>();
   test<unsigned char>();
   test<wchar_t>();
-#if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
+#if _CCCL_HAS_CHAR8_T()
   test<char8_t>();
-#endif
+#endif // _CCCL_HAS_CHAR8_T()
   test<char16_t>();
   test<char32_t>();
   test<short>();

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/radix.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/radix.pass.cpp
@@ -31,9 +31,9 @@ int main(int, char**)
   test<signed char, 2>();
   test<unsigned char, 2>();
   test<wchar_t, 2>();
-#if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
+#if _CCCL_HAS_CHAR8_T()
   test<char8_t, 2>();
-#endif
+#endif // _CCCL_HAS_CHAR8_T()
   test<char16_t, 2>();
   test<char32_t, 2>();
   test<short, 2>();

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/round_error.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/round_error.pass.cpp
@@ -33,9 +33,9 @@ int main(int, char**)
   test<signed char>(0);
   test<unsigned char>(0);
   test<wchar_t>(0);
-#if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
+#if _CCCL_HAS_CHAR8_T()
   test<char8_t>(0);
-#endif
+#endif // _CCCL_HAS_CHAR8_T()
   test<char16_t>(0);
   test<char32_t>(0);
   test<short>(0);

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/round_style.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/round_style.pass.cpp
@@ -30,9 +30,9 @@ int main(int, char**)
   test<signed char, cuda::std::round_toward_zero>();
   test<unsigned char, cuda::std::round_toward_zero>();
   test<wchar_t, cuda::std::round_toward_zero>();
-#if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
+#if _CCCL_HAS_CHAR8_T()
   test<char8_t, cuda::std::round_toward_zero>();
-#endif
+#endif // _CCCL_HAS_CHAR8_T()
   test<char16_t, cuda::std::round_toward_zero>();
   test<char32_t, cuda::std::round_toward_zero>();
   test<short, cuda::std::round_toward_zero>();

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/signaling_NaN.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/signaling_NaN.pass.cpp
@@ -49,9 +49,9 @@ int main(int, char**)
   test<signed char>();
   test<unsigned char>();
   test<wchar_t>();
-#if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
+#if _CCCL_HAS_CHAR8_T()
   test<char8_t>();
-#endif
+#endif // _CCCL_HAS_CHAR8_T()
   test<char16_t>();
   test<char32_t>();
   test<short>();

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/tinyness_before.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/tinyness_before.pass.cpp
@@ -30,9 +30,9 @@ int main(int, char**)
   test<signed char, false>();
   test<unsigned char, false>();
   test<wchar_t, false>();
-#if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
+#if _CCCL_HAS_CHAR8_T()
   test<char8_t, false>();
-#endif
+#endif // _CCCL_HAS_CHAR8_T()
   test<char16_t, false>();
   test<char32_t, false>();
   test<short, false>();

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/traps.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/traps.pass.cpp
@@ -36,9 +36,9 @@ int main(int, char**)
   test<signed char, integral_types_trap>();
   test<unsigned char, integral_types_trap>();
   test<wchar_t, integral_types_trap>();
-#if TEST_STD_VER > 2017 && defined(__cpp_char8_t)
+#if _CCCL_HAS_CHAR8_T()
   test<char8_t, integral_types_trap>();
-#endif
+#endif // _CCCL_HAS_CHAR8_T()
   test<char16_t, integral_types_trap>();
   test<char32_t, integral_types_trap>();
   test<short, integral_types_trap>();

--- a/libcudacxx/test/support/test_macros.h
+++ b/libcudacxx/test/support/test_macros.h
@@ -87,7 +87,7 @@
 #  endif
 #endif
 
-#if !_CCCL_HAS_FEATURE(cxx_rtti) && !defined(__cpp_rtti) && !defined(__GXX_RTTI)
+#if !_CCCL_HAS_FEATURE(cxx_rtti) && !__cpp_rtti && !defined(__GXX_RTTI)
 #  define TEST_HAS_NO_RTTI
 #endif
 

--- a/thrust/testing/device_ptr.cu
+++ b/thrust/testing/device_ptr.cu
@@ -7,7 +7,7 @@
 
 #include <unittest/unittest.h>
 
-#ifdef __cpp_lib_concepts
+#if __cpp_lib_concepts
 static_assert(std::indirectly_writable<thrust::device_ptr<uint8_t>, uint8_t>);
 #endif // __cpp_lib_concepts
 static_assert(cuda::std::indirectly_writable<thrust::device_ptr<uint8_t>, uint8_t>);

--- a/thrust/testing/zip_function.cu
+++ b/thrust/testing/zip_function.cu
@@ -33,7 +33,7 @@ struct TestZipFunctionCtor
   {
     ASSERT_EQUAL(thrust::zip_function<SumThree>()(thrust::make_tuple(1, 2, 3)), SumThree{}(1, 2, 3));
     ASSERT_EQUAL(thrust::zip_function<SumThree>(SumThree{})(thrust::make_tuple(1, 2, 3)), SumThree{}(1, 2, 3));
-#ifdef __cpp_deduction_guides
+#if __cpp_deduction_guides
     ASSERT_EQUAL(thrust::zip_function(SumThree{})(thrust::make_tuple(1, 2, 3)), SumThree{}(1, 2, 3));
 #endif // __cpp_deduction_guides
   }

--- a/thrust/thrust/mr/new.h
+++ b/thrust/thrust/mr/new.h
@@ -46,7 +46,7 @@ class new_delete_resource_base : public memory_resource<>
 public:
   void* do_allocate(std::size_t bytes, std::size_t alignment = THRUST_MR_DEFAULT_ALIGNMENT) override
   {
-#if defined(__cpp_aligned_new)
+#if __cpp_aligned_new
     return ::operator new(bytes, std::align_val_t(alignment));
 #else
     // allocate memory for bytes, plus potential alignment correction,
@@ -69,8 +69,8 @@ public:
                      [[maybe_unused]] std::size_t bytes,
                      [[maybe_unused]] std::size_t alignment = THRUST_MR_DEFAULT_ALIGNMENT) override
   {
-#if defined(__cpp_aligned_new)
-#  if defined(__cpp_sized_deallocation)
+#if __cpp_aligned_new
+#  if __cpp_sized_deallocation
     ::operator delete(p, bytes, std::align_val_t(alignment));
 #  else
     ::operator delete(p, std::align_val_t(alignment));


### PR DESCRIPTION
If undefined, the symbol will expand to `0` anyway. This PR also replaces some use of `__cpp_char8_t` with `_CCCL_HAS_CHAR8_T()`.