### PR TITLE
incidental fixes for ustdex

### DIFF
--- a/cudax/include/cuda/experimental/__execution/apply_sender.cuh
+++ b/cudax/include/cuda/experimental/__execution/apply_sender.cuh
@@ -56,7 +56,7 @@ public:
   //! @tparam _Args The arguments to pass to the algorithm.
   //! @param __sndr The sender object.
   //! @param __args The arguments to pass to the algorithm.
-  //! @return `DOM().apply_sender(_Tag(), __sndr, __args...)`, where `DOM` is the first of
+  //! @return `DOM{}.apply_sender(_Tag{}, __sndr, __args...)`, where `DOM` is the first of
   //! [`_Domain`, `default_domain`] to make the expression well-formed.
   //! @note This function is `constexpr` and `noexcept` if the underlying domain's
   //! `apply_sender` is `noexcept`.

--- a/cudax/include/cuda/experimental/__execution/env.cuh
+++ b/cudax/include/cuda/experimental/__execution/env.cuh
@@ -25,9 +25,12 @@
 #include <cuda/__memory_resource/properties.h>
 #include <cuda/__stream/get_stream.h>
 #include <cuda/std/__execution/env.h>
+#include <cuda/std/__tuple_dir/ignore.h>
+#include <cuda/std/__type_traits/conditional.h>
 #include <cuda/std/__type_traits/is_nothrow_move_constructible.h>
 #include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/__utility/move.h>
+#include <cuda/std/cstdint>
 
 #include <cuda/experimental/__execution/policy.cuh>
 #include <cuda/experimental/__execution/queries.cuh>
@@ -41,19 +44,8 @@ namespace cuda::experimental
 {
 namespace execution
 {
-// NOLINTBEGIN(misc-unused-using-decls)
-using _CUDA_STD_EXEC::__unwrap_reference_t;
-using _CUDA_STD_EXEC::env;
-using _CUDA_STD_EXEC::env_of_t;
-using _CUDA_STD_EXEC::get_env;
-using _CUDA_STD_EXEC::get_env_t;
-using _CUDA_STD_EXEC::prop;
-
-using _CUDA_STD_EXEC::__nothrow_queryable_with;
-using _CUDA_STD_EXEC::__query_result_t;
-using _CUDA_STD_EXEC::__queryable_with;
-// NOLINTEND(misc-unused-using-decls)
-
+// For senders that adapt other senders, the attribute queries are forwarded. __fwd_env_
+// is a utility that forwards queries to a given environment.
 template <class _Env>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __fwd_env_
 {
@@ -62,7 +54,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __fwd_env_
   [[nodiscard]] _CCCL_API constexpr auto query(_Query) const noexcept(__nothrow_queryable_with<_Env, _Query>)
     -> __query_result_t<_Env, _Query>
   {
-    return __env_.query(_Query());
+    return __env_.query(_Query{});
   }
 
   _Env __env_;
@@ -74,30 +66,17 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __fwd_env_fn
 {
   template <class _Env>
   [[nodiscard]] _CCCL_TRIVIAL_API constexpr auto operator()(_Env&& __env) const noexcept(__nothrow_movable<_Env>)
-    -> __fwd_env_<_Env>
+    -> decltype(auto)
   {
-    return __fwd_env_<_Env>{static_cast<_Env&&>(__env)};
-  }
-
-  template <class _Env>
-  [[nodiscard]] _CCCL_TRIVIAL_API constexpr auto operator()(__fwd_env_<_Env>&& __env) const noexcept -> __fwd_env_<_Env>
-  {
-    static_assert(noexcept(__fwd_env_<_Env>{static_cast<_Env&&>(__env)}),
-                  "The move constructor of __fwd_env_ must be noexcept");
-    return static_cast<__fwd_env_<_Env>&&>(__env);
-  }
-
-  template <class _Env>
-  [[nodiscard]] _CCCL_TRIVIAL_API constexpr auto operator()(__fwd_env_<_Env>& __env) const noexcept -> __fwd_env_<_Env>&
-  {
-    return __env;
-  }
-
-  template <class _Env>
-  [[nodiscard]] _CCCL_TRIVIAL_API constexpr auto operator()(const __fwd_env_<_Env>& __env) const noexcept
-    -> const __fwd_env_<_Env>&
-  {
-    return __env;
+    if constexpr (__is_specialization_of_v<_CUDA_VSTD::remove_cvref_t<_Env>, __fwd_env_>)
+    {
+      // If the environment is already a forwarding environment, we can just return it.
+      return static_cast<_Env>(static_cast<_Env&&>(__env)); // take care to not return an rvalue reference
+    }
+    else
+    {
+      return __fwd_env_<_Env>{static_cast<_Env&&>(__env)};
+    }
   }
 };
 } // namespace __detail

--- a/cudax/include/cuda/experimental/__execution/just.cuh
+++ b/cudax/include/cuda/experimental/__execution/just.cuh
@@ -129,12 +129,12 @@ _CCCL_TRIVIAL_API constexpr auto __just_t<_Disposition>::operator()(_Ts... __ts)
   return __sndr_t<_Ts...>{{}, {static_cast<_Ts&&>(__ts)...}};
 }
 
-template <class _Fn>
-inline constexpr size_t structured_binding_size<just_t::__sndr_t<_Fn>> = 2;
-template <class _Fn>
-inline constexpr size_t structured_binding_size<just_error_t::__sndr_t<_Fn>> = 2;
-template <class _Fn>
-inline constexpr size_t structured_binding_size<just_stopped_t::__sndr_t<_Fn>> = 2;
+template <class... _Ts>
+inline constexpr size_t structured_binding_size<just_t::__sndr_t<_Ts...>> = 2;
+template <class... _Ts>
+inline constexpr size_t structured_binding_size<just_error_t::__sndr_t<_Ts...>> = 2;
+template <class... _Ts>
+inline constexpr size_t structured_binding_size<just_stopped_t::__sndr_t<_Ts...>> = 2;
 
 _CCCL_GLOBAL_CONSTANT auto just         = just_t{};
 _CCCL_GLOBAL_CONSTANT auto just_error   = just_error_t{};

--- a/cudax/include/cuda/experimental/__execution/just_from.cuh
+++ b/cudax/include/cuda/experimental/__execution/just_from.cuh
@@ -59,7 +59,7 @@ private:
   using _SetTag _CCCL_NODEBUG_ALIAS  = decltype(__detail::__set_tag<_Disposition>());
 
   using __diag_t _CCCL_NODEBUG_ALIAS =
-    _CUDA_VSTD::conditional_t<_SetTag() == set_error,
+    _CUDA_VSTD::conditional_t<_SetTag{} == set_error,
                               _AN_ERROR_COMPLETION_MUST_HAVE_EXACTLY_ONE_ERROR_ARGUMENT,
                               _A_STOPPED_COMPLETION_MUST_HAVE_NO_ARGUMENTS>;
 
@@ -84,7 +84,7 @@ private:
     template <class... _Ts>
     _CCCL_API auto operator()(_Ts&&... __ts) const noexcept
     {
-      _SetTag()(static_cast<_Rcvr&&>(__rcvr_), static_cast<_Ts&&>(__ts)...);
+      _SetTag{}(static_cast<_Rcvr&&>(__rcvr_), static_cast<_Ts&&>(__ts)...);
     }
   };
 

