### PR TITLE
Draft of nondeterministic reduce that uses atomics

### DIFF
--- a/cub/benchmarks/bench/nondeterministic_reduce/base.cuh
+++ b/cub/benchmarks/bench/nondeterministic_reduce/base.cuh
@@ -1,0 +1,130 @@
+/******************************************************************************
+ * Copyright (c) 2011-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+#include <cub/device/device_nondeterministic_reduce.cuh>
+
+#ifndef TUNE_BASE
+#  define TUNE_ITEMS_PER_VEC_LOAD (1 << TUNE_ITEMS_PER_VEC_LOAD_POW2)
+#endif
+
+#if !TUNE_BASE
+template <typename AccumT, typename OffsetT>
+struct policy_hub_t
+{
+  struct policy_t : cub::ChainedPolicy<300, policy_t, policy_t>
+  {
+    static constexpr int threads_per_block  = TUNE_THREADS_PER_BLOCK;
+    static constexpr int items_per_thread   = TUNE_ITEMS_PER_THREAD;
+    static constexpr int items_per_vec_load = TUNE_ITEMS_PER_VEC_LOAD;
+
+    using ReducePolicy = cub::AgentNondeterministicReducePolicy<
+      threads_per_block,
+      items_per_thread,
+      AccumT,
+      items_per_vec_load,
+      cub::BLOCK_NONDETERMINISTIC_REDUCE_WARP_REDUCTIONS,
+      cub::LOAD_LDG>;
+
+    // SingleTilePolicy
+    using SingleTilePolicy = ReducePolicy;
+
+    // SegmentedReducePolicy
+    using SegmentedReducePolicy = ReducePolicy;
+
+    using ReduceLastBlockPolicy = ReducePolicy;
+    using ReduceAtomicPolicy    = ReducePolicy;
+
+    static constexpr cub::detail::nondeterministic_reduce::Algorithm algorithm =
+      cub::detail::nondeterministic_reduce::Algorithm::atomic;
+  };
+
+  using MaxPolicy = policy_t;
+};
+#endif // !TUNE_BASE
+
+template <typename T, typename OffsetT>
+void reduce(nvbench::state& state, nvbench::type_list<T, OffsetT>)
+{
+  using accum_t     = T;
+  using input_it_t  = const T*;
+  using output_it_t = T*;
+  using offset_t    = cub::detail::choose_offset_t<OffsetT>;
+  using output_t    = T;
+  using init_t      = T;
+  using dispatch_t  = cub::detail::nondeterministic_reduce::DispatchNondeterministicReduce<
+     input_it_t,
+     output_it_t,
+     offset_t,
+     op_t,
+     init_t,
+     accum_t,
+     ::cuda::std::identity
+#if !TUNE_BASE
+    ,
+    policy_hub_t<accum_t, offset_t>
+#endif // TUNE_BASE
+    >;
+
+  // Retrieve axis parameters
+  const auto elements         = static_cast<std::size_t>(state.get_int64("Elements{io}"));
+  thrust::device_vector<T> in = generate(elements);
+  thrust::device_vector<T> out(1);
+
+  input_it_t d_in   = thrust::raw_pointer_cast(in.data());
+  output_it_t d_out = thrust::raw_pointer_cast(out.data());
+
+  // Enable throughput calculations and add "Size" column to results.
+  state.add_element_count(elements);
+  state.add_global_memory_reads<T>(elements, "Size");
+  state.add_global_memory_writes<T>(1);
+
+  // Allocate temporary storage:
+  std::size_t temp_size;
+  dispatch_t::Dispatch(
+    nullptr, temp_size, d_in, d_out, nullptr, static_cast<offset_t>(elements), op_t{}, init_t{}, 0 /* stream */);
+
+  thrust::device_vector<nvbench::uint8_t> temp(temp_size);
+  auto* temp_storage = thrust::raw_pointer_cast(temp.data());
+
+  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
+    dispatch_t::Dispatch(
+      temp_storage,
+      temp_size,
+      d_in,
+      d_out,
+      nullptr,
+      static_cast<offset_t>(elements),
+      op_t{},
+      init_t{},
+      launch.get_stream());
+  });
+}
+
+NVBENCH_BENCH_TYPES(reduce, NVBENCH_TYPE_AXES(value_types, offset_types))
+  .set_name("base")
+  .set_type_axes_names({"T{ct}", "OffsetT{ct}"})
+  .add_int64_axis("Elements{io}", {65536, 1048576, 16777216, 52428800, 268435456});

