### PR TITLE
make `strided_iterator`'s `runtime_value` implicit constructible

### DIFF
--- a/thrust/thrust/iterator/strided_iterator.h
+++ b/thrust/thrust/iterator/strided_iterator.h
@@ -30,6 +30,10 @@ template <typename T>
 struct runtime_value
 {
   T value;
+
+  _CCCL_HOST_DEVICE runtime_value(T stride = {})
+      : value(stride)
+  {}
 };
 
 //! Holds a compile-time value


### PR DESCRIPTION
See #4104 [here](https://github.com/NVIDIA/cccl/pull/4014#issuecomment-2944509351).
**Thank you!**