### PR TITLE
Remove -G/-g/-lineinfo from ptx-json tests.

### DIFF
--- a/cub/test/ptx-json/CMakeLists.txt
+++ b/cub/test/ptx-json/CMakeLists.txt
@@ -17,6 +17,10 @@ if(NOT is_20_available)
   return()
 endif()
 
+# Remove -G, -g, and -lineinfo from CUDA_FLAGS, otherwise the location information
+# will throw off the JSON output. This will only apply to targets created in this directory.
+string(REGEX REPLACE "(-G|-g|-lineinfo)" "" CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS}")
+
 include(CheckIncludeFileCXX)
 check_include_file_cxx("format" _CCCL_PTX_JSON_TEST_HAS_FORMAT)
 mark_as_advanced(_CCCL_PTX_JSON_TEST_HAS_FORMAT)


### PR DESCRIPTION
These parse JSON data embedded in the PTX output, and the location information throws off the parsing.

This fixes the compute sanitizer jobs: https://github.com/NVIDIA/cccl/actions/runs/15221321923/job/42818232189#step:4:3116