--- a/cudax/include/cuda/experimental/__execution/queries.cuh
+++ b/cudax/include/cuda/experimental/__execution/queries.cuh
@@ -36,6 +36,7 @@ _CCCL_SUPPRESS_DEPRECATED_POP
 #include <cuda/experimental/__execution/stop_token.cuh>
 #include <cuda/experimental/__execution/type_traits.cuh>
 #include <cuda/experimental/__execution/utility.cuh>
+#include <cuda/experimental/__launch/configuration.cuh>
 
 #include <cuda/experimental/__execution/prologue.cuh>
 
@@ -43,9 +44,18 @@ namespace cuda::experimental::execution
 {
 // NOLINTBEGIN(misc-unused-using-decls)
 using _CUDA_STD_EXEC::__forwarding_query;
-using _CUDA_STD_EXEC::__queryable_with;
+using _CUDA_STD_EXEC::__unwrap_reference_t;
+using _CUDA_STD_EXEC::env;
+using _CUDA_STD_EXEC::env_of_t;
 using _CUDA_STD_EXEC::forwarding_query;
 using _CUDA_STD_EXEC::forwarding_query_t;
+using _CUDA_STD_EXEC::get_env;
+using _CUDA_STD_EXEC::get_env_t;
+using _CUDA_STD_EXEC::prop;
+
+using _CUDA_STD_EXEC::__nothrow_queryable_with;
+using _CUDA_STD_EXEC::__query_result_t;
+using _CUDA_STD_EXEC::__queryable_with;
 // NOLINTEND(misc-unused-using-decls)
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/cudax/include/cuda/experimental/__execution/rcvr_ref.cuh
+++ b/cudax/include/cuda/experimental/__execution/rcvr_ref.cuh
@@ -44,27 +44,24 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __rcvr_ref
       : __rcvr_{_CUDA_VSTD::addressof(__rcvr)}
   {}
 
-  _CCCL_EXEC_CHECK_DISABLE
   template <class... _As>
   _CCCL_TRIVIAL_API void set_value(_As&&... __as) noexcept
   {
-    static_cast<_Rcvr&&>(*__rcvr_).set_value(static_cast<_As&&>(__as)...);
+    execution::set_value(static_cast<_Rcvr&&>(*__rcvr_), static_cast<_As&&>(__as)...);
   }
 
-  _CCCL_EXEC_CHECK_DISABLE
   template <class _Error>
   _CCCL_TRIVIAL_API void set_error(_Error&& __err) noexcept
   {
-    static_cast<_Rcvr&&>(*__rcvr_).set_error(static_cast<_Error&&>(__err));
+    execution::set_error(static_cast<_Rcvr&&>(*__rcvr_), static_cast<_Error&&>(__err));
   }
 
-  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TRIVIAL_API void set_stopped() noexcept
   {
-    static_cast<_Rcvr&&>(*__rcvr_).set_stopped();
+    execution::set_stopped(static_cast<_Rcvr&&>(*__rcvr_));
   }
 
-  _CCCL_API auto get_env() const noexcept -> _Env
+  [[nodiscard]] _CCCL_TRIVIAL_API auto get_env() const noexcept -> _Env
   {
     static_assert(_CUDA_VSTD::is_same_v<_Env, env_of_t<_Rcvr>>,
                   "get_env() must return the same type as env_of_t<_Rcvr>");
@@ -116,13 +113,13 @@ template <class _Env = void, class _Rcvr>
   {
     return __rcvr_ref<_Rcvr, _Env>{__rcvr};
   }
-  else if constexpr (_CUDA_VSTD::is_nothrow_copy_constructible_v<_Rcvr>)
+  else if constexpr (__nothrow_constructible<_Rcvr, const _Rcvr&> && _CUDA_VSTD::is_copy_constructible_v<_Rcvr>)
   {
-    return __rcvr;
+    return const_cast<const _Rcvr&>(__rcvr);
   }
   else
   {
-    return __rcvr_ref<_Rcvr, _Env>{__rcvr};
+    return __rcvr_ref{__rcvr};
   }
   _CCCL_UNREACHABLE();
 }

--- a/cudax/include/cuda/experimental/__execution/rcvr_with_env.cuh
+++ b/cudax/include/cuda/experimental/__execution/rcvr_with_env.cuh
@@ -33,45 +33,46 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __rcvr_with_env_t : _Rcvr
 {
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __env_t
   {
-    template <class _Query>
-    [[nodiscard]] _CCCL_TRIVIAL_API static constexpr auto __get_1st(const __env_t& __self) noexcept -> decltype(auto)
-    {
-      if constexpr (__queryable_with<_Env, _Query>)
-      {
-        return (__self.__rcvr_->__env_);
-      }
-      else
-      {
-        return execution::get_env(__self.__rcvr_->__base());
-      }
-    }
-
-    template <class _Query>
-    using __1st_env_t _CCCL_NODEBUG_ALIAS = decltype(__env_t::__get_1st<_Query>(declval<const __env_t&>()));
-
+    // Prefer to query _Env
     _CCCL_EXEC_CHECK_DISABLE
     _CCCL_TEMPLATE(class _Query)
-    _CCCL_REQUIRES(__forwarding_query<_Query> _CCCL_AND __queryable_with<__1st_env_t<_Query>, _Query>)
-    [[nodiscard]] _CCCL_TRIVIAL_API constexpr auto query(_Query) const
-      noexcept(__nothrow_queryable_with<__1st_env_t<_Query>, _Query>) -> __query_result_t<__1st_env_t<_Query>, _Query>
+    _CCCL_REQUIRES(__queryable_with<_Env, _Query>)
+    [[nodiscard]] _CCCL_TRIVIAL_API constexpr auto query(_Query) const noexcept(__nothrow_queryable_with<_Env, _Query>)
+      -> __query_result_t<_Env, _Query>
     {
-      return __env_t::__get_1st<_Query>(*this).query(_Query{});
+      return __rcvr_->__env_.query(_Query{});
+    }
+
+    // Fallback to querying the inner receiver's environment, but only for forwarding
+    // queries.
+    _CCCL_EXEC_CHECK_DISABLE
+    _CCCL_TEMPLATE(class _Query)
+    _CCCL_REQUIRES((!__queryable_with<_Env, _Query>)
+                     _CCCL_AND __forwarding_query<_Query> _CCCL_AND __queryable_with<env_of_t<_Rcvr>, _Query>)
+    [[nodiscard]] _CCCL_TRIVIAL_API constexpr auto query(_Query) const
+      noexcept(__nothrow_queryable_with<env_of_t<_Rcvr>, _Query>) -> __query_result_t<env_of_t<_Rcvr>, _Query>
+    {
+      // If _Env has a value for the `get_scheduler` query, then we should not be
+      // forwarding a get_domain query to the parent receiver's environment.
+      static_assert(!_CUDA_VSTD::is_same_v<_Query, get_domain_t> || !__queryable_with<_Env, get_scheduler_t>,
+                    "_Env specifies a scheduler but not a domain.");
+      return execution::get_env(__rcvr_->__base()).query(_Query{});
     }
 
     __rcvr_with_env_t const* __rcvr_;
   };
 
-  _CCCL_TRIVIAL_API auto __base() && noexcept -> _Rcvr&&
+  [[nodiscard]] _CCCL_TRIVIAL_API auto __base() && noexcept -> _Rcvr&&
   {
     return static_cast<_Rcvr&&>(*this);
   }
 
-  _CCCL_TRIVIAL_API auto __base() & noexcept -> _Rcvr&
+  [[nodiscard]] _CCCL_TRIVIAL_API auto __base() & noexcept -> _Rcvr&
   {
     return *this;
   }
 
-  _CCCL_TRIVIAL_API auto __base() const& noexcept -> _Rcvr const&
+  [[nodiscard]] _CCCL_TRIVIAL_API auto __base() const& noexcept -> _Rcvr const&
   {
     return *this;
   }
@@ -85,7 +86,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __rcvr_with_env_t : _Rcvr
 };
 
 template <class _Rcvr, class _Env>
-__rcvr_with_env_t(_Rcvr, _Env) -> __rcvr_with_env_t<_Rcvr, _Env>;
+_CCCL_HOST_DEVICE __rcvr_with_env_t(_Rcvr, _Env) -> __rcvr_with_env_t<_Rcvr, _Env>;
 
 } // namespace cuda::experimental::execution
 

