### PR TITLE
Fix _CountOneBits  when building against MSVC older than 14.31.

### DIFF
--- a/libcudacxx/include/cuda/std/__bit/popcount.h
+++ b/libcudacxx/include/cuda/std/__bit/popcount.h
@@ -73,7 +73,8 @@ template <typename _Tp>
   {
     return static_cast<int>(::__popcnt64(__v));
   }
-#  elif _CCCL_COMPILER(MSVC) && _CCCL_ARCH(ARM64)
+  // _CountOneBits exists after MSVC 1931
+#  elif _CCCL_COMPILER(MSVC, >, 19, 30) && _CCCL_ARCH(ARM64)
   if constexpr (sizeof(_Tp) == sizeof(uint32_t))
   {
     return static_cast<int>(::_CountOneBits(__v));


### PR DESCRIPTION
## Description

Fixes issues when building with older MSVC internally.

## Checklist
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
