### PR TITLE
cuda.parallel: Skip SASS verification for complex input in scan tests

### DIFF
--- a/python/cuda_parallel/tests/test_scan.py
+++ b/python/cuda_parallel/tests/test_scan.py
@@ -45,7 +45,18 @@ def scan_device(d_input, d_output, num_items, op, h_init, force_inclusive, strea
     "force_inclusive",
     [True, False],
 )
-def test_scan_array_input(force_inclusive, input_array):
+def test_scan_array_input(force_inclusive, input_array, monkeypatch):
+    # Skip sass verification if input is complex
+    # as LDL/STL instructions are emitted for complex types.
+    if np.issubdtype(input_array.dtype, np.complexfloating):
+        import cuda.parallel.experimental._cccl_interop
+
+        monkeypatch.setattr(
+            cuda.parallel.experimental._cccl_interop,
+            "_check_sass",
+            False,
+        )
+
     def op(a, b):
         return a + b
 


### PR DESCRIPTION
## Description

`scan` is known to emit LDL/STL instructions in the SASS for custom data types. We're also noticing failures for complex data types ([example](https://productionresultssa4.blob.core.windows.net/actions-results/4a33123c-3e02-439b-94d8-e2522dc685f7/workflow-job-run-f0e78800-e8e7-50e7-5396-5fbb674a0fda/logs/job/job-logs.txt?rsct=text%2Fplain&se=2025-05-28T16%3A35%3A59Z&sig=%2B%2FpWTwb9YhoqKilyeQk2NQDhDDB22vSKil6RA4bvu%2FI%3D&ske=2025-05-29T01%3A02%3A11Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2025-05-28T13%3A02%3A11Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-05-05&sp=r&spr=https&sr=b&st=2025-05-28T16%3A25%3A54Z&sv=2025-05-05)).

This PR ensures SASS verification is skipped for complex data types as well. 

The SASS is emitted due to a known internal issue; when that's resolved we'll remove these skips.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