--- a/cub/benchmarks/bench/nondeterministic_reduce/sum.cu
+++ b/cub/benchmarks/bench/nondeterministic_reduce/sum.cu
@@ -1,0 +1,46 @@
+/******************************************************************************
+ * Copyright (c) 2011-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+// This benchmark is intended to cover redux instructions on Ampere+ architectures. It specifically uses
+// cuda::std::plus<> instead of a user-defined operator, which CUB recognizes to select an optimized code path.
+
+// Tuning parameters found for signed integer types apply equally for unsigned integer types
+
+#include <nvbench_helper.cuh>
+
+// %RANGE% TUNE_SUBSCRIPTION_FACTOR sf 5:10:5
+// %RANGE% TUNE_USE_ATOMIC_BLOCK_REDUCE uabr 0:1:1
+// %RANGE% TUNE_USE_GRID_EVEN_SHARE uges 0:1:1
+// %RANGE% TUNE_ITEMS_PER_THREAD ipt 7:24:1
+// %RANGE% TUNE_THREADS_PER_BLOCK tpb 128:1024:32
+// %RANGE% TUNE_ITEMS_PER_VEC_LOAD_POW2 ipv 1:2:1
+
+// TODO(bgruber): let's add __half and __nv_bfloat16 eventually when they compile, since we have fast paths for them.
+// using value_types = all_types;
+using value_types = nvbench::type_list<float>;
+using op_t        = ::cuda::std::plus<>;
+#include "base.cuh"

--- a/cub/cub/agent/agent_nondeterministic_reduce.cuh
+++ b/cub/cub/agent/agent_nondeterministic_reduce.cuh
@@ -1,0 +1,658 @@
+/******************************************************************************
+ * Copyright (c) 2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2022, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/**
+ * @file cub::AgentReduce implements a stateful abstraction of CUDA thread
+ *       blocks for participating in device-wide reduction.
+ */
+
+#pragma once
+
+#include <cub/config.cuh>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cub/block/block_load.cuh>
+#include <cub/block/block_nondeterministic_reduce.cuh>
+#include <cub/detail/type_traits.cuh>
+#include <cub/grid/grid_even_share.cuh>
+#include <cub/grid/grid_mapping.cuh>
+#include <cub/iterator/cache_modified_input_iterator.cuh>
+#include <cub/util_type.cuh>
+
+#include <cuda/std/functional>
+#include <cuda/std/type_traits>
+
+CUB_NAMESPACE_BEGIN
+
+/******************************************************************************
+ * Tuning policy types
+ ******************************************************************************/
+
+/**
+ * Parameterizable tuning policy type for AgentReduce
+ * @tparam NOMINAL_BLOCK_THREADS_4B Threads per thread block
+ * @tparam NOMINAL_ITEMS_PER_THREAD_4B Items per thread (per tile of input)
+ * @tparam ComputeT Dominant compute type
+ * @tparam _VECTOR_LOAD_LENGTH Number of items per vectorized load
+ * @tparam _BLOCK_ALGORITHM Cooperative block-wide reduction algorithm to use
+ * @tparam _LOAD_MODIFIER Cache load modifier for reading input elements
+ */
+template <
+  int NOMINAL_BLOCK_THREADS_4B,
+  int NOMINAL_ITEMS_PER_THREAD_4B,
+  typename ComputeT,
+  int _VECTOR_LOAD_LENGTH,
+  BlockNondeterministicReduceAlgorithm _BLOCK_ALGORITHM,
+  CacheLoadModifier _LOAD_MODIFIER,
+  typename ScalingType = detail::MemBoundScaling<NOMINAL_BLOCK_THREADS_4B, NOMINAL_ITEMS_PER_THREAD_4B, ComputeT>>
+struct AgentNondeterministicReducePolicy : ScalingType
+{
+  /// Number of items per vectorized load
+  static constexpr int VECTOR_LOAD_LENGTH = _VECTOR_LOAD_LENGTH;
+
+  /// Cooperative block-wide reduction algorithm to use
+  static constexpr BlockNondeterministicReduceAlgorithm BLOCK_ALGORITHM = _BLOCK_ALGORITHM;
+
+  /// Cache load modifier for reading input elements
+  static constexpr CacheLoadModifier LOAD_MODIFIER = _LOAD_MODIFIER;
+};
+
+/**
+ * Parameterizable tuning policy type for AgentReduce
+ * @tparam _BLOCK_THREADS Threads per thread block
+ * @tparam _WARP_THREADS Threads per warp
+ * @tparam NOMINAL_ITEMS_PER_THREAD_4B Items per thread (per tile of input)
+ * @tparam ComputeT Dominant compute type
+ * @tparam _VECTOR_LOAD_LENGTH Number of items per vectorized load
+ * @tparam _LOAD_MODIFIER Cache load modifier for reading input elements
+ */
+template <int _BLOCK_THREADS,
+          int _WARP_THREADS,
+          int NOMINAL_ITEMS_PER_THREAD_4B,
+          typename ComputeT,
+          int _VECTOR_LOAD_LENGTH,
+          CacheLoadModifier _LOAD_MODIFIER>
+struct AgentNondeterministicWarpReducePolicy
+{
+  /// Number of threads per warp
+  static constexpr int WARP_THREADS = _WARP_THREADS;
+
+  /// Number of items per vectorized load
+  static constexpr int VECTOR_LOAD_LENGTH = _VECTOR_LOAD_LENGTH;
+
+  /// Number of threads per block
+  static constexpr int BLOCK_THREADS = _BLOCK_THREADS;
+
+  /// Number of items per thread
+  static constexpr int ITEMS_PER_THREAD =
+    detail::MemBoundScaling<0, NOMINAL_ITEMS_PER_THREAD_4B, ComputeT>::ITEMS_PER_THREAD;
+
+  /// Cache load modifier for reading input elements
+  static constexpr CacheLoadModifier LOAD_MODIFIER = _LOAD_MODIFIER;
+
+  /// Number of items per tile
+  constexpr static int ITEMS_PER_TILE = ITEMS_PER_THREAD * WARP_THREADS;
+
+  /// Number of segments per block
+  constexpr static int SEGMENTS_PER_BLOCK = BLOCK_THREADS / WARP_THREADS;
+
+  static_assert((BLOCK_THREADS % WARP_THREADS) == 0, "Block should be multiple of warp");
+};
+
+/******************************************************************************
+ * Thread block abstractions
+ ******************************************************************************/
+
+namespace detail
+{
+namespace nondeterministic_reduce
+{
+
+/**
+ * @brief AgentReduceImpl implements a stateful abstraction of CUDA thread blocks
+ *        and warps, for participating in device-wide reduction .
+ *
+ * Each thread reduces only the values it loads. If `FIRST_TILE`, this partial
+ * reduction is stored into `thread_aggregate`. Otherwise it is accumulated
+ * into `thread_aggregate`.
+ *
+ * @tparam AgentReducePolicy
+ *   Parameterized AgentReducePolicy tuning policy type
+ *
+ * @tparam InputIteratorT
+ *   Random-access iterator type for input
+ *
+ * @tparam OutputIteratorT
+ *   Random-access iterator type for output
+ *
+ * @tparam OffsetT
+ *   Signed integer type for global offsets
+ *
+ * @tparam ReductionOp
+ *   Binary reduction operator type having member
+ *   `auto operator()(T &&a, U &&b)`
+ *
+ * @tparam AccumT
+ *   The type of intermediate accumulator (according to P2322R6)
+ *
+ * @tparam TransformOp
+ *    Unary operator type having member `auto operator()(T &&a)`
+ *
+ * @tparam CollectiveReduceT
+ *   Block or Warp reduction type
+ *
+ * @tparam NumThreads
+ *   Number of threads participating in the collective reduction
+ *
+ * @tparam IsWarpReduction
+ *   Whether or not this is a warp reduction
+ */
+template <typename AgentReducePolicy,
+          typename InputIteratorT,
+          typename OutputIteratorT,
+          typename OffsetT,
+          typename ReductionOp,
+          typename AccumT,
+          typename TransformOp,
+          typename CollectiveReduceT,
+          int NumThreads,
+          bool IsWarpReduction = false>
+struct AgentReduceImpl
+{
+  //---------------------------------------------------------------------
+  // Types and constants
+  //---------------------------------------------------------------------
+
+  /// The input value type
+  using InputT = it_value_t<InputIteratorT>;
+
+  /// Vector type of InputT for data movement
+  using VectorT = typename CubVector<InputT, AgentReducePolicy::VECTOR_LOAD_LENGTH>::Type;
+
+  /// Input iterator wrapper type (for applying cache modifier)
+  // Wrap the native input pointer with CacheModifiedInputIterator
+  // or directly use the supplied input iterator type
+  using WrappedInputIteratorT =
+    ::cuda::std::_If<::cuda::std::is_pointer_v<InputIteratorT>,
+                     CacheModifiedInputIterator<AgentReducePolicy::LOAD_MODIFIER, InputT, OffsetT>,
+                     InputIteratorT>;
+
+  /// Constants
+  static constexpr int ITEMS_PER_THREAD   = AgentReducePolicy::ITEMS_PER_THREAD;
+  static constexpr int TILE_ITEMS         = NumThreads * ITEMS_PER_THREAD;
+  static constexpr int VECTOR_LOAD_LENGTH = _CUDA_VSTD::min(ITEMS_PER_THREAD, AgentReducePolicy::VECTOR_LOAD_LENGTH);
+
+  // Can vectorize according to the policy if the input iterator is a native
+  // pointer to a primitive type
+  static constexpr bool ATTEMPT_VECTORIZATION =
+    (VECTOR_LOAD_LENGTH > 1) && (ITEMS_PER_THREAD % VECTOR_LOAD_LENGTH == 0)
+    && (::cuda::std::is_pointer_v<InputIteratorT>) && is_primitive<InputT>::value;
+
+  static constexpr CacheLoadModifier LOAD_MODIFIER = AgentReducePolicy::LOAD_MODIFIER;
+
+  /// Shared memory type required by this thread block
+  struct _TempStorage
+  {
+    typename CollectiveReduceT::TempStorage reduce;
+  };
+
+  /// Alias wrapper allowing storage to be unioned
+  struct TempStorage : Uninitialized<_TempStorage>
+  {};
+
+  //---------------------------------------------------------------------
+  // Per-thread fields
+  //---------------------------------------------------------------------
+
+  _TempStorage& temp_storage; ///< Reference to temp_storage
+  InputIteratorT d_in; ///< Input data to reduce
+  WrappedInputIteratorT d_wrapped_in; ///< Wrapped input data to reduce
+  ReductionOp reduction_op; ///< Binary reduction operator
+  TransformOp transform_op; ///< Transform operator
+  unsigned int lane_id; ///< Local thread index inside a Warp or Block
+
+  //---------------------------------------------------------------------
+  // Utility
+  //---------------------------------------------------------------------
+
+  // Whether or not the input is aligned with the vector type (specialized for
+  // types we can vectorize)
+  template <typename Iterator>
+  static _CCCL_DEVICE _CCCL_FORCEINLINE bool IsAligned(Iterator d_in, ::cuda::std::true_type /*can_vectorize*/)
+  {
+    return (size_t(d_in) & (sizeof(VectorT) - 1)) == 0;
+  }
+
+  // Whether or not the input is aligned with the vector type (specialized for
+  // types we cannot vectorize)
+  template <typename Iterator>
+  static _CCCL_DEVICE _CCCL_FORCEINLINE bool IsAligned(Iterator /*d_in*/, ::cuda::std::false_type /*can_vectorize*/)
+  {
+    return false;
+  }
+
+  //---------------------------------------------------------------------
+  // Constructor
+  //---------------------------------------------------------------------
+
+  /**
+   * @brief Constructor
+   * @param temp_storage Reference to temp_storage
+   * @param d_in Input data to reduce
+   * @param reduction_op Binary reduction operator
+   */
+  _CCCL_DEVICE _CCCL_FORCEINLINE AgentReduceImpl(
+    TempStorage& temp_storage, InputIteratorT d_in, ReductionOp reduction_op, TransformOp transform_op, int lane_id)
+      : temp_storage(temp_storage.Alias())
+      , d_in(d_in)
+      , d_wrapped_in(d_in)
+      , reduction_op(reduction_op)
+      , transform_op(transform_op)
+      , lane_id(lane_id)
+  {}
+
+  //---------------------------------------------------------------------
+  // Tile consumption
+  //---------------------------------------------------------------------
+
+  /**
+   * @brief Consume a full tile of input (non-vectorized)
+   * @param block_offset The offset the tile to consume
+   * @param valid_items The number of valid items in the tile
+   * @param is_full_tile Whether or not this is a full tile
+   * @param can_vectorize Whether or not we can vectorize loads
+   */
+  template <int IS_FIRST_TILE>
+  _CCCL_DEVICE _CCCL_FORCEINLINE void ConsumeTile(
+    AccumT& thread_aggregate,
+    OffsetT block_offset,
+    int /*valid_items*/,
+    ::cuda::std::true_type /*is_full_tile*/,
+    ::cuda::std::false_type /*can_vectorize*/)
+  {
+    AccumT items[ITEMS_PER_THREAD];
+
+    // Load items in striped fashion
+    load_transform_direct_striped<NumThreads>(lane_id, d_wrapped_in + block_offset, items, transform_op);
+
+    // Reduce items within each thread stripe
+    thread_aggregate = (IS_FIRST_TILE) ? cub::ThreadReduce(items, reduction_op)
+                                       : cub::ThreadReduce(items, reduction_op, thread_aggregate);
+  }
+
+  /**
+   * Consume a full tile of input (vectorized)
+   * @param block_offset The offset the tile to consume
+   * @param valid_items The number of valid items in the tile
+   * @param is_full_tile Whether or not this is a full tile
+   * @param can_vectorize Whether or not we can vectorize loads
+   */
+  template <int IS_FIRST_TILE>
+  _CCCL_DEVICE _CCCL_FORCEINLINE void ConsumeTile(
+    AccumT& thread_aggregate,
+    OffsetT block_offset,
+    int /*valid_items*/,
+    ::cuda::std::true_type /*is_full_tile*/,
+    ::cuda::std::true_type /*can_vectorize*/)
+  {
+    // Alias items as an array of VectorT and load it in striped fashion
+    enum
+    {
+      WORDS = ITEMS_PER_THREAD / VECTOR_LOAD_LENGTH
+    };
+
+    // Fabricate a vectorized input iterator
+    InputT* d_in_unqualified = const_cast<InputT*>(d_in) + block_offset + (lane_id * VECTOR_LOAD_LENGTH);
+    CacheModifiedInputIterator<AgentReducePolicy::LOAD_MODIFIER, VectorT, OffsetT> d_vec_in(
+      reinterpret_cast<VectorT*>(d_in_unqualified));
+
+    // Load items as vector items
+    InputT input_items[ITEMS_PER_THREAD];
+    VectorT* vec_items = reinterpret_cast<VectorT*>(input_items);
+
+    _CCCL_PRAGMA_UNROLL_FULL()
+    for (int i = 0; i < WORDS; ++i)
+    {
+      vec_items[i] = d_vec_in[NumThreads * i];
+    }
+
+    // Convert from input type to output type
+    AccumT items[ITEMS_PER_THREAD];
+
+    _CCCL_PRAGMA_UNROLL_FULL()
+    for (int i = 0; i < ITEMS_PER_THREAD; ++i)
+    {
+      items[i] = transform_op(input_items[i]);
+    }
+
+    // Reduce items within each thread stripe
+    thread_aggregate = (IS_FIRST_TILE) ? cub::ThreadReduce(items, reduction_op)
+                                       : cub::ThreadReduce(items, reduction_op, thread_aggregate);
+  }
+
+  /**
+   * Consume a partial tile of input
+   * @param block_offset The offset the tile to consume
+   * @param valid_items The number of valid items in the tile
+   * @param is_full_tile Whether or not this is a full tile
+   * @param can_vectorize Whether or not we can vectorize loads
+   */
+  template <int IS_FIRST_TILE, bool CAN_VECTORIZE>
+  _CCCL_DEVICE _CCCL_FORCEINLINE void ConsumeTile(
+    AccumT& thread_aggregate,
+    OffsetT block_offset,
+    int valid_items,
+    ::cuda::std::false_type /*is_full_tile*/,
+    ::cuda::std::bool_constant<CAN_VECTORIZE> /*can_vectorize*/)
+  {
+    // Partial tile
+    int thread_offset = lane_id;
+
+    // Read first item
+    if ((IS_FIRST_TILE) && (thread_offset < valid_items))
+    {
+      thread_aggregate = transform_op(d_wrapped_in[block_offset + thread_offset]);
+      thread_offset += NumThreads;
+    }
+
+    // Continue reading items (block-striped)
+    while (thread_offset < valid_items)
+    {
+      InputT item(d_wrapped_in[block_offset + thread_offset]);
+
+      thread_aggregate = reduction_op(thread_aggregate, transform_op(item));
+      thread_offset += NumThreads;
+    }
+  }
+
+  //---------------------------------------------------------------
+  // Consume a contiguous segment of tiles
+  //---------------------------------------------------------------------
+
+  /**
+   * @brief Reduce a contiguous segment of input tiles
+   * @param even_share GridEvenShare descriptor
+   * @param can_vectorize Whether or not we can vectorize loads
+   */
+  template <bool CAN_VECTORIZE>
+  _CCCL_DEVICE _CCCL_FORCEINLINE AccumT
+  ConsumeRange(GridEvenShare<OffsetT>& even_share, ::cuda::std::bool_constant<CAN_VECTORIZE> can_vectorize)
+  {
+    AccumT thread_aggregate{};
+
+    if (even_share.block_end - even_share.block_offset < TILE_ITEMS)
+    {
+      // First tile isn't full (not all threads have valid items)
+      int valid_items = even_share.block_end - even_share.block_offset;
+      ConsumeTile<true>(
+        thread_aggregate, even_share.block_offset, valid_items, ::cuda::std::false_type(), can_vectorize);
+
+      // For Warp Reduction, we need to explicitly handle the valid_items,
+      // whereas for Block Reduction it is implicitly handled
+      if constexpr (IsWarpReduction)
+      {
+        valid_items = (NumThreads <= valid_items) ? NumThreads : valid_items;
+      }
+      return CollectiveReduceT(temp_storage.reduce).Reduce(thread_aggregate, reduction_op, valid_items);
+    }
+
+    // Extracting this into a function saves 8% of generated kernel size by allowing to reuse
+    // the block reduction below. This also workaround hang in nvcc.
+    ConsumeFullTileRange(thread_aggregate, even_share, can_vectorize);
+
+    // Compute block-wide reduction (all threads have valid items)
+    return CollectiveReduceT(temp_storage.reduce).Reduce(thread_aggregate, reduction_op);
+  }
+
+  /**
+   * @brief Reduce a contiguous segment of input tiles
+   * @param[in] block_offset Threadblock begin offset (inclusive)
+   * @param[in] block_end Threadblock end offset (exclusive)
+   */
+  _CCCL_DEVICE _CCCL_FORCEINLINE AccumT ConsumeRange(OffsetT block_offset, OffsetT block_end)
+  {
+    GridEvenShare<OffsetT> even_share;
+    even_share.template BlockInit<TILE_ITEMS>(block_offset, block_end);
+
+    return (IsAligned(d_in + block_offset, bool_constant_v<ATTEMPT_VECTORIZATION>))
+           ? ConsumeRange(even_share, bool_constant_v<ATTEMPT_VECTORIZATION>)
+           : ConsumeRange(even_share, ::cuda::std::false_type{});
+  }
+
+  /**
+   * Reduce a contiguous segment of input tiles
+   * @param[in] even_share GridEvenShare descriptor
+   */
+  _CCCL_DEVICE _CCCL_FORCEINLINE AccumT ConsumeTiles(GridEvenShare<OffsetT>& even_share)
+  {
+    // Initialize GRID_MAPPING_STRIP_MINE even-share descriptor for this thread block
+    even_share.template BlockInit<TILE_ITEMS, GRID_MAPPING_STRIP_MINE>();
+
+    return (IsAligned(d_in, bool_constant_v<ATTEMPT_VECTORIZATION>))
+           ? ConsumeRange(even_share, bool_constant_v<ATTEMPT_VECTORIZATION>)
+           : ConsumeRange(even_share, ::cuda::std::false_type{});
+  }
+
+private:
+  /**
+   * @brief Reduce a contiguous segment of input tiles with more than `TILE_ITEMS` elements
+   * @param even_share GridEvenShare descriptor
+   * @param can_vectorize Whether or not we can vectorize loads
+   */
+  template <bool CAN_VECTORIZE>
+  _CCCL_DEVICE _CCCL_FORCEINLINE void ConsumeFullTileRange(
+    AccumT& thread_aggregate,
+    GridEvenShare<OffsetT>& even_share,
+    ::cuda::std::bool_constant<CAN_VECTORIZE> can_vectorize)
+  {
+    // At least one full block
+    ConsumeTile<true>(thread_aggregate, even_share.block_offset, TILE_ITEMS, ::cuda::std::true_type(), can_vectorize);
+
+    if (even_share.block_end - even_share.block_offset < even_share.block_stride)
+    {
+      // Exit early to handle offset overflow
+      return;
+    }
+
+    even_share.block_offset += even_share.block_stride;
+
+    // Consume subsequent full tiles of input, at least one full tile was processed, so
+    // `even_share.block_end >= TILE_ITEMS`
+    while (even_share.block_offset <= even_share.block_end - TILE_ITEMS)
+    {
+      ConsumeTile<false>(thread_aggregate, even_share.block_offset, TILE_ITEMS, ::cuda::std::true_type(), can_vectorize);
+
+      if (even_share.block_end - even_share.block_offset < even_share.block_stride)
+      {
+        // Exit early to handle offset overflow
+        return;
+      }
+
+      even_share.block_offset += even_share.block_stride;
+    }
+
+    // Consume a partially-full tile
+    if (even_share.block_offset < even_share.block_end)
+    {
+      int valid_items = even_share.block_end - even_share.block_offset;
+      ConsumeTile<false>(
+        thread_aggregate, even_share.block_offset, valid_items, ::cuda::std::false_type(), can_vectorize);
+    }
+  }
+};
+
+/**
+ * @brief AgentReduce implements a stateful abstraction of CUDA thread blocks
+ *        and warps, for participating in device-wide reduction .
+ *
+ * Each thread reduces only the values it loads. If `FIRST_TILE`, this partial
+ * reduction is stored into `thread_aggregate`. Otherwise it is accumulated
+ * into `thread_aggregate`.
+ *
+ * @tparam AgentReducePolicy
+ *   Parameterized AgentReducePolicy tuning policy type
+ *
+ * @tparam InputIteratorT
+ *   Random-access iterator type for input
+ *
+ * @tparam OutputIteratorT
+ *   Random-access iterator type for output
+ *
+ * @tparam OffsetT
+ *   Signed integer type for global offsets
+ *
+ * @tparam ReductionOp
+ *   Binary reduction operator type having member
+ *   `auto operator()(T &&a, U &&b)`
+ *
+ * @tparam AccumT
+ *   The type of intermediate accumulator (according to P2322R6)
+ *
+ * @tparam TransformOp
+ *    Unary operator type having member `auto operator()(T &&a)`
+ */
+template <typename AgentReducePolicy,
+          typename InputIteratorT,
+          typename OutputIteratorT,
+          typename OffsetT,
+          typename ReductionOp,
+          typename AccumT,
+          typename TransformOp = ::cuda::std::identity>
+struct AgentReduce
+    : AgentReduceImpl<
+        AgentReducePolicy,
+        InputIteratorT,
+        OutputIteratorT,
+        OffsetT,
+        ReductionOp,
+        AccumT,
+        TransformOp,
+        BlockNondeterministicReduce<AccumT, AgentReducePolicy::BLOCK_THREADS, AgentReducePolicy::BLOCK_ALGORITHM>,
+        AgentReducePolicy::BLOCK_THREADS>
+{
+  using base_t = AgentReduceImpl<
+    AgentReducePolicy,
+    InputIteratorT,
+    OutputIteratorT,
+    OffsetT,
+    ReductionOp,
+    AccumT,
+    TransformOp,
+    BlockNondeterministicReduce<AccumT, AgentReducePolicy::BLOCK_THREADS, AgentReducePolicy::BLOCK_ALGORITHM>,
+    AgentReducePolicy::BLOCK_THREADS>;
+
+  _CCCL_DEVICE _CCCL_FORCEINLINE AgentReduce(
+    typename base_t::TempStorage& temp_storage,
+    InputIteratorT d_in,
+    ReductionOp reduction_op,
+    TransformOp transform_op = {})
+      : base_t(temp_storage, d_in, reduction_op, transform_op, threadIdx.x)
+  {}
+};
+
+/**
+ * @brief AgentWarpReduce implements a stateful abstraction of CUDA warps,
+ *        for participating in device-wide reduction .
+ *
+ * Each thread reduces only the values it loads. If `FIRST_TILE`, this partial
+ * reduction is stored into `thread_aggregate`. Otherwise it is accumulated
+ * into `thread_aggregate`.
+ *
+ * @tparam AgentReducePolicy
+ *   Parameterized AgentReducePolicy tuning policy type
+ *
+ * @tparam InputIteratorT
+ *   Random-access iterator type for input
+ *
+ * @tparam OutputIteratorT
+ *   Random-access iterator type for output
+ *
+ * @tparam OffsetT
+ *   Signed integer type for global offsets
+ *
+ * @tparam ReductionOp
+ *   Binary reduction operator type having member
+ *   `auto operator()(T &&a, U &&b)`
+ *
+ * @tparam AccumT
+ *   The type of intermediate accumulator (according to P2322R6)
+ *
+ * @tparam TransformOp
+ *    Unary operator type having member `auto operator()(T &&a)`
+ */
+template <typename AgentReducePolicy,
+          typename InputIteratorT,
+          typename OutputIteratorT,
+          typename OffsetT,
+          typename ReductionOp,
+          typename AccumT,
+          typename TransformOp = ::cuda::std::identity>
+struct AgentWarpReduce
+    : AgentReduceImpl<AgentReducePolicy,
+                      InputIteratorT,
+                      OutputIteratorT,
+                      OffsetT,
+                      ReductionOp,
+                      AccumT,
+                      TransformOp,
+                      WarpReduce<AccumT, AgentReducePolicy::WARP_THREADS>,
+                      AgentReducePolicy::WARP_THREADS,
+                      true>
+{
+  using base_t =
+    AgentReduceImpl<AgentReducePolicy,
+                    InputIteratorT,
+                    OutputIteratorT,
+                    OffsetT,
+                    ReductionOp,
+                    AccumT,
+                    TransformOp,
+                    WarpReduce<AccumT, AgentReducePolicy::WARP_THREADS>,
+                    AgentReducePolicy::WARP_THREADS,
+                    true>;
+
+  _CCCL_DEVICE _CCCL_FORCEINLINE AgentWarpReduce(
+    typename base_t::TempStorage& temp_storage,
+    InputIteratorT d_in,
+    ReductionOp reduction_op,
+    TransformOp transform_op = {})
+      : base_t(temp_storage, d_in, reduction_op, transform_op, threadIdx.x % AgentReducePolicy::WARP_THREADS)
+  {}
+};
+
+} // namespace nondeterministic_reduce
+} // namespace detail
+
+CUB_NAMESPACE_END

