### PR TITLE
Speedup runtime of c/parallel/test/test_radix_sort.cpp

### DIFF
--- a/c/parallel/test/test_radix_sort.cpp
+++ b/c/parallel/test/test_radix_sort.cpp
@@ -23,6 +23,32 @@
 using key_types = std::tuple<uint8_t, int16_t, uint32_t, double>;
 using item_t    = float;
 
+template <typename KeyTy, typename ItemTy, bool descending = false, bool overwrite_okay = false>
+struct TestParameters
+{
+  using KeyT                             = KeyTy;
+  using ItemT                            = ItemTy;
+  static constexpr bool m_descending     = descending;
+  static constexpr bool m_overwrite_okay = overwrite_okay;
+
+  constexpr TestParameters() {}
+
+  bool is_descending() const
+  {
+    return m_descending;
+  }
+  bool is_overwrite_okay() const
+  {
+    return m_overwrite_okay;
+  }
+};
+
+using test_params_tuple =
+  std::tuple<TestParameters<std::tuple_element_t<0, key_types>, item_t, false, false>,
+             TestParameters<std::tuple_element_t<1, key_types>, item_t, true, false>,
+             TestParameters<std::tuple_element_t<2, key_types>, item_t, false, true>,
+             TestParameters<std::tuple_element_t<3, key_types>, item_t, true, true>>;
+
 using BuildResultT = cccl_device_radix_sort_build_result_t;
 
 struct radix_sort_cleanup
@@ -139,29 +165,34 @@ void radix_sort(
 }
 
 struct DeviceRadixSort_SortKeys_Fixture_Tag;
