### PR TITLE
Fix async buffer example

### DIFF
--- a/cudax/examples/CMakeLists.txt
+++ b/cudax/examples/CMakeLists.txt
@@ -53,6 +53,8 @@ file(GLOB example_srcs
   *.cu *.cpp
 )
 
+find_package(CUDAToolkit REQUIRED) # for CUDAToolkit_VERSION
+
 # Example requires pinned_memory_resource.
 if(CUDAToolkit_VERSION VERSION_LESS 12.6)
   list(REMOVE_ITEM example_srcs async_buffer_add.cu)

--- a/cudax/examples/async_buffer_add.cu
+++ b/cudax/examples/async_buffer_add.cu
@@ -75,7 +75,7 @@ int main()
   cudax::async_host_buffer<float> h_C{host_env, C};
 
   // Do not forget to sync afterwards
-  stream.wait();
+  stream.sync();
 
   for (int i = 0; i < numElements; ++i)
   {


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
cudax examples conditionally exclude examples based on CTK version, but `CUDAToolkit_VERSION` is not defined at that point. This PR fixes CMake along with error in example code. 

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
