### PR TITLE
Add vectorized `cub::DeviceTransform` algorithm

### DIFF
--- a/c/parallel/src/transform.cu
+++ b/c/parallel/src/transform.cu
@@ -10,7 +10,7 @@
 #include <cub/detail/choose_offset.cuh>
 #include <cub/detail/launcher/cuda_driver.cuh>
 #include <cub/device/dispatch/dispatch_transform.cuh>
-#include <cub/device/dispatch/tuning/tuning_transform.cuh> // cub::detail::transform::Algorithm
+#include <cub/device/dispatch/tuning/tuning_transform.cuh>
 #include <cub/util_arch.cuh>
 #include <cub/util_temporary_storage.cuh>
 #include <cub/util_type.cuh>
@@ -54,44 +54,71 @@ constexpr auto output_iterator_name = "output_iterator_t";
 
 struct transform_runtime_tuning_policy
 {
+  int min_bif;
   int block_threads;
   int items_per_thread_no_input;
   int min_items_per_thread;
   int max_items_per_thread;
+  int items_per_thread_vectorized;
+  int load_store_word_size;
+
+  int MinBif() const
+  {
+    return min_bif;
+  }
 
   // Note: when we extend transform to support UBLKCP, we may no longer
   // be able to keep this constexpr:
   static constexpr cub::detail::transform::Algorithm GetAlgorithm()
   {
+    // FIXME(bgruber): this needs to incorporate the algorithm selection logic from CUB policy_hub
     return cub::detail::transform::Algorithm::prefetch;
   }
 
-  int BlockThreads()
+  int BlockThreads() const
   {
     return block_threads;
   }
 
-  int ItemsPerThreadNoInput()
+  int ItemsPerThreadNoInput() const
   {
     return items_per_thread_no_input;
   }
 
-  int MinItemsPerThread()
+  int MinItemsPerThread() const
   {
     return min_items_per_thread;
   }
 
-  int MaxItemsPerThread()
+  int MaxItemsPerThread() const
   {
     return max_items_per_thread;
   }
-  static constexpr int min_bif = 1024 * 12;
+
+  int ItemsPerThreadForVectorizedPath() const
+  {
+    return items_per_thread_vectorized;
+  }
+
+  int LoadStoreWordSize() const
+  {
+    return load_store_word_size;
+  }
 };
 
-transform_runtime_tuning_policy get_policy()
+transform_runtime_tuning_policy get_policy(int sm_arch)
 {
-  // return prefetch policy defaults:
-  return {256, 2, 1, 32};
+  constexpr int load_store_word_size = 8; // TODO(bgruber): should be fused with the constant in CUB
+  constexpr int value_type_size = 4; // FIXME(bgruber): this should be derived from the value types of the iterators
+  constexpr int target_bytes_per_thread = 32; // TODO(bgruber): should be fused with the constant in CUB
+  return {
+    .min_bif                     = cub::detail::transform::arch_to_min_bytes_in_flight(sm_arch),
+    .block_threads               = 256,
+    .items_per_thread_no_input   = 2,
+    .min_items_per_thread        = 1,
+    .max_items_per_thread        = 32,
+    .items_per_thread_vectorized = ::cuda::round_up(target_bytes_per_thread, load_store_word_size) / value_type_size,
+    .load_store_word_size        = load_store_word_size};
 }
 
 template <typename StorageT>
@@ -159,9 +186,9 @@ struct dynamic_transform_policy_t
   using max_policy = dynamic_transform_policy_t;
 
   template <typename F>
-  cudaError_t Invoke(int /*device_ptx_version*/, F& op)
+  cudaError_t Invoke(int device_ptx_version, F& op)
   {
-    return op.template Invoke<transform_runtime_tuning_policy>(GetPolicy());
+    return op.template Invoke<transform_runtime_tuning_policy>(GetPolicy(device_ptx_version));
   }
 };
 
@@ -207,7 +234,7 @@ CUresult cccl_device_unary_transform_build(
     const char* name = "test";
 
     const int cc                 = cc_major * 10 + cc_minor;
-    const auto policy            = transform::get_policy();
+    const auto policy            = transform::get_policy(cc * 10 /* convert to ptx version */);
     const auto input_it_value_t  = cccl_type_enum_to_name<input_storage_t>(input_it.value_type.type);
     const auto output_it_value_t = cccl_type_enum_to_name<output_storage_t>(output_it.value_type.type);
     const auto offset_t          = cccl_type_enum_to_name(cccl_type_enum::CCCL_INT64);
@@ -389,7 +416,7 @@ CUresult cccl_device_binary_transform_build(
     const char* name = "test";
 
     const int cc                 = cc_major * 10 + cc_minor;
-    const auto policy            = transform::get_policy();
+    const auto policy            = transform::get_policy(cc * 10 /* convert to ptx version */);
     const auto input1_it_value_t = cccl_type_enum_to_name<input1_storage_t>(input1_it.value_type.type);
     const auto input2_it_value_t = cccl_type_enum_to_name<input2_storage_t>(input2_it.value_type.type);
 

--- a/cub/cub/device/dispatch/dispatch_transform.cuh
+++ b/cub/cub/device/dispatch/dispatch_transform.cuh
@@ -22,6 +22,7 @@
 #include <cub/util_math.cuh>
 #include <cub/util_type.cuh>
 
+#include <thrust/detail/util/align.h>
 #include <thrust/system/cuda/detail/core/triple_chevron_launch.h>
 #include <thrust/type_traits/is_trivially_relocatable.h>
 #include <thrust/type_traits/unwrap_contiguous_iterator.h>
@@ -74,7 +75,7 @@ struct TransformKernelSource<Offset,
     transform_kernel<typename PolicyHub::max_policy,
                      Offset,
                      TransformOp,
-                     RandomAccessIteratorOut,
+                     THRUST_NS_QUALIFIER::try_unwrap_contiguous_iterator_t<RandomAccessIteratorOut>,
                      THRUST_NS_QUALIFIER::try_unwrap_contiguous_iterator_t<RandomAccessIteratorsIn>...>);
 
   CUB_RUNTIME_FUNCTION static constexpr int LoadedBytesPerIteration()
@@ -133,15 +134,17 @@ struct prefetch_config
   int sm_count;
 };
 
-template <requires_stable_address StableAddress,
-          typename Offset,
-          typename RandomAccessIteratorTupleIn,
-          typename RandomAccessIteratorOut,
-          typename TransformOp,
-          typename PolicyHub = policy_hub<StableAddress == requires_stable_address::yes, RandomAccessIteratorTupleIn>,
-          typename KernelSource = detail::transform::
-            TransformKernelSource<Offset, RandomAccessIteratorTupleIn, RandomAccessIteratorOut, TransformOp, PolicyHub>,
-          typename KernelLauncherFactory = CUB_DETAIL_DEFAULT_KERNEL_LAUNCHER_FACTORY>
+template <
+  requires_stable_address StableAddress,
+  typename Offset,
+  typename RandomAccessIteratorTupleIn,
+  typename RandomAccessIteratorOut,
+  typename TransformOp,
+  typename PolicyHub =
+    policy_hub<StableAddress == requires_stable_address::yes, RandomAccessIteratorTupleIn, RandomAccessIteratorOut>,
+  typename KernelSource =
+    TransformKernelSource<Offset, RandomAccessIteratorTupleIn, RandomAccessIteratorOut, TransformOp, PolicyHub>,
+  typename KernelLauncherFactory = CUB_DETAIL_DEFAULT_KERNEL_LAUNCHER_FACTORY>
 struct dispatch_t;
 
 template <requires_stable_address StableAddress,
