### PR TITLE
Env-based API for CUB part 1/3

### DIFF
--- a/libcudacxx/include/cuda/__memory_resource/get_memory_resource.h
+++ b/libcudacxx/include/cuda/__memory_resource/get_memory_resource.h
@@ -58,17 +58,19 @@ _CCCL_CONCEPT __has_query_get_memory_resource = _CCCL_REQUIRES_EXPR((_Env))(
 //! resource
 struct __get_memory_resource_t
 {
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(__has_member_get_resource<_Tp>)
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI constexpr decltype(auto) operator()(const _Tp& __t) const noexcept
+  [[nodiscard]] _CCCL_API constexpr decltype(auto) operator()(const _Tp& __t) const noexcept
   {
     static_assert(noexcept(__t.get_memory_resource()), "get_memory_resource must be noexcept");
     return __t.get_memory_resource();
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Env)
   _CCCL_REQUIRES(__has_query_get_memory_resource<_Env>)
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI constexpr decltype(auto) operator()(const _Env& __env) const noexcept
+  [[nodiscard]] _CCCL_API constexpr decltype(auto) operator()(const _Env& __env) const noexcept
   {
     static_assert(noexcept(__env.query(*this)), "get_memory_resource_t query must be noexcept");
     return __env.query(*this);

--- a/libcudacxx/include/cuda/__stream/get_stream.h
+++ b/libcudacxx/include/cuda/__stream/get_stream.h
@@ -56,7 +56,7 @@ struct get_stream_t
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(__convertible_to_stream_ref<_Tp>)
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI constexpr ::cuda::stream_ref operator()(const _Tp& __t) const
+  [[nodiscard]] _CCCL_API constexpr ::cuda::stream_ref operator()(const _Tp& __t) const
     noexcept(noexcept(static_cast<::cuda::stream_ref>(__t)))
   {
     return static_cast<::cuda::stream_ref>(__t);
@@ -65,7 +65,7 @@ struct get_stream_t
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(__has_member_get_stream<_Tp>)
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI constexpr ::cuda::stream_ref operator()(const _Tp& __t) const
+  [[nodiscard]] _CCCL_API constexpr ::cuda::stream_ref operator()(const _Tp& __t) const
     noexcept(noexcept(__t.get_stream()))
   {
     return __t.get_stream();
@@ -74,13 +74,13 @@ struct get_stream_t
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Env)
   _CCCL_REQUIRES(__has_query_get_stream<_Env>)
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI constexpr ::cuda::stream_ref operator()(const _Env& __env) const noexcept
+  [[nodiscard]] _CCCL_API constexpr ::cuda::stream_ref operator()(const _Env& __env) const noexcept
   {
     static_assert(noexcept(__env.query(*this)), "");
     return __env.query(*this);
   }
 
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI static constexpr auto query(_CUDA_STD_EXEC::forwarding_query_t) noexcept -> bool
+  [[nodiscard]] _CCCL_API static constexpr auto query(_CUDA_STD_EXEC::forwarding_query_t) noexcept -> bool
   {
     return true;
   }

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/get_memory_resource/get_memory_resource.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/get_memory_resource/get_memory_resource.pass.cpp
@@ -15,33 +15,33 @@
 
 struct test_resource
 {
-  void* allocate(std::size_t, std::size_t)
+  __host__ __device__ void* allocate(std::size_t, std::size_t)
   {
     return nullptr;
   }
 
-  void deallocate(void* ptr, std::size_t, std::size_t) noexcept
+  __host__ __device__ void deallocate(void* ptr, std::size_t, std::size_t) noexcept
   {
     // ensure that we did get the right inputs forwarded
     _val = *static_cast<int*>(ptr);
   }
 
-  void* allocate_async(std::size_t, std::size_t, cuda::stream_ref)
+  __host__ __device__ void* allocate_async(std::size_t, std::size_t, cuda::stream_ref)
   {
     return &_val;
   }
 
-  void deallocate_async(void* ptr, std::size_t, std::size_t, cuda::stream_ref)
+  __host__ __device__ void deallocate_async(void* ptr, std::size_t, std::size_t, cuda::stream_ref)
   {
     // ensure that we did get the right inputs forwarded
     _val = *static_cast<int*>(ptr);
   }
 
-  bool operator==(const test_resource& other) const
+  __host__ __device__ bool operator==(const test_resource& other) const
   {
     return _val == other._val;
   }
-  bool operator!=(const test_resource& other) const
+  __host__ __device__ bool operator!=(const test_resource& other) const
   {
     return _val != other._val;
   }
@@ -49,14 +49,14 @@ struct test_resource
   int _val = 0;
 };
 
-void test()
+__host__ __device__ void test()
 {
   { // Can call get_memory_resource on a type with a get_memory_resource method that returns a const lvalue
     struct with_get_resource_const_lvalue
     {
       test_resource res_{};
 
-      const test_resource& get_memory_resource() const noexcept
+      __host__ __device__ const test_resource& get_memory_resource() const noexcept
       {
         return res_;
       }
@@ -72,7 +72,7 @@ void test()
     {
       test_resource res_{};
 
-      test_resource get_memory_resource() const noexcept
+      __host__ __device__ test_resource get_memory_resource() const noexcept
       {
         return res_;
       }
@@ -88,7 +88,7 @@ void test()
     {
       test_resource res_{};
 
-      test_resource get_memory_resource() noexcept
+      __host__ __device__ test_resource get_memory_resource() noexcept
       {
         return res_;
       }
@@ -101,7 +101,7 @@ void test()
     {
       test_resource res_{};
 
-      const test_resource& query(::cuda::mr::get_memory_resource_t) const noexcept
+      __host__ __device__ const test_resource& query(::cuda::mr::get_memory_resource_t) const noexcept
       {
         return res_;
       }
@@ -117,7 +117,7 @@ void test()
     {
       test_resource res_{};
 
-      test_resource query(::cuda::mr::get_memory_resource_t) const noexcept
+      __host__ __device__ test_resource query(::cuda::mr::get_memory_resource_t) const noexcept
       {
         return res_;
       }
@@ -134,7 +134,7 @@ void test()
     {
       test_resource res_{};
 
-      const test_resource& query(::cuda::mr::get_memory_resource_t) noexcept
+      __host__ __device__ const test_resource& query(::cuda::mr::get_memory_resource_t) noexcept
       {
         return res_;
       }
@@ -147,12 +147,12 @@ void test()
     {
       test_resource res_{};
 
-      const test_resource& get_memory_resource() const noexcept
+      __host__ __device__ const test_resource& get_memory_resource() const noexcept
       {
         return res_;
       }
 
-      test_resource query(::cuda::mr::get_memory_resource_t) const noexcept
+      __host__ __device__ test_resource query(::cuda::mr::get_memory_resource_t) const noexcept
       {
         return res_;
       }
@@ -169,25 +169,26 @@ void test()
     {
       struct resource
       {
-        void* allocate(std::size_t, std::size_t)
+        __host__ __device__ void* allocate(std::size_t, std::size_t)
         {
           return nullptr;
         }
 
-        void deallocate(void*, std::size_t, std::size_t) noexcept {}
+        __host__ __device__ void deallocate(void*, std::size_t, std::size_t) noexcept {}
 
-        bool operator==(const resource&) const noexcept
+        __host__ __device__ bool operator==(const resource&) const noexcept
         {
           return true;
         }
-        bool operator!=(const resource&) const noexcept
+
+        __host__ __device__ bool operator!=(const resource&) const noexcept
         {
           return false;
         }
       };
       resource res_{};
 
-      resource get_memory_resource() const noexcept
+      __host__ __device__ resource get_memory_resource() const noexcept
       {
         return res_;
       }
@@ -198,7 +199,7 @@ void test()
 
 int main(int argc, char** argv)
 {
-  NV_IF_TARGET(NV_IS_HOST, test();)
+  test();
 
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/cuda/stream_ref/get_stream.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/stream_ref/get_stream.pass.cpp
@@ -12,7 +12,7 @@
 #include <cuda/std/type_traits>
 #include <cuda/stream_ref>
 
-void test()
+__host__ __device__ void test()
 {
   ::cudaStream_t stream = reinterpret_cast<::cudaStream_t>(42);
   { // Can call get_stream on a cudaStream_t
@@ -25,7 +25,7 @@ void test()
     {
       ::cudaStream_t stream_;
 
-      ::cuda::stream_ref get_stream() const noexcept
+      __host__ __device__ ::cuda::stream_ref get_stream() const noexcept
       {
         return ::cuda::stream_ref{stream_};
       }
@@ -40,7 +40,7 @@ void test()
     {
       ::cudaStream_t stream_;
 
-      ::cuda::stream_ref get_stream() noexcept
+      __host__ __device__ ::cuda::stream_ref get_stream() noexcept
       {
         return ::cuda::stream_ref{stream_};
       }
@@ -53,7 +53,7 @@ void test()
     {
       ::cudaStream_t stream_{};
 
-      ::cudaStream_t get_stream() const noexcept
+      __host__ __device__ ::cudaStream_t get_stream() const noexcept
       {
         return stream_;
       }
@@ -66,7 +66,7 @@ void test()
   { // Cannot call get_stream on a type with a non-const get_stream method
     struct returns_not_convertible_to_stream_ref
     {
-      int get_stream() const noexcept
+      __host__ __device__ int get_stream() const noexcept
       {
         return 42;
       }
@@ -79,7 +79,7 @@ void test()
     {
       ::cudaStream_t stream_{};
 
-      ::cuda::stream_ref query(::cuda::get_stream_t) const noexcept
+      __host__ __device__ ::cuda::stream_ref query(::cuda::get_stream_t) const noexcept
       {
         return ::cuda::stream_ref{stream_};
       }
@@ -94,7 +94,7 @@ void test()
     {
       ::cudaStream_t stream_{};
 
-      ::cudaStream_t query(::cuda::get_stream_t) const noexcept
+      __host__ __device__ ::cudaStream_t query(::cuda::get_stream_t) const noexcept
       {
         return stream_;
       }
@@ -107,7 +107,7 @@ void test()
   { // Cannot call get_stream on a type with a non-const get_stream method
     struct with_query_not_convertible_to_stream_ref
     {
-      int query(::cuda::get_stream_t) const noexcept
+      __host__ __device__ int query(::cuda::get_stream_t) const noexcept
       {
         return 42;
       }
@@ -118,7 +118,7 @@ void test()
 
 int main(int argc, char** argv)
 {
-  NV_IF_TARGET(NV_IS_HOST, test();)
+  test();
 
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/std/execution/exec.env/env.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/execution/exec.env/env.pass.cpp
@@ -57,6 +57,10 @@ __host__ __device__ TEST_CONSTEXPR_CXX20 bool test()
 
   cuda::std::execution::env e2{cuda::std::execution::prop{query1, 42}};
   assert(e2.query(query1) == 42);
+  assert(cuda::std::execution::__query_or(e2, query1, 24) == 42);
+  assert(cuda::std::execution::__query_or(e2, query2, 24) == 24);
+  static_assert(cuda::std::is_same_v<cuda::std::execution::__query_result_or_t<decltype(e2), query1_t, float>, int>);
+  static_assert(cuda::std::is_same_v<cuda::std::execution::__query_result_or_t<decltype(e2), query2_t, float>, float>);
   using expected_e2_t = cuda::std::execution::env<cuda::std::execution::prop<query1_t, int>>;
   static_assert(cuda::std::is_same_v<decltype(e2), expected_e2_t>);
   static_assert(is_trivial_aggregate<expected_e2_t>(), "");

--- a/libcudacxx/test/libcudacxx/std/execution/exec.env/env.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/execution/exec.env/env.pass.cpp
@@ -59,8 +59,12 @@ __host__ __device__ TEST_CONSTEXPR_CXX20 bool test()
   assert(e2.query(query1) == 42);
   assert(cuda::std::execution::__query_or(e2, query1, 24) == 42);
   assert(cuda::std::execution::__query_or(e2, query2, 24) == 24);
-  static_assert(cuda::std::is_same_v<cuda::std::execution::__query_result_or_t<decltype(e2), query1_t, float>, int>);
-  static_assert(cuda::std::is_same_v<cuda::std::execution::__query_result_or_t<decltype(e2), query2_t, float>, float>);
+  static_assert(cuda::std::is_same_v<
+                cuda::std::remove_cvref_t<cuda::std::execution::__query_result_or_t<decltype(e2), query1_t, float>>,
+                int>);
+  static_assert(cuda::std::is_same_v<
+                cuda::std::remove_cvref_t<cuda::std::execution::__query_result_or_t<decltype(e2), query2_t, float>>,
+                float>);
   using expected_e2_t = cuda::std::execution::env<cuda::std::execution::prop<query1_t, int>>;
   static_assert(cuda::std::is_same_v<decltype(e2), expected_e2_t>);
   static_assert(is_trivial_aggregate<expected_e2_t>(), "");


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
This PR makes `cuda::get_stream` and `cuda::mr::get_memory_resource` queries device-friendly. This is needed for device-side use of new env-based CUB API. 

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
