### PR TITLE
[CUDAX] Introduce driver stack checking macro and apply in it to device, event and stream tests

### DIFF
--- a/c2h/include/c2h/catch2_test_helper.h
+++ b/c2h/include/c2h/catch2_test_helper.h
@@ -264,6 +264,13 @@ struct Catch::StringMaker<cudaError>
 
 #define C2H_TEST(NAME, TAG, ...) C2H_TEST_IMPL(__LINE__, NAME, TAG, __VA_ARGS__)
 
+#define C2H_TEST_WITH_FIXTURE_IMPL(ID, FIXTURE, NAME, TAG, ...)            \
+  using C2H_TEST_CONCAT(types_, ID) = c2h::cartesian_product<__VA_ARGS__>; \
+  TEMPLATE_LIST_TEST_CASE_METHOD(FIXTURE, C2H_TEST_NAME(NAME), TAG, C2H_TEST_CONCAT(types_, ID))
+
+#define C2H_TEST_WITH_FIXTURE(FIXTURE, NAME, TAG, ...) \
+  C2H_TEST_WITH_FIXTURE_IMPL(__LINE__, FIXTURE, NAME, TAG, __VA_ARGS__)
+
 #define C2H_TEST_LIST_IMPL(ID, NAME, TAG, ...)                     \
   using C2H_TEST_CONCAT(types_, ID) = c2h::type_list<__VA_ARGS__>; \
   TEMPLATE_LIST_TEST_CASE(C2H_TEST_NAME(NAME), TAG, C2H_TEST_CONCAT(types_, ID))

--- a/cudax/include/cuda/experimental/__event/timed_event.cuh
+++ b/cudax/include/cuda/experimental/__event/timed_event.cuh
@@ -92,8 +92,7 @@ public:
   [[nodiscard]] friend _CUDA_VSTD::chrono::nanoseconds operator-(const timed_event& __end, const timed_event& __start)
   {
     float __ms = 0.0f;
-    _CCCL_TRY_CUDA_API(
-      ::cudaEventElapsedTime, "Failed to get CUDA event elapsed time", &__ms, __start.get(), __end.get());
+    __detail::driver::eventElapsedTime(__start.get(), __end.get(), &__ms);
     return _CUDA_VSTD::chrono::nanoseconds(static_cast<_CUDA_VSTD::chrono::nanoseconds::rep>(__ms * 1'000'000.0));
   }
 

--- a/cudax/include/cuda/experimental/__stream/stream_ref.cuh
+++ b/cudax/include/cuda/experimental/__stream/stream_ref.cuh
@@ -89,8 +89,6 @@ struct stream_ref : ::cuda::stream_ref
   }
 
   //! @brief Deprecated. Use is_done() instead.
-  //!
-  //! @deprecated Use is_done() instead.
   [[deprecated("Use is_done() instead.")]] [[nodiscard]] bool ready() const
   {
     return is_done();

--- a/cudax/include/cuda/experimental/__stream/stream_ref.cuh
+++ b/cudax/include/cuda/experimental/__stream/stream_ref.cuh
@@ -76,7 +76,35 @@ struct stream_ref : ::cuda::stream_ref
    */
   [[nodiscard]] bool is_done() const
   {
-    return ready();
+    const auto __result = __detail::driver::streamQuery(__stream);
+    switch (__result)
+    {
+      case ::cudaErrorNotReady:
+        return false;
+      case ::cudaSuccess:
+        return true;
+      default:
+        ::cuda::__throw_cuda_error(__result, "Failed to query stream.");
+    }
+  }
+
+  //! @brief Deprecated. Use is_done() instead.
+  //!
+  //! @deprecated Use is_done() instead.
+  [[deprecated("Use is_done() instead.")]] [[nodiscard]] bool ready() const
+  {
+    return is_done();
+  }
+
+  //! @brief Get the priority of the stream
+  //!
+  //! @return The priority of the stream
+  //!
+  //! @throws cuda_error if the priority query fails
+  // Needs to be without "get_" prefix, because it is this way in cuda::stream_ref
+  [[nodiscard]] _CCCL_HOST_API int priority() const
+  {
+    return __detail::driver::streamGetPriority(__stream);
   }
 
   //! @brief Create a new event and record it into this stream
@@ -99,7 +127,13 @@ struct stream_ref : ::cuda::stream_ref
     return timed_event(*this, __flags);
   }
 