--- a/cub/cub/block/block_nondeterministic_reduce.cuh
+++ b/cub/cub/block/block_nondeterministic_reduce.cuh
@@ -1,0 +1,628 @@
+/******************************************************************************
+ * Copyright (c) 2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2018, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+//! @file
+//! The cub::BlockReduce class provides :ref:`collective <collective-primitives>` methods for computing a parallel
+//! reduction of items partitioned across a CUDA thread block.
+
+#pragma once
+
+#include <cub/config.cuh>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cub/block/specializations/block_reduce_raking.cuh>
+#include <cub/block/specializations/block_reduce_raking_commutative_only.cuh>
+#include <cub/block/specializations/block_reduce_warp_nondeterministic_reductions.cuh>
+#include <cub/thread/thread_operators.cuh>
+#include <cub/util_ptx.cuh>
+#include <cub/util_type.cuh>
+
+#include <cuda/std/type_traits>
+
+CUB_NAMESPACE_BEGIN
+
+/******************************************************************************
+ * Algorithmic variants
+ ******************************************************************************/
+
+//! BlockNondeterministicReduceAlgorithm enumerates alternative algorithms for parallel reduction across a CUDA thread
+//! block.
+enum BlockNondeterministicReduceAlgorithm
+{
+
+  //! @rst
+  //! Overview
+  //! ++++++++++++++++++++++++++
+  //!
+  //! An efficient "raking" reduction algorithm that only supports commutative
+  //! reduction operators (true for most operations, e.g., addition).
+  //!
+  //! Execution is comprised of three phases:
+  //!   #. Upsweep sequential reduction in registers (if threads contribute more
+  //!      than one input each). Threads in warps other than the first warp place
+  //!      their partial reductions into shared memory.
+  //!   #. Upsweep sequential reduction in shared memory. Threads within the first
+  //!      warp continue to accumulate by raking across segments of shared partial reductions
+  //!   #. A warp-synchronous Kogge-Stone style reduction within the raking warp.
+  //!
+  //! Performance Considerations
+  //! ++++++++++++++++++++++++++
+  //!
+  //! - This variant performs less communication than BLOCK_NONDETERMINISTIC_REDUCE_RAKING_NON_COMMUTATIVE
+  //!   and is preferable when the reduction operator is commutative. This variant
+  //!   applies fewer reduction operators than BLOCK_NONDETERMINISTIC_REDUCE_WARP_REDUCTIONS, and can provide higher
+  //!   overall throughput across the GPU when suitably occupied. However, turn-around latency may be higher than to
+  //!   BLOCK_NONDETERMINISTIC_REDUCE_WARP_REDUCTIONS and thus less-desirable when the GPU is under-occupied.
+  //!
+  //! @endrst
+  BLOCK_NONDETERMINISTIC_REDUCE_RAKING_COMMUTATIVE_ONLY,
+
+  //! @rst
+  //! Overview
+  //! ++++++++++++++++++++++++++
+  //!
+  //! An efficient "raking" reduction algorithm that supports commutative
+  //! (e.g., addition) and non-commutative (e.g., string concatenation) reduction
+  //! operators. @blocked.
+  //!
+  //! Execution is comprised of three phases:
+  //!   #. Upsweep sequential reduction in registers (if threads contribute more
+  //!      than one input each). Each thread then places the partial reduction
+  //!      of its item(s) into shared memory.
+  //!   #. Upsweep sequential reduction in shared memory. Threads within a
+  //!      single warp rake across segments of shared partial reductions.
+  //!   #. A warp-synchronous Kogge-Stone style reduction within the raking warp.
+  //!
+  //! Performance Considerations
+  //! ++++++++++++++++++++++++++
+  //!
+  //! - This variant performs more communication than BLOCK_NONDETERMINISTIC_REDUCE_RAKING
+  //!   and is only preferable when the reduction operator is non-commutative. This variant
+  //!   applies fewer reduction operators than BLOCK_NONDETERMINISTIC_REDUCE_WARP_REDUCTIONS, and can provide higher
+  //!   overall throughput across the GPU when suitably occupied. However, turn-around latency may be higher than to
+  //!   BLOCK_NONDETERMINISTIC_REDUCE_WARP_REDUCTIONS and thus less-desirable when the GPU is under-occupied.
+  //!
+  //! @endrst
+  BLOCK_NONDETERMINISTIC_REDUCE_RAKING,
+
+  //! @rst
+  //! Overview
+  //! ++++++++++++++++++++++++++
+  //!
+  //! A quick "tiled warp-reductions" reduction algorithm that supports commutative
+  //! (e.g., addition) and non-commutative (e.g., string concatenation) reduction
+  //! operators.
+  //!
+  //! Execution is comprised of four phases:
+  //!   #. Upsweep sequential reduction in registers (if threads contribute more
+  //!      than one input each). Each thread then places the partial reduction
+  //!      of its item(s) into shared memory.
+  //!   #. Compute a shallow, but inefficient warp-synchronous Kogge-Stone style
+  //!      reduction within each warp.
+  //!   #. A propagation phase where the warp reduction outputs in each warp are
+  //!      updated with the aggregate from each preceding warp.
+  //!
+  //! Performance Considerations
+  //! ++++++++++++++++++++++++++
+  //!
+  //! - This variant applies more reduction operators than BLOCK_NONDETERMINISTIC_REDUCE_RAKING
+  //!   or BLOCK_NONDETERMINISTIC_REDUCE_RAKING_NON_COMMUTATIVE, which may result in lower overall
+  //!   throughput across the GPU. However turn-around latency may be lower and
+  //!   thus useful when the GPU is under-occupied.
+  //!
+  //! @endrst
+  BLOCK_NONDETERMINISTIC_REDUCE_WARP_REDUCTIONS,
+};
+
+//! @rst
+//! The BlockReduce class provides :ref:`collective <collective-primitives>` methods for computing a parallel reduction
+//! of items partitioned across a CUDA thread block.
+//!
+//! Overview
+//! +++++++++++++++++++++++++++++++++++++++++++++
+//!
+//! - A `reduction <http://en.wikipedia.org/wiki/Reduce_(higher-order_function)>`_ (or *fold*) uses a binary combining
+//!   operator to compute a single aggregate from a list of input elements.
+//! - @rowmajor
+//! - BlockReduce can be optionally specialized by algorithm to accommodate different latency/throughput
+//!   workload profiles:
+//!
+//!   #. :cpp:enumerator:`cub::BLOCK_NONDETERMINISTIC_REDUCE_RAKING_COMMUTATIVE_ONLY`:
+//!      An efficient "raking" reduction algorithm that only supports commutative reduction operators.
+//!   #. :cpp:enumerator:`cub::BLOCK_NONDETERMINISTIC_REDUCE_RAKING`:
+//!      An efficient "raking" reduction algorithm that supports commutative and non-commutative reduction operators.
+//!   #. :cpp:enumerator:`cub::BLOCK_NONDETERMINISTIC_REDUCE_WARP_REDUCTIONS`:
+//!      A quick "tiled warp-reductions" reduction algorithm that supports commutative and non-commutative
+//!      reduction operators.
+//!
+//! Performance Considerations
+//! +++++++++++++++++++++++++++++++++++++++++++++
+//!
+//! - @granularity
+//! - Very efficient (only one synchronization barrier).
+//! - Incurs zero bank conflicts for most types
+//! - Computation is slightly more efficient (i.e., having lower instruction overhead) for:
+//!   - Summation (vs. generic reduction)
+//!   - ``BLOCK_THREADS`` is a multiple of the architecture's warp size
+//!   - Every thread has a valid input (i.e., full vs. partial-tiles)
+//! - See cub::BlockNondeterministicReduceAlgorithm for performance details regarding algorithmic alternatives
+//!
+//! A Simple Example
+//! +++++++++++++++++++++++++++++++++++++++++++++
+//!
+//! @blockcollective{BlockReduce}
+//!
+//! The code snippet below illustrates a sum reduction of 512 integer items that
+//! are partitioned in a :ref:`blocked arrangement <flexible-data-arrangement>` across 128 threads
+//! where each thread owns 4 consecutive items.
+//!
+//! .. code-block:: c++
+//!
+//!    #include <cub/cub.cuh>   // or equivalently <cub/block/block_reduce.cuh>
+//!
+//!    __global__ void ExampleKernel(...)
+//!    {
+//!        // Specialize BlockReduce for a 1D block of 128 threads of type int
+//!        using BlockReduce = cub::BlockReduce<int, 128>;
+//!
+//!        // Allocate shared memory for BlockReduce
+//!        __shared__ typename BlockReduce::TempStorage temp_storage;
+//!
+//!        // Obtain a segment of consecutive items that are blocked across threads
+//!        int thread_data[4];
+//!        ...
+//!
+//!        // Compute the block-wide sum for thread0
+//!        int aggregate = BlockReduce(temp_storage).Sum(thread_data);
+//!    }
+//!
+//! Re-using dynamically allocating shared memory
+//! +++++++++++++++++++++++++++++++++++++++++++++
+//!
+//! The ``block/example_block_reduce_dyn_smem.cu`` example illustrates usage of dynamically shared memory with
+//! BlockReduce and how to re-purpose the same memory region.
+//!
+//! @endrst
+//!
+//! @tparam T
+//!   Data type being reduced
+//!
+//! @tparam BLOCK_DIM_X
+//!   The thread block length in threads along the X dimension
+//!
+//! @tparam ALGORITHM
+//!   **[optional]** cub::BlockNondeterministicReduceAlgorithm enumerator specifying the underlying algorithm to use
+//!   (default: cub::BLOCK_NONDETERMINISTIC_REDUCE_WARP_REDUCTIONS)
+//!
+//! @tparam BLOCK_DIM_Y
+//!   **[optional]** The thread block length in threads along the Y dimension (default: 1)
+//!
+//! @tparam BLOCK_DIM_Z
+//!   **[optional]** The thread block length in threads along the Z dimension (default: 1)
+//!
+template <typename T,
+          int BLOCK_DIM_X,
+          BlockNondeterministicReduceAlgorithm ALGORITHM = BLOCK_NONDETERMINISTIC_REDUCE_WARP_REDUCTIONS,
+          int BLOCK_DIM_Y                                = 1,
+          int BLOCK_DIM_Z                                = 1>
+class BlockNondeterministicReduce
+{
+private:
+  /// Constants
+  enum
+  {
+    /// The thread block size in threads
+    BLOCK_THREADS = BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z,
+  };
+
+  using WarpReductions = detail::BlockNondeterministicReduceWarpReductions<T, BLOCK_DIM_X, BLOCK_DIM_Y, BLOCK_DIM_Z>;
+  using RakingCommutativeOnly = detail::BlockReduceRakingCommutativeOnly<T, BLOCK_DIM_X, BLOCK_DIM_Y, BLOCK_DIM_Z>;
+  using Raking                = detail::BlockReduceRaking<T, BLOCK_DIM_X, BLOCK_DIM_Y, BLOCK_DIM_Z>;
+
+  /// Internal specialization type
+  using InternalBlockReduce =
+    ::cuda::std::_If<ALGORITHM == BLOCK_NONDETERMINISTIC_REDUCE_WARP_REDUCTIONS,
+                     WarpReductions,
+                     ::cuda::std::_If<ALGORITHM == BLOCK_NONDETERMINISTIC_REDUCE_RAKING_COMMUTATIVE_ONLY,
+                                      RakingCommutativeOnly,
+                                      Raking>>; // BlockReduceRaking
+
+  /// Shared memory storage layout type for BlockReduce
+  using _TempStorage = typename InternalBlockReduce::TempStorage;
+
+  /// Internal storage allocator
+  _CCCL_DEVICE _CCCL_FORCEINLINE _TempStorage& PrivateStorage()
+  {
+    __shared__ _TempStorage private_storage;
+    return private_storage;
+  }
+
+  /// Shared storage reference
+  _TempStorage& temp_storage;
+
+  /// Linear thread-id
+  unsigned int linear_tid;
+
+public:
+  /// @smemstorage{BlockReduce}
+  struct TempStorage : Uninitialized<_TempStorage>
+  {};
+
+  //! @name Collective constructors
+  //! @{
+
+  //! @brief Collective constructor using a private static allocation of shared memory as temporary storage.
+  _CCCL_DEVICE _CCCL_FORCEINLINE BlockNondeterministicReduce()
+      : temp_storage(PrivateStorage())
+      , linear_tid(RowMajorTid(BLOCK_DIM_X, BLOCK_DIM_Y, BLOCK_DIM_Z))
+  {}
+
+  /**
+   * @brief Collective constructor using the specified memory allocation as temporary storage.
+   *
+   * @param[in] temp_storage
+   *   Reference to memory allocation having layout type TempStorage
+   */
+  _CCCL_DEVICE _CCCL_FORCEINLINE BlockNondeterministicReduce(TempStorage& temp_storage)
+      : temp_storage(temp_storage.Alias())
+      , linear_tid(RowMajorTid(BLOCK_DIM_X, BLOCK_DIM_Y, BLOCK_DIM_Z))
+  {}
+
+  //! @}  end member group
+  //! @name Generic reductions
+  //! @{
+
+  //! @rst
+  //! Computes a block-wide reduction for thread\ :sub:`0` using the specified binary reduction functor.
+  //! Each thread contributes one input element.
+  //!
+  //! - The return value is undefined in threads other than thread\ :sub:`0`.
+  //! - @rowmajor
+  //! - @smemreuse
+  //!
+  //! Snippet
+  //! +++++++
+  //!
+  //! The code snippet below illustrates a max reduction of 128 integer items that
+  //! are partitioned across 128 threads.
+  //!
+  //! .. code-block:: c++
+  //!
+  //!    #include <cub/cub.cuh>   // or equivalently <cub/block/block_reduce.cuh>
+  //!
+  //!    __global__ void ExampleKernel(...)
+  //!    {
+  //!        // Specialize BlockReduce for a 1D block of 128 threads of type int
+  //!        using BlockReduce = cub::BlockReduce<int, 128>;
+  //!
+  //!        // Allocate shared memory for BlockReduce
+  //!        __shared__ typename BlockReduce::TempStorage temp_storage;
+  //!
+  //!        // Each thread obtains an input item
+  //!        int thread_data;
+  //!        ...
+  //!
+  //!        // Compute the block-wide max for thread0
+  //!        int aggregate = BlockReduce(temp_storage).Reduce(thread_data, cuda::maximum<>{});
+  //!    }
+  //!
+  //! @endrst
+  //!
+  //! @tparam ReductionOp
+  //!   **[inferred]** Binary reduction functor type having member `T operator()(const T &a, const T &b)`
+  //!
+  //! @param[in] input
+  //!   Calling thread's input
+  //!
+  //! @param[in] reduction_op
+  //!   Binary reduction functor
+  template <typename ReductionOp>
+  _CCCL_DEVICE _CCCL_FORCEINLINE T Reduce(T input, ReductionOp reduction_op)
+  {
+    return InternalBlockReduce(temp_storage).template Reduce<true>(input, BLOCK_THREADS, reduction_op);
+  }
+
+  //! @rst
+  //! Computes a block-wide reduction for thread\ :sub:`0` using the specified binary reduction functor.
+  //! Each thread contributes an array of consecutive input elements.
+  //!
+  //! - The return value is undefined in threads other than thread\ :sub:`0`.
+  //! - @granularity
+  //! - @smemreuse
+  //!
+  //! Snippet
+  //! +++++++
+  //!
+  //! The code snippet below illustrates a max reduction of 512 integer items that are partitioned in a
+  //! :ref:`blocked arrangement <flexible-data-arrangement>` across 128 threads where each thread owns
+  //! 4 consecutive items.
+  //!
+  //! .. code-block:: c++
+  //!
+  //!    #include <cub/cub.cuh>   // or equivalently <cub/block/block_reduce.cuh>
+  //!
+  //!    __global__ void ExampleKernel(...)
+  //!    {
+  //!        // Specialize BlockReduce for a 1D block of 128 threads of type int
+  //!        using BlockReduce = cub::BlockReduce<int, 128>;
+  //!
+  //!        // Allocate shared memory for BlockReduce
+  //!        __shared__ typename BlockReduce::TempStorage temp_storage;
+  //!
+  //!        // Obtain a segment of consecutive items that are blocked across threads
+  //!        int thread_data[4];
+  //!        ...
+  //!
+  //!        // Compute the block-wide max for thread0
+  //!        int aggregate = BlockReduce(temp_storage).Reduce(thread_data, cuda::maximum<>{});
+  //!
+  //! @endrst
+  //!
+  //! @tparam ITEMS_PER_THREAD
+  //!   **[inferred]** The number of consecutive items partitioned onto each thread.
+  //!
+  //! @tparam ReductionOp
+  //!   **[inferred]** Binary reduction functor type having member `T operator()(const T &a, const T &b)`
+  //!
+  //! @param[in] inputs
+  //!   Calling thread's input segment
+  //!
+  //! @param[in] reduction_op
+  //!   Binary reduction functor
+  template <int ITEMS_PER_THREAD, typename ReductionOp>
+  _CCCL_DEVICE _CCCL_FORCEINLINE T Reduce(T (&inputs)[ITEMS_PER_THREAD], ReductionOp reduction_op)
+  {
+    // Reduce partials
+    T partial = cub::ThreadReduce(inputs, reduction_op);
+    return Reduce(partial, reduction_op);
+  }
+
+  //! @rst
+  //! Computes a block-wide reduction for thread\ :sub:`0` using the specified binary reduction functor.
+  //! The first ``num_valid`` threads each contribute one input element.
+  //!
+  //! - The return value is undefined in threads other than thread<sub>0</sub>.
+  //! - @rowmajor
+  //! - @smemreuse
+  //!
+  //! Snippet
+  //! +++++++
+  //!
+  //! The code snippet below illustrates a max reduction of a partially-full tile of integer items
+  //! that are partitioned across 128 threads.
+  //!
+  //! .. code-block:: c++
+  //!
+  //!    #include <cub/cub.cuh>   // or equivalently <cub/block/block_reduce.cuh>
+  //!
+  //!    __global__ void ExampleKernel(int num_valid, ...)
+  //!    {
+  //!        // Specialize BlockReduce for a 1D block of 128 threads of type int
+  //!        using BlockReduce = cub::BlockReduce<int, 128>;
+  //!
+  //!        // Allocate shared memory for BlockReduce
+  //!        __shared__ typename BlockReduce::TempStorage temp_storage;
+  //!
+  //!        // Each thread obtains an input item
+  //!        int thread_data;
+  //!        if (threadIdx.x < num_valid) thread_data = ...
+  //!
+  //!        // Compute the block-wide max for thread0
+  //!        int aggregate = BlockReduce(temp_storage).Reduce(thread_data, cuda::maximum<>{}, num_valid);
+  //!    }
+  //!
+  //! @endrst
+  //!
+  //! @tparam ReductionOp
+  //!   **[inferred]** Binary reduction functor type having member `T operator()(const T &a, const T &b)`
+  //!
+  //! @param[in] input
+  //!   Calling thread's input
+  //!
+  //! @param[in] reduction_op
+  //!   Binary reduction functor
+  //!
+  //! @param[in] num_valid
+  //!   Number of threads containing valid elements (may be less than BLOCK_THREADS)
+  template <typename ReductionOp>
+  _CCCL_DEVICE _CCCL_FORCEINLINE T Reduce(T input, ReductionOp reduction_op, int num_valid)
+  {
+    // Determine if we skip bounds checking
+    if (num_valid >= BLOCK_THREADS)
+    {
+      return InternalBlockReduce(temp_storage).template Reduce<true>(input, num_valid, reduction_op);
+    }
+    else
+    {
+      return InternalBlockReduce(temp_storage).template Reduce<false>(input, num_valid, reduction_op);
+    }
+  }
+
+  //! @}  end member group
+  //! @name Summation reductions
+  //! @{
+
+  //! @rst
+  //! Computes a block-wide reduction for thread\ :sub:`0` using addition (+) as the reduction operator.
+  //! Each thread contributes one input element.
+  //!
+  //! - The return value is undefined in threads other than thread\ :sub:`0`.
+  //! - @rowmajor
+  //! - @smemreuse
+  //!
+  //! Snippet
+  //! +++++++
+  //!
+  //! The code snippet below illustrates a sum reduction of 128 integer items that
+  //! are partitioned across 128 threads.
+  //!
+  //! .. code-block:: c++
+  //!
+  //!    #include <cub/cub.cuh>   // or equivalently <cub/block/block_reduce.cuh>
+  //!
+  //!    __global__ void ExampleKernel(...)
+  //!    {
+  //!        // Specialize BlockReduce for a 1D block of 128 threads of type int
+  //!        using BlockReduce = cub::BlockReduce<int, 128>;
+  //!
+  //!        // Allocate shared memory for BlockReduce
+  //!        __shared__ typename BlockReduce::TempStorage temp_storage;
+  //!
+  //!        // Each thread obtains an input item
+  //!        int thread_data;
+  //!        ...
+  //!
+  //!        // Compute the block-wide sum for thread0
+  //!        int aggregate = BlockReduce(temp_storage).Sum(thread_data);
+  //!    }
+  //!
+  //! @endrst
+  //!
+  //! @param[in] input
+  //!   Calling thread's input
+  _CCCL_DEVICE _CCCL_FORCEINLINE T Sum(T input)
+  {
+    return InternalBlockReduce(temp_storage).template Sum<true>(input, BLOCK_THREADS);
+  }
+
+  //! @rst
+  //! Computes a block-wide reduction for thread<sub>0</sub> using addition (+) as the reduction operator.
+  //! Each thread contributes an array of consecutive input elements.
+  //!
+  //! - The return value is undefined in threads other than thread\ :sub:`0`.
+  //! - @granularity
+  //! - @smemreuse
+  //!
+  //! Snippet
+  //! +++++++
+  //!
+  //! The code snippet below illustrates a sum reduction of 512 integer items that are partitioned in a
+  //! :ref:`blocked arrangement <flexible-data-arrangement>` across 128 threads where each thread owns
+  //! 4 consecutive items.
+  //!
+  //! .. code-block:: c++
+  //!
+  //!    #include <cub/cub.cuh>   // or equivalently <cub/block/block_reduce.cuh>
+  //!
+  //!    __global__ void ExampleKernel(...)
+  //!    {
+  //!        // Specialize BlockReduce for a 1D block of 128 threads of type int
+  //!        using BlockReduce = cub::BlockReduce<int, 128>;
+  //!
+  //!        // Allocate shared memory for BlockReduce
+  //!        __shared__ typename BlockReduce::TempStorage temp_storage;
+  //!
+  //!        // Obtain a segment of consecutive items that are blocked across threads
+  //!        int thread_data[4];
+  //!        ...
+  //!
+  //!        // Compute the block-wide sum for thread0
+  //!        int aggregate = BlockReduce(temp_storage).Sum(thread_data);
+  //!    }
+  //!
+  //! @endrst
+  //!
+  //! @tparam ITEMS_PER_THREAD
+  //!   **[inferred]** The number of consecutive items partitioned onto each thread.
+  //!
+  //! @param[in] inputs
+  //!   Calling thread's input segment
+  template <int ITEMS_PER_THREAD>
+  _CCCL_DEVICE _CCCL_FORCEINLINE T Sum(T (&inputs)[ITEMS_PER_THREAD])
+  {
+    // Reduce partials
+    T partial = cub::ThreadReduce(inputs, ::cuda::std::plus<>{});
+    return Sum(partial);
+  }
+
+  //! @rst
+  //! Computes a block-wide reduction for thread\ :sub:`0` using addition (+) as the reduction operator.
+  //! The first ``num_valid`` threads each contribute one input element.
+  //!
+  //! - The return value is undefined in threads other than thread\ :sub:`0`.
+  //! - @rowmajor
+  //! - @smemreuse
+  //!
+  //! Snippet
+  //! +++++++
+  //!
+  //! The code snippet below illustrates a sum reduction of a partially-full tile of integer items
+  //! that are partitioned across 128 threads.
+  //!
+  //! .. code-block:: c++
+  //!
+  //!    #include <cub/cub.cuh>   // or equivalently <cub/block/block_reduce.cuh>
+  //!
+  //!    __global__ void ExampleKernel(int num_valid, ...)
+  //!    {
+  //!        // Specialize BlockReduce for a 1D block of 128 threads of type int
+  //!        using BlockReduce = cub::BlockReduce<int, 128>;
+  //!
+  //!        // Allocate shared memory for BlockReduce
+  //!        __shared__ typename BlockReduce::TempStorage temp_storage;
+  //!
+  //!        // Each thread obtains an input item (up to num_items)
+  //!        int thread_data;
+  //!        if (threadIdx.x < num_valid)
+  //!            thread_data = ...
+  //!
+  //!        // Compute the block-wide sum for thread0
+  //!        int aggregate = BlockReduce(temp_storage).Sum(thread_data, num_valid);
+  //!    }
+  //!
+  //! @endrst
+  //!
+  //! @param[in] input
+  //!   Calling thread's input
+  //!
+  //! @param[in] num_valid
+  //!   Number of threads containing valid elements (may be less than BLOCK_THREADS)
+  _CCCL_DEVICE _CCCL_FORCEINLINE T Sum(T input, int num_valid)
+  {
+    // Determine if we skip bounds checking
+    if (num_valid >= BLOCK_THREADS)
+    {
+      return InternalBlockReduce(temp_storage).template Sum<true>(input, num_valid);
+    }
+    else
+    {
+      return InternalBlockReduce(temp_storage).template Sum<false>(input, num_valid);
+    }
+  }
+
+  //! @}  end member group
+};
+
+CUB_NAMESPACE_END

