### PR TITLE
Improve RFA PR 2234

### DIFF
--- a/cub/benchmarks/bench/reduce/base.cuh
+++ b/cub/benchmarks/bench/reduce/base.cuh
@@ -85,10 +85,9 @@ void reduce(nvbench::state& state, nvbench::type_list<T, OffsetT>)
     >;
 
   // Retrieve axis parameters
-  const auto elements       = static_cast<std::size_t>(state.get_int64("Elements{io}"));
-  const bit_entropy entropy = str_to_entropy(state.get_string("Entropy"));
+  const auto elements = static_cast<std::size_t>(state.get_int64("Elements{io}"));
 
-  thrust::device_vector<T> in = generate(elements, entropy);
+  thrust::device_vector<T> in = generate(elements);
   thrust::device_vector<T> out(1);
 
   input_it_t d_in   = thrust::raw_pointer_cast(in.data());
@@ -116,5 +115,4 @@ void reduce(nvbench::state& state, nvbench::type_list<T, OffsetT>)
 NVBENCH_BENCH_TYPES(reduce, NVBENCH_TYPE_AXES(value_types, offset_types))
   .set_name("base")
   .set_type_axes_names({"T{ct}", "OffsetT{ct}"})
-  .add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 28, 4))
-  .add_string_axis("Entropy", {"1.000", "0.544", "0.201"});
+  .add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 28, 4));

--- a/cub/benchmarks/bench/reduce/deterministic.cu
+++ b/cub/benchmarks/bench/reduce/deterministic.cu
@@ -55,10 +55,10 @@ struct policy_hub_t
 {
   struct Policy350 : cub::ChainedPolicy<350, Policy350, Policy350>
   {
-    using DeterministicReducePolicy = AgentReducePolicy;
+    using ReducePolicy = AgentReducePolicy;
 
     // SingleTilePolicy
-    using SingleTilePolicy = DeterministicReducePolicy;
+    using SingleTilePolicy = ReducePolicy;
   };
 
   using MaxPolicy = Policy350;

--- a/cub/benchmarks/bench/reduce/deterministic.cu
+++ b/cub/benchmarks/bench/reduce/deterministic.cu
@@ -114,7 +114,7 @@ void deterministic_sum(nvbench::state& state, nvbench::type_list<T, OffsetT>)
   });
 }
 
-using types = nvbench::type_list<float, double>;
+using types               = nvbench::type_list<float, double>;
 using custom_offset_types = nvbench::type_list<int32_t>;
 
 NVBENCH_BENCH_TYPES(deterministic_sum, NVBENCH_TYPE_AXES(types, custom_offset_types))

--- a/cub/benchmarks/bench/reduce/deterministic.cu
+++ b/cub/benchmarks/bench/reduce/deterministic.cu
@@ -115,8 +115,9 @@ void deterministic_sum(nvbench::state& state, nvbench::type_list<T, OffsetT>)
 }
 
 using types = nvbench::type_list<float, double>;
+using custom_offset_types = nvbench::type_list<int32_t>;
 
-NVBENCH_BENCH_TYPES(deterministic_sum, NVBENCH_TYPE_AXES(types, offset_types))
+NVBENCH_BENCH_TYPES(deterministic_sum, NVBENCH_TYPE_AXES(types, custom_offset_types))
   .set_name("base")
   .set_type_axes_names({"T{ct}", "OffsetT{ct}"})
   .add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 28, 4));

--- a/cub/benchmarks/bench/reduce/deterministic.cu
+++ b/cub/benchmarks/bench/reduce/deterministic.cu
@@ -91,10 +91,9 @@ void deterministic_sum(nvbench::state& state, nvbench::type_list<T, OffsetT>)
 #endif
     >;
 
-  const auto elements       = static_cast<T>(state.get_int64("Elements{io}"));
-  const bit_entropy entropy = str_to_entropy(state.get_string("Entropy"));
+  const auto elements = static_cast<T>(state.get_int64("Elements{io}"));
 
-  thrust::device_vector<T> in = generate(elements, entropy);
+  thrust::device_vector<T> in = generate(elements);
   thrust::device_vector<T> out(1);
 
   input_it_t d_in   = thrust::raw_pointer_cast(in.data());
