### PR TITLE
[CUDAX] Fix cub cudax example after default device removal

### DIFF
--- a/cudax/examples/cub_reduce.cu
+++ b/cudax/examples/cub_reduce.cu
@@ -25,10 +25,10 @@ int main()
   constexpr int num_items = 50000;
 
   // A CUDA stream on which to execute the reduction
-  cudax::stream stream{};
+  cudax::stream stream{cudax::devices[0]};
 
   // An environment we use to pass all necessary information to the containers
-  cudax::env_t<cuda::mr::device_accessible> env{cudax::device_memory_resource{}, stream};
+  cudax::env_t<cuda::mr::device_accessible> env{cudax::device_memory_resource{cudax::devices[0]}, stream};
 
   // Allocate input and output, but do not zero initialize output (`cudax::no_init`)
   cudax::async_device_buffer<int> d_in{env, num_items, 1};


### PR DESCRIPTION
I think we run into simultaneous modification issue that escaped CI, where one PR removed default device arguments from `stream` and `device_memory_resource` and another one still used them.