### PR TITLE
Disable bulk copy transform on sm120

### DIFF
--- a/cub/cub/device/dispatch/tuning/tuning_transform.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_transform.cuh
@@ -256,11 +256,25 @@ struct policy_hub<RequiresStableAddress, ::cuda::std::tuple<RandomAccessIterator
       : bulkcopy_policy<128, 1000>
       , ChainedPolicy<1000, policy1000, policy900>
   {};
-
-  using max_policy = policy1000;
-#else // _CUB_HAS_TRANSFORM_UBLKCP
-  using max_policy = policy300;
 #endif // _CUB_HAS_TRANSFORM_UBLKCP
+
+  // UBLKCP is disabled on sm120 for now
+  struct policy1200
+      : ChainedPolicy<1200,
+                      policy1200,
+#ifdef _CUB_HAS_TRANSFORM_UBLKCP
+                      policy1000
+#else // _CUB_HAS_TRANSFORM_UBLKCP
+                      policy300
+#endif // _CUB_HAS_TRANSFORM_UBLKCP
+                      >
+  {
+    static constexpr int min_bif    = arch_to_min_bytes_in_flight(1200);
+    static constexpr auto algorithm = Algorithm::prefetch;
+    using algo_policy               = prefetch_policy_t<256>;
+  };
+
+  using max_policy = policy1200;
 };
 
 } // namespace transform

--- a/cub/test/catch2_test_device_transform.cu
+++ b/cub/test/catch2_test_device_transform.cu
@@ -90,10 +90,14 @@ using algorithms =
 using offset_types = c2h::type_list<std::int32_t, std::int64_t>;
 
 #ifdef _CUB_HAS_TRANSFORM_UBLKCP
-#  define FILTER_UBLKCP                                \
-    if (alg == Algorithm::ublkcp && ptx_version < 900) \
-    {                                                  \
-      return;                                          \
+#  define FILTER_UBLKCP                                 \
+    if (alg == Algorithm::ublkcp && ptx_version < 900)  \
+    {                                                   \
+      return;                                           \
+    }                                                   \
+    if (alg == Algorithm::ublkcp && ptx_version > 1000) \
+    {                                                   \
+      return;                                           \
     }
 #else // _CUB_HAS_TRANSFORM_UBLKCP
 #  define FILTER_UBLKCP

--- a/cub/test/catch2_test_util_device.cu
+++ b/cub/test/catch2_test_util_device.cu
@@ -140,6 +140,7 @@ struct policy_hub_all
   GEN_POLICY(890, 870);
   GEN_POLICY(900, 890);
   GEN_POLICY(1000, 900);
+  GEN_POLICY(1200, 1000);
   // add more policies here when new architectures emerge
   GEN_POLICY(2000, 1000); // non-existing architecture, just to test pruning
 

--- a/cub/test/catch2_test_util_device.cu
+++ b/cub/test/catch2_test_util_device.cu
@@ -142,7 +142,7 @@ struct policy_hub_all
   GEN_POLICY(1000, 900);
   GEN_POLICY(1200, 1000);
   // add more policies here when new architectures emerge
-  GEN_POLICY(2000, 1000); // non-existing architecture, just to test pruning
+  GEN_POLICY(2000, 1200); // non-existing architecture, just to test pruning
 
   using max_policy = policy2000;
 };

--- a/cudax/test/containers/async_buffer/transform.cu
+++ b/cudax/test/containers/async_buffer/transform.cu
@@ -73,10 +73,14 @@ using algorithms =
                  >;
 
 #ifdef _CUB_HAS_TRANSFORM_UBLKCP
-#  define FILTER_UBLKCP                                \
-    if (alg == Algorithm::ublkcp && ptx_version < 900) \
-    {                                                  \
-      return;                                          \
+#  define FILTER_UBLKCP                                 \
+    if (alg == Algorithm::ublkcp && ptx_version < 900)  \
+    {                                                   \
+      return;                                           \
+    }                                                   \
+    if (alg == Algorithm::ublkcp && ptx_version > 1000) \
+    {                                                   \
+      return;                                           \
     }
 #else // _CUB_HAS_TRANSFORM_UBLKCP
 #  define FILTER_UBLKCP


### PR DESCRIPTION
We observed a few crashes internally that we need to investigate. So let's disable the feature for now.