### PR TITLE
do not constexpr cast to enum a value that is outside the enum's range

### DIFF
--- a/cudax/include/cuda/experimental/__device/attributes.cuh
+++ b/cudax/include/cuda/experimental/__device/attributes.cuh
@@ -226,7 +226,7 @@ struct __dev_attr<::cudaDevAttrMemoryPoolSupportedHandleTypes> //
 #if CUDART_VERSION >= 12040
   static constexpr type fabric = ::cudaMemHandleTypeFabric;
 #else
-  static constexpr type fabric = static_cast<::cudaMemAllocationHandleType>(0x8);
+  static inline const type fabric = static_cast<::cudaMemAllocationHandleType>(0x8);
 #endif
 };
 #if CUDART_VERSION >= 12020


### PR DESCRIPTION
## Description

For older CTK's, cudax's device attributes code defines the following:

```c++
  static constexpr type fabric = static_cast<::cudaMemAllocationHandleType>(0x8);
```

the trouble is that that is not actually valid code. `0x8` is outside the range of the `cudaMemAllocationHandleType` enum before 12.4. I'm not sure why we are skating by in the tests. maybe it's because we use the `system_header` pragma.

but clangd flags this as broken, which causes most of the cudax headers appear red (as having errors) in vscode when using one of the cuda12.0 devcontainers. and that makes clangd less useful.

i like clangd. i also like conforming code. make the class static an `inline const` instead of `constexpr`.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