@@ -269,17 +272,19 @@ struct dispatch_t<StableAddress,
       kernel,
       num_items,
       elem_per_thread,
+      false,
       op,
-      out,
+      THRUST_NS_QUALIFIER::try_unwrap_contiguous_iterator(out),
       make_aligned_base_ptr_kernel_arg(
         THRUST_NS_QUALIFIER::try_unwrap_contiguous_iterator(::cuda::std::get<Is>(in)), alignment)...);
   }
 
   template <typename ActivePolicy, size_t... Is>
   CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t
-  invoke_prefetch_algorithm(::cuda::std::index_sequence<Is...>, ActivePolicy policy)
+  invoke_prefetch_or_vectorized_algorithm(::cuda::std::index_sequence<Is...>, ActivePolicy active_policy)
   {
-    const int block_threads = policy.BlockThreads();
+    auto wrapped_policy     = detail::transform::MakeTransformPolicyWrapper(active_policy);
+    const int block_threads = wrapped_policy.BlockThreads();
 
     auto determine_config = [&]() -> cuda_expected<prefetch_config> {
       int max_occupancy = 0;
@@ -314,28 +319,68 @@ struct dispatch_t<StableAddress,
       return config.error();
     }
 
-    auto loaded_bytes_per_iter = kernel_source.LoadedBytesPerIteration();
-    // choose items per thread to reach minimum bytes in flight
-    const int items_per_thread =
-      loaded_bytes_per_iter == 0
-        ? +policy.ItemsPerThreadNoInput()
-        : ::cuda::ceil_div(policy.min_bif, config->max_occupancy * block_threads * loaded_bytes_per_iter);
+    auto can_vectorize = false;
+    // the policy already handles the compile-time checks if we can vectorize. Do the remaining alignment check here
+#ifdef CCCL_C_EXPERIMENTAL
+    if (Algorithm::vectorized == wrapped_policy.GetAlgorithm())
+#else // CCCL_C_EXPERIMENTAL
+    if constexpr (Algorithm::vectorized == ActivePolicy::algorithm)
+#endif // CCCL_C_EXPERIMENTAL
+    {
+      const int alignment     = wrapped_policy.LoadStoreWordSize();
+      auto is_pointer_aligned = [&](auto it) {
+        if constexpr (THRUST_NS_QUALIFIER::is_contiguous_iterator_v<decltype(it)>)
+        {
+          return THRUST_NS_QUALIFIER::detail::util::is_aligned(
+            THRUST_NS_QUALIFIER::try_unwrap_contiguous_iterator(it), alignment);
+        }
+        else
+        {
+          return true; // fancy iterators are aligned, since the vectorized kernel chooses a different code path
+        }
+      };
+      can_vectorize = (is_pointer_aligned(::cuda::std::get<Is>(in)) && ...) && is_pointer_aligned(out);
+    }
 
-    // but also generate enough blocks for full occupancy to optimize small problem sizes, e.g., 2^16 or 2^20 elements
-    const int items_per_thread_evenly_spread = static_cast<int>((::cuda::std::min)(
-      Offset{items_per_thread}, num_items / (config->sm_count * block_threads * config->max_occupancy)));
+    const int ipt = [&] {
+#ifdef CCCL_C_EXPERIMENTAL
+      if (Algorithm::vectorized == wrapped_policy.GetAlgorithm())
+#else // CCCL_C_EXPERIMENTAL
+      if constexpr (Algorithm::vectorized == ActivePolicy::algorithm)
+#endif // CCCL_C_EXPERIMENTAL
+      {
+        if (can_vectorize)
+        {
+          return wrapped_policy.ItemsPerThreadForVectorizedPath();
+        }
+      }
+      // otherwise, setup the prefetch kernel
 
-    const int items_per_thread_clamped =
-      ::cuda::std::clamp(items_per_thread_evenly_spread, +policy.MinItemsPerThread(), +policy.MaxItemsPerThread());
-    const int tile_size = block_threads * items_per_thread_clamped;
+      auto loaded_bytes_per_iter = kernel_source.LoadedBytesPerIteration();
+      // choose items per thread to reach minimum bytes in flight
+      const int items_per_thread =
+        loaded_bytes_per_iter == 0
+          ? wrapped_policy.ItemsPerThreadNoInput()
+          : ::cuda::ceil_div(wrapped_policy.MinBif(), config->max_occupancy * block_threads * loaded_bytes_per_iter);
+
+      // but also generate enough blocks for full occupancy to optimize small problem sizes, e.g., 2^16 or 2^20
+      // elements
+      const int items_per_thread_evenly_spread = static_cast<int>((::cuda::std::min)(
+        Offset{items_per_thread}, num_items / (config->sm_count * block_threads * config->max_occupancy)));
+      const int items_per_thread_clamped       = ::cuda::std::clamp(
+        items_per_thread_evenly_spread, +wrapped_policy.MinItemsPerThread(), +wrapped_policy.MaxItemsPerThread());
+      return items_per_thread_clamped;
+    }();
+    const int tile_size = block_threads * ipt;
     const auto grid_dim = static_cast<unsigned int>(::cuda::ceil_div(num_items, Offset{tile_size}));
     return CubDebug(
       launcher_factory(grid_dim, block_threads, 0, stream)
         .doit(kernel_source.TransformKernel(),
               num_items,
-              items_per_thread_clamped,
+              ipt,
+              can_vectorize,
               op,
-              out,
+              THRUST_NS_QUALIFIER::try_unwrap_contiguous_iterator(out),
               kernel_source.MakeIteratorKernelArg(
                 THRUST_NS_QUALIFIER::try_unwrap_contiguous_iterator(::cuda::std::get<Is>(in)))...));
   }
@@ -361,7 +406,7 @@ struct dispatch_t<StableAddress,
     }
     else
     {
-      return invoke_prefetch_algorithm(seq, wrapped_policy);
+      return invoke_prefetch_or_vectorized_algorithm(seq, active_policy);
     }
   }
 

--- a/cub/cub/device/dispatch/kernels/transform.cuh
+++ b/cub/cub/device/dispatch/kernels/transform.cuh
@@ -474,6 +474,7 @@ _CCCL_DEVICE void transform_kernel_impl(
   ::cuda::std::integral_constant<Algorithm, Algorithm::memcpy_async>,
   Offset num_items,
   int num_elem_per_thread,
+  bool /*can_vectorize*/,
   F f,
   RandomAccessIteratorOut out,
   aligned_base_ptr<InTs>... aligned_ptrs)

