### PR TITLE
avoid the use of `[[no_unique_address]]` in `prop` and `env` on nvcc

### DIFF
--- a/libcudacxx/include/cuda/std/__execution/env.h
+++ b/libcudacxx/include/cuda/std/__execution/env.h
@@ -180,7 +180,9 @@ struct __basic_query<_Query, void>
   }
 };
 
-#if _CCCL_HAS_ATTRIBUTE_NO_UNIQUE_ADDRESS() || defined(_CCCL_DOXYGEN_INVOKED)
+// nvvm/bin/cicc segfaults when `prop` uses [[no_unique_address]]
+#if (_CCCL_HAS_ATTRIBUTE_NO_UNIQUE_ADDRESS() || defined(_CCCL_DOXYGEN_INVOKED)) && !_CCCL_CUDA_COMPILER(NVCC) \
+  && !_CCCL_CUDA_COMPILER(NVRTC)
 
 //! @brief A template structure representing a query with a query and a value.
 //!
@@ -219,7 +221,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT _CCCL_DECLSPEC_EMPTY_BASES prop : _Query
     return __value;
   }
 
-  _CCCL_NO_UNIQUE_ADDRESS _Value __value;
+  _Value __value;
 };
 
 #endif // !_CCCL_HAS_ATTRIBUTE_NO_UNIQUE_ADDRESS()
@@ -395,7 +397,7 @@ template <class _Tag>
 _CCCL_CONCEPT __forwarding_query = forwarding_query(_Tag{});
 
 //////////////////////////////////////////////////////////////////////////////////////////
-// __query_or_default
+// __query_or
 namespace __detail
 {
 // query an environment, or return a default value if the query is not supported

--- a/libcudacxx/include/cuda/std/__execution/env.h
+++ b/libcudacxx/include/cuda/std/__execution/env.h
@@ -289,7 +289,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT env
     return env::__get_1st<_Query>(*this).query(__query);
   }
 
-  _CCCL_NO_UNIQUE_ADDRESS __tuple<_Envs...> __envs_;
+  __tuple<_Envs...> __envs_;
 };
 
 template <class... _Envs>


### PR DESCRIPTION
## Description

this change is split out of #4579, which is taking a long time to land. that change exposed an ICE in `cicc` due to the use of the `[[no_unique_address]]` attribute in `cuda::std::execution::prop`. this pr avoids using that attribute in `prop` when building with nvcc or nvrtc.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