--- a/cudax/include/cuda/experimental/__execution/read_env.cuh
+++ b/cudax/include/cuda/experimental/__execution/read_env.cuh
@@ -66,13 +66,13 @@ private:
       {
         // This looks like a use after move, but `set_value` takes its
         // arguments by forwarding reference, so it's safe.
-        execution::set_value(static_cast<_Rcvr&&>(__rcvr_), _Query()(execution::get_env(__rcvr_)));
+        execution::set_value(static_cast<_Rcvr&&>(__rcvr_), _Query{}(execution::get_env(__rcvr_)));
       }
       else
       {
         _CUDAX_TRY( //
           ({ //
-            execution::set_value(static_cast<_Rcvr&&>(__rcvr_), _Query()(execution::get_env(__rcvr_)));
+            execution::set_value(static_cast<_Rcvr&&>(__rcvr_), _Query{}(execution::get_env(__rcvr_)));
           }),
           _CUDAX_CATCH(...) //
           ({ //

--- a/cudax/include/cuda/experimental/__execution/run_loop.cuh
+++ b/cudax/include/cuda/experimental/__execution/run_loop.cuh
@@ -85,7 +85,7 @@ private:
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __opstate_t : __task
   {
     __atomic_intrusive_queue<&__task::__next_>* __queue_;
-    _CCCL_NO_UNIQUE_ADDRESS _Rcvr __rcvr_;
+    _Rcvr __rcvr_;
 
     _CCCL_API static void __execute_impl(__task* __p) noexcept
     {
@@ -103,7 +103,10 @@ private:
         }),
         _CUDAX_CATCH(...) //
         ({ //
-          set_error(static_cast<_Rcvr&&>(__rcvr), ::std::current_exception());
+          if constexpr (!noexcept(get_stop_token(declval<env_of_t<_Rcvr>>()).stop_requested()))
+          {
+            set_error(static_cast<_Rcvr&&>(__rcvr), ::std::current_exception());
+          }
         }) //
       )
     }
@@ -123,6 +126,17 @@ private:
 public:
   class _CCCL_TYPE_VISIBILITY_DEFAULT scheduler
   {
+    friend run_loop;
+
+    _CCCL_API explicit scheduler(run_loop* __loop) noexcept
+        : __loop_(__loop)
+    {}
+
+    run_loop* __loop_;
+
+  public:
+    using scheduler_concept _CCCL_NODEBUG_ALIAS = scheduler_t;
+
     struct _CCCL_TYPE_VISIBILITY_DEFAULT __sndr_t
     {
       using sender_concept _CCCL_NODEBUG_ALIAS = sender_t;
@@ -133,14 +147,17 @@ public:
         return {&__loop_->__queue_, static_cast<_Rcvr&&>(__rcvr)};
       }
 
-      template <class _Self>
+      template <class _Self, class _Env>
       [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL auto get_completion_signatures() noexcept
       {
 #if _CCCL_HAS_EXCEPTIONS()
-        return completion_signatures<set_value_t(), set_error_t(::std::exception_ptr), set_stopped_t()>{};
-#else // ^^^ _CCCL_HAS_EXCEPTIONS() ^^^ / vvv !_CCCL_HAS_EXCEPTIONS() vvv
-        return completion_signatures<set_value_t(), set_stopped_t()>{};
+        if constexpr (!noexcept(get_stop_token(declval<_Env>()).stop_requested()))
+        {
+          return completion_signatures<set_value_t(), set_error_t(::std::exception_ptr), set_stopped_t()>{};
+        }
+        else
 #endif // !_CCCL_HAS_EXCEPTIONS()
+          return completion_signatures<set_value_t(), set_stopped_t()>{};
       }
 
     private:
@@ -175,25 +192,14 @@ public:
       run_loop* const __loop_;
     };
 
-    friend run_loop;
-
-    _CCCL_API explicit scheduler(run_loop* __loop) noexcept
-        : __loop_(__loop)
-    {}
+    [[nodiscard]] _CCCL_API auto schedule() const noexcept -> __sndr_t
+    {
+      return __sndr_t{__loop_};
+    }
 
     _CCCL_API auto query(get_forward_progress_guarantee_t) const noexcept -> forward_progress_guarantee
     {
       return forward_progress_guarantee::parallel;
-    }
-
-    run_loop* __loop_;
-
-  public:
-    using scheduler_concept _CCCL_NODEBUG_ALIAS = scheduler_t;
-
-    [[nodiscard]] _CCCL_API auto schedule() const noexcept -> __sndr_t
-    {
-      return __sndr_t{__loop_};
     }
 
     [[nodiscard]] _CCCL_API friend bool operator==(const scheduler& __a, const scheduler& __b) noexcept

--- a/cudax/include/cuda/experimental/__execution/starts_on.cuh
+++ b/cudax/include/cuda/experimental/__execution/starts_on.cuh
@@ -40,12 +40,17 @@ namespace cuda::experimental::execution
 template <class _Sch>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __sch_env_t
 {
-  _Sch __sch_;
-
-  auto query(get_scheduler_t) const noexcept -> _Sch
+  [[nodiscard]] _CCCL_API constexpr auto query(get_scheduler_t) const noexcept -> _Sch
   {
     return __sch_;
   }
+
+  [[nodiscard]] static _CCCL_API _CCCL_CONSTEVAL auto query(get_domain_t) noexcept
+  {
+    return _CUDA_VSTD::__call_result_t<get_domain_t, _Sch>{};
+  }
+
+  _Sch __sch_;
 };
 
 struct starts_on_t
@@ -55,7 +60,7 @@ private:
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __opstate_t : __rcvr_with_env_t<_Rcvr, __sch_env_t<_Sch>>
   {
     using operation_state_concept _CCCL_NODEBUG_ALIAS = operation_state_t;
-    using __env_t _CCCL_NODEBUG_ALIAS                 = env_of_t<_Rcvr>;
+    using __env_t _CCCL_NODEBUG_ALIAS                 = __fwd_env_t<env_of_t<_Rcvr>>;
     using __rcvr_with_sch_t _CCCL_NODEBUG_ALIAS       = __rcvr_with_env_t<_Rcvr, __sch_env_t<_Sch>>;
 
     _CCCL_API __opstate_t(_Sch __sch, _Rcvr __rcvr, _CvSndr&& __sndr)
@@ -76,9 +81,9 @@ private:
       execution::start(__opstate2_);
     }
 
-    _CCCL_API auto get_env() const noexcept -> __env_t
+    [[nodiscard]] _CCCL_API auto get_env() const noexcept -> __env_t
     {
-      return execution::get_env(this->__base());
+      return __fwd_env(execution::get_env(this->__base()));
     }
 
     connect_result_t<schedule_result_t<_Sch&>, __rcvr_ref_t<__opstate_t, __env_t>> __opstate1_;
@@ -123,13 +128,13 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT starts_on_t::__sndr_t
   }
 
   template <class _Rcvr>
-  _CCCL_API auto connect(_Rcvr __rcvr) && -> __opstate_t<_Rcvr, _Sch, _Sndr>
+  [[nodiscard]] _CCCL_API auto connect(_Rcvr __rcvr) && -> __opstate_t<_Rcvr, _Sch, _Sndr>
   {
     return __opstate_t<_Rcvr, _Sch, _Sndr>{__sch_, static_cast<_Rcvr&&>(__rcvr), static_cast<_Sndr&&>(__sndr_)};
   }
 
   template <class _Rcvr>
-  _CCCL_API auto connect(_Rcvr __rcvr) const& -> __opstate_t<_Rcvr, _Sch, const _Sndr&>
+  [[nodiscard]] _CCCL_API auto connect(_Rcvr __rcvr) const& -> __opstate_t<_Rcvr, _Sch, const _Sndr&>
   {
     return __opstate_t<_Rcvr, _Sch, const _Sndr&>{__sch_, static_cast<_Rcvr&&>(__rcvr), __sndr_};
   }
@@ -141,7 +146,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT starts_on_t::__sndr_t
 };
 
 template <class _Sch, class _Sndr>
-_CCCL_TRIVIAL_API constexpr auto starts_on_t::operator()(_Sch __sch, _Sndr __sndr) const
+[[nodiscard]] _CCCL_TRIVIAL_API constexpr auto starts_on_t::operator()(_Sch __sch, _Sndr __sndr) const
 {
   using __sndr_t _CCCL_NODEBUG_ALIAS = starts_on_t::__sndr_t<_Sch, _Sndr>;
   return transform_sender(get_domain(__sch), __sndr_t{{}, static_cast<_Sch&&>(__sch), static_cast<_Sndr&&>(__sndr)});

--- a/cudax/include/cuda/experimental/__execution/stop_token.cuh
+++ b/cudax/include/cuda/experimental/__execution/stop_token.cuh
@@ -275,7 +275,7 @@ private:
     static_cast<_Fun&&>(static_cast<inplace_stop_callback*>(__cb)->__fun)();
   }
 
-  _CCCL_NO_UNIQUE_ADDRESS _Fun __fun;
+  _Fun __fun;
 };
 
 namespace __stok

