### PR TITLE
Env-based API for CUB part 2/3

### DIFF
--- a/libcudacxx/include/cuda/__execution/determinism.h
+++ b/libcudacxx/include/cuda/__execution/determinism.h
@@ -1,0 +1,102 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __CUDA_STD__DETERMINISM_H
+#define __CUDA_STD__DETERMINISM_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/__execution/require.h>
+#include <cuda/std/__execution/env.h>
+#include <cuda/std/__type_traits/is_one_of.h>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_CUDA_EXECUTION
+
+namespace determinism
+{
+
+struct get_determinism_t;
+
+enum __determinism_t
+{
+  _not_guaranteed,
+  _run_to_run,
+  _gpu_to_gpu
+};
+
+template <__determinism_t _Guarantee>
+struct __determinism_holder_t : __requirement
+{
+  static constexpr __determinism_t value = _Guarantee;
+
+  [[nodiscard]] _CCCL_TRIVIAL_API constexpr auto query(const get_determinism_t&) const noexcept
+    -> __determinism_holder_t<_Guarantee>
+  {
+    return *this;
+  }
+};
+
+using gpu_to_gpu_t     = __determinism_holder_t<__determinism_t::_gpu_to_gpu>;
+using run_to_run_t     = __determinism_holder_t<__determinism_t::_run_to_run>;
+using not_guaranteed_t = __determinism_holder_t<__determinism_t::_not_guaranteed>;
+
+_CCCL_GLOBAL_CONSTANT gpu_to_gpu_t gpu_to_gpu{};
+_CCCL_GLOBAL_CONSTANT run_to_run_t run_to_run{};
+_CCCL_GLOBAL_CONSTANT not_guaranteed_t not_guaranteed{};
+
+template <class _Tp>
+_CCCL_CONCEPT_FRAGMENT(
+  __is_determinism_holder_,
+  requires()(requires(_CUDA_VSTD::__is_one_of_v<_Tp, gpu_to_gpu_t, run_to_run_t, not_guaranteed_t>)));
+
+template <class _Tp>
+_CCCL_CONCEPT __is_determinism_holder = _CCCL_FRAGMENT(__is_determinism_holder_, _Tp);
+
+template <class _Env>
+_CCCL_CONCEPT __has_query_get_determinism =
+  _CCCL_REQUIRES_EXPR((_Env), const _Env& __env, const get_determinism_t& __cpo)(
+    requires(__is_determinism_holder<decltype(__env.query(__cpo))>));
+
+struct get_determinism_t
+{
+  _CCCL_EXEC_CHECK_DISABLE
+  _CCCL_TEMPLATE(class _Env)
+  _CCCL_REQUIRES(__has_query_get_determinism<_Env>)
+  [[nodiscard]] _CCCL_TRIVIAL_API constexpr auto operator()(const _Env& __env) const noexcept
+  {
+    static_assert(noexcept(__env.query(*this)), "");
+    return __env.query(*this);
+  }
+
+  [[nodiscard]] _CCCL_TRIVIAL_API static constexpr auto query(_CUDA_STD_EXEC::forwarding_query_t) noexcept -> bool
+  {
+    return true;
+  }
+};
+
+_CCCL_GLOBAL_CONSTANT auto get_determinism = get_determinism_t{};
+
+} // namespace determinism
+
+_LIBCUDACXX_END_NAMESPACE_CUDA_EXECUTION
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // __CUDA_STD__DETERMINISM_H

--- a/libcudacxx/include/cuda/__execution/require.h
+++ b/libcudacxx/include/cuda/__execution/require.h
@@ -1,0 +1,67 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __CUDA_STD__REQUIRE_H
+#define __CUDA_STD__REQUIRE_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__execution/env.h>
+#include <cuda/std/__type_traits/conjunction.h>
+#include <cuda/std/__type_traits/is_base_of.h>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_CUDA_EXECUTION
+
+class __requirement
+{};
+
+struct get_requirements_t
+{
+  _CCCL_EXEC_CHECK_DISABLE
+  _CCCL_TEMPLATE(class _Env)
+  _CCCL_REQUIRES(_CUDA_STD_EXEC::__queryable_with<_Env, get_requirements_t>)
+  [[nodiscard]] _CCCL_TRIVIAL_API constexpr auto operator()(const _Env& __env) const noexcept
+  {
+    static_assert(noexcept(__env.query(*this)), "");
+    return __env.query(*this);
+  }
+
+  [[nodiscard]] _CCCL_TRIVIAL_API static constexpr auto query(_CUDA_STD_EXEC::forwarding_query_t) noexcept -> bool
+  {
+    return true;
+  }
+};
+
+_CCCL_GLOBAL_CONSTANT auto get_requirements = get_requirements_t{};
+
+template <class... _Requirements>
+[[nodiscard]] _CCCL_TRIVIAL_API auto require(_Requirements... __requirements)
+{
+  static_assert(_CUDA_VSTD::conjunction_v<_CUDA_VSTD::is_base_of<__requirement, _Requirements>...>,
+                "Only requirements can be passed to require");
+
+  return _CUDA_STD_EXEC::prop{get_requirements_t{}, _CUDA_STD_EXEC::env{__requirements...}};
+}
+
+_LIBCUDACXX_END_NAMESPACE_CUDA_EXECUTION
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // __CUDA_STD__REQUIRE_H

