### PR TITLE
Fix RadixEncoder<int> operator() signature for radix sort

### DIFF
--- a/thrust/testing/sort.cu
+++ b/thrust/testing/sort.cu
@@ -115,3 +115,14 @@ void TestSortBoolDescending()
   ASSERT_EQUAL(h_data, d_data);
 }
 DECLARE_UNITTEST(TestSortBoolDescending);
+
+// See also: https://github.com/NVIDIA/cccl/issues/4919
+void TestSortTrivial()
+{
+  thrust::host_vector<int> h_data = {1, 0, -1, -2, -3};
+  thrust::host_vector<int> ref    = {-3, -2, -1, 0, 1};
+
+  thrust::sort(h_data.begin(), h_data.end());
+  ASSERT_EQUAL(h_data, ref);
+}
+DECLARE_UNITTEST(TestSortTrivial);

--- a/thrust/thrust/system/detail/sequential/stable_radix_sort.inl
+++ b/thrust/thrust/system/detail/sequential/stable_radix_sort.inl
@@ -94,7 +94,7 @@ struct RadixEncoder<short>
 template <>
 struct RadixEncoder<int>
 {
-  _CCCL_HOST_DEVICE unsigned long operator()(long x) const
+  _CCCL_HOST_DEVICE unsigned int operator()(int x) const
   {
     return x ^ static_cast<unsigned int>(1) << (8 * sizeof(unsigned int) - 1);
   }


### PR DESCRIPTION
## Description

Fixes the signature for the `RadixEncoder<int>::operator()` function to use unsigned int instead of unsigned long.
```
template <>
struct RadixEncoder<int>
{
  _CCCL_HOST_DEVICE unsigned int operator()(int x) const
  {
    return x ^ static_cast<unsigned int>(1) << (8 * sizeof(unsigned int) - 1);
  }
};
```

Closes #4919 

## Checklist
- [x] I am familiar with the Contributing Guidelines
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
