### PR TITLE
add a `__query_or_default` function for querying an environment with a fallback value

### DIFF
--- a/libcudacxx/include/cuda/std/__execution/env.h
+++ b/libcudacxx/include/cuda/std/__execution/env.h
@@ -399,7 +399,7 @@ _CCCL_CONCEPT __forwarding_query = forwarding_query(_Tag{});
 namespace __detail
 {
 // query an environment, or return a default value if the query is not supported
-struct __query_or_default_t
+struct __query_or_t
 {
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Env, class _Query, class _Default)
@@ -421,11 +421,11 @@ struct __query_or_default_t
 };
 } // namespace __detail
 
-_CCCL_GLOBAL_CONSTANT __detail::__query_or_default_t __query_or_default{};
+_CCCL_GLOBAL_CONSTANT __detail::__query_or_t __query_or{};
 
 template <class _Env, class _Query, class _Default>
-using __query_result_or_default_t _CCCL_NODEBUG_ALIAS =
-  decltype(__query_or_default(declval<_Env>(), _Query{}, declval<_Default>()));
+using __query_result_or_t _CCCL_NODEBUG_ALIAS =
+  decltype(__query_or(_CUDA_VSTD::declval<_Env>(), _Query{}, _CUDA_VSTD::declval<_Default>()));
 
 _LIBCUDACXX_END_NAMESPACE_EXECUTION
 

--- a/libcudacxx/include/cuda/std/__execution/env.h
+++ b/libcudacxx/include/cuda/std/__execution/env.h
@@ -26,6 +26,7 @@
 #include <cuda/std/__functional/reference_wrapper.h>
 #include <cuda/std/__tuple_dir/ignore.h>
 #include <cuda/std/__type_traits/enable_if.h>
+#include <cuda/std/__type_traits/is_nothrow_move_constructible.h>
 #include <cuda/std/__type_traits/is_valid_expansion.h>
 #include <cuda/std/__utility/declval.h>
 #include <cuda/std/__utility/pod_tuple.h>
@@ -392,6 +393,39 @@ _CCCL_GLOBAL_CONSTANT struct forwarding_query_t
 
 template <class _Tag>
 _CCCL_CONCEPT __forwarding_query = forwarding_query(_Tag{});
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// __query_or_default
+namespace __detail
+{
+// query an environment, or return a default value if the query is not supported
+struct __query_or_default_t
+{
+  _CCCL_EXEC_CHECK_DISABLE
+  _CCCL_TEMPLATE(class _Env, class _Query, class _Default)
+  _CCCL_REQUIRES(__queryable_with<_Env, _Query>)
+  [[nodiscard]] _CCCL_API constexpr auto operator()(const _Env& __env, _Query, _Default&&) const
+    noexcept(__nothrow_queryable_with<_Env, _Query>) -> __query_result_t<_Env, _Query>
+  {
+    return __env.query(_Query{});
+  }
+
+  _CCCL_EXEC_CHECK_DISABLE
+  template <class _Default>
+  [[nodiscard]] _CCCL_API constexpr auto
+  operator()(_CUDA_VSTD::__ignore_t, _CUDA_VSTD::__ignore_t, _Default&& __default) const
+    noexcept(_CUDA_VSTD::is_nothrow_move_constructible_v<_Default>) -> _Default
+  {
+    return static_cast<_Default&&>(__default);
+  }
+};
+} // namespace __detail
+
+_CCCL_GLOBAL_CONSTANT __detail::__query_or_default_t __query_or_default{};
+
+template <class _Env, class _Query, class _Default>
+using __query_result_or_default_t _CCCL_NODEBUG_ALIAS =
+  decltype(__query_or_default(declval<_Env>(), _Query{}, declval<_Default>()));
 
 _LIBCUDACXX_END_NAMESPACE_EXECUTION
 

--- a/libcudacxx/test/libcudacxx/std/execution/exec.env/env.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/execution/exec.env/env.pass.cpp
@@ -85,8 +85,8 @@ __host__ __device__ TEST_CONSTEXPR_CXX20 bool test()
   static_assert(cuda::std::is_same_v<decltype(e4.query(query1)), int>);
   static_assert(cuda::std::is_same_v<decltype(e4.query(query2)), const double&>);
 
-  assert(cuda::std::execution::__query_or_default(e2, query1, 0) == 42);
-  assert(cuda::std::execution::__query_or_default(e2, query2, &e2) == &e2);
+  assert(cuda::std::execution::__query_or(e2, query1, 0) == 42);
+  assert(cuda::std::execution::__query_or(e2, query2, &e2) == &e2);
 
   return true;
 }

--- a/libcudacxx/test/libcudacxx/std/execution/exec.env/env.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/execution/exec.env/env.pass.cpp
@@ -85,6 +85,9 @@ __host__ __device__ TEST_CONSTEXPR_CXX20 bool test()
   static_assert(cuda::std::is_same_v<decltype(e4.query(query1)), int>);
   static_assert(cuda::std::is_same_v<decltype(e4.query(query2)), const double&>);
 
+  assert(cuda::std::execution::__query_or_default(e2, query1, 0) == 42);
+  assert(cuda::std::execution::__query_or_default(e2, query2, &e2) == &e2);
+
   return true;
 }
 


### PR DESCRIPTION
## Description

it is very useful to be able to query an environment for a property, and provide a default value to use if the environment does not support that property. i use this in #4579. i think it is generally useful, enough to put it into `cuda::std::execution`.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
