### PR TITLE
[Backport 3.0] Avoid errors in `get_device_address` tests (#4209)

### DIFF
--- a/libcudacxx/test/libcudacxx/cuda/functional/get_device_address.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/functional/get_device_address.pass.cpp
@@ -29,7 +29,11 @@ void test_host(T& object)
     cudaPointerAttributes attributes;
     cudaError_t status = cudaPointerGetAttributes(&attributes, host_address);
     assert(status == cudaSuccess);
-    assert(attributes.devicePointer == nullptr);
+
+    if (attributes.devicePointer)
+    {
+      assert(attributes.devicePointer == host_address);
+    }
   }
 
   {


### PR DESCRIPTION
Depending on certain device properties, `cuda::std::addressof` returns a valid device pointer even when called on host.

Avoid spurious test failures by checking that if that is the case we get the correct result;
