### PR TITLE
Make `cuda::stream_ref` an env for itself

### DIFF
--- a/libcudacxx/include/cuda/__fwd/get_stream.h
+++ b/libcudacxx/include/cuda/__fwd/get_stream.h
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA___FWD_GET_STREAM_H
+#define _CUDA___FWD_GET_STREAM_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#if _CCCL_HAS_CTK()
+
+#  include <cuda/std/__cccl/prologue.h>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_CUDA
+
+struct get_stream_t;
+
+_LIBCUDACXX_END_NAMESPACE_CUDA
+
+#  include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CCCL_HAS_CTK()
+
+#endif // _CUDA___FWD_PIPELINE_H

--- a/libcudacxx/include/cuda/__stream/get_stream.h
+++ b/libcudacxx/include/cuda/__stream/get_stream.h
@@ -22,6 +22,7 @@
 
 #if _CCCL_HAS_CTK()
 
+#  include <cuda/__fwd/get_stream.h>
 #  include <cuda/__stream/stream_ref.h>
 #  include <cuda/std/__concepts/concept_macros.h>
 #  include <cuda/std/__concepts/convertible_to.h>
@@ -34,7 +35,6 @@
 _LIBCUDACXX_BEGIN_NAMESPACE_CUDA
 
 class stream_ref;
-struct get_stream_t;
 
 template <class _Tp>
 _CCCL_CONCEPT __convertible_to_stream_ref = _CUDA_VSTD::convertible_to<_Tp, ::cuda::stream_ref>;

--- a/libcudacxx/include/cuda/__stream/stream_ref.h
+++ b/libcudacxx/include/cuda/__stream/stream_ref.h
@@ -23,6 +23,7 @@
 
 #if _CCCL_HAS_CTK()
 
+#  include <cuda/__fwd/get_stream.h>
 #  include <cuda/std/__cuda/api_wrapper.h>
 #  include <cuda/std/__exception/cuda_error.h>
 #  include <cuda/std/cstddef>
@@ -145,6 +146,13 @@ public:
     int __result = 0;
     _CCCL_TRY_CUDA_API(::cudaStreamGetPriority, "Failed to get stream priority", get(), &__result);
     return __result;
+  }
+
+  //! @brief Queries the \c stream_ref for itself. This makes \c stream_ref usable in places where we expect an
+  //! environment with a \c get_stream_t query
+  [[nodiscard]] stream_ref query(const ::cuda::get_stream_t&) const noexcept
+  {
+    return *this;
   }
 };
 

--- a/libcudacxx/test/libcudacxx/cuda/stream_ref/stream_ref.query.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/stream_ref/stream_ref.query.cpp
@@ -1,0 +1,30 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: nvrtc
+
+#include <cuda/std/cassert>
+#include <cuda/stream_ref>
+
+__host__ __device__ void test()
+{
+  static_assert(cuda::std::execution::__queryable_with<cuda::stream_ref, cuda::get_stream_t>);
+
+  cudaStream_t stream = reinterpret_cast<cudaStream_t>(42);
+  cuda::stream_ref ref{stream};
+  assert(ref == ref.query(cuda::get_stream));
+}
+
+int main(int argc, char** argv)
+{
+  test();
+
+  return 0;
+}


### PR DESCRIPTION
We want to move to environment based APIs.
However, sometimes it would be nice to direclty pass a `cuda::stream_ref` around.

That does not work because `cuda::stream_ref` is not a queryable for `cuda::get_stream_t`

So turn it into one so that `cuda::stream_ref` can return itself on that query
