### PR TITLE
Added f32/fp64 specializations for complex exp function.

### DIFF
--- a/libcudacxx/include/cuda/std/detail/libcxx/include/complex
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/complex
@@ -1097,6 +1097,196 @@ template <class _Tp>
   return complex<_Tp>(__e * _CUDA_VSTD::cos(__i), __e * _CUDA_VSTD::sin(__i));
 }
 
+// exp fp32 specialization
+
+template <>
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI complex<float> exp(const complex<float>& __x)
+{
+  const float __r = __x.real();
+  const float __i = __x.imag();
+
+  // Some Inf/NaN special cases that don't filter through:
+  if(!_CUDA_VSTD::isfinite(__r)){
+    if(_CUDA_VSTD::isinf(__r) && !_CUDA_VSTD::isfinite(__i)){
+      // __r == +-INF
+      return (__r ==  INFINITY) ? complex<float>{INFINITY, NAN} : complex<float>{0.0f, 0.0f};
+    }
+    // __r NaN:
+    if(_CUDA_VSTD::isnan(__r) && (__i == 0.0f)){return __x;}
+  }
+
+  // e^real, deal with overflow after:
+  float __j = _CUDA_VSTD::roundf(__r * 1.4426950408889634073599246810018921374f);
+  float __exp_mant;
+
+  // exp() range reduction.
+  // https://arxiv.org/PS_cache/arxiv/pdf/0708/0708.3722v1.pdf
+  float __r_reduced;
+  __r_reduced = _CUDA_VSTD::fmaf (-__j, 0.693147182464599609375f, __r);
+  __r_reduced = _CUDA_VSTD::fmaf (-__j, -1.904652435769094154e-9f, __r_reduced);
+  __r_reduced = _CUDA_VSTD::fmaf (-__j, -1.864189073832837884e-15f, __r_reduced);
+
+  // __r_reduced is in [log(sqrt(0.5)), log(sqrt(2))].
+  __exp_mant = 1.95693559362553060054779052734375e-4f;
+  __exp_mant = _CUDA_VSTD::fmaf (__exp_mant, __r_reduced, 1.39354146085679531097412109375e-3f);
+  __exp_mant = _CUDA_VSTD::fmaf (__exp_mant, __r_reduced, 8.333896286785602569580078125e-3f);
+  __exp_mant = _CUDA_VSTD::fmaf (__exp_mant, __r_reduced, 4.16664592921733856201171875e-2f);
+  __exp_mant = _CUDA_VSTD::fmaf (__exp_mant, __r_reduced, 0.16666664183139801025390625f);
+  __exp_mant = _CUDA_VSTD::fmaf (__exp_mant, __r_reduced, 0.5f);
+  __exp_mant = _CUDA_VSTD::fmaf (__exp_mant, __r_reduced, 1.0f);
+  __exp_mant = _CUDA_VSTD::fmaf (__exp_mant, __r_reduced, 1.0f);
+
+  // Get some close bounds when the answer is fully guarenteed to under/overflow.
+  // Sometime close to but >= log(max_flt / min_denom_float):
+  if(_CUDA_VSTD::fabsf(__r) >= 194.0f){
+    // real/imag return value must always underflow or overflow.
+    // Clamp to a low value that still under/overflows.
+    // This helps avoids multiple other branches earlier/later.
+    __exp_mant = (__r < 0.0f) ? 0.0f : 1e3f;
+  }
+
+  // Compile to sincos when possible:
+  #ifdef __CUDA_ARCH__
+    float __sin_i;
+    float __cos_i;
+    sincosf(__i, &__sin_i, &__cos_i);
+  #else
+    const float __sin_i = _CUDA_VSTD::sinf(__i);
+    const float __cos_i = _CUDA_VSTD::cosf(__i);
+  #endif
+
+  // Our answer now is: (ldexp(__exp_mant * __sin_r, __j_int), ldexp(__exp_mant * __sin_r, __j_int))
+  // However we don't need a full ldexp here, and if __exp_mant*__sin_r is denormal we can lose bits.
+  // Instead, do an inlined/simplified ldexp.
+
+  // With fabs(sin or cos) <= 1, the unbiased exponent of sin or cos is in [-149, 0].
+  // So for an inlined ldexp, we can clamp __j to [-151, 277].
+  // (Go as low as -151 for underflow to 0 denormal rounding.)
+  // This allows to to do an ldexp via some faster integer ops.
+
+  // __j converted to int32, clamp so nothing bad happens. Will not change any results.
+  // 151 = 127 + 24
+  // 277 = 23 + 2*127 + 1
+  if(__j >  278.0f){__j =  278.0f;}
+  if(__j < -151.0f){__j = -151.0f;}
+
+  const int __j_int = int(__j);
+
+  // Split this j up into four parts to fit it into four float exponents's.
+  // (Splitting j in 4 better than in 3).
+  uint32_t __j_quarter  = (__j_int / 4);
+  uint32_t __j_remainder = __j_int - (3*__j_quarter);
+
+  // Pack these into exponents:
+  __j_quarter = (__j_quarter + 127) << 23;
+  __j_remainder = (__j_remainder + 127) << 23;
+
+  const float __ldexp_factor_1 = reinterpret_cast<float&>(__j_quarter);
+  const float __ldexp_factor_2 = reinterpret_cast<float&>(__j_remainder);
+
+  // Need to order our multiplications to avoid intermediate under/overflow, including when __sin_r is denormal.
+  // Experiment suggests this is (one of) the better ways to do it, there's not that many combinations that work for all inputs:
+  const float __ans_r = ((((__cos_i * __ldexp_factor_1) * __ldexp_factor_1) * __ldexp_factor_1) * (__exp_mant * __ldexp_factor_2));
+  const float __ans_i = ((((__sin_i * __ldexp_factor_1) * __ldexp_factor_1) * __ldexp_factor_1) * (__exp_mant * __ldexp_factor_2));
+
+  return complex<float>(__ans_r, __ans_i);
+}
+
+// exp fp64 specialization
+
+template <>
+[[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI complex<double> exp<double>(const complex<double>& __x)
+{
+  const double __r = __x.real();
+  const double __i = __x.imag();
+
+  // Special cases that don't filter through:
+  if(!_CUDA_VSTD::isfinite(__r)){
+    if(_CUDA_VSTD::isinf(__r) && !_CUDA_VSTD::isfinite(__i)){
+      return (__r == INFINITY) ? complex<double>{INFINITY, NAN} : complex<double>{0.0, 0.0};
+    }
+    if(_CUDA_VSTD::isnan(__r) && (__i == 0.0)){return __x;}
+  }
+
+  // e^real, deal with overflow after:
+  double __j = _CUDA_VSTD::round(__r * 1.442695040888963407);
+  double __exp_mant;
+
+  // exp() range reduction.
+  // https://arxiv.org/PS_cache/arxiv/pdf/0708/0708.3722v1.pdf
+  double __r_reduced;
+  __r_reduced = _CUDA_VSTD::fma (-__j, 0.6931471805599453972491, __r);
+  __r_reduced = _CUDA_VSTD::fma (-__j, -8.78318343240526554e-17, __r_reduced);
+  __r_reduced = _CUDA_VSTD::fma (-__j, -2.51071706717795650e-33, __r_reduced);
+
+  // __r_reduced is in [log(sqrt(0.5)), log(sqrt(2))].
+  __exp_mant = 2.5022322536502990e-8;
+  __exp_mant = _CUDA_VSTD::fma (__exp_mant, __r_reduced, 2.7630903488173108e-7);
+  __exp_mant = _CUDA_VSTD::fma (__exp_mant, __r_reduced, 2.7557514545882439e-6);
+  __exp_mant = _CUDA_VSTD::fma (__exp_mant, __r_reduced, 2.4801491039099165e-5);
+  __exp_mant = _CUDA_VSTD::fma (__exp_mant, __r_reduced, 1.9841269589115497e-4);
+  __exp_mant = _CUDA_VSTD::fma (__exp_mant, __r_reduced, 1.3888888945916380e-3);
+  __exp_mant = _CUDA_VSTD::fma (__exp_mant, __r_reduced, 8.3333333334550432e-3);
+  __exp_mant = _CUDA_VSTD::fma (__exp_mant, __r_reduced, 4.1666666666519754e-2);
+  __exp_mant = _CUDA_VSTD::fma (__exp_mant, __r_reduced, 1.6666666666666477e-1);
+  __exp_mant = _CUDA_VSTD::fma (__exp_mant, __r_reduced, 5.0000000000000122e-1);
+  __exp_mant = _CUDA_VSTD::fma (__exp_mant, __r_reduced, 1.0);
+  __exp_mant = _CUDA_VSTD::fma (__exp_mant, __r_reduced, 1.0);
+
+  if(_CUDA_VSTD::fabs(__r) >= 1457.0){
+    // real/imag return value must always underflow or overflow.
+    // This helps avoid other checks later.
+    __exp_mant = (__r < 0.0) ? 0.0 : 1e10;
+  }
+
+  // Compile to sincos when possible:
+  #ifdef __CUDA_ARCH__
+    double __sin_i;
+    double __cos_i;
+    sincos(__i, &__sin_i, &__cos_i);
+  #else
+    double __sin_i = _CUDA_VSTD::sin(__i);
+    double __cos_i = _CUDA_VSTD::cos(__i);
+  #endif
+  // Our answer now is: (ldexp(__exp_mant * __sin_r, __j_int), ldexp(__exp_mant * __sin_r, __j_int))
+  // However we don't need a full ldexp here, and if __exp_mant*__sin_r is denormal we can lose bits.
+  // Instead, do an inlined/simplified ldexp.
+
+  // With fabs(sin or cos) <= 1, the unbiased exponent of sin or cos is in [-1074, 0].
+  // So for an inlined ldexp, we can clamp __j to [-1076, 2098].
+  // (Go as low as -1076 for underflow to 0 denormal rounding.)
+  // This allows to to do an ldexp via some faster integer ops.
+
+  // __j is converted to int32, clamp so nothing bad happens. Will not change any results.
+  // Need to add 1 for rounding reasons
+  // 1076 = 1023 + 53
+  // 2099 = 52 + 2*1023 + 1
+  if(__j >  2099.0){__j =  2099.0;}
+  if(__j < -1076.0){__j = -1076.0;}
+
+  const int __j_int = int(__j);
+
+  // We can split this j up into three parts to fit it into three double exponents's.
+  // j can be in a set of 3174 values.
+  // (Splitting j in 4 better than in 3).
+  uint64_t __j_quarter  = (__j_int / 4);
+  uint64_t __j_remainder = __j_int - (3*__j_quarter);
+
+  // Pack these into exponents:
+  __j_quarter = (__j_quarter + 1023) << 52;
+  __j_remainder = (__j_remainder + 1023) << 52;
+
+  const double __ldexp_factor_1 = reinterpret_cast<double&>(__j_quarter);
+  const double __ldexp_factor_2 = reinterpret_cast<double&>(__j_remainder);
+
+  // Need to order our multiplications to avoid intermediate under/overflow, including when __sin_r is denormal.
+  // Experiment suggests this is (one of) the best way to do it:
+  const double __ans_r = ((((__cos_i * __ldexp_factor_1) * __ldexp_factor_1) * __ldexp_factor_1) * (__exp_mant * __ldexp_factor_2));
+  const double __ans_i = ((((__sin_i * __ldexp_factor_1) * __ldexp_factor_1) * __ldexp_factor_1) * (__exp_mant * __ldexp_factor_2));
+
+  return complex<double>(__ans_r, __ans_i);
+}
+
 // pow
 
 template <class _Tp>


### PR DESCRIPTION
## Updated the complex exp function to avoid under/overflow issues.

There are a few issues with the bounds in the cexp function relating to under/overflow.

In the current version, it can be the case that the real/imag parts of the answer, which is implemented as:
`(e^real * cos(imag), e^real * sin(imag))`,

can have the `e^real` part overflow, while the next sin/cos multiplication would bring it back into the fp range, however we return `INF`.

It can also generate `NaN` results, when `imag == 0.0` -> `sin(imag) == 0`, and exp overflows.
Here the correct `imag` result is 0, but the naive implementation returns `NaN`.

This new version fixes all these possible under/overflow issues, and through inlining some of the function calls and stripping out unneeded checks does so with minimal perf disruption.

## Perf
For fp64 precision performance was faster on H100 and Quadro RTX 8000.
For fp32 precision performance was only faster on the Quadro RTX 8000.

Using the math-teams standard `math_bench` test we have the following on H100 (averaged summary):
**Operations/SM/cycle:**
| H100 |  old | new |
| --- | --- | ---|
| fp64 | 0.66082 | 0.70204 | 
| fp32 | 1.61528 | 1.53386 | 

(See https://docs.google.com/spreadsheets/d/1TdOpEbLgoL1QOWKjeO3pwFDDMoPr4iqnPjz_XrL7UEA for raw/non-averaged info.)

## Correctness GPU/CPU
The before / after accuracy accuracy is similar on regions where the current function does not have issues.
An intensive bracket and bisect search, along with testing special hard values, gives:
```
GPU fp64:
Max ulp real error (2.98,0.9139) @ (5.217369075,0.849946261)    (0x4014de95ffae7653,0x3feb32c280518909)
        Ours = (121.7401997,138.5658332)    Ref = (121.7401997,138.5658332)
        Ours = (0x405e6f5f6e98d3e1,0x4061521b4e34f7e3)               Ref = (0x405e6f5f6e98d3de,0x4061521b4e34f7e2)

Max ulp imag error (0.666,2.852) @ (8.78730102e-12,3.14673129e+293)     (0x3da352cf8a03ca22,0x7cdf886be6d24ce9)
        Ours = (-0.9685123725,-0.2489654278)    Ref = (-0.9685123725,-0.2489654278)
        Ours = (0xbfeefe0da8ba09b5,0xbfcfde1961370bc6)               Ref = (0xbfeefe0da8ba09b6,0xbfcfde1961370bc9)
```

```
GPU fp32:
Max ulp real error (3.206,1.588) @ (39.83263779,7.382916255e+37)        (0x421f549f,0x7e5e2beb)
        Ours = (-1.419121705e+17,1.396640729e+17)    Ref = (-1.419121447e+17,1.396640558e+17)
        Ours = (0xdbfc162f,0x5bf817de)               Ref = (0xdbfc162c,0x5bf817dc)

Max ulp imag error (1.272,3.172) @ (5.828636646,5.381953992e+32)        (0x40ba8431,0x75d447d9)
        Ours = (228.6749878,-251.4684296)    Ref = (228.6749725,-251.4683838)
        Ours = (0x4364accc,0xc37b77eb)               Ref = (0x4364accb,0xc37b77e8)
```

```
CPU fp64:
Max ulp real error (2.322,1.704) @ (256.7589006,4.832923854e+61)        (0x40700c2474f00000,0x4cbe134ab9e75400)
        Ours = (-2.361656648e+111,-2.201020209e+111)    Ref = (-2.361656648e+111,-2.201020209e+111)
        Ours = (0xd70f6cabdc4ed10f,0xd70d497c09efb5e3)               Ref = (0xd70f6cabdc4ed111,0xd70d497c09efb5e5)

Max ulp imag error (0.8213,2.311) @ (-3.834169936,8.576369563e+12)      (0xc00eac6149836800,0x429f335dd850e400)
        Ours = (-0.0202071154,-0.007685414766)    Ref = (-0.0202071154,-0.007685414766)
        Ours = (0xbf94b12c8f1cc18c,0xbf7f7abdd1402e07)               Ref = (0xbf94b12c8f1cc18b,0xbf7f7abdd1402e05)
```

```
CPU fp32:
Max ulp real error (2.307,0.9254) @ (5.177964211,45.91706467)   (0x40a5b1e2,0x4237ab13)
        Ours = (-63.12431335,165.7052002)    Ref = (-63.12432098,165.7052155)
        Ours = (0xc27c7f4c,0x4325b488)               Ref = (0xc27c7f4e,0x4325b489)

Max ulp imag error (1.298,2.302) @ (-3.816472054,1.394906292e+38)       (0xc0744114,0x7ed1e1d6)
        Ours = (-0.02060239203,0.007731408812)    Ref = (-0.02060239017,0.007731407881)
        Ours = (0xbca8c659,0x3bfd57c2)               Ref = (0xbca8c658,0x3bfd57c0)
```

## Note on __half/__nv_bfloat16
If the header is hacked to get the __half/__nv_bfloat16 verions to call the new fp32 version, it results in nearly correctly-rounded functions, and also (maybe surprisingly) faster functions than the template generated functions here.
However, due to the way the header is structured it is not possible to easily specialize `exp` for these types, as the type support for these is only included at the end of this file and no template specialization is (easily) possible.
```
...
#if _LIBCUDACXX_HAS_NVFP16()
#  include <cuda/std/__complex/nvfp16.h>
#endif // _LIBCUDACXX_HAS_NVFP16()

#if _LIBCUDACXX_HAS_NVBF16()
#  include <cuda/std/__complex/nvbf16.h>
#endif // _LIBCUDACXX_HAS_NVBF16()
```