--- a/libcudacxx/include/cuda/__execution/tune.h
+++ b/libcudacxx/include/cuda/__execution/tune.h
@@ -1,0 +1,61 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __CUDA_STD__TUNE_H
+#define __CUDA_STD__TUNE_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__execution/env.h>
+#include <cuda/std/__type_traits/conjunction.h>
+#include <cuda/std/__type_traits/is_base_of.h>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_CUDA_EXECUTION
+
+struct get_tuning_t
+{
+  _CCCL_EXEC_CHECK_DISABLE
+  _CCCL_TEMPLATE(class _Env)
+  _CCCL_REQUIRES(_CUDA_STD_EXEC::__queryable_with<_Env, get_tuning_t>)
+  [[nodiscard]] _CCCL_TRIVIAL_API constexpr auto operator()(const _Env& __env) const noexcept
+  {
+    static_assert(noexcept(__env.query(*this)), "");
+    return __env.query(*this);
+  }
+
+  [[nodiscard]] _CCCL_TRIVIAL_API static constexpr auto query(_CUDA_STD_EXEC::forwarding_query_t) noexcept -> bool
+  {
+    return true;
+  }
+};
+
+_CCCL_GLOBAL_CONSTANT auto get_tuning = get_tuning_t{};
+
+template <class... _Tunings>
+[[nodiscard]] _CCCL_TRIVIAL_API auto tune(_Tunings... __tunings)
+{
+  return _CUDA_STD_EXEC::prop{get_tuning_t{}, _CUDA_STD_EXEC::env{__tunings...}};
+}
+
+_LIBCUDACXX_END_NAMESPACE_CUDA_EXECUTION
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // __CUDA_STD__TUNE_H

--- a/libcudacxx/include/cuda/std/__internal/namespaces.h
+++ b/libcudacxx/include/cuda/std/__internal/namespaces.h
@@ -73,6 +73,9 @@
 #  define _LIBCUDACXX_BEGIN_NAMESPACE_EXECUTION _LIBCUDACXX_PROLOGUE_INCLUDE_CHECK() namespace cuda::std::execution { inline namespace _LIBCUDACXX_ABI_NAMESPACE {
 #  define _LIBCUDACXX_END_NAMESPACE_EXECUTION } } _LIBCUDACXX_PROLOGUE_INCLUDE_CHECK()
 
+#  define _LIBCUDACXX_BEGIN_NAMESPACE_CUDA_EXECUTION namespace cuda { namespace execution { inline namespace _LIBCUDACXX_ABI_NAMESPACE {
+#  define _LIBCUDACXX_END_NAMESPACE_CUDA_EXECUTION } } }
+
 // Namespace to avoid name collisions with CPOs on clang-16 (see https://godbolt.org/z/9TadonrdM for example)
 #if _CCCL_COMPILER(CLANG, ==, 16)
 #  define _LIBCUDACXX_BEGIN_HIDDEN_FRIEND_NAMESPACE namespace __hidden {

