### PR TITLE
Fix ValueError encountered when running test_device_reduce on machine without CTK installed

### DIFF
--- a/c/parallel/src/nvrtc/command_list.h
+++ b/c/parallel/src/nvrtc/command_list.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdlib>
 #include <iostream>
@@ -191,7 +192,12 @@ struct nvrtc2_pre_build
   // Compile program
   inline nvrtc2_post_build_nl compile_program(nvrtc_compile compile_args)
   {
-    auto result = nvrtcCompileProgram(context.program, compile_args.num_args, compile_args.args);
+    size_t n_actual_args = std::distance(
+      compile_args.args,
+      std::remove_if(compile_args.args, compile_args.args + compile_args.num_args, [](const char* ptr) -> bool {
+        return (ptr == nullptr);
+      }));
+    nvrtcResult result = nvrtcCompileProgram(context.program, n_actual_args, compile_args.args);
 
     size_t log_size{};
     check(nvrtcGetProgramLogSize(context.program, &log_size));

--- a/python/cuda_cccl/cuda/cccl/parallel/experimental/_bindings_impl.pyx
+++ b/python/cuda_cccl/cuda/cccl/parallel/experimental/_bindings_impl.pyx
@@ -1124,16 +1124,16 @@ cdef class CommonData:
         return self.cc_minor
 
     cdef inline const char * cub_path_get_c_str(self):
-        return <const char *>self.encoded_cub_path
+        return <const char *>self.encoded_cub_path if self.encoded_cub_path else NULL
 
     cdef inline const char * thrust_path_get_c_str(self):
-        return <const char *>self.encoded_thrust_path
+        return <const char *>self.encoded_thrust_path if self.encoded_thrust_path else NULL
 
     cdef inline const char * libcudacxx_path_get_c_str(self):
-        return <const char *>self.encoded_libcudacxx_path
+        return <const char *>self.encoded_libcudacxx_path if self.encoded_libcudacxx_path else NULL
 
     cdef inline const char * ctk_path_get_c_str(self):
-        return <const char *>self.encoded_ctk_path
+        return <const char *>self.encoded_ctk_path if self.encoded_ctk_path else NULL
 
     @property
     def compute_capability(self):

--- a/python/cuda_cccl/cuda/cccl/parallel/experimental/_cccl_interop.py
+++ b/python/cuda_cccl/cuda/cccl/parallel/experimental/_cccl_interop.py
@@ -302,7 +302,7 @@ def set_cccl_iterator_state(cccl_it: Iterator, input_it):
 def get_includes() -> List[str]:
     def as_option(p):
         if p is None:
-            return "-I/"
+            return ""
         return f"-I{p}"
 
     paths = get_include_paths().as_tuple()

--- a/python/cuda_cccl/cuda/cccl/parallel/experimental/_cccl_interop.py
+++ b/python/cuda_cccl/cuda/cccl/parallel/experimental/_cccl_interop.py
@@ -299,9 +299,15 @@ def set_cccl_iterator_state(cccl_it: Iterator, input_it):
 
 
 @functools.lru_cache()
-def get_paths() -> List[str]:
-    paths = [f"-I{path}" for path in get_include_paths().as_tuple() if path is not None]
-    return paths
+def get_includes() -> List[str]:
+    def as_option(p):
+        if p is None:
+            return "-I/"
+        return f"-I{p}"
+
+    paths = get_include_paths().as_tuple()
+    opts = [as_option(path) for path in paths]
+    return opts
 
 
 def _check_compile_result(cubin: bytes):
@@ -335,7 +341,7 @@ def call_build(build_impl_fn: Callable, *args, **kwargs):
     global _check_sass
 
     cc_major, cc_minor = cuda.get_current_device().compute_capability
-    cub_path, thrust_path, libcudacxx_path, cuda_include_path = get_paths()
+    cub_path, thrust_path, libcudacxx_path, cuda_include_path = get_includes()
     common_data = CommonData(
         cc_major, cc_minor, cub_path, thrust_path, libcudacxx_path, cuda_include_path
     )

--- a/python/cuda_cccl/cuda/cccl/parallel/experimental/_cccl_interop.py
+++ b/python/cuda_cccl/cuda/cccl/parallel/experimental/_cccl_interop.py
@@ -9,6 +9,7 @@ import os
 import subprocess
 import tempfile
 import textwrap
+import warnings
 from typing import TYPE_CHECKING, Callable, List
 
 import numba
@@ -321,6 +322,9 @@ def _check_compile_result(cubin: bytes):
         if out.returncode != 0:
             raise RuntimeError("nvdisasm failed")
         sass = out.stdout.decode("utf-8")
+    except FileNotFoundError:
+        sass = "nvdiasm not found, skipping SASS validation"
+        warnings.warn(sass)
     finally:
         os.unlink(temp_cubin_file.name)
 


### PR DESCRIPTION
Fix 'ValueError: not enough values to unpack (expected 4, got 3)' when CTK is absent

Running on vanilla Ubuntu container, with only CUDA drivers, but no CUDA toolkit,

```
pytest tests/parallel/test_reduce_api.py::test_device_reduce
```

encounters

```
build_impl_fn = <class 'cccl.parallel.experimental._bindings_impl.DeviceReduceBuildResult'>
args = (<cccl.parallel.experimental._bindings_impl.Iterator object at 0x7eb9025c06d0>, <cccl.parallel.experimental._bindings_...bindings_impl.Op object at 0x7eb8fa1c0490>, <cccl.parallel.experimental._bindings_impl.Value object at 0x7eb9031afbe0>)
kwargs = {}, cc_major = 8, cc_minor = 6

    def call_build(build_impl_fn: Callable, *args, **kwargs):
        """Calls given build_impl_fn callable while providing compute capability and paths

        Returns result of the call.
        """
        global _check_sass

        cc_major, cc_minor = cuda.get_current_device().compute_capability
>       cub_path, thrust_path, libcudacxx_path, cuda_include_path = get_paths()
E       ValueError: not enough values to unpack (expected 4, got 3)

miniforge/envs/cccl/lib/python3.10/site-packages/cuda/cccl/parallel/experimental/_cccl_interop.py:338: ValueError
```

This is caused by `get_paths` skipping entries with None values.

Since c.parallel library's `build` routines require 4 include options, replace None path returned by cuda.cccl.headers with `-I/`.

This is safe, since root folder is priviledges. The C library presently does not permit dropping an option and no pass it to compiler.

## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes <!-- Link issue here -->

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