--- a/cub/cub/block/specializations/block_reduce_warp_nondeterministic_reductions.cuh
+++ b/cub/cub/block/specializations/block_reduce_warp_nondeterministic_reductions.cuh
@@ -1,0 +1,277 @@
+/******************************************************************************
+ * Copyright (c) 2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2025, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/**
+ * @file
+ * cub::BlockNondeterministicReduceWarpReductions provides variants of warp-reduction-based parallel reduction
+ * across a CUDA thread block. Supports non-commutative reduction operators.
+ */
+
+#pragma once
+
+#include <cub/config.cuh>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cub/detail/uninitialized_copy.cuh>
+#include <cub/util_ptx.cuh>
+#include <cub/warp/warp_reduce.cuh>
+
+#include <cuda/ptx>
+
+CUB_NAMESPACE_BEGIN
+namespace detail
+{
+/**
+ * @brief BlockNondeterministicReduceWarpReductions provides variants of warp-reduction-based parallel reduction
+ *        across a CUDA thread block. Supports non-commutative reduction operators.
+ * @tparam T
+ *   Data type being reduced
+ *
+ * @tparam BLOCK_DIM_X
+ *   The thread block length in threads along the X dimension
+ *
+ * @tparam BLOCK_DIM_Y
+ *   The thread block length in threads along the Y dimension
+ *
+ * @tparam BLOCK_DIM_Z
+ *   The thread block length in threads along the Z dimension
+ */
+template <typename T, int BLOCK_DIM_X, int BLOCK_DIM_Y, int BLOCK_DIM_Z>
+struct BlockNondeterministicReduceWarpReductions
+{
+  /// Constants
+  enum
+  {
+    /// The thread block size in threads
+    BLOCK_THREADS = BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z,
+
+    /// Number of warp threads
+    WARP_THREADS = warp_threads,
+
+    /// Number of active warps
+    WARPS = (BLOCK_THREADS + WARP_THREADS - 1) / WARP_THREADS,
+
+    /// The logical warp size for warp reductions
+    LOGICAL_WARP_SIZE = (BLOCK_THREADS < WARP_THREADS ? BLOCK_THREADS : WARP_THREADS), // MSVC bug with cuda::std::min
+
+    /// Whether or not the logical warp size evenly divides the thread block size
+    EVEN_WARP_MULTIPLE = (BLOCK_THREADS % LOGICAL_WARP_SIZE == 0)
+  };
+
+  ///  WarpReduce utility type
+  using WarpReduceInternal = typename WarpReduce<T, LOGICAL_WARP_SIZE>::InternalWarpReduce;
+
+  /// Shared memory storage layout type
+  struct _TempStorage
+  {
+    /// Buffer for warp-synchronous reduction
+    typename WarpReduceInternal::TempStorage warp_reduce[WARPS];
+
+    /// Shared totals from each warp-synchronous reduction
+    T warp_aggregates[WARPS];
+
+    /// Shared prefix for the entire thread block
+    T block_prefix;
+  };
+
+  /// Alias wrapper allowing storage to be unioned
+  struct TempStorage : Uninitialized<_TempStorage>
+  {};
+
+  // Thread fields
+  _TempStorage& temp_storage;
+  int linear_tid;
+  int warp_id;
+  int lane_id;
+
+  /// Constructor
+  _CCCL_DEVICE _CCCL_FORCEINLINE BlockNondeterministicReduceWarpReductions(TempStorage& temp_storage)
+      : temp_storage(temp_storage.Alias())
+      , linear_tid(RowMajorTid(BLOCK_DIM_X, BLOCK_DIM_Y, BLOCK_DIM_Z))
+      , warp_id((WARPS == 1) ? 0 : linear_tid / WARP_THREADS)
+      , lane_id(::cuda::ptx::get_sreg_laneid())
+  {}
+
+  /**
+   * @param[in] reduction_op
+   *   Binary reduction operator
+   *
+   * @param[in] warp_aggregate
+   *   <b>[<em>lane</em><sub>0</sub> only]</b> Warp-wide aggregate reduction of input items
+   *
+   * @param[in] num_valid
+   *   Number of valid elements (may be less than BLOCK_THREADS)
+   */
+  template <bool FULL_TILE, typename ReductionOp, int SUCCESSOR_WARP>
+  _CCCL_DEVICE _CCCL_FORCEINLINE T ApplyWarpAggregates(
+    ReductionOp reduction_op, T warp_aggregate, int num_valid, constant_t<SUCCESSOR_WARP> /*successor_warp*/)
+  {
+    if (FULL_TILE || (SUCCESSOR_WARP * LOGICAL_WARP_SIZE < num_valid))
+    {
+      T addend       = temp_storage.warp_aggregates[SUCCESSOR_WARP];
+      warp_aggregate = reduction_op(warp_aggregate, addend);
+    }
+    return ApplyWarpAggregates<FULL_TILE>(reduction_op, warp_aggregate, num_valid, constant_v<SUCCESSOR_WARP + 1>);
+  }
+
+  /**
+   * @param[in] reduction_op
+   *   Binary reduction operator
+   *
+   * @param[in] warp_aggregate
+   *   <b>[<em>lane</em><sub>0</sub> only]</b> Warp-wide aggregate reduction of input items
+   *
+   * @param[in] num_valid
+   *   Number of valid elements (may be less than BLOCK_THREADS)
+   */
+  template <bool FULL_TILE, typename ReductionOp>
+  _CCCL_DEVICE _CCCL_FORCEINLINE T ApplyWarpAggregates(
+    ReductionOp /*reduction_op*/, T warp_aggregate, int /*num_valid*/, constant_t<int{WARPS}> /*successor_warp*/)
+  {
+    return warp_aggregate;
+  }
+
+  /**
+   * @brief Returns block-wide aggregate in <em>thread</em><sub>0</sub>.
+   *
+   * @param[in] reduction_op
+   *   Binary reduction operator
+   *
+   * @param[in] warp_aggregate
+   *   <b>[<em>lane</em><sub>0</sub> only]</b> Warp-wide aggregate reduction of input items
+   *
+   * @param[in] num_valid
+   *   Number of valid elements (may be less than BLOCK_THREADS)
+   */
+  template <bool FULL_TILE, typename ReductionOp>
+  _CCCL_DEVICE _CCCL_FORCEINLINE T ApplyWarpAggregates(ReductionOp reduction_op, T warp_aggregate, int num_valid)
+  {
+#if TUNE_USE_ATOMIC_BLOCK_REDUCE
+    if (linear_tid == 0)
+    {
+      detail::uninitialized_copy_single(temp_storage.warp_aggregates, warp_aggregate);
+    }
+
+    __syncthreads();
+
+    if (lane_id == 0 && warp_id != 0)
+    {
+      // printf("adding %f\n", warp_aggregate);
+      atomicAdd(temp_storage.warp_aggregates, warp_aggregate);
+    }
+
+    __syncthreads();
+    return temp_storage.warp_aggregates[0];
+#else
+    // Share lane aggregates
+    if (lane_id == 0)
+    {
+      detail::uninitialized_copy_single(temp_storage.warp_aggregates + warp_id, warp_aggregate);
+    }
+
+    __syncthreads();
+
+    // Update total aggregate in warp 0, lane 0
+    if (linear_tid == 0)
+    {
+      warp_aggregate = ApplyWarpAggregates<FULL_TILE>(reduction_op, warp_aggregate, num_valid, constant_v<1>);
+    }
+
+    return warp_aggregate;
+#endif
+  }
+
+  /**
+   * @brief Computes a thread block-wide reduction using addition (+) as the reduction operator.
+   *        The first num_valid threads each contribute one reduction partial. The return value is
+   *        only valid for thread<sub>0</sub>.
+   *
+   * @param[in] input
+   *   Calling thread's input partial reductions
+   *
+   * @param[in] num_valid
+   *   Number of valid elements (may be less than BLOCK_THREADS)
+   */
+  template <bool FULL_TILE>
+  _CCCL_DEVICE _CCCL_FORCEINLINE T Sum(T input, int num_valid)
+  {
+    ::cuda::std::plus<> reduction_op;
+    int warp_offset    = (warp_id * LOGICAL_WARP_SIZE);
+    int warp_num_valid = ((FULL_TILE && EVEN_WARP_MULTIPLE) || (warp_offset + LOGICAL_WARP_SIZE <= num_valid))
+                         ? LOGICAL_WARP_SIZE
+                         : num_valid - warp_offset;
+
+    // Warp reduction in every warp
+    T warp_aggregate =
+      WarpReduceInternal(temp_storage.warp_reduce[warp_id])
+        .template Reduce<(FULL_TILE && EVEN_WARP_MULTIPLE)>(input, warp_num_valid, ::cuda::std::plus<>{});
+
+    // Update outputs and block_aggregate with warp-wide aggregates from lane-0s
+    return ApplyWarpAggregates<FULL_TILE>(reduction_op, warp_aggregate, num_valid);
+  }
+
+  /**
+   * @brief Computes a thread block-wide reduction using the specified reduction operator.
+   *        The first num_valid threads each contribute one reduction partial.
+   *        The return value is only valid for thread<sub>0</sub>.
+   *
+   * @param[in] input
+   *   Calling thread's input partial reductions
+   *
+   * @param[in] num_valid
+   *   Number of valid elements (may be less than BLOCK_THREADS)
+   *
+   * @param[in] reduction_op
+   *   Binary reduction operator
+   */
+  template <bool FULL_TILE, typename ReductionOp>
+  _CCCL_DEVICE _CCCL_FORCEINLINE T Reduce(T input, int num_valid, ReductionOp reduction_op)
+  {
+    int warp_offset    = warp_id * LOGICAL_WARP_SIZE;
+    int warp_num_valid = ((FULL_TILE && EVEN_WARP_MULTIPLE) || (warp_offset + LOGICAL_WARP_SIZE <= num_valid))
+                         ? LOGICAL_WARP_SIZE
+                         : num_valid - warp_offset;
+
+    // Warp reduction in every warp
+    T warp_aggregate = WarpReduceInternal(temp_storage.warp_reduce[warp_id])
+                         .template Reduce<(FULL_TILE && EVEN_WARP_MULTIPLE)>(input, warp_num_valid, reduction_op);
+
+    // Update outputs and block_aggregate with warp-wide aggregates from lane-0s
+    return ApplyWarpAggregates<FULL_TILE>(reduction_op, warp_aggregate, num_valid);
+  }
+};
+} // namespace detail
+
+CUB_NAMESPACE_END

