### PR TITLE
bring the design of the cudax execution policies in line with C++17

### DIFF
--- a/cudax/include/cuda/experimental/__container/async_buffer.cuh
+++ b/cudax/include/cuda/experimental/__container/async_buffer.cuh
@@ -111,7 +111,7 @@ public:
   using difference_type        = _CUDA_VSTD::ptrdiff_t;
 
   using __env_t          = ::cuda::experimental::env_t<_Properties...>;
-  using __policy_t       = ::cuda::experimental::execution::execution_policy;
+  using __policy_t       = ::cuda::experimental::execution::any_execution_policy;
   using __buffer_t       = ::cuda::experimental::uninitialized_async_buffer<_Tp, _Properties...>;
   using __resource_t     = ::cuda::experimental::any_async_resource<_Properties...>;
   using __resource_ref_t = _CUDA_VMR::async_resource_ref<_Properties...>;

--- a/cudax/include/cuda/experimental/__execution/env.cuh
+++ b/cudax/include/cuda/experimental/__execution/env.cuh
@@ -96,18 +96,17 @@ private:
   using __stream_ref = stream_ref;
 
   __resource __mr_;
-  __stream_ref __stream_                = __detail::__invalid_stream;
-  execution::execution_policy __policy_ = execution::execution_policy::invalid_execution_policy;
+  __stream_ref __stream_                    = __detail::__invalid_stream;
+  execution::any_execution_policy __policy_ = {};
 
 public:
   //! @brief Construct an env_t from an any_resource, a stream and a policy
   //! @param __mr The any_resource passed in
   //! @param __stream The stream_ref passed in
   //! @param __policy The execution_policy passed in
-  _CCCL_HIDE_FROM_ABI
-  env_t(__resource __mr,
-        __stream_ref __stream                = __detail::__invalid_stream,
-        execution::execution_policy __policy = execution::execution_policy::invalid_execution_policy) noexcept
+  _CCCL_HIDE_FROM_ABI env_t(__resource __mr,
+                            __stream_ref __stream                    = __detail::__invalid_stream,
+                            execution::any_execution_policy __policy = {}) noexcept
       : __mr_(_CUDA_VSTD::move(__mr))
       , __stream_(__stream)
       , __policy_(__policy)
@@ -141,7 +140,8 @@ public:
     return __stream_;
   }
 
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI execution::execution_policy query(execution::get_execution_policy_t) const noexcept
+  [[nodiscard]] _CCCL_HIDE_FROM_ABI execution::any_execution_policy
+  query(execution::get_execution_policy_t) const noexcept
   {
     return __policy_;
   }

--- a/cudax/test/execution/env.cu
+++ b/cudax/test/execution/env.cu
@@ -56,8 +56,7 @@ C2H_TEST("env_t is default constructible", "[execution, env]")
 {
   env_t env{cudax::device_memory_resource{cudax::device_ref{0}}};
   CHECK(env.query(cuda::get_stream) == ::cuda::experimental::__detail::__invalid_stream);
-  CHECK(env.query(cudax::execution::get_execution_policy)
-        == cudax::execution::execution_policy::invalid_execution_policy);
+  CHECK(env.query(cudax::execution::get_execution_policy) == cudax::execution::any_execution_policy{});
   CHECK(env.query(cuda::mr::get_memory_resource) == cudax::device_memory_resource{cudax::device_ref{0}});
 }
 
@@ -69,8 +68,7 @@ C2H_TEST("env_t is constructible from an any_resource", "[execution, env]")
   {
     env_t env{mr};
     CHECK(env.query(cuda::get_stream) == ::cuda::experimental::__detail::__invalid_stream);
-    CHECK(env.query(cudax::execution::get_execution_policy)
-          == cudax::execution::execution_policy::invalid_execution_policy);
+    CHECK(env.query(cudax::execution::get_execution_policy) == cudax::execution::any_execution_policy{});
     CHECK(env.query(cuda::mr::get_memory_resource) == mr);
   }
 
@@ -79,18 +77,16 @@ C2H_TEST("env_t is constructible from an any_resource", "[execution, env]")
     cudax::stream stream{cudax::device_ref{0}};
     env_t env{mr, stream};
     CHECK(env.query(cuda::get_stream) == stream);
