### PR TITLE
[CUDAX] Add make_async_buffer overload for each constructor

### DIFF
--- a/cudax/include/cuda/experimental/__container/async_buffer.cuh
+++ b/cudax/include/cuda/experimental/__container/async_buffer.cuh
@@ -683,6 +683,135 @@ auto make_async_buffer(stream_ref __stream, _Resource&& __mr, const async_buffer
   return __res;
 }
 
+// Empty buffer make function
+template <class _Tp, class... _Properties>
+async_buffer<_Tp, _Properties...> make_async_buffer(stream_ref __stream, any_async_resource<_Properties...> __mr)
+{
+  env_t<_Properties...> __env{__mr, __stream};
+  return async_buffer<_Tp, _Properties...>{__env};
+}
+
+_CCCL_TEMPLATE(class _Tp, class _Resource)
+_CCCL_REQUIRES(_CUDA_VMR::async_resource<_Resource> _CCCL_AND __has_default_queries<_Resource>)
+auto make_async_buffer(stream_ref __stream, _Resource&& __mr)
+{
+  using __buffer_type = __buffer_type_for_props<_Tp, typename _CUDA_VSTD::decay_t<_Resource>::default_queries>;
+  typename __buffer_type::__env_t __env{__mr, __stream};
+  return __buffer_type{__env};
+}
+
+// Size-only make function
+template <class _Tp, class... _Properties>
+async_buffer<_Tp, _Properties...>
+make_async_buffer(stream_ref __stream, any_async_resource<_Properties...> __mr, size_t __size)
+{
+  env_t<_Properties...> __env{__mr, __stream};
+  return async_buffer<_Tp, _Properties...>{__env, __size};
+}
+
+_CCCL_TEMPLATE(class _Tp, class _Resource)
+_CCCL_REQUIRES(_CUDA_VMR::async_resource<_Resource> _CCCL_AND __has_default_queries<_Resource>)
+auto make_async_buffer(stream_ref __stream, _Resource&& __mr, size_t __size)
+{
+  using __buffer_type = __buffer_type_for_props<_Tp, typename _CUDA_VSTD::decay_t<_Resource>::default_queries>;
+  typename __buffer_type::__env_t __env{__mr, __stream};
+  return __buffer_type{__env, __size};
+}
+
+// Size and value make function
+template <class _Tp, class... _Properties>
+async_buffer<_Tp, _Properties...>
+make_async_buffer(stream_ref __stream, any_async_resource<_Properties...> __mr, size_t __size, const _Tp& __value)
+{
+  env_t<_Properties...> __env{__mr, __stream};
+  return async_buffer<_Tp, _Properties...>{__env, __size, __value};
+}
+
+_CCCL_TEMPLATE(class _Tp, class _Resource)
+_CCCL_REQUIRES(_CUDA_VMR::async_resource<_Resource> _CCCL_AND __has_default_queries<_Resource>)
+auto make_async_buffer(stream_ref __stream, _Resource&& __mr, size_t __size, const _Tp& __value)
+{
+  using __buffer_type = __buffer_type_for_props<_Tp, typename _CUDA_VSTD::decay_t<_Resource>::default_queries>;
+  typename __buffer_type::__env_t __env{__mr, __stream};
+  return __buffer_type{__env, __size, __value};
+}
+
+// Size with no initialization make function
+template <class _Tp, class... _Properties>
+async_buffer<_Tp, _Properties...> make_async_buffer(
+  stream_ref __stream, any_async_resource<_Properties...> __mr, size_t __size, ::cuda::experimental::no_init_t)
+{
+  env_t<_Properties...> __env{__mr, __stream};
+  return async_buffer<_Tp, _Properties...>{__env, __size, ::cuda::experimental::no_init};
+}
+
+_CCCL_TEMPLATE(class _Tp, class _Resource)
+_CCCL_REQUIRES(_CUDA_VMR::async_resource<_Resource> _CCCL_AND __has_default_queries<_Resource>)
+auto make_async_buffer(stream_ref __stream, _Resource&& __mr, size_t __size, ::cuda::experimental::no_init_t)
+{
+  using __buffer_type = __buffer_type_for_props<_Tp, typename _CUDA_VSTD::decay_t<_Resource>::default_queries>;
+  typename __buffer_type::__env_t __env{__mr, __stream};
+  return __buffer_type{__env, __size, ::cuda::experimental::no_init};
+}
+
+// Iterator range make function
+_CCCL_TEMPLATE(class _Tp, class... _Properties, class _Iter)
+_CCCL_REQUIRES(_CUDA_VSTD::__is_cpp17_forward_iterator<_Iter>::value)
+async_buffer<_Tp, _Properties...>
+make_async_buffer(stream_ref __stream, any_async_resource<_Properties...> __mr, _Iter __first, _Iter __last)
+{
+  env_t<_Properties...> __env{__mr, __stream};
+  return async_buffer<_Tp, _Properties...>{__env, __first, __last};
+}
+
+_CCCL_TEMPLATE(class _Tp, class _Resource, class _Iter)
+_CCCL_REQUIRES(_CUDA_VMR::async_resource<_Resource> _CCCL_AND __has_default_queries<_Resource> _CCCL_AND
+                 _CUDA_VSTD::__is_cpp17_forward_iterator<_Iter>::value)
+auto make_async_buffer(stream_ref __stream, _Resource&& __mr, _Iter __first, _Iter __last)
+{
+  using __buffer_type = __buffer_type_for_props<_Tp, typename _CUDA_VSTD::decay_t<_Resource>::default_queries>;
+  typename __buffer_type::__env_t __env{__mr, __stream};
+  return __buffer_type{__env, __first, __last};
+}
+
+// Initializer list make function
+template <class _Tp, class... _Properties>
+async_buffer<_Tp, _Properties...> make_async_buffer(
+  stream_ref __stream, any_async_resource<_Properties...> __mr, _CUDA_VSTD::initializer_list<_Tp> __ilist)
+{
+  env_t<_Properties...> __env{__mr, __stream};
+  return async_buffer<_Tp, _Properties...>{__env, __ilist};
+}
+
+_CCCL_TEMPLATE(class _Tp, class _Resource)
+_CCCL_REQUIRES(_CUDA_VMR::async_resource<_Resource> _CCCL_AND __has_default_queries<_Resource>)
+auto make_async_buffer(stream_ref __stream, _Resource&& __mr, _CUDA_VSTD::initializer_list<_Tp> __ilist)
+{
+  using __buffer_type = __buffer_type_for_props<_Tp, typename _CUDA_VSTD::decay_t<_Resource>::default_queries>;
+  typename __buffer_type::__env_t __env{__mr, __stream};
+  return __buffer_type{__env, __ilist};
+}
+
+// Range make function for ranges
+_CCCL_TEMPLATE(class _Tp, class... _Properties, class _Range)
+_CCCL_REQUIRES(_CUDA_VRANGES::forward_range<_Range>)
+async_buffer<_Tp, _Properties...>
+make_async_buffer(stream_ref __stream, any_async_resource<_Properties...> __mr, _Range&& __range)
+{
+  env_t<_Properties...> __env{__mr, __stream};
+  return async_buffer<_Tp, _Properties...>{__env, _CUDA_VSTD::forward<_Range>(__range)};
+}
+
+_CCCL_TEMPLATE(class _Tp, class _Resource, class _Range)
+_CCCL_REQUIRES(_CUDA_VMR::async_resource<_Resource> _CCCL_AND __has_default_queries<_Resource> _CCCL_AND
+                 _CUDA_VRANGES::forward_range<_Range>)
+auto make_async_buffer(stream_ref __stream, _Resource&& __mr, _Range&& __range)
+{
+  using __buffer_type = __buffer_type_for_props<_Tp, typename _CUDA_VSTD::decay_t<_Resource>::default_queries>;
+  typename __buffer_type::__env_t __env{__mr, __stream};
+  return __buffer_type{__env, _CUDA_VSTD::forward<_Range>(__range)};
+}
+
 } // namespace cuda::experimental
 
 #include <cuda/std/__cccl/epilogue.h>