--- a/cub/cub/detail/launcher/cuda_driver.cuh
+++ b/cub/cub/detail/launcher/cuda_driver.cuh
@@ -111,6 +111,12 @@ struct CudaDriverLauncherFactory
     return static_cast<cudaError_t>(cuDeviceGetAttribute(&max_grid_dim_x, CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_X, device));
   }
 
+  _CCCL_HIDE_FROM_ABI cudaError_t
+  MemsetAsync(void* dst, int value, size_t num_elements, size_t /*element_size*/, CUstream stream) const
+  {
+    return static_cast<cudaError_t>(cuMemsetD32Async(reinterpret_cast<CUdeviceptr>(dst), value, num_elements, stream));
+  }
+
   CUdevice device;
   int cc;
 };

--- a/cub/cub/detail/launcher/cuda_runtime.cuh
+++ b/cub/cub/detail/launcher/cuda_runtime.cuh
@@ -67,6 +67,12 @@ struct TripleChevronFactory
     // Get max grid dimension
     return cudaDeviceGetAttribute(&max_grid_dim_x, cudaDevAttrMaxGridDimX, device_ordinal);
   }
+
+  _CCCL_HIDE_FROM_ABI CUB_RUNTIME_FUNCTION cudaError_t
+  MemsetAsync(void* dst, int value, size_t num_elements, size_t element_size, cudaStream_t stream) const
+  {
+    return cudaMemsetAsync(dst, value, num_elements * element_size, stream);
+  }
 };
 
 } // namespace detail

