### PR TITLE
strip `-G` from clangd command line for all-dev debug build

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -70,6 +70,7 @@ CompileFlags:
     - "-ferror-limit=0"
     - "-ftemplate-backtrace-limit=0"
   Remove:
+    - -G
     - -stdpar
     # strip CUDA fatbin args
     - "-Xfatbin*"


### PR DESCRIPTION
## Description

right now, all cccl files appear "red" with clangd when using the `all-dev debug` preset because it does not like the `-G` flag. remove `-G` from clangd's command line.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
