### PR TITLE
make `cudax::stream_ref` a scheduler

### DIFF
--- a/cudax/include/cuda/experimental/__execution/completion_signatures.cuh
+++ b/cudax/include/cuda/experimental/__execution/completion_signatures.cuh
@@ -23,23 +23,17 @@
 
 #include <cuda/std/__tuple_dir/ignore.h>
 #include <cuda/std/__type_traits/conditional.h>
-#include <cuda/std/__type_traits/disjunction.h>
-#include <cuda/std/__type_traits/enable_if.h>
-#include <cuda/std/__type_traits/is_base_of.h>
+#include <cuda/std/__type_traits/integral_constant.h>
 #include <cuda/std/__type_traits/is_callable.h>
+#include <cuda/std/__type_traits/is_empty.h>
+#include <cuda/std/__type_traits/is_trivially_constructible.h>
 #include <cuda/std/__type_traits/remove_const.h>
 #include <cuda/std/__type_traits/type_list.h>
 #include <cuda/std/__type_traits/type_set.h>
-#include <cuda/std/__utility/pod_tuple.h>
-#include <cuda/std/__utility/typeid.h>
-#include <cuda/std/tuple>
 
-#include <cuda/experimental/__detail/utility.cuh>
 #include <cuda/experimental/__execution/cpos.cuh>
-#include <cuda/experimental/__execution/exception.cuh>
-#include <cuda/experimental/__execution/transform_sender.cuh>
+#include <cuda/experimental/__execution/fwd.cuh>
 #include <cuda/experimental/__execution/type_traits.cuh>
-#include <cuda/experimental/__execution/utility.cuh>
 
 // include this last:
 #include <cuda/experimental/__execution/prologue.cuh>