-  using ::cuda::stream_ref::sync;
+  //! @brief Synchronize the stream
+  //!
+  //! @throws cuda_error if synchronization fails
+  _CCCL_HOST_API void sync() const
+  {
+    __detail::driver::streamSynchronize(__stream);
+  }
 
   //! @brief Make all future work submitted into this stream depend on completion of the specified event
   //!

--- a/cudax/include/cuda/experimental/__utility/driver_api.cuh
+++ b/cudax/include/cuda/experimental/__utility/driver_api.cuh
@@ -137,6 +137,12 @@ inline bool isPrimaryCtxActive(CUdevice dev)
   return result == 1;
 }
 
+inline void streamSynchronize(CUstream stream)
+{
+  static auto driver_fn = CUDAX_GET_DRIVER_FUNCTION(cuStreamSynchronize);
+  call_driver_fn(driver_fn, "Failed to synchronize a stream", stream);
+}
+
 inline CUcontext streamGetCtx(CUstream stream)
 {
   static auto driver_fn = CUDAX_GET_DRIVER_FUNCTION(cuStreamGetCtx);
@@ -189,6 +195,20 @@ inline void streamWaitEvent(CUstream stream, CUevent event)
   call_driver_fn(driver_fn, "Failed to make a stream wait for an event", stream, event, CU_EVENT_WAIT_DEFAULT);
 }
 
+inline cudaError_t streamQuery(CUstream stream)
+{
+  static auto driver_fn = CUDAX_GET_DRIVER_FUNCTION(cuStreamQuery);
+  return static_cast<cudaError_t>(driver_fn(stream));
+}
+
+inline int streamGetPriority(CUstream stream)
+{
+  int __priority;
+  static auto driver_fn = CUDAX_GET_DRIVER_FUNCTION(cuStreamGetPriority);
+  call_driver_fn(driver_fn, "Failed to get the priority of a stream", stream, &__priority);
+  return __priority;
+}
+
 inline void eventRecord(CUevent event, CUstream stream)
 {
   static auto driver_fn = CUDAX_GET_DRIVER_FUNCTION(cuEventRecord);
@@ -206,6 +226,12 @@ inline cudaError_t eventDestroy(CUevent event)
 {
   static auto driver_fn = CUDAX_GET_DRIVER_FUNCTION(cuEventDestroy);
   return static_cast<cudaError_t>(driver_fn(event));
+}
+
+inline void eventElapsedTime(CUevent start, CUevent end, float* ms)
+{
+  static auto driver_fn = CUDAX_GET_DRIVER_FUNCTION(cuEventElapsedTime);
+  call_driver_fn(driver_fn, "Failed to get CUDA event elapsed time", ms, start, end);
 }
 
 #if CUDART_VERSION >= 12050
@@ -231,6 +257,7 @@ inline CUcontext ctxFromGreenCtx(CUgreenCtx green_ctx)
   call_driver_fn(driver_fn, "Failed to convert a green context", &result, green_ctx);
   return result;
 }
+
 #endif // CUDART_VERSION >= 12050
 } // namespace cuda::experimental::__detail::driver
 

--- a/cudax/test/common/host_device.cuh
+++ b/cudax/test/common/host_device.cuh
@@ -11,7 +11,7 @@
 #ifndef __COMMON_HOST_DEVICE_H__
 #define __COMMON_HOST_DEVICE_H__
 
-#include "testing.cuh"
+#include "utility.cuh"
 
 template <typename Dims, typename Lambda>
 void __global__ lambda_launcher(const Dims dims, const Lambda lambda)

--- a/cudax/test/common/utility.cuh
+++ b/cudax/test/common/utility.cuh
@@ -11,6 +11,8 @@
 #ifndef __COMMON_UTILITY_H__
 #define __COMMON_UTILITY_H__
 
+#include <nv/detail/__preprocessor>
+
 #include <cuda_runtime_api.h>
 // cuda_runtime_api needs to come first
 
@@ -40,11 +42,13 @@ private:
 public:
   explicit _malloc_managed(std::size_t size)
   {
+    cudax::__ensure_current_device guard(cudax::device_ref{0});
     _CCCL_TRY_CUDA_API(::cudaMallocManaged, "failed to allocate managed memory", &pv, size);
   }
 
   ~_malloc_managed()
   {
+    cudax::__ensure_current_device guard(cudax::device_ref{0});
     [[maybe_unused]] auto status = ::cudaFree(pv);
   }
 
