### PR TITLE
Implement `format_parse_context` and `format_error`

### DIFF
--- a/libcudacxx/include/cuda/std/__format/format_error.h
+++ b/libcudacxx/include/cuda/std/__format/format_error.h
@@ -1,0 +1,76 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___FORMAT_FORMAT_ERROR_H
+#define _LIBCUDACXX___FORMAT_FORMAT_ERROR_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__exception/terminate.h>
+
+#if _CCCL_HAS_EXCEPTIONS()
+#  if _CCCL_STD_VER >= 2020 && __cpp_lib_format >= 201907L
+#    include <format>
+#  else // ^^^ _CCCL_STD_VER >= 2020 && __cpp_lib_format >= 201907L ^^^ /
+        // vvv _CCCL_STD_VER < 2020 || __cpp_lib_format < 201907L vvv
+#    include <stdexcept>
+#  endif // ^^^ _CCCL_STD_VER < 2020 || __cpp_lib_format < 201907L ^^^
+#endif // _CCCL_HAS_EXCEPTIONS()
+
+#include <cuda/std/__cccl/prologue.h>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_STD_NOVERSION
+
+#if _CCCL_HAS_EXCEPTIONS()
+#  if _CCCL_STD_VER >= 2020 && __cpp_lib_format >= 201907L
+using ::std::format_error;
+#  else // ^^^ _CCCL_STD_VER >= 2020 && __cpp_lib_format >= 201907L ^^^ /
+        // vvv _CCCL_STD_VER < 2020 || __cpp_lib_format < 201907L vvv
+class _CCCL_TYPE_VISIBILITY_DEFAULT format_error : public ::std::runtime_error
+{
+public:
+  _CCCL_HIDE_FROM_ABI explicit format_error(const ::std::string& __s)
+      : ::std::runtime_error(__s)
+  {}
+  _CCCL_HIDE_FROM_ABI explicit format_error(const char* __s)
+      : ::std::runtime_error(__s)
+  {}
+  _CCCL_HIDE_FROM_ABI format_error(const format_error&)            = default;
+  _CCCL_HIDE_FROM_ABI format_error& operator=(const format_error&) = default;
+  _CCCL_HIDE_FROM_ABI virtual ~format_error() noexcept override    = default;
+};
+#  endif // ^^^ _CCCL_STD_VER < 2020 || __cpp_lib_format < 201907L ^^^
+#endif // _CCCL_HAS_EXCEPTIONS()
+
+_LIBCUDACXX_END_NAMESPACE_STD_NOVERSION
+
+_LIBCUDACXX_BEGIN_NAMESPACE_STD
+
+[[noreturn]] _LIBCUDACXX_HIDE_FROM_ABI void __throw_format_error(const char* __s)
+{
+#if _CCCL_HAS_EXCEPTIONS()
+  NV_IF_ELSE_TARGET(NV_IS_HOST, (throw _CUDA_VSTD_NOVERSION::format_error(__s);), (_CUDA_VSTD_NOVERSION::terminate();))
+#else // ^^^ _CCCL_HAS_EXCEPTIONS() ^^^ / vvv !_CCCL_HAS_EXCEPTIONS() vvv
+  _CUDA_VSTD_NOVERSION::terminate();
+#endif // ^^^ !_CCCL_HAS_EXCEPTIONS() ^^^
+}
+
+_LIBCUDACXX_END_NAMESPACE_STD
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _LIBCUDACXX___FORMAT_FORMAT_PARSE_CONTEXT_H

