### PR TITLE
Update pip packages to include colorama

### DIFF
--- a/docs/cub/benchmarking.rst
+++ b/docs/cub/benchmarking.rst
@@ -250,7 +250,7 @@ Furthermore, you can plot the results, which requires additional python packages
 
 .. code-block:: bash
 
-    pip install fpzip pandas matplotlib seaborn tabulate PyQt5
+    pip install fpzip pandas matplotlib seaborn tabulate PyQt5 colorama
 
 You can plot one or more tuning databases as a bar chart or a box plot (add `--box`):
 


### PR DESCRIPTION
`colorama` needs to be installed too otherwise `nvbenhch_compare.py` complains. Maybe add suggestions to do these from within a virtual environment. 