--- a/cudax/test/containers/async_buffer/constructor.cu
+++ b/cudax/test/containers/async_buffer/constructor.cu
@@ -98,153 +98,155 @@ C2H_TEST("cudax::async_buffer constructors", "[container][async_buffer]", test_t
       CUDAX_CHECK(buf.size() == 5);
       CUDAX_CHECK(equal_size_value(buf, 5, T(42)));
     }
+  }
 
-    { // from env and size with no_init, no allocation
-      SECTION("from env and size with no_init, no allocation")
-      {
-        const Buffer buf{env, 0, cudax::no_init};
-        CUDAX_CHECK(buf.empty());
-        CUDAX_CHECK(buf.data() == nullptr);
-      }
-      {
-        const auto buf = cudax::make_async_buffer<T>(stream, Resource{}, 0, cudax::no_init);
-        CUDAX_CHECK(buf.empty());
-        CUDAX_CHECK(buf.data() == nullptr);
-      }
-
-      { // from env and size with no_init
-        const Buffer buf{env, 5, cudax::no_init};
-        CUDAX_CHECK(buf.size() == 5);
-        CUDAX_CHECK(buf.data() != nullptr);
-      }
-      {
-        const auto buf = cudax::make_async_buffer<T>(stream, Resource{}, 5, cudax::no_init);
-        CUDAX_CHECK(buf.size() == 5);
-        CUDAX_CHECK(buf.data() != nullptr);
-      }
-    }
-
-    SECTION("Construction from iterators")
+  { // from env and size with no_init, no allocation
+    SECTION("from env and size with no_init, no allocation")
     {
-      const cuda::std::array<T, 6> input{T(1), T(42), T(1337), T(0), T(12), T(-1)};
-      { // can be constructed from two equal input iterators
-        Buffer buf(env, input.begin(), input.begin());
-        CUDAX_CHECK(buf.empty());
-        CUDAX_CHECK(buf.data() == nullptr);
-      }
-      {
-        const auto buf = cudax::make_async_buffer<T>(stream, Resource{}, input.begin(), input.begin());
-        CUDAX_CHECK(buf.empty());
-        CUDAX_CHECK(buf.data() == nullptr);
-      }
-
-      { // can be constructed from two input iterators
-        Buffer buf(env, input.begin(), input.end());
-        CUDAX_CHECK(buf.size() == 6);
-        CUDAX_CHECK(equal_range(buf));
-      }
-      {
-        const auto buf = cudax::make_async_buffer<T>(stream, Resource{}, input.begin(), input.end());
-        CUDAX_CHECK(buf.size() == 6);
-        CUDAX_CHECK(equal_range(buf));
-      }
+      const Buffer buf{env, 0, cudax::no_init};
+      CUDAX_CHECK(buf.empty());
+      CUDAX_CHECK(buf.data() == nullptr);
     }
-
-    SECTION("Construction from range")
     {
-      { // can be constructed from an empty random access range
-        Buffer buf(env, cuda::std::array<T, 0>{});
-        CUDAX_CHECK(buf.empty());
-        CUDAX_CHECK(buf.data() == nullptr);
-      }
-      {
-        const auto buf = cudax::make_async_buffer<T>(stream, Resource{}, cuda::std::array<T, 0>{});
-        CUDAX_CHECK(buf.empty());
-        CUDAX_CHECK(buf.data() == nullptr);
-      }
-
-      { // can be constructed from a non-empty random access range
-        Buffer buf(env, cuda::std::array<T, 6>{T(1), T(42), T(1337), T(0), T(12), T(-1)});
-        CUDAX_CHECK(!buf.empty());
-        CUDAX_CHECK(equal_range(buf));
-      }
-      {
-        const auto buf = cudax::make_async_buffer<T>(
-          stream, Resource{}, cuda::std::array<T, 6>{T(1), T(42), T(1337), T(0), T(12), T(-1)});
-        CUDAX_CHECK(!buf.empty());
-        CUDAX_CHECK(equal_range(buf));
-      }
+      const auto buf = cudax::make_async_buffer<T>(stream, Resource{}, 0, cudax::no_init);
+      CUDAX_CHECK(buf.empty());
+      CUDAX_CHECK(buf.data() == nullptr);
     }
 
-    SECTION("Construction from initializer_list")
+    { // from env and size with no_init
+      const Buffer buf{env, 5, cudax::no_init};
+      CUDAX_CHECK(buf.size() == 5);
+      CUDAX_CHECK(buf.data() != nullptr);
+    }
     {
-      { // can be constructed from an empty initializer_list
-        const cuda::std::initializer_list<T> input{};
-        Buffer buf(env, input);
-        CUDAX_CHECK(buf.empty());
-        CUDAX_CHECK(buf.data() == nullptr);
-      }
-      {
-        const auto buf = cudax::make_async_buffer(stream, Resource{}, cuda::std::initializer_list<T>{});
-        CUDAX_CHECK(buf.empty());
-        CUDAX_CHECK(buf.data() == nullptr);
-      }
-
-      { // can be constructed from a non-empty initializer_list
-        const cuda::std::initializer_list<T> input{T(1), T(42), T(1337), T(0), T(12), T(-1)};
-        Buffer buf(env, input);
-        CUDAX_CHECK(buf.size() == 6);
-        CUDAX_CHECK(equal_range(buf));
-      }
-      {
-        const auto buf = cudax::make_async_buffer(
-          stream, Resource{}, cuda::std::initializer_list<T>{T(1), T(42), T(1337), T(0), T(12), T(-1)});
-        CUDAX_CHECK(buf.size() == 6);
-        CUDAX_CHECK(equal_range(buf));
-      }
+      const auto buf = cudax::make_async_buffer<T>(stream, Resource{}, 5, cudax::no_init);
+      CUDAX_CHECK(buf.size() == 5);
+      CUDAX_CHECK(buf.data() != nullptr);
     }
+  }
 