--- a/cudax/include/cuda/experimental/__execution/sync_wait.cuh
+++ b/cudax/include/cuda/experimental/__execution/sync_wait.cuh
@@ -32,6 +32,7 @@
 #include <cuda/experimental/__execution/exception.cuh>
 #include <cuda/experimental/__execution/meta.cuh>
 #include <cuda/experimental/__execution/run_loop.cuh>
+#include <cuda/experimental/__execution/type_traits.cuh>
 #include <cuda/experimental/__execution/utility.cuh>
 #include <cuda/experimental/__execution/variant.cuh>
 #include <cuda/experimental/__execution/write_env.cuh>
@@ -48,18 +49,17 @@ struct sync_wait_t
 {
 private:
   template <class _Env>
-  struct _CCCL_TYPE_VISIBILITY_DEFAULT __env_state_t
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __state_base_t
   {
     // FUTURE: if _Env provides a delegation scheduler, we don't need the run_loop
     run_loop __loop_;
-    _CCCL_NO_UNIQUE_ADDRESS _Env __env_;
+    _Env __env_;
   };
 
   template <class _Env>
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __env_t
   {
-    __env_state_t<_Env>* __state_;
-
+    _CCCL_EXEC_CHECK_DISABLE
     _CCCL_TEMPLATE(class _Query)
     _CCCL_REQUIRES(__queryable_with<_Env, _Query>)
     [[nodiscard]] _CCCL_API auto query(_Query) const noexcept(__nothrow_queryable_with<_Env, _Query>)
@@ -68,6 +68,7 @@ private:
       return __state_->__env_.query(_Query{});
     }
 
+    _CCCL_EXEC_CHECK_DISABLE
     [[nodiscard]] _CCCL_API auto query(get_scheduler_t) const noexcept
     {
       if constexpr (__queryable_with<_Env, get_scheduler_t>)
@@ -81,6 +82,7 @@ private:
       _CCCL_UNREACHABLE();
     }
 
+    _CCCL_EXEC_CHECK_DISABLE
     [[nodiscard]] _CCCL_API auto query(get_delegation_scheduler_t) const noexcept
     {
       if constexpr (__queryable_with<_Env, get_delegation_scheduler_t>)
@@ -93,55 +95,65 @@ private:
       }
       _CCCL_UNREACHABLE();
     }
