### PR TITLE
[CUDAX] Remove default device argument from stream and device_memory_resource constructor

### DIFF
--- a/cudax/examples/async_buffer_add.cu
+++ b/cudax/examples/async_buffer_add.cu
@@ -54,7 +54,7 @@ int main()
   auto policy = thrust::cuda::par_nosync.on(stream.get());
 
   // An environment we use to pass all necessary information to the containers
-  cudax::env_t<cuda::mr::device_accessible> env{cudax::device_memory_resource{}, stream};
+  cudax::env_t<cuda::mr::device_accessible> env{cudax::device_memory_resource{cudax::device_ref{0}}, stream};
 
   // Allocate the two inputs and output, but do not zero initialize via `cudax::no_init`
   cudax::async_device_buffer<float> A{env, numElements, cudax::no_init};

--- a/cudax/examples/async_buffer_add.cu
+++ b/cudax/examples/async_buffer_add.cu
@@ -48,7 +48,7 @@ struct generator
 int main()
 {
   // A CUDA stream on which to execute the vector addition kernel
-  cudax::stream stream{};
+  cudax::stream stream{cudax::device_ref{0}};
 
   // The execution policy we want to use to run all work on the same stream
   auto policy = thrust::cuda::par_nosync.on(stream.get());

--- a/cudax/examples/stdexec_stream.cu
+++ b/cudax/examples/stdexec_stream.cu
@@ -38,7 +38,7 @@ __host__ void run()
   try
   {
     task::thread_context tctx;
-    task::stream_context sctx;
+    task::stream_context sctx{cuda::experimental::device_ref{0}};
     auto sch = sctx.get_scheduler();
 
     auto start = //

--- a/cudax/include/cuda/experimental/__execution/env.cuh
+++ b/cudax/include/cuda/experimental/__execution/env.cuh
@@ -95,15 +95,11 @@ private:
   using __resource   = any_async_resource<_Properties...>;
   using __stream_ref = stream_ref;
 
-  __resource __mr_                      = device_memory_resource{};
+  __resource __mr_;
   __stream_ref __stream_                = __detail::__invalid_stream;
   execution::execution_policy __policy_ = execution::execution_policy::invalid_execution_policy;
 
 public:
-  //! @brief Default constructs an environment using ``device_memory_resource`` as the resource the default stream
-  //! ``execution_policy::invalid_execution_policy`` as the execution policy
-  _CCCL_HIDE_FROM_ABI env_t() = default;
-
   //! @brief Construct an env_t from an any_resource, a stream and a policy
   //! @param __mr The any_resource passed in
   //! @param __stream The stream_ref passed in

--- a/cudax/include/cuda/experimental/__execution/stream/context.cuh
+++ b/cudax/include/cuda/experimental/__execution/stream/context.cuh
@@ -54,10 +54,6 @@ __launch_bounds__(1) __global__ static void __stream_complete(_Tag, _Rcvr* __rcv
 // stream_context
 struct _CCCL_TYPE_VISIBILITY_DEFAULT stream_context : private __immovable
 {
-  _CCCL_HOST_API stream_context()
-      : stream_context(device_ref{0})
-  {}
-
   _CCCL_HOST_API explicit stream_context(device_ref __device)
       : __stream_{__device}
   {}
@@ -220,7 +216,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT stream_context : private __immovable
     __attrs_t __env_;
   };
 
-  stream __stream_{};
+  stream __stream_{no_init};
 };
 
 using stream_scheduler = stream_context::scheduler;

--- a/cudax/include/cuda/experimental/__memory_resource/device_memory_resource.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/device_memory_resource.cuh
@@ -75,12 +75,6 @@ private:
   }
 
 public:
-  //! @brief Default constructs the device_memory_resource using the default \c cudaMemPool_t of the default device.
-  //! @throws cuda_error if retrieving the default \c cudaMemPool_t fails.
-  device_memory_resource()
-      : __memory_resource_base(__get_default_device_mem_pool(0))
-  {}
-
   //! @brief Constructs a device_memory_resource using the default \c cudaMemPool_t of a given device.
   //! @throws cuda_error if retrieving the default \c cudaMemPool_t fails.
   explicit device_memory_resource(::cuda::experimental::device_ref __device)

--- a/cudax/include/cuda/experimental/__stream/internal_streams.cuh
+++ b/cudax/include/cuda/experimental/__stream/internal_streams.cuh
@@ -33,7 +33,7 @@ namespace cuda::experimental
 //! should ever be pushed into it
 inline ::cuda::stream_ref __cccl_allocation_stream()
 {
-  static ::cuda::experimental::stream __stream{};
+  static ::cuda::experimental::stream __stream{device_ref{0}};
   return __stream;
 }
 

--- a/cudax/include/cuda/experimental/__stream/stream.cuh
+++ b/cudax/include/cuda/experimental/__stream/stream.cuh
@@ -67,13 +67,6 @@ struct stream : stream_ref
       ::cudaStreamCreateWithPriority, "Failed to create a stream", &__stream, cudaStreamNonBlocking, __priority);
   }
 
