### PR TITLE
implement the proposed resolution of P3718 by adding a `get_domain_late` query.

### DIFF
--- a/cudax/include/cuda/experimental/__execution/domain.cuh
+++ b/cudax/include/cuda/experimental/__execution/domain.cuh
@@ -23,20 +23,35 @@
 
 #include <cuda/std/__execution/env.h>
 #include <cuda/std/__tuple_dir/ignore.h>
-#include <cuda/std/__type_traits/is_nothrow_move_constructible.h>
+#include <cuda/std/__type_traits/is_callable.h>
 #include <cuda/std/__type_traits/type_list.h>
 
 #include <cuda/experimental/__detail/utility.cuh>
 #include <cuda/experimental/__execution/fwd.cuh>
+#include <cuda/experimental/__execution/utility.cuh>
+#include <cuda/experimental/__execution/visit.cuh>
 
 #include <cuda/experimental/__execution/prologue.cuh>
 
 namespace cuda::experimental::execution
 {
 // NOLINTBEGIN(misc-unused-using-decls)
+using _CUDA_STD_EXEC::__forwarding_query;
+using _CUDA_STD_EXEC::__unwrap_reference_t;
+using _CUDA_STD_EXEC::env;
+using _CUDA_STD_EXEC::env_of_t;
+using _CUDA_STD_EXEC::forwarding_query;
+using _CUDA_STD_EXEC::forwarding_query_t;
+using _CUDA_STD_EXEC::get_env;
+using _CUDA_STD_EXEC::get_env_t;
+using _CUDA_STD_EXEC::prop;
+
+using _CUDA_STD_EXEC::__nothrow_queryable_with;
 using _CUDA_STD_EXEC::__query_result_t;
 using _CUDA_STD_EXEC::__queryable_with;
-using _CUDA_STD_EXEC::env_of_t;
+
+using _CUDA_STD_EXEC::__query_or;
+using _CUDA_STD_EXEC::__query_result_or_t;
 // NOLINTEND(misc-unused-using-decls)
 
 template <class _DomainOrTag, class... _Args>
@@ -81,7 +96,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT default_domain
   //! @return The result of transforming the sender with the given environment.
   _CCCL_EXEC_CHECK_DISABLE
   template <class _Sndr, class _Env>
-  _CCCL_TRIVIAL_API static constexpr auto transform_sender(_Sndr&& __sndr, const _Env& __env) noexcept(
+  [[nodiscard]] _CCCL_TRIVIAL_API static constexpr auto transform_sender(_Sndr&& __sndr, const _Env& __env) noexcept(
     noexcept(tag_of_t<_Sndr>{}.transform_sender(static_cast<_Sndr&&>(__sndr), __env)))
     -> __transform_sender_result_t<tag_of_t<_Sndr>, _Sndr, _Env>
   {
@@ -91,7 +106,8 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT default_domain
   //! @overload
   _CCCL_EXEC_CHECK_DISABLE
   template <class _Sndr>
-  _CCCL_TRIVIAL_API static constexpr auto transform_sender(_Sndr&& __sndr) noexcept(__nothrow_movable<_Sndr>) -> _Sndr
+  [[nodiscard]] _CCCL_TRIVIAL_API static constexpr auto
+  transform_sender(_Sndr&& __sndr) noexcept(__nothrow_movable<_Sndr>) -> _Sndr
   {
     // FUTURE TODO: add a transform for the split sender once we have a split sender
     return static_cast<_Sndr&&>(__sndr);
@@ -100,7 +116,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT default_domain
   //! @overload
   _CCCL_EXEC_CHECK_DISABLE
   template <class _Sndr>
-  _CCCL_TRIVIAL_API static constexpr auto
+  [[nodiscard]] _CCCL_TRIVIAL_API static constexpr auto
   transform_sender(_Sndr&& __sndr, _CUDA_VSTD::__ignore_t) noexcept(__nothrow_movable<_Sndr>) -> _Sndr
   {
     return static_cast<_Sndr&&>(__sndr);
@@ -108,114 +124,86 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT default_domain
 };
 
 //////////////////////////////////////////////////////////////////////////////////////////
-// get_domain
-template <class _Tag>
-extern _CUDA_VSTD::__undefined<_Tag> get_domain;
-
-// Used to query a sender's attributes for the domain on which `start` will be called,
-// if it knows. Also used to query a receiver's environment for the "current" domain,
-// if it knows.
-template <>
-struct get_domain_t<start_t>
+// get_domain has the following semantics:
+//
+// * When used to query a receiver's environment, returns the "current" domain, which is
+//   where `start` will be called on the operation state that results from connecting the
+//   receiver to a sender.
+// * When used to query a sender's attributes, returns the domain on which the sender's
+//   operation will complete, if the sender knows.
+// * When used to query a scheduler `sch`, it is equivalent to
+//   `get_domain(get_env(schedule(sch)))`.
+struct get_domain_t
 {
   _CCCL_EXEC_CHECK_DISABLE
   template <class _Env>
-  [[nodiscard]] _CCCL_API constexpr auto operator()([[maybe_unused]] const _Env& __env) const noexcept
+  [[nodiscard]] _CCCL_API constexpr auto operator()(const _Env&) const noexcept -> __query_result_t<_Env, get_domain_t>
   {
-    if constexpr (__queryable_with<_Env, get_domain_t<start_t>>)
-    {
-      static_assert(noexcept(__env.query(*this)));
-      return __query_result_t<_Env, get_domain_t<start_t>>{};
-    }
-    else
-    {
-      return default_domain{};
-    }
+    return {};
   }
-};
 
-// Explicitly instantiate this because of variable template weirdness in device code
-template <>
-_CCCL_GLOBAL_CONSTANT get_domain_t<start_t> get_domain<start_t>{};
-
-// For querying a sender's attributes for the domain on which `set_value` will be called,
-// if it knows.
-template <>
-struct get_domain_t<set_value_t>
-{
-  _CCCL_EXEC_CHECK_DISABLE
-  template <class _Env>
-  [[nodiscard]] _CCCL_API constexpr auto operator()([[maybe_unused]] const _Env& __env) const noexcept
-  {
-    if constexpr (__queryable_with<_Env, get_domain_t<set_value_t>>)
-    {
-      static_assert(noexcept(__env.query(*this)));
-      return __query_result_t<_Env, get_domain_t<set_value_t>>{};
-    }
-    else
-    {
-      // As a default, senders complete on the domain they start on
-      return get_domain<start_t>(__env);
-    }
-  }
-};
-
-// Explicitly instantiate this because of variable template weirdness in device code
-template <>
-_CCCL_GLOBAL_CONSTANT get_domain_t<set_value_t> get_domain<set_value_t>{};
-
-namespace __detail
-{
-template <class _Env, class _GetScheduler, class _Tag>
-_CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto __get_domain_impl() noexcept
-{
-  if constexpr (__queryable_with<_Env, get_domain_t<_Tag>>)
-  {
-    return __query_result_t<_Env, get_domain_t<_Tag>>{};
-  }
-  else if constexpr (__queryable_with<_Env, _GetScheduler>)
-  {
-    if constexpr (__queryable_with<__query_result_t<_Env, _GetScheduler>, get_domain_t<_Tag>>)
-    {
-      return __query_result_t<__query_result_t<_Env, _GetScheduler>, get_domain_t<_Tag>>{};
-    }
-    else
-    {
-      return default_domain{};
-    }
-  }
-  else
+  // NOT TO SPEC: return default_domain if the environment does not provide a domain.
+  [[nodiscard]] _CCCL_API constexpr auto operator()(_CUDA_VSTD::__ignore_t) const noexcept
   {
     return default_domain{};
   }
-  _CCCL_UNREACHABLE();
-}
 
-template <class _Sndr>
+  _CCCL_TRIVIAL_API static constexpr auto query(forwarding_query_t) noexcept
+  {
+    return true;
+  }
+};
+
+_CCCL_GLOBAL_CONSTANT get_domain_t get_domain{};
+
+// Used by the schedule_from and continues_on senders
+struct get_domain_late_t
+{
+  _CCCL_EXEC_CHECK_DISABLE
+  template <class _Env>
+  [[nodiscard]] _CCCL_API constexpr auto operator()(const _Env&) const noexcept
+    -> __query_result_t<_Env, get_domain_late_t>
+  {
+    return {};
+  }
+};
+
+_CCCL_GLOBAL_CONSTANT get_domain_late_t get_domain_late{};
+
+namespace __detail
+{
+template <class _Env, class _GetScheduler, class _Default>
+_CCCL_API auto __domain_of_fn(const _Env& __env, _GetScheduler, _Default) noexcept -> decltype(__query_or(
+  __env, get_domain, __query_or(__query_or(__env, _GetScheduler{}, __nil{}), get_domain, _Default{})));
+
+template <class _Env, class _GetScheduler, class _Default = default_domain>
+using __domain_of_t =
+  decltype(__detail::__domain_of_fn(declval<_Env>(), declval<_GetScheduler>(), declval<_Default>()));
+
+template <class _Sndr, class _Default = default_domain>
 _CCCL_TRIVIAL_API constexpr auto __get_domain_early() noexcept
 {
-  static_assert(!__sender_for<_Sndr, schedule_from_t>);
-  return __detail::__get_domain_impl<env_of_t<_Sndr>, get_completion_scheduler_t<set_value_t>, set_value_t>();
+  return __domain_of_t<env_of_t<_Sndr>, get_completion_scheduler_t<set_value_t>, _Default>{};
 }
 
 template <class _Sndr, class _Env>
 _CCCL_TRIVIAL_API constexpr auto __get_domain_late() noexcept
 {
-  if constexpr (__sender_for<_Sndr, schedule_from_t>)
+  using __env_domain_t _CCCL_NODEBUG_ALIAS = __domain_of_t<_Env, get_scheduler_t>;
+
+  // If the sender is a continues_on or schedule_from sender, we check with the sender for
+  // its domain. If it does not provide one, we fall back to using the domain from the
+  // receiver's environment.
+  if constexpr (__queryable_with<env_of_t<_Sndr>, get_domain_late_t>)
   {
-    // schedule_from always dispatches based on the domain of the scheduler
-    return __query_result_t<env_of_t<_Sndr>, get_domain_t<set_value_t>>{};
-  }
-  else if constexpr (__queryable_with<env_of_t<_Sndr>, get_domain_t<start_t>>)
-  {
-    return __query_result_t<env_of_t<_Sndr>, get_domain_t<start_t>>{};
+    using __late_domain_t _CCCL_NODEBUG_ALIAS = __query_result_t<env_of_t<_Sndr>, get_domain_late_t>;
+    return _CUDA_VSTD::_If<_CUDA_VSTD::is_same_v<__late_domain_t, __nil>, __env_domain_t, __late_domain_t>{};
   }
   else
   {
-    return __detail::__get_domain_impl<_Env, get_scheduler_t, start_t>();
+    return __env_domain_t{};
   }
 }
-
 } // namespace __detail
 
 template <class... _Ts>

--- a/cudax/include/cuda/experimental/__execution/let_value.cuh
+++ b/cudax/include/cuda/experimental/__execution/let_value.cuh
@@ -127,7 +127,7 @@ private:
     template <class _Tag, class... _As>
     _CCCL_API void __complete(_Tag, _As&&... __as) noexcept
     {
-      if constexpr (_Tag() == _SetTag())
+      if constexpr (_Tag{} == _SetTag())
       {
         _CUDAX_TRY( //
           ({ //
@@ -150,7 +150,7 @@ private:
       else
       {
         // Forward the completion to the receiver unchanged.
-        _Tag()(static_cast<_Rcvr&&>(__rcvr_), static_cast<_As&&>(__as)...);
+        _Tag{}(static_cast<_Rcvr&&>(__rcvr_), static_cast<_As&&>(__as)...);
       }
     }
 
@@ -228,14 +228,7 @@ private:
     {
       using __result_t _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::__call_result_t<_Fn, _CUDA_VSTD::decay_t<_Ts>&...>;
       // ask the result sender if it knows where it will complete:
-      if constexpr (__queryable_with<env_of_t<__result_t>, get_domain_t<set_value_t>>)
-      {
-        return __query_result_t<env_of_t<__result_t>, get_domain_t<set_value_t>>{};
-      }
-      else
-      {
-        return __nil{};
-      }
+      return __detail::__domain_of_t<env_of_t<__result_t>, get_completion_scheduler_t<set_value_t>, __nil>{};
     }
   };
 
@@ -302,26 +295,16 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __let_t<_Disposition>::__sndr_t
     template <class _SetTag>
     _CCCL_API auto query(get_completion_scheduler_t<_SetTag>) const = delete;
 
-    // Returns the domain on which the let sender will start:
-    _CCCL_TEMPLATE(class _Env = env_of_t<_Sndr>)
-    _CCCL_REQUIRES(__queryable_with<_Env, get_domain_t<start_t>>)
-    [[nodiscard]] _CCCL_API static constexpr auto query(get_domain_t<start_t>) noexcept
-      -> __query_result_t<_Env, get_domain_t<start_t>>
-    {
-      return {};
-    }
-
     // Returns the domain on which the let sender will complete:
     _CCCL_TEMPLATE(class _Sndr2 = _Sndr)
     _CCCL_REQUIRES((!_CUDA_VSTD::same_as<__completion_domain_of_t<_Sndr2, _Fn>, __nil>) )
-    [[nodiscard]] _CCCL_API static constexpr auto query(get_domain_t<set_value_t>) noexcept
-      -> __completion_domain_of_t<_Sndr2, _Fn>
+    [[nodiscard]] _CCCL_API static constexpr auto query(get_domain_t) noexcept -> __completion_domain_of_t<_Sndr2, _Fn>
     {
       return {};
     }
 
     _CCCL_TEMPLATE(class _Query)
-    _CCCL_REQUIRES(__forwarding_query<_Query> _CCCL_AND(!__is_specialization_of_v<_Query, get_domain_t>)
+    _CCCL_REQUIRES(__forwarding_query<_Query> _CCCL_AND(!_CUDA_VSTD::same_as<_Query, get_domain_t>)
                      _CCCL_AND __queryable_with<env_of_t<_Sndr>, _Query>)
     [[nodiscard]] _CCCL_API auto query(_Query) const noexcept(__nothrow_queryable_with<env_of_t<_Sndr>, _Query>)
       -> __query_result_t<env_of_t<_Sndr>, _Query>

--- a/cudax/include/cuda/experimental/__execution/meta.cuh
+++ b/cudax/include/cuda/experimental/__execution/meta.cuh
@@ -40,9 +40,6 @@ _CCCL_DIAG_SUPPRESS_GCC("-Wnon-template-friend")
 
 namespace cuda::experimental::execution
 {
-template <class _Ret, class... _Args>
-using __fn_t _CCCL_NODEBUG_ALIAS = _Ret(_Args...);
-
 // The following must be left undefined
 template <class...>
 struct _DIAGNOSTIC;

--- a/cudax/include/cuda/experimental/__execution/schedule_from.cuh
+++ b/cudax/include/cuda/experimental/__execution/schedule_from.cuh
@@ -73,6 +73,15 @@ struct __transfer_sndr_t
 {
   using sender_concept = sender_t;
 
+  // For schedule_from, the domain to use when transforming the sender is the same as the
+  // scheduler's domain, or default_domain if it does not define one. For continues_on,
+  // the transformation domain is the same as the predecessor sender's domain, if it
+  // defines one.
+  using __sched_domain_t _CCCL_NODEBUG_ALIAS = __query_result_or_t<_Sch, get_domain_t, default_domain>;
+  using __sndr_domain_t _CCCL_NODEBUG_ALIAS  = __early_domain_of_t<_Sndr, __nil>;
+  using __late_domain_t _CCCL_NODEBUG_ALIAS =
+    _CUDA_VSTD::_If<_CUDA_VSTD::is_same_v<_Tag, schedule_from_t>, __sched_domain_t, __sndr_domain_t>;
+
   // see SCHED-ATTRS here: https://eel.is/c++draft/exec#snd.expos-6
   struct __attrs_t
   {
@@ -84,24 +93,25 @@ struct __transfer_sndr_t
       return __self_->__sch_;
     }
 
-    // Returns the domain on which the schedule_from/continues_on sender will start:
-    _CCCL_TEMPLATE(class _Env = env_of_t<_Sndr>)
-    _CCCL_REQUIRES(__queryable_with<_Env, get_domain_t<start_t>>)
-    [[nodiscard]] _CCCL_API static constexpr auto query(get_domain_t<start_t>) noexcept
-      -> __query_result_t<_Env, get_domain_t<start_t>>
+    // Both schedule_from and continues_on senders complete on the scheduler's domain.
+    [[nodiscard]] _CCCL_API static constexpr auto query(get_domain_t) noexcept -> __sched_domain_t
     {
       return {};
     }
 
-    // Returns the domain on which the schedule_from/continues_on sender will complete:
-    [[nodiscard]] _CCCL_API static constexpr auto query(get_domain_t<set_value_t>) noexcept
+    // schedule_from and continues_on have special rules for the domain used to transform
+    // the sender.
+    _CCCL_TEMPLATE(class _LateDomain = __late_domain_t)
+    _CCCL_REQUIRES((!_CUDA_VSTD::same_as<_LateDomain, __nil>) )
+    [[nodiscard]] _CCCL_API static constexpr auto query(get_domain_late_t) noexcept -> _LateDomain
     {
-      return _CUDA_VSTD::__call_result_t<get_domain_t<set_value_t>, _Sch>();
+      return {};
     }
 
+    // The following overload will not be considered when _Query is get_domain_late_t
+    // because get_domain_late_t is not a forwarding query.
     _CCCL_TEMPLATE(class _Query)
-    _CCCL_REQUIRES(__forwarding_query<_Query> _CCCL_AND(!__is_specialization_of_v<_Query, get_domain_t>)
-                     _CCCL_AND __queryable_with<env_of_t<_Sndr>, _Query>)
+    _CCCL_REQUIRES(__forwarding_query<_Query> _CCCL_AND __queryable_with<env_of_t<_Sndr>, _Query>)
     [[nodiscard]] _CCCL_API constexpr auto query(_Query) const
       noexcept(__nothrow_queryable_with<env_of_t<_Sndr>, _Query>) -> __query_result_t<env_of_t<_Sndr>, _Query>
     {
@@ -153,20 +163,36 @@ private:
 
   using __set_stopped_tuple_t _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::__tuple<set_stopped_t>;
 
-  using __complete_fn _CCCL_NODEBUG_ALIAS = void (*)(void*) noexcept;
+  struct __send_result_fn
+  {
+    template <class _Rcvr, class _Tag, class... _As>
+    _CCCL_API void operator()(_Rcvr& __rcvr, _Tag, _As&&... __args) const noexcept
+    {
+      _Tag{}(static_cast<_Rcvr&&>(__rcvr), static_cast<_As&&>(__args)...);
+    }
+  };
+
+  template <class _Rcvr>
+  struct __send_result_visitor
+  {
+    template <class _Tuple>
+    _CCCL_API void operator()(_Tuple&& __tuple) const noexcept
+    {
+      _CUDA_VSTD::__apply(__send_result_fn{}, static_cast<_Tuple&&>(__tuple), __rcvr_);
+    }
+
+    _Rcvr& __rcvr_;
+  };
 
   template <class _Rcvr, class _Result>
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __rcvr_t
   {
     using receiver_concept _CCCL_NODEBUG_ALIAS = receiver_t;
-    _Rcvr __rcvr_;
-    _Result __result_;
-    __complete_fn __complete_;
 
     template <class _Tag, class... _As>
     _CCCL_API void operator()(_Tag, _As&... __as) noexcept
     {
-      _Tag()(static_cast<_Rcvr&&>(__rcvr_), static_cast<_As&&>(__as)...);
+      _Tag{}(static_cast<_Rcvr&&>(__rcvr_), static_cast<_As&&>(__as)...);
     }
 
     template <class _Tag, class... _As>
@@ -175,13 +201,13 @@ private:
       using __tupl_t _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::__tuple<_Tag, _CUDA_VSTD::decay_t<_As>...>;
       if constexpr (__nothrow_decay_copyable<_As...>)
       {
-        __result_.template __emplace<__tupl_t>(_Tag(), static_cast<_As&&>(__as)...);
+        __result_.template __emplace<__tupl_t>(_Tag{}, static_cast<_As&&>(__as)...);
       }
       else
       {
         _CUDAX_TRY( //
           ({ //
-            __result_.template __emplace<__tupl_t>(_Tag(), static_cast<_As&&>(__as)...);
+            __result_.template __emplace<__tupl_t>(_Tag{}, static_cast<_As&&>(__as)...);
           }),
           _CUDAX_CATCH(...) //
           ({ //
@@ -189,33 +215,31 @@ private:
           }) //
         )
       }
-      __complete_ = +[](void* __ptr) noexcept {
-        auto& __self = *static_cast<__rcvr_t*>(__ptr);
-        auto& __tupl = *static_cast<__tupl_t*>(__self.__result_.__ptr());
-        _CUDA_VSTD::__apply(__self, __tupl);
-      };
     }
 
     _CCCL_API void set_value() noexcept
     {
-      __complete_(this);
+      _Result::__visit(__send_result_visitor<_Rcvr>{__rcvr_}, __result_);
     }
 
     template <class _Error>
-    _CCCL_API void set_error(_Error&& __error) noexcept
+    _CCCL_TRIVIAL_API void set_error(_Error&& __error) noexcept
     {
       execution::set_error(static_cast<_Rcvr&&>(__rcvr_), static_cast<_Error&&>(__error));
     }
 
-    _CCCL_API void set_stopped() noexcept
+    _CCCL_TRIVIAL_API void set_stopped() noexcept
     {
       execution::set_stopped(static_cast<_Rcvr&&>(__rcvr_));
     }
 
-    _CCCL_API auto get_env() const noexcept -> env_of_t<_Rcvr>
+    _CCCL_API auto get_env() const noexcept -> __fwd_env_t<env_of_t<_Rcvr>>
     {
-      return execution::get_env(__rcvr_);
+      return __fwd_env(execution::get_env(__rcvr_));
     }
+
+    _Rcvr __rcvr_;
+    _Result __result_;
   };
 
   template <class _Rcvr, class _CvSndr, class _Sch>
@@ -223,13 +247,13 @@ private:
   {
     using operation_state_concept _CCCL_NODEBUG_ALIAS = operation_state_t;
     using __env_t _CCCL_NODEBUG_ALIAS                 = __fwd_env_t<env_of_t<_Rcvr>>;
+    using __completions_t _CCCL_NODEBUG_ALIAS         = completion_signatures_of_t<_CvSndr, __env_t>;
 
     using __result_t _CCCL_NODEBUG_ALIAS =
-      typename completion_signatures_of_t<_CvSndr,
-                                          __env_t>::template __transform_q<_CUDA_VSTD::__decayed_tuple, __variant>;
+      typename __completions_t::template __transform_q<_CUDA_VSTD::__decayed_tuple, __variant>;
 
     _CCCL_API __opstate_t(_CvSndr&& __sndr, _Sch __sch, _Rcvr __rcvr)
-        : __rcvr_{static_cast<_Rcvr&&>(__rcvr), {}, nullptr}
+        : __rcvr_{static_cast<_Rcvr&&>(__rcvr), {}}
         , __opstate1_{execution::connect(static_cast<_CvSndr&&>(__sndr), __ref_rcvr(*this))}
         , __opstate2_{execution::connect(schedule(__sch), __ref_rcvr(__rcvr_))}
     {}
@@ -244,29 +268,30 @@ private:
     template <class... _As>
     _CCCL_API void set_value(_As&&... __as) noexcept
     {
-      __rcvr_.__set_result(set_value_t(), static_cast<_As&&>(__as)...);
+      __rcvr_.__set_result(set_value_t{}, static_cast<_As&&>(__as)...);
       execution::start(__opstate2_);
     }
 
     template <class _Error>
     _CCCL_API void set_error(_Error&& __error) noexcept
     {
-      __rcvr_.__set_result(set_error_t(), static_cast<_Error&&>(__error));
+      __rcvr_.__set_result(set_error_t{}, static_cast<_Error&&>(__error));
       execution::start(__opstate2_);
     }
 
     _CCCL_API void set_stopped() noexcept
     {
-      __rcvr_.__set_result(set_stopped_t());
+      __rcvr_.__set_result(set_stopped_t{});
       execution::start(__opstate2_);
     }
 
     [[nodiscard]] _CCCL_API auto get_env() const noexcept -> __env_t
     {
-      return __fwd_env(execution::get_env(__rcvr_.__rcvr));
+      return __fwd_env(execution::get_env(__rcvr_.__rcvr_));
     }
 
     __rcvr_t<_Rcvr, __result_t> __rcvr_;
+    // FUTURE: these two opstates have disjoint lifetimes, so store them in a variant:
     connect_result_t<_CvSndr, __rcvr_ref_t<__opstate_t, __env_t>> __opstate1_;
     connect_result_t<schedule_result_t<_Sch>, __rcvr_ref_t<__rcvr_t<_Rcvr, __result_t>>> __opstate2_;
   };
@@ -294,8 +319,7 @@ public:
     static_assert(__is_sender<_Sndr>);
     static_assert(__is_scheduler<_Sch>);
     // schedule_from always dispatches based on the domain of the scheduler
-    return transform_sender(get_domain<set_value_t>(__sch),
-                            __sndr_t<_Sndr, _Sch>{{{}, __sch, static_cast<_Sndr&&>(__sndr)}});
+    return transform_sender(get_domain(__sch), __sndr_t<_Sndr, _Sch>{{{}, __sch, static_cast<_Sndr&&>(__sndr)}});
   }
 };
 

--- a/cudax/include/cuda/experimental/__execution/starts_on.cuh
+++ b/cudax/include/cuda/experimental/__execution/starts_on.cuh
@@ -144,8 +144,7 @@ template <class _Sch, class _Sndr>
 _CCCL_TRIVIAL_API constexpr auto starts_on_t::operator()(_Sch __sch, _Sndr __sndr) const
 {
   using __sndr_t _CCCL_NODEBUG_ALIAS = starts_on_t::__sndr_t<_Sch, _Sndr>;
-  return transform_sender(get_domain<set_value_t>(__sch),
-                          __sndr_t{{}, static_cast<_Sch&&>(__sch), static_cast<_Sndr&&>(__sndr)});
+  return transform_sender(get_domain(__sch), __sndr_t{{}, static_cast<_Sch&&>(__sch), static_cast<_Sndr&&>(__sndr)});
 }
 
 template <class _Sch, class _Sndr>

--- a/cudax/include/cuda/experimental/__execution/type_traits.cuh
+++ b/cudax/include/cuda/experimental/__execution/type_traits.cuh
@@ -41,6 +41,12 @@ namespace cuda::experimental::execution
 template <template <class...> class _Fn, class... _Ts>
 inline constexpr bool __is_instantiable_with_v = _CUDA_VSTD::_IsValidExpansion<_Fn, _Ts...>::value;
 
+template <class _Ret, class... _Args>
+using __fn_t _CCCL_NODEBUG_ALIAS = _Ret(_Args...);
+
+template <class _Ret, class... _Args>
+using __fn_ptr_t _CCCL_NODEBUG_ALIAS = _Ret (*)(_Args...);
+
 template <class _Ty>
 using __cref_t _CCCL_NODEBUG_ALIAS = _Ty const&;
 

--- a/cudax/include/cuda/experimental/__execution/visit.cuh
+++ b/cudax/include/cuda/experimental/__execution/visit.cuh
@@ -133,6 +133,10 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT visit_t
 [[maybe_unused]]
 _CCCL_GLOBAL_CONSTANT visit_t visit{};
 
+template <class _Visitor, class _CvSndr, class _Context>
+using __visit_result_t _CCCL_NODEBUG_ALIAS =
+  decltype(execution::visit(declval<_Visitor&>(), declval<_CvSndr>(), declval<_Context&>()));
+
 } // namespace cuda::experimental::execution
 
 #undef _CCCL_FWD_LIKE

--- a/cudax/include/cuda/experimental/__execution/when_all.cuh
+++ b/cudax/include/cuda/experimental/__execution/when_all.cuh
@@ -490,12 +490,12 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT when_all_t::__sndr_t
   {
     if constexpr (sizeof...(_Sndrs) == 0)
     {
-      return prop{get_domain<start_t>, default_domain{}};
+      return prop{get_domain, default_domain{}};
     }
     else
     {
       using __dom_t _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::common_type_t<__early_domain_of_t<_Sndrs>...>;
-      return prop{get_domain<start_t>, __dom_t{}};
+      return prop{get_domain, __dom_t{}};
     }
     _CCCL_UNREACHABLE();
   }

--- a/cudax/test/execution/test_let_value.cu
+++ b/cudax/test/execution/test_let_value.cu
@@ -394,11 +394,10 @@ C2H_TEST("let_value keeps sends_stopped from input sender", "[adaptors][let_valu
 C2H_TEST("let_value can be customized", "[adaptors][let_value]")
 {
   // The customization will return a different value
-  auto sndr =
-    ex::just(std::string{"hello"}) | write_attrs(ex::prop{ex::get_domain<ex::set_value_t>, let_value_test_domain{}})
-    | ex::let_value([](std::string& x) {
-        return ex::just(x + ", world");
-      });
+  auto sndr = ex::just(std::string{"hello"}) | write_attrs(ex::prop{ex::get_domain, let_value_test_domain{}})
+            | ex::let_value([](std::string& x) {
+                return ex::just(x + ", world");
+              });
   wait_for_value(std::move(sndr), std::string{"hallo"});
 }
 
@@ -451,11 +450,11 @@ C2H_TEST("let_value can nest", "[adaptors][let_value]")
 
 C2H_TEST("let_value has the correct completion domain", "[adaptors][let_value]")
 {
-  auto attrs = ex::prop{ex::get_domain<ex::set_value_t>, let_value_test_domain{}};
+  auto attrs = ex::prop{ex::get_domain, let_value_test_domain{}};
   auto sndr  = ex::just() | ex::let_value([=] {
                 return write_attrs(ex::just(), attrs);
               });
-  auto dom   = ex::get_domain<ex::set_value_t>(ex::get_env(sndr));
+  auto dom   = ex::get_domain(ex::get_env(sndr));
   static_assert(_CUDA_VSTD::is_same_v<decltype(dom), let_value_test_domain>);
 }
 


### PR DESCRIPTION
## Description

this pr is a follow-up to #4779, which addressed the lazy customization of the `continues_on` algorithm by splitting the `get_domain` query into `get_domain<start_t>` and `get_domain<set_value_t>`. that solution received feedback from some other `std::execution` authors, so this pr skins the cat in a different, and simpler, way. the full write-up can be found in [P3718](https://isocpp.org/files/papers/P3718R0.html).

these changes to how sender algorithm customization were factored out of the very large PR #4579, which is taking a long time to land. That PR has already been reviewed and approved.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