-    CHECK(env.query(cudax::execution::get_execution_policy)
-          == cudax::execution::execution_policy::invalid_execution_policy);
+    CHECK(env.query(cudax::execution::get_execution_policy) == cudax::execution::any_execution_policy{});
     CHECK(env.query(cuda::mr::get_memory_resource) == mr);
   }
 
   SECTION("Passing an any_resource, a stream and a policy")
   {
     cudax::stream stream{cudax::device_ref{0}};
-    env_t env{mr, stream, cudax::execution::execution_policy::parallel_unsequenced_device};
+    env_t env{mr, stream, cudax::execution::par_unseq};
     CHECK(env.query(cuda::get_stream) == stream);
-    CHECK(env.query(cudax::execution::get_execution_policy)
-          == cudax::execution::execution_policy::parallel_unsequenced_device);
+    CHECK((env.query(cudax::execution::get_execution_policy) == cudax::execution::par_unseq));
     CHECK(env.query(cuda::mr::get_memory_resource) == mr);
   }
 }
@@ -101,8 +97,7 @@ C2H_TEST("env_t is constructible from an any_resource passed as an rvalue", "[ex
   {
     env_t env{cudax::any_async_resource<cuda::mr::device_accessible>{test_resource{}}};
     CHECK(env.query(cuda::get_stream) == ::cuda::experimental::__detail::__invalid_stream);
-    CHECK(env.query(cudax::execution::get_execution_policy)
-          == cudax::execution::execution_policy::invalid_execution_policy);
+    CHECK(env.query(cudax::execution::get_execution_policy) == cudax::execution::any_execution_policy{});
     CHECK(env.query(cuda::mr::get_memory_resource)
           == cudax::any_async_resource<cuda::mr::device_accessible>{test_resource{}});
   }
@@ -112,8 +107,7 @@ C2H_TEST("env_t is constructible from an any_resource passed as an rvalue", "[ex
     cudax::stream stream{cudax::device_ref{0}};
     env_t env{cudax::any_async_resource<cuda::mr::device_accessible>{test_resource{}}, stream};
     CHECK(env.query(cuda::get_stream) == stream);
-    CHECK(env.query(cudax::execution::get_execution_policy)
-          == cudax::execution::execution_policy::invalid_execution_policy);
+    CHECK(env.query(cudax::execution::get_execution_policy) == cudax::execution::any_execution_policy{});
     CHECK(env.query(cuda::mr::get_memory_resource)
           == cudax::any_async_resource<cuda::mr::device_accessible>{test_resource{}});
   }
@@ -121,12 +115,10 @@ C2H_TEST("env_t is constructible from an any_resource passed as an rvalue", "[ex
   SECTION("Passing an any_resource, a stream and a policy")
   {
     cudax::stream stream{cudax::device_ref{0}};
-    env_t env{cudax::any_async_resource<cuda::mr::device_accessible>{test_resource{}},
-              stream,
-              cudax::execution::execution_policy::parallel_unsequenced_device};
+    env_t env{
+      cudax::any_async_resource<cuda::mr::device_accessible>{test_resource{}}, stream, cudax::execution::par_unseq};
     CHECK(env.query(cuda::get_stream) == stream);
-    CHECK(env.query(cudax::execution::get_execution_policy)
-          == cudax::execution::execution_policy::parallel_unsequenced_device);
+    CHECK(env.query(cudax::execution::get_execution_policy) == cudax::execution::par_unseq);
     CHECK(env.query(cuda::mr::get_memory_resource)
           == cudax::any_async_resource<cuda::mr::device_accessible>{test_resource{}});
   }
@@ -140,8 +132,7 @@ C2H_TEST("env_t is constructible from a resource", "[execution, env]")
   {
     env_t env{mr};
     CHECK(env.query(cuda::get_stream) == ::cuda::experimental::__detail::__invalid_stream);
-    CHECK(env.query(cudax::execution::get_execution_policy)
-          == cudax::execution::execution_policy::invalid_execution_policy);
+    CHECK(env.query(cudax::execution::get_execution_policy) == cudax::execution::any_execution_policy{});
     CHECK(env.query(cuda::mr::get_memory_resource) == mr);
   }
 
@@ -150,18 +141,16 @@ C2H_TEST("env_t is constructible from a resource", "[execution, env]")
     cudax::stream stream{cudax::device_ref{0}};
     env_t env{mr, stream};
     CHECK(env.query(cuda::get_stream) == stream);
-    CHECK(env.query(cudax::execution::get_execution_policy)
-          == cudax::execution::execution_policy::invalid_execution_policy);
+    CHECK(env.query(cudax::execution::get_execution_policy) == cudax::execution::any_execution_policy{});
     CHECK(env.query(cuda::mr::get_memory_resource) == mr);
   }
 
   SECTION("Passing an any_resource, a stream and a policy")
   {
     cudax::stream stream{cudax::device_ref{0}};
-    env_t env{mr, stream, cudax::execution::execution_policy::parallel_unsequenced_device};
+    env_t env{mr, stream, cudax::execution::par_unseq};
     CHECK(env.query(cuda::get_stream) == stream);
-    CHECK(env.query(cudax::execution::get_execution_policy)
-          == cudax::execution::execution_policy::parallel_unsequenced_device);
+    CHECK(env.query(cudax::execution::get_execution_policy) == cudax::execution::par_unseq);
     CHECK(env.query(cuda::mr::get_memory_resource) == mr);
   }
 }