@@ -122,34 +126,6 @@ struct empty_kernel
 {
   __device__ void operator()() const noexcept {}
 };
-
-inline int count_driver_stack()
-{
-  if (cudax::__detail::driver::ctxGetCurrent() != nullptr)
-  {
-    auto ctx    = cudax::__detail::driver::ctxPop();
-    auto result = 1 + count_driver_stack();
-    cudax::__detail::driver::ctxPush(ctx);
-    return result;
-  }
-  else
-  {
-    return 0;
-  }
-}
-
-inline void empty_driver_stack()
-{
-  while (cudax::__detail::driver::ctxGetCurrent() != nullptr)
-  {
-    cudax::__detail::driver::ctxPop();
-  }
-}
-
-inline int cuda_driver_version()
-{
-  return cudax::__detail::driver::getVersion();
-}
 
 } // namespace test
 } // namespace

--- a/cudax/test/common/utility.cuh
+++ b/cudax/test/common/utility.cuh
@@ -11,8 +11,6 @@
 #ifndef __COMMON_UTILITY_H__
 #define __COMMON_UTILITY_H__
 
-#include <nv/detail/__preprocessor>
-
 #include <cuda_runtime_api.h>
 // cuda_runtime_api needs to come first
 

--- a/cudax/test/device/arch_traits.cu
+++ b/cudax/test/device/arch_traits.cu
@@ -97,7 +97,7 @@ void constexpr compare_static_and_dynamic()
   static_assert(casted.compute_capability == dynamic_traits.compute_capability);
 }
 
-C2H_TEST("Traits", "[device]")
+C2H_CCCLRT_TEST("Traits", "[device]")
 {
   compare_static_and_dynamic<700>();
   compare_static_and_dynamic<750>();

--- a/cudax/test/device/device_smoke.cu
+++ b/cudax/test/device/device_smoke.cu
@@ -12,7 +12,7 @@
 
 #include <cuda/experimental/device.cuh>
 
-#include <testing.cuh>
+#include <utility.cuh>
 
 namespace
 {
@@ -31,7 +31,7 @@ template <const auto& Attr, ::cudaDeviceAttr ExpectedAttr, class ExpectedResult>
 }
 } // namespace
 
-C2H_TEST("Smoke", "[device]")
+C2H_CCCLRT_TEST("Smoke", "[device]")
 {
   using cudax::device;
   using cudax::device_ref;
@@ -284,7 +284,7 @@ C2H_TEST("Smoke", "[device]")
   }
 }
 