+
+    __state_base_t<_Env>* __state_;
   };
 
-  template <class _Values, class _Errors, class _Env>
-  struct _CCCL_TYPE_VISIBILITY_DEFAULT __state_t : __env_state_t<_Env>
+  template <class _Sndr, class _Env>
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __state_t : __state_base_t<_Env>
   {
-    struct _CCCL_TYPE_VISIBILITY_DEFAULT __rcvr_t
+    using __completions_t _CCCL_NODEBUG_ALIAS = completion_signatures_of_t<_Sndr, __env_t<_Env>>;
+    using __values_t _CCCL_NODEBUG_ALIAS = __value_types<__completions_t, _CUDA_VSTD::tuple, _CUDA_VSTD::__type_self_t>;
+    using __errors_t _CCCL_NODEBUG_ALIAS = __error_types<__completions_t, __decayed_variant>;
+
+    _CUDA_VSTD::optional<__values_t>* __values_;
+    __errors_t __errors_;
+  };
+
+  template <class _Sndr, class _Env>
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __rcvr_t
+  {
+    using receiver_concept _CCCL_NODEBUG_ALIAS = receiver_t;
+    using __values_t _CCCL_NODEBUG_ALIAS       = typename __state_t<_Sndr, _Env>::__values_t;
+
+    template <class... _As>
+    _CCCL_API void set_value(_As&&... __as) && noexcept
     {
-      using receiver_concept _CCCL_NODEBUG_ALIAS = receiver_t;
+      _CUDAX_TRY( //
+        ({ //
+          __state_->__values_->emplace(static_cast<_As&&>(__as)...);
+        }), //
+        _CUDAX_CATCH(...) //
+        ({ //
+          // avoid ODR-using a call to __emplace(exception_ptr) if this code is
+          // unreachable.
+          if constexpr (!__nothrow_constructible<__values_t, _As...>)
+          {
+            __state_->__errors_.__emplace(::std::current_exception());
+          }
+        }) //
+      )
+      __state_->__loop_.finish();
+    }
 
-      template <class... _As>
-      _CCCL_API void set_value(_As&&... __as) && noexcept
-      {
-        _CUDAX_TRY( //
-          ({ //
-            __state_->__values_->emplace(static_cast<_As&&>(__as)...);
-          }), //
-          _CUDAX_CATCH(...) //
-          ({ //
-            if constexpr (!__nothrow_constructible<_Values, _As...>)
-            {
-              __state_->__errors_.__emplace(::std::current_exception());
-            }
-          }) //
-        )
-        __state_->__loop_.finish();
-      }
+    template <class _Error>
+    _CCCL_API void set_error(_Error __err) && noexcept
+    {
+      __state_->__errors_.__emplace(static_cast<_Error&&>(__err));
+      __state_->__loop_.finish();
+    }
 
-      template <class _Error>
-      _CCCL_API void set_error(_Error __err) && noexcept
-      {
-        __state_->__errors_.__emplace(static_cast<_Error&&>(__err));
-        __state_->__loop_.finish();
-      }
+    _CCCL_API void set_stopped() && noexcept
+    {
+      __state_->__loop_.finish();
+    }
 
-      _CCCL_API void set_stopped() && noexcept
-      {
-        __state_->__loop_.finish();
-      }
+    [[nodiscard]] _CCCL_API auto get_env() const noexcept -> __env_t<_Env>
+    {
+      return __env_t<_Env>{__state_};
+    }
 
-      [[nodiscard]] _CCCL_API auto get_env() const noexcept -> __env_t<_Env>
-      {
-        return __env_t<_Env>{__state_};
-      }
-
-      __state_t* __state_;
-    };
-
-    _CUDA_VSTD::optional<_Values>* __values_;
-    _Errors __errors_;
+    __state_t<_Sndr, _Env>* __state_;
   };
 
   struct __throw_error_fn