@@ -172,8 +161,7 @@ C2H_TEST("env_t is constructible from a resource passed as an rvalue", "[executi
   {
     env_t env{test_resource{}};
     CHECK(env.query(cuda::get_stream) == ::cuda::experimental::__detail::__invalid_stream);
-    CHECK(env.query(cudax::execution::get_execution_policy)
-          == cudax::execution::execution_policy::invalid_execution_policy);
+    CHECK(env.query(cudax::execution::get_execution_policy) == cudax::execution::any_execution_policy{});
     CHECK(env.query(cuda::mr::get_memory_resource) == test_resource{});
   }
 
@@ -182,18 +170,16 @@ C2H_TEST("env_t is constructible from a resource passed as an rvalue", "[executi
     cudax::stream stream{cudax::device_ref{0}};
     env_t env{test_resource{}, stream};
     CHECK(env.query(cuda::get_stream) == stream);
-    CHECK(env.query(cudax::execution::get_execution_policy)
-          == cudax::execution::execution_policy::invalid_execution_policy);
+    CHECK(env.query(cudax::execution::get_execution_policy) == cudax::execution::any_execution_policy{});
     CHECK(env.query(cuda::mr::get_memory_resource) == test_resource{});
   }
 
   SECTION("Passing an any_resource, a stream and a policy")
   {
     cudax::stream stream{cudax::device_ref{0}};
-    env_t env{test_resource{}, stream, cudax::execution::execution_policy::parallel_unsequenced_device};
+    env_t env{test_resource{}, stream, cudax::execution::par_unseq};
     CHECK(env.query(cuda::get_stream) == stream);
-    CHECK(env.query(cudax::execution::get_execution_policy)
-          == cudax::execution::execution_policy::parallel_unsequenced_device);
+    CHECK(env.query(cudax::execution::get_execution_policy) == cudax::execution::par_unseq);
     CHECK(env.query(cuda::mr::get_memory_resource) == test_resource{});
   }
 }
