### PR TITLE
Fix RFA dispatch template parameters

### DIFF
--- a/cub/cub/device/device_reduce.cuh
+++ b/cub/cub/device/device_reduce.cuh
@@ -237,7 +237,7 @@ private:
         __query_result_or_t<TuningEnvT, detail::reduce::get_tuning_query_t, detail::reduce::default_rfa_tuning>;
       using policy_t = typename reduce_tuning_t::template fn<accum_t, offset_t, ReductionOpT>;
       using dispatch_t =
-        detail::DispatchReduceDeterministic<InputIteratorT, OutputIteratorT, offset_t, T, accum_t, transform_t, policy_t>;
+        detail::DispatchReduceDeterministic<InputIteratorT, OutputIteratorT, offset_t, T, transform_t, accum_t, policy_t>;
 
       return dispatch_t::Dispatch(
         d_temp_storage, temp_storage_bytes, d_in, d_out, static_cast<offset_t>(num_items), init, stream);

--- a/cub/test/catch2_test_device_reduce_env.cu
+++ b/cub/test/catch2_test_device_reduce_env.cu
@@ -213,7 +213,7 @@ C2H_TEST("Device reduce uses environment", "[reduce][device]", requirements)
                                                             decltype(d_out.begin())>;
 
       using dispatch_t = cub::detail::
-        DispatchReduceDeterministic<decltype(d_in), decltype(d_out.begin()), offset_t, init_t, accumulator_t, transform_t>;
+        DispatchReduceDeterministic<decltype(d_in), decltype(d_out.begin()), offset_t, init_t, transform_t, accumulator_t>;
 
       REQUIRE(
         cudaSuccess == dispatch_t::Dispatch(nullptr, expected_bytes_allocated, d_in, d_out.begin(), num_items, init));


### PR DESCRIPTION
## Description

 Fixes **ordering** of `accum_t` and `transform_t` **template parameters** for `DispatchReduceDeterministic`