@@ -180,47 +192,32 @@ private:
 public:
   // This is the actual default sync_wait implementation.
   template <class _Sndr, class _Env>
-  _CCCL_HOST_API static auto apply_sender(_Sndr&& __sndr, _Env&& __env)
+  _CCCL_API static auto apply_sender(_Sndr&& __sndr, _Env&& __env)
   {
-    using __completions _CCCL_NODEBUG_ALIAS = completion_signatures_of_t<_Sndr, __env_t<_Env>>;
+    using __values_t _CCCL_NODEBUG_ALIAS = typename __state_t<_Sndr, _Env>::__values_t;
+    using __errors_t _CCCL_NODEBUG_ALIAS = typename __state_t<_Sndr, _Env>::__errors_t;
 
-    if constexpr (!__valid_completion_signatures<__completions>)
+    _CUDA_VSTD::optional<__values_t> __result{};
+    __state_t<_Sndr, _Env> __state{{{}, static_cast<_Env&&>(__env)}, &__result, {}};
+
+    // Launch the sender with a continuation that will fill in a variant
+    auto __opstate = execution::connect(static_cast<_Sndr&&>(__sndr), __rcvr_t<_Sndr, _Env>{&__state});
+    execution::start(__opstate);
+
+    // While waiting for the variant to be filled in, process any work that may be
+    // delegated to this thread.
+    __state.__loop_.run();
+
+    if (__state.__errors_.__index() != __npos)
     {
-      return __bad_sync_wait<__completions>::__result();
+      __errors_t::__visit(__throw_error_fn{}, static_cast<__errors_t&&>(__state.__errors_));
     }
-    else if constexpr (__completions().count(set_value) != 1)
-    {
-      static_assert(__completions().count(set_value) == 1,
-                    "sync_wait requires a sender with exactly one value completion signature.");
-    }
-    else
-    {
-      using __values_t _CCCL_NODEBUG_ALIAS = __value_types<__completions, _CUDA_VSTD::tuple, _CUDA_VSTD::__type_self_t>;
-      using __errors_t _CCCL_NODEBUG_ALIAS = __error_types<__completions, __decayed_variant>;
-      _CUDA_VSTD::optional<__values_t> __result{};
-      __state_t<__values_t, __errors_t, _Env> __state{{{}, static_cast<_Env&&>(__env)}, &__result, {}};
 
-      // Launch the sender with a continuation that will fill in a variant
-      using __rcvr_t = typename __state_t<__values_t, __errors_t, _Env>::__rcvr_t;
-      auto __opstate = execution::connect(static_cast<_Sndr&&>(__sndr), __rcvr_t{&__state});
-
-      execution::start(__opstate);
-
-      // While waiting for the variant to be filled in, process any work that may be
-      // delegated to this thread.
-      __state.__loop_.run();
-
-      if (__state.__errors_.__index() != __npos)
-      {
-        __errors_t::__visit(__throw_error_fn{}, static_cast<__errors_t&&>(__state.__errors_));
-      }
-
-      return __result; // uses NRVO to return the result
-    }
+    return __result; // uses NRVO to return the result
   }
 
   template <class _Sndr>
