### PR TITLE
Cuda cccl dependencies

### DIFF
--- a/python/cuda_cccl/pyproject.toml
+++ b/python/cuda_cccl/pyproject.toml
@@ -21,8 +21,11 @@ dependencies = [
   "numpy",
   "cuda-python==12.9.0",
   "cupy-cuda12x",
+  "numba-cuda",
   "nvidia-cuda-nvrtc-cu12",
   "nvidia-nvjitlink-cu12",
+  # pynvjitlink is needed here for MVC support
+  # in numba-cuda, which treats it as optional dependency
   "pynvjitlink-cu12>=0.2.4",
   "jinja2",
   "typing_extensions",


### PR DESCRIPTION
## Description

This PR modifies `cuda_cccl/pyproject.toml` to move `typing_extensions` from extra test dependency to run-time depedency.

It also adds `numba-cuda` to the list of run-time dependencies, and add comment explaining why dependency on `pynvjitlink-cu12` is there.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
