### PR TITLE
using the "magic_get" trick to infer a type's structured binding size

### DIFF
--- a/cudax/include/cuda/experimental/__execution/visit.cuh
+++ b/cudax/include/cuda/experimental/__execution/visit.cuh
@@ -23,6 +23,7 @@
 
 #include <cuda/std/__tuple_dir/ignore.h>
 #include <cuda/std/__type_traits/copy_cvref.h>
+#include <cuda/std/__type_traits/is_aggregate.h>
 
 #include <cuda/experimental/__execution/type_traits.cuh>
 
@@ -42,9 +43,38 @@ inline constexpr size_t structured_binding_size = __builtin_structured_binding_s
 #else // ^^^ _CCCL_HAS_BUILTIN(__builtin_structured_binding_size) ^^^ /
       // vvv !_CCCL_HAS_BUILTIN(__builtin_structured_binding_size) vvv
 
+struct __any_t
+{
+  template <class _Ty>
+  _CCCL_API operator _Ty&&();
+};
+
+_CCCL_DIAG_PUSH
+_CCCL_DIAG_SUPPRESS_CLANG("-Wmissing-field-initializers")
+
+// use the "magic tuple" trick to get the arity of a structured binding
+// see https://github.com/apolukhin/magic_get
+template <class _Ty, bool = _CUDA_VSTD::is_aggregate_v<_Ty>>
+struct __arity_of_t
+{
+  template <class... _Ts, class _Uy = _Ty, class _Uy2 = decltype(_Uy{_Ts{}...}), class _Self = __arity_of_t>
+  _CCCL_API auto operator()(_Ts... __ts) -> decltype(_Self{}(__ts..., __any_t{}));
+
+  template <class... _Ts>
+  _CCCL_API auto operator()(_Ts...) const -> char (*)[sizeof...(_Ts) + 1];
+};
+
+template <class _Ty>
+struct __arity_of_t<_Ty, false>
+{
+  _CCCL_API auto operator()() const -> char*;
+};
+
+_CCCL_DIAG_POP
+
 // Specialize this for each sender type that can be used to initialize a structured binding.
 template <class _Sndr>
-inline constexpr size_t structured_binding_size = static_cast<size_t>(-1);
+inline constexpr size_t structured_binding_size = sizeof(*__arity_of_t<_Sndr>{}()) - 2ul;
 
 #endif // _CCCL_HAS_BUILTIN(__builtin_structured_binding_size)
 

--- a/cudax/test/execution/test_visit.cu
+++ b/cudax/test/execution/test_visit.cu
@@ -16,6 +16,20 @@
 
 namespace
 {
+struct S0
+{};
+struct S1
+{
+  int a;
+};
+struct S2
+{
+  int a, b;
+};
+static_assert(cudax_async::structured_binding_size<S0> == 0);
+static_assert(cudax_async::structured_binding_size<S1> == 1);
+static_assert(cudax_async::structured_binding_size<S2> == 2);
+
 template <class Fn>
 struct recursive_lambda
 {


### PR DESCRIPTION

## Description

`std::execution` uses structured bindings for de-structuring a sender expression. there is no way in portable c++ to ask a type what size of structured binding it requires, or even if it can be used to initialize a structured binding at all.

in ustdex, i have worked around this with a `structured_binding_size` variable template, which needs to be specialized for a sender type if you want that type to be introspect-able.

in this pr, i augment that with the ["magic_get"](https://github.com/apolukhin/magic_get) trick to infer the number of fields that a plain struct has. this makes senders introspect-able without needing to specialize `structured_binding_size`.

```c++
struct S0
{};
struct S1
{
  int a;
};
struct S2
{
  int a, b;
};

static_assert(cuda::experimental::execution::structured_binding_size<S0> == 0);
static_assert(cuda::experimental::execution::structured_binding_size<S1> == 1);
static_assert(cuda::experimental::execution::structured_binding_size<S2> == 2);
```


## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