--- a/cub/cub/device/device_nondeterministic_reduce.cuh
+++ b/cub/cub/device/device_nondeterministic_reduce.cuh
@@ -1,0 +1,337 @@
+/******************************************************************************
+ * Copyright (c) 2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2024, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+//! @file
+//! cub::DeviceReduce provides device-wide, parallel operations for computing a reduction across a sequence of data
+//! items residing within device-accessible memory.
+
+#pragma once
+
+#include <cub/config.cuh>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cub/detail/choose_offset.cuh>
+#include <cub/detail/nvtx.cuh>
+#include <cub/device/dispatch/dispatch_nondeterministic_reduce.cuh>
+#include <cub/util_type.cuh>
+
+#include <thrust/iterator/tabulate_output_iterator.h>
+
+#include <cuda/std/limits>
+
+#include <iterator>
+
+CUB_NAMESPACE_BEGIN
+
+namespace detail
+{
+namespace nondeterminstic_reduce
+{
+template <typename ExtremumOutIteratorT, typename IndexOutIteratorT>
+struct unzip_and_write_arg_extremum_op
+{
+  ExtremumOutIteratorT result_out_it;
+  IndexOutIteratorT index_out_it;
+
+  template <typename IndexT, typename KeyValuePairT>
+  _CCCL_DEVICE _CCCL_FORCEINLINE void operator()(IndexT, KeyValuePairT reduced_result)
+  {
+    *result_out_it = reduced_result.value;
+    *index_out_it  = reduced_result.key;
+  }
+};
+} // namespace nondeterminstic_reduce
+} // namespace detail
+
+//! @rst
+//! DeviceReduce provides device-wide, parallel operations for computing
+//! a reduction across a sequence of data items residing within
+//! device-accessible memory.
+//!
+//! .. image:: ../../img/reduce_logo.png
+//!     :align: center
+//!
+//! Overview
+//! ====================================
+//!
+//! A `reduction <http://en.wikipedia.org/wiki/Reduce_(higher-order_function)>`_
+//! (or *fold*) uses a binary combining operator to compute a single aggregate
+//! from a sequence of input elements.
+//!
+//! Usage Considerations
+//! ====================================
+//!
+//! @cdp_class{DeviceReduce}
+//!
+//! Performance
+//! ====================================
+//!
+//! @linear_performance{reduction, reduce-by-key, and run-length encode}
+//!
+//! @endrst
+struct DeviceNondeterministicReduce
+{
+  //! @rst
+  //! Computes a device-wide reduction using the specified binary ``reduction_op`` functor and initial value ``init``.
+  //!
+  //! - Does not support binary reduction operators that are non-commutative.
+  //! - Provides "run-to-run" determinism for pseudo-associative reduction
+  //!   (e.g., addition of floating point types) on the same GPU device.
+  //!   However, results for pseudo-associative reduction may be inconsistent
+  //!   from one device to a another device of a different compute-capability
+  //!   because CUB can employ different tile-sizing for different architectures.
+  //! - The range ``[d_in, d_in + num_items)`` shall not overlap ``d_out``.
+  //! - @devicestorage
+  //!
+  //! Snippet
+  //! +++++++++++++++++++++++++++++++++++++++++++++
+  //!
+  //! The code snippet below illustrates a user-defined min-reduction of a
+  //! device vector of ``int`` data elements.
+  //!
+  //! .. code-block:: c++
+  //!
+  //!    #include <cub/cub.cuh>
+  //!    // or equivalently <cub/device/device_reduce.cuh>
+  //!
+  //!    // CustomMin functor
+  //!    struct CustomMin
+  //!    {
+  //!        template <typename T>
+  //!        __device__ __forceinline__
+  //!        T operator()(const T &a, const T &b) const {
+  //!            return (b < a) ? b : a;
+  //!        }
+  //!    };
+  //!
+  //!    // Declare, allocate, and initialize device-accessible pointers for
+  //!    // input and output
+  //!    int          num_items;  // e.g., 7
+  //!    int          *d_in;      // e.g., [8, 6, 7, 5, 3, 0, 9]
+  //!    int          *d_out;     // e.g., [-]
+  //!    CustomMin    min_op;
+  //!    int          init;       // e.g., INT_MAX
+  //!    ...
+  //!
+  //!    // Determine temporary device storage requirements
+  //!    void     *d_temp_storage = nullptr;
+  //!    size_t   temp_storage_bytes = 0;
+  //!    cub::DeviceReduce::Reduce(
+  //!      d_temp_storage, temp_storage_bytes,
+  //!      d_in, d_out, num_items, min_op, init);
+  //!
+  //!    // Allocate temporary storage
+  //!    cudaMalloc(&d_temp_storage, temp_storage_bytes);
+  //!
+  //!    // Run reduction
+  //!    cub::DeviceReduce::Reduce(
+  //!      d_temp_storage, temp_storage_bytes,
+  //!      d_in, d_out, num_items, min_op, init);
+  //!
+  //!    // d_out <-- [0]
+  //!
+  //! @endrst
+  //!
+  //! @tparam InputIteratorT
+  //!   **[inferred]** Random-access input iterator type for reading input items @iterator
+  //!
+  //! @tparam OutputIteratorT
+  //!   **[inferred]** Output iterator type for recording the reduced aggregate @iterator
+  //!
+  //! @tparam ReductionOpT
+  //!   **[inferred]** Binary reduction functor type having member `T operator()(const T &a, const T &b)`
+  //!
+  //! @tparam T
+  //!   **[inferred]** Data element type that is convertible to the `value` type of `InputIteratorT`
+  //!
+  //! @tparam NumItemsT
+  //!   **[inferred]** Type of num_items
+  //!
+  //! @param[in] d_temp_storage
+  //!   Device-accessible allocation of temporary storage. When `nullptr`, the
+  //!   required allocation size is written to `temp_storage_bytes` and no work
+  //!   is done.
+  //!
+  //! @param[in,out] temp_storage_bytes
+  //!   Reference to size in bytes of `d_temp_storage` allocation
+  //!
+  //! @param[in] d_in
+  //!   Pointer to the input sequence of data items
+  //!
+  //! @param[out] d_out
+  //!   Pointer to the output aggregate
+  //!
+  //! @param[in] num_items
+  //!   Total number of input items (i.e., length of `d_in`)
+  //!
+  //! @param[in] reduction_op
+  //!   Binary reduction functor
+  //!
+  //! @param[in] init
+  //!   Initial value of the reduction
+  //!
+  //! @param[in] stream
+  //!   @rst
+  //!   **[optional]** CUDA stream to launch kernels within. Default is stream\ :sub:`0`.
+  //!   @endrst
+  template <typename InputIteratorT, typename OutputIteratorT, typename ReductionOpT, typename T, typename NumItemsT>
+  CUB_RUNTIME_FUNCTION static cudaError_t Reduce(
+    void* d_temp_storage,
+    size_t& temp_storage_bytes,
+    InputIteratorT d_in,
+    OutputIteratorT d_out,
+    NumItemsT num_items,
+    ReductionOpT reduction_op,
+    T init,
+    cudaStream_t stream = 0)
+  {
+    CUB_DETAIL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceNondeterministicReduce::Reduce");
+
+    // Signed integer type for global offsets
+    using OffsetT = detail::choose_offset_t<NumItemsT>;
+
+    return detail::nondeterministic_reduce::
+      DispatchNondeterministicReduce<InputIteratorT, OutputIteratorT, OffsetT, ReductionOpT, T>::Dispatch(
+        d_temp_storage, temp_storage_bytes, d_in, d_out, static_cast<OffsetT>(num_items), reduction_op, init, stream);
+  }
+
+  //! @rst
+  //! Computes a device-wide sum using the addition (``+``) operator.
+  //!
+  //! - Uses ``0`` as the initial value of the reduction.
+  //! - Does not support ``+`` operators that are non-commutative..
+  //! - Provides "run-to-run" determinism for pseudo-associative reduction
+  //!   (e.g., addition of floating point types) on the same GPU device.
+  //!   However, results for pseudo-associative reduction may be inconsistent
+  //!   from one device to a another device of a different compute-capability
+  //!   because CUB can employ different tile-sizing for different architectures.
+  //! - The range ``[d_in, d_in + num_items)`` shall not overlap ``d_out``.
+  //! - @devicestorage
+  //!
+  //! Snippet
+  //! +++++++++++++++++++++++++++++++++++++++++++++
+  //!
+  //! The code snippet below illustrates the sum-reduction of a device vector
+  //! of ``int`` data elements.
+  //!
+  //! .. code-block:: c++
+  //!
+  //!    #include <cub/cub.cuh> // or equivalently <cub/device/device_reduce.cuh>
+  //!
+  //!    // Declare, allocate, and initialize device-accessible pointers
+  //!    // for input and output
+  //!    int  num_items;      // e.g., 7
+  //!    int  *d_in;          // e.g., [8, 6, 7, 5, 3, 0, 9]
+  //!    int  *d_out;         // e.g., [-]
+  //!    ...
+  //!
+  //!    // Determine temporary device storage requirements
+  //!    void     *d_temp_storage = nullptr;
+  //!    size_t   temp_storage_bytes = 0;
+  //!    cub::DeviceReduce::Sum(
+  //!      d_temp_storage, temp_storage_bytes, d_in, d_out, num_items);
+  //!
+  //!    // Allocate temporary storage
+  //!    cudaMalloc(&d_temp_storage, temp_storage_bytes);
+  //!
+  //!    // Run sum-reduction
+  //!    cub::DeviceReduce::Sum(d_temp_storage, temp_storage_bytes, d_in, d_out, num_items);
+  //!
+  //!    // d_out <-- [38]
+  //!
+  //! @endrst
+  //!
+  //! @tparam InputIteratorT
+  //!   **[inferred]** Random-access input iterator type for reading input items @iterator
+  //!
+  //! @tparam OutputIteratorT
+  //!   **[inferred]** Output iterator type for recording the reduced aggregate @iterator
+  //!
+  //! @tparam NumItemsT
+  //!   **[inferred]** Type of num_items
+  //!
+  //! @param[in] d_temp_storage
+  //!   Device-accessible allocation of temporary storage. When `nullptr`, the
+  //!   required allocation size is written to `temp_storage_bytes` and no work is done.
+  //!
+  //! @param[in,out] temp_storage_bytes
+  //!   Reference to size in bytes of `d_temp_storage` allocation
+  //!
+  //! @param[in] d_in
+  //!   Pointer to the input sequence of data items
+  //!
+  //! @param[out] d_out
+  //!   Pointer to the output aggregate
+  //!
+  //! @param[in] num_items
+  //!   Total number of input items (i.e., length of `d_in`)
+  //!
+  //! @param[in] stream
+  //!   @rst
+  //!   **[optional]** CUDA stream to launch kernels within. Default is stream\ :sub:`0`.
+  //!   @endrst
+  template <typename InputIteratorT, typename OutputIteratorT, typename NumItemsT>
+  CUB_RUNTIME_FUNCTION static cudaError_t
+  Sum(void* d_temp_storage,
+      size_t& temp_storage_bytes,
+      InputIteratorT d_in,
+      OutputIteratorT d_out,
+      NumItemsT num_items,
+      cudaStream_t stream = 0)
+  {
+    CUB_DETAIL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceNondeterministicReduce::Sum");
+
+    // Signed integer type for global offsets
+    using OffsetT = detail::choose_offset_t<NumItemsT>;
+
+    // The output value type
+    using OutputT = cub::detail::non_void_value_t<OutputIteratorT, cub::detail::it_value_t<InputIteratorT>>;
+
+    using InitT = OutputT;
+
+    return detail::nondeterministic_reduce::
+      DispatchNondeterministicReduce<InputIteratorT, OutputIteratorT, OffsetT, ::cuda::std::plus<>, InitT>::Dispatch(
+        d_temp_storage,
+        temp_storage_bytes,
+        d_in,
+        d_out,
+        static_cast<OffsetT>(num_items),
+        ::cuda::std::plus<>{},
+        InitT{}, // zero-initialize
+        stream);
+  }
+};
+
+CUB_NAMESPACE_END

--- a/cub/cub/device/dispatch/dispatch_nondeterministic_reduce.cuh
+++ b/cub/cub/device/dispatch/dispatch_nondeterministic_reduce.cuh
@@ -1,0 +1,571 @@
+/******************************************************************************
+ * Copyright (c) 2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2024, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/**
+ * @file cub::DeviceReduce provides device-wide, parallel operations for
+ *       computing a reduction across a sequence of data items residing within
+ *       device-accessible memory.
+ */
+
+#pragma once
+
+#include <cub/config.cuh>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cub/detail/launcher/cuda_runtime.cuh>
+#include <cub/detail/type_traits.cuh> // for cub::detail::invoke_result_t
+#include <cub/device/dispatch/dispatch_advance_iterators.cuh>
+#include <cub/device/dispatch/kernels/nondeterministic_reduce.cuh>
+#include <cub/device/dispatch/tuning/tuning_nondeterministic_reduce.cuh>
+#include <cub/grid/grid_even_share.cuh>
+#include <cub/thread/thread_operators.cuh>
+#include <cub/thread/thread_store.cuh>
+#include <cub/util_debug.cuh>
+#include <cub/util_device.cuh>
+#include <cub/util_temporary_storage.cuh>
+#include <cub/util_type.cuh> // for cub::detail::non_void_value_t, cub::detail::value_t
+
+#include <cuda/std/functional>
+
+#include <stdio.h>
+
+CUB_NAMESPACE_BEGIN
+
+namespace detail::nondeterministic_reduce
+{
+
+using CounterT = int;
+
+template <typename MaxPolicyT,
+          typename InputIteratorT,
+          typename OutputIteratorT,
+          typename OffsetT,
+          typename ReductionOpT,
+          typename InitT,
+          typename AccumT,
+          typename TransformOpT>
+struct DeviceReduceKernelSource
+{
+  CUB_DEFINE_KERNEL_GETTER(
+    LastBlockKernel,
+    DeviceReduceLastBlockKernel<
+      MaxPolicyT,
+      InputIteratorT,
+      OutputIteratorT,
+      OffsetT,
+      ReductionOpT,
+      InitT,
+      AccumT,
+      TransformOpT,
+      CounterT>);
+
+  CUB_DEFINE_KERNEL_GETTER(
+    AtomicKernel,
+    DeviceReduceAtomicKernel<MaxPolicyT, InputIteratorT, OutputIteratorT, OffsetT, ReductionOpT, InitT, AccumT, TransformOpT>);
+
+  CUB_RUNTIME_FUNCTION static constexpr size_t AccumSize()
+  {
+    return sizeof(AccumT);
+  }
+};
+} // namespace detail::nondeterministic_reduce
+
+namespace detail::nondeterministic_reduce
+{
+
+// This function handles both pointers passed from C++ and indirect_arg_t. We pass the address of the device pointer
+// here, cast it to a double pointer, and dereference it. This is necessary because indirect_arg_t stores the address of
+// the device pointer in `ptr`, which is a host pointer stored in `void*`. We can't dereference it directly, so we cast
+// it to a double pointer. This also just works for pointers from the C++ path.
+void* unwrap_indirect_arg(void* iterator)
+{
+  return *reinterpret_cast<void**>(iterator);
+}
+
+/**
+ * @brief Utility class for dispatching the appropriately-tuned kernels for
+ *        device-wide reduction
+ *
+ * @tparam InputIteratorT
+ *   Random-access input iterator type for reading input items @iterator
+ *
+ * @tparam OutputIteratorT
+ *   Output iterator type for recording the reduced aggregate @iterator
+ *
+ * @tparam OffsetT
+ *   Signed integer type for global offsets
+ *
+ * @tparam ReductionOpT
+ *   Binary reduction functor type having member
+ *   `auto operator()(const T &a, const U &b)`
+ *
+ * @tparam InitT
+ *   Initial value type
+ */
+template <typename InputIteratorT,
+          typename OutputIteratorT,
+          typename OffsetT,
+          typename ReductionOpT,
+          typename InitT  = cub::detail::non_void_value_t<OutputIteratorT, cub::detail::it_value_t<InputIteratorT>>,
+          typename AccumT = ::cuda::std::__accumulator_t<ReductionOpT, cub::detail::it_value_t<InputIteratorT>, InitT>,
+          typename TransformOpT = ::cuda::std::identity,
+          typename PolicyHub    = detail::nondeterministic_reduce::policy_hub<AccumT, OffsetT, ReductionOpT>,
+          typename KernelSource = detail::nondeterministic_reduce::DeviceReduceKernelSource<
+            typename PolicyHub::MaxPolicy,
+            InputIteratorT,
+            OutputIteratorT,
+            OffsetT,
+            ReductionOpT,
+            InitT,
+            AccumT,
+            TransformOpT>,
+          typename KernelLauncherFactory = detail::TripleChevronFactory>
+struct DispatchNondeterministicReduce
+{
+  //---------------------------------------------------------------------------
+  // Problem state
+  //---------------------------------------------------------------------------
+
+  /// Device-accessible allocation of temporary storage. When `nullptr`, the
+  /// required allocation size is written to `temp_storage_bytes` and no work
+  /// is done.
+  void* d_temp_storage;
+
+  /// Reference to size in bytes of `d_temp_storage` allocation
+  size_t& temp_storage_bytes;
+
+  /// Pointer to the input sequence of data items
+  InputIteratorT d_in;
+
+  /// Pointer to the output aggregate
+  OutputIteratorT d_out;
+
+  // Needed to call cuMemsetD32Async
+  void* d_out_ptr;
+
+  /// Total number of input items (i.e., length of `d_in`)
+  OffsetT num_items;
+
+  /// Binary reduction functor
+  ReductionOpT reduction_op;
+
+  /// The initial value of the reduction
+  InitT init;
+
+  /// CUDA stream to launch kernels within. Default is stream<sub>0</sub>.
+  cudaStream_t stream;
+
+  int ptx_version;
+
+  TransformOpT transform_op;
+
+  KernelSource kernel_source;
+
+  KernelLauncherFactory launcher_factory;
+
+  //---------------------------------------------------------------------------
+  // Constructor
+  //---------------------------------------------------------------------------
+
+  /// Constructor
+  CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE DispatchNondeterministicReduce(
+    void* d_temp_storage,
+    size_t& temp_storage_bytes,
+    InputIteratorT d_in,
+    OutputIteratorT d_out,
+    void* d_out_ptr,
+    OffsetT num_items,
+    ReductionOpT reduction_op,
+    InitT init,
+    cudaStream_t stream,
+    int ptx_version,
+    TransformOpT transform_op              = {},
+    KernelSource kernel_source             = {},
+    KernelLauncherFactory launcher_factory = {})
+      : d_temp_storage(d_temp_storage)
+      , temp_storage_bytes(temp_storage_bytes)
+      , d_in(d_in)
+      , d_out(d_out)
+      , d_out_ptr(d_out_ptr)
+      , num_items(num_items)
+      , reduction_op(reduction_op)
+      , init(init)
+      , stream(stream)
+      , ptx_version(ptx_version)
+      , transform_op(transform_op)
+      , kernel_source(kernel_source)
+      , launcher_factory(launcher_factory)
+  {}
+
+  //---------------------------------------------------------------------------
+  // Small-problem (single tile) invocation
+  //---------------------------------------------------------------------------
+
+  /**
+   * @brief Invoke a single block block to reduce in-core
+   *
+   * @tparam ActivePolicyT
+   *   Umbrella policy active for the target device
+   *
+   * @tparam LastBlockKernelT
+   *   Function type of cub::DeviceReduceLastBlockKernel
+   *
+   * @param[in] last_block_kernel
+   *   Kernel function pointer to parameterization of
+   *   cub::DeviceReduceLastBlockKernel
+   */
+  template <typename ActivePolicyT, typename LastBlockKernelT>
+  CUB_RUNTIME_FUNCTION _CCCL_VISIBILITY_HIDDEN _CCCL_FORCEINLINE cudaError_t
+  InvokeLastBlockKernel(LastBlockKernelT last_block_kernel, ActivePolicyT active_policy = {})
+  {
+    cudaError error = cudaSuccess;
+    do
+    {
+      // Get SM count
+      int sm_count;
+      error = CubDebug(launcher_factory.MultiProcessorCount(sm_count));
+      if (cudaSuccess != error)
+      {
+        break;
+      }
+
+      // Init regular kernel configuration
+      detail::KernelConfig reduce_config;
+      error = CubDebug(reduce_config.Init(last_block_kernel, active_policy.LastBlock(), launcher_factory));
+      if (cudaSuccess != error)
+      {
+        break;
+      }
+
+      int reduce_device_occupancy = reduce_config.sm_occupancy * sm_count;
+
+      // Even-share work distribution
+      int max_blocks = reduce_device_occupancy * detail::subscription_factor;
+      GridEvenShare<OffsetT> even_share;
+      even_share.DispatchInit(num_items, max_blocks, reduce_config.tile_size);
+
+      // Temporary storage allocation requirements
+      void* allocations[2]       = {nullptr, nullptr};
+      size_t allocation_sizes[2] = {max_blocks * kernel_source.AccumSize(), // bytes needed for privatized block
+                                                                            // reductions
+                                    sizeof(CounterT)};
+
+      // Alias the temporary allocations from the single storage blob (or
+      // compute the necessary size of the blob)
+      error = CubDebug(detail::AliasTemporaries(d_temp_storage, temp_storage_bytes, allocations, allocation_sizes));
+      if (cudaSuccess != error)
+      {
+        break;
+      }
+
+      if (d_temp_storage == nullptr)
+      {
+        // Return if the caller is simply requesting the size of the storage
+        // allocation
+        return cudaSuccess;
+      }
+
+      // Alias the allocation for the privatized per-block reductions
+      AccumT* d_block_reductions = static_cast<AccumT*>(allocations[0]);
+
+      // Alias the allocation for the counter
+      CounterT* d_counter = static_cast<CounterT*>(allocations[1]);
+
+      error = CubDebug(launcher_factory.MemsetAsync(d_counter, 0, 1, sizeof(CounterT), stream));
+      if (cudaSuccess != error)
+      {
+        break;
+      }
+
+      // Get grid size for device_reduce_sweep_kernel
+      int reduce_grid_size = even_share.grid_size;
+
+// Log device_reduce_sweep_kernel configuration
+#ifdef CUB_DEBUG_LOG
+      _CubLog("Invoking DeviceLastBlockKernel<<<%lu, %d, 0, %lld>>>(), %d items "
+              "per thread, %d SM occupancy\n",
+              (unsigned long) reduce_grid_size,
+              active_policy.LastBlockReduce().BlockThreads(),
+              (long long) stream,
+              active_policy.LastBlockReduce().ItemsPerThread(),
+              reduce_config.sm_occupancy);
+#endif // CUB_DEBUG_LOG
+
+      // Invoke DeviceReduceKernel
+      launcher_factory(reduce_grid_size, active_policy.LastBlock().BlockThreads(), 0, stream)
+        .doit(
+          last_block_kernel, d_in, d_out, d_block_reductions, even_share, reduction_op, init, transform_op, d_counter);
+
+      // Check for failure to launch
+      error = CubDebug(cudaPeekAtLastError());
+      if (cudaSuccess != error)
+      {
+        break;
+      }
+
+      // Sync the stream if specified to flush runtime errors
+      error = CubDebug(detail::DebugSyncStream(stream));
+      if (cudaSuccess != error)
+      {
+        break;
+      }
+    } while (0);
+
+    return error;
+  }
+
+  /**
+   * @brief Invoke a single block block to reduce in-core
+   *
+   * @tparam ActivePolicyT
+   *   Umbrella policy active for the target device
+   *
+   * @tparam AtomicKernelT
+   *   Function type of cub::DeviceReduceAtomicKernel
+   *
+   * @param[in] last_block_kernel
+   *   Kernel function pointer to parameterization of
+   *   cub::DeviceReduceLastBlockKernel
+   */
+  template <typename ActivePolicyT, typename AtomicKernelT>
+  CUB_RUNTIME_FUNCTION _CCCL_VISIBILITY_HIDDEN _CCCL_FORCEINLINE cudaError_t
+  InvokeAtomicKernel(AtomicKernelT atomic_kernel, ActivePolicyT active_policy = {})
+  {
+    cudaError error = cudaSuccess;
+    do
+    {
+      // This memory is not actually needed but we keep it to make sure the API is consistent
+      if (d_temp_storage == nullptr)
+      {
+        temp_storage_bytes = 1;
+        // Return if the caller is simply requesting the size of the storage
+        // allocation
+        return cudaSuccess;
+      }
+
+      // Init regular kernel configuration
+      detail::KernelConfig reduce_config;
+      error = CubDebug(reduce_config.Init(atomic_kernel, active_policy.Atomic(), launcher_factory));
+      if (cudaSuccess != error)
+      {
+        break;
+      }
+
+#if TUNE_USE_GRID_EVEN_SHARE
+      // Get SM count
+      int sm_count;
+      error = CubDebug(launcher_factory.MultiProcessorCount(sm_count));
+      if (cudaSuccess != error)
+      {
+        break;
+      }
+      int reduce_device_occupancy = reduce_config.sm_occupancy * sm_count;
+
+      // Even-share work distribution
+      int max_blocks = reduce_device_occupancy * detail::subscription_factor;
+      GridEvenShare<OffsetT> even_share;
+      even_share.DispatchInit(num_items, max_blocks, reduce_config.tile_size);
+      // Get grid size for device_reduce_sweep_kernel
+      int reduce_grid_size = even_share.grid_size;
+#else
+      int reduce_grid_size = static_cast<int>(::cuda::ceil_div(num_items, reduce_config.tile_size));
+#endif
+
+      error =
+        CubDebug(launcher_factory.MemsetAsync(unwrap_indirect_arg(&d_out), 0, 1, kernel_source.AccumSize(), stream));
+      if (cudaSuccess != error)
+      {
+        break;
+      }
+
+// Log device_reduce_sweep_kernel configuration
+#ifdef CUB_DEBUG_LOG
+      _CubLog("Invoking DeviceLastBlockKernel<<<%lu, %d, 0, %lld>>>(), %d items "
+              "per thread, %d SM occupancy\n",
+              (unsigned long) reduce_grid_size,
+              active_policy.Atomic().BlockThreads(),
+              (long long) stream,
+              active_policy.Atomic().ItemsPerThread(),
+              reduce_config.sm_occupancy);
+#endif // CUB_DEBUG_LOG
+
+      // Invoke DeviceReduceKernel
+      launcher_factory(reduce_grid_size, active_policy.Atomic().BlockThreads(), 0, stream)
+        .doit(atomic_kernel,
+              d_in,
+              d_out,
+              num_items,
+#if TUNE_USE_GRID_EVEN_SHARE
+              even_share,
+#endif
+              reduction_op,
+              init,
+              transform_op);
+
+      // Check for failure to launch
+      error = CubDebug(cudaPeekAtLastError());
+      if (cudaSuccess != error)
+      {
+        break;
+      }
+
+      // Sync the stream if specified to flush runtime errors
+      error = CubDebug(detail::DebugSyncStream(stream));
+      if (cudaSuccess != error)
+      {
+        break;
+      }
+    } while (0);
+
+    return error;
+  }
+
+  //---------------------------------------------------------------------------
+  // Chained policy invocation
+  //---------------------------------------------------------------------------
+
+  /// Invocation
+  template <typename ActivePolicyT>
+  CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t Invoke(ActivePolicyT active_policy = {})
+  {
+    if (num_items == 0)
+    {
+      return cudaSuccess;
+    }
+
+    auto wrapped_policy = detail::nondeterministic_reduce::MakeReducePolicyWrapper(active_policy);
+
+    if (Algorithm::atomic == wrapped_policy.GetAlgorithm())
+    {
+      return InvokeAtomicKernel(kernel_source.AtomicKernel(), wrapped_policy);
+    }
+    else
+    {
+      return InvokeLastBlockKernel(kernel_source.LastBlockKernel(), wrapped_policy);
+    }
+  }
+
+  //---------------------------------------------------------------------------
+  // Dispatch entrypoints
+  //---------------------------------------------------------------------------
+
+  /**
+   * @brief Internal dispatch routine for computing a device-wide reduction
+   *
+   * @param[in] d_temp_storage
+   *   Device-accessible allocation of temporary storage. When `nullptr`, the
+   *   required allocation size is written to `temp_storage_bytes` and no work
+   *   is done.
+   *
+   * @param[in,out] temp_storage_bytes
+   *   Reference to size in bytes of `d_temp_storage` allocation
+   *
+   * @param[in] d_in
+   *   Pointer to the input sequence of data items
+   *
+   * @param[out] d_out
+   *   Pointer to the output aggregate
+   *
+   * @param[in] num_items
+   *   Total number of input items (i.e., length of `d_in`)
+   *
+   * @param[in] reduction_op
+   *   Binary reduction functor
+   *
+   * @param[in] init
+   *   The initial value of the reduction
+   *
+   * @param[in] stream
+   *   **[optional]** CUDA stream to launch kernels within.
+   *   Default is stream<sub>0</sub>.
+   */
+  template <typename MaxPolicyT = typename PolicyHub::MaxPolicy>
+  CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t Dispatch(
+    void* d_temp_storage,
+    size_t& temp_storage_bytes,
+    InputIteratorT d_in,
+    OutputIteratorT d_out,
+    void* d_out_ptr,
+    OffsetT num_items,
+    ReductionOpT reduction_op,
+    InitT init,
+    cudaStream_t stream,
+    TransformOpT transform_op              = {},
+    KernelSource kernel_source             = {},
+    KernelLauncherFactory launcher_factory = {},
+    MaxPolicyT max_policy                  = {})
+  {
+    cudaError error = cudaSuccess;
+    do
+    {
+      // Get PTX version
+      int ptx_version = 0;
+      error           = CubDebug(launcher_factory.PtxVersion(ptx_version));
+      if (cudaSuccess != error)
+      {
+        break;
+      }
+
+      // Create dispatch functor
+      DispatchNondeterministicReduce dispatch(
+        d_temp_storage,
+        temp_storage_bytes,
+        d_in,
+        d_out,
+        d_out_ptr,
+        num_items,
+        reduction_op,
+        init,
+        stream,
+        ptx_version,
+        transform_op,
+        kernel_source,
+        launcher_factory);
+
+      // Dispatch to chained policy
+      error = CubDebug(max_policy.Invoke(ptx_version, dispatch));
+      if (cudaSuccess != error)
+      {
+        break;
+      }
+    } while (0);
+
+    return error;
+  }
+};
+
+} // namespace detail::nondeterministic_reduce
+
+CUB_NAMESPACE_END