-C2H_TEST("global devices vector", "[device]")
+C2H_CCCLRT_TEST("global devices vector", "[device]")
 {
   CUDAX_REQUIRE(cudax::devices.size() > 0);
   CUDAX_REQUIRE(cudax::devices.begin() != cudax::devices.end());

--- a/cudax/test/event/event_smoke.cu
+++ b/cudax/test/event/event_smoke.cu
@@ -29,8 +29,9 @@ static_assert(!_CUDA_VSTD::is_default_constructible_v<cudax::event_ref>);
 static_assert(!_CUDA_VSTD::is_default_constructible_v<cudax::event>);
 static_assert(!_CUDA_VSTD::is_default_constructible_v<cudax::timed_event>);
 
-C2H_TEST("can construct an event_ref from a cudaEvent_t", "[event]")
+C2H_CCCLRT_TEST("can construct an event_ref from a cudaEvent_t", "[event]")
 {
+  cudax::__ensure_current_device guard(cudax::device_ref{0});
   ::cudaEvent_t ev;
   CUDAX_REQUIRE(::cudaEventCreate(&ev) == ::cudaSuccess);
   cudax::event_ref ref(ev);
@@ -46,8 +47,9 @@ C2H_TEST("can construct an event_ref from a cudaEvent_t", "[event]")
   CUDAX_REQUIRE(!ref3);
 }
 
-C2H_TEST("can copy construct an event_ref and compare for equality", "[event]")
+C2H_CCCLRT_TEST("can copy construct an event_ref and compare for equality", "[event]")
 {
+  cudax::__ensure_current_device guard(cudax::device_ref{0});
   ::cudaEvent_t ev;
   CUDAX_REQUIRE(::cudaEventCreate(&ev) == ::cudaSuccess);
   const cudax::event_ref ref(ev);
@@ -66,8 +68,9 @@ C2H_TEST("can copy construct an event_ref and compare for equality", "[event]")
   CUDAX_REQUIRE(!ref4);
 }
 
-C2H_TEST("can use event_ref to record and wait on an event", "[event]")
+C2H_CCCLRT_TEST("can use event_ref to record and wait on an event", "[event]")
 {
+  cudax::__ensure_current_device guard(cudax::device_ref{0});
   ::cudaEvent_t ev;
   CUDAX_REQUIRE(::cudaEventCreate(&ev) == ::cudaSuccess);
   const cudax::event_ref ref(ev);
@@ -84,14 +87,14 @@ C2H_TEST("can use event_ref to record and wait on an event", "[event]")
   CUDAX_REQUIRE(::cudaEventDestroy(ev) == ::cudaSuccess);
 }
 
-C2H_TEST("can construct an event with a stream_ref", "[event]")
+C2H_CCCLRT_TEST("can construct an event with a stream_ref", "[event]")
 {
   cudax::stream stream;
   cudax::event ev(static_cast<cuda::stream_ref>(stream));
   CUDAX_REQUIRE(ev.get() != ::cudaEvent_t{});
 }
 
-C2H_TEST("can wait on an event", "[event]")
+C2H_CCCLRT_TEST("can wait on an event", "[event]")
 {
   cudax::stream stream;
   ::test::managed<int> i(0);
@@ -103,7 +106,7 @@ C2H_TEST("can wait on an event", "[event]")
   stream.sync();
 }
 
-C2H_TEST("can take the difference of two timed_event objects", "[event]")
+C2H_CCCLRT_TEST("can take the difference of two timed_event objects", "[event]")
 {
   cudax::stream stream;
   ::test::managed<int> i(0);
@@ -119,7 +122,7 @@ C2H_TEST("can take the difference of two timed_event objects", "[event]")
   stream.sync();
 }
 
-C2H_TEST("can observe the event in not ready state", "[event]")
+C2H_CCCLRT_TEST("can observe the event in not ready state", "[event]")
 {
   ::test::managed<int> i(0);
   ::cuda::atomic_ref atomic_i(*i);

--- a/cudax/test/launch/launch_smoke.cu
+++ b/cudax/test/launch/launch_smoke.cu
@@ -133,6 +133,7 @@ struct launch_transform_to_int_convertible
 // Needs a separate function for Windows extended lambda
 void launch_smoke_test()
 {
+  cudax::__ensure_current_device guard(cudax::device_ref{0});
   // Use raw stream to make sure it can be implicitly converted on call to launch
   cudaStream_t stream;
 
@@ -320,7 +321,7 @@ void block_stream(cudax::stream_ref stream, cuda::atomic<int>& atomic)
 
 void unblock_and_wait_stream(cudax::stream_ref stream, cuda::atomic<int>& atomic)
 {
-  CUDAX_REQUIRE(!stream.ready());
+  CUDAX_REQUIRE(!stream.is_done());
   atomic = 1;
   stream.sync();
   atomic = 0;

--- a/cudax/test/utility/ensure_current_device.cu
+++ b/cudax/test/utility/ensure_current_device.cu
@@ -42,94 +42,11 @@ C2H_TEST("ensure current device", "[device]")
   test::empty_driver_stack();
   // If possible use something different than CUDART default 0
   int target_device = static_cast<int>(cudax::devices.size() - 1);
-  int dev_id        = 0;
 
   SECTION("device setter")
   {
     recursive_check_device_setter(target_device);
 
-    CUDAX_REQUIRE(test::count_driver_stack() == 0);
-  }
-
-  SECTION("stream interactions with driver stack")
-  {
-    {
-      cudax::stream stream(target_device);
-      CUDAX_REQUIRE(test::count_driver_stack() == 0);
-      {
-        cudax::__ensure_current_device setter(cudax::device_ref{target_device});
-        CUDAX_REQUIRE(driver::ctxGetCurrent() == driver::streamGetCtx(stream.get()));
-      }
-      {
-        auto ev = stream.record_event();
-        CUDAX_REQUIRE(test::count_driver_stack() == 0);
-      }
-      CUDAX_REQUIRE(test::count_driver_stack() == 0);
-      {
-        auto ev = stream.record_timed_event();
-        CUDAX_REQUIRE(test::count_driver_stack() == 0);
-      }
-      {
-        auto lambda = [&](int dev_id) {
-          cudax::stream another_stream(dev_id);
-          CUDAX_REQUIRE(test::count_driver_stack() == 0);
-          stream.wait(another_stream);
-          CUDAX_REQUIRE(test::count_driver_stack() == 0);
-          another_stream.wait(stream);
-          CUDAX_REQUIRE(test::count_driver_stack() == 0);
-        };
-        lambda(target_device);
-        if (cudax::devices.size() > 1)
-        {
-          lambda(0);
-        }
-      }
-
-      cudax::__ensure_current_device setter(stream);
-      CUDAX_REQUIRE(test::count_driver_stack() == 1);
-      CUDART(cudaGetDevice(&dev_id));
-      CUDAX_REQUIRE(dev_id == target_device);
-      CUDAX_REQUIRE(driver::ctxGetCurrent() == driver::streamGetCtx(stream.get()));
-    }
-
-    CUDAX_CHECK(test::count_driver_stack() == 0);
-
-    {
-      // Check NULL stream ref is handled ok
-      cudax::__ensure_current_device setter1(cudax::device_ref{target_device});
-      cudaStream_t null_stream = nullptr;
-      auto ref                 = cuda::stream_ref(null_stream);
-      auto ctx                 = driver::ctxGetCurrent();
-      CUDAX_REQUIRE(test::count_driver_stack() == 1);
-
-      cudax::__ensure_current_device setter2(ref);
-      CUDAX_REQUIRE(test::count_driver_stack() == 2);
-      CUDAX_REQUIRE(ctx == driver::ctxGetCurrent());
-      CUDART(cudaGetDevice(&dev_id));
-      CUDAX_REQUIRE(dev_id == target_device);
-    }
-  }
-
-  SECTION("event interactions with driver stack")
-  {
-    {
-      cudax::stream stream(target_device);
-      CUDAX_REQUIRE(test::count_driver_stack() == 0);
-
-      cudax::event event(stream);
-      CUDAX_REQUIRE(test::count_driver_stack() == 0);
-
-      event.record(stream);
-      CUDAX_REQUIRE(test::count_driver_stack() == 0);
-    }
-    CUDAX_REQUIRE(test::count_driver_stack() == 0);
-  }
-
-  SECTION("launch interactions with driver stack")
-  {
-    cudax::stream stream(target_device);
-    CUDAX_REQUIRE(test::count_driver_stack() == 0);
-    cudax::launch(stream, cudax::make_config(cudax::block_dims<1>(), cudax::grid_dims<1>()), test::empty_kernel{});
     CUDAX_REQUIRE(test::count_driver_stack() == 0);
   }
 }


### PR DESCRIPTION
We currently use a mix of driver and runtime APIs in cudax and that is ok, as long as runtime won't automatically initialize device 0 and push it onto the driver stack. This PR adds a `C2H_CCCLRT_TEST` macro that should be used in place of `C2H_TEST` macro for cccl-rt tests. That macro will empty the driver stack pre-test to ensure there isn't some current device set leftover from another test. It will also check at the end that the stack remained empty, which means the tested APIs didn't accidentally initialize device 0 through the runtime usage.

Eventually we will fully transition to use driver APIs, but the checks added in this PR will remain useful event then. Our testing should ensure whatever Driver API we call it works correctly with empty driver stack. If there is something left at the stack it might mean we called some API outside cccl-rt in the test that pushed something on the stack and it might hide issues that would happen if the stack was empty.

This PR also switches device, event and stream testing to use the new macro and adjusts these APIs to use driver APIs to make it correctly end the tests with empty driver stack.
It also removes some small-scale driver stack testing we had before, since it became redundant now.

Future changes will convert more tests to use the new test macro.

Note: I hoped I could implement `C2H_CCCLRT_TEST` in a way where the declared function is not a static function so we wouldn't have to outline tests using extended lambda because they can't be declared in static functions on Windows. Unfortunately I couldn't figure out how to implement it in a robust way without the function being static.