@@ -51,10 +45,40 @@ namespace cuda::experimental::execution
 {
 using _CUDA_VSTD::__type_list;
 
-template <class _ValueTuplesList = _CUDA_VSTD::__type_list<>,
-          class _ErrorsList      = _CUDA_VSTD::__type_list<>,
-          class _StoppedList     = _CUDA_VSTD::__type_list<>>
+// __partitioned_completions is a cache of completion signatures for fast
+// access. The completion_signatures<Sigs...>::__partitioned nested struct
+// inherits from __partitioned_completions. If the cache is never accessed,
+// it is never instantiated.
+template <class _ValueTuplesList = __type_list<>, class _ErrorsList = __type_list<>, class _StoppedList = __type_list<>>
 struct __partitioned_completions;
+
+template <class... _ValueTuples, class... _Errors, class... _Stopped>
+struct __partitioned_completions<__type_list<_ValueTuples...>, __type_list<_Errors...>, __type_list<_Stopped...>>
+{
+  template <template <class...> class _Tuple, template <class...> class _Variant>
+  using __value_types _CCCL_NODEBUG_ALIAS =
+    _Variant<_CUDA_VSTD::__type_call1<_ValueTuples, _CUDA_VSTD::__type_quote<_Tuple>>...>;
+
+  template <template <class...> class _Variant, template <class...> class _Transform = _CUDA_VSTD::__type_self_t>
+  using __error_types _CCCL_NODEBUG_ALIAS = _Variant<_Transform<_Errors>...>;
+
+  template <template <class...> class _Variant, class _Type = set_stopped_t()>
+  using __stopped_types _CCCL_NODEBUG_ALIAS = _Variant<__type_second<_Stopped, _Type>...>;
+
+  using __count_values  = _CUDA_VSTD::integral_constant<size_t, sizeof...(_ValueTuples)>;
+  using __count_errors  = _CUDA_VSTD::integral_constant<size_t, sizeof...(_Errors)>;
+  using __count_stopped = _CUDA_VSTD::integral_constant<size_t, sizeof...(_Stopped)>;
+
+  struct __nothrow_decay_copyable
+  {
+    // These aliases are placed in a separate struct to avoid computing them
+    // if they are not needed.
+    using __fn     = _CUDA_VSTD::__type_quote<__nothrow_decay_copyable_t>;
+    using __values = _CUDA_VSTD::_And<_CUDA_VSTD::__type_call1<_ValueTuples, __fn>...>;
+    using __errors = __nothrow_decay_copyable_t<_Errors...>;
+    using __all    = _CUDA_VSTD::_And<__values, __errors>;
+  };
+};
 
 template <class _Tag>
 struct __partitioned_fold_fn;
@@ -93,7 +117,7 @@ template <class _Partitioned, class _Tag, class... _Args>
 _CCCL_API auto operator*(_CUDA_VSTD::__undefined<_Partitioned>&, _Tag (*)(_Args...)) -> _CUDA_VSTD::
   __call_result_t<__partitioned_fold_fn<_Tag>, _Partitioned&, _CUDA_VSTD::__undefined<__type_list<_Args...>>&>;
 
-// This unary overload is used to extract the cache from the `_CUDA_VSTD::__undefined` type.
+// This function declaration is used to extract the cache from the `__undefined` type.
 template <class _Partitioned>
 _CCCL_API auto __unpack_partitioned_completions(_CUDA_VSTD::__undefined<_Partitioned>&) -> _Partitioned;
 
@@ -102,11 +126,78 @@ using __partition_completion_signatures_t _CCCL_NODEBUG_ALIAS = //
   decltype(execution::__unpack_partitioned_completions(
     (declval<_CUDA_VSTD::__undefined<__partitioned_completions<>>&>() * ... * static_cast<_Sigs*>(nullptr))));
 
-struct __concat_completion_signatures_helper;
+template <class _Completions>
+using __partitioned_completions_of _CCCL_NODEBUG_ALIAS = typename _Completions::__partitioned::type;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// completion signatures type traits
+template <class _Sigs, template <class...> class _Tuple, template <class...> class _Variant>
+using __value_types _CCCL_NODEBUG_ALIAS =
+  typename __partitioned_completions_of<_Sigs>::template __value_types<_Tuple, _Variant>;
+
+template <class _Sndr, class _Env, template <class...> class _Tuple, template <class...> class _Variant>
+using value_types_of_t _CCCL_NODEBUG_ALIAS =
+  __value_types<completion_signatures_of_t<_Sndr, _Env>, _Tuple, __type_try_quote<_Variant>::template __call>;
+
+template <class _Sigs,
+          template <class...> class _Variant,
+          template <class...> class _Transform = _CUDA_VSTD::__type_self_t>
+using __error_types _CCCL_NODEBUG_ALIAS =
+  typename __partitioned_completions_of<_Sigs>::template __error_types<_Variant, _Transform>;
+
+template <class _Sndr, class _Env, template <class...> class _Variant>
+using error_types_of_t _CCCL_NODEBUG_ALIAS = __error_types<completion_signatures_of_t<_Sndr, _Env>, _Variant>;
+
+template <class _Sigs, template <class...> class _Variant, class _Type = set_stopped_t()>
+using __stopped_types _CCCL_NODEBUG_ALIAS =
+  typename __partitioned_completions_of<_Sigs>::template __stopped_types<_Variant, _Type>;
+
+template <class _Sigs>
+inline constexpr bool __sends_stopped = __partitioned_completions_of<_Sigs>::__count_stopped::value != 0;
+
+template <class _Sndr, class... _Env>
+inline constexpr bool sends_stopped = __sends_stopped<completion_signatures_of_t<_Sndr, _Env...>>;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// __valid_completion_signatures
+template <class _Ty>
+_CCCL_CONCEPT __valid_completion_signatures =
+  __is_specialization_of_v<_CUDA_VSTD::remove_const_t<_Ty>, completion_signatures>;
+
+template <class... _Sigs>
+_CCCL_API _CCCL_CONSTEVAL void __assert_valid_completion_signatures(const completion_signatures<_Sigs...>&)
+{}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// make_completion_signatures
+template <class _Tag, class... _As>
+_CCCL_API auto __normalize_impl(_As&&...) -> _Tag (*)(_As...);
+
+template <class _Tag, class... _As>
+_CCCL_API auto __normalize(_Tag (*)(_As...)) -> decltype(execution::__normalize_impl<_Tag>(declval<_As>()...));
+
+template <class... _Sigs>
+_CCCL_API auto __make_unique(_Sigs*...)
+  -> _CUDA_VSTD::__type_apply<_CUDA_VSTD::__type_quote<completion_signatures>, _CUDA_VSTD::__make_type_set<_Sigs...>>;
+
+template <class... _Sigs>
+using __make_completion_signatures_t _CCCL_NODEBUG_ALIAS =
+  decltype(execution::__make_unique(execution::__normalize(static_cast<_Sigs*>(nullptr))...));
+
+template <class... _ExplicitSigs, class... _DeducedSigs>
+[[nodiscard]] _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto make_completion_signatures(_DeducedSigs*...) noexcept
+  -> __make_completion_signatures_t<_ExplicitSigs..., _DeducedSigs...>
+{
+  return {};
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// concat_completion_signatures
+struct __concat_completion_signatures_impl;
 
 template <class... _Sigs>
 using __concat_completion_signatures_t _CCCL_NODEBUG_ALIAS =
-  _CUDA_VSTD::__call_result_t<_CUDA_VSTD::__call_result_t<__concat_completion_signatures_helper, const _Sigs&...>>;
+  _CUDA_VSTD::__call_result_t<_CUDA_VSTD::__call_result_t<__concat_completion_signatures_impl, const _Sigs&...>>;
 
 struct __concat_completion_signatures_fn
 {
@@ -118,16 +209,72 @@ struct __concat_completion_signatures_fn
   }
 };
 
+extern const completion_signatures<>& __empty_completion_signatures;
+
+struct __concat_completion_signatures_impl
+{
+  _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto operator()() const noexcept -> completion_signatures<> (*)()
+  {
+    return nullptr;
+  }
+
+  template <class... _Sigs>
+  _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto operator()(const completion_signatures<_Sigs...>&) const noexcept
+    -> __make_completion_signatures_t<_Sigs...> (*)()
+  {
+    return nullptr;
+  }
+
+  template <class _Self = __concat_completion_signatures_impl,
+            class... _As,
+            class... _Bs,
+            class... _Cs,
+            class... _Ds,
+            class... _Rest>
+  _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto operator()(
+    const completion_signatures<_As...>&,
+    const completion_signatures<_Bs...>&,
+    const completion_signatures<_Cs...>& = __empty_completion_signatures,
+    const completion_signatures<_Ds...>& = __empty_completion_signatures,
+    const _Rest&...) const noexcept
+  {
+    using _Tmp                           = completion_signatures<_As..., _Bs..., _Cs..., _Ds...>;
+    using _SigsFnPtr _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::__call_result_t<_Self, const _Tmp&, const _Rest&...>;
+    return static_cast<_SigsFnPtr>(nullptr);
+  }
+
+  template <class _Ap,
+            class _Bp = _CUDA_VSTD::__ignore_t,
+            class _Cp = _CUDA_VSTD::__ignore_t,
+            class _Dp = _CUDA_VSTD::__ignore_t,
+            class... _Rest>
+  _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto
+  operator()(const _Ap&, const _Bp& = {}, const _Cp& = {}, const _Dp& = {}, const _Rest&...) const noexcept
+  {
+    if constexpr (!__valid_completion_signatures<_Ap>)
+    {
+      return static_cast<_Ap (*)()>(nullptr);
+    }
+    else if constexpr (!__valid_completion_signatures<_Bp>)
+    {
+      return static_cast<_Bp (*)()>(nullptr);
+    }
+    else if constexpr (!__valid_completion_signatures<_Cp>)
+    {
+      return static_cast<_Cp (*)()>(nullptr);
+    }
+    else
+    {
+      static_assert(!__valid_completion_signatures<_Dp>);
+      return static_cast<_Dp (*)()>(nullptr);
+    }
+  }
+};
+
 _CCCL_GLOBAL_CONSTANT __concat_completion_signatures_fn concat_completion_signatures{};
 
-#if defined(__cpp_constexpr_exceptions) // C++26, https://wg21.link/p3068
-template <class... _What, class... _Values>
-[[noreturn, nodiscard]] constexpr completion_signatures<> invalid_completion_signature(_Values... __values);
-#else // ^^^ constexpr exceptions ^^^ / vvv no constexpr exceptions vvv
-template <class... _What, class... _Values>
-[[nodiscard]] _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto invalid_completion_signature(_Values... __values);
-#endif // ^^^ no constexpr exceptions ^^^
-
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// implementation details of the completion_signatures class template
 struct _IN_COMPLETION_SIGNATURES_APPLY;
 struct _IN_COMPLETION_SIGNATURES_TRANSFORM_REDUCE;
 struct _FUNCTION_IS_NOT_CALLABLE_WITH_THESE_SIGNATURES;
@@ -290,22 +437,18 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT completion_signatures
   [[nodiscard]]
   _CCCL_API static _CCCL_CONSTEVAL auto select(_Tag) noexcept
   {
-    using __partitioned_t = typename __partitioned::type;
     if constexpr (_Tag{} == set_value)
     {
-      using __result_t = typename __partitioned_t::template __value_types<__set_value_sig_t, completion_signatures>;
-      return __result_t{};
+      return __value_types<completion_signatures, __set_value_sig_t, __completion_signatures>{};
     }
     else if constexpr (_Tag{} == set_error)
     {
-      using __result_t = typename __partitioned_t::template __error_types<completion_signatures, __set_error_sig_t>;
-      return __result_t{};
+      return __error_types<completion_signatures, __completion_signatures, __set_error_sig_t>{};
     }
     else
     {
       static_assert(_Tag{} == set_stopped, "The tag must be set_value, set_error, or set_stopped.");
-      using __result_t = typename __partitioned_t::template __stopped_types<completion_signatures>;
-      return __result_t{};
+      return __stopped_types<completion_signatures, __completion_signatures>{};
     }
   }
 
@@ -415,280 +558,8 @@ operator!=(completion_signatures<_SelfSigs...> __self, completion_signatures<_Ot
 
 #undef _CCCL_CONSTEVAL_OPERATOR
 
-template <class _Ty>
-_CCCL_CONCEPT __valid_completion_signatures =
-  __is_specialization_of_v<_CUDA_VSTD::remove_const_t<_Ty>, completion_signatures>;
-
-template <class... _Sigs>
-_CCCL_API _CCCL_CONSTEVAL void __assert_valid_completion_signatures(const completion_signatures<_Sigs...>&)
-{}
-
-template <class _Derived>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT __compile_time_error // : ::std::exception
-{
-  _CCCL_HIDE_FROM_ABI __compile_time_error() = default;
-
-  [[nodiscard]] auto what() const noexcept -> const char* // override
-  {
-    return _CCCL_TYPEID(_Derived*).name();
-  }
-};
-
-template <class _Data, class... _What>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT __sender_type_check_failure //
-    : __compile_time_error<__sender_type_check_failure<_Data, _What...>>
-{
-  _CCCL_HIDE_FROM_ABI __sender_type_check_failure() = default;
-
-  explicit constexpr __sender_type_check_failure(_Data data)
-      : data_(data)
-  {}
-
-  _Data data_{};
-};
-
-struct _CCCL_TYPE_VISIBILITY_DEFAULT dependent_sender_error // : ::std::exception
-{
-  [[nodiscard]] _CCCL_TRIVIAL_API auto what() const noexcept -> char const* // override
-  {
-    return what_;
-  }
-
-  char const* what_;
-};
-
-template <class _Sndr>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT __dependent_sender_error : dependent_sender_error
-{
-  _CCCL_TRIVIAL_API constexpr __dependent_sender_error() noexcept
-      : dependent_sender_error{"This sender needs to know its execution " //
-                               "environment before it can know how it will complete."}
-  {}
-
-  _CCCL_HOST_DEVICE auto operator+() -> __dependent_sender_error;
-
-  template <class _Ty>
-  _CCCL_HOST_DEVICE auto operator,(_Ty&) -> __dependent_sender_error&;
-
-  template <class... _What>
-  _CCCL_HOST_DEVICE auto operator,(_ERROR<_What...>&) -> _ERROR<_What...>&;
-};
-
-// Below is the definition of the _CUDAX_LET_COMPLETIONS portability macro. It
-// is used to check that an expression's type is a valid completion_signature
-// specialization.
-//
-// USAGE:
-//
-//   _CUDAX_LET_COMPLETIONS(auto(__cs) = <expression>)
-//   {
-//     // __cs is guaranteed to be a specialization of completion_signatures.
-//   }
-//
-// When constexpr exceptions are available (C++26), the macro simply expands to
-// the moral equivalent of:
-//
-//   // With constexpr exceptions:
-//   auto __cs = <expression>; // throws if __cs is not a completion_signatures
-//
-// When constexpr exceptions are not available, the macro expands to:
-//
-//   // Without constexpr exceptions:
-//   if constexpr (auto __cs = <expression>; !__valid_completion_signatures<decltype(__cs)>)
-//   {
-//     return __cs;
-//   }
-//   else
-
-#if _CCCL_HAS_EXCEPTIONS() && defined(__cpp_constexpr_exceptions) // C++26, https://wg21.link/p3068
-
-#  define _CUDAX_LET_COMPLETIONS(...)                  \
-    if constexpr ([[maybe_unused]] __VA_ARGS__; false) \
-    {                                                  \
-    }                                                  \
-    else
-
-template <class... _What, class... _Values>
-[[noreturn, nodiscard]] _CCCL_API consteval completion_signatures<> invalid_completion_signature(_Values... __values)
-{
-  if constexpr (sizeof...(_Values) == 1)
-  {
-    throw __sender_type_check_failure<_Values..., _What...>(__values...);
-  }
-  else
-  {
-    throw __sender_type_check_failure<_CUDA_VSTD::__tuple<_Values...>, _What...>(_CUDA_VSTD::__tuple{__values...});
-  }
-}
-
-template <class... _Sndr>
-[[noreturn, nodiscard]] _CCCL_API consteval auto __dependent_sender() -> completion_signatures<>
-{
-  throw __dependent_sender_error<_Sndr...>{};
-}
-
-#else // ^^^ constexpr exceptions ^^^ / vvv no constexpr exceptions vvv
-
-#  define _CUDAX_PP_EAT_AUTO_auto(_ID)    _ID _CCCL_PP_EAT _CCCL_PP_LPAREN
-#  define _CUDAX_PP_EXPAND_AUTO_auto(_ID) auto _ID
-#  define _CUDAX_LET_COMPLETIONS_ID(...)  _CCCL_PP_EXPAND(_CCCL_PP_CAT(_CUDAX_PP_EAT_AUTO_, __VA_ARGS__) _CCCL_PP_RPAREN)
-
-#  define _CUDAX_LET_COMPLETIONS(...)                                                                                 \
-    if constexpr (_CCCL_PP_CAT(_CUDAX_PP_EXPAND_AUTO_, __VA_ARGS__);                                                  \
-                  !::cuda::experimental::execution::__valid_completion_signatures<decltype(_CUDAX_LET_COMPLETIONS_ID( \
-                    __VA_ARGS__))>)                                                                                   \
-    {                                                                                                                 \
-      return _CUDAX_LET_COMPLETIONS_ID(__VA_ARGS__);                                                                  \
-    }                                                                                                                 \
-    else
-
-template <class... _What, class... _Values>
-[[nodiscard]] _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto invalid_completion_signature([[maybe_unused]] _Values... __values)
-{
-  return _ERROR<_What...>{};
-}
-
-template <class... _Sndr>
-[[nodiscard]] _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto __dependent_sender() -> __dependent_sender_error<_Sndr...>
-{
-  return __dependent_sender_error<_Sndr...>{};
-}
-
-#endif // ^^^ no constexpr exceptions ^^^
-
-_CCCL_DIAG_PUSH
-// warning C4913: user defined binary operator ',' exists but no overload could convert all operands,
-// default built-in binary operator ',' used
-_CCCL_DIAG_SUPPRESS_MSVC(4913)
-
-#define _CUDAX_GET_COMPLSIGS(...) \
-  _CUDA_VSTD::remove_reference_t<_Sndr>::template get_completion_signatures<__VA_ARGS__>()
-
-#define _CUDAX_CHECKED_COMPLSIGS(...) \
-  (static_cast<void>(__VA_ARGS__), void(), execution::__checked_complsigs<decltype(__VA_ARGS__)>())
-
-struct _A_GET_COMPLETION_SIGNATURES_CUSTOMIZATION_RETURNED_A_TYPE_THAT_IS_NOT_A_COMPLETION_SIGNATURES_SPECIALIZATION
-{};
-
-template <class _Completions>
-_CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto __checked_complsigs()
-{
-  _CUDAX_LET_COMPLETIONS(auto(__cs) = _Completions())
-  {
-    if constexpr (__valid_completion_signatures<_Completions>)
-    {
-      return __cs;
-    }
-    else
-    {
-      return invalid_completion_signature<
-        _A_GET_COMPLETION_SIGNATURES_CUSTOMIZATION_RETURNED_A_TYPE_THAT_IS_NOT_A_COMPLETION_SIGNATURES_SPECIALIZATION,
-        _WITH_SIGNATURES(_Completions)>();
-    }
-  }
-}
-
-template <class _Sndr, class... _Env>
-inline constexpr bool __has_get_completion_signatures = false;
-
-// clang-format off
-template <class _Sndr>
-inline constexpr bool __has_get_completion_signatures<_Sndr> =
-  _CCCL_REQUIRES_EXPR((_Sndr))
-  (
-    (_CUDAX_GET_COMPLSIGS(_Sndr))
-  );
-
-template <class _Sndr, class _Env>
-inline constexpr bool __has_get_completion_signatures<_Sndr, _Env> =
-  _CCCL_REQUIRES_EXPR((_Sndr, _Env))
-  (
-    (_CUDAX_GET_COMPLSIGS(_Sndr, _Env))
-  );
-// clang-format on
-
-struct _COULD_NOT_DETERMINE_COMPLETION_SIGNATURES_FOR_THIS_SENDER
-{};
-
-_CCCL_EXEC_CHECK_DISABLE
-template <class _Sndr, class... _Env>
-[[nodiscard]] _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto __get_completion_signatures_helper()
-{
-  if constexpr (__has_get_completion_signatures<_Sndr, _Env...>)
-  {
-    return _CUDAX_CHECKED_COMPLSIGS(_CUDAX_GET_COMPLSIGS(_Sndr, _Env...));
-  }
-  else if constexpr (__has_get_completion_signatures<_Sndr>)
-  {
-    return _CUDAX_CHECKED_COMPLSIGS(_CUDAX_GET_COMPLSIGS(_Sndr));
-  }
-  // else if constexpr (__is_awaitable<_Sndr, __env_promise<_Env>...>)
-  // {
-  //   using Result _CCCL_NODEBUG_ALIAS = __await_result_t<_Sndr, __env_promise<_Env>...>;
-  //   return completion_signatures{__set_value_v<Result>, __set_error_v<>, __set_stopped_v};
-  // }
-  else if constexpr (sizeof...(_Env) == 0)
-  {
-    return __dependent_sender<_Sndr>();
-  }
-  else
-  {
-    return invalid_completion_signature<_COULD_NOT_DETERMINE_COMPLETION_SIGNATURES_FOR_THIS_SENDER,
-                                        _WITH_SENDER(_Sndr),
-                                        _WITH_ENVIRONMENT(_Env...)>();
-  }
-}
-
-template <class _Sndr, class... _Env>
-[[nodiscard]] _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto get_completion_signatures()
-{
-  static_assert(sizeof...(_Env) <= 1, "At most one environment is allowed.");
-  if constexpr (0 == sizeof...(_Env))
-  {
-    return execution::__get_completion_signatures_helper<_Sndr>();
-  }
-  else if constexpr (!__has_sender_transform<_Sndr, _Env...>)
-  {
-    return execution::__get_completion_signatures_helper<_Sndr, _Env...>();
-  }
-  else
-  {
-    // Apply a lazy sender transform if one exists before computing the completion signatures:
-    using _NewSndr _CCCL_NODEBUG_ALIAS =
-      _CUDA_VSTD::__call_result_t<transform_sender_t, __late_domain_of_t<_Sndr, _Env...>, _Sndr, _Env...>;
-    return execution::__get_completion_signatures_helper<_NewSndr, _Env...>();
-  }
-}
-
-template <class _Parent, class _Child, class... _Env>
-[[nodiscard]] _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto get_child_completion_signatures()
-{
-  return get_completion_signatures<_CUDA_VSTD::__copy_cvref_t<_Parent, _Child>, __fwd_env_t<_Env>...>();
-}
-
-#undef _CUDAX_GET_COMPLSIGS
-#undef _CUDAX_CHECKED_COMPLSIGS
-_CCCL_DIAG_POP
-
-template <class _Completions>
-using __partitioned_completions_of _CCCL_NODEBUG_ALIAS = typename _Completions::__partitioned::type;
-
-constexpr int __invalid_disposition = -1;
-
-// A metafunction to determine whether a type is a completion signature, and if
-// so, what its disposition is.
-template <class>
-inline constexpr int __signature_disposition = __invalid_disposition;
-
-template <class... _Values>
-inline constexpr __disposition_t __signature_disposition<set_value_t(_Values...)> = __disposition_t::__value;
-
-template <class _Error>
-inline constexpr __disposition_t __signature_disposition<set_error_t(_Error)> = __disposition_t::__error;
-
-template <>
-inline constexpr __disposition_t __signature_disposition<set_stopped_t()> = __disposition_t::__stopped;
-
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// __gather_completion_signatures
 template <class _WantedTag>
 struct __gather_sigs_fn;
 
@@ -696,323 +567,29 @@ template <>
 struct __gather_sigs_fn<set_value_t>
 {
   template <class _Sigs, template <class...> class _Tuple, template <class...> class _Variant>
-  using __call _CCCL_NODEBUG_ALIAS =
-    typename __partitioned_completions_of<_Sigs>::template __value_types<_Tuple, _Variant>;
+  using __call _CCCL_NODEBUG_ALIAS = __value_types<_Sigs, _Tuple, _Variant>;
 };
 
 template <>
 struct __gather_sigs_fn<set_error_t>
 {
   template <class _Sigs, template <class...> class _Tuple, template <class...> class _Variant>
-  using __call _CCCL_NODEBUG_ALIAS =
-    typename __partitioned_completions_of<_Sigs>::template __error_types<_Variant, _Tuple>;
+  using __call _CCCL_NODEBUG_ALIAS = __error_types<_Sigs, _Variant, _Tuple>;
 };
 
 template <>
 struct __gather_sigs_fn<set_stopped_t>
 {
   template <class _Sigs, template <class...> class _Tuple, template <class...> class _Variant>
-  using __call _CCCL_NODEBUG_ALIAS =
-    typename __partitioned_completions_of<_Sigs>::template __stopped_types<_Variant, _Tuple<>>;
+  using __call _CCCL_NODEBUG_ALIAS = __stopped_types<_Sigs, _Variant, _Tuple<>>;
 };
 
 template <class _Sigs, class _WantedTag, template <class...> class _TaggedTuple, template <class...> class _Variant>
 using __gather_completion_signatures _CCCL_NODEBUG_ALIAS =
   typename __gather_sigs_fn<_WantedTag>::template __call<_Sigs, _TaggedTuple, _Variant>;
 
-// __partitioned_completions is a cache of completion signatures for fast
-// access. The completion_signatures<Sigs...>::__partitioned nested struct
-// inherits from __partitioned_completions. If the cache is never accessed,
-// it is never instantiated.
-template <class... _ValueTuples, class... _Errors, class... _Stopped>
-struct __partitioned_completions<_CUDA_VSTD::__type_list<_ValueTuples...>,
-                                 _CUDA_VSTD::__type_list<_Errors...>,
-                                 _CUDA_VSTD::__type_list<_Stopped...>>
-{
-  template <template <class...> class _Tuple, template <class...> class _Variant>
-  using __value_types _CCCL_NODEBUG_ALIAS =
-    _Variant<_CUDA_VSTD::__type_call1<_ValueTuples, _CUDA_VSTD::__type_quote<_Tuple>>...>;
-
-  template <template <class...> class _Variant, template <class> class _Transform = _CUDA_VSTD::__type_self_t>
-  using __error_types _CCCL_NODEBUG_ALIAS = _Variant<_Transform<_Errors>...>;
-
-  template <template <class...> class _Variant, class _Type = set_stopped_t()>
-  using __stopped_types _CCCL_NODEBUG_ALIAS = _Variant<__type_second<_Stopped, _Type>...>;
-
-  using __count_values  = _CUDA_VSTD::integral_constant<size_t, sizeof...(_ValueTuples)>;
-  using __count_errors  = _CUDA_VSTD::integral_constant<size_t, sizeof...(_Errors)>;
-  using __count_stopped = _CUDA_VSTD::integral_constant<size_t, sizeof...(_Stopped)>;
-
-  struct __nothrow_decay_copyable
-  {
-    // These aliases are placed in a separate struct to avoid computing them
-    // if they are not needed.
-    using __fn     = _CUDA_VSTD::__type_quote<__nothrow_decay_copyable_t>;
-    using __values = _CUDA_VSTD::_And<_CUDA_VSTD::__type_call1<_ValueTuples, __fn>...>;
-    using __errors = __nothrow_decay_copyable_t<_Errors...>;
-    using __all    = _CUDA_VSTD::_And<__values, __errors>;
-  };
-};
-
-// make_completion_signatures
-template <class _Tag, class... _As>
-_CCCL_API auto __normalize_helper(_As&&...) -> _Tag (*)(_As...);
-
-template <class _Tag, class... _As>
-_CCCL_API auto __normalize(_Tag (*)(_As...)) -> decltype(execution::__normalize_helper<_Tag>(declval<_As>()...));
-
-template <class... _Sigs>
-_CCCL_API auto __make_unique(_Sigs*...)
-  -> _CUDA_VSTD::__type_apply<_CUDA_VSTD::__type_quote<completion_signatures>, _CUDA_VSTD::__make_type_set<_Sigs...>>;
-
-template <class... _Sigs>
-using __make_completion_signatures_t _CCCL_NODEBUG_ALIAS =
-  decltype(execution::__make_unique(execution::__normalize(static_cast<_Sigs*>(nullptr))...));
-
-template <class... _ExplicitSigs, class... _DeducedSigs>
-[[nodiscard]] _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto make_completion_signatures(_DeducedSigs*...) noexcept
-  -> __make_completion_signatures_t<_ExplicitSigs..., _DeducedSigs...>
-{
-  return {};
-}
-
-// concat_completion_signatures
-extern const completion_signatures<>& __empty_completion_signatures;
-
-struct __concat_completion_signatures_helper
-{
-  _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto operator()() const noexcept -> completion_signatures<> (*)()
-  {
-    return nullptr;
-  }
-
-  template <class... _Sigs>
-  _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto operator()(const completion_signatures<_Sigs...>&) const noexcept
-    -> __make_completion_signatures_t<_Sigs...> (*)()
-  {
-    return nullptr;
-  }
-
-  template <class _Self = __concat_completion_signatures_helper,
-            class... _As,
-            class... _Bs,
-            class... _Cs,
-            class... _Ds,
-            class... _Rest>
-  _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto operator()(
-    const completion_signatures<_As...>&,
-    const completion_signatures<_Bs...>&,
-    const completion_signatures<_Cs...>& = __empty_completion_signatures,
-    const completion_signatures<_Ds...>& = __empty_completion_signatures,
-    const _Rest&...) const noexcept
-  {
-    using _Tmp _CCCL_NODEBUG_ALIAS       = completion_signatures<_As..., _Bs..., _Cs..., _Ds...>;
-    using _SigsFnPtr _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::__call_result_t<_Self, const _Tmp&, const _Rest&...>;
-    return static_cast<_SigsFnPtr>(nullptr);
-  }
-
-  template <class _Ap,
-            class _Bp = _CUDA_VSTD::__ignore_t,
-            class _Cp = _CUDA_VSTD::__ignore_t,
-            class _Dp = _CUDA_VSTD::__ignore_t,
-            class... _Rest>
-  _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto
-  operator()(const _Ap&, const _Bp& = {}, const _Cp& = {}, const _Dp& = {}, const _Rest&...) const noexcept
-  {
-    if constexpr (!__valid_completion_signatures<_Ap>)
-    {
-      return static_cast<_Ap (*)()>(nullptr);
-    }
-    else if constexpr (!__valid_completion_signatures<_Bp>)
-    {
-      return static_cast<_Bp (*)()>(nullptr);
-    }
-    else if constexpr (!__valid_completion_signatures<_Cp>)
-    {
-      return static_cast<_Cp (*)()>(nullptr);
-    }
-    else
-    {
-      static_assert(!__valid_completion_signatures<_Dp>);
-      return static_cast<_Dp (*)()>(nullptr);
-    }
-  }
-};
-
-template <class _Sigs, template <class...> class _Tuple, template <class...> class _Variant>
-using __value_types _CCCL_NODEBUG_ALIAS = typename _Sigs::__partitioned::type::template __value_types<_Tuple, _Variant>;
-
-template <class _Sndr, class _Env, template <class...> class _Tuple, template <class...> class _Variant>
-using value_types_of_t _CCCL_NODEBUG_ALIAS =
-  __value_types<completion_signatures_of_t<_Sndr, _Env>, _Tuple, __type_try_quote<_Variant>::template __call>;
-
-template <class _Sigs, template <class...> class _Variant>
-using __error_types _CCCL_NODEBUG_ALIAS =
-  typename _Sigs::__partitioned::type::template __error_types<_Variant, _CUDA_VSTD::__type_self_t>;
-
-template <class _Sndr, class _Env, template <class...> class _Variant>
-using error_types_of_t _CCCL_NODEBUG_ALIAS = __error_types<completion_signatures_of_t<_Sndr, _Env>, _Variant>;
-
-template <class _Sigs, template <class...> class _Variant, class _Type>
-using __stopped_types _CCCL_NODEBUG_ALIAS =
-  typename _Sigs::__partitioned::type::template __stopped_types<_Variant, _Type>;
-
-template <class _Sigs>
-inline constexpr bool __sends_stopped = _Sigs::__partitioned::type::__count_stopped::value != 0;
-
-template <class _Sndr, class... _Env>
-inline constexpr bool sends_stopped = __sends_stopped<completion_signatures_of_t<_Sndr, _Env...>>;
-
-template <class _Tag>
-struct __default_transform_fn
-{
-  template <class... _Ts>
-  _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto operator()() const noexcept -> completion_signatures<_Tag(_Ts...)>
-  {
-    return {};
-  }
-};
-
-struct __swallow_transform
-{
-  template <class... _Ts>
-  _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto operator()() const noexcept -> completion_signatures<>
-  {
-    return {};
-  }
-};
-
-template <class _Tag>
-struct __decay_transform
-{
-  template <class... _Ts>
-  _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto operator()() const noexcept
-    -> completion_signatures<_Tag(_CUDA_VSTD::decay_t<_Ts>...)>
-  {
-    return {};
-  }
-};
-
-template <class _Fn, class... _As>
-using __meta_call_result_t _CCCL_NODEBUG_ALIAS = decltype(declval<_Fn>().template operator()<_As...>());
-
-_CCCL_EXEC_CHECK_DISABLE
-template <class _Ay, class... _As, class _Fn>
-[[nodiscard]] _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto __transform_expr(const _Fn& __fn)
-  -> __meta_call_result_t<const _Fn&, _Ay, _As...>
-{
-  return __fn.template operator()<_Ay, _As...>();
-}
-
-_CCCL_EXEC_CHECK_DISABLE
-template <class _Fn>
-[[nodiscard]] _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto __transform_expr(const _Fn& __fn)
-  -> _CUDA_VSTD::__call_result_t<const _Fn&>
-{
-  return __fn();
-}
-
-template <class _Fn, class... _As>
-using __transform_expr_t _CCCL_NODEBUG_ALIAS = decltype(execution::__transform_expr<_As...>(declval<const _Fn&>()));
-
-struct _IN_TRANSFORM_COMPLETION_SIGNATURES;
-struct _A_TRANSFORM_FUNCTION_RETURNED_A_TYPE_THAT_IS_NOT_A_COMPLETION_SIGNATURES_SPECIALIZATION;
-struct _COULD_NOT_CALL_THE_TRANSFORM_FUNCTION_WITH_THE_GIVEN_TEMPLATE_ARGUMENTS;
-
-// transform_completion_signatures:
-template <class... _As, class _Fn>
-[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL auto __apply_transform(const _Fn& __fn)
-{
-  if constexpr (__is_instantiable_with_v<__transform_expr_t, _Fn, _As...>)
-  {
-    using __completions _CCCL_NODEBUG_ALIAS = __transform_expr_t<_Fn, _As...>;
-    if constexpr (__valid_completion_signatures<__completions> || __type_is_error<__completions>
-                  || _CUDA_VSTD::is_base_of_v<dependent_sender_error, __completions>)
-    {
-      return execution::__transform_expr<_As...>(__fn);
-    }
-    else
-    {
-      (void) execution::__transform_expr<_As...>(__fn); // potentially throwing
-      return invalid_completion_signature<
-        _IN_TRANSFORM_COMPLETION_SIGNATURES,
-        _A_TRANSFORM_FUNCTION_RETURNED_A_TYPE_THAT_IS_NOT_A_COMPLETION_SIGNATURES_SPECIALIZATION,
-        _WITH_FUNCTION(_Fn),
-        _WITH_ARGUMENTS(_As...)>();
-    }
-  }
-  else
-  {
-    return invalid_completion_signature< //
-      _IN_TRANSFORM_COMPLETION_SIGNATURES,
-      _COULD_NOT_CALL_THE_TRANSFORM_FUNCTION_WITH_THE_GIVEN_TEMPLATE_ARGUMENTS,
-      _WITH_FUNCTION(_Fn),
-      _WITH_ARGUMENTS(_As...)>();
-  }
-}
-
-template <class _ValueFn, class _ErrorFn, class _StoppedFn>
-struct __transform_one
-{
-  _ValueFn __value_fn;
-  _ErrorFn __error_fn;
-  _StoppedFn __stopped_fn;
-
-  template <class _Tag, class... _Ts>
-  [[nodiscard]] _CCCL_API _CCCL_CONSTEVAL auto operator()(_Tag (*)(_Ts...)) const
-  {
-    if constexpr (_Tag{} == set_value)
-    {
-      return __apply_transform<_Ts...>(__value_fn);
-    }
-    else if constexpr (_Tag{} == set_error)
-    {
-      return __apply_transform<_Ts...>(__error_fn);
-    }
-    else
-    {
-      return __apply_transform<_Ts...>(__stopped_fn);
-    }
-  }
-};
-
-template <class _TransformOne>
-struct __transform_all_fn
-{
-  _TransformOne __tfx1;
-
-  template <class... _Sigs>
-  [[nodiscard]] _CCCL_API _CCCL_CONSTEVAL auto operator()(_Sigs*... __sigs) const
-  {
-    return concat_completion_signatures(__tfx1(__sigs)...);
-  }
-};
-
-template <class _TransformOne>
-__transform_all_fn(_TransformOne) -> __transform_all_fn<_TransformOne>;
-
-template <class _Completions,
-          class _ValueFn   = __default_transform_fn<set_value_t>,
-          class _ErrorFn   = __default_transform_fn<set_error_t>,
-          class _StoppedFn = __default_transform_fn<set_stopped_t>,
-          class _ExtraSigs = completion_signatures<>>
-_CCCL_API _CCCL_CONSTEVAL auto transform_completion_signatures(
-  _Completions, //
-  _ValueFn __value_fn     = {},
-  _ErrorFn __error_fn     = {},
-  _StoppedFn __stopped_fn = {},
-  _ExtraSigs              = {})
-{
-  _CUDAX_LET_COMPLETIONS(auto(__completions) = _Completions{})
-  {
-    _CUDAX_LET_COMPLETIONS(auto(__extra) = _ExtraSigs{})
-    {
-      __transform_one<_ValueFn, _ErrorFn, _StoppedFn> __tfx1{__value_fn, __error_fn, __stopped_fn};
-      return concat_completion_signatures(__completions.apply(__transform_all_fn{__tfx1}), __extra);
-    }
-  }
-}
-
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// __eptr_completion and __eptr_completion_if
 #if _CCCL_HAS_EXCEPTIONS()
 [[nodiscard]] _CCCL_API inline _CCCL_CONSTEVAL auto __eptr_completion() noexcept
 {
@@ -1038,31 +615,32 @@ template <bool _PotentiallyThrowing>
   }
 }
 
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// invalid_completion_signature
 #if _CCCL_HAS_EXCEPTIONS() && defined(__cpp_constexpr_exceptions) // C++26, https://wg21.link/p3068
-// When asked for its completions without an envitonment, a dependent sender
-// will throw an exception of a type derived from `dependent_sender_error`.
-template <class _Sndr>
-[[nodiscard]] _CCCL_API consteval bool __is_dependent_sender() noexcept
-try
+
+template <class... _What, class... _Values>
+[[noreturn, nodiscard]] _CCCL_API consteval auto invalid_completion_signature(_Values... __values)
+  -> completion_signatures<>
 {
-  (void) get_completion_signatures<_Sndr>();
-  return false; // didn't throw, not a dependent sender
+  if constexpr (sizeof...(_Values) == 1)
+  {
+    throw __sender_type_check_failure<_Values..., _What...>(__values...);
+  }
+  else
+  {
+    throw __sender_type_check_failure<_CUDA_VSTD::__tuple<_Values...>, _What...>(_CUDA_VSTD::__tuple{__values...});
+  }
 }
-catch (dependent_sender_error&)
-{
-  return true;
-}
-catch (...)
-{
-  return false; // different kind of exception was thrown; not a dependent sender
-}
+
 #else // ^^^ constexpr exceptions ^^^ / vvv no constexpr exceptions vvv
-template <class _Sndr>
-[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL auto __is_dependent_sender() noexcept -> bool
+
+template <class... _What, class... _Values>
+[[nodiscard]] _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto invalid_completion_signature(_Values...)
 {
-  using _Completions _CCCL_NODEBUG_ALIAS = decltype(get_completion_signatures<_Sndr>());
-  return _CUDA_VSTD::is_base_of_v<dependent_sender_error, _Completions>;
+  return _ERROR<_What...>{};
 }
+
 #endif // ^^^ no constexpr exceptions ^^^
 
 } // namespace cuda::experimental::execution

--- a/cudax/include/cuda/experimental/__execution/concepts.cuh
+++ b/cudax/include/cuda/experimental/__execution/concepts.cuh
@@ -25,13 +25,13 @@
 #include <cuda/std/__concepts/concept_macros.h>
 #include <cuda/std/__concepts/constructible.h>
 #include <cuda/std/__type_traits/decay.h>
-#include <cuda/std/__type_traits/fold.h>
 #include <cuda/std/__type_traits/integral_constant.h>
 #include <cuda/std/__type_traits/is_callable.h>
 #include <cuda/std/__type_traits/is_move_constructible.h>
+#include <cuda/std/__type_traits/is_nothrow_move_constructible.h>
 
-#include <cuda/experimental/__execution/completion_signatures.cuh>
 #include <cuda/experimental/__execution/cpos.cuh>
+#include <cuda/experimental/__execution/get_completion_signatures.cuh>
 
 #include <cuda/experimental/__execution/prologue.cuh>
 
@@ -134,7 +134,7 @@ _CCCL_CONCEPT sender_in = //
   ( //
     requires(sender<_Sndr>), //
     requires(sizeof...(_Env) <= 1), //
-    requires(_CUDA_VSTD::__fold_and_v<__queryable<_Env>...>), //
+    requires((__queryable<_Env> && ... && true)), //
     requires(__completions_tester<_Env...>::template __is_valid<_Sndr>(0)) //
   );
 

--- a/cudax/include/cuda/experimental/__execution/conditional.cuh
+++ b/cudax/include/cuda/experimental/__execution/conditional.cuh
@@ -30,6 +30,7 @@
 #include <cuda/experimental/__execution/completion_signatures.cuh>
 #include <cuda/experimental/__execution/concepts.cuh>
 #include <cuda/experimental/__execution/env.cuh>
+#include <cuda/experimental/__execution/exception.cuh>
 #include <cuda/experimental/__execution/just_from.cuh>
 #include <cuda/experimental/__execution/meta.cuh>
 #include <cuda/experimental/__execution/rcvr_ref.cuh>

--- a/cudax/include/cuda/experimental/__execution/cpos.cuh
+++ b/cudax/include/cuda/experimental/__execution/cpos.cuh
@@ -33,25 +33,25 @@
 namespace cuda::experimental::execution
 {
 // make the completion tags equality comparable
-template <__disposition_t _Disposition>
+template <__disposition _Disposition>
 struct __completion_tag
 {
-  template <__disposition_t _OtherDisposition>
+  template <__disposition _OtherDisposition>
   _CCCL_TRIVIAL_API constexpr auto operator==(__completion_tag<_OtherDisposition>) const noexcept -> bool
   {
     return _Disposition == _OtherDisposition;
   }
 
-  template <__disposition_t _OtherDisposition>
+  template <__disposition _OtherDisposition>
   _CCCL_TRIVIAL_API constexpr auto operator!=(__completion_tag<_OtherDisposition>) const noexcept -> bool
   {
     return _Disposition != _OtherDisposition;
   }
 
-  static constexpr __disposition_t __disposition = _Disposition;
+  static constexpr __disposition __disposition = _Disposition;
 };
 
-struct set_value_t : __completion_tag<__value>
+struct set_value_t : __completion_tag<__disposition::__value>
 {
   _CCCL_EXEC_CHECK_DISABLE
   template <class _Rcvr, class... _Ts>
@@ -65,7 +65,7 @@ struct set_value_t : __completion_tag<__value>
   }
 };
 
-struct set_error_t : __completion_tag<__error>
+struct set_error_t : __completion_tag<__disposition::__error>
 {
   _CCCL_EXEC_CHECK_DISABLE
   template <class _Rcvr, class _Ey>
@@ -79,7 +79,7 @@ struct set_error_t : __completion_tag<__error>
   }
 };
 
-struct set_stopped_t : __completion_tag<__stopped>
+struct set_stopped_t : __completion_tag<__disposition::__stopped>
 {
   _CCCL_EXEC_CHECK_DISABLE
   template <class _Rcvr>

--- a/cudax/include/cuda/experimental/__execution/fwd.cuh
+++ b/cudax/include/cuda/experimental/__execution/fwd.cuh
@@ -47,7 +47,7 @@ namespace execution
 {
 namespace __detail
 {
-using namespace cuda::experimental::__detail; // // NOLINT(misc-unused-using-decls)
+using namespace cuda::experimental::__detail; // NOLINT(misc-unused-using-decls)
 } // namespace __detail
 
 struct _CCCL_TYPE_VISIBILITY_DEFAULT receiver_t
@@ -87,7 +87,6 @@ inline constexpr bool __is_scheduler = __is_instantiable_with_v<__scheduler_conc
 template <class _Ty>
 inline constexpr bool __is_operation_state = __is_instantiable_with_v<__operation_state_concept_t, _Ty>;
 
-struct stream_domain;
 struct dependent_sender_error;
 
 struct default_domain;
@@ -99,11 +98,12 @@ template <class _Sndr, class... _Env>
 _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto get_completion_signatures();
 
 template <class _Sndr, class... _Env>
-using completion_signatures_of_t _CCCL_NODEBUG_ALIAS = decltype(get_completion_signatures<_Sndr, _Env...>());
+using completion_signatures_of_t _CCCL_NODEBUG_ALIAS = decltype(execution::get_completion_signatures<_Sndr, _Env...>());
 
 // handy enumerations for keeping type names readable
-enum __disposition_t
+enum class __disposition : int8_t
 {
+  __invalid = -1,
   __value,
   __error,
   __stopped
@@ -127,32 +127,32 @@ template <class _Sndr, class _Rcvr>
 inline constexpr bool __nothrow_connectable = noexcept(declval<connect_t>()(declval<_Sndr>(), declval<_Rcvr>()));
 
 // sender factory algorithms:
-template <__disposition_t>
+template <__disposition>
 struct __just_t;
-using just_t         = __just_t<__value>;
-using just_error_t   = __just_t<__error>;
-using just_stopped_t = __just_t<__stopped>;
+using just_t         = __just_t<__disposition::__value>;
+using just_error_t   = __just_t<__disposition::__error>;
+using just_stopped_t = __just_t<__disposition::__stopped>;
 
-template <__disposition_t>
+template <__disposition>
 struct __just_from_t;
-using just_from_t         = __just_from_t<__value>;
-using just_error_from_t   = __just_from_t<__error>;
-using just_stopped_from_t = __just_from_t<__stopped>;
+using just_from_t         = __just_from_t<__disposition::__value>;
+using just_error_from_t   = __just_from_t<__disposition::__error>;
+using just_stopped_from_t = __just_from_t<__disposition::__stopped>;
 
 struct read_env_t;
 
 // sender adaptor algorithms:
-template <__disposition_t>
+template <__disposition>
 struct __let_t;
-using let_value_t   = __let_t<__value>;
-using let_error_t   = __let_t<__error>;
-using let_stopped_t = __let_t<__stopped>;
+using let_value_t   = __let_t<__disposition::__value>;
+using let_error_t   = __let_t<__disposition::__error>;
+using let_stopped_t = __let_t<__disposition::__stopped>;
 
-template <__disposition_t>
+template <__disposition>
 struct __upon_t;
-using then_t         = __upon_t<__value>;
-using upon_error_t   = __upon_t<__error>;
-using upon_stopped_t = __upon_t<__stopped>;
+using then_t         = __upon_t<__disposition::__value>;
+using upon_error_t   = __upon_t<__disposition::__error>;
+using upon_stopped_t = __upon_t<__disposition::__stopped>;
 
 struct when_all_t;
 struct conditional_t;
@@ -176,6 +176,15 @@ struct get_forward_progress_guarantee_t;
 template <class _Tag>
 struct get_completion_scheduler_t;
 struct get_domain_t;
+struct get_domain_late_t;
+
+// get_forward_progress_guarantee:
+enum class forward_progress_guarantee
+{
+  concurrent,
+  parallel,
+  weakly_parallel
+};
 
 namespace __detail
 {
@@ -200,15 +209,29 @@ _CCCL_CONCEPT __sender_for = _CCCL_REQUIRES_EXPR((_Sndr, _Tag))(_Same_as(_Tag) t
 
 namespace __detail
 {
-template <__disposition_t, class _Void = void>
+template <__disposition, class _Void = void>
 extern _CUDA_VSTD::__undefined<_Void> __set_tag;
 template <class _Void>
-extern __fn_t<set_value_t>* __set_tag<__value, _Void>;
+extern __fn_t<set_value_t>* __set_tag<__disposition::__value, _Void>;
 template <class _Void>
-extern __fn_t<set_error_t>* __set_tag<__error, _Void>;
+extern __fn_t<set_error_t>* __set_tag<__disposition::__error, _Void>;
 template <class _Void>
-extern __fn_t<set_stopped_t>* __set_tag<__stopped, _Void>;
+extern __fn_t<set_stopped_t>* __set_tag<__disposition::__stopped, _Void>;
+
+template <class _Sig>
+inline constexpr __disposition __signature_disposition = __disposition::__invalid;
+template <class... _Ts>
+inline constexpr __disposition __signature_disposition<set_value_t(_Ts...)> = __disposition::__value;
+template <class _Ty>
+inline constexpr __disposition __signature_disposition<set_error_t(_Ty)> = __disposition::__error;
+template <>
+inline constexpr __disposition __signature_disposition<set_stopped_t()> = __disposition::__stopped;
+
 } // namespace __detail
+
+struct stream_domain;
+struct stream_context;
+struct stream_scheduler;
 
 } // namespace execution
 

--- a/cudax/include/cuda/experimental/__execution/get_completion_signatures.cuh
+++ b/cudax/include/cuda/experimental/__execution/get_completion_signatures.cuh
@@ -1,0 +1,304 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __CUDAX_EXECUTION_GET_COMPLETION_SIGNATURES
+#define __CUDAX_EXECUTION_GET_COMPLETION_SIGNATURES
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__type_traits/is_callable.h>
+#include <cuda/std/__type_traits/type_list.h>
+#include <cuda/std/__type_traits/type_set.h>
+
+#include <cuda/experimental/__execution/completion_signatures.cuh> // IWYU pragma: export
+#include <cuda/experimental/__execution/fwd.cuh>
+#include <cuda/experimental/__execution/transform_sender.cuh>
+
+// include this last:
+#include <cuda/experimental/__execution/prologue.cuh>
+
+namespace cuda::experimental::execution
+{
+
+template <class _Derived>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT __compile_time_error // : ::std::exception
+{
+  _CCCL_HIDE_FROM_ABI __compile_time_error() = default;
+
+  [[nodiscard]] auto what() const noexcept -> const char* // override
+  {
+    return static_cast<_Derived const*>(this)->__what();
+  }
+};
+
+template <class _Data, class... _What>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT __sender_type_check_failure //
+    : __compile_time_error<__sender_type_check_failure<_Data, _What...>>
+{
+  _CCCL_HIDE_FROM_ABI __sender_type_check_failure() = default;
+
+  _CCCL_API explicit constexpr __sender_type_check_failure(_Data data)
+      : data_(data)
+  {}
+
+  _CCCL_TRIVIAL_API auto __what() const noexcept -> const char*
+  {
+    return "This sender is not well-formed. It does not meet the requirements of a sender type.";
+  }
+
+  _Data data_{};
+};
+
+struct _CCCL_TYPE_VISIBILITY_DEFAULT dependent_sender_error // : ::std::exception
+{
+  [[nodiscard]] _CCCL_TRIVIAL_API auto what() const noexcept -> char const* // override
+  {
+    return what_;
+  }
+
+  char const* what_;
+};
+
+template <class _Sndr>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT __dependent_sender_error : dependent_sender_error
+{
+  _CCCL_TRIVIAL_API constexpr __dependent_sender_error() noexcept
+      : dependent_sender_error{"This sender needs to know its execution " //
+                               "environment before it can know how it will complete."}
+  {}
+
+  _CCCL_HOST_DEVICE auto operator+() -> __dependent_sender_error;
+
+  template <class _Ty>
+  _CCCL_HOST_DEVICE auto operator,(_Ty&) -> __dependent_sender_error&;
+
+  template <class... _What>
+  _CCCL_HOST_DEVICE auto operator,(_ERROR<_What...>&) -> _ERROR<_What...>&;
+};
+
+// Below is the definition of the _CUDAX_LET_COMPLETIONS portability macro. It
+// is used to check that an expression's type is a valid completion_signature
+// specialization.
+//
+// USAGE:
+//
+//   _CUDAX_LET_COMPLETIONS(auto(__cs) = <expression>)
+//   {
+//     // __cs is guaranteed to be a specialization of completion_signatures.
+//   }
+//
+// When constexpr exceptions are available (C++26), the macro simply expands to
+// the moral equivalent of:
+//
+//   // With constexpr exceptions:
+//   auto __cs = <expression>; // throws if __cs is not a completion_signatures
+//
+// When constexpr exceptions are not available, the macro expands to:
+//
+//   // Without constexpr exceptions:
+//   if constexpr (auto __cs = <expression>; !__valid_completion_signatures<decltype(__cs)>)
+//   {
+//     return __cs;
+//   }
+//   else
+
+#if _CCCL_HAS_EXCEPTIONS() && defined(__cpp_constexpr_exceptions) // C++26, https://wg21.link/p3068
+
+#  define _CUDAX_LET_COMPLETIONS(...)                  \
+    if constexpr ([[maybe_unused]] __VA_ARGS__; false) \
+    {                                                  \
+    }                                                  \
+    else
+
+template <class... _Sndr>
+[[noreturn, nodiscard]] _CCCL_API consteval auto __dependent_sender() -> completion_signatures<>
+{
+  throw __dependent_sender_error<_Sndr...>{};
+}
+
+#else // ^^^ constexpr exceptions ^^^ / vvv no constexpr exceptions vvv
+
+#  define _CUDAX_PP_EAT_AUTO_auto(_ID)    _ID _CCCL_PP_EAT _CCCL_PP_LPAREN
+#  define _CUDAX_PP_EXPAND_AUTO_auto(_ID) auto _ID
+#  define _CUDAX_LET_COMPLETIONS_ID(...)  _CCCL_PP_EXPAND(_CCCL_PP_CAT(_CUDAX_PP_EAT_AUTO_, __VA_ARGS__) _CCCL_PP_RPAREN)
+
+#  define _CUDAX_LET_COMPLETIONS(...)                                                                                 \
+    if constexpr (_CCCL_PP_CAT(_CUDAX_PP_EXPAND_AUTO_, __VA_ARGS__);                                                  \
+                  !::cuda::experimental::execution::__valid_completion_signatures<decltype(_CUDAX_LET_COMPLETIONS_ID( \
+                    __VA_ARGS__))>)                                                                                   \
+    {                                                                                                                 \
+      return _CUDAX_LET_COMPLETIONS_ID(__VA_ARGS__);                                                                  \
+    }                                                                                                                 \
+    else
+
+template <class... _Sndr>
+[[nodiscard]] _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto __dependent_sender() -> __dependent_sender_error<_Sndr...>
+{
+  return __dependent_sender_error<_Sndr...>{};
+}
+
+#endif // ^^^ no constexpr exceptions ^^^
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// get_completion_signatures
+_CCCL_DIAG_PUSH
+// warning C4913: user defined binary operator ',' exists but no overload could convert all operands,
+// default built-in binary operator ',' used
+_CCCL_DIAG_SUPPRESS_MSVC(4913)
+
+#define _CUDAX_GET_COMPLSIGS(...) \
+  _CUDA_VSTD::remove_reference_t<_Sndr>::template get_completion_signatures<__VA_ARGS__>()
+
+#define _CUDAX_CHECKED_COMPLSIGS(...) \
+  (static_cast<void>(__VA_ARGS__), void(), execution::__checked_complsigs<decltype(__VA_ARGS__)>())
+
+struct _A_GET_COMPLETION_SIGNATURES_CUSTOMIZATION_RETURNED_A_TYPE_THAT_IS_NOT_A_COMPLETION_SIGNATURES_SPECIALIZATION
+{};
+
+template <class _Completions>
+_CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto __checked_complsigs()
+{
+  _CUDAX_LET_COMPLETIONS(auto(__cs) = _Completions())
+  {
+    if constexpr (__valid_completion_signatures<_Completions>)
+    {
+      return __cs;
+    }
+    else
+    {
+      return invalid_completion_signature<
+        _A_GET_COMPLETION_SIGNATURES_CUSTOMIZATION_RETURNED_A_TYPE_THAT_IS_NOT_A_COMPLETION_SIGNATURES_SPECIALIZATION,
+        _WITH_SIGNATURES(_Completions)>();
+    }
+  }
+}
+
+template <class _Sndr, class... _Env>
+inline constexpr bool __has_get_completion_signatures = false;
+
+// clang-format off
+template <class _Sndr>
+inline constexpr bool __has_get_completion_signatures<_Sndr> =
+  _CCCL_REQUIRES_EXPR((_Sndr))
+  (
+    (_CUDAX_GET_COMPLSIGS(_Sndr))
+  );
+
+template <class _Sndr, class _Env>
+inline constexpr bool __has_get_completion_signatures<_Sndr, _Env> =
+  _CCCL_REQUIRES_EXPR((_Sndr, _Env))
+  (
+    (_CUDAX_GET_COMPLSIGS(_Sndr, _Env))
+  );
+// clang-format on
+
+struct _COULD_NOT_DETERMINE_COMPLETION_SIGNATURES_FOR_THIS_SENDER
+{};
+
+_CCCL_EXEC_CHECK_DISABLE
+template <class _Sndr, class... _Env>
+[[nodiscard]] _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto __get_completion_signatures_helper()
+{
+  if constexpr (__has_get_completion_signatures<_Sndr, _Env...>)
+  {
+    return _CUDAX_CHECKED_COMPLSIGS(_CUDAX_GET_COMPLSIGS(_Sndr, _Env...));
+  }
+  else if constexpr (__has_get_completion_signatures<_Sndr>)
+  {
+    return _CUDAX_CHECKED_COMPLSIGS(_CUDAX_GET_COMPLSIGS(_Sndr));
+  }
+  // else if constexpr (__is_awaitable<_Sndr, __env_promise<_Env>...>)
+  // {
+  //   using Result _CCCL_NODEBUG_ALIAS = __await_result_t<_Sndr, __env_promise<_Env>...>;
+  //   return completion_signatures{__set_value_v<Result>, __set_error_v<>, __set_stopped_v};
+  // }
+  else if constexpr (sizeof...(_Env) == 0)
+  {
+    return __dependent_sender<_Sndr>();
+  }
+  else
+  {
+    return invalid_completion_signature<_COULD_NOT_DETERMINE_COMPLETION_SIGNATURES_FOR_THIS_SENDER,
+                                        _WITH_SENDER(_Sndr),
+                                        _WITH_ENVIRONMENT(_Env...)>();
+  }
+}
+
+template <class _Sndr, class... _Env>
+[[nodiscard]] _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto get_completion_signatures()
+{
+  static_assert(sizeof...(_Env) <= 1, "At most one environment is allowed.");
+  if constexpr (0 == sizeof...(_Env))
+  {
+    return execution::__get_completion_signatures_helper<_Sndr>();
+  }
+  else if constexpr (!__has_sender_transform<_Sndr, _Env...>)
+  {
+    return execution::__get_completion_signatures_helper<_Sndr, _Env...>();
+  }
+  else
+  {
+    // Apply a lazy sender transform if one exists before computing the completion signatures:
+    using _NewSndr _CCCL_NODEBUG_ALIAS =
+      _CUDA_VSTD::__call_result_t<transform_sender_t, __late_domain_of_t<_Sndr, _Env...>, _Sndr, _Env...>;
+    return execution::__get_completion_signatures_helper<_NewSndr, _Env...>();
+  }
+}
+
+template <class _Parent, class _Child, class... _Env>
+[[nodiscard]] _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto get_child_completion_signatures()
+{
+  return get_completion_signatures<_CUDA_VSTD::__copy_cvref_t<_Parent, _Child>, __fwd_env_t<_Env>...>();
+}
+
+#undef _CUDAX_GET_COMPLSIGS
+#undef _CUDAX_CHECKED_COMPLSIGS
+_CCCL_DIAG_POP
+
+#if _CCCL_HAS_EXCEPTIONS() && defined(__cpp_constexpr_exceptions) // C++26, https://wg21.link/p3068
+// When asked for its completions without an envitonment, a dependent sender
+// will throw an exception of a type derived from `dependent_sender_error`.
+template <class _Sndr>
+[[nodiscard]] _CCCL_API consteval bool __is_dependent_sender() noexcept
+try
+{
+  (void) get_completion_signatures<_Sndr>();
+  return false; // didn't throw, not a dependent sender
+}
+catch (dependent_sender_error&)
+{
+  return true;
+}
+catch (...)
+{
+  return false; // different kind of exception was thrown; not a dependent sender
+}
+#else // ^^^ constexpr exceptions ^^^ / vvv no constexpr exceptions vvv
+template <class _Sndr>
+[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL auto __is_dependent_sender() noexcept -> bool
+{
+  using _Completions _CCCL_NODEBUG_ALIAS = decltype(get_completion_signatures<_Sndr>());
+  return _CUDA_VSTD::is_base_of_v<dependent_sender_error, _Completions>;
+}
+#endif // ^^^ no constexpr exceptions ^^^
+
+} // namespace cuda::experimental::execution
+
+#include <cuda/experimental/__execution/epilogue.cuh>
+
+#endif // __CUDAX_EXECUTION_GET_COMPLETION_SIGNATURES

--- a/cudax/include/cuda/experimental/__execution/just.cuh
+++ b/cudax/include/cuda/experimental/__execution/just.cuh
@@ -36,17 +36,17 @@ namespace cuda::experimental::execution
 // Map from a disposition to the corresponding tag types:
 namespace __detail
 {
-template <__disposition_t, class _Void = void>
+template <__disposition, class _Void = void>
 extern _CUDA_VSTD::__undefined<_Void> __just_tag;
 template <class _Void>
-extern __fn_t<just_t>* __just_tag<__value, _Void>;
+extern __fn_t<just_t>* __just_tag<__disposition::__value, _Void>;
 template <class _Void>
-extern __fn_t<just_error_t>* __just_tag<__error, _Void>;
+extern __fn_t<just_error_t>* __just_tag<__disposition::__error, _Void>;
 template <class _Void>
-extern __fn_t<just_stopped_t>* __just_tag<__stopped, _Void>;
+extern __fn_t<just_stopped_t>* __just_tag<__disposition::__stopped, _Void>;
 } // namespace __detail
 
-template <__disposition_t _Disposition>
+template <__disposition _Disposition>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT _CCCL_PREFERRED_NAME(just_t) _CCCL_PREFERRED_NAME(just_error_t)
   _CCCL_PREFERRED_NAME(just_stopped_t) __just_t
 {
@@ -92,7 +92,7 @@ public:
   _CCCL_TRIVIAL_API constexpr auto operator()(_Ts... __ts) const;
 };
 
-template <__disposition_t _Disposition>
+template <__disposition _Disposition>
 template <class... _Ts>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __just_t<_Disposition>::__sndr_t
 {
@@ -123,7 +123,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __just_t<_Disposition>::__sndr_t
   _CUDA_VSTD::__tuple<_Ts...> __values_;
 };
 
-template <__disposition_t _Disposition>
+template <__disposition _Disposition>
 template <class... _Ts>
 _CCCL_TRIVIAL_API constexpr auto __just_t<_Disposition>::operator()(_Ts... __ts) const
 {

--- a/cudax/include/cuda/experimental/__execution/queries.cuh
+++ b/cudax/include/cuda/experimental/__execution/queries.cuh
@@ -190,15 +190,6 @@ _CCCL_GLOBAL_CONSTANT struct get_delegation_scheduler_t
   }
 } get_delegation_scheduler{};
 
-//////////////////////////////////////////////////////////////////////////////////////////
-// get_forward_progress_guarantee
-enum class forward_progress_guarantee
-{
-  concurrent,
-  parallel,
-  weakly_parallel
-};
-
 // This query is not a forwarding query.
 _CCCL_GLOBAL_CONSTANT struct get_forward_progress_guarantee_t
 {

--- a/cudax/include/cuda/experimental/__execution/read_env.cuh
+++ b/cudax/include/cuda/experimental/__execution/read_env.cuh
@@ -30,6 +30,7 @@
 #include <cuda/experimental/__execution/cpos.cuh>
 #include <cuda/experimental/__execution/env.cuh>
 #include <cuda/experimental/__execution/exception.cuh>
+#include <cuda/experimental/__execution/get_completion_signatures.cuh>
 #include <cuda/experimental/__execution/queries.cuh>
 #include <cuda/experimental/__execution/utility.cuh>
 #include <cuda/experimental/__execution/visit.cuh>

--- a/cudax/include/cuda/experimental/__execution/schedule_from.cuh
+++ b/cudax/include/cuda/experimental/__execution/schedule_from.cuh
@@ -31,9 +31,11 @@
 #include <cuda/experimental/__execution/cpos.cuh>
 #include <cuda/experimental/__execution/env.cuh>
 #include <cuda/experimental/__execution/exception.cuh>
+#include <cuda/experimental/__execution/get_completion_signatures.cuh>
 #include <cuda/experimental/__execution/meta.cuh>
 #include <cuda/experimental/__execution/queries.cuh>
 #include <cuda/experimental/__execution/rcvr_ref.cuh>
+#include <cuda/experimental/__execution/transform_completion_signatures.cuh>
 #include <cuda/experimental/__execution/transform_sender.cuh>
 #include <cuda/experimental/__execution/utility.cuh>
 #include <cuda/experimental/__execution/variant.cuh>

--- a/cudax/include/cuda/experimental/__execution/sequence.cuh
+++ b/cudax/include/cuda/experimental/__execution/sequence.cuh
@@ -29,8 +29,10 @@
 #include <cuda/experimental/__execution/cpos.cuh>
 #include <cuda/experimental/__execution/env.cuh>
 #include <cuda/experimental/__execution/exception.cuh>
+#include <cuda/experimental/__execution/get_completion_signatures.cuh>
 #include <cuda/experimental/__execution/lazy.cuh>
 #include <cuda/experimental/__execution/rcvr_ref.cuh>
+#include <cuda/experimental/__execution/transform_completion_signatures.cuh>
 #include <cuda/experimental/__execution/transform_sender.cuh>
 #include <cuda/experimental/__execution/utility.cuh>
 #include <cuda/experimental/__execution/variant.cuh>

--- a/cudax/include/cuda/experimental/__execution/starts_on.cuh
+++ b/cudax/include/cuda/experimental/__execution/starts_on.cuh
@@ -27,9 +27,11 @@
 #include <cuda/experimental/__detail/utility.cuh>
 #include <cuda/experimental/__execution/completion_signatures.cuh>
 #include <cuda/experimental/__execution/cpos.cuh>
+#include <cuda/experimental/__execution/get_completion_signatures.cuh>
 #include <cuda/experimental/__execution/queries.cuh>
 #include <cuda/experimental/__execution/rcvr_ref.cuh>
 #include <cuda/experimental/__execution/rcvr_with_env.cuh>
+#include <cuda/experimental/__execution/transform_completion_signatures.cuh>
 #include <cuda/experimental/__execution/utility.cuh>
 #include <cuda/experimental/__execution/variant.cuh>
 #include <cuda/experimental/__execution/visit.cuh>

--- a/cudax/include/cuda/experimental/__execution/stream/adaptor.cuh
+++ b/cudax/include/cuda/experimental/__execution/stream/adaptor.cuh
@@ -33,9 +33,10 @@
 #include <cuda/std/__utility/pod_tuple.h>
 
 #include <cuda/experimental/__detail/utility.cuh>
-#include <cuda/experimental/__execution/completion_signatures.cuh>
 #include <cuda/experimental/__execution/domain.cuh>
+#include <cuda/experimental/__execution/get_completion_signatures.cuh>
 #include <cuda/experimental/__execution/stream/domain.cuh>
+#include <cuda/experimental/__execution/utility.cuh>
 #include <cuda/experimental/__execution/variant.cuh>
 #include <cuda/experimental/__launch/configuration.cuh>
 #include <cuda/experimental/__launch/launch.cuh>
@@ -339,7 +340,14 @@ struct __sndr_t
 template <class _Sndr>
 _CCCL_API constexpr auto __adapt(_Sndr __sndr, stream_ref __stream) -> decltype(auto)
 {
-  return __sndr_t<_Sndr>{{__stream, static_cast<_Sndr&&>(__sndr)}};
+  if constexpr (__is_specialization_of_v<_Sndr, __sndr_t>)
+  {
+    return _Sndr(static_cast<_Sndr&&>(__sndr));
+  }
+  else
+  {
+    return __sndr_t<_Sndr>{{__stream, static_cast<_Sndr&&>(__sndr)}};
+  }
 }
 
 template <class _Sndr>

--- a/cudax/include/cuda/experimental/__execution/stream/context.cuh
+++ b/cudax/include/cuda/experimental/__execution/stream/context.cuh
@@ -22,35 +22,15 @@
 #endif // no system header
 
 #include <cuda/__stream/get_stream.h>
-#include <cuda/std/__memory/unique_ptr.h>
-#include <cuda/std/__type_traits/is_callable.h>
 
-#include <cuda/experimental/__detail/utility.cuh>
-#include <cuda/experimental/__execution/completion_signatures.cuh>
-#include <cuda/experimental/__execution/cpos.cuh>
-#include <cuda/experimental/__execution/domain.cuh>
-#include <cuda/experimental/__execution/fwd.cuh>
-#include <cuda/experimental/__execution/queries.cuh>
-#include <cuda/experimental/__execution/rcvr_ref.cuh>
-#include <cuda/experimental/__execution/stream/domain.cuh>
-#include <cuda/experimental/__execution/utility.cuh>
-#include <cuda/experimental/device.cuh>
+#include <cuda/experimental/__device/device_ref.cuh>
+#include <cuda/experimental/__execution/stream/scheduler.cuh>
 #include <cuda/experimental/stream.cuh>
-
-#include <new> // IWYU pragma: keep for placement new
-
-#include <cuda_runtime_api.h>
 
 #include <cuda/experimental/__execution/prologue.cuh>
 
 namespace cuda::experimental::execution
 {
-template <class _Tag, class _Rcvr, class... _Args>
-__launch_bounds__(1) __global__ static void __stream_complete(_Tag, _Rcvr* __rcvr, _Args... __args)
-{
-  _Tag{}(static_cast<_Rcvr&&>(*__rcvr), static_cast<_Args&&>(__args)...);
-}
-
 //////////////////////////////////////////////////////////////////////////////////////////
 // stream_context
 struct _CCCL_TYPE_VISIBILITY_DEFAULT stream_context : private __immovable
@@ -69,158 +49,14 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT stream_context : private __immovable
     return __stream_;
   }
 
-  ////////////////////////////////////////////////////////////////////////////////////////
-  // stream scheduler
-  struct _CCCL_TYPE_VISIBILITY_DEFAULT scheduler
+  [[nodiscard]] _CCCL_TRIVIAL_HOST_API auto get_scheduler() noexcept -> stream_scheduler
   {
-    using scheduler_concept = scheduler_t;
-
-    [[nodiscard]] _CCCL_API constexpr auto query(get_stream_t) const noexcept -> stream_ref
-    {
-      return __stream_;
-    }
-
-    [[nodiscard]] _CCCL_API static constexpr auto query(get_domain_t) noexcept -> stream_domain
-    {
-      return {};
-    }
-
-    [[nodiscard]] _CCCL_API static constexpr auto query(get_forward_progress_guarantee_t) noexcept
-      -> forward_progress_guarantee
-    {
-      return forward_progress_guarantee::weakly_parallel;
-    }
-
-    [[nodiscard]] _CCCL_API auto schedule() const noexcept
-    {
-      return __sndr_t{{}, {__stream_}};
-    }
-
-    [[nodiscard]] _CCCL_API friend bool operator==(const scheduler& __lhs, const scheduler& __rhs) noexcept
-    {
-      return __lhs.__stream_ == __rhs.__stream_;
-    }
-
-    [[nodiscard]] _CCCL_API friend bool operator!=(const scheduler& __lhs, const scheduler& __rhs) noexcept
-    {
-      return __lhs.__stream_ != __rhs.__stream_;
-    }
-
-    stream_ref __stream_;
-  };
-
-  [[nodiscard]] _CCCL_TRIVIAL_HOST_API auto get_scheduler() noexcept -> scheduler
-  {
-    return scheduler{__stream_};
+    return stream_scheduler{__stream_};
   }
 
-  _CUDAX_SEMI_PRIVATE :
-  ////////////////////////////////////////////////////////////////////////////////////////
-  // attributes of the stream scheduler's sender
-  struct _CCCL_TYPE_VISIBILITY_DEFAULT __attrs_t
-  {
-    [[nodiscard]] _CCCL_API constexpr auto query(get_stream_t) const noexcept -> stream_ref
-    {
-      return __stream_;
-    }
-
-    [[nodiscard]] _CCCL_API constexpr auto query(get_completion_scheduler_t<set_value_t>) const noexcept -> scheduler
-    {
-      return scheduler{__stream_};
-    }
-
-    [[nodiscard]] _CCCL_TRIVIAL_API static constexpr auto query(get_domain_t) noexcept -> stream_domain
-    {
-      return {};
-    }
-
-    [[nodiscard]] _CCCL_TRIVIAL_API static constexpr auto query(get_domain_late_t) noexcept -> stream_domain
-    {
-      return {};
-    }
-
-    stream_ref __stream_;
-  };
-
-  ////////////////////////////////////////////////////////////////////////////////////////
-  // stream scheduler's operation state
-  template <class _Rcvr>
-  struct _CCCL_TYPE_VISIBILITY_DEFAULT __opstate_t
-  {
-    using operation_state_concept = operation_state_t;
-
-    _CCCL_EXEC_CHECK_DISABLE
-    _CCCL_API constexpr explicit __opstate_t(_Rcvr __rcvr, stream_ref __stream_ref) noexcept(__nothrow_movable<_Rcvr>)
-        : __rcvr_{static_cast<_Rcvr&&>(__rcvr)}
-        , __stream_{__stream_ref}
-    {
-      _CCCL_ASSERT(execution::__get_pointer_attributes(this).type == ::cudaMemoryTypeManaged,
-                   "stream scheduler's operation state must be allocated in managed memory");
-    }
-
-    _CCCL_IMMOVABLE_OPSTATE(__opstate_t);
-
-    _CCCL_API constexpr void start() noexcept
-    {
-      NV_IF_TARGET(NV_IS_HOST, (__host_start();), (__device_start();));
-    }
-
-  private:
-    _CCCL_HOST_API void __host_start() noexcept
-    {
-      __stream_complete<<<1, 1, 0, __stream_.get()>>>(set_value, &__rcvr_);
-      if (auto __status = cudaGetLastError(); __status != cudaSuccess)
-      {
-        execution::set_error(static_cast<_Rcvr&&>(__rcvr_), cudaError_t(__status));
-      }
-    }
-
-    _CCCL_DEVICE_API void __device_start() noexcept
-    {
-      // without the following, the kernel in __host_start will fail to launch with
-      // cudaErrorInvalidDeviceFunction.
-      [[maybe_unused]] auto __ignore = &__stream_complete<set_value_t, _Rcvr>;
-      execution::set_value(static_cast<_Rcvr&&>(__rcvr_));
-    }
-
-    _Rcvr __rcvr_;
-    stream_ref __stream_;
-  };
-
-  struct _CCCL_TYPE_VISIBILITY_DEFAULT __tag_t
-  {};
-
-  ////////////////////////////////////////////////////////////////////////////////////////
-  // stream scheduler's sender
-  struct _CCCL_TYPE_VISIBILITY_DEFAULT __sndr_t
-  {
-    using sender_concept = sender_t;
-
-    template <class _Self>
-    _CCCL_API static _CCCL_CONSTEVAL auto get_completion_signatures() noexcept
-    {
-      return completion_signatures<set_value_t(), set_error_t(cudaError_t)>{};
-    }
-
-    [[nodiscard]] _CCCL_API constexpr auto get_env() const noexcept -> const __attrs_t&
-    {
-      return __env_;
-    }
-
-    template <class _Rcvr>
-    [[nodiscard]] _CCCL_API constexpr auto connect(_Rcvr __rcvr) const noexcept -> __opstate_t<_Rcvr>
-    {
-      return __opstate_t<_Rcvr>{static_cast<_Rcvr&&>(__rcvr), __env_.__stream_};
-    }
-
-    _CCCL_NO_UNIQUE_ADDRESS __tag_t __tag_;
-    __attrs_t __env_;
-  };
-
-  stream __stream_{no_init};
+private:
+  stream __stream_;
 };
-
-using stream_scheduler = stream_context::scheduler;
 
 } // namespace cuda::experimental::execution
 

--- a/cudax/include/cuda/experimental/__execution/stream/let_value.cuh
+++ b/cudax/include/cuda/experimental/__execution/stream/let_value.cuh
@@ -31,7 +31,7 @@ namespace cuda::experimental::execution
 {
 /////////////////////////////////////////////////////////////////////////////////
 // let_value, let_error, let_stopped: customization for the stream scheduler
-template <__disposition_t _Disposition>
+template <__disposition _Disposition>
 struct stream_domain::__apply_t<__let_t<_Disposition>>
 {
   template <class _Sndr, class _Env>

--- a/cudax/include/cuda/experimental/__execution/stream/scheduler.cuh
+++ b/cudax/include/cuda/experimental/__execution/stream/scheduler.cuh
@@ -1,0 +1,220 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __CUDAX_EXECUTION_STREAM_SCHEDULER
+#define __CUDAX_EXECUTION_STREAM_SCHEDULER
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/__stream/get_stream.h>
+
+#include <cuda/experimental/__execution/completion_signatures.cuh>
+#include <cuda/experimental/__execution/cpos.cuh>
+#include <cuda/experimental/__execution/fwd.cuh>
+#include <cuda/experimental/__execution/queries.cuh>
+#include <cuda/experimental/__execution/stream/domain.cuh>
+#include <cuda/experimental/__execution/type_traits.cuh>
+#include <cuda/experimental/__execution/utility.cuh>
+#include <cuda/experimental/__stream/stream_ref.cuh>
+
+#include <cuda_runtime_api.h>
+
+#include <cuda/experimental/__execution/prologue.cuh>
+
+namespace cuda::experimental
+{
+namespace execution
+{
+template <class _Tag, class _Rcvr, class... _Args>
+__launch_bounds__(1) __global__ static void __stream_complete(_Tag, _Rcvr* __rcvr, _Args... __args)
+{
+  _Tag{}(static_cast<_Rcvr&&>(*__rcvr), static_cast<_Args&&>(__args)...);
+}
+
+////////////////////////////////////////////////////////////////////////////////////////
+// stream scheduler
+struct _CCCL_TYPE_VISIBILITY_DEFAULT stream_scheduler
+{
+  using scheduler_concept = scheduler_t;
+
+  _CUDAX_SEMI_PRIVATE:
+  ////////////////////////////////////////////////////////////////////////////////////////
+  // attributes of the stream scheduler's sender
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __attrs_t
+  {
+    [[nodiscard]] _CCCL_API constexpr auto query(get_stream_t) const noexcept -> stream_ref
+    {
+      return __stream_;
+    }
+
+    [[nodiscard]] _CCCL_API constexpr auto query(get_completion_scheduler_t<set_value_t>) const noexcept
+      -> stream_scheduler
+    {
+      return stream_scheduler{__stream_};
+    }
+
+    [[nodiscard]] _CCCL_TRIVIAL_API static constexpr auto query(get_domain_t) noexcept -> stream_domain
+    {
+      return {};
+    }
+
+    [[nodiscard]] _CCCL_TRIVIAL_API static constexpr auto query(get_domain_late_t) noexcept -> stream_domain
+    {
+      return {};
+    }
+
+    stream_ref __stream_;
+  };
+
+  ////////////////////////////////////////////////////////////////////////////////////////
+  // stream scheduler's operation state
+  template <class _Rcvr>
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __opstate_t
+  {
+    using operation_state_concept = operation_state_t;
+
+    _CCCL_EXEC_CHECK_DISABLE
+    _CCCL_API explicit __opstate_t(_Rcvr __rcvr, stream_ref __stream_ref) noexcept
+        : __rcvr_{static_cast<_Rcvr&&>(__rcvr)}
+        , __stream_{__stream_ref}
+    {
+      _CCCL_ASSERT(execution::__get_pointer_attributes(this).type == cudaMemoryTypeManaged,
+                   "stream scheduler's operation state must be allocated in managed memory");
+    }
+
+    _CCCL_IMMOVABLE_OPSTATE(__opstate_t);
+
+    _CCCL_API void start() noexcept
+    {
+      NV_IF_TARGET(NV_IS_HOST, (__host_start();), (__device_start();));
+    }
+
+  private:
+    _CCCL_HOST_API void __host_start() noexcept
+    {
+      __stream_complete<<<1, 1, 0, __stream_.get()>>>(set_value, &__rcvr_);
+      if (auto __status = cudaGetLastError(); __status != cudaSuccess)
+      {
+        execution::set_error(static_cast<_Rcvr&&>(__rcvr_), cudaError_t(__status));
+      }
+    }
+
+    _CCCL_DEVICE_API void __device_start() noexcept
+    {
+      // without the following, the kernel in __host_start will fail to launch with
+      // cudaErrorInvalidDeviceFunction.
+      [[maybe_unused]] auto __ignore = &__stream_complete<set_value_t, _Rcvr>;
+      execution::set_value(static_cast<_Rcvr&&>(__rcvr_));
+    }
+
+    _Rcvr __rcvr_;
+    stream_ref __stream_;
+  };
+
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __tag_t
+  {};
+
+public:
+  _CCCL_API explicit constexpr stream_scheduler(stream_ref __stream) noexcept
+      : __stream_{__stream}
+  {}
+
+  ////////////////////////////////////////////////////////////////////////////////////////
+  // stream scheduler's sender
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __sndr_t
+  {
+    using sender_concept = sender_t;
+
+    _CCCL_API constexpr explicit __sndr_t(stream_ref __stream) noexcept
+        : __attrs_{__stream}
+    {}
+
+    template <class _Self>
+    _CCCL_API static _CCCL_CONSTEVAL auto get_completion_signatures() noexcept
+    {
+      return completion_signatures<set_value_t(), set_error_t(cudaError_t)>{};
+    }
+
+    [[nodiscard]] _CCCL_API constexpr auto get_env() const noexcept -> const __attrs_t&
+    {
+      return __attrs_;
+    }
+
+    template <class _Rcvr>
+    [[nodiscard]] _CCCL_API auto connect(_Rcvr __rcvr) const noexcept -> __opstate_t<_Rcvr>
+    {
+      return __opstate_t<_Rcvr>{static_cast<_Rcvr&&>(__rcvr), __attrs_.__stream_};
+    }
+
+    _CCCL_NO_UNIQUE_ADDRESS __tag_t __tag_;
+    __attrs_t __attrs_;
+  };
+
+  [[nodiscard]] _CCCL_API constexpr auto query(get_stream_t) const noexcept -> stream_ref
+  {
+    return __stream_;
+  }
+
+  [[nodiscard]] _CCCL_API static constexpr auto query(get_domain_t) noexcept -> stream_domain
+  {
+    return {};
+  }
+
+  [[nodiscard]] _CCCL_API static constexpr auto query(get_forward_progress_guarantee_t) noexcept
+    -> forward_progress_guarantee
+  {
+    return forward_progress_guarantee::weakly_parallel;
+  }
+
+  [[nodiscard]] _CCCL_API auto schedule() const noexcept -> __sndr_t
+  {
+    return __sndr_t{__stream_};
+  }
+
+  [[nodiscard]] _CCCL_API friend bool operator==(const stream_scheduler& __lhs, const stream_scheduler& __rhs) noexcept
+  {
+    return __lhs.__stream_ == __rhs.__stream_;
+  }
+
+  [[nodiscard]] _CCCL_API friend bool operator!=(const stream_scheduler& __lhs, const stream_scheduler& __rhs) noexcept
+  {
+    return __lhs.__stream_ != __rhs.__stream_;
+  }
+
+private:
+  stream_ref __stream_;
+};
+
+} // namespace execution
+
+_CCCL_HOST_API inline auto stream_ref::schedule() const noexcept
+{
+  return execution::schedule(execution::stream_scheduler{*this});
+}
+
+[[nodiscard]] _CCCL_API constexpr auto stream_ref::query(const execution::get_domain_t&) noexcept
+  -> execution::stream_domain
+{
+  return {};
+}
+
+} // namespace cuda::experimental
+
+#include <cuda/experimental/__execution/epilogue.cuh>
+
+#endif // __CUDAX_EXECUTION_STREAM_SCHEDULER

--- a/cudax/include/cuda/experimental/__execution/then.cuh
+++ b/cudax/include/cuda/experimental/__execution/then.cuh
@@ -46,14 +46,14 @@ namespace cuda::experimental::execution
 // Map from a disposition to the corresponding tag types:
 namespace __detail
 {
-template <__disposition_t, class _Void = void>
+template <__disposition, class _Void = void>
 extern _CUDA_VSTD::__undefined<_Void> __upon_tag;
 template <class _Void>
-extern __fn_t<then_t>* __upon_tag<__value, _Void>;
+extern __fn_t<then_t>* __upon_tag<__disposition::__value, _Void>;
 template <class _Void>
-extern __fn_t<upon_error_t>* __upon_tag<__error, _Void>;
+extern __fn_t<upon_error_t>* __upon_tag<__disposition::__error, _Void>;
 template <class _Void>
-extern __fn_t<upon_stopped_t>* __upon_tag<__stopped, _Void>;
+extern __fn_t<upon_stopped_t>* __upon_tag<__disposition::__stopped, _Void>;
 } // namespace __detail
 
 namespace __upon
@@ -95,7 +95,7 @@ using __completion _CCCL_NODEBUG_ALIAS =
   __completion_<_CUDA_VSTD::__call_result_t<_Fn, _Ts...>, __nothrow_callable<_Fn, _Ts...>>;
 } // namespace __upon
 
-template <__disposition_t _Disposition>
+template <__disposition _Disposition>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT _CCCL_PREFERRED_NAME(then_t) _CCCL_PREFERRED_NAME(upon_error_t)
   _CCCL_PREFERRED_NAME(upon_stopped_t) __upon_t
 {
@@ -227,7 +227,7 @@ public:
   _CCCL_TRIVIAL_API constexpr auto operator()(_Fn __fn) const;
 };
 
-template <__disposition_t _Disposition>
+template <__disposition _Disposition>
 template <class _Fn, class _Sndr>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __upon_t<_Disposition>::__sndr_t
 {
@@ -241,11 +241,11 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __upon_t<_Disposition>::__sndr_t
   {
     _CUDAX_LET_COMPLETIONS(auto(__child_completions) = get_child_completion_signatures<_Self, _Sndr, _Env...>())
     {
-      if constexpr (_Disposition == __disposition_t::__value)
+      if constexpr (_Disposition == __disposition::__value)
       {
         return transform_completion_signatures(__child_completions, __transform_args_fn<_Fn>{});
       }
-      else if constexpr (_Disposition == __disposition_t::__error)
+      else if constexpr (_Disposition == __disposition::__error)
       {
         return transform_completion_signatures(__child_completions, {}, __transform_args_fn<_Fn>{});
       }
@@ -284,7 +284,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __upon_t<_Disposition>::__sndr_t
   }
 };
 
-template <__disposition_t _Disposition>
+template <__disposition _Disposition>
 template <class _Fn>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __upon_t<_Disposition>::__closure_t
 {
@@ -305,7 +305,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __upon_t<_Disposition>::__closure_t
   }
 };
 
-template <__disposition_t _Disposition>
+template <__disposition _Disposition>
 template <class _Sndr, class _Fn>
 _CCCL_TRIVIAL_API constexpr auto __upon_t<_Disposition>::operator()(_Sndr __sndr, _Fn __fn) const
 {
@@ -319,7 +319,7 @@ _CCCL_TRIVIAL_API constexpr auto __upon_t<_Disposition>::operator()(_Sndr __sndr
   return transform_sender(__dom_t{}, __sndr_t<_Fn, _Sndr>{{}, static_cast<_Fn&&>(__fn), static_cast<_Sndr&&>(__sndr)});
 }
 
-template <__disposition_t _Disposition>
+template <__disposition _Disposition>
 template <class _Fn>
 _CCCL_TRIVIAL_API constexpr auto __upon_t<_Disposition>::operator()(_Fn __fn) const
 {

--- a/cudax/include/cuda/experimental/__execution/transform_completion_signatures.cuh
+++ b/cudax/include/cuda/experimental/__execution/transform_completion_signatures.cuh
@@ -1,0 +1,193 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __CUDAX_EXECUTION_TRANSFORM_COMPLETION_SIGNATURES
+#define __CUDAX_EXECUTION_TRANSFORM_COMPLETION_SIGNATURES
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__type_traits/decay.h>
+#include <cuda/std/__type_traits/is_base_of.h>
+#include <cuda/std/__type_traits/is_callable.h>
+#include <cuda/std/__type_traits/type_list.h>
+#include <cuda/std/__type_traits/type_set.h>
+
+#include <cuda/experimental/__execution/completion_signatures.cuh> // IWYU pragma: export
+#include <cuda/experimental/__execution/fwd.cuh>
+#include <cuda/experimental/__execution/get_completion_signatures.cuh>
+
+// include this last:
+#include <cuda/experimental/__execution/prologue.cuh>
+
+namespace cuda::experimental::execution
+{
+template <class _Tag>
+struct __default_transform_fn
+{
+  template <class... _Ts>
+  _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto operator()() const noexcept -> completion_signatures<_Tag(_Ts...)>
+  {
+    return {};
+  }
+};
+
+struct __swallow_transform
+{
+  template <class... _Ts>
+  _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto operator()() const noexcept -> completion_signatures<>
+  {
+    return {};
+  }
+};
+
+template <class _Tag>
+struct __decay_transform
+{
+  template <class... _Ts>
+  _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto operator()() const noexcept
+    -> completion_signatures<_Tag(_CUDA_VSTD::decay_t<_Ts>...)>
+  {
+    return {};
+  }
+};
+
+template <class _Fn, class... _As>
+using __meta_call_result_t _CCCL_NODEBUG_ALIAS = decltype(declval<_Fn>().template operator()<_As...>());
+
+_CCCL_EXEC_CHECK_DISABLE
+template <class _Ay, class... _As, class _Fn>
+[[nodiscard]] _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto __transform_expr(const _Fn& __fn)
+  -> __meta_call_result_t<const _Fn&, _Ay, _As...>
+{
+  return __fn.template operator()<_Ay, _As...>();
+}
+
+_CCCL_EXEC_CHECK_DISABLE
+template <class _Fn>
+[[nodiscard]] _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto __transform_expr(const _Fn& __fn)
+  -> _CUDA_VSTD::__call_result_t<const _Fn&>
+{
+  return __fn();
+}
+
+template <class _Fn, class... _As>
+using __transform_expr_t _CCCL_NODEBUG_ALIAS = decltype(execution::__transform_expr<_As...>(declval<const _Fn&>()));
+
+struct _IN_TRANSFORM_COMPLETION_SIGNATURES;
+struct _A_TRANSFORM_FUNCTION_RETURNED_A_TYPE_THAT_IS_NOT_A_COMPLETION_SIGNATURES_SPECIALIZATION;
+struct _COULD_NOT_CALL_THE_TRANSFORM_FUNCTION_WITH_THE_GIVEN_TEMPLATE_ARGUMENTS;
+
+// transform_completion_signatures:
+template <class... _As, class _Fn>
+[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL auto __apply_transform(const _Fn& __fn)
+{
+  if constexpr (__is_instantiable_with_v<__transform_expr_t, _Fn, _As...>)
+  {
+    using __completions _CCCL_NODEBUG_ALIAS = __transform_expr_t<_Fn, _As...>;
+    if constexpr (__valid_completion_signatures<__completions> || __type_is_error<__completions>
+                  || _CUDA_VSTD::is_base_of_v<dependent_sender_error, __completions>)
+    {
+      return execution::__transform_expr<_As...>(__fn);
+    }
+    else
+    {
+      (void) execution::__transform_expr<_As...>(__fn); // potentially throwing
+      return invalid_completion_signature<
+        _IN_TRANSFORM_COMPLETION_SIGNATURES,
+        _A_TRANSFORM_FUNCTION_RETURNED_A_TYPE_THAT_IS_NOT_A_COMPLETION_SIGNATURES_SPECIALIZATION,
+        _WITH_FUNCTION(_Fn),
+        _WITH_ARGUMENTS(_As...)>();
+    }
+  }
+  else
+  {
+    return invalid_completion_signature< //
+      _IN_TRANSFORM_COMPLETION_SIGNATURES,
+      _COULD_NOT_CALL_THE_TRANSFORM_FUNCTION_WITH_THE_GIVEN_TEMPLATE_ARGUMENTS,
+      _WITH_FUNCTION(_Fn),
+      _WITH_ARGUMENTS(_As...)>();
+  }
+}
+
+template <class _ValueFn, class _ErrorFn, class _StoppedFn>
+struct __transform_one
+{
+  _ValueFn __value_fn;
+  _ErrorFn __error_fn;
+  _StoppedFn __stopped_fn;
+
+  template <class _Tag, class... _Ts>
+  [[nodiscard]] _CCCL_API _CCCL_CONSTEVAL auto operator()(_Tag (*)(_Ts...)) const
+  {
+    if constexpr (_Tag{} == set_value)
+    {
+      return __apply_transform<_Ts...>(__value_fn);
+    }
+    else if constexpr (_Tag{} == set_error)
+    {
+      return __apply_transform<_Ts...>(__error_fn);
+    }
+    else
+    {
+      return __apply_transform<_Ts...>(__stopped_fn);
+    }
+  }
+};
+
+template <class _TransformOne>
+struct __transform_all_fn
+{
+  _TransformOne __tfx1;
+
+  template <class... _Sigs>
+  [[nodiscard]] _CCCL_API _CCCL_CONSTEVAL auto operator()(_Sigs*... __sigs) const
+  {
+    return concat_completion_signatures(__tfx1(__sigs)...);
+  }
+};
+
+template <class _TransformOne>
+__transform_all_fn(_TransformOne) -> __transform_all_fn<_TransformOne>;
+
+template <class _Completions,
+          class _ValueFn   = __default_transform_fn<set_value_t>,
+          class _ErrorFn   = __default_transform_fn<set_error_t>,
+          class _StoppedFn = __default_transform_fn<set_stopped_t>,
+          class _ExtraSigs = completion_signatures<>>
+_CCCL_API _CCCL_CONSTEVAL auto transform_completion_signatures(
+  _Completions, //
+  _ValueFn __value_fn     = {},
+  _ErrorFn __error_fn     = {},
+  _StoppedFn __stopped_fn = {},
+  _ExtraSigs              = {})
+{
+  _CUDAX_LET_COMPLETIONS(auto(__completions) = _Completions{})
+  {
+    _CUDAX_LET_COMPLETIONS(auto(__extra) = _ExtraSigs{})
+    {
+      __transform_one<_ValueFn, _ErrorFn, _StoppedFn> __tfx1{__value_fn, __error_fn, __stopped_fn};
+      return concat_completion_signatures(__completions.apply(__transform_all_fn{__tfx1}), __extra);
+    }
+  }
+}
+
+} // namespace cuda::experimental::execution
+
+#include <cuda/experimental/__execution/epilogue.cuh>
+
+#endif // __CUDAX_EXECUTION_TRANSFORM_COMPLETION_SIGNATURES

--- a/cudax/include/cuda/experimental/__execution/when_all.cuh
+++ b/cudax/include/cuda/experimental/__execution/when_all.cuh
@@ -44,6 +44,7 @@
 #include <cuda/experimental/__execution/meta.cuh>
 #include <cuda/experimental/__execution/queries.cuh>
 #include <cuda/experimental/__execution/stop_token.cuh>
+#include <cuda/experimental/__execution/transform_completion_signatures.cuh>
 #include <cuda/experimental/__execution/transform_sender.cuh>
 #include <cuda/experimental/__execution/type_traits.cuh>
 #include <cuda/experimental/__execution/utility.cuh>

--- a/cudax/include/cuda/experimental/__stream/stream.cuh
+++ b/cudax/include/cuda/experimental/__stream/stream.cuh
@@ -27,7 +27,7 @@
 
 #include <cuda/experimental/__device/device_ref.cuh>
 #include <cuda/experimental/__device/logical_device.cuh>
-#include <cuda/experimental/__stream/stream_ref.cuh>
+#include <cuda/experimental/__stream/stream_ref.cuh> // IWYU pragma: export
 #include <cuda/experimental/__utility/ensure_current_device.cuh>
 
 #include <cuda/std/__cccl/prologue.h>
@@ -139,6 +139,12 @@ struct stream : stream_ref
   [[nodiscard]] ::cudaStream_t release()
   {
     return _CUDA_VSTD::exchange(__stream, __detail::__invalid_stream);
+  }
+
+  //! @brief Returns a \c execution::scheduler that enqueues work on this stream.
+  auto get_scheduler() const noexcept -> stream_ref
+  {
+    return *this;
   }
 
 private:

--- a/cudax/include/cuda/experimental/__stream/stream_ref.cuh
+++ b/cudax/include/cuda/experimental/__stream/stream_ref.cuh
@@ -26,6 +26,7 @@
 #include <cuda/experimental/__device/all_devices.cuh>
 #include <cuda/experimental/__device/logical_device.cuh>
 #include <cuda/experimental/__event/timed_event.cuh>
+#include <cuda/experimental/__execution/fwd.cuh>
 #include <cuda/experimental/__utility/ensure_current_device.cuh>
 
 #include <cuda_runtime_api.h>
@@ -67,13 +68,11 @@ struct stream_ref : ::cuda::stream_ref
   /// Disallow construction from `nullptr`.
   stream_ref(_CUDA_VSTD::nullptr_t) = delete;
 
-  /**
-   * \brief Queries if all operations on the stream have completed.
-   *
-   * \throws cuda::cuda_error if the query fails.
-   *
-   * \return `true` if all operations have completed, or `false` if not.
-   */
+  //! \brief Queries if all operations on the stream have completed.
+  //!
+  //! \throws cuda::cuda_error if the query fails.
+  //!
+  //! \return `true` if all operations have completed, or `false` if not.
   [[nodiscard]] bool is_done() const
   {
     const auto __result = __detail::driver::streamQuery(__stream);
@@ -145,6 +144,11 @@ struct stream_ref : ::cuda::stream_ref
     __detail::driver::streamWaitEvent(get(), __ev.get());
   }
 
+  //! @brief Returns a \c execution::sender that completes on this stream.
+  //!
+  //! @note Equivalent to `execution::schedule(execution::stream_scheduler{*this})`.
+  _CCCL_HOST_API auto schedule() const noexcept;
+
   //! @brief Make all future work submitted into this stream depend on completion of all work from the specified
   //! stream
   //!
@@ -210,6 +214,20 @@ struct stream_ref : ::cuda::stream_ref
   {
     return get_logical_device().get_underlying_device();
   }
+
+  [[nodiscard]] _CCCL_API constexpr auto query(const get_stream_t&) const noexcept -> stream_ref
+  {
+    return *this;
+  }
+
+  [[nodiscard]] _CCCL_API static constexpr auto query(const execution::get_forward_progress_guarantee_t&) noexcept
+    -> execution::forward_progress_guarantee
+  {
+    return execution::forward_progress_guarantee::weakly_parallel;
+  }
+
+  [[nodiscard]] _CCCL_API static constexpr auto query(const execution::get_domain_t&) noexcept
+    -> execution::stream_domain;
 };
 
 } // namespace cuda::experimental

--- a/cudax/include/cuda/experimental/execution.cuh
+++ b/cudax/include/cuda/experimental/execution.cuh
@@ -13,11 +13,13 @@
 
 // IWYU pragma: begin_exports
 #include <cuda/experimental/__execution/apply_sender.cuh>
+#include <cuda/experimental/__execution/completion_signatures.cuh>
 #include <cuda/experimental/__execution/conditional.cuh>
 #include <cuda/experimental/__execution/continues_on.cuh>
 #include <cuda/experimental/__execution/cpos.cuh>
 #include <cuda/experimental/__execution/domain.cuh>
 #include <cuda/experimental/__execution/env.cuh>
+#include <cuda/experimental/__execution/get_completion_signatures.cuh>
 #include <cuda/experimental/__execution/just.cuh>
 #include <cuda/experimental/__execution/just_from.cuh>
 #include <cuda/experimental/__execution/let_value.cuh>
@@ -34,6 +36,7 @@
 #include <cuda/experimental/__execution/sync_wait.cuh>
 #include <cuda/experimental/__execution/then.cuh>
 #include <cuda/experimental/__execution/thread_context.cuh>
+#include <cuda/experimental/__execution/transform_completion_signatures.cuh>
 #include <cuda/experimental/__execution/transform_sender.cuh>
 #include <cuda/experimental/__execution/visit.cuh>
 #include <cuda/experimental/__execution/when_all.cuh>

--- a/cudax/include/cuda/experimental/stream.cuh
+++ b/cudax/include/cuda/experimental/stream.cuh
@@ -11,6 +11,7 @@
 #ifndef __CUDAX_STREAM__
 #define __CUDAX_STREAM__
 
+#include <cuda/experimental/__execution/stream/scheduler.cuh>
 #include <cuda/experimental/__stream/stream.cuh>
 
 #endif // __CUDAX_STREAM__

--- a/cudax/test/execution/test_completion_signatures.cu
+++ b/cudax/test/execution/test_completion_signatures.cu
@@ -108,8 +108,8 @@ struct filter_value_only
   template <class Sig>
   constexpr bool operator()(Sig*) const noexcept
   {
-    return cuda::experimental::execution::__signature_disposition<Sig>
-        == cuda::experimental::execution::__disposition_t::__value;
+    return cuda::experimental::execution::__detail::__signature_disposition<Sig>
+        == cuda::experimental::execution::__disposition::__value;
   }
 };
 

--- a/cudax/test/execution/test_stream_context.cu
+++ b/cudax/test/execution/test_stream_context.cu
@@ -82,6 +82,35 @@ void stream_context_test2()
   printf("All done on the host! result = %d\n", i);
 }
 
+void stream_ref_as_scheduler()
+{
+  cudax_async::thread_context tctx;
+  cudax::stream sctx{cuda::experimental::device_ref{0}};
+  auto sch = sctx.get_scheduler();
+
+  auto start = //
+    cudax_async::schedule(sch) // begin work on the GPU
+    | cudax_async::then(_say_hello{42}) // enqueue a function object on the GPU
+    | cudax_async::then([] __device__(int i) noexcept -> int { // enqueue a lambda on the GPU
+        CUDAX_CHECK(_is_on_device());
+        printf("Hello again from lambda on device! i = %d\n", i);
+        return i + 1;
+      })
+    | cudax_async::continues_on(tctx.get_scheduler()) // continue work on the CPU
+    | cudax_async::then([] __host__ __device__(int i) noexcept -> int { // run a lambda on the CPU
+        CUDAX_CHECK(!_is_on_device());
+        NV_IF_TARGET(NV_IS_HOST,
+                     (printf("Hello from lambda on host! i = %d\n", i);),
+                     (printf("OOPS! still on the device! i = %d\n", i);))
+        return i;
+      });
+
+  // run the cudax_async, wait for it to finish, and get the result
+  auto [i] = cudax_async::sync_wait(std::move(start)).value();
+  CHECK(i == 43);
+  printf("All done on the host! result = %d\n", i);
+}
+
 // Test code is placed in separate functions to avoid an nvc++ issue with
 // extended lambdas in functions with internal linkage (as is the case
 // with C2H tests).
@@ -94,5 +123,10 @@ C2H_TEST("a simple use of the stream context", "[context][stream]")
 C2H_TEST("a simple use of the stream context", "[context][stream]")
 {
   REQUIRE_NOTHROW(stream_context_test2());
+}
+
+C2H_TEST("use stream_ref as a scheduler", "[context][stream]")
+{
+  REQUIRE_NOTHROW(stream_ref_as_scheduler());
 }
 } // namespace


### PR DESCRIPTION
## Description

i have an idea that most of the places that take a stream argument today should in fact take a scheduler instead. this pr arranges things that `stream_ref` is itself a scheduler so that users can continue passing streams as before.

this now works:

```c++
  cudax::stream stream;
  auto sch = stream.get_scheduler(); // sch is a stream_ref

  auto start =
      cudax::execution::schedule(sch) // begin work on the GPU
    | cudax::execution::then([] __device__() noexcept -> int { // enqueue a lambda on the GPU
        CUDAX_CHECK(_is_on_device());
        printf("Hello from device lambda!\n");
        return 0;
      })

auto [result] = cudax::execution::sync_wait(std::move(start)).value();
```

i wanted the change to have as little impact as possible. it wouldn't be right if `__stream/stream_ref.cuh` became an expensive file to include. in this pr, the `__stream/stream_ref.cuh` depends only the forward declarations of the execution library.

to achieve that, i had to do some significant refactorization to minimize dependencies. To wit:

- `__execution/completion_signatures.cuh` has been refactored into three separate headers:
  - `completion_signatures.cuh`, contains the following:
    - `completion_signatures` class template
    - `make_completion_signatures` utility function
    - `concat_completion_signatures` utility function
    - completion signature type traits
  - `get_completion_signatures.cuh`, contains the following:
    - `get_completion_signatures` function template
    - `get_child_completion_signatures` function template
  - `transform_completion_signatures.cuh`, contains the following:
    - `transform_completion_signatures` utility function
- `stream_scheduler` has been factored out of the `stream_context` and moved to a new header `__execution/stream/scheduler.cuh`


## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