--- a/cub/cub/device/dispatch/kernels/nondeterministic_reduce.cuh
+++ b/cub/cub/device/dispatch/kernels/nondeterministic_reduce.cuh
@@ -1,0 +1,288 @@
+/******************************************************************************
+ * Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+#pragma once
+
+#include <cub/config.cuh>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cub/agent/agent_nondeterministic_reduce.cuh>
+#include <cub/grid/grid_even_share.cuh>
+
+CUB_NAMESPACE_BEGIN
+
+namespace detail
+{
+namespace nondeterministic_reduce
+{
+
+/**
+ * All cub::DeviceReduce::* algorithms are using the same implementation. Some of them, however,
+ * should use initial value only for empty problems. If this struct is used as initial value with
+ * one of the `DeviceReduce` algorithms, the `init` value wrapped by this struct will only be used
+ * for empty problems; it will not be incorporated into the aggregate of non-empty problems.
+ */
+template <class T>
+struct empty_problem_init_t
+{
+  T init;
+
+  _CCCL_HOST_DEVICE operator T() const
+  {
+    return init;
+  }
+};
+
+template <class InitT>
+_CCCL_HOST_DEVICE _CCCL_FORCEINLINE InitT unwrap_empty_problem_init(InitT init)
+{
+  return init;
+}
+
+template <class InitT>
+_CCCL_HOST_DEVICE _CCCL_FORCEINLINE InitT unwrap_empty_problem_init(empty_problem_init_t<InitT> empty_problem_init)
+{
+  return empty_problem_init.init;
+}
+
+/**
+ * @brief Applies initial value to the block aggregate and stores the result to the output iterator.
+ *
+ * @param d_out Iterator to the output aggregate
+ * @param reduction_op Binary reduction functor
+ * @param init Initial value
+ * @param block_aggregate Aggregate value computed by the block
+ */
+template <class OutputIteratorT, class ReductionOpT, class InitT, class AccumT>
+_CCCL_HOST_DEVICE void
+finalize_and_store_aggregate(OutputIteratorT d_out, ReductionOpT reduction_op, InitT init, AccumT block_aggregate)
+{
+  *d_out = reduction_op(init, block_aggregate);
+}
+
+/**
+ * @brief Ignores initial value and stores the block aggregate to the output iterator.
+ *
+ * @param d_out Iterator to the output aggregate
+ * @param block_aggregate Aggregate value computed by the block
+ */
+template <class OutputIteratorT, class ReductionOpT, class InitT, class AccumT>
+_CCCL_HOST_DEVICE void
+finalize_and_store_aggregate(OutputIteratorT d_out, ReductionOpT, empty_problem_init_t<InitT>, AccumT block_aggregate)
+{
+  *d_out = block_aggregate;
+}
+
+/**
+ * @brief Reduce region kernel entry point (multi-block). Computes privatized
+ *        reductions, one per thread block.
+ *
+ * @tparam ChainedPolicyT
+ *   Chained tuning policy
+ *
+ * @tparam InputIteratorT
+ *   Random-access input iterator type for reading input items @iterator
+ *
+ * @tparam OffsetT
+ *   Signed integer type for global offsets
+ *
+ * @tparam ReductionOpT
+ *   Binary reduction functor type having member
+ *   `auto operator()(const T &a, const U &b)`
+ *
+ * @tparam InitT
+ *   Initial value type
+ *
+ * @tparam AccumT
+ *   Accumulator type
+ *
+ * @param[in] d_in
+ *   Pointer to the input sequence of data items
+ *
+ * @param[out] d_out
+ *   Pointer to the output aggregate
+ *
+ * @param[in] num_items
+ *   Total number of input data items
+ *
+ * @param[in] even_share
+ *   Even-share descriptor for mapping an equal number of tiles onto each
+ *   thread block
+ *
+ * @param[in] reduction_op
+ *   Binary reduction functor
+ */
+template <typename ChainedPolicyT,
+          typename InputIteratorT,
+          typename OutputIteratorT,
+          typename OffsetT,
+          typename ReductionOpT,
+          typename InitT,
+          typename AccumT,
+          typename TransformOpT,
+          typename CounterT>
+CUB_DETAIL_KERNEL_ATTRIBUTES
+__launch_bounds__(int(ChainedPolicyT::ActivePolicy::ReduceLastBlockPolicy::BLOCK_THREADS)) void DeviceReduceLastBlockKernel(
+  InputIteratorT d_in,
+  OutputIteratorT d_out,
+  AccumT* d_block_reductions,
+  GridEvenShare<OffsetT> even_share,
+  ReductionOpT reduction_op,
+  InitT init,
+  TransformOpT transform_op,
+  CounterT* counter)
+{
+  // Thread block type for reducing input tiles
+  using AgentReduceT = detail::nondeterministic_reduce::AgentReduce<
+    typename ChainedPolicyT::ActivePolicy::ReduceLastBlockPolicy,
+    InputIteratorT,
+    AccumT*,
+    OffsetT,
+    ReductionOpT,
+    AccumT,
+    TransformOpT>;
+
+  // Thread block type for reducing input tiles
+  using FinalAgentReduceT = detail::nondeterministic_reduce::AgentReduce<
+    typename ChainedPolicyT::ActivePolicy::ReduceLastBlockPolicy,
+    AccumT*,
+    OutputIteratorT,
+    OffsetT,
+    ReductionOpT,
+    AccumT>;
+
+  // Shared memory storage
+  union temp_storage_t
+  {
+    typename AgentReduceT::TempStorage partial_reduce;
+    typename FinalAgentReduceT::TempStorage final_reduce;
+  };
+
+  __shared__ temp_storage_t temp_storage;
+
+  // Consume input tiles
+  AccumT block_aggregate =
+    AgentReduceT(temp_storage.partial_reduce, d_in, reduction_op, transform_op).ConsumeTiles(even_share);
+
+  // Output result
+  if (threadIdx.x == 0)
+  {
+    // ony thread 0 has valid value in block aggregate
+    detail::uninitialized_copy_single(d_block_reductions + blockIdx.x, block_aggregate);
+  }
+
+  __threadfence();
+
+  int perform_final_reduce = false;
+  if (threadIdx.x == 0)
+  {
+    CounterT old_counter = atomicAdd(counter, static_cast<CounterT>(1));
+    perform_final_reduce = old_counter == gridDim.x - 1;
+  }
+
+  if (__syncthreads_or(perform_final_reduce))
+  {
+    // Consume input tiles
+    AccumT block_aggregate =
+      FinalAgentReduceT(temp_storage.final_reduce, d_block_reductions, reduction_op).ConsumeRange(OffsetT(0), gridDim.x);
+
+    // Output result
+    if (threadIdx.x == 0)
+    {
+      detail::nondeterministic_reduce::finalize_and_store_aggregate(d_out, reduction_op, init, block_aggregate);
+    }
+  }
+}
+
+template <typename ChainedPolicyT,
+          typename InputIteratorT,
+          typename OutputIteratorT,
+          typename OffsetT,
+          typename ReductionOpT,
+          typename InitT,
+          typename AccumT,
+          typename TransformOpT>
+CUB_DETAIL_KERNEL_ATTRIBUTES
+__launch_bounds__(int(ChainedPolicyT::ActivePolicy::ReduceAtomicPolicy::BLOCK_THREADS)) void DeviceReduceAtomicKernel(
+  InputIteratorT d_in,
+  OutputIteratorT d_out,
+  OffsetT num_items,
+#if TUNE_USE_GRID_EVEN_SHARE
+  GridEvenShare<OffsetT> even_share,
+#endif
+  ReductionOpT reduction_op,
+  InitT init,
+  TransformOpT transform_op)
+{
+  // Thread block type for reducing input tiles
+  using AgentReduceT = detail::nondeterministic_reduce::AgentReduce<
+    typename ChainedPolicyT::ActivePolicy::ReduceAtomicPolicy,
+    InputIteratorT,
+    AccumT*,
+    OffsetT,
+    ReductionOpT,
+    AccumT,
+    TransformOpT>;
+
+  // Shared memory storage
+  __shared__ typename AgentReduceT::TempStorage temp_storage;
+
+#if TUNE_USE_GRID_EVEN_SHARE
+  // Consume input tiles
+  AccumT block_aggregate = AgentReduceT(temp_storage, d_in, reduction_op, transform_op).ConsumeTiles(even_share);
+#else
+  AccumT block_aggregate =
+    AgentReduceT(temp_storage, d_in, reduction_op, transform_op)
+      .ConsumeRange(blockIdx.x * AgentReduceT::TILE_ITEMS,
+                    _CUDA_VSTD::min(static_cast<OffsetT>((blockIdx.x + 1) * AgentReduceT::TILE_ITEMS), num_items));
+#endif
+
+  // Output result
+  if (threadIdx.x == 0)
+  {
+    // ony thread 0 has valid value in block aggregate
+    // detail::uninitialized_copy_single(d_block_reductions + blockIdx.x, block_aggregate);
+    if (blockIdx.x == 0)
+    {
+      atomicAdd(d_out, init);
+    }
+
+    atomicAdd(d_out, block_aggregate);
+  }
+}
+
+} // namespace nondeterministic_reduce
+} // namespace detail
+
+CUB_NAMESPACE_END