--- a/libcudacxx/test/libcudacxx/cuda/execution/determinism.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/execution/determinism.pass.cpp
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/__execution/determinism.h>
+
+__host__ __device__ void test()
+{
+  namespace exec = cuda::execution;
+  static_assert(cuda::std::is_base_of_v<exec::__requirement, exec::determinism::run_to_run_t>);
+  static_assert(cuda::std::is_base_of_v<exec::__requirement, exec::determinism::not_guaranteed_t>);
+  static_assert(cuda::std::is_base_of_v<exec::__requirement, exec::determinism::gpu_to_gpu_t>);
+
+  static_assert(cuda::std::is_same_v<decltype(exec::determinism::get_determinism(exec::determinism::run_to_run)),
+                                     exec::determinism::run_to_run_t>);
+  static_assert(cuda::std::is_same_v<decltype(exec::determinism::get_determinism(exec::determinism::not_guaranteed)),
+                                     exec::determinism::not_guaranteed_t>);
+  static_assert(cuda::std::is_same_v<decltype(exec::determinism::get_determinism(exec::determinism::gpu_to_gpu)),
+                                     exec::determinism::gpu_to_gpu_t>);
+}
+
+int main(int, char**)
+{
+  test();
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/execution/require.fail.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/execution/require.fail.cpp
@@ -1,0 +1,29 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/__execution/determinism.h>
+
+[[maybe_unused]] _CCCL_GLOBAL_CONSTANT struct query_t
+{
+} query{};
+
+__host__ __device__ void test()
+{
+  // not every environment is a requirement
+  cuda::std::execution::prop p{query, 42};
+  cuda::execution::require(p);
+}
+
+int main(int, char**)
+{
+  test();
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/execution/require.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/execution/require.pass.cpp
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/__execution/determinism.h>
+
+__host__ __device__ void test()
+{
+  static_assert(
+    cuda::std::is_same_v<decltype(cuda::execution::determinism::get_determinism(cuda::execution::get_requirements(
+                           cuda::execution::require(cuda::execution::determinism::run_to_run)))),
+                         cuda::execution::determinism::run_to_run_t>);
+
+  static_assert(
+    cuda::std::is_same_v<decltype(cuda::execution::determinism::get_determinism(cuda::execution::get_requirements(
+                           cuda::execution::require(cuda::execution::determinism::not_guaranteed)))),
+                         cuda::execution::determinism::not_guaranteed_t>);
+}
+
+int main(int, char**)
+{
+  test();
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/execution/tune.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/execution/tune.pass.cpp
@@ -1,0 +1,84 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/__execution/tune.h>
+
+struct get_reduce_tuning_query_t
+{};
+
+template <class Derived>
+struct reduce_tuning
+{
+  [[nodiscard]] _CCCL_TRIVIAL_API constexpr auto query(const get_reduce_tuning_query_t&) const noexcept -> Derived
+  {
+    return static_cast<const Derived&>(*this);
+  }
+};
+
+template <int BlockThreads>
+struct reduce : reduce_tuning<reduce<BlockThreads>>
+{
+  template <class T>
+  struct type
+  {
+    struct max_policy
+    {
+      struct reduce_policy
+      {
+        static constexpr int block_threads = BlockThreads / sizeof(T);
+      };
+    };
+  };
+};
+
+struct get_scan_tuning_query_t
+{};
+
+struct scan_tuning
+{
+  [[nodiscard]] _CCCL_TRIVIAL_API constexpr auto query(const get_scan_tuning_query_t&) const noexcept
+  {
+    return *this;
+  }
+
+  struct type
+  {
+    struct max_policy
+    {
+      struct reduce_policy
+      {
+        static constexpr int block_threads = 1;
+      };
+    };
+  };
+};
+
+__host__ __device__ void test()
+{
+  constexpr int nominal_block_threads = 256;
+  constexpr int block_threads         = nominal_block_threads / sizeof(int);
+
+  using env_t           = decltype(cuda::execution::tune(reduce<nominal_block_threads>{}, scan_tuning{}));
+  using tuning_t        = cuda::std::execution::__query_result_t<env_t, cuda::execution::get_tuning_t>;
+  using reduce_tuning_t = cuda::std::execution::__query_result_t<tuning_t, get_reduce_tuning_query_t>;
+  using scan_tuning_t   = cuda::std::execution::__query_result_t<tuning_t, get_scan_tuning_query_t>;
+  using reduce_policy_t = reduce_tuning_t::type<int>;
+  using scan_policy_t   = scan_tuning_t::type;
+
+  static_assert(reduce_policy_t::max_policy::reduce_policy::block_threads == block_threads);
+  static_assert(scan_policy_t::max_policy::reduce_policy::block_threads == 1);
+}
+
+int main(int, char**)
+{
+  test();
+
+  return 0;
+}


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
This PR adds new queries to support env-based API in CUB:

- `cuda::execution::require` - way for user to provide functional requirements
- `cuda::execution::get_requirements` - way for implementation to query functional requirements
- `cuda::execution::tune` - way for user to provide performance tuning parameters
- `cuda::execution::get_tuning` - way for implementation to query tunings
- `cuda::execution::determinism::get_determinism` - way for implementation to query determinism requirements
- `cuda::execution::determinism::` - way for user to provide determinism requirements (should be passed as part of `cuda::execution::require(...)`
   - `*::gpu_to_gpu` - requirement for an implementation to provide same results across different GPUs
   - `*::run_to_run` - requirement for an implementation to provide same results across executions on the same GPU
   - `*::not_guaranteed` - relaxed requirement allowing non-deterministic executions.

Guarantees are left outside of the scope untill we have a use case for them. 

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