--- a/libcudacxx/include/cuda/std/__format/format_parse_context.h
+++ b/libcudacxx/include/cuda/std/__format/format_parse_context.h
@@ -1,0 +1,127 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___FORMAT_FORMAT_PARSE_CONTEXT_H
+#define _LIBCUDACXX___FORMAT_FORMAT_PARSE_CONTEXT_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__cstddef/types.h>
+#include <cuda/std/__format/format_error.h>
+#include <cuda/std/__type_traits/is_constant_evaluated.h>
+#include <cuda/std/string_view>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_STD
+
+template <class _CharT>
+class basic_format_parse_context
+{
+public:
+  using char_type      = _CharT;
+  using const_iterator = typename basic_string_view<_CharT>::const_iterator;
+  using iterator       = const_iterator;
+
+  _LIBCUDACXX_HIDE_FROM_ABI constexpr explicit basic_format_parse_context(
+    basic_string_view<_CharT> __fmt, size_t __num_args = 0) noexcept
+      : __begin_(__fmt.begin())
+      , __end_(__fmt.end())
+      , __indexing_(_Indexing::__unknown)
+      , __next_arg_id_(0)
+      , __num_args_(__num_args)
+  {}
+
+  basic_format_parse_context(const basic_format_parse_context&) = delete;
+
+  basic_format_parse_context& operator=(const basic_format_parse_context&) = delete;
+
+  [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr const_iterator begin() const noexcept
+  {
+    return __begin_;
+  }
+
+  [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr const_iterator end() const noexcept
+  {
+    return __end_;
+  }
+
+  _LIBCUDACXX_HIDE_FROM_ABI constexpr void advance_to(const_iterator __it)
+  {
+    __begin_ = __it;
+  }
+
+  [[nodiscard]] _LIBCUDACXX_HIDE_FROM_ABI constexpr size_t next_arg_id()
+  {
+    if (__indexing_ == _Indexing::__manual)
+    {
+      _CUDA_VSTD::__throw_format_error("using automatic argument numbering in manual argument numbering mode");
+    }
+    if (__indexing_ == _Indexing::__unknown)
+    {
+      __indexing_ = _Indexing::__automatic;
+    }
+    if (_CUDA_VSTD::is_constant_evaluated())
+    {
+      _CCCL_VERIFY(__next_arg_id_ < __num_args_, "argument index outside the valid range");
+    }
+    return __next_arg_id_++;
+  }
+
+  _LIBCUDACXX_HIDE_FROM_ABI constexpr void check_arg_id(size_t __id)
+  {
+    if (__indexing_ == _Indexing::__automatic)
+    {
+      _CUDA_VSTD::__throw_format_error("using manual argument numbering in automatic argument numbering mode");
+    }
+    if (__indexing_ == _Indexing::__unknown)
+    {
+      __indexing_ = _Indexing::__manual;
+    }
+    if (_CUDA_VSTD::is_constant_evaluated())
+    {
+      _CCCL_VERIFY(__id < __num_args_, "argument index outside the valid range");
+    }
+  }
+
+private:
+  enum class _Indexing
+  {
+    __unknown,
+    __manual,
+    __automatic
+  };
+
+  iterator __begin_;
+  iterator __end_;
+  _Indexing __indexing_;
+  size_t __next_arg_id_;
+  size_t __num_args_;
+};
+
+_LIBCUDACXX_CTAD_SUPPORTED_FOR_TYPE(basic_format_parse_context);
+
+using format_parse_context = basic_format_parse_context<char>;
+#if _CCCL_HAS_WCHAR_T()
+using wformat_parse_context = basic_format_parse_context<wchar_t>;
+#endif // _CCCL_HAS_WCHAR_T()
+
+_LIBCUDACXX_END_NAMESPACE_STD
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _LIBCUDACXX___FORMAT_FORMAT_PARSE_CONTEXT_H

--- a/libcudacxx/include/cuda/std/__format_
+++ b/libcudacxx/include/cuda/std/__format_
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_FORMAT
+#define _CUDA_STD_FORMAT
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__format/format_error.h>
+#include <cuda/std/__format/format_parse_context.h>
+#include <cuda/std/version>
+
+#endif // _CUDA_STD_FORMAT

--- a/libcudacxx/test/libcudacxx/std/text/format/format.error/format.error.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.error/format.error.pass.cpp
@@ -1,0 +1,61 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: no-exceptions
+
+// <cuda/std/format>
+
+// class format_error;
+
+#include <cuda/std/__format_>
+#include <cuda/std/cassert>
+#include <cuda/std/cstring>
+#include <cuda/std/type_traits>
+
+#include <string>
+
+#include "test_macros.h"
+
+#if TEST_HAS_EXCEPTIONS()
+
+void test_format_error()
+{
+  static_assert(cuda::std::is_base_of_v<std::runtime_error, cuda::std::format_error>);
+  static_assert(cuda::std::is_polymorphic_v<cuda::std::format_error>);
+
+  {
+    const char* msg = "format_error message c-string";
+    cuda::std::format_error e(msg);
+    assert(cuda::std::strcmp(e.what(), msg) == 0);
+    cuda::std::format_error e2(e);
+    assert(cuda::std::strcmp(e2.what(), msg) == 0);
+    e2 = e;
+    assert(cuda::std::strcmp(e2.what(), msg) == 0);
+  }
+  {
+    std::string msg("format_error message std::string");
+    cuda::std::format_error e(msg);
+    assert(e.what() == msg);
+    cuda::std::format_error e2(e);
+    assert(e2.what() == msg);
+    e2 = e;
+    assert(e2.what() == msg);
+  }
+}
+
+#endif // TEST_HAS_EXCEPTIONS()
+
+int main(int, char**)
+{
+#if TEST_HAS_EXCEPTIONS()
+  NV_IF_TARGET(NV_IS_HOST, (test_format_error();))
+#endif // TEST_HAS_EXCEPTIONS()
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/advance_to.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/advance_to.pass.cpp
@@ -1,0 +1,72 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/format>
+
+// constexpr void advance_to(const_iterator it);
+
+#include <cuda/std/__format_>
+#include <cuda/std/cassert>
+#include <cuda/std/string_view>
+
+#include "literal.h"
+
+template <class CharT>
+__host__ __device__ constexpr void test()
+{
+  constexpr const CharT* fmt = TEST_STRLIT(CharT, "abc");
+
+  {
+    cuda::std::basic_format_parse_context<CharT> context(fmt);
+
+    context.advance_to(context.begin() + 1);
+    assert(cuda::std::to_address(context.begin()) == fmt + 1);
+
+    context.advance_to(context.begin() + 1);
+    assert(cuda::std::to_address(context.begin()) == fmt + 2);
+
+    context.advance_to(context.begin() + 1);
+    assert(context.begin() == context.end());
+  }
+  {
+    cuda::std::basic_string_view view{fmt};
+    cuda::std::basic_format_parse_context context(view);
+
+    context.advance_to(context.begin() + 1);
+    assert(cuda::std::to_address(context.begin()) == fmt + 1);
+
+    context.advance_to(context.begin() + 1);
+    assert(cuda::std::to_address(context.begin()) == fmt + 2);
+
+    context.advance_to(context.begin() + 1);
+    assert(context.begin() == context.end());
+  }
+}
+
+__host__ __device__ constexpr bool test()
+{
+  test<char>();
+#if _CCCL_HAS_CHAR8_T()
+  test<char8_t>();
+#endif // _CCCL_HAS_CHAR8_T()
+  test<char16_t>();
+  test<char32_t>();
+#if _CCCL_HAS_WCHAR_T()
+  test<wchar_t>();
+#endif // _CCCL_HAS_WCHAR_T()
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/begin.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/begin.pass.cpp
@@ -1,0 +1,59 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/format>
+
+// constexpr begin() const noexcept;
+
+#include <cuda/std/__format_>
+#include <cuda/std/cassert>
+#include <cuda/std/string_view>
+
+#include "literal.h"
+
+template <class CharT>
+__host__ __device__ constexpr void test()
+{
+  constexpr const CharT* fmt = TEST_STRLIT(CharT, "abc");
+
+  {
+    cuda::std::basic_format_parse_context<CharT> context(fmt);
+    assert(cuda::std::to_address(context.begin()) == &fmt[0]);
+    static_assert(noexcept(context.begin()));
+  }
+  {
+    cuda::std::basic_string_view view{fmt};
+    cuda::std::basic_format_parse_context context(view);
+    assert(context.begin() == view.begin());
+    static_assert(noexcept(context.begin()));
+  }
+}
+
+__host__ __device__ constexpr bool test()
+{
+  test<char>();
+#if _CCCL_HAS_CHAR8_T()
+  test<char8_t>();
+#endif // _CCCL_HAS_CHAR8_T()
+  test<char16_t>();
+  test<char32_t>();
+#if _CCCL_HAS_WCHAR_T()
+  test<wchar_t>();
+#endif // _CCCL_HAS_WCHAR_T()
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/check_arg_id.fail.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/check_arg_id.fail.cpp
@@ -1,0 +1,32 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// constexpr void check_arg_id(size_t id);
+
+#include <cuda/std/__format_>
+
+__host__ __device__ constexpr bool test()
+{
+  // [format.parse.ctx]/11
+  // Remarks: Call expressions where id >= num_args_ are not
+  // core constant expressions ([expr.const]).
+  cuda::std::format_parse_context context("", 0);
+  context.check_arg_id(1);
+
+  return true;
+}
+
+void f()
+{
+#if defined(_CCCL_BUILTIN_IS_CONSTANT_EVALUATED)
+  static_assert(test());
+#else // ^^^ _CCCL_BUILTIN_IS_CONSTANT_EVALUATED ^^^ / vvv !_CCCL_BUILTIN_IS_CONSTANT_EVALUATED vvv
+  static_assert(false);
+#endif // ^^^ !_CCCL_BUILTIN_IS_CONSTANT_EVALUATED ^^^
+}

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/check_arg_id.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/check_arg_id.pass.cpp
@@ -1,0 +1,74 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: no-exceptions
+
+// <cuda/std/format>
+
+// constexpr void check_arg_id(size_t id);
+
+#include <cuda/std/__format_>
+#include <cuda/std/cassert>
+#include <cuda/std/cstddef>
+#include <cuda/std/string_view>
+
+#include "literal.h"
+#include "test_macros.h"
+
+__host__ __device__ constexpr bool test()
+{
+  cuda::std::format_parse_context context("", 10);
+  for (cuda::std::size_t i = 0; i < 10; ++i)
+  {
+    context.check_arg_id(i);
+  }
+
+  return true;
+}
+
+#if TEST_HAS_EXCEPTIONS()
+void test_exception()
+{
+  {
+    cuda::std::format_parse_context context("", 1);
+    (void) context.next_arg_id();
+    try
+    {
+      context.check_arg_id(0);
+      assert(false);
+    }
+    catch (const cuda::std::format_error&)
+    {}
+    catch (...)
+    {
+      assert(false);
+    }
+  }
+
+  for (cuda::std::size_t i = 0; i < 10; ++i)
+  {
+    cuda::std::format_parse_context context("", i);
+    // Out of bounds access is valid if !cuda::std::is_constant_evaluated()
+    for (cuda::std::size_t j = 0; j <= i; ++j)
+    {
+      context.check_arg_id(j);
+    }
+  }
+}
+#endif // TEST_HAS_EXCEPTIONS()
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+#if TEST_HAS_EXCEPTIONS()
+  NV_IF_TARGET(NV_IS_HOST, (test_exception();))
+#endif // TEST_HAS_EXCEPTIONS()
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/ctor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/ctor.pass.cpp
@@ -1,0 +1,75 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/format>
+
+// constexpr explicit
+// basic_format_parse_context(basic_string_view<charT> fmt,
+//                            size_t num_args = 0) noexcept
+
+#include <cuda/std/__format_>
+#include <cuda/std/cassert>
+#include <cuda/std/string_view>
+#include <cuda/std/type_traits>
+
+#include "literal.h"
+
+template <class CharT>
+__host__ __device__ constexpr void test()
+{
+  // Validate the constructor is explicit.
+  static_assert(
+    !cuda::std::is_convertible_v<cuda::std::basic_string_view<CharT>, cuda::std::basic_format_parse_context<CharT>>);
+  static_assert(!cuda::std::is_copy_constructible_v<cuda::std::basic_format_parse_context<CharT>>);
+  static_assert(!cuda::std::is_copy_assignable_v<cuda::std::basic_format_parse_context<CharT>>);
+  // The move operations are implicitly deleted due to the
+  // deleted copy operations.
+  static_assert(!cuda::std::is_move_constructible_v<cuda::std::basic_format_parse_context<CharT>>);
+  static_assert(!cuda::std::is_move_assignable_v<cuda::std::basic_format_parse_context<CharT>>);
+
+  static_assert(noexcept(cuda::std::basic_format_parse_context{cuda::std::basic_string_view<CharT>{}}));
+  static_assert(noexcept(cuda::std::basic_format_parse_context{cuda::std::basic_string_view<CharT>{}, 42}));
+
+  constexpr const CharT* fmt = TEST_STRLIT(CharT, "abc");
+
+  {
+    cuda::std::basic_format_parse_context<CharT> context(fmt);
+    assert(cuda::std::to_address(context.begin()) == &fmt[0]);
+    assert(cuda::std::to_address(context.end()) == &fmt[3]);
+  }
+  {
+    cuda::std::basic_string_view view{fmt};
+    cuda::std::basic_format_parse_context context(view);
+    assert(context.begin() == view.begin());
+    assert(context.end() == view.end());
+  }
+}
+
+__host__ __device__ constexpr bool test()
+{
+  test<char>();
+#if _CCCL_HAS_CHAR8_T()
+  test<char8_t>();
+#endif // _CCCL_HAS_CHAR8_T()
+  test<char16_t>();
+  test<char32_t>();
+#if _CCCL_HAS_WCHAR_T()
+  test<wchar_t>();
+#endif // _CCCL_HAS_WCHAR_T()
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/end.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/end.pass.cpp
@@ -1,0 +1,59 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/format>
+
+// constexpr end() const noexcept;
+
+#include <cuda/std/__format_>
+#include <cuda/std/cassert>
+#include <cuda/std/string_view>
+
+#include "literal.h"
+
+template <class CharT>
+__host__ __device__ constexpr void test()
+{
+  constexpr const CharT* fmt = TEST_STRLIT(CharT, "abc");
+
+  {
+    cuda::std::basic_format_parse_context<CharT> context(fmt);
+    assert(cuda::std::to_address(context.end()) == &fmt[3]);
+    static_assert(noexcept(context.end()));
+  }
+  {
+    cuda::std::basic_string_view view{fmt};
+    cuda::std::basic_format_parse_context context(view);
+    assert(context.end() == view.end());
+    static_assert(noexcept(context.end()));
+  }
+}
+
+__host__ __device__ constexpr bool test()
+{
+  test<char>();
+#if _CCCL_HAS_CHAR8_T()
+  test<char8_t>();
+#endif // _CCCL_HAS_CHAR8_T()
+  test<char16_t>();
+  test<char32_t>();
+#if _CCCL_HAS_WCHAR_T()
+  test<wchar_t>();
+#endif // _CCCL_HAS_WCHAR_T()
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/next_arg_id.fail.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/next_arg_id.fail.cpp
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// constexpr size_t next_arg_id()
+
+#include <cuda/std/__format_>
+
+__host__ __device__ constexpr bool test()
+{
+  // [format.parse.ctx]/8
+  // Let cur-arg-id be the value of next_arg_id_ prior to this call. Call
+  // expressions where cur-arg-id >= num_args_ is true are not core constant
+  // expressions (7.7 [expr.const]).
+  cuda::std::format_parse_context context("", 0);
+  context.next_arg_id();
+
+  return true;
+}
+
+__host__ __device__ void f()
+{
+#if defined(_CCCL_BUILTIN_IS_CONSTANT_EVALUATED)
+  static_assert(test());
+#else // ^^^ _CCCL_BUILTIN_IS_CONSTANT_EVALUATED ^^^ / vvv !_CCCL_BUILTIN_IS_CONSTANT_EVALUATED vvv
+  static_assert(false);
+#endif // ^^^ !_CCCL_BUILTIN_IS_CONSTANT_EVALUATED ^^^
+}

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/next_arg_id.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/next_arg_id.pass.cpp
@@ -1,0 +1,63 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: no-exceptions
+
+// <cuda/std/format>
+
+// constexpr size_t next_arg_id();
+
+#include <cuda/std/__format_>
+#include <cuda/std/cassert>
+#include <cuda/std/string_view>
+
+#include "literal.h"
+#include "test_macros.h"
+
+__host__ __device__ constexpr bool test()
+{
+  cuda::std::format_parse_context context("", 10);
+  for (cuda::std::size_t i = 0; i < 10; ++i)
+  {
+    assert(i == context.next_arg_id());
+  }
+
+  return true;
+}
+
+#if TEST_HAS_EXCEPTIONS()
+void test_exception()
+{
+  cuda::std::format_parse_context context("", 1);
+  context.check_arg_id(0);
+
+  try
+  {
+    (void) context.next_arg_id();
+    assert(false);
+  }
+  catch (const cuda::std::format_error&)
+  {}
+  catch (...)
+  {
+    assert(false);
+  }
+}
+#endif // TEST_HAS_EXCEPTIONS()
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+#if TEST_HAS_EXCEPTIONS()
+  NV_IF_TARGET(NV_IS_HOST, (test_exception();))
+#endif // TEST_HAS_EXCEPTIONS()
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/types.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.parse.ctx/types.compile.pass.cpp
@@ -1,0 +1,65 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/format>
+
+// Class typedefs:
+// template<class charT>
+// class basic_format_parse_context {
+// public:
+//   using char_type = charT;
+//   using const_iterator = typename basic_string_view<charT>::const_iterator;
+//   using iterator = const_iterator;
+// }
+//
+// Namespace std typedefs:
+// using format_parse_context = basic_format_parse_context<char>;
+// using wformat_parse_context = basic_format_parse_context<wchar_t>;
+
+#include <cuda/std/__format_>
+#include <cuda/std/string_view>
+#include <cuda/std/type_traits>
+
+#include "test_macros.h"
+
+template <class CharT>
+__host__ __device__ constexpr void test()
+{
+  static_assert(cuda::std::is_same_v<typename cuda::std::basic_format_parse_context<CharT>::char_type, CharT>);
+  static_assert(cuda::std::is_same_v<typename cuda::std::basic_format_parse_context<CharT>::const_iterator,
+                                     typename cuda::std::basic_string_view<CharT>::const_iterator>);
+  static_assert(cuda::std::is_same_v<typename cuda::std::basic_format_parse_context<CharT>::iterator,
+                                     typename cuda::std::basic_format_parse_context<CharT>::const_iterator>);
+}
+
+__host__ __device__ constexpr bool test()
+{
+  test<char>();
+#if _CCCL_HAS_CHAR8_T()
+  test<char8_t>();
+#endif // _CCCL_HAS_CHAR8_T()
+  test<char16_t>();
+  test<char32_t>();
+#if _CCCL_HAS_WCHAR_T()
+  test<wchar_t>();
+#endif // _CCCL_HAS_WCHAR_T()
+
+  return true;
+}
+
+static_assert(cuda::std::is_same_v<cuda::std::format_parse_context, cuda::std::basic_format_parse_context<char>>);
+#if _CCCL_HAS_WCHAR_T()
+static_assert(cuda::std::is_same_v<cuda::std::wformat_parse_context, cuda::std::basic_format_parse_context<wchar_t>>);
+#endif // _CCCL_HAS_WCHAR_T()
+
+int main(int, char**)
+{
+  static_assert(test());
+  return 0;
+}


### PR DESCRIPTION
This PR implements `cuda::std::format_parse_context` and `cuda::std::format_error` from `<cuda/std/format>` header.