@@ -120,5 +119,4 @@ using types = nvbench::type_list<float, double>;
 NVBENCH_BENCH_TYPES(deterministic_sum, NVBENCH_TYPE_AXES(types, offset_types))
   .set_name("base")
   .set_type_axes_names({"T{ct}", "OffsetT{ct}"})
-  .add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 28, 4))
-  .add_string_axis("Entropy", {"1.000", "0.544", "0.201"});
+  .add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 28, 4));

--- a/cub/benchmarks/bench/reduce/deterministic.cu
+++ b/cub/benchmarks/bench/reduce/deterministic.cu
@@ -55,8 +55,6 @@ struct policy_hub_t
 {
   struct Policy350 : cub::ChainedPolicy<350, Policy350, Policy350>
   {
-    constexpr static int ITEMS_PER_THREAD = TUNE_ITEMS_PER_THREAD;
-
     using DeterministicReducePolicy = AgentReducePolicy;
 
     // SingleTilePolicy

--- a/cub/cub/device/dispatch/dispatch_reduce_deterministic.cuh
+++ b/cub/cub/device/dispatch/dispatch_reduce_deterministic.cuh
@@ -252,8 +252,7 @@ struct DispatchReduceDeterministic
   CUB_RUNTIME_FUNCTION _CCCL_VISIBILITY_HIDDEN _CCCL_FORCEINLINE cudaError_t
   InvokePasses(ReduceKernelT reduce_kernel, SingleTileKernelT single_tile_kernel)
   {
-    const auto tile_size = ActivePolicyT::DeterministicReducePolicy::BLOCK_THREADS
-                         * ActivePolicyT::DeterministicReducePolicy::ITEMS_PER_THREAD;
+    const auto tile_size = ActivePolicyT::ReducePolicy::BLOCK_THREADS * ActivePolicyT::ReducePolicy::ITEMS_PER_THREAD;
     // Get device ordinal
     int device_ordinal;
     auto error = CubDebug(cudaGetDevice(&device_ordinal));
@@ -270,7 +269,7 @@ struct DispatchReduceDeterministic
     }
 
     KernelConfig reduce_config;
-    error = CubDebug(reduce_config.Init<typename ActivePolicyT::DeterministicReducePolicy>(reduce_kernel));
+    error = CubDebug(reduce_config.Init<typename ActivePolicyT::ReducePolicy>(reduce_kernel));
     if (cudaSuccess != error)
     {
       return error;
@@ -313,14 +312,14 @@ struct DispatchReduceDeterministic
     _CubLog("Invoking DeterministicDeviceReduceKernel<<<%d, %d, 0, %lld>>>(), %d items "
             "per thread, %d SM occupancy\n",
             reduce_grid_size,
-            ActivePolicyT::DeterministicReducePolicy::BLOCK_THREADS,
+            ActivePolicyT::ReducePolicy::BLOCK_THREADS,
             (long long) stream,
-            ActivePolicyT::DeterministicReducePolicy::ITEMS_PER_THREAD,
+            ActivePolicyT::ReducePolicy::ITEMS_PER_THREAD,
             reduce_config.sm_occupancy);
 #endif // CUB_DETAIL_DEBUG_ENABLE_LOG
 
     THRUST_NS_QUALIFIER::cuda_cub::detail::triple_chevron(
-      reduce_grid_size, ActivePolicyT::DeterministicReducePolicy::BLOCK_THREADS, 0, stream)
+      reduce_grid_size, ActivePolicyT::ReducePolicy::BLOCK_THREADS, 0, stream)
       .doit(reduce_kernel, d_in, d_block_reductions, num_items, reduction_op, transform_op, reduce_grid_size);
 
     // Check for failure to launch

--- a/cub/cub/device/dispatch/dispatch_reduce_deterministic.cuh
+++ b/cub/cub/device/dispatch/dispatch_reduce_deterministic.cuh
@@ -322,13 +322,7 @@ struct DispatchReduceDeterministic
 
     THRUST_NS_QUALIFIER::cuda_cub::detail::triple_chevron(
       reduce_grid_size, ActivePolicyT::DeterministicReducePolicy::BLOCK_THREADS, 0, stream)
-      .doit(reduce_kernel,
-            d_in,
-            d_block_reductions,
-            static_cast<int>(num_items),
-            reduction_op,
-            transform_op,
-            reduce_grid_size);
+      .doit(reduce_kernel, d_in, d_block_reductions, num_items, reduction_op, transform_op, reduce_grid_size);
 
     // Check for failure to launch
     error = CubDebug(cudaPeekAtLastError());
@@ -467,6 +461,8 @@ struct DispatchReduceDeterministic
     cudaStream_t stream                              = {},
     TransformOpT transform_op                        = {})
   {
+    static_assert(sizeof(OffsetT) <= 4, "OffsetT must be 4 bytes or less for deterministic reduction");
+
     cudaError error = cudaSuccess;
 
     // Get PTX version

--- a/cub/cub/device/dispatch/kernels/reduce.cuh
+++ b/cub/cub/device/dispatch/kernels/reduce.cuh
@@ -513,7 +513,7 @@ __launch_bounds__(int(ChainedPolicyT::SingleTilePolicy::BLOCK_THREADS), 1) void 
   // Output result
   if (threadIdx.x == 0)
   {
-    detail::reduce::finalize_and_store_aggregate(d_out, reduction_op, init, block_aggregate);
+    detail::reduce::finalize_and_store_aggregate(d_out, reduction_op, init, block_aggregate.conv_to_fp());
   }
 }
 

--- a/cub/cub/device/dispatch/kernels/reduce.cuh
+++ b/cub/cub/device/dispatch/kernels/reduce.cuh
@@ -324,7 +324,7 @@ template <typename ChainedPolicyT,
           typename AccumT,
           typename TransformOpT>
 CUB_DETAIL_KERNEL_ATTRIBUTES
-__launch_bounds__(int(ChainedPolicyT::DeterministicReducePolicy::BLOCK_THREADS)) void DeterministicDeviceReduceKernel(
+__launch_bounds__(int(ChainedPolicyT::ReducePolicy::BLOCK_THREADS)) void DeterministicDeviceReduceKernel(
   InputIteratorT d_in,
   AccumT* d_out,
   OffsetT num_items,
@@ -334,22 +334,22 @@ __launch_bounds__(int(ChainedPolicyT::DeterministicReducePolicy::BLOCK_THREADS))
 {
   using BlockReduceT =
     BlockReduce<AccumT,
-                ChainedPolicyT::ActivePolicy::DeterministicReducePolicy::BLOCK_THREADS,
-                ChainedPolicyT::ActivePolicy::DeterministicReducePolicy::BLOCK_ALGORITHM>;
+                ChainedPolicyT::ActivePolicy::ReducePolicy::BLOCK_THREADS,
+                ChainedPolicyT::ActivePolicy::ReducePolicy::BLOCK_ALGORITHM>;
   // Shared memory storage
   __shared__ typename BlockReduceT::TempStorage temp_storage;
 
   using FloatType                 = typename AccumT::ftype;
   constexpr int BinLength         = AccumT::max_index + AccumT::max_fold;
-  constexpr auto ITEMS_PER_THREAD = ChainedPolicyT::DeterministicReducePolicy::ITEMS_PER_THREAD;
-  constexpr auto BLOCK_THREADS    = ChainedPolicyT::DeterministicReducePolicy::BLOCK_THREADS;
+  constexpr auto ITEMS_PER_THREAD = ChainedPolicyT::ReducePolicy::ITEMS_PER_THREAD;
+  constexpr auto BLOCK_THREADS    = ChainedPolicyT::ReducePolicy::BLOCK_THREADS;
   const int GRID_DIM              = reduce_grid_size;
   const int tid                   = BLOCK_THREADS * blockIdx.x + threadIdx.x;
 
   FloatType* shared_bins = detail::rfa::get_shared_bin_array<FloatType, BinLength>();
 
   _CCCL_PRAGMA_UNROLL_FULL()
-  for (int index = threadIdx.x; index < BinLength; index += ChainedPolicyT::DeterministicReducePolicy::BLOCK_THREADS)
+  for (int index = threadIdx.x; index < BinLength; index += ChainedPolicyT::ReducePolicy::BLOCK_THREADS)
   {
     shared_bins[index] = AccumT::initialize_bin(index);
   }

--- a/cub/cub/device/dispatch/kernels/reduce.cuh
+++ b/cub/cub/device/dispatch/kernels/reduce.cuh
@@ -41,6 +41,8 @@
 #include <cub/detail/rfa.cuh>
 #include <cub/grid/grid_even_share.cuh>
 
+#include <thrust/type_traits/unwrap_contiguous_iterator.h>
+
 CUB_NAMESPACE_BEGIN
 
 namespace detail
@@ -366,7 +368,7 @@ __launch_bounds__(int(ChainedPolicyT::DeterministicReducePolicy::BLOCK_THREADS))
       const int idx = i + j * GRID_DIM * BLOCK_THREADS;
       if (idx < num_items)
       {
-        items[j] = transform_op(d_in[idx]);
+        items[j] = transform_op(THRUST_NS_QUALIFIER::unwrap_contiguous_iterator(d_in)[idx]);
       }
     }
 
@@ -505,7 +507,7 @@ __launch_bounds__(int(ChainedPolicyT::SingleTilePolicy::BLOCK_THREADS), 1) void 
   _CCCL_PRAGMA_UNROLL_FULL()
   for (int i = threadIdx.x; i < num_items; i += BLOCK_THREADS)
   {
-    thread_aggregate += transform_op(d_in[i]);
+    thread_aggregate += transform_op(THRUST_NS_QUALIFIER::unwrap_contiguous_iterator(d_in)[i]);
   }
 
   AccumT block_aggregate = BlockReduceT(temp_storage).Reduce(thread_aggregate, reduction_op, num_items);

--- a/cub/cub/device/dispatch/tuning/tuning_reduce.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_reduce.cuh
@@ -308,7 +308,7 @@ struct policy_hub
 
     // ReducePolicy (GTX Titan: 255.1 GB/s @ 48M 4B items; 228.7 GB/s @ 192M 1B
     // items)
-    using DeterministicReducePolicy =
+    using ReducePolicy =
       AgentReducePolicy<threads_per_block,
                         items_per_thread,
                         AccumT,
@@ -317,7 +317,7 @@ struct policy_hub
                         LOAD_LDG>;
 
     // SingleTilePolicy
-    using SingleTilePolicy = DeterministicReducePolicy;
+    using SingleTilePolicy = ReducePolicy;
   };
 
   /// SM60
@@ -328,7 +328,7 @@ struct policy_hub
     static constexpr int items_per_vec_load = 4;
 
     // ReducePolicy (P100: 591 GB/s @ 64M 4B items; 583 GB/s @ 256M 1B items)
-    using DeterministicReducePolicy =
+    using ReducePolicy =
       AgentReducePolicy<threads_per_block,
                         items_per_thread,
                         AccumT,
@@ -337,7 +337,7 @@ struct policy_hub
                         LOAD_LDG>;
 
     // SingleTilePolicy
-    using SingleTilePolicy = DeterministicReducePolicy;
+    using SingleTilePolicy = ReducePolicy;
   };
 
   using MaxPolicy = Policy600;

--- a/cub/test/catch2_test_device_reduce_deterministic.cu
+++ b/cub/test/catch2_test_device_reduce_deterministic.cu
@@ -94,13 +94,13 @@ struct hub_t
   {
     constexpr static int ITEMS_PER_THREAD = ItemsPerThread;
 
-    using DeterministicReducePolicy = AgentReducePolicy<BlockSize, ItemsPerThread>;
+    using ReducePolicy = AgentReducePolicy<BlockSize, ItemsPerThread>;
 
     // SingleTilePolicy
-    using SingleTilePolicy = DeterministicReducePolicy;
+    using SingleTilePolicy = ReducePolicy;
 
     // SegmentedReducePolicy
-    using SegmentedReducePolicy = DeterministicReducePolicy;
+    using SegmentedReducePolicy = ReducePolicy;
   };
 
   using MaxPolicy = Policy;


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
Addresses feedback from PR #2234  

<!-- Provide a standalone description of changes in this PR. -->
- Removes usage of entropy in benchmark as it doesn't effect the performance. 
- **Enable** **RFA** only with **32 bit offset types**
- Eliminates use of `OutputIteratorTransformT`, by replacing with `OutputIteratorT` and **converting** to **float type** during writing the result in the kernel
- Improve's RFA test by enabling testing negative values; by additionally checking  catching cudaError_t. 
- Support's device_vector iterator's by unwrapping before passing on to unary transform in the kernel. 
- Replace `DeterministicReducePolicy with ReducePolicy`

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
