### PR TITLE
[CUDAX] Add device argument to legacy pinned memory resource

### DIFF
--- a/c2h/include/c2h/catch2_test_helper.h
+++ b/c2h/include/c2h/catch2_test_helper.h
@@ -277,6 +277,13 @@ struct Catch::StringMaker<cudaError>
 
 #define C2H_TEST_LIST(NAME, TAG, ...) C2H_TEST_LIST_IMPL(__LINE__, NAME, TAG, __VA_ARGS__)
 
+#define C2H_TEST_LIST_WITH_FIXTURE_IMPL(ID, FIXTURE, NAME, TAG, ...) \
+  using C2H_TEST_CONCAT(types_, ID) = c2h::type_list<__VA_ARGS__>;   \
+  TEMPLATE_LIST_TEST_CASE_METHOD(FIXTURE, C2H_TEST_NAME(NAME), TAG, C2H_TEST_CONCAT(types_, ID))
+
+#define C2H_TEST_LIST_WITH_FIXTURE(FIXTURE, NAME, TAG, ...) \
+  C2H_TEST_LIST_WITH_FIXTURE_IMPL(__LINE__, FIXTURE, NAME, TAG, __VA_ARGS__)
+
 #define C2H_TEST_STR(a) #a
 
 namespace c2h

--- a/cudax/include/cuda/experimental/__memory_resource/legacy_pinned_memory_resource.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/legacy_pinned_memory_resource.cuh
@@ -47,6 +47,13 @@ namespace cuda::experimental
 class legacy_pinned_memory_resource
 {
 public:
+  //! @brief Construct a new legacy_pinned_memory_resource object.
+  //! @note Memory allocated through this resource resides in host memory, but is internally tracked under a device.
+  //! Because of this, the resource constructor takes an optional device argument to select the device to track the
+  //! memory under. If no device is provided, the resource will default to device 0, which will be initialized as a side
+  //! effect. If initialization of device 0 this way in not desired, the user should explicitly provide a different
+  //! device. The device setting does not affect comparison results for this type.
+  //! @param __device The device to track the memory under.
   constexpr legacy_pinned_memory_resource(device_ref __device = device_ref{0}) noexcept
       : __device_(__device)
   {}

--- a/cudax/include/cuda/experimental/__stream/internal_streams.cuh
+++ b/cudax/include/cuda/experimental/__stream/internal_streams.cuh
@@ -31,7 +31,7 @@ namespace cuda::experimental
 {
 //! @brief internal stream used for memory allocations, no real blocking work
 //! should ever be pushed into it
-inline ::cuda::stream_ref __cccl_allocation_stream()
+inline ::cuda::experimental::stream_ref __cccl_allocation_stream()
 {
   static ::cuda::experimental::stream __stream{device_ref{0}};
   return __stream;

--- a/cudax/include/cuda/experimental/__utility/driver_api.cuh
+++ b/cudax/include/cuda/experimental/__utility/driver_api.cuh
@@ -258,6 +258,21 @@ inline CUcontext ctxFromGreenCtx(CUgreenCtx green_ctx)
   return result;
 }
 
+inline void* memAllocHost(size_t __bytes)
+{
+  void* __ptr;
+  static auto driver_fn = CUDAX_GET_DRIVER_FUNCTION(cuMemAllocHost);
+  call_driver_fn(driver_fn, "Failed to allocate memory with cuMemAllocHost", &__ptr, __bytes);
+  return __ptr;
+}
+
+inline cudaError_t memFreeHost(void* __ptr)
+{
+  static auto driver_fn = CUDAX_GET_DRIVER_FUNCTION(cuMemFreeHost);
+  CUresult status       = driver_fn(__ptr);
+  return static_cast<cudaError_t>(status);
+}
+
 #endif // CUDART_VERSION >= 12050
 } // namespace cuda::experimental::__detail::driver
 

--- a/cudax/test/common/testing.cuh
+++ b/cudax/test/common/testing.cuh
@@ -148,4 +148,7 @@ struct ccclrt_test_fixture
 // our APIs work with empty driver stack.
 #define C2H_CCCLRT_TEST(NAME, TAGS, ...) C2H_TEST_WITH_FIXTURE(::test::ccclrt_test_fixture, NAME, TAGS, __VA_ARGS__)
 
+#define C2H_CCCLRT_TEST_LIST(NAME, TAGS, ...) \
+  C2H_TEST_LIST_WITH_FIXTURE(::test::ccclrt_test_fixture, NAME, TAGS, __VA_ARGS__)
+
 #endif // __COMMON_TESTING_H__

--- a/cudax/test/memory_resource/pinned_memory_resource.cu
+++ b/cudax/test/memory_resource/pinned_memory_resource.cu
@@ -60,7 +60,7 @@ static void ensure_pinned_ptr(void* ptr)
   // CHECK(attributes.devicePointer != nullptr);
 }
 
-C2H_TEST_LIST("pinned_memory_resource allocation", "[memory_resource]", TEST_TYPES)
+C2H_CCCLRT_TEST_LIST("pinned_memory_resource allocation", "[memory_resource]", TEST_TYPES)
 {
   using pinned_resource = TestType;
   pinned_resource res{};
@@ -218,7 +218,7 @@ struct derived_pinned_resource : cudax::legacy_pinned_memory_resource
 };
 static_assert(cuda::mr::resource<derived_pinned_resource>, "");
 
-C2H_TEST_LIST("pinned_memory_resource comparison", "[memory_resource]", TEST_TYPES)
+C2H_CCCLRT_TEST_LIST("pinned_memory_resource comparison", "[memory_resource]", TEST_TYPES)
 {
   using pinned_resource = TestType;
   pinned_resource first{};
@@ -279,7 +279,7 @@ C2H_TEST_LIST("pinned_memory_resource comparison", "[memory_resource]", TEST_TYP
 }
 
 #if _CCCL_CUDACC_AT_LEAST(12, 6)
-C2H_TEST("pinned_memory_resource async deallocate", "[memory_resource]")
+C2H_CCCLRT_TEST("pinned_memory_resource async deallocate", "[memory_resource]")
 {
   cudax::pinned_memory_resource resource{};
   test_deallocate_async(resource);


### PR DESCRIPTION
Memory allocations not based on a memory pool require a device/context current for resource bookkeeping. We don't want to use the runtime APIs for them, because in case current device is not set, it will initialize device 0, even if the application does not use that device.

Instead this PR adds an optional device argument to `legacy_pinned_memory_resource` that will be set current on each allocation. This way if the device 0 initialization is not desired, user can pass device to the resource constructor to avoid it. It might be a bit confusing why host memory resource needs a device argument, but hopefully the default value will make it more of a detail for ninjas

This change also moves pinned resource testing to use the new ccclrt testing macro