-TEMPLATE_LIST_TEST_CASE("DeviceRadixSort::SortKeys works", "[radix_sort]", key_types)
+TEMPLATE_LIST_TEST_CASE("DeviceRadixSort::SortKeys works", "[radix_sort]", test_params_tuple)
 {
+  using T     = TestType;
+  using KeyT  = typename T::KeyT;
+  using ItemT = typename T::ItemT;
+
+  constexpr auto this_test_params = T();
   // We want a mix of small and large sizes because different implementations will be called
-  const int num_items      = GENERATE_COPY(take(2, random(1, 1000000)), values({500, 1000000, 2000000}));
-  const bool is_descending = GENERATE(false, true);
-  const auto order         = is_descending ? CCCL_DESCENDING : CCCL_ASCENDING;
+  const int num_items = GENERATE_COPY(take(2, random(1, 1000000)), values({500, 1000000, 2000000}));
+  bool is_descending  = this_test_params.is_descending();
+  const auto order    = is_descending ? CCCL_DESCENDING : CCCL_ASCENDING;
 
   const int begin_bit          = 0;
-  const int end_bit            = sizeof(TestType) * 8;
-  const bool is_overwrite_okay = GENERATE(false, true);
+  const int end_bit            = sizeof(KeyT) * 8;
+  const bool is_overwrite_okay = this_test_params.is_overwrite_okay();
   int selector                 = -1;
 
   static constexpr cccl_op_t decomposer_no_op{};
   static constexpr const char* unused_decomposer_retty = "";
 
   // problem descriptor: (order, TestType, item_t, is_overwrite_ok, items_present = false)
-  std::vector<TestType> input_keys    = make_shuffled_sequence<TestType>(num_items);
-  std::vector<TestType> expected_keys = input_keys;
+  std::vector<KeyT> input_keys    = make_shuffled_sequence<KeyT>(num_items);
+  std::vector<KeyT> expected_keys = input_keys;
 
-  pointer_t<TestType> input_keys_it(input_keys);
-  pointer_t<TestType> output_keys_it(num_items);
+  pointer_t<KeyT> input_keys_it(input_keys);
+  pointer_t<KeyT> output_keys_it(num_items);
 
-  pointer_t<item_t> input_items_it, output_items_it;
+  pointer_t<ItemT> input_items_it, output_items_it;
 
   auto& build_cache = get_cache<DeviceRadixSort_SortKeys_Fixture_Tag>();
 
@@ -192,7 +223,7 @@ TEMPLATE_LIST_TEST_CASE("DeviceRadixSort::SortKeys works", "[radix_sort]", key_t
 
   if (is_descending)
   {
-    std::sort(expected_keys.begin(), expected_keys.end(), std::greater<TestType>());
+    std::sort(expected_keys.begin(), expected_keys.end(), std::greater<KeyT>());
   }
   else
   {
@@ -200,19 +231,24 @@ TEMPLATE_LIST_TEST_CASE("DeviceRadixSort::SortKeys works", "[radix_sort]", key_t
   }
 
   auto& output_keys = (is_overwrite_okay && selector == 0) ? input_keys_it : output_keys_it;
-  REQUIRE(expected_keys == std::vector<TestType>(output_keys));
+  REQUIRE(expected_keys == std::vector<KeyT>(output_keys));
 }
 
 struct DeviceRadixSort_SortPairs_Fixture_Tag;
-TEMPLATE_LIST_TEST_CASE("DeviceRadixSort::SortPairs works", "[radix_sort]", key_types)
+TEMPLATE_LIST_TEST_CASE("DeviceRadixSort::SortPairs works", "[radix_sort]", test_params_tuple)
 {
-  const int num_items      = GENERATE_COPY(take(2, random(1, 1000000)), values({500, 1000000, 2000000}));
-  const bool is_descending = GENERATE(false, true);
-  const auto order         = is_descending ? CCCL_DESCENDING : CCCL_ASCENDING;
+  using T     = TestType;
+  using KeyT  = typename T::KeyT;
+  using ItemT = typename T::ItemT;
+
+  constexpr auto this_test_params = T();
+  const int num_items             = GENERATE_COPY(take(2, random(1, 1000000)), values({500, 1000000, 2000000}));
+  const bool is_descending        = this_test_params.is_descending();
+  const auto order                = is_descending ? CCCL_DESCENDING : CCCL_ASCENDING;
 
   const int begin_bit          = 0;
-  const int end_bit            = sizeof(TestType) * 8;
-  const bool is_overwrite_okay = GENERATE(false, true);
+  const int end_bit            = sizeof(KeyT) * 8;
+  const bool is_overwrite_okay = this_test_params.is_overwrite_okay();
   int selector                 = -1;
 
   static constexpr cccl_op_t decomposer_no_op{};
@@ -220,27 +256,27 @@ TEMPLATE_LIST_TEST_CASE("DeviceRadixSort::SortPairs works", "[radix_sort]", key_
 
   // problem descriptor in this example: (order, TestType, item_t, is_overwrite_ok)
 
-  std::vector<TestType> input_keys = make_shuffled_sequence<TestType>(num_items);
-  std::vector<item_t> input_items(num_items);
-  std::transform(input_keys.begin(), input_keys.end(), input_items.begin(), [](TestType key) {
-    return static_cast<item_t>(key);
+  std::vector<KeyT> input_keys = make_shuffled_sequence<KeyT>(num_items);
+  std::vector<ItemT> input_items(num_items);
+  std::transform(input_keys.begin(), input_keys.end(), input_items.begin(), [](KeyT key) {
+    return static_cast<ItemT>(key);
   });
 
-  std::vector<TestType> expected_keys = input_keys;
-  std::vector<item_t> expected_items  = input_items;
+  std::vector<KeyT> expected_keys   = input_keys;
+  std::vector<ItemT> expected_items = input_items;
 
-  pointer_t<TestType> input_keys_it(input_keys);
-  pointer_t<TestType> output_keys_it(num_items);
+  pointer_t<KeyT> input_keys_it(input_keys);
+  pointer_t<KeyT> output_keys_it(num_items);
 
-  pointer_t<item_t> input_items_it(input_items);
-  pointer_t<item_t> output_items_it(num_items);
+  pointer_t<ItemT> input_items_it(input_items);
+  pointer_t<ItemT> output_items_it(num_items);
 
   auto& build_cache = get_cache<DeviceRadixSort_SortPairs_Fixture_Tag>();
 
   const std::string& key_string = KeyBuilder::join(
     {KeyBuilder::bool_as_key(is_descending),
-     KeyBuilder::type_as_key<TestType>(),
-     KeyBuilder::type_as_key<item_t>(),
+     KeyBuilder::type_as_key<KeyT>(),
+     KeyBuilder::type_as_key<ItemT>(),
      KeyBuilder::bool_as_key(is_overwrite_okay)});
   const auto& test_key = std::make_optional(key_string);
 
@@ -264,8 +300,8 @@ TEMPLATE_LIST_TEST_CASE("DeviceRadixSort::SortPairs works", "[radix_sort]", key_
 
   if (is_descending)
   {
-    std::sort(expected_keys.begin(), expected_keys.end(), std::greater<TestType>());
-    std::sort(expected_items.begin(), expected_items.end(), std::greater<TestType>());
+    std::sort(expected_keys.begin(), expected_keys.end(), std::greater<KeyT>());
+    std::sort(expected_items.begin(), expected_items.end(), std::greater<KeyT>());
   }
   else
   {
@@ -275,6 +311,6 @@ TEMPLATE_LIST_TEST_CASE("DeviceRadixSort::SortPairs works", "[radix_sort]", key_
 
   auto& output_keys  = (is_overwrite_okay && selector == 0) ? input_keys_it : output_keys_it;
   auto& output_items = (is_overwrite_okay && selector == 0) ? input_items_it : output_items_it;
-  REQUIRE(expected_keys == std::vector<TestType>(output_keys));
-  REQUIRE(expected_items == std::vector<item_t>(output_items));
+  REQUIRE(expected_keys == std::vector<KeyT>(output_keys));
+  REQUIRE(expected_items == std::vector<ItemT>(output_items));
 }


### PR DESCRIPTION
## Description

For every one of 4 test key types, the test was running 4 combinations where is_descending was true/false, and is_overwrite_okay was independently was true/false.

This resulted in 16 distinct compilations. This change pairs it down to replacing direct product of iteration spaces with zip of them, reducing it to 4 distinct compilations.

This way we still exercise each of distinct choices of boolean build parameters but at a fewer number of builds


## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
