### PR TITLE
Generate a version from git/JSON for packages

### DIFF
--- a/ci/build_cuda_parallel_wheel.sh
+++ b/ci/build_cuda_parallel_wheel.sh
@@ -16,7 +16,10 @@ which python
 python --version
 echo "Done setting up python env"
 
-# Figure out the version to use for the package
+# Figure out the version to use for the package, we need repo history
+if $(git rev-parse --is-shallow-repository); then
+  git fetch --unshallow
+fi
 export PACKAGE_VERSION_PREFIX="0.1."
 package_version=$(/workspace/ci/generate_version.sh)
 echo "Using package version ${package_version}"

--- a/ci/build_cuda_parallel_wheel.sh
+++ b/ci/build_cuda_parallel_wheel.sh
@@ -16,6 +16,13 @@ which python
 python --version
 echo "Done setting up python env"
 
+# Figure out the version to use for the package
+export PACKAGE_VERSION_PREFIX="0.1."
+package_version=$(/workspace/ci/generate_version.sh)
+echo "Using package version ${package_version}"
+# Override the version used by setuptools_scm to the custom version
+export SETUPTOOLS_SCM_PRETEND_VERSION_FOR_CUDA_PARALLEL="${package_version}"
+
 # Build wheels
 python -m pip wheel --no-deps /workspace/python/cuda_cccl
 python -m pip wheel --no-deps .

--- a/ci/generate_version.sh
+++ b/ci/generate_version.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Generate a version number string using metadata from git or JSON.
+# Use the PyPi package versioning convention for pre-release or
+# post release patches.
+
+# Set some defaults for variables.
+CCCL_BRANCH="${CCCL_BRANCH:-dev}"
+PACKAGE_VERSION_PREFIX="${PACKAGE_VERSION_PREFIX:-}"
+
+GIT_DESCRIBE_TAG=$(git describe --abbrev=0)
+GIT_DESCRIBE_NUMBER=$(git rev-list ${GIT_DESCRIBE_TAG}..HEAD --count)
+
+JSON_VERSION=$(jq -r .full /workspace/cccl-version.json)
+
+# Generate a suffix depending on release or dev branch.
+PACKAGE_VERSION_SUFFIX=""
+if [[ "${GIT_DESCRIBE_NUMBER}" != "0" ]]; then
+  if [[ ${CCCL_BRANCH} == "dev" ]]; then
+    PACKAGE_VERSION_SUFFIX=".dev${GIT_DESCRIBE_NUMBER}"
+  else
+    PACKAGE_VERSION_SUFFIX=".post${GIT_DESCRIBE_NUMBER}"
+  fi
+fi
+
+# If using Git metadata this could generate it from the last tag.
+# VERSION="${GIT_DESCRIBE_TAG#v}.dev${GIT_DESCRIBE_NUMBER}"
+
+# Generate the version using a combination of JSON and git commit number.
+VERSION="${PACKAGE_VERSION_PREFIX}${JSON_VERSION}${PACKAGE_VERSION_SUFFIX}"
+
+echo -n "${VERSION}"

--- a/python/cuda_parallel/pyproject.toml
+++ b/python/cuda_parallel/pyproject.toml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 [build-system]
-requires = ["scikit-build-core>=0.10", "cython"]
+requires = ["scikit-build-core>=0.10", "setuptools_scm", "cython"]
 build-backend = "scikit_build_core.build"
 
 [project]
@@ -60,9 +60,12 @@ make-fallback = true
 "cuda/parallel/experimental" = "cuda/parallel/experimental"
 
 [tool.scikit-build.metadata.version]
-provider = "scikit_build_core.metadata.regex"
-input = "cuda/parallel/_version.py"
-# use default regex
+provider = "scikit_build_core.metadata.setuptools_scm"
+
+[tool.setuptools_scm]
+root = "../.."
+# The _version.py files could be removed from version control.
+# write_to = "python/cuda_parallel/cuda/parallel/_version.py"
 
 [tool.mypy]
 python_version = "3.10"


### PR DESCRIPTION
## Description

Adding some versioning information to the wheels packages will enable the solver to install the latest pre-release or post-release packages, closes #4900. This uses `setuptools_scm` to determine a version using `git` by default, but then overrides that in CI with a custom version string that has a prefix and optional suffix if not on a clean tag.

It uses the version from `cccl-version.json` by default, and the commit count from the last tag. In the future it could move to just the last tag and the commit count once we have tags on `main` that more closely match what is desired.

## Checklist
- [x] I am familiar with the [Contributing Guidelines]().
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
