### PR TITLE
Ensuring CTK minor version compatibility for cccl.c.parallel

### DIFF
--- a/c/parallel/src/nvrtc/command_list.h
+++ b/c/parallel/src/nvrtc/command_list.h
@@ -19,9 +19,9 @@
 #include <tuple>
 #include <vector>
 
-#include <nvJitLink.h>
 #include <nvrtc.h>
 
+#include <nvrtc/nvjitlink_helper.h>
 #include <util/errors.h>
 
 struct nvrtc_ptx

--- a/c/parallel/src/nvrtc/nvjitlink_helper.h
+++ b/c/parallel/src/nvrtc/nvjitlink_helper.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#define NVJITLINK_NO_INLINE
+#include <nvJitLink.h>
+#undef NVJITLINK_NO_INLINE
+
+// declare unversioned functions
+
+extern "C" {
+nvJitLinkResult nvJitLinkCreate(nvJitLinkHandle*, uint32_t, const char**);
+nvJitLinkResult nvJitLinkDestroy(nvJitLinkHandle*);
+nvJitLinkResult nvJitLinkAddData(nvJitLinkHandle, nvJitLinkInputType, const void*, size_t, const char*);
+nvJitLinkResult nvJitLinkAddFile(nvJitLinkHandle, nvJitLinkInputType, const char*);
+nvJitLinkResult nvJitLinkComplete(nvJitLinkHandle);
+nvJitLinkResult nvJitLinkGetLinkedCubinSize(nvJitLinkHandle, size_t*);
+nvJitLinkResult nvJitLinkGetLinkedCubin(nvJitLinkHandle, void*);
+nvJitLinkResult nvJitLinkGetLinkedPtxSize(nvJitLinkHandle, size_t*);
+nvJitLinkResult nvJitLinkGetLinkedPtx(nvJitLinkHandle, char*);
+nvJitLinkResult nvJitLinkGetErrorLogSize(nvJitLinkHandle, size_t*);
+nvJitLinkResult nvJitLinkGetErrorLog(nvJitLinkHandle, char*);
+nvJitLinkResult nvJitLinkGetInfoLogSize(nvJitLinkHandle, size_t*);
+nvJitLinkResult nvJitLinkGetInfoLog(nvJitLinkHandle, char*);
+}

--- a/c/parallel/src/util/context.h
+++ b/c/parallel/src/util/context.h
@@ -11,7 +11,8 @@
 #pragma once
 
 #include <cuda.h>
-#include <nvJitLink.h>
 #include <nvrtc.h>
+
+#include <nvrtc/nvjitlink_helper.h>
 
 bool try_push_context();

--- a/c/parallel/src/util/errors.h
+++ b/c/parallel/src/util/errors.h
@@ -11,8 +11,9 @@
 #pragma once
 
 #include <cuda.h>
-#include <nvJitLink.h>
 #include <nvrtc.h>
+
+#include <nvrtc/nvjitlink_helper.h>
 
 void check(nvrtcResult result);
 void check(CUresult result);


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes gh-4845


`<nvJitLink.h>` header file provides unversioned inline functions which inject versionsed symbols. For example:

```
static inline nvJitLinkResult nvJitLinkCreate(
  nvJitLinkHandle *handle,
  uint32_t numOptions,
  const char **options)
{
  return __nvJitLinkCreate_12_8 (handle, numOptions, options);
}
```

c/parallel uses unversioned symbols, but due to inlining, the object files of each TU in c/parallel contains versioned symbols, and hence the final shared library depends on the specific CTK version it was built with.

The nvJitLink.so.12 does provide unversioned symbols too, which map to versioned symbols at run-time.

```
(nvbench) opavlyk@ee09c48-lcedt:~/repos/cccl$ nm -D /usr/local/cuda/lib64/libnvJitLink.so.12 | grep nvJitLinkCreate
00000000004ba560 T nvJitLinkCreate@@libnvJitLink.so.12
00000000004ba660 T __nvJitLinkCreate_12_0@@libnvJitLink.so.12
00000000004ba670 T __nvJitLinkCreate_12_1@@libnvJitLink.so.12
00000000004ba680 T __nvJitLinkCreate_12_2@@libnvJitLink.so.12
00000000004ba690 T __nvJitLinkCreate_12_3@@libnvJitLink.so.12
00000000004ba6a0 T __nvJitLinkCreate_12_4@@libnvJitLink.so.12
00000000004ba6b0 T __nvJitLinkCreate_12_5@@libnvJitLink.so.12
00000000004ba6c0 T __nvJitLinkCreate_12_6@@libnvJitLink.so.12
00000000004ba6d0 T __nvJitLinkCreate_12_7@@libnvJitLink.so.12
00000000004ba6e0 T __nvJitLinkCreate_12_8@@libnvJitLink.so.12
```

This change replaces direct uses of `#include <nvJitLink.h>` with `#include <nvrtc/nvjitlink_helper.h>` which defines `NVJITLINK_NO_INLINE` before  `#include <nvJitLink.h>` (thanks for the idea @leofang). It then simply declares unversioned symbols as `extern "C"`. 

Linking with subsequently result in using the dynamic unversioned symbols provided by `nvJitLink.so.12` shared library guaranteeing CTK minor version compatibility.

I verified that gh-4845 is resolved with this change by installing cuda-parallel wheel from this PR after torch built with CTK 12.8 was installed.

```
(pathfinder-trouble) opavlyk@ee09c48-lcedt:~$ python
Python 3.12.10 | packaged by conda-forge | (main, Apr 10 2025, 22:21:13) [GCC 13.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>>
>>> import torch
>>> import cuda.parallel.experimental.algorithms as algorithms
>>>
>>> import ctypes
>>>
>>> lib = ctypes.cdll.LoadLibrary("libnvJitLink.so.12")
>>> lib
<CDLL 'libnvJitLink.so.12', handle 60a782c77790 at 0x76ced9bf9640>
>>> fn = lib.nvJitLinkVersion
>>> fn.restype = ctypes.c_int
>>> fn.argtypes = [ctypes.POINTER(ctypes.c_int), ctypes.POINTER(ctypes.c_int)]
>>> maj = ctypes.c_int(0)
>>> min = ctypes.c_int(0)
>>>
>>>
>>> fn(maj, min)
0
>>> maj, min
(c_int(12), c_int(8))
>>> quit()
```


<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