-  //! @brief Constructs a stream on the default device
-  //!
-  //! @throws cuda_error if stream creation fails.
-  stream()
-      : stream(device_ref{0})
-  {}
-
   //! @brief Construct a new `stream` object into the moved-from state.
   //!
   //! @post `stream()` returns an invalid stream handle

--- a/cudax/test/algorithm/copy.cu
+++ b/cudax/test/algorithm/copy.cu
@@ -12,11 +12,11 @@
 
 C2H_TEST("1d Copy", "[data_manipulation]")
 {
-  cudax::stream _stream;
+  cudax::stream _stream{cudax::device_ref{0}};
 
   SECTION("Device resource")
   {
-    cudax::device_memory_resource device_resource;
+    cudax::device_memory_resource device_resource{cudax::device_ref{0}};
     std::vector<int> host_vector(buffer_size);
 
     {
@@ -133,7 +133,7 @@ void test_mdspan_copy_bytes(
 
 C2H_TEST("Mdspan copy", "[data_manipulation]")
 {
-  cudax::stream stream;
+  cudax::stream stream{cudax::device_ref{0}};
 
   SECTION("Different extents")
   {
@@ -171,7 +171,7 @@ C2H_TEST("Mdspan copy", "[data_manipulation]")
 
 C2H_TEST("Non exhaustive mdspan copy_bytes", "[data_manipulation]")
 {
-  cudax::stream stream;
+  cudax::stream stream{cudax::device_ref{0}};
   {
     auto fake_strided_mdspan = create_fake_strided_mdspan();
 

--- a/cudax/test/algorithm/fill.cu
+++ b/cudax/test/algorithm/fill.cu
@@ -12,7 +12,7 @@
 
 C2H_TEST("Fill", "[data_manipulation]")
 {
-  cudax::stream _stream;
+  cudax::stream _stream{cudax::device_ref{0}};
   SECTION("Host resource")
   {
     cudax::legacy_pinned_memory_resource host_resource;
@@ -25,7 +25,7 @@ C2H_TEST("Fill", "[data_manipulation]")
 
   SECTION("Device resource")
   {
-    cudax::device_memory_resource device_resource;
+    cudax::device_memory_resource device_resource{cudax::device_ref{0}};
     cudax::uninitialized_buffer<int, cuda::mr::device_accessible> buffer(device_resource, buffer_size);
     cudax::fill_bytes(_stream, buffer, fill_byte);
 
@@ -47,7 +47,7 @@ C2H_TEST("Fill", "[data_manipulation]")
 
 C2H_TEST("Mdspan Fill", "[data_manipulation]")
 {
-  cudax::stream stream;
+  cudax::stream stream{cudax::device_ref{0}};
   {
     cuda::std::dextents<size_t, 3> dynamic_extents{1, 2, 3};
     auto buffer = make_buffer_for_mdspan(dynamic_extents, 0);
@@ -77,7 +77,7 @@ C2H_TEST("Mdspan Fill", "[data_manipulation]")
 
 C2H_TEST("Non exhaustive mdspan fill_bytes", "[data_manipulation]")
 {
-  cudax::stream stream;
+  cudax::stream stream{cudax::device_ref{0}};
   {
     auto fake_strided_mdspan = create_fake_strided_mdspan();
 

--- a/cudax/test/containers/async_buffer/access.cu
+++ b/cudax/test/containers/async_buffer/access.cu
@@ -43,7 +43,7 @@ C2H_TEST("cudax::async_buffer access", "[container][async_buffer]", test_types)
   using pointer         = typename Buffer::pointer;
   using const_pointer   = typename Buffer::const_pointer;
 
-  cudax::stream stream{};
+  cudax::stream stream{cudax::device_ref{0}};
   Env env{Resource{}, stream};
 
   SECTION("cudax::async_buffer::get_unsynchronized")

--- a/cudax/test/containers/async_buffer/capacity.cu
+++ b/cudax/test/containers/async_buffer/capacity.cu
@@ -39,7 +39,7 @@ C2H_TEST("cudax::async_buffer capacity", "[container][async_buffer]", test_types
   using T         = typename Buffer::value_type;
   using size_type = typename Buffer::size_type;
 
-  cudax::stream stream{};
+  cudax::stream stream{cudax::device_ref{0}};
   Env env{Resource{}, stream};
 
   SECTION("cudax::async_buffer::empty")

--- a/cudax/test/containers/async_buffer/constructor.cu
+++ b/cudax/test/containers/async_buffer/constructor.cu
@@ -39,7 +39,7 @@ C2H_TEST("cudax::async_buffer constructors", "[container][async_buffer]", test_t
   using Buffer   = typename extract_properties<TestT>::async_buffer;
   using T        = typename Buffer::value_type;
 
-  cudax::stream stream{};
+  cudax::stream stream{cudax::device_ref{0}};
   Env env{Resource{}, stream};
 
   SECTION("Construction with explicit size")

--- a/cudax/test/containers/async_buffer/conversion.cu
+++ b/cudax/test/containers/async_buffer/conversion.cu
@@ -38,7 +38,7 @@ C2H_TEST("cudax::async_buffer conversion", "[container][async_buffer]", test_typ
   using Buffer   = typename extract_properties<TestT>::async_buffer;
   using T        = typename Buffer::value_type;
 
-  cudax::stream stream{};
+  cudax::stream stream{cudax::device_ref{0}};
   Resource resource{};
   Env env{resource, stream};
 

--- a/cudax/test/containers/async_buffer/helper.h
+++ b/cudax/test/containers/async_buffer/helper.h
@@ -137,6 +137,15 @@ constexpr bool equal_range(const Range1& range1, const Range2& range2)
   }
 }
 
+struct dev0_device_memory_resource : cudax::device_memory_resource
+{
+  dev0_device_memory_resource()
+      : cudax::device_memory_resource{cudax::device_ref{0}}
+  {}
+
+  using default_queries = cudax::properties_list<cuda::mr::device_accessible>;
+};
+
 // helper class as we need to pass the properties in a tuple to the catch tests
 template <class>
 struct extract_properties;
@@ -152,7 +161,7 @@ struct extract_properties<cuda::std::tuple<Properties...>>
 #else
                                             void,
 #endif
-                                            cudax::device_memory_resource>;
+                                            dev0_device_memory_resource>;
   using iterator       = cudax::heterogeneous_iterator<int, Properties...>;
   using const_iterator = cudax::heterogeneous_iterator<const int, Properties...>;
 

--- a/cudax/test/containers/async_buffer/iterators.cu
+++ b/cudax/test/containers/async_buffer/iterators.cu
@@ -47,7 +47,7 @@ C2H_TEST("cudax::async_buffer iterators", "[container][async_buffer]", test_type
   using reverse_iterator       = cuda::std::reverse_iterator<iterator>;
   using const_reverse_iterator = cuda::std::reverse_iterator<const_iterator>;
 
-  cudax::stream stream{};
+  cudax::stream stream{cudax::device_ref{0}};
   Env env{Resource{}, stream};
 
   SECTION("cudax::async_buffer::begin/end properties")

--- a/cudax/test/containers/async_buffer/swap.cu
+++ b/cudax/test/containers/async_buffer/swap.cu
@@ -38,7 +38,7 @@ C2H_TEST("cudax::async_buffer swap", "[container][async_buffer]", test_types)
   using T         = typename Buffer::value_type;
   using size_type = typename Buffer::size_type;
 
-  cudax::stream stream{};
+  cudax::stream stream{cudax::device_ref{0}};
   Env env{Resource{}, stream};
   STATIC_REQUIRE(
     cuda::std::is_same_v<decltype(cuda::std::declval<Buffer&>().swap(cuda::std::declval<Buffer&>())), void>);

--- a/cudax/test/containers/async_buffer/transform.cu
+++ b/cudax/test/containers/async_buffer/transform.cu
@@ -101,8 +101,8 @@ C2H_TEST("DeviceTransform::Transform cudax::async_device_buffer", "[device][devi
   FILTER_UNSUPPORTED_ALGS
   const int num_items = 1 << 24;
 
-  cudax::stream stream{};
-  cudax::env_t<cuda::mr::device_accessible> env{cudax::device_memory_resource{}, stream};
+  cudax::stream stream{cudax::device_ref{0}};
+  cudax::env_t<cuda::mr::device_accessible> env{cudax::device_memory_resource{cudax::device_ref{0}}, stream};
 
   cudax::async_device_buffer<type> a{env, num_items, cudax::no_init};
   cudax::async_device_buffer<type> b{env, num_items, cudax::no_init};
@@ -148,8 +148,8 @@ struct add_kernel
 
 C2H_TEST("cudax::async_buffer launch transform", "[container][async_buffer]")
 {
-  cudax::stream stream{};
-  cudax::env_t<cuda::mr::device_accessible> env{cudax::device_memory_resource{}, stream};
+  cudax::stream stream{cudax::device_ref{0}};
+  cudax::env_t<cuda::mr::device_accessible> env{cudax::device_memory_resource{cudax::device_ref{0}}, stream};
 
   const cuda::std::array array = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
 

--- a/cudax/test/containers/uninitialized_async_buffer.cu
+++ b/cudax/test/containers/uninitialized_async_buffer.cu
@@ -55,8 +55,8 @@ C2H_TEST_LIST(
   static_assert(!cuda::std::is_copy_constructible<uninitialized_async_buffer>::value, "");
   static_assert(!cuda::std::is_copy_assignable<uninitialized_async_buffer>::value, "");
 
-  cuda::experimental::device_memory_resource resource{};
-  cuda::experimental::stream stream{};
+  cuda::experimental::device_memory_resource resource{cudax::device_ref{0}};
+  cuda::experimental::stream stream{cuda::experimental::device_ref{0}};
 
   SECTION("construction")
   {
@@ -104,7 +104,7 @@ C2H_TEST_LIST(
     static_assert(!cuda::std::is_copy_assignable<uninitialized_async_buffer>::value, "");
 
     {
-      cuda::experimental::stream other_stream{};
+      cuda::experimental::stream other_stream{cuda::experimental::device_ref{0}};
       uninitialized_async_buffer input{resource, other_stream, 42};
       const TestType* ptr = input.data();
 
@@ -231,6 +231,7 @@ struct test_async_device_memory_resource : cudax::device_memory_resource
   static int count;
 
   test_async_device_memory_resource()
+      : cudax::device_memory_resource{cudax::device_ref{0}}
   {
     ++count;
   }
@@ -251,9 +252,9 @@ int test_async_device_memory_resource::count = 0;
 
 C2H_TEST("uninitialized_async_buffer's memory resource does not dangle", "[container]")
 {
-  cuda::experimental::stream stream{};
+  cuda::experimental::stream stream{cuda::experimental::device_ref{0}};
   cudax::uninitialized_async_buffer<int, ::cuda::mr::device_accessible> buffer{
-    cudax::device_memory_resource{}, stream, 0};
+    cudax::device_memory_resource{cudax::device_ref{0}}, stream, 0};
 
   {
     CHECK(test_async_device_memory_resource::count == 0);

--- a/cudax/test/event/event_smoke.cu
+++ b/cudax/test/event/event_smoke.cu
@@ -73,7 +73,7 @@ C2H_TEST("can use event_ref to record and wait on an event", "[event]")
   const cudax::event_ref ref(ev);
 
   test::managed<int> i(0);
-  cudax::stream stream;
+  cudax::stream stream{cudax::device_ref{0}};
   cudax::launch(stream, ::test::one_thread_dims, ::test::assign_42{}, i.get());
   ref.record(stream);
   ref.sync();
@@ -86,14 +86,14 @@ C2H_TEST("can use event_ref to record and wait on an event", "[event]")
 
 C2H_TEST("can construct an event with a stream_ref", "[event]")
 {
-  cudax::stream stream;
+  cudax::stream stream{cudax::device_ref{0}};
   cudax::event ev(static_cast<cuda::stream_ref>(stream));
   CUDAX_REQUIRE(ev.get() != ::cudaEvent_t{});
 }
 
 C2H_TEST("can wait on an event", "[event]")
 {
-  cudax::stream stream;
+  cudax::stream stream{cudax::device_ref{0}};
   ::test::managed<int> i(0);
   cudax::launch(stream, ::test::one_thread_dims, ::test::assign_42{}, i.get());
   cudax::event ev(stream);
@@ -105,7 +105,7 @@ C2H_TEST("can wait on an event", "[event]")
 
 C2H_TEST("can take the difference of two timed_event objects", "[event]")
 {
-  cudax::stream stream;
+  cudax::stream stream{cudax::device_ref{0}};
   ::test::managed<int> i(0);
   cudax::timed_event start(stream);
   cudax::launch(stream, ::test::one_thread_dims, ::test::assign_42{}, i.get());
@@ -124,7 +124,7 @@ C2H_TEST("can observe the event in not ready state", "[event]")
   ::test::managed<int> i(0);
   ::cuda::atomic_ref atomic_i(*i);
 
-  cudax::stream stream;
+  cudax::stream stream{cudax::device_ref{0}};
 
   cudax::launch(stream, ::test::one_thread_dims, ::test::spin_until_80{}, i.get());
   cudax::event ev(stream);

--- a/cudax/test/execution/env.cu
+++ b/cudax/test/execution/env.cu
@@ -54,11 +54,11 @@ C2H_TEST("env_t is queryable for all properties we want", "[execution, env]")
 
 C2H_TEST("env_t is default constructible", "[execution, env]")
 {
-  env_t env;
+  env_t env{cudax::device_memory_resource{cudax::device_ref{0}}};
   CHECK(env.query(cuda::get_stream) == ::cuda::experimental::__detail::__invalid_stream);
   CHECK(env.query(cudax::execution::get_execution_policy)
         == cudax::execution::execution_policy::invalid_execution_policy);
-  CHECK(env.query(cuda::mr::get_memory_resource) == cudax::device_memory_resource{});
+  CHECK(env.query(cuda::mr::get_memory_resource) == cudax::device_memory_resource{cudax::device_ref{0}});
 }
 
 C2H_TEST("env_t is constructible from an any_resource", "[execution, env]")
@@ -76,7 +76,7 @@ C2H_TEST("env_t is constructible from an any_resource", "[execution, env]")
 
   SECTION("Passing an any_resource and a stream")
   {
-    cudax::stream stream{};
+    cudax::stream stream{cudax::device_ref{0}};
     env_t env{mr, stream};
     CHECK(env.query(cuda::get_stream) == stream);
     CHECK(env.query(cudax::execution::get_execution_policy)
@@ -86,7 +86,7 @@ C2H_TEST("env_t is constructible from an any_resource", "[execution, env]")
 
   SECTION("Passing an any_resource, a stream and a policy")
   {
-    cudax::stream stream{};
+    cudax::stream stream{cudax::device_ref{0}};
     env_t env{mr, stream, cudax::execution::execution_policy::parallel_unsequenced_device};
     CHECK(env.query(cuda::get_stream) == stream);
     CHECK(env.query(cudax::execution::get_execution_policy)
@@ -109,7 +109,7 @@ C2H_TEST("env_t is constructible from an any_resource passed as an rvalue", "[ex
 
   SECTION("Passing an any_resource and a stream")
   {
-    cudax::stream stream{};
+    cudax::stream stream{cudax::device_ref{0}};
     env_t env{cudax::any_async_resource<cuda::mr::device_accessible>{test_resource{}}, stream};
     CHECK(env.query(cuda::get_stream) == stream);
     CHECK(env.query(cudax::execution::get_execution_policy)
@@ -120,7 +120,7 @@ C2H_TEST("env_t is constructible from an any_resource passed as an rvalue", "[ex
 
   SECTION("Passing an any_resource, a stream and a policy")
   {
-    cudax::stream stream{};
+    cudax::stream stream{cudax::device_ref{0}};
     env_t env{cudax::any_async_resource<cuda::mr::device_accessible>{test_resource{}},
               stream,
               cudax::execution::execution_policy::parallel_unsequenced_device};
@@ -147,7 +147,7 @@ C2H_TEST("env_t is constructible from a resource", "[execution, env]")
 
   SECTION("Passing an any_resource and a stream")
   {
-    cudax::stream stream{};
+    cudax::stream stream{cudax::device_ref{0}};
     env_t env{mr, stream};
     CHECK(env.query(cuda::get_stream) == stream);
     CHECK(env.query(cudax::execution::get_execution_policy)
@@ -157,7 +157,7 @@ C2H_TEST("env_t is constructible from a resource", "[execution, env]")
 
   SECTION("Passing an any_resource, a stream and a policy")
   {
-    cudax::stream stream{};
+    cudax::stream stream{cudax::device_ref{0}};
     env_t env{mr, stream, cudax::execution::execution_policy::parallel_unsequenced_device};
     CHECK(env.query(cuda::get_stream) == stream);
     CHECK(env.query(cudax::execution::get_execution_policy)
@@ -179,7 +179,7 @@ C2H_TEST("env_t is constructible from a resource passed as an rvalue", "[executi
 
   SECTION("Passing an any_resource and a stream")
   {
-    cudax::stream stream{};
+    cudax::stream stream{cudax::device_ref{0}};
     env_t env{test_resource{}, stream};
     CHECK(env.query(cuda::get_stream) == stream);
     CHECK(env.query(cudax::execution::get_execution_policy)
@@ -189,7 +189,7 @@ C2H_TEST("env_t is constructible from a resource passed as an rvalue", "[executi
 
   SECTION("Passing an any_resource, a stream and a policy")
   {
-    cudax::stream stream{};
+    cudax::stream stream{cudax::device_ref{0}};
     env_t env{test_resource{}, stream, cudax::execution::execution_policy::parallel_unsequenced_device};
     CHECK(env.query(cuda::get_stream) == stream);
     CHECK(env.query(cudax::execution::get_execution_policy)
@@ -201,7 +201,7 @@ C2H_TEST("env_t is constructible from a resource passed as an rvalue", "[executi
 struct some_env_t
 {
   test_resource res_{};
-  cudax::stream stream_{};
+  cudax::stream stream_{cudax::device_ref{0}};
   cudax::execution::execution_policy policy_ = cudax::execution::execution_policy::parallel_unsequenced_device;
 
   const test_resource& query(cuda::mr::get_memory_resource_t) const noexcept
@@ -232,7 +232,7 @@ template <bool WithResource, bool WithStream, bool WithPolicy>
 struct bad_env_t
 {
   test_resource res_{};
-  cudax::stream stream_{};
+  cudax::stream stream_{cudax::device_ref{0}};
   cudax::execution::execution_policy policy_ = cudax::execution::execution_policy::parallel_unsequenced_device;
 
   template <bool Enable = WithResource, cuda::std::enable_if_t<Enable, int> = 0>
@@ -272,7 +272,7 @@ C2H_TEST("Can use query to construct various objects", "[execution, env]")
 
   SECTION("Can create an uninitialized_async_buffer")
   {
-    cudax::stream stream_{};
+    cudax::stream stream_{cudax::device_ref{0}};
     env_t env{test_resource{}, stream_};
     cudax::uninitialized_async_buffer<int, cuda::mr::device_accessible> buf{
       env.query(cuda::mr::get_memory_resource), env.query(cuda::get_stream), 0ull};

--- a/cudax/test/execution/test_stream_context.cu
+++ b/cudax/test/execution/test_stream_context.cu
@@ -41,7 +41,7 @@ struct _say_hello
 
 void stream_context_test1()
 {
-  cudax_async::stream_context ctx;
+  cudax_async::stream_context ctx{cuda::experimental::device_ref{0}};
   auto sched = ctx.get_scheduler();
 
   auto sndr = cudax_async::schedule(sched) //
@@ -56,7 +56,7 @@ void stream_context_test1()
 void stream_context_test2()
 {
   cudax_async::thread_context tctx;
-  cudax_async::stream_context sctx;
+  cudax_async::stream_context sctx{cuda::experimental::device_ref{0}};
   auto sch = sctx.get_scheduler();
 
   auto start = //

--- a/cudax/test/graph/graph_smoke.cu
+++ b/cudax/test/graph/graph_smoke.cu
@@ -82,7 +82,7 @@ C2H_TEST("can instantiate and launch a graph", "[graph]")
   CUDAX_REQUIRE(exec.get() != nullptr);
 
   // Create a stream and launch the graph
-  cuda::experimental::stream s;
+  cuda::experimental::stream s{cuda::experimental::device_ref{0}};
   exec.launch(s);
 
   // Wait for completion

--- a/cudax/test/launch/launch_smoke.cu
+++ b/cudax/test/launch/launch_smoke.cu
@@ -271,7 +271,7 @@ struct kernel_with_default_config
 
 void test_default_config()
 {
-  cudax::stream stream;
+  cudax::stream stream{cudax::device_ref{0}};
   auto grid  = cudax::grid_dims(4);
   auto block = cudax::block_dims<256>;
 
@@ -369,7 +369,7 @@ struct lambda_wrapper
 C2H_TEST("Host launch", "")
 {
   cuda::atomic<int> atomic = 0;
-  cudax::stream stream;
+  cudax::stream stream{cudax::device_ref{0}};
   int i = 0;
 
   auto set_lambda = [&](int set) {

--- a/cudax/test/memory_resource/any_async_resource.cu
+++ b/cudax/test/memory_resource/any_async_resource.cu
@@ -109,7 +109,7 @@ TEMPLATE_TEST_CASE_METHOD(test_fixture, "any_async_resource", "[container][resou
     Counts expected{};
     CHECK(this->counts == expected);
     {
-      cudax::stream stream{};
+      cudax::stream stream{cudax::device_ref{0}};
       cudax::any_async_resource<cudax::host_accessible> mr{TestResource{42, this}};
       expected.new_count += is_big;
       ++expected.object_count;

--- a/cudax/test/memory_resource/common_tests.cuh
+++ b/cudax/test/memory_resource/common_tests.cuh
@@ -17,7 +17,7 @@
 template <typename ResourceType>
 void test_deallocate_async(ResourceType& resource)
 {
-  cudax::stream stream;
+  cudax::stream stream{cudax::device_ref{0}};
   test::managed<int> i(0);
   cuda::atomic_ref atomic_i(*i);
 

--- a/cudax/test/memory_resource/device_memory_resource.cu
+++ b/cudax/test/memory_resource/device_memory_resource.cu
@@ -23,7 +23,6 @@ namespace cudax = cuda::experimental;
 
 static_assert(!cuda::std::is_trivial<cudax::device_memory_resource>::value, "");
 static_assert(!cuda::std::is_trivially_default_constructible<cudax::device_memory_resource>::value, "");
-static_assert(cuda::std::is_default_constructible<cudax::device_memory_resource>::value, "");
 static_assert(cuda::std::is_copy_constructible<cudax::device_memory_resource>::value, "");
 static_assert(cuda::std::is_move_constructible<cudax::device_memory_resource>::value, "");
 static_assert(cuda::std::is_copy_assignable<cudax::device_memory_resource>::value, "");
@@ -91,7 +90,7 @@ C2H_TEST("device_memory_resource construction", "[memory_resource]")
   SECTION("Default construction")
   {
     {
-      async_resource default_constructed{};
+      async_resource default_constructed{cudax::device_ref{0}};
       CHECK(default_constructed.get() == current_default_pool);
     }
 
@@ -220,7 +219,7 @@ static void ensure_device_ptr(void* ptr)
 
 C2H_TEST("device_memory_resource allocation", "[memory_resource]")
 {
-  cudax::device_memory_resource res{};
+  cudax::device_memory_resource res{cudax::device_ref{0}};
 
   { // allocate / deallocate
     auto* ptr = res.allocate(42);
@@ -391,9 +390,9 @@ C2H_TEST("device_memory_resource comparison", "[memory_resource]")
     _CCCL_TRY_CUDA_API(::cudaGetDevice, "Failed to query current device with cudaGetDevice.", &current_device);
   }
 
-  cudax::device_memory_resource first{};
+  cudax::device_memory_resource first{cudax::device_ref{0}};
   { // comparison against a plain device_memory_resource
-    cudax::device_memory_resource second{};
+    cudax::device_memory_resource second{cudax::device_ref{0}};
     CHECK((first == second));
     CHECK(!(first != second));
   }
@@ -414,7 +413,7 @@ C2H_TEST("device_memory_resource comparison", "[memory_resource]")
   }
 
   { // comparison against a device_memory_resource wrapped inside a resource_ref<device_accessible>
-    cudax::device_memory_resource second{};
+    cudax::device_memory_resource second{cudax::device_ref{0}};
     cudax::resource_ref<cudax::device_accessible> second_ref{second};
     CHECK((first == second_ref));
     CHECK(!(first != second_ref));
@@ -423,7 +422,7 @@ C2H_TEST("device_memory_resource comparison", "[memory_resource]")
   }
 
   { // comparison against a device_memory_resource wrapped inside a async_resource_ref
-    cudax::device_memory_resource second{};
+    cudax::device_memory_resource second{cudax::device_ref{0}};
     cudax::async_resource_ref<cudax::device_accessible> second_ref{second};
 
     CHECK((first == second_ref));
@@ -514,8 +513,8 @@ C2H_TEST("Async memory resource access", "")
       resource.enable_access_from(peers);
 
       // Check the resource using the default pool
-      cudax::device_memory_resource default_pool_resource{};
-      cudax::device_memory_resource another_default_pool_resource{};
+      cudax::device_memory_resource default_pool_resource{cudax::device_ref{0}};
+      cudax::device_memory_resource another_default_pool_resource{cudax::device_ref{0}};
 
       default_pool_resource.enable_access_from(peers.front());
 

--- a/cudax/test/memory_resource/managed_memory_resource.cu
+++ b/cudax/test/memory_resource/managed_memory_resource.cu
@@ -59,7 +59,7 @@ C2H_TEST("managed_memory_resource construction", "[memory_resource]")
 C2H_TEST("managed_memory_resource allocation", "[memory_resource]")
 {
   managed_resource res{};
-  cudax::stream stream{};
+  cudax::stream stream{cudax::device_ref{0}};
 
   { // allocate / deallocate
     auto* ptr = res.allocate(42);

--- a/cudax/test/memory_resource/memory_pools.cu
+++ b/cudax/test/memory_resource/memory_pools.cu
@@ -343,7 +343,7 @@ C2H_TEST_LIST("device_memory_pool accessors", "[memory_resource]", TEST_TYPES)
 
     // prime the pool to a given size
     memory_resource_for_pool<memory_pool> resource{pool};
-    cudax::stream stream{};
+    cudax::stream stream{cudax::device_ref{0}};
 
     // Allocate a buffer to prime
     auto* ptr = resource.allocate_async(256 * sizeof(int), stream);
@@ -467,7 +467,7 @@ C2H_TEST_LIST("device_memory_pool accessors", "[memory_resource]", TEST_TYPES)
 
     // prime the pool to a given size
     memory_resource_for_pool<memory_pool> resource{pool};
-    cudax::stream stream{};
+    cudax::stream stream{cudax::device_ref{0}};
 
     // Allocate 2 buffers
     auto* ptr1 = resource.allocate_async(2048 * sizeof(int), stream);

--- a/cudax/test/memory_resource/pinned_memory_resource.cu
+++ b/cudax/test/memory_resource/pinned_memory_resource.cu
@@ -64,7 +64,7 @@ C2H_TEST_LIST("pinned_memory_resource allocation", "[memory_resource]", TEST_TYP
 {
   using pinned_resource = TestType;
   pinned_resource res{};
-  cudax::stream stream{};
+  cudax::stream stream{cudax::device_ref{0}};
 
   { // allocate / deallocate
     auto* ptr = res.allocate(42);

--- a/cudax/test/stream/stream_smoke.cu
+++ b/cudax/test/stream/stream_smoke.cu
@@ -16,7 +16,7 @@
 
 C2H_TEST("Can create a stream and launch work into it", "[stream]")
 {
-  cudax::stream str;
+  cudax::stream str{cudax::device_ref{0}};
   ::test::managed<int> i(0);
   cudax::launch(str, ::test::one_thread_dims, ::test::assign_42{}, i.get());
   str.sync();
@@ -93,7 +93,7 @@ void add_dependency_test(const StreamType& waiter, const StreamType& waitee)
 
 C2H_TEST("Can add dependency into a stream", "[stream]")
 {
-  cudax::stream waiter, waitee;
+  cudax::stream waiter{cudax::device_ref{0}}, waitee{cudax::device_ref{0}};
 
   add_dependency_test<cudax::stream>(waiter, waitee);
   add_dependency_test<cudax::stream_ref>(waiter, waitee);
@@ -101,11 +101,11 @@ C2H_TEST("Can add dependency into a stream", "[stream]")
 
 C2H_TEST("Stream priority", "[stream]")
 {
-  cudax::stream stream_default_prio;
+  cudax::stream stream_default_prio{cudax::device_ref{0}};
   CUDAX_REQUIRE(stream_default_prio.priority() == cudax::stream::default_priority);
 
   auto priority = cudax::stream::default_priority - 1;
-  cudax::stream stream(0, priority);
+  cudax::stream stream{cudax::device_ref{0}, priority};
   CUDAX_REQUIRE(stream.priority() == priority);
 }
 


### PR DESCRIPTION
We agreed to remove the default device argument to APIs. It is convenient to default to device 0 for those APIs, but it carries a risk of accidental misuse.
Because it is much harder to remove a default once added then to add a new default, we would like to start with no default and add it later if we see complaints.

I found two places where default device argument was used: `stream` and `device_memory_resource` constructor. This PR removes those defaults and adjusts usage in tests/examples