@@ -202,7 +188,7 @@ struct some_env_t
 {
   test_resource res_{};
   cudax::stream stream_{cudax::device_ref{0}};
-  cudax::execution::execution_policy policy_ = cudax::execution::execution_policy::parallel_unsequenced_device;
+  cudax::execution::any_execution_policy policy_ = cudax::execution::par_unseq;
 
   const test_resource& query(cuda::mr::get_memory_resource_t) const noexcept
   {
@@ -214,7 +200,7 @@ struct some_env_t
     return stream_;
   }
 
-  cudax::execution::execution_policy query(cudax::execution::get_execution_policy_t) const noexcept
+  cudax::execution::any_execution_policy query(cudax::execution::get_execution_policy_t) const noexcept
   {
     return policy_;
   }
@@ -233,7 +219,7 @@ struct bad_env_t
 {
   test_resource res_{};
   cudax::stream stream_{cudax::device_ref{0}};
-  cudax::execution::execution_policy policy_ = cudax::execution::execution_policy::parallel_unsequenced_device;
+  cudax::execution::any_execution_policy policy_ = cudax::execution::par_unseq;
 
   template <bool Enable = WithResource, cuda::std::enable_if_t<Enable, int> = 0>
   const test_resource& query(cuda::mr::get_memory_resource_t) const noexcept
@@ -248,7 +234,7 @@ struct bad_env_t
   }
 
   template <bool Enable = WithPolicy, cuda::std::enable_if_t<Enable, int> = 0>
-  cudax::execution::execution_policy query(cudax::execution::get_execution_policy_t) const noexcept
+  cudax::execution::any_execution_policy query(cudax::execution::get_execution_policy_t) const noexcept
   {
     return policy_;
   }

--- a/cudax/test/execution/policies/get_execution_policy.cu
+++ b/cudax/test/execution/policies/get_execution_policy.cu
@@ -14,13 +14,13 @@
 
 #include <testing.cuh>
 
-using cuda::experimental::execution::execution_policy;
+namespace execution = cuda::experimental::execution;
 
 struct with_get_execution_policy_const_lvalue
 {
-  execution_policy pol_ = execution_policy::sequenced_host;
+  execution::any_execution_policy pol_ = execution::seq;
 
-  const execution_policy& get_execution_policy() const noexcept
+  const execution::any_execution_policy& get_execution_policy() const noexcept
   {
     return pol_;
   }
@@ -30,15 +30,15 @@ C2H_TEST("Can call get_execution_policy on a type with a get_execution_policy me
 {
   with_get_execution_policy_const_lvalue val{};
   auto&& res = cuda::experimental::execution::get_execution_policy(val);
-  STATIC_REQUIRE(cuda::std::is_same_v<decltype(res), execution_policy&&>);
+  STATIC_REQUIRE(cuda::std::is_same_v<decltype(res), execution::any_execution_policy&&>);
   CHECK(val.pol_ == res);
 }
 
 struct with_get_execution_policy_rvalue
 {
-  execution_policy pol_{};
+  execution::any_execution_policy pol_{};
 
-  execution_policy get_execution_policy() const noexcept
+  execution::any_execution_policy get_execution_policy() const noexcept
   {
     return pol_;
   }
@@ -48,15 +48,15 @@ C2H_TEST("Can call get_execution_policy on a type with a get_execution_policy me
 {
   with_get_execution_policy_rvalue val{};
   auto&& res = cuda::experimental::execution::get_execution_policy(val);
-  STATIC_REQUIRE(cuda::std::is_same_v<decltype(res), execution_policy&&>);
+  STATIC_REQUIRE(cuda::std::is_same_v<decltype(res), execution::any_execution_policy&&>);
   CHECK(val.pol_ == res);
 }
 
 struct with_get_execution_policy_non_const
 {
-  execution_policy pol_{};
+  execution::any_execution_policy pol_{};
 
-  execution_policy get_execution_policy() noexcept
+  execution::any_execution_policy get_execution_policy() noexcept
   {
     return pol_;
   }
@@ -70,9 +70,9 @@ C2H_TEST("Cannot call get_execution_policy on a type with a non-const get_execut
 
 struct env_with_query_const_ref
 {
-  execution_policy pol_{};
+  execution::any_execution_policy pol_{};
 
-  execution_policy query(cuda::experimental::execution::get_execution_policy_t) const noexcept
+  execution::any_execution_policy query(cuda::experimental::execution::get_execution_policy_t) const noexcept
   {
     return pol_;
   }
@@ -82,15 +82,15 @@ C2H_TEST("Can call get_execution_policy on an env with a get_execution_policy qu
 {
   env_with_query_const_ref val{};
   auto&& res = cuda::experimental::execution::get_execution_policy(val);
-  STATIC_REQUIRE(cuda::std::is_same_v<decltype(res), execution_policy&&>);
+  STATIC_REQUIRE(cuda::std::is_same_v<decltype(res), execution::any_execution_policy&&>);
   CHECK(val.pol_ == res);
 }
 
 struct env_with_query_rvalue
 {
-  execution_policy pol_{};
+  execution::any_execution_policy pol_{};
 
-  execution_policy query(cuda::experimental::execution::get_execution_policy_t) const noexcept
+  execution::any_execution_policy query(cuda::experimental::execution::get_execution_policy_t) const noexcept
   {
     return pol_;
   }
@@ -100,15 +100,15 @@ C2H_TEST("Can call get_execution_policy on an env with a get_execution_policy qu
 {
   env_with_query_rvalue val{};
   auto&& res = cuda::experimental::execution::get_execution_policy(val);
-  STATIC_REQUIRE(cuda::std::is_same_v<decltype(res), execution_policy&&>);
+  STATIC_REQUIRE(cuda::std::is_same_v<decltype(res), execution::any_execution_policy&&>);
   CHECK(val.pol_ == res);
 }
 
 struct env_with_query_non_const
 {
-  execution_policy pol_{};
+  execution::any_execution_policy pol_{};
 
-  execution_policy query(cuda::experimental::execution::get_execution_policy_t) noexcept
+  execution::any_execution_policy query(cuda::experimental::execution::get_execution_policy_t) noexcept
   {
     return pol_;
   }
@@ -121,14 +121,14 @@ C2H_TEST("Cannot call get_execution_policy on an env with a non-const query", "[
 
 struct env_with_query_and_method
 {
-  execution_policy pol_{};
+  execution::any_execution_policy pol_{};
 
-  execution_policy get_execution_policy() const noexcept
+  execution::any_execution_policy get_execution_policy() const noexcept
   {
     return pol_;
   }
 
-  execution_policy query(cuda::experimental::execution::get_execution_policy_t) const noexcept
+  execution::any_execution_policy query(cuda::experimental::execution::get_execution_policy_t) const noexcept
   {
     return pol_;
   }
@@ -137,6 +137,6 @@ C2H_TEST("Can call get_execution_policy on a type with both get_execution_policy
 {
   env_with_query_and_method val{};
   auto&& res = cuda::experimental::execution::get_execution_policy(val);
-  STATIC_REQUIRE(cuda::std::is_same_v<decltype(res), execution_policy&&>);
+  STATIC_REQUIRE(cuda::std::is_same_v<decltype(res), execution::any_execution_policy&&>);
   CHECK(val.pol_ == res);
 }

--- a/cudax/test/execution/policies/policies.cu
+++ b/cudax/test/execution/policies/policies.cu
@@ -21,55 +21,54 @@ using is_same = cuda::std::is_same<cuda::std::remove_cvref_t<T>, U>;
 
 C2H_TEST("Execution policies", "[execution, policies]")
 {
-  using cuda::experimental::execution::execution_policy;
+  namespace execution = cuda::experimental::execution;
   SECTION("Individual options")
   {
-    execution_policy pol = execution_policy::sequenced_host;
-    pol                  = execution_policy::sequenced_device;
-    pol                  = execution_policy::parallel_host;
-    pol                  = execution_policy::parallel_device;
-    pol                  = execution_policy::parallel_unsequenced_host;
-    pol                  = execution_policy::parallel_unsequenced_device;
-    pol                  = execution_policy::unsequenced_host;
-    pol                  = execution_policy::unsequenced_device;
-    CHECK(pol == execution_policy::unsequenced_device);
+    execution::any_execution_policy pol = execution::seq;
+    pol                                 = execution::par;
+    pol                                 = execution::par_unseq;
+    pol                                 = execution::unseq;
+    CHECK(pol == execution::unseq);
   }
 
   SECTION("Global instances")
   {
-    CHECK(cuda::experimental::execution::seq_host == execution_policy::sequenced_host);
-    CHECK(cuda::experimental::execution::seq_device == execution_policy::sequenced_device);
-    CHECK(cuda::experimental::execution::par_host == execution_policy::parallel_host);
-    CHECK(cuda::experimental::execution::par_device == execution_policy::parallel_device);
-    CHECK(cuda::experimental::execution::par_unseq_host == execution_policy::parallel_unsequenced_host);
-    CHECK(cuda::experimental::execution::par_unseq_device == execution_policy::parallel_unsequenced_device);
-    CHECK(cuda::experimental::execution::unseq_host == execution_policy::unsequenced_host);
-    CHECK(cuda::experimental::execution::unseq_device == execution_policy::unsequenced_device);
+    STATIC_CHECK(execution::seq == execution::seq);
+    STATIC_CHECK(execution::par == execution::par);
+    STATIC_CHECK(execution::par_unseq == execution::par_unseq);
+    STATIC_CHECK(execution::unseq == execution::unseq);
+
+    STATIC_CHECK_FALSE(execution::seq != execution::seq);
+    STATIC_CHECK_FALSE(execution::par != execution::par);
+    STATIC_CHECK_FALSE(execution::par_unseq != execution::par_unseq);
+    STATIC_CHECK_FALSE(execution::unseq != execution::unseq);
+
+    STATIC_CHECK_FALSE(execution::seq == execution::unseq);
+    STATIC_CHECK_FALSE(execution::par == execution::seq);
+    STATIC_CHECK_FALSE(execution::par_unseq == execution::par);
+    STATIC_CHECK_FALSE(execution::unseq == execution::par_unseq);
+
+    STATIC_CHECK(execution::seq != execution::unseq);
+    STATIC_CHECK(execution::par != execution::seq);
+    STATIC_CHECK(execution::par_unseq != execution::par);
+    STATIC_CHECK(execution::unseq != execution::par_unseq);
   }
 
   SECTION("is_parallel_execution_policy")
   {
-    using cuda::experimental::execution::__is_parallel_execution_policy;
-    static_assert(!__is_parallel_execution_policy<execution_policy::sequenced_host>, "");
-    static_assert(!__is_parallel_execution_policy<execution_policy::sequenced_device>, "");
-    static_assert(__is_parallel_execution_policy<execution_policy::parallel_host>, "");
-    static_assert(__is_parallel_execution_policy<execution_policy::parallel_device>, "");
-    static_assert(__is_parallel_execution_policy<execution_policy::parallel_unsequenced_host>, "");
-    static_assert(__is_parallel_execution_policy<execution_policy::parallel_unsequenced_device>, "");
-    static_assert(!__is_parallel_execution_policy<execution_policy::unsequenced_host>, "");
-    static_assert(!__is_parallel_execution_policy<execution_policy::unsequenced_device>, "");
+    using execution::__is_parallel_execution_policy;
+    STATIC_CHECK(!__is_parallel_execution_policy<execution::seq>);
+    STATIC_CHECK(__is_parallel_execution_policy<execution::par>);
+    STATIC_CHECK(__is_parallel_execution_policy<execution::par_unseq>);
+    STATIC_CHECK(!__is_parallel_execution_policy<execution::unseq>);
   }
 
   SECTION("is_unsequenced_execution_policy")
   {
-    using cuda::experimental::execution::__is_unsequenced_execution_policy;
-    static_assert(!__is_unsequenced_execution_policy<execution_policy::sequenced_host>, "");
-    static_assert(!__is_unsequenced_execution_policy<execution_policy::sequenced_device>, "");
-    static_assert(!__is_unsequenced_execution_policy<execution_policy::parallel_host>, "");
-    static_assert(!__is_unsequenced_execution_policy<execution_policy::parallel_device>, "");
-    static_assert(__is_unsequenced_execution_policy<execution_policy::parallel_unsequenced_host>, "");
-    static_assert(__is_unsequenced_execution_policy<execution_policy::parallel_unsequenced_device>, "");
-    static_assert(__is_unsequenced_execution_policy<execution_policy::unsequenced_host>, "");
-    static_assert(__is_unsequenced_execution_policy<execution_policy::unsequenced_device>, "");
+    using execution::__is_unsequenced_execution_policy;
+    STATIC_CHECK(!__is_unsequenced_execution_policy<execution::seq>);
+    STATIC_CHECK(!__is_unsequenced_execution_policy<execution::par>);
+    STATIC_CHECK(__is_unsequenced_execution_policy<execution::par_unseq>);
+    STATIC_CHECK(__is_unsequenced_execution_policy<execution::unseq>);
   }
 }


### PR DESCRIPTION
## Description

cudax defines execution policies. their design diverges from the C++17 standard execution policies. i would like to have conforming execution policies, in part because i need them to implement a standard-conforming `bulk` algorithm for the stream & graph schedulers.

i'm curious about the reasons the current design makes a distinction between host vs. device execution policies. if that is needed, i'd like to find a different way to express it.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