-  _CCCL_HOST_API static auto apply_sender(_Sndr&& __sndr)
+  _CCCL_API static auto apply_sender(_Sndr&& __sndr)
   {
     return apply_sender(static_cast<_Sndr&&>(__sndr), env{});
   }
@@ -252,18 +249,27 @@ public:
   ///         `cudaError_t`.
   /// @throws error otherwise
   // clang-format on
-  template <class _Sndr, class _Env>
-  _CCCL_HOST_API auto operator()(_Sndr&& __sndr, _Env&& __env) const
-  {
-    using __dom_t = __late_domain_of_t<_Sndr, __env_t<_Env>>;
-    return execution::apply_sender(__dom_t{}, *this, static_cast<_Sndr&&>(__sndr), static_cast<_Env&&>(__env));
-  }
-
   template <class _Sndr, class... _Env>
-  _CCCL_HOST_API auto operator()(_Sndr&& __sndr) const
+  _CCCL_API auto operator()(_Sndr&& __sndr, _Env&&... __env) const
   {
-    using __dom_t = __late_domain_of_t<_Sndr, __env_t<env<>>>;
-    return execution::apply_sender(__dom_t{}, *this, static_cast<_Sndr&&>(__sndr));
+    using __env_t                = sync_wait_t::__env_t<_CUDA_VSTD::__type_index_c<0, _Env..., env<>>>;
+    constexpr auto __completions = get_completion_signatures<_Sndr, __env_t>();
+    using __completions_t        = decltype(__completions);
+
+    if constexpr (!__valid_completion_signatures<__completions_t>)
+    {
+      return __bad_sync_wait<__completions_t>::__result();
+    }
+    else if constexpr (__completions.count(set_value) != 1)
+    {
+      static_assert(__completions.count(set_value) == 1,
+                    "sync_wait requires a sender with exactly one value completion signature.");
+    }
+    else
+    {
+      using __dom_t = __late_domain_of_t<_Sndr, __env_t>;
+      return execution::apply_sender(__dom_t{}, *this, static_cast<_Sndr&&>(__sndr), static_cast<_Env&&>(__env)...);
+    }
   }
 };
 

--- a/cudax/include/cuda/experimental/__execution/then.cuh
+++ b/cudax/include/cuda/experimental/__execution/then.cuh
@@ -161,7 +161,7 @@ private:
       }
       else
       {
-        _Tag()(static_cast<_Rcvr&&>(__rcvr_), static_cast<_Ts&&>(__ts)...);
+        _Tag{}(static_cast<_Rcvr&&>(__rcvr_), static_cast<_Ts&&>(__ts)...);
       }
     }
 

--- a/cudax/include/cuda/experimental/__execution/thread_context.cuh
+++ b/cudax/include/cuda/experimental/__execution/thread_context.cuh
@@ -21,30 +21,28 @@
 #  pragma system_header
 #endif // no system header
 
-#if _CCCL_HOST_COMPILATION()
+#include <cuda/experimental/__execution/run_loop.cuh>
 
-#  include <cuda/experimental/__execution/run_loop.cuh>
+#include <thread>
 
