### PR TITLE
Fix `cuda::warp_match_all` test case

### DIFF
--- a/libcudacxx/test/libcudacxx/cuda/warp/warp_match.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/warp/warp_match.pass.cpp
@@ -23,8 +23,11 @@ __device__ void test_types(T valueA = T{}, T valueB = T{1})
   {
     auto mask = cuda::device::lane_mask{(1u << i) - 1};
     assert(cuda::device::warp_match_all(valueA, mask));
-    auto value = threadIdx.x == 0 ? valueA : valueB;
-    assert(!cuda::device::warp_match_all(value, mask));
+    if (i > 1)
+    {
+      [[maybe_unused]] auto value = threadIdx.x == 0 ? valueA : valueB;
+      assert(!cuda::device::warp_match_all(value, mask));
+    }
   }
 }
 


### PR DESCRIPTION
## Description

Fix nightly CI failure related to `cuda::warp_match_all`.
Fix: when `mask == 1`, the primitive `__match_all_sync` has undefined behavior depending on the SM version. The PR excludes this test case.