-    SECTION("copy construction")
+  SECTION("Construction from iterators")
+  {
+    const cuda::std::array<T, 6> input{T(1), T(42), T(1337), T(0), T(12), T(-1)};
+    { // can be constructed from two equal input iterators
+      Buffer buf(env, input.begin(), input.begin());
+      CUDAX_CHECK(buf.empty());
+      CUDAX_CHECK(buf.data() == nullptr);
+    }
     {
-      static_assert(!cuda::std::is_nothrow_copy_constructible<Buffer>::value, "");
-      { // can be copy constructed from empty input
-        const Buffer input{env, 0};
-        Buffer buf(input);
-        CUDAX_CHECK(buf.empty());
-      }
-
-      { // can be copy constructed from non-empty input
-        const Buffer input{env, {T(1), T(42), T(1337), T(0), T(12), T(-1)}};
-        Buffer buf(input);
-        CUDAX_CHECK(!buf.empty());
-        CUDAX_CHECK(equal_range(buf));
-      }
+      const auto buf = cudax::make_async_buffer<T>(stream, Resource{}, input.begin(), input.begin());
+      CUDAX_CHECK(buf.empty());
+      CUDAX_CHECK(buf.data() == nullptr);
     }
 
-    SECTION("move construction")
+    { // can be constructed from two input iterators
+      Buffer buf(env, input.begin(), input.end());
+      CUDAX_CHECK(buf.size() == 6);
+      CUDAX_CHECK(equal_range(buf));
+    }
     {
-      static_assert(cuda::std::is_nothrow_move_constructible<Buffer>::value, "");
-
-      { // can be move constructed with empty input
-        Buffer input{env, 0};
-        Buffer buf(cuda::std::move(input));
-        CUDAX_CHECK(buf.empty());
-        CUDAX_CHECK(input.empty());
-      }
-
-      { // can be move constructed from non-empty input
-        Buffer input{env, {T(1), T(42), T(1337), T(0), T(12), T(-1)}};
-
-        // ensure that we steal the data
-        const auto* allocation = input.data();
-        Buffer buf(cuda::std::move(input));
-        CUDAX_CHECK(buf.size() == 6);
-        CUDAX_CHECK(buf.data() == allocation);
-        CUDAX_CHECK(input.size() == 0);
-        CUDAX_CHECK(input.data() == nullptr);
-        CUDAX_CHECK(equal_range(buf));
-      }
+      const auto buf = cudax::make_async_buffer<T>(stream, Resource{}, input.begin(), input.end());
+      CUDAX_CHECK(buf.size() == 6);
+      CUDAX_CHECK(equal_range(buf));
     }
+  }
+
+  SECTION("Construction from range")
+  {
+    { // can be constructed from an empty random access range
+      Buffer buf(env, cuda::std::array<T, 0>{});
+      CUDAX_CHECK(buf.empty());
+      CUDAX_CHECK(buf.data() == nullptr);
+    }
+    {
+      const auto buf = cudax::make_async_buffer<T>(stream, Resource{}, cuda::std::array<T, 0>{});
+      CUDAX_CHECK(buf.empty());
+      CUDAX_CHECK(buf.data() == nullptr);
+    }
+
+    { // can be constructed from a non-empty random access range
+      Buffer buf(env, cuda::std::array<T, 6>{T(1), T(42), T(1337), T(0), T(12), T(-1)});
+      CUDAX_CHECK(!buf.empty());
+      CUDAX_CHECK(equal_range(buf));
+    }
+    {
+      const auto buf = cudax::make_async_buffer<T>(
+        stream, Resource{}, cuda::std::array<T, 6>{T(1), T(42), T(1337), T(0), T(12), T(-1)});
+      CUDAX_CHECK(!buf.empty());
+      CUDAX_CHECK(equal_range(buf));
+    }
+  }
+
+  SECTION("Construction from initializer_list")
+  {
+    { // can be constructed from an empty initializer_list
+      const cuda::std::initializer_list<T> input{};
+      Buffer buf(env, input);
+      CUDAX_CHECK(buf.empty());
+      CUDAX_CHECK(buf.data() == nullptr);
+    }
+    {
+      const auto buf = cudax::make_async_buffer(stream, Resource{}, cuda::std::initializer_list<T>{});
+      CUDAX_CHECK(buf.empty());
+      CUDAX_CHECK(buf.data() == nullptr);
+    }
+
+    { // can be constructed from a non-empty initializer_list
+      const cuda::std::initializer_list<T> input{T(1), T(42), T(1337), T(0), T(12), T(-1)};
+      Buffer buf(env, input);
+      CUDAX_CHECK(buf.size() == 6);
+      CUDAX_CHECK(equal_range(buf));
+    }
+    {
+      const auto buf = cudax::make_async_buffer(
+        stream, Resource{}, cuda::std::initializer_list<T>{T(1), T(42), T(1337), T(0), T(12), T(-1)});
+      CUDAX_CHECK(buf.size() == 6);
+      CUDAX_CHECK(equal_range(buf));
+    }
+  }
+
+  SECTION("copy construction")
+  {
+    static_assert(!cuda::std::is_nothrow_copy_constructible<Buffer>::value, "");
+    { // can be copy constructed from empty input
+      const Buffer input{env, 0};
+      Buffer buf(input);
+      CUDAX_CHECK(buf.empty());
+    }
+
+    { // can be copy constructed from non-empty input
+      const Buffer input{env, {T(1), T(42), T(1337), T(0), T(12), T(-1)}};
+      Buffer buf(input);
+      CUDAX_CHECK(!buf.empty());
+      CUDAX_CHECK(equal_range(buf));
+    }
+  }
+
+  SECTION("move construction")
+  {
+    static_assert(cuda::std::is_nothrow_move_constructible<Buffer>::value, "");
+
+    { // can be move constructed with empty input
+      Buffer input{env, 0};
+      Buffer buf(cuda::std::move(input));
+      CUDAX_CHECK(buf.empty());
+      CUDAX_CHECK(input.empty());
+    }
+
+    { // can be move constructed from non-empty input
+      Buffer input{env, {T(1), T(42), T(1337), T(0), T(12), T(-1)}};
+
+      // ensure that we steal the data
+      const auto* allocation = input.data();
+      Buffer buf(cuda::std::move(input));
+      CUDAX_CHECK(buf.size() == 6);
+      CUDAX_CHECK(buf.data() == allocation);
+      CUDAX_CHECK(input.size() == 0);
+      CUDAX_CHECK(input.data() == nullptr);
+      CUDAX_CHECK(equal_range(buf));
+    }
+  }
+  stream.sync();
 
 #if 0 // Implement exception handling
 #  if _CCCL_HAS_EXCEPTIONS()
@@ -336,4 +338,4 @@ C2H_TEST("cudax::async_buffer constructors", "[container][async_buffer]", test_t
   }
 #  endif // _CCCL_HAS_EXCEPTIONS()
 #endif // 0
-  }
+}


### PR DESCRIPTION
In addition to `async_buffer` constructors I would like to provide a `make_async_buffer` overload for each of the constructors with the same arguments. The benefit of `make_async_buffer` is that it can deduce default properties of the memory resource. It also takes an explicit stream argument, which might fit better with our future plans with graphs.