### PR TITLE
Retry configure step when CPM hits network issues in CI.

### DIFF
--- a/ci/build_common.sh
+++ b/ci/build_common.sh
@@ -188,8 +188,15 @@ function configure_preset()
     local GROUP_NAME="🛠️  CMake Configure ${BUILD_NAME}"
 
     pushd .. > /dev/null
-    run_command "$GROUP_NAME" cmake --preset=$PRESET --log-level=VERBOSE $CMAKE_OPTIONS "${GLOBAL_CMAKE_OPTIONS[@]}"
-    status=$?
+    if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
+      # Retry 5 times with 30 seconds between attempts to try to WAR network issues during CPM fetch on CI runners:
+      export RUN_COMMAND_RETRY_PARAMS="5 30"
+    fi
+    status=0
+    run_command "$GROUP_NAME" cmake --preset=$PRESET --log-level=VERBOSE $CMAKE_OPTIONS "${GLOBAL_CMAKE_OPTIONS[@]}" || status=$?
+    if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
+        unset RUN_COMMAND_RETRY_PARAMS
+    fi
     popd > /dev/null
 
     if $CONFIGURE_ONLY; then
@@ -221,8 +228,8 @@ function build_preset() {
     source "./sccache_stats.sh" "start" || :
 
     pushd .. > /dev/null
-    run_command "$GROUP_NAME" cmake --build --preset=$PRESET -v
-    status=$?
+    status=0
+    run_command "$GROUP_NAME" cmake --build --preset=$PRESET -v || status=$?
     popd > /dev/null
 
     sccache --show-adv-stats --stats-format=json > "${sccache_json}" || :
@@ -272,8 +279,8 @@ function test_preset()
     local ctest_log="${preset_dir}/ctest.log"
 
     pushd .. > /dev/null
-    run_command "$GROUP_NAME" ctest --output-log "${ctest_log}" --preset=$PRESET
-    status=$?
+    status=0
+    run_command "$GROUP_NAME" ctest --output-log "${ctest_log}" --preset=$PRESET || status=$?
     popd > /dev/null
 
     print_test_time_summary ${ctest_log}

--- a/ci/util/retry.sh
+++ b/ci/util/retry.sh
@@ -12,21 +12,24 @@ fi
 num_tries=$1
 sleep_time=$2
 shift 2
-command="$@"
+command=()
+for arg in "$@"; do
+    command+=( "$(printf '%q' "$arg")" )
+done
 
 # Loop until the command succeeds or we reach the maximum number of attempts:
 for ((i=1; i<=num_tries; i++)); do
-    echo "Attempt ${i} of ${num_tries}: Running command '${command}'"
-    eval "$command"
-    status=$?
+    echo "Attempt ${i} of ${num_tries}: Running command '${command[*]}'"
+    status=0
+    eval "${command[*]}" || status=$?
 
     if [ $status -eq 0 ]; then
-        echo "Command '${command}' succeeded on attempt ${i}."
+        echo "Command '${command[*]}' succeeded on attempt ${i}."
         exit 0
     else
-        echo "Command '${command}' failed with status ${status}. Retrying in ${sleep_time} seconds..."
+        echo "Command '${command[*]}' failed with status ${status}. Retrying in ${sleep_time} seconds..."
         sleep $sleep_time
     fi
 done
-echo "Command '${command}' failed after ${num_tries} attempts."
+echo "Command '${command[*]}' failed after ${num_tries} attempts."
 exit 1

--- a/ci/util/retry.sh
+++ b/ci/util/retry.sh
@@ -12,10 +12,7 @@ fi
 num_tries=$1
 sleep_time=$2
 shift 2
-command=()
-for arg in "$@"; do
-    command+=( "$(printf '%q' "$arg")" )
-done
+command=("${*@Q}")
 
 # Loop until the command succeeds or we reach the maximum number of attempts:
 for ((i=1; i<=num_tries; i++)); do


### PR DESCRIPTION
This has been a common issue in our CI lately, CPM downloads fail due to spurious network issues.

This attempts to mitigate these issues by attempting to configure 5 times, waiting 30 seconds between attempts.,

This PR also updates several return status captures to work as-intended under `set -e`.