-#  include <thread>
-
-#  include <cuda/experimental/__execution/prologue.cuh>
+#include <cuda/experimental/__execution/prologue.cuh>
 
 namespace cuda::experimental::execution
 {
 struct _CCCL_TYPE_VISIBILITY_DEFAULT thread_context
 {
-  thread_context() noexcept
+  _CCCL_HOST_API thread_context() noexcept
       : __thrd_{[this] {
         __loop_.run();
       }}
   {}
 
-  ~thread_context() noexcept
+  _CCCL_HOST_API ~thread_context() noexcept
   {
     join();
   }
 
-  void join() noexcept
+  _CCCL_HOST_API void join() noexcept
   {
     if (__thrd_.joinable())
     {
@@ -53,7 +51,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT thread_context
     }
   }
 
-  auto get_scheduler()
+  _CCCL_HOST_API auto get_scheduler()
   {
     return __loop_.get_scheduler();
   }
@@ -64,8 +62,6 @@ private:
 };
 } // namespace cuda::experimental::execution
 
-#  include <cuda/experimental/__execution/epilogue.cuh>
-
-#endif // _CCCL_HOST_COMPILATION()
+#include <cuda/experimental/__execution/epilogue.cuh>
 
 #endif // __CUDAX_EXECUTION_THREAD_CONTEXT

--- a/cudax/include/cuda/experimental/__execution/variant.cuh
+++ b/cudax/include/cuda/experimental/__execution/variant.cuh
@@ -21,15 +21,19 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/std/__cccl/assert.h>
+#include <cuda/std/__concepts/same_as.h>
 #include <cuda/std/__memory/construct_at.h>
 #include <cuda/std/__new/launder.h>
 #include <cuda/std/__type_traits/decay.h>
+#include <cuda/std/__type_traits/type_set.h>
 #include <cuda/std/__utility/integer_sequence.h>
 
 #include <cuda/experimental/__execution/meta.cuh>
 #include <cuda/experimental/__execution/type_traits.cuh>
 #include <cuda/experimental/__execution/utility.cuh>
 
+#include <exception> // IWYU pragma: keep
 #include <new> // IWYU pragma: keep
 
 #include <cuda/experimental/__execution/prologue.cuh>
@@ -111,8 +115,7 @@ public:
 
   _CCCL_EXEC_CHECK_DISABLE
   template <class _Ty, class... _As>
-  _CCCL_API auto __emplace(_As&&... __as) //
-    noexcept(__nothrow_constructible<_Ty, _As...>) -> _Ty&
+  _CCCL_API auto __emplace(_As&&... __as) noexcept(__nothrow_constructible<_Ty, _As...>) -> _Ty&
   {
     constexpr size_t __new_index = execution::__index_of<_Ty, _Ts...>();
     static_assert(__new_index != __npos, "Type not in variant");
@@ -125,8 +128,7 @@ public:
 
   _CCCL_EXEC_CHECK_DISABLE
   template <size_t _Ny, class... _As>
-  _CCCL_API auto __emplace_at(_As&&... __as) //
-    noexcept(__nothrow_constructible<__at<_Ny>, _As...>) -> __at<_Ny>&
+  _CCCL_API auto __emplace_at(_As&&... __as) noexcept(__nothrow_constructible<__at<_Ny>, _As...>) -> __at<_Ny>&
   {
     static_assert(_Ny < sizeof...(_Ts), "variant index is too large");
 

--- a/cudax/include/cuda/experimental/__execution/visit.cuh
+++ b/cudax/include/cuda/experimental/__execution/visit.cuh
@@ -82,9 +82,9 @@ struct __unpack
 {
   // This is to generate a compile-time error if the sender type cannot be used to
   // initialize a structured binding.
-  auto operator()(_CUDA_VSTD::__ignore_t,
-                  __sender_type_cannot_be_used_to_initialize_a_structured_binding<_Arity>,
-                  _CUDA_VSTD::__ignore_t) const -> void;
+  _CCCL_API void operator()(_CUDA_VSTD::__ignore_t,
+                            __sender_type_cannot_be_used_to_initialize_a_structured_binding<_Arity>,
+                            _CUDA_VSTD::__ignore_t) const;
 };
 
 #  define _CCCL_UNPACK_SENDER(_Arity)                                                                               \

--- a/cudax/include/cuda/experimental/__execution/when_all.cuh
+++ b/cudax/include/cuda/experimental/__execution/when_all.cuh
@@ -96,7 +96,7 @@ private:
     [[nodiscard]] _CCCL_API auto query(_Query) const noexcept(__nothrow_queryable_with<env_of_t<__rcvr_t>, _Query>)
       -> __query_result_t<env_of_t<__rcvr_t>, _Query>
     {
-      return execution::get_env(__state_.__rcvr_).query(_Query());
+      return execution::get_env(__state_.__rcvr_).query(_Query{});
     }
   };
 
@@ -282,7 +282,6 @@ private:
     inplace_stop_token __stop_token_;
     _CUDA_VSTD::atomic<_CUDA_VSTD::underlying_type_t<__estate_t>> __state_;
     __errors_t __errors_;
-    // _CCCL_NO_UNIQUE_ADDRESS // gcc doesn't like this
     __values_t __values_;
     __lazy<__stop_callback_t> __on_stop_;
   };


### PR DESCRIPTION
## Description

this PR contains an assortment of fixes and simplifications to ustdex that have been split from #4579. this pr contains changes of the following kinds:

* change default initialization syntax from `()` to `{}`.
* add missing #includes.
* replace overload sets with `if constexpr`.
* added qualification on function calls.
* avoid instantiating code paths that are never taken.
* add missing `_CCCL_EXEC_CHECK_DISABLE` macros.
* add `[[nodiscard]]` in more places.
* add missing `__host__`/`__device__` annotations in places.
* factor type-checking out of `sync_wait` for reuse.

i have called out the bug fixes in review comments.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