--- a/cub/cub/device/dispatch/tuning/tuning_nondeterministic_reduce.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_nondeterministic_reduce.cuh
@@ -1,0 +1,314 @@
+/******************************************************************************
+ * Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+#pragma once
+
+#include <cub/config.cuh>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cub/agent/agent_nondeterministic_reduce.cuh>
+#include <cub/util_device.cuh>
+#include <cub/util_macro.cuh>
+
+CUB_NAMESPACE_BEGIN
+
+namespace detail
+{
+namespace nondeterministic_reduce
+{
+template <typename PolicyT, typename = void>
+struct ReducePolicyWrapper : PolicyT
+{
+  CUB_RUNTIME_FUNCTION ReducePolicyWrapper(PolicyT base)
+      : PolicyT(base)
+  {}
+};
+
+enum class Algorithm
+{
+  original,
+  last_block,
+  atomic,
+};
+
+template <typename StaticPolicyT>
+struct ReducePolicyWrapper<StaticPolicyT,
+                           _CUDA_VSTD::void_t<typename StaticPolicyT::ReducePolicy,
+                                              typename StaticPolicyT::SingleTilePolicy,
+                                              typename StaticPolicyT::SegmentedReducePolicy,
+                                              typename StaticPolicyT::ReduceLastBlockPolicy,
+                                              typename StaticPolicyT::ReduceAtomicPolicy>> : StaticPolicyT
+{
+  CUB_RUNTIME_FUNCTION ReducePolicyWrapper(StaticPolicyT base)
+      : StaticPolicyT(base)
+  {}
+
+  _CCCL_HOST_DEVICE static constexpr Algorithm GetAlgorithm()
+  {
+    return StaticPolicyT::algorithm;
+  }
+
+  CUB_DEFINE_SUB_POLICY_GETTER(Reduce)
+  CUB_DEFINE_SUB_POLICY_GETTER(SingleTile)
+  CUB_DEFINE_SUB_POLICY_GETTER(SegmentedReduce)
+
+  CUB_RUNTIME_FUNCTION static constexpr auto LastBlock()
+  {
+    return cub::detail::MakePolicyWrapper(typename StaticPolicyT::ReduceLastBlockPolicy());
+  }
+
+  CUB_RUNTIME_FUNCTION static constexpr auto Atomic()
+  {
+    return cub::detail::MakePolicyWrapper(typename StaticPolicyT::ReduceAtomicPolicy());
+  }
+};
+
+template <typename PolicyT>
+CUB_RUNTIME_FUNCTION ReducePolicyWrapper<PolicyT> MakeReducePolicyWrapper(PolicyT policy)
+{
+  return ReducePolicyWrapper<PolicyT>{policy};
+}
+enum class offset_size
+{
+  _4,
+  _8,
+  unknown
+};
+enum class op_type
+{
+  plus,
+  min_or_max,
+  unknown
+};
+enum class accum_size
+{
+  _1,
+  _2,
+  _4,
+  _8,
+  _16,
+  unknown
+};
+template <class AccumT>
+constexpr accum_size classify_accum_size()
+{
+  return sizeof(AccumT) == 1 ? accum_size::_1
+       : sizeof(AccumT) == 2 ? accum_size::_2
+       : sizeof(AccumT) == 4 ? accum_size::_4
+       : sizeof(AccumT) == 8 ? accum_size::_8
+       : sizeof(AccumT) == 16
+         ? accum_size::_16
+         : accum_size::unknown;
+}
+template <class OffsetT>
+constexpr offset_size classify_offset_size()
+{
+  return sizeof(OffsetT) == 4 ? offset_size::_4 : sizeof(OffsetT) == 8 ? offset_size::_8 : offset_size::unknown;
+}
+
+template <typename Op>
+struct is_plus
+{
+  static constexpr bool value = false;
+};
+
+template <typename T>
+struct is_plus<::cuda::std::plus<T>>
+{
+  static constexpr bool value = true;
+};
+template <typename Op>
+struct is_min_or_max
+{
+  static constexpr bool value = false;
+};
+template <typename T>
+struct is_min_or_max<::cuda::minimum<T>>
+{
+  static constexpr bool value = true;
+};
+template <typename T>
+struct is_min_or_max<::cuda::maximum<T>>
+{
+  static constexpr bool value = true;
+};
+
+template <class ScanOpT>
+constexpr op_type classify_op()
+{
+  return is_plus<ScanOpT>::value
+         ? op_type::plus
+         : (is_min_or_max<ScanOpT>::value ? op_type::min_or_max : op_type::unknown);
+}
+
+template <class AccumT,
+          class OffsetT,
+          op_type OpTypeT        = classify_op<OffsetT>(),
+          offset_size OffsetSize = classify_offset_size<OffsetT>(),
+          accum_size AccumSize   = classify_accum_size<AccumT>()>
+struct sm100_tuning;
+
+// sum
+
+// Tunings for offset size 4/8 and accum size 1/2/4 all showed no significant improvement during verification
+
+template <class T, class OffsetT>
+struct sm100_tuning<T, OffsetT, op_type::plus, offset_size::_4, accum_size::_8>
+{
+  // ipt_15.tpb_512.ipv_2 1.019887   1.0  1.017636  1.058036
+  static constexpr int items              = 15;
+  static constexpr int threads            = 512;
+  static constexpr int items_per_vec_load = 2;
+};
+
+template <class T, class OffsetT>
+struct sm100_tuning<T, OffsetT, op_type::plus, offset_size::_8, accum_size::_8>
+{
+  // ipt_15.tpb_512.ipv_1 1.019414  1.000000  1.017218  1.057143
+  static constexpr int items              = 15;
+  static constexpr int threads            = 512;
+  static constexpr int items_per_vec_load = 1;
+};
+
+template <class OffsetT>
+struct sm100_tuning<float, OffsetT, op_type::plus, offset_size::_4, accum_size::_4>
+{
+  // ipt_16.tpb_512.ipv_2 1.061295  1.000000  1.065478  1.167139
+  static constexpr int items              = 16;
+  static constexpr int threads            = 512;
+  static constexpr int items_per_vec_load = 2;
+};
+
+template <class OffsetT>
+struct sm100_tuning<double, OffsetT, op_type::plus, offset_size::_4, accum_size::_8>
+{
+  // ipt_16.tpb_640.ipv_1 1.017834  1.000000  1.015835  1.057092
+  static constexpr int items              = 16;
+  static constexpr int threads            = 640;
+  static constexpr int items_per_vec_load = 1;
+};
+
+// For min or max, verification showed the benefits were too small (within noise)
+
+template <typename AccumT, typename OffsetT, typename ReductionOpT>
+struct policy_hub
+{
+  struct Policy500 : ChainedPolicy<500, Policy500, Policy500>
+  {
+    static constexpr int threads_per_block  = 256;
+    static constexpr int items_per_thread   = 20;
+    static constexpr int items_per_vec_load = 4;
+
+    // ReducePolicy (GTX Titan: 255.1 GB/s @ 48M 4B items; 228.7 GB/s @ 192M 1B items)
+    using ReducePolicy = AgentNondeterministicReducePolicy<
+      threads_per_block,
+      items_per_thread,
+      AccumT,
+      items_per_vec_load,
+      BLOCK_NONDETERMINISTIC_REDUCE_WARP_REDUCTIONS,
+      LOAD_LDG>;
+
+    using SingleTilePolicy      = ReducePolicy;
+    using SegmentedReducePolicy = ReducePolicy;
+
+    using ReduceLastBlockPolicy = ReducePolicy;
+    using ReduceAtomicPolicy    = ReducePolicy;
+
+    // static constexpr Algorithm algorithm = Algorithm::last_block;
+    static constexpr Algorithm algorithm = Algorithm::atomic;
+  };
+
+  struct Policy600 : ChainedPolicy<600, Policy600, Policy500>
+  {
+    static constexpr int threads_per_block  = 256;
+    static constexpr int items_per_thread   = 16;
+    static constexpr int items_per_vec_load = 4;
+
+    // ReducePolicy (P100: 591 GB/s @ 64M 4B items; 583 GB/s @ 256M 1B items)
+    using ReducePolicy = AgentNondeterministicReducePolicy<
+      threads_per_block,
+      items_per_thread,
+      AccumT,
+      items_per_vec_load,
+      BLOCK_NONDETERMINISTIC_REDUCE_WARP_REDUCTIONS,
+      LOAD_LDG>;
+
+    using SingleTilePolicy      = ReducePolicy;
+    using SegmentedReducePolicy = ReducePolicy;
+
+    using ReduceLastBlockPolicy = ReducePolicy;
+    using ReduceAtomicPolicy    = ReducePolicy;
+
+    // static constexpr Algorithm algorithm = Algorithm::last_block;
+    static constexpr Algorithm algorithm = Algorithm::atomic;
+  };
+
+  struct Policy1000 : ChainedPolicy<1000, Policy1000, Policy600>
+  {
+    // Use values from tuning if a specialization exists, otherwise pick Policy600
+    template <typename Tuning>
+    static auto select_agent_policy(int) -> AgentNondeterministicReducePolicy<
+      Tuning::threads,
+      Tuning::items,
+      AccumT,
+      Tuning::items_per_vec_load,
+      BLOCK_NONDETERMINISTIC_REDUCE_WARP_REDUCTIONS,
+      LOAD_LDG>;
+    // use Policy600 as DefaultPolicy
+    template <typename Tuning>
+    static auto select_agent_policy(long) -> typename Policy600::ReducePolicy;
+
+    using ReducePolicy =
+      decltype(select_agent_policy<sm100_tuning<AccumT,
+                                                OffsetT,
+                                                classify_op<ReductionOpT>(),
+                                                classify_offset_size<OffsetT>(),
+                                                classify_accum_size<AccumT>()>>(0));
+
+    using SingleTilePolicy      = ReducePolicy;
+    using SegmentedReducePolicy = ReducePolicy;
+
+    using ReduceLastBlockPolicy = ReducePolicy;
+    using ReduceAtomicPolicy    = ReducePolicy;
+
+    // static constexpr Algorithm algorithm = Algorithm::last_block;
+    static constexpr Algorithm algorithm = Algorithm::atomic;
+  };
+
+  using MaxPolicy = Policy1000;
+};
+} // namespace nondeterministic_reduce
+} // namespace detail
+
+CUB_NAMESPACE_END


### PR DESCRIPTION
## Description

This is a draft PR that shows my current implementations of non deterministic reduce that use atomics. There are two implementations, one that uses a single block to compute the final reduction value at the end, and another where each block atomically adds its partial value to the final result. For now, the new implementations are in separate files than the original reduce so there is some redundancy but I am working on integrating it better.

This PR also includes a macro to enable atomics at the block level as well.

There is also a benchmark specifically for nondeterministic reduce that can be built with target `cub.bench.nondeterministic_reduce.sum.base`

## Checklist
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
