### PR TITLE
Avoid warning in `cuda::ilog10`

### DIFF
--- a/libcudacxx/include/cuda/__cmath/ilog.h
+++ b/libcudacxx/include/cuda/__cmath/ilog.h
@@ -25,7 +25,6 @@
 #include <cuda/std/__bit/integral.h>
 #include <cuda/std/__cmath/rounding_functions.h>
 #include <cuda/std/__concepts/concept_macros.h>
-#include <cuda/std/__iterator/size.h>
 #include <cuda/std/__limits/numeric_limits.h>
 #include <cuda/std/__type_traits/is_constant_evaluated.h>
 #include <cuda/std/__type_traits/is_integer.h>
@@ -153,7 +152,7 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr int ilog10(_Tp __t) noexcept
   auto __log10_approx                 = static_cast<int>(__log2);
   if constexpr (sizeof(_Tp) <= sizeof(uint32_t))
   {
-    _CCCL_ASSERT(__log10_approx < int{_CUDA_VSTD::size(::cuda::__power_of_10_32bit())}, "out of bounds");
+    _CCCL_ASSERT(__log10_approx < static_cast<int>(::cuda::__power_of_10_32bit().size()), "out of bounds");
     if constexpr (_CUDA_VSTD::is_same_v<_Tp, uint32_t>)
     {
       // don't replace +1 with >= because wraparound behavior is needed here
@@ -166,14 +165,14 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr int ilog10(_Tp __t) noexcept
   }
   else if constexpr (sizeof(_Tp) == sizeof(uint64_t))
   {
-    _CCCL_ASSERT(__log10_approx < int{_CUDA_VSTD::size(::cuda::__power_of_10_64bit())}, "out of bounds");
+    _CCCL_ASSERT(__log10_approx < static_cast<int>(::cuda::__power_of_10_64bit().size()), "out of bounds");
     // +1 is not needed here
     __log10_approx += static_cast<uint64_t>(__t) >= ::cuda::__power_of_10_64bit()[__log10_approx];
   }
 #if _CCCL_HAS_INT128()
   else
   {
-    _CCCL_ASSERT(__log10_approx < int{_CUDA_VSTD::size(::cuda::__power_of_10_128bit())}, "out of bounds");
+    _CCCL_ASSERT(__log10_approx < static_cast<int>(::cuda::__power_of_10_128bit().size()), "out of bounds");
     if constexpr (_CUDA_VSTD::is_same_v<_Tp, __uint128_t>)
     {
       // don't replace +1 with >= because wraparound behavior is needed here


### PR DESCRIPTION
The warning seems bogus, but there is no reason not to work around it.