--- a/cub/test/catch2_test_device_transform.cu
+++ b/cub/test/catch2_test_device_transform.cu
@@ -5,15 +5,16 @@
 
 #include <cub/device/device_for.cuh>
 #include <cub/device/device_transform.cuh>
+#include <cub/iterator/cache_modified_output_iterator.cuh>
 
 #include <thrust/iterator/constant_iterator.h>
 #include <thrust/iterator/counting_iterator.h>
-#include <thrust/iterator/discard_iterator.h>
 #include <thrust/iterator/transform_output_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/sequence.h>
 #include <thrust/zip_function.h>
 
+#include <cuda/iterator>
 #include <cuda/std/__functional/identity.h>
 
 #include <sstream>
@@ -32,8 +33,8 @@ DECLARE_LAUNCH_WRAPPER(cub::DeviceTransform::TransformStableArgumentAddresses, t
 using offset_types = c2h::type_list<std::int32_t, std::int64_t>;
 
 C2H_TEST("DeviceTransform::Transform BabelStream add",
-         "[device][device_transform]",
-         c2h::type_list<std::uint8_t, std::uint16_t, std::uint32_t, std::uint64_t>,
+         "[device][transform]",
+         c2h::type_list<std::uint8_t, std::uint16_t, std::uint32_t, std::uint64_t, uchar3>,
          offset_types)
 {
   using type     = c2h::get<0, TestType>;
@@ -60,7 +61,7 @@ C2H_TEST("DeviceTransform::Transform BabelStream add",
 }
 
 C2H_TEST("DeviceTransform::Transform works for large number of items",
-         "[device][device_transform][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]",
+         "[device][transform][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]",
          offset_types)
 {
   using offset_t = c2h::get<0, TestType>;
@@ -86,7 +87,7 @@ C2H_TEST("DeviceTransform::Transform works for large number of items",
 }
 
 C2H_TEST("DeviceTransform::Transform with multiple inputs works for large number of items",
-         "[device][device_transform][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]",
+         "[device][transform][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]",
          offset_types)
 {
   using offset_t = c2h::get<0, TestType>;
@@ -121,7 +122,7 @@ struct times_seven
 };
 
 C2H_TEST("DeviceTransform::Transform with large input",
-         "[device][device_transform][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]")
+         "[device][transform][skip-cs-initcheck][skip-cs-racecheck][skip-cs-synccheck]")
 try
 {
   using type     = unsigned char;
@@ -224,7 +225,7 @@ struct uncommon_plus
   }
 };
 
-C2H_TEST("DeviceTransform::Transform uncommon types", "[device][device_transform]", uncommon_types)
+C2H_TEST("DeviceTransform::Transform uncommon types", "[device][transform]", uncommon_types)
 {
   using type = c2h::get<0, TestType>;
   CAPTURE(c2h::type_name<type>());
@@ -246,6 +247,43 @@ C2H_TEST("DeviceTransform::Transform uncommon types", "[device][device_transform
   REQUIRE(c2h::host_vector<type>(result) == reference_h);
 }
 
+struct non_default_constructible
+{
+  int data;
+
+  non_default_constructible()                                            = delete;
+  non_default_constructible(const non_default_constructible&)            = default;
+  non_default_constructible& operator=(const non_default_constructible&) = default;
+  ~non_default_constructible()                                           = default;
+
+  _CCCL_HOST_DEVICE explicit non_default_constructible(int data)
+      : data(data)
+  {}
+
+  friend _CCCL_HOST_DEVICE auto operator==(non_default_constructible a, non_default_constructible b) -> bool
+  {
+    return a.data == b.data;
+  }
+};
+static_assert(!::cuda::std::is_trivially_default_constructible_v<non_default_constructible>);
+static_assert(!::cuda::std::is_default_constructible_v<non_default_constructible>);
+static_assert(::cuda::std::is_trivially_copyable_v<non_default_constructible>); // as required by the standard
+static_assert(thrust::is_trivially_relocatable_v<non_default_constructible>); // CUB uses this check internally
+
+C2H_TEST("DeviceTransform::Transform non-default constructible types", "[device][transform]")
+{
+  using type          = non_default_constructible;
+  const int num_items = GENERATE(0, 1, 100, 1'000, 100'000); // try to hit the small and full tile code paths
+
+  c2h::device_vector<type> input(num_items, non_default_constructible{42});
+  c2h::device_vector<type> result(num_items, non_default_constructible{0});
+
+  transform_many(::cuda::std::make_tuple(input.begin()), result.begin(), num_items, cuda::std::identity{});
+
+  c2h::host_vector<type> reference_h(num_items, non_default_constructible{42});
+  REQUIRE(c2h::host_vector<type>(result) == reference_h);
+}
+
 template <typename T>
 struct nstream_kernel
 {
@@ -259,7 +297,7 @@ struct nstream_kernel
 
 // overwrites one input stream
 C2H_TEST("DeviceTransform::Transform BabelStream nstream",
-         "[device][device_transform]",
+         "[device][transform]",
          c2h::type_list<std::uint8_t, std::uint16_t, std::uint32_t, std::uint64_t>,
          offset_types)
 {
@@ -296,7 +334,7 @@ struct sum_five
   }
 };
 
-C2H_TEST("DeviceTransform::Transform add five streams", "[device][device_transform]")
+C2H_TEST("DeviceTransform::Transform add five streams", "[device][transform]")
 {
   const int num_items = GENERATE(100, 100'000); // try to hit the small and full tile code paths
   c2h::device_vector<std::int8_t> a(num_items, thrust::no_init);
@@ -337,7 +375,7 @@ struct give_me_five
   }
 };
 
-C2H_TEST("DeviceTransform::Transform no streams", "[device][device_transform]")
+C2H_TEST("DeviceTransform::Transform no streams", "[device][transform]")
 {
   const int num_items = GENERATE(100, 100'000); // try to hit the small and full tile code paths
   c2h::device_vector<int> result(num_items, thrust::no_init);
@@ -348,7 +386,7 @@ C2H_TEST("DeviceTransform::Transform no streams", "[device][device_transform]")
   REQUIRE(reference == result);
 }
 
-C2H_TEST("DeviceTransform::Transform fancy input iterator types", "[device][device_transform]")
+C2H_TEST("DeviceTransform::Transform fancy input iterator types", "[device][transform]")
 {
   using type          = int;
   const int num_items = GENERATE(100, 100'000); // try to hit the small and full tile code paths
@@ -364,7 +402,7 @@ C2H_TEST("DeviceTransform::Transform fancy input iterator types", "[device][devi
   REQUIRE(reference_h == result);
 }
 
-C2H_TEST("DeviceTransform::Transform fancy output iterator type", "[device][device_transform]")
+C2H_TEST("DeviceTransform::Transform fancy output iterator type", "[device][transform]")
 {
   using type          = int;
   const int num_items = GENERATE(100, 100'000); // try to hit the small and full tile code paths
@@ -378,7 +416,22 @@ C2H_TEST("DeviceTransform::Transform fancy output iterator type", "[device][devi
   REQUIRE(result == c2h::device_vector<type>(num_items, (13 + 35) + 4));
 }
 
-C2H_TEST("DeviceTransform::Transform mixed input iterator types", "[device][device_transform]")
+C2H_TEST("DeviceTransform::Transform fancy output iterator type with void value type", "[device][transform]")
+{
+  using type          = int;
+  const int num_items = GENERATE(100, 100'000); // try to hit the small and full tile code paths
+  c2h::device_vector<type> a(num_items, 1);
+  c2h::device_vector<type> b(num_items, 2);
+  c2h::device_vector<type> result(num_items, thrust::no_init);
+
+  using it_t = cub::CacheModifiedOutputIterator<cub::CacheStoreModifier::STORE_DEFAULT, int>;
+  static_assert(cuda::std::is_void_v<it_t::value_type>);
+  auto out = it_t{thrust::raw_pointer_cast(result.data())};
+  transform_many(::cuda::std::make_tuple(a.begin(), b.begin()), out, num_items, ::cuda::std::plus<type>{});
+  REQUIRE(result == c2h::device_vector<type>(num_items, 3));
+}
+
+C2H_TEST("DeviceTransform::Transform mixed input iterator types", "[device][transform]")
 {
   using type          = int;
   const int num_items = GENERATE(100, 100'000); // try to hit the small and full tile code paths
@@ -408,7 +461,7 @@ struct plus_needs_stable_address
   }
 };
 
-C2H_TEST("DeviceTransform::Transform address stability", "[device][device_transform]")
+C2H_TEST("DeviceTransform::Transform address stability", "[device][transform]")
 {
   using type          = int;
   const int num_items = GENERATE(100, 100'000); // try to hit the small and full tile code paths
@@ -470,7 +523,7 @@ static_assert(!thrust::is_trivially_relocatable_v<non_trivial>); // CUB uses thi
 // (e.g. by tracking/counting invocations of those), since C++ allows (but not guarantees) elision of these operations.
 // Also thrust algorithms perform a lot of copies in-between, so the test needs to use only raw allocations and
 // iteration for setup and checking.
-C2H_TEST("DeviceTransform::Transform not trivially relocatable", "[device][device_transform]")
+C2H_TEST("DeviceTransform::Transform not trivially relocatable", "[device][transform]")
 {
   const int num_items = GENERATE(100, 100'000); // try to hit the small and full tile code paths
   c2h::device_vector<non_trivial> input(num_items, non_trivial{42});
@@ -483,7 +536,7 @@ C2H_TEST("DeviceTransform::Transform not trivially relocatable", "[device][devic
 }
 
 C2H_TEST("DeviceTransform::Transform buffer start alignment",
-         "[device][device_transform]",
+         "[device][transform]",
          c2h::type_list<std::uint8_t, std::uint16_t, float, double>)
 {
   using type          = c2h::get<0, TestType>;
@@ -524,7 +577,7 @@ struct StringMaker<cub::detail::transform::aligned_base_ptr<T>>
 } // namespace Catch
 
 // TODO(bgruber): rewrite this example using int3
-C2H_TEST("DeviceTransform::Transform aligned_base_ptr", "[device][device_transform]")
+C2H_TEST("DeviceTransform::Transform aligned_base_ptr", "[device][transform]")
 {
   alignas(128) int arr[256];
   using namespace cub::detail::transform;
@@ -539,11 +592,88 @@ C2H_TEST("DeviceTransform::Transform aligned_base_ptr", "[device][device_transfo
   CHECK(make_aligned_base_ptr(&arr[129], 128) == aligned_base_ptr<int>{reinterpret_cast<char*>(&arr[128]), 4});
 }
 
-C2H_TEST("DeviceTransform::Transform aligned_base_ptr", "[device][device_transform]")
+C2H_TEST("DeviceTransform::Transform aligned_base_ptr", "[device][transform]")
 {
   using It         = thrust::reverse_iterator<thrust::detail::normal_iterator<thrust::device_ptr<int>>>;
   using kernel_arg = cub::detail::transform::kernel_arg<It>;
 
   STATIC_REQUIRE(::cuda::std::is_constructible_v<kernel_arg>);
   STATIC_REQUIRE(::cuda::std::is_copy_constructible_v<kernel_arg>);
+}
+
+// See discussion on: https://github.com/NVIDIA/cccl/pull/4815
+C2H_TEST("DeviceTransform::Transform vectorized output bug", "[device][transform]")
+{
+  using thrust::placeholders::_1;
+
+  int num_items = std::numeric_limits<std::uint16_t>::max() - 1;
+  c2h::device_vector<std::uint16_t> input(num_items);
+  c2h::device_vector<std::uint16_t> output(num_items);
+  thrust::sequence(input.begin(), input.end());
+
+  auto out_it = thrust::make_transform_output_iterator(output.begin(), _1);
+  transform_many(input.begin(), out_it, num_items, _1 + 1);
+
+  c2h::host_vector<std::uint16_t> reference(num_items);
+  thrust::generate(reference.begin(), reference.end(), [i = 0]() mutable {
+    return static_cast<std::uint16_t>(++i);
+  });
+  CHECK(output == reference);
+}
+
+// See discussion on: https://github.com/NVIDIA/cccl/pull/4815
+struct A
+{
+  int value;
+};
+
+struct B
+{
+  int value;
+};
+
+struct C
+{
+  int value;
+
+  __host__ __device__ friend auto operator==(C a, C b) -> bool
+  {
+    return a.value == b.value;
+  }
+
+  friend auto operator<<(std::ostream& os, C c) -> std::ostream&
+  {
+    return os << "C{" << c.value << "}";
+  }
+};
+
+struct AtoB
+{
+  __host__ __device__ B operator()(A a) const
+  {
+    return B{a.value + 1};
+  }
+};
+
+struct BtoC
+{
+  __host__ __device__ C operator()(B b) const
+  {
+    return C{-b.value};
+  }
+};
+
+C2H_TEST("DeviceTransform::Transform function/output_iter return type not convertible", "[device][transform]")
+{
+  using thrust::placeholders::_1;
+
+  const int num_items = 10'000;
+  c2h::device_vector<A> input(num_items, A{42});
+  c2h::device_vector<C> output(num_items, thrust::no_init);
+
+  auto out_it = thrust::make_transform_output_iterator(output.begin(), BtoC{});
+  transform_many(input.begin(), out_it, num_items, AtoB{});
+
+  c2h::device_vector<C> reference(num_items, C{-43});
+  CHECK(output == reference);
 }

--- a/thrust/thrust/system/cuda/detail/core/util.h
+++ b/thrust/thrust/system/cuda/detail/core/util.h
@@ -544,51 +544,32 @@ template <class T, size_t N>
 struct uninitialized_array
 {
   using value_type = T;
-  using ref        = T[N];
-  enum
-  {
-    SIZE = N
-  };
+  static constexpr ::cuda::std::integral_constant<size_t, N> size{};
+  alignas(T) char data_[N * sizeof(T)];
 
-private:
-  char data_[N * sizeof(T)];
-
-public:
   _CCCL_HOST_DEVICE T* data()
   {
-    return data_;
+    return reinterpret_cast<T*>(data_);
   }
+
   _CCCL_HOST_DEVICE const T* data() const
   {
-    return data_;
+    return reinterpret_cast<T*>(data_);
   }
+
   _CCCL_HOST_DEVICE T& operator[](unsigned int idx)
   {
-    return ((T*) data_)[idx];
+    return data()[idx];
   }
+
   _CCCL_HOST_DEVICE T const& operator[](unsigned int idx) const
   {
-    return ((T*) data_)[idx];
+    return data()[idx];
   }
-  _CCCL_HOST_DEVICE T& operator[](int idx)
+
+  _CCCL_HOST_DEVICE T (&as_array())[N]
   {
-    return ((T*) data_)[idx];
-  }
-  _CCCL_HOST_DEVICE T const& operator[](int idx) const
-  {
-    return ((T*) data_)[idx];
-  }
-  _CCCL_HOST_DEVICE unsigned int size() const
-  {
-    return N;
-  }
-  _CCCL_HOST_DEVICE operator ref&()
-  {
-    return *reinterpret_cast<ref*>(data_);
-  }
-  _CCCL_HOST_DEVICE ref& get_ref()
-  {
-    return (ref&) *this;
+    return static_cast<T(&)[N]>(data_);
   }
 };
 

--- a/thrust/thrust/system/cuda/detail/unique.h
+++ b/thrust/thrust/system/cuda/detail/unique.h
@@ -251,8 +251,6 @@ struct UniqueAgent
     template <bool IS_LAST_TILE, bool IS_FIRST_TILE>
     Size THRUST_DEVICE_FUNCTION consume_tile_impl(int num_tile_items, int tile_idx, Size tile_base)
     {
-      using core::detail::uninitialized_array;
-
       item_type items_loc[ITEMS_PER_THREAD];
       Size selection_flags[ITEMS_PER_THREAD];
       Size selection_idx[ITEMS_PER_THREAD];


### PR DESCRIPTION
Fixes: #4837

Review and merge the test reorganizatin first:
- [x] #4899 

prefetch (base) vs. vectorized (new)
```
# mul

## [0] NVIDIA A100 80GB PCIe

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |        Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-------------|---------|----------|
|   I8    |      I32      |      2^16      |   6.211 us |       8.99% |   6.214 us |       7.87% |    0.003 us |   0.05% |   SAME   |
|   I8    |      I32      |      2^20      |   9.096 us |       6.60% |   7.407 us |       6.67% |   -1.689 us | -18.57% |   FAST   |
|   I8    |      I32      |      2^24      |  41.172 us |       1.16% |  26.186 us |       2.82% |  -14.987 us | -36.40% |   FAST   |
|   I8    |      I32      |      2^28      | 548.129 us |       0.15% | 329.840 us |       0.33% | -218.289 us | -39.82% |   FAST   |
|   I8    |      I64      |      2^16      |   6.532 us |       8.40% |   6.390 us |       9.35% |   -0.141 us |  -2.16% |   SAME   |
|   I8    |      I64      |      2^20      |   9.213 us |       5.71% |   7.494 us |       6.69% |   -1.718 us | -18.65% |   FAST   |
|   I8    |      I64      |      2^24      |  41.518 us |       1.30% |  26.204 us |       2.82% |  -15.314 us | -36.88% |   FAST   |
|   I8    |      I64      |      2^28      | 546.369 us |       0.12% | 329.836 us |       0.34% | -216.533 us | -39.63% |   FAST   |
|   I16   |      I32      |      2^16      |   6.447 us |       8.73% |   6.393 us |       9.42% |   -0.054 us |  -0.84% |   SAME   |
|   I16   |      I32      |      2^20      |   9.876 us |       5.89% |   8.724 us |       6.18% |   -1.152 us | -11.66% |   FAST   |
|   I16   |      I32      |      2^24      |  55.500 us |       0.81% |  48.768 us |       2.51% |   -6.732 us | -12.13% |   FAST   |
|   I16   |      I32      |      2^28      | 770.512 us |       0.43% | 647.768 us |       0.34% | -122.745 us | -15.93% |   FAST   |
|   I16   |      I64      |      2^16      |   6.653 us |       8.31% |   6.703 us |       8.25% |    0.050 us |   0.75% |   SAME   |
|   I16   |      I64      |      2^20      |   9.932 us |       5.35% |   8.610 us |       6.11% |   -1.322 us | -13.31% |   FAST   |
|   I16   |      I64      |      2^24      |  56.165 us |       0.98% |  48.852 us |       2.28% |   -7.313 us | -13.02% |   FAST   |
|   I16   |      I64      |      2^28      | 779.228 us |       0.39% | 647.730 us |       0.29% | -131.498 us | -16.88% |   FAST   |
|   F32   |      I32      |      2^16      |   6.742 us |       8.44% |   6.778 us |       8.47% |    0.036 us |   0.54% |   SAME   |
|   F32   |      I32      |      2^20      |  11.622 us |       4.33% |  10.803 us |       5.26% |   -0.819 us |  -7.05% |   FAST   |
|   F32   |      I32      |      2^24      |  91.943 us |       1.50% |  88.965 us |       1.08% |   -2.978 us |  -3.24% |   FAST   |
|   F32   |      I32      |      2^28      |   1.338 ms |       0.13% |   1.282 ms |       0.29% |  -56.040 us |  -4.19% |   FAST   |
|   F32   |      I64      |      2^16      |   6.700 us |       7.93% |   6.735 us |       8.41% |    0.035 us |   0.52% |   SAME   |
|   F32   |      I64      |      2^20      |  12.444 us |       3.90% |  11.408 us |       5.51% |   -1.035 us |  -8.32% |   FAST   |
|   F32   |      I64      |      2^24      |  92.213 us |       1.45% |  89.081 us |       1.17% |   -3.131 us |  -3.40% |   FAST   |
|   F32   |      I64      |      2^28      |   1.343 ms |       0.14% |   1.282 ms |       0.29% |  -60.999 us |  -4.54% |   FAST   |
|   F64   |      I32      |      2^16      |   6.909 us |       8.49% |   7.004 us |       8.36% |    0.095 us |   1.38% |   SAME   |
|   F64   |      I32      |      2^20      |  16.426 us |       3.99% |  16.289 us |       4.70% |   -0.137 us |  -0.83% |   SAME   |
|   F64   |      I32      |      2^24      | 171.163 us |       0.78% | 169.549 us |       0.67% |   -1.614 us |  -0.94% |   FAST   |
|   F64   |      I32      |      2^28      |   2.605 ms |       0.06% |   2.551 ms |       0.27% |  -54.102 us |  -2.08% |   FAST   |
|   F64   |      I64      |      2^16      |   7.157 us |       8.56% |   7.015 us |       8.51% |   -0.141 us |  -1.97% |   SAME   |
|   F64   |      I64      |      2^20      |  16.933 us |       3.22% |  16.988 us |       3.73% |    0.056 us |   0.33% |   SAME   |
|   F64   |      I64      |      2^24      | 172.511 us |       1.28% | 171.720 us |       1.63% |   -0.791 us |  -0.46% |   SAME   |
|   F64   |      I64      |      2^28      |   2.608 ms |       0.06% |   2.552 ms |       0.31% |  -56.600 us |  -2.17% |   FAST   |
|  I128   |      I32      |      2^16      |   8.007 us |       7.44% |   7.977 us |       7.42% |   -0.030 us |  -0.38% |   SAME   |
|  I128   |      I32      |      2^20      |  26.945 us |       4.85% |  27.474 us |       3.18% |    0.528 us |   1.96% |   SAME   |
|  I128   |      I32      |      2^24      | 324.881 us |       1.38% | 332.013 us |       1.34% |    7.132 us |   2.20% |   SLOW   |
|  I128   |      I32      |      2^28      |   5.024 ms |       0.07% |   5.090 ms |       0.19% |   65.816 us |   1.31% |   SLOW   |
|  I128   |      I64      |      2^16      |   7.991 us |       7.90% |   7.989 us |       7.67% |   -0.002 us |  -0.02% |   SAME   |
|  I128   |      I64      |      2^20      |  27.095 us |       4.87% |  27.475 us |       3.26% |    0.380 us |   1.40% |   SAME   |
|  I128   |      I64      |      2^24      | 331.745 us |       0.98% | 339.311 us |       0.41% |    7.566 us |   2.28% |   SLOW   |
|  I128   |      I64      |      2^28      |   5.024 ms |       0.07% |   5.122 ms |       0.30% |   97.524 us |   1.94% |   SLOW   |

# add

## [0] NVIDIA A100 80GB PCIe

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |        Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-------------|---------|----------|
|   I8    |      I32      |      2^16      |   6.839 us |       8.63% |   6.819 us |       8.30% |   -0.020 us |  -0.29% |   SAME   |
|   I8    |      I32      |      2^20      |  10.813 us |       5.36% |   9.279 us |       5.86% |   -1.534 us | -14.19% |   FAST   |
|   I8    |      I32      |      2^24      |  57.299 us |       1.09% |  41.613 us |       2.60% |  -15.686 us | -27.38% |   FAST   |
|   I8    |      I32      |      2^28      | 770.916 us |       0.30% | 487.361 us |       1.24% | -283.555 us | -36.78% |   FAST   |
|   I8    |      I64      |      2^16      |   6.907 us |       8.94% |   6.684 us |       8.81% |   -0.222 us |  -3.22% |   SAME   |
|   I8    |      I64      |      2^20      |  10.059 us |       5.32% |   8.589 us |       6.02% |   -1.470 us | -14.62% |   FAST   |
|   I8    |      I64      |      2^24      |  57.102 us |       1.01% |  40.307 us |       2.35% |  -16.796 us | -29.41% |   FAST   |
|   I8    |      I64      |      2^28      | 777.898 us |       0.09% | 482.333 us |       0.17% | -295.565 us | -38.00% |   FAST   |
|   I16   |      I32      |      2^16      |   6.825 us |       9.01% |   6.789 us |       8.41% |   -0.036 us |  -0.53% |   SAME   |
|   I16   |      I32      |      2^20      |  11.595 us |       4.38% |  10.348 us |       5.37% |   -1.247 us | -10.75% |   FAST   |
|   I16   |      I32      |      2^24      |  77.191 us |       1.06% |  70.817 us |       1.15% |   -6.374 us |  -8.26% |   FAST   |
|   I16   |      I32      |      2^28      |   1.089 ms |       0.34% | 954.920 us |       0.12% | -133.766 us | -12.29% |   FAST   |
|   I16   |      I64      |      2^16      |   6.908 us |       8.43% |   6.849 us |       8.82% |   -0.058 us |  -0.85% |   SAME   |
|   I16   |      I64      |      2^20      |  11.790 us |       4.65% |  10.711 us |       6.07% |   -1.078 us |  -9.15% |   FAST   |
|   I16   |      I64      |      2^24      |  78.410 us |       0.69% |  70.697 us |       1.15% |   -7.713 us |  -9.84% |   FAST   |
|   I16   |      I64      |      2^28      |   1.106 ms |       0.37% | 955.224 us |       0.12% | -150.416 us | -13.60% |   FAST   |
|   F32   |      I32      |      2^16      |   6.987 us |       8.33% |   7.168 us |       0.00% |    0.181 us |   2.59% |   ????   |
|   F32   |      I32      |      2^20      |  15.011 us |       3.80% |  14.774 us |       3.74% |   -0.237 us |  -1.58% |   SAME   |
|   F32   |      I32      |      2^24      | 138.430 us |       1.41% | 129.061 us |       0.66% |   -9.368 us |  -6.77% |   FAST   |
|   F32   |      I32      |      2^28      |   2.048 ms |       0.13% |   1.896 ms |       0.07% | -151.060 us |  -7.38% |   FAST   |
|   F32   |      I64      |      2^16      |   7.038 us |       8.56% |   7.142 us |       8.52% |    0.104 us |   1.47% |   SAME   |
|   F32   |      I64      |      2^20      |  16.043 us |       3.56% |  14.791 us |       3.94% |   -1.252 us |  -7.81% |   FAST   |
|   F32   |      I64      |      2^24      | 138.728 us |       1.36% | 130.017 us |       1.26% |   -8.711 us |  -6.28% |   FAST   |
|   F32   |      I64      |      2^28      |   2.055 ms |       0.13% |   1.897 ms |       0.08% | -158.386 us |  -7.71% |   FAST   |
|   F64   |      I32      |      2^16      |   7.592 us |       6.92% |   7.703 us |       7.59% |    0.111 us |   1.46% |   SAME   |
|   F64   |      I32      |      2^20      |  24.308 us |       4.04% |  23.461 us |       2.83% |   -0.847 us |  -3.48% |   FAST   |
|   F64   |      I32      |      2^24      | 251.357 us |       0.80% | 248.087 us |       1.01% |   -3.270 us |  -1.30% |   FAST   |
|   F64   |      I32      |      2^28      |   3.823 ms |       0.04% |   3.783 ms |       0.06% |  -39.097 us |  -1.02% |   FAST   |
|   F64   |      I64      |      2^16      |   7.639 us |       7.08% |   7.776 us |       7.24% |    0.137 us |   1.79% |   SAME   |
|   F64   |      I64      |      2^20      |  24.364 us |       3.94% |  23.535 us |       2.62% |   -0.830 us |  -3.41% |   FAST   |
|   F64   |      I64      |      2^24      | 253.481 us |       1.11% | 249.780 us |       1.28% |   -3.701 us |  -1.46% |   FAST   |
|   F64   |      I64      |      2^28      |   3.832 ms |       0.04% |   3.784 ms |       0.06% |  -48.374 us |  -1.26% |   FAST   |
|  I128   |      I32      |      2^16      |   8.976 us |       6.82% |   9.058 us |       6.75% |    0.081 us |   0.91% |   SAME   |
|  I128   |      I32      |      2^20      |  41.502 us |       2.37% |  41.378 us |       2.52% |   -0.124 us |  -0.30% |   SAME   |
|  I128   |      I32      |      2^24      | 487.215 us |       1.22% | 485.603 us |       1.16% |   -1.612 us |  -0.33% |   SAME   |
|  I128   |      I32      |      2^28      |   7.606 ms |       0.12% |   7.555 ms |       0.06% |  -50.412 us |  -0.66% |   FAST   |
|  I128   |      I64      |      2^16      |   8.974 us |       6.37% |   9.110 us |       6.74% |    0.136 us |   1.52% |   SAME   |
|  I128   |      I64      |      2^20      |  41.581 us |       2.32% |  41.378 us |       2.40% |   -0.203 us |  -0.49% |   SAME   |
|  I128   |      I64      |      2^24      | 495.258 us |       0.27% | 494.053 us |       0.18% |   -1.205 us |  -0.24% |   FAST   |
|  I128   |      I64      |      2^28      |   7.609 ms |       0.43% |   7.558 ms |       0.42% |  -51.222 us |  -0.67% |   FAST   |

# triad

## [0] NVIDIA A100 80GB PCIe

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |        Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-------------|---------|----------|
|   I8    |      I32      |      2^16      |   6.809 us |       8.70% |   6.989 us |       8.17% |    0.180 us |   2.64% |   SAME   |
|   I8    |      I32      |      2^20      |  10.479 us |       5.17% |   9.299 us |       6.08% |   -1.180 us | -11.26% |   FAST   |
|   I8    |      I32      |      2^24      |  59.640 us |       0.89% |  41.617 us |       2.62% |  -18.023 us | -30.22% |   FAST   |
|   I8    |      I32      |      2^28      | 811.043 us |       0.28% | 494.674 us |       0.20% | -316.369 us | -39.01% |   FAST   |
|   I8    |      I64      |      2^16      |   6.639 us |       8.69% |   6.892 us |       8.66% |    0.253 us |   3.81% |   SAME   |
|   I8    |      I64      |      2^20      |   9.925 us |       5.83% |   9.240 us |       6.39% |   -0.685 us |  -6.90% |   FAST   |
|   I8    |      I64      |      2^24      |  58.260 us |       0.88% |  40.519 us |       2.33% |  -17.741 us | -30.45% |   FAST   |
|   I8    |      I64      |      2^28      | 798.070 us |       0.08% | 482.451 us |       0.18% | -315.619 us | -39.55% |   FAST   |
|   I16   |      I32      |      2^16      |   6.712 us |       8.21% |   6.848 us |       8.95% |    0.135 us |   2.02% |   SAME   |
|   I16   |      I32      |      2^20      |  11.735 us |       4.57% |  10.426 us |       4.62% |   -1.308 us | -11.15% |   FAST   |
|   I16   |      I32      |      2^24      |  77.240 us |       0.76% |  70.606 us |       1.10% |   -6.634 us |  -8.59% |   FAST   |
|   I16   |      I32      |      2^28      |   1.093 ms |       0.36% | 955.357 us |       0.13% | -138.119 us | -12.63% |   FAST   |
|   I16   |      I64      |      2^16      |   6.969 us |       8.46% |   6.989 us |       8.91% |    0.020 us |   0.28% |   SAME   |
|   I16   |      I64      |      2^20      |  11.861 us |       4.71% |  10.752 us |       6.05% |   -1.109 us |  -9.35% |   FAST   |
|   I16   |      I64      |      2^24      |  78.568 us |       0.77% |  70.727 us |       1.14% |   -7.841 us |  -9.98% |   FAST   |
|   I16   |      I64      |      2^28      |   1.113 ms |       0.35% | 955.360 us |       0.12% | -157.497 us | -14.15% |   FAST   |
|   F32   |      I32      |      2^16      |   7.078 us |       7.86% |   7.142 us |       7.96% |    0.064 us |   0.91% |   SAME   |
|   F32   |      I32      |      2^20      |  15.192 us |       4.51% |  14.715 us |       4.89% |   -0.477 us |  -3.14% |   SAME   |
|   F32   |      I32      |      2^24      | 138.144 us |       1.41% | 128.971 us |       0.52% |   -9.173 us |  -6.64% |   FAST   |
|   F32   |      I32      |      2^28      |   2.047 ms |       0.13% |   1.898 ms |       0.08% | -149.063 us |  -7.28% |   FAST   |
|   F32   |      I64      |      2^16      |   7.089 us |       8.27% |   7.132 us |       7.58% |    0.043 us |   0.60% |   SAME   |
|   F32   |      I64      |      2^20      |  15.807 us |       3.43% |  15.221 us |       4.39% |   -0.586 us |  -3.71% |   FAST   |
|   F32   |      I64      |      2^24      | 139.660 us |       1.69% | 129.745 us |       1.15% |   -9.915 us |  -7.10% |   FAST   |
|   F32   |      I64      |      2^28      |   2.056 ms |       0.13% |   1.898 ms |       0.08% | -158.195 us |  -7.69% |   FAST   |
|   F64   |      I32      |      2^16      |   7.726 us |       7.39% |   7.696 us |       7.20% |   -0.029 us |  -0.38% |   SAME   |
|   F64   |      I32      |      2^20      |  24.134 us |       3.94% |  23.323 us |       2.73% |   -0.812 us |  -3.36% |   FAST   |
|   F64   |      I32      |      2^24      | 250.755 us |       0.29% | 247.339 us |       0.61% |   -3.416 us |  -1.36% |   FAST   |
|   F64   |      I32      |      2^28      |   3.823 ms |       0.04% |   3.784 ms |       0.06% |  -38.522 us |  -1.01% |   FAST   |
|   F64   |      I64      |      2^16      |   7.864 us |       7.43% |   7.747 us |       7.25% |   -0.117 us |  -1.49% |   SAME   |
|   F64   |      I64      |      2^20      |  24.226 us |       3.36% |  23.395 us |       2.28% |   -0.831 us |  -3.43% |   FAST   |
|   F64   |      I64      |      2^24      | 256.492 us |       0.29% | 249.976 us |       1.26% |   -6.515 us |  -2.54% |   FAST   |
|   F64   |      I64      |      2^28      |   3.831 ms |       0.04% |   3.785 ms |       0.07% |  -46.810 us |  -1.22% |   FAST   |
|  I128   |      I32      |      2^16      |   9.062 us |       6.57% |   9.022 us |       6.68% |   -0.040 us |  -0.44% |   SAME   |
|  I128   |      I32      |      2^20      |  41.513 us |       2.41% |  41.516 us |       2.72% |    0.003 us |   0.01% |   SAME   |
|  I128   |      I32      |      2^24      | 487.286 us |       1.21% | 485.353 us |       1.15% |   -1.932 us |  -0.40% |   SAME   |
|  I128   |      I32      |      2^28      |   7.605 ms |       0.13% |   7.560 ms |       0.06% |  -44.934 us |  -0.59% |   FAST   |
|  I128   |      I64      |      2^16      |   9.081 us |       6.69% |   9.061 us |       6.66% |   -0.021 us |  -0.23% |   SAME   |
|  I128   |      I64      |      2^20      |  41.594 us |       2.57% |  41.475 us |       2.67% |   -0.119 us |  -0.29% |   SAME   |
|  I128   |      I64      |      2^24      | 495.329 us |       0.27% | 494.169 us |       0.19% |   -1.160 us |  -0.23% |   FAST   |
|  I128   |      I64      |      2^28      |   7.609 ms |       0.32% |   7.565 ms |       0.46% |  -43.533 us |  -0.57% |   FAST   |

# nstream

## [0] NVIDIA A100 80GB PCIe

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |        Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-------------|---------|----------|
|   I8    |      I32      |      2^16      |   6.992 us |       9.20% |   8.170 us |       7.03% |    1.178 us |  16.84% |   SLOW   |
|   I8    |      I32      |      2^20      |  11.636 us |       4.56% |  10.462 us |       4.60% |   -1.175 us | -10.10% |   FAST   |
|   I8    |      I32      |      2^24      |  73.633 us |       0.89% |  53.804 us |       1.88% |  -19.829 us | -26.93% |   FAST   |
|   I8    |      I32      |      2^28      |   1.025 ms |       0.31% | 644.709 us |       1.15% | -380.405 us | -37.11% |   FAST   |
|   I8    |      I64      |      2^16      |   6.856 us |       8.95% |   7.811 us |       7.89% |    0.955 us |  13.93% |   SLOW   |
|   I8    |      I64      |      2^20      |  11.220 us |       5.34% |   9.801 us |       5.50% |   -1.418 us | -12.64% |   FAST   |
|   I8    |      I64      |      2^24      |  74.743 us |       0.74% |  52.288 us |       1.82% |  -22.454 us | -30.04% |   FAST   |
|   I8    |      I64      |      2^28      |   1.057 ms |       0.06% | 637.927 us |       0.15% | -418.740 us | -39.63% |   FAST   |
|   I16   |      I32      |      2^16      |   6.978 us |       8.61% |   7.430 us |       7.48% |    0.451 us |   6.47% |   SAME   |
|   I16   |      I32      |      2^20      |  13.066 us |       4.64% |  12.210 us |       4.60% |   -0.856 us |  -6.55% |   FAST   |
|   I16   |      I32      |      2^24      | 105.414 us |       0.53% |  91.645 us |       0.79% |  -13.769 us | -13.06% |   FAST   |
|   I16   |      I32      |      2^28      |   1.511 ms |       0.07% |   1.257 ms |       0.08% | -254.020 us | -16.81% |   FAST   |
|   I16   |      I64      |      2^16      |   7.078 us |       8.19% |   7.565 us |       6.87% |    0.487 us |   6.88% |   SLOW   |
|   I16   |      I64      |      2^20      |  13.255 us |       5.01% |  12.235 us |       4.61% |   -1.020 us |  -7.69% |   FAST   |
|   I16   |      I64      |      2^24      | 105.376 us |       0.62% |  91.707 us |       0.80% |  -13.670 us | -12.97% |   FAST   |
|   I16   |      I64      |      2^28      |   1.526 ms |       0.11% |   1.257 ms |       0.09% | -268.611 us | -17.61% |   FAST   |
|   F32   |      I32      |      2^16      |   7.374 us |       7.16% |   7.300 us |       6.77% |   -0.074 us |  -1.01% |   SAME   |
|   F32   |      I32      |      2^20      |  18.055 us |       4.05% |  17.871 us |       3.91% |   -0.184 us |  -1.02% |   SAME   |
|   F32   |      I32      |      2^24      | 177.667 us |       1.00% | 168.987 us |       0.44% |   -8.679 us |  -4.89% |   FAST   |
|   F32   |      I32      |      2^28      |   2.678 ms |       0.10% |   2.492 ms |       0.10% | -185.827 us |  -6.94% |   FAST   |
|   F32   |      I64      |      2^16      |   7.305 us |       7.76% |   7.394 us |       6.63% |    0.088 us |   1.21% |   SAME   |
|   F32   |      I64      |      2^20      |  18.432 us |       0.00% |  18.448 us |       3.16% |    0.016 us |   0.09% |   SLOW   |
|   F32   |      I64      |      2^24      | 180.493 us |       1.45% | 169.607 us |       0.92% |  -10.886 us |  -6.03% |   FAST   |
|   F32   |      I64      |      2^28      |   2.682 ms |       0.10% |   2.492 ms |       0.09% | -190.515 us |  -7.10% |   FAST   |
|   F64   |      I32      |      2^16      |   8.201 us |       6.82% |   8.199 us |       6.46% |   -0.003 us |  -0.03% |   SAME   |
|   F64   |      I32      |      2^20      |  31.512 us |       3.85% |  30.977 us |       3.97% |   -0.535 us |  -1.70% |   SAME   |
|   F64   |      I32      |      2^24      | 327.386 us |       0.78% | 323.840 us |       0.26% |   -3.546 us |  -1.08% |   FAST   |
|   F64   |      I32      |      2^28      |   5.015 ms |       0.06% |   4.970 ms |       0.08% |  -45.630 us |  -0.91% |   FAST   |
|   F64   |      I64      |      2^16      |   8.307 us |       6.41% |   8.116 us |       7.12% |   -0.191 us |  -2.30% |   SAME   |
|   F64   |      I64      |      2^20      |  31.708 us |       3.99% |  30.959 us |       3.93% |   -0.749 us |  -2.36% |   SAME   |
|   F64   |      I64      |      2^24      | 329.386 us |       1.12% | 326.994 us |       1.16% |   -2.393 us |  -0.73% |   SAME   |
|   F64   |      I64      |      2^28      |   5.014 ms |       0.05% |   4.971 ms |       0.08% |  -43.678 us |  -0.87% |   FAST   |
|  I128   |      I32      |      2^16      |   9.944 us |       5.72% |  10.173 us |       5.77% |    0.229 us |   2.30% |   SAME   |
|  I128   |      I32      |      2^20      |  53.521 us |       1.64% |  52.927 us |       1.65% |   -0.594 us |  -1.11% |   SAME   |
|  I128   |      I32      |      2^24      | 639.128 us |       1.10% | 639.581 us |       1.03% |    0.453 us |   0.07% |   SAME   |
|  I128   |      I32      |      2^28      |   9.942 ms |       0.03% |   9.959 ms |       0.04% |   17.793 us |   0.18% |   SLOW   |
|  I128   |      I64      |      2^16      |   9.923 us |       5.67% |  10.200 us |       5.79% |    0.277 us |   2.79% |   SAME   |
|  I128   |      I64      |      2^20      |  53.668 us |       1.45% |  53.012 us |       1.68% |   -0.655 us |  -1.22% |   SAME   |
|  I128   |      I64      |      2^24      | 649.992 us |       0.14% | 650.407 us |       0.15% |    0.415 us |   0.06% |   SAME   |
|  I128   |      I64      |      2^28      |   9.945 ms |       0.26% |   9.972 ms |       0.21% |   27.313 us |   0.27% |   SLOW   |
```