### PR TITLE
Port thrust extrema algs to use CUB

### DIFF
--- a/cub/cub/device/dispatch/dispatch_streaming_reduce.cuh
+++ b/cub/cub/device/dispatch/dispatch_streaming_reduce.cuh
@@ -193,9 +193,6 @@ struct dispatch_streaming_arg_reduce_t
     InitT init,
     cudaStream_t stream)
   {
-    // Constant iterator to provide the offset of the current partition for the user-provided input iterator
-    using constant_offset_it_t = THRUST_NS_QUALIFIER::constant_iterator<GlobalOffsetT>;
-
     // Wrapped input iterator to produce index-value tuples, i.e., <PerPartitionOffsetT, InputT>-tuples
     // We make sure to offset the user-provided input iterator by the current partition's offset
     using arg_index_input_iterator_t = ArgIndexInputIterator<InputIteratorT, PerPartitionOffsetT, InitT>;

--- a/cub/cub/thread/thread_operators.cuh
+++ b/cub/cub/thread/thread_operators.cuh
@@ -127,6 +127,21 @@ struct ArgMin
 
 namespace detail
 {
+template <typename KeyLessThen>
+struct arg_min_custom_key_compare : KeyLessThen
+{
+  template <typename T, typename OffsetT>
+  _CCCL_HOST_DEVICE _CCCL_FORCEINLINE KeyValuePair<OffsetT, T>
+  operator()(const KeyValuePair<OffsetT, T>& a, const KeyValuePair<OffsetT, T>& b) const
+  {
+    if ((b.value < a.value) || ((a.value == b.value) && static_cast<const KeyLessThen&>(*this)(b.key, a.key)))
+    {
+      return b;
+    }
+
+    return a;
+  }
+};
 
 /// @brief Arg max functor (keeps the value and offset of the first occurrence
 ///        of the larger item)

--- a/thrust/thrust/system/cuda/detail/extrema.h
+++ b/thrust/thrust/system/cuda/detail/extrema.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -36,49 +36,35 @@
 #  pragma system_header
 #endif // no system header
 
-#if _CCCL_HAS_CUDA_COMPILER()
+#include <thrust/system/cuda/config.h>
 
-#  include <thrust/system/cuda/config.h>
+#include <cub/util_type.cuh>
 
-#  include <cub/util_math.cuh>
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/iterator/iterator_traits.h>
+#include <thrust/pair.h>
+#include <thrust/system/cuda/detail/cdp_dispatch.h>
+#include <thrust/system/cuda/detail/reduce.h>
 
-#  include <thrust/detail/temporary_array.h>
-#  include <thrust/distance.h>
-#  include <thrust/extrema.h>
-#  include <thrust/iterator/counting_iterator.h>
-#  include <thrust/iterator/transform_iterator.h>
-#  include <thrust/pair.h>
-#  include <thrust/system/cuda/detail/cdp_dispatch.h>
-#  include <thrust/system/cuda/detail/reduce.h>
-
-#  include <cuda/std/cstdint>
-#  include <cuda/std/iterator>
+#include <cuda/std/__algorithm_>
 
 THRUST_NAMESPACE_BEGIN
 namespace cuda_cub
 {
-
 namespace __extrema
 {
-
-template <class InputType, class IndexType, class Predicate>
+template <class Predicate>
 struct arg_min_f
 {
   Predicate predicate;
-  using pair_type = tuple<InputType, IndexType>;
 
-  _CCCL_HOST_DEVICE arg_min_f(Predicate p)
-      : predicate(p)
-  {}
-
-  pair_type _CCCL_DEVICE operator()(pair_type const& lhs, pair_type const& rhs)
+  template <typename Value, typename Index>
+  _CCCL_DEVICE auto operator()(tuple<Value, Index> const& lhs, tuple<Value, Index> const& rhs) -> tuple<Value, Index>
   {
-    InputType const& rhs_value = get<0>(rhs);
-    InputType const& lhs_value = get<0>(lhs);
-    IndexType const& rhs_key   = get<1>(rhs);
-    IndexType const& lhs_key   = get<1>(lhs);
+    const auto& [lhs_value, lhs_index] = lhs;
+    const auto& [rhs_value, rhs_index] = rhs;
 
-    // check values first
+    // compare the values
     if (predicate(lhs_value, rhs_value))
     {
       return lhs;
@@ -89,7 +75,7 @@ struct arg_min_f
     }
 
     // values are equivalent, prefer smaller index
-    if (lhs_key < rhs_key)
+    if (lhs_index < rhs_index)
     {
       return lhs;
     }
@@ -98,26 +84,20 @@ struct arg_min_f
       return rhs;
     }
   }
-}; // struct arg_min_f
+};
 
-template <class InputType, class IndexType, class Predicate>
+template <class Predicate>
 struct arg_max_f
 {
   Predicate predicate;
-  using pair_type = tuple<InputType, IndexType>;
 
-  _CCCL_HOST_DEVICE arg_max_f(Predicate p)
-      : predicate(p)
-  {}
-
-  pair_type _CCCL_DEVICE operator()(pair_type const& lhs, pair_type const& rhs)
+  template <typename Value, typename Index>
+  _CCCL_DEVICE auto operator()(tuple<Value, Index> const& lhs, tuple<Value, Index> const& rhs) -> tuple<Value, Index>
   {
-    InputType const& rhs_value = get<0>(rhs);
-    InputType const& lhs_value = get<0>(lhs);
-    IndexType const& rhs_key   = get<1>(rhs);
-    IndexType const& lhs_key   = get<1>(lhs);
+    const auto& [lhs_value, lhs_index] = lhs;
+    const auto& [rhs_value, rhs_index] = rhs;
 
-    // check values first
+    // compare values first
     if (predicate(lhs_value, rhs_value))
     {
       return rhs;
@@ -128,7 +108,7 @@ struct arg_max_f
     }
 
     // values are equivalent, prefer smaller index
-    if (lhs_key < rhs_key)
+    if (lhs_index < rhs_index)
     {
       return lhs;
     }
@@ -137,340 +117,124 @@ struct arg_max_f
       return rhs;
     }
   }
-}; // struct arg_max_f
+};
 
-template <class InputType, class IndexType, class Predicate>
+template <class Predicate>
 struct arg_minmax_f
 {
   Predicate predicate;
 
-  using pair_type      = tuple<InputType, IndexType>;
-  using two_pairs_type = tuple<pair_type, pair_type>;
-
-  using arg_min_t = arg_min_f<InputType, IndexType, Predicate>;
-  using arg_max_t = arg_max_f<InputType, IndexType, Predicate>;
-
-  _CCCL_HOST_DEVICE arg_minmax_f(Predicate p)
-      : predicate(p)
-  {}
-
-  two_pairs_type _CCCL_DEVICE operator()(two_pairs_type const& lhs, two_pairs_type const& rhs)
+  template <typename ValueMin, typename ValueMax, typename IndexMin, typename IndexMax>
+  _CCCL_DEVICE auto operator()(tuple<ValueMin, ValueMax, IndexMin, IndexMax> const& lhs,
+                               tuple<ValueMin, ValueMax, IndexMin, IndexMax> const& rhs)
+    -> tuple<ValueMin, ValueMax, IndexMin, IndexMax>
   {
-    pair_type const& rhs_min = get<0>(rhs);
-    pair_type const& lhs_min = get<0>(lhs);
-    pair_type const& rhs_max = get<1>(rhs);
-    pair_type const& lhs_max = get<1>(lhs);
+    const auto& [lhs_value_min, lhs_value_max, lhs_index_min, lhs_index_max] = lhs;
+    const auto& [rhs_value_min, rhs_value_max, rhs_index_min, rhs_index_max] = rhs;
 
-    auto result = thrust::make_tuple(arg_min_t(predicate)(lhs_min, rhs_min), arg_max_t(predicate)(lhs_max, rhs_max));
+    const auto [value_min, index_min] =
+      arg_min_f<Predicate>{predicate}(tuple{lhs_value_min, lhs_index_min}, tuple{rhs_value_min, rhs_index_min});
+    const auto [value_max, index_max] =
+      arg_max_f<Predicate>{predicate}(tuple{lhs_value_max, lhs_index_max}, tuple{rhs_value_max, rhs_index_max});
 
-    return result;
+    return tuple{value_min, value_max, index_min, index_max};
   }
+};
 
-  struct duplicate_tuple
-  {
-    _CCCL_DEVICE two_pairs_type operator()(pair_type const& t)
-    {
-      return thrust::make_tuple(t, t);
-    }
-  };
-}; // struct arg_minmax_f
-
-template <class T, class InputIt, class OutputIt, class Size, class ReductionOp>
-cudaError_t THRUST_RUNTIME_FUNCTION doit_step(
-  void* d_temp_storage,
-  size_t& temp_storage_bytes,
-  InputIt input_it,
-  Size num_items,
-  ReductionOp reduction_op,
-  OutputIt output_it,
-  cudaStream_t stream)
+template <class Derived, class ItemsIt, class BinaryPred>
+ItemsIt CUB_RUNTIME_FUNCTION
+cub_min_element(execution_policy<Derived>& policy, ItemsIt first, ItemsIt last, BinaryPred binary_pred)
 {
-  using core::detail::AgentLauncher;
-  using core::detail::AgentPlan;
-  using core::detail::cuda_optional;
-  using core::detail::get_agent_plan;
+  cudaStream_t stream  = cuda_cub::stream(policy);
+  using size_type      = thrust::detail::it_difference_t<ItemsIt>;
+  using output_it_t    = size_type*;
+  const auto num_items = static_cast<size_type>(::cuda::std::distance(first, last));
 
-  using UnsignedSize = typename detail::make_unsigned_special<Size>::type;
+  size_t tmp_size = 0;
+  auto error      = cub::DeviceReduce::ArgMin(
+    nullptr, tmp_size, first, ::cuda::discard_iterator{}, output_it_t{nullptr}, num_items, stream, binary_pred);
+  throw_on_error(error, "after determining ArgMin temporary storage size");
 
-  if (num_items == 0)
-  {
-    return cudaErrorNotSupported;
-  }
+  // We allocate both the temporary storage needed for the algorithm, and a `size_type` to store the result.
+  thrust::detail::temporary_array<char, Derived> tmp(policy, sizeof(size_type) + tmp_size);
+  size_type* index_ptr = thrust::detail::aligned_reinterpret_cast<size_type*>(tmp.data().get());
+  void* tmp_ptr        = static_cast<void*>((tmp.data() + sizeof(size_type)).get());
 
-  using reduce_agent = AgentLauncher<__reduce::ReduceAgent<InputIt, OutputIt, T, Size, ReductionOp>>;
+  error = cub::DeviceReduce::ArgMin(
+    tmp_ptr, tmp_size, first, ::cuda::discard_iterator{}, index_ptr, num_items, stream, binary_pred);
+  cuda_cub::throw_on_error(error, "after ArgMin invocation");
 
-  typename reduce_agent::Plan reduce_plan = reduce_agent::get_plan(stream);
+  cuda_cub::throw_on_error(cuda_cub::synchronize(policy), "min_element failed to synchronize");
 
-  cudaError_t status = cudaSuccess;
-
-  if (num_items <= reduce_plan.items_per_tile)
-  {
-    size_t vshmem_size = core::detail::vshmem_size(reduce_plan.shared_memory_size, 1);
-
-    // small, single tile size
-    if (d_temp_storage == nullptr)
-    {
-      temp_storage_bytes = max<size_t>(1, vshmem_size);
-      return status;
-    }
-    char* vshmem_ptr = vshmem_size > 0 ? (char*) d_temp_storage : nullptr;
-
-    reduce_agent ra(reduce_plan, num_items, stream, vshmem_ptr, "reduce_agent: single_tile only");
-    ra.launch(input_it, output_it, num_items, reduction_op);
-    _CUDA_CUB_RET_IF_FAIL(cudaPeekAtLastError());
-  }
-  else
-  {
-    // regular size
-    cuda_optional<int> sm_count = core::detail::get_sm_count();
-    _CUDA_CUB_RET_IF_FAIL(sm_count.status());
-
-    // reduction will not use more cta counts than requested
-    cuda_optional<int> max_blocks_per_sm = reduce_agent::template get_max_blocks_per_sm<
-      InputIt,
-      OutputIt,
-      Size,
-      cub::GridEvenShare<Size>,
-      cub::GridQueue<UnsignedSize>,
-      ReductionOp>(reduce_plan);
-    _CUDA_CUB_RET_IF_FAIL(max_blocks_per_sm.status());
-
-    int reduce_device_occupancy = (int) max_blocks_per_sm * sm_count;
-
-    int sm_oversubscription = 5;
-    int max_blocks          = reduce_device_occupancy * sm_oversubscription;
-
-    cub::GridEvenShare<Size> even_share;
-    even_share.DispatchInit(num_items, max_blocks, reduce_plan.items_per_tile);
-
-    // we will launch at most "max_blocks" blocks in a grid
-    // so preallocate virtual shared memory storage for this if required
-    //
-    size_t vshmem_size = core::detail::vshmem_size(reduce_plan.shared_memory_size, max_blocks);
-
-    // Temporary storage allocation requirements
-    void* allocations[3]       = {nullptr, nullptr, nullptr};
-    size_t allocation_sizes[3] = {
-      max_blocks * sizeof(T), // bytes needed for privatized block reductions
-      cub::GridQueue<UnsignedSize>::AllocationSize(), // bytes needed for grid queue descriptor0
-      vshmem_size // size of virtualized shared memory storage
-    };
-    status = cub::detail::AliasTemporaries(d_temp_storage, temp_storage_bytes, allocations, allocation_sizes);
-    _CUDA_CUB_RET_IF_FAIL(status);
-    if (d_temp_storage == nullptr)
-    {
-      return status;
-    }
-
-    T* d_block_reductions = (T*) allocations[0];
-    cub::GridQueue<UnsignedSize> queue(allocations[1]);
-    char* vshmem_ptr = vshmem_size > 0 ? (char*) allocations[2] : nullptr;
-
-    // Get grid size for device_reduce_sweep_kernel
-    int reduce_grid_size = 0;
-    if (reduce_plan.grid_mapping == cub::GRID_MAPPING_RAKE)
-    {
-      // Work is distributed evenly
-      reduce_grid_size = even_share.grid_size;
-    }
-    else if (reduce_plan.grid_mapping == cub::GRID_MAPPING_DYNAMIC)
-    {
-      // Work is distributed dynamically
-      size_t num_tiles = ::cuda::ceil_div(num_items, reduce_plan.items_per_tile);
-
-      // if not enough to fill the device with threadblocks
-      // then fill the device with threadblocks
-      reduce_grid_size = static_cast<int>((min) (num_tiles, static_cast<size_t>(reduce_device_occupancy)));
-
-      using drain_agent    = AgentLauncher<__reduce::DrainAgent<Size>>;
-      AgentPlan drain_plan = drain_agent::get_plan();
-      drain_plan.grid_size = 1;
-      drain_agent da(drain_plan, stream, "__reduce::drain_agent");
-      da.launch(queue, num_items);
-      _CUDA_CUB_RET_IF_FAIL(cudaPeekAtLastError());
-    }
-    else
-    {
-      _CUDA_CUB_RET_IF_FAIL(cudaErrorNotSupported);
-    }
-
-    reduce_plan.grid_size = reduce_grid_size;
-    reduce_agent ra(reduce_plan, stream, vshmem_ptr, "reduce_agent: regular size reduce");
-    ra.launch(input_it, d_block_reductions, num_items, even_share, queue, reduction_op);
-    _CUDA_CUB_RET_IF_FAIL(cudaPeekAtLastError());
-
-    using reduce_agent_single = AgentLauncher<__reduce::ReduceAgent<T*, OutputIt, T, Size, ReductionOp>>;
-
-    reduce_plan.grid_size = 1;
-    reduce_agent_single ra1(reduce_plan, stream, vshmem_ptr, "reduce_agent: single tile reduce");
-
-    ra1.launch(d_block_reductions, output_it, reduce_grid_size, reduction_op);
-    _CUDA_CUB_RET_IF_FAIL(cudaPeekAtLastError());
-  }
-
-  return status;
-} // func doit_step
-
-// this is an init-less reduce, needed for min/max-element functionality
-// this will avoid copying the first value from device->host
-template <typename Derived, typename InputIt, typename Size, typename BinaryOp, typename T>
-THRUST_RUNTIME_FUNCTION T
-extrema(execution_policy<Derived>& policy, InputIt first, Size num_items, BinaryOp binary_op, T*)
-{
-  size_t temp_storage_bytes = 0;
-  cudaStream_t stream       = cuda_cub::stream(policy);
-
-  cudaError_t status;
-  THRUST_INDEX_TYPE_DISPATCH(
-    status,
-    doit_step<T>,
-    num_items,
-    (nullptr, temp_storage_bytes, first, num_items_fixed, binary_op, static_cast<T*>(nullptr), stream));
-  cuda_cub::throw_on_error(status, "extrema failed on 1st step");
-
-  size_t allocation_sizes[2] = {sizeof(T*), temp_storage_bytes};
-  void* allocations[2]       = {nullptr, nullptr};
-
-  size_t storage_size = 0;
-  status              = core::detail::alias_storage(nullptr, storage_size, allocations, allocation_sizes);
-  cuda_cub::throw_on_error(status, "extrema failed on 1st alias storage");
-
-  // Allocate temporary storage.
-  thrust::detail::temporary_array<std::uint8_t, Derived> tmp(policy, storage_size);
-  void* ptr = static_cast<void*>(tmp.data().get());
-
-  status = core::detail::alias_storage(ptr, storage_size, allocations, allocation_sizes);
-  cuda_cub::throw_on_error(status, "extrema failed on 2nd alias storage");
-
-  T* d_result = thrust::detail::aligned_reinterpret_cast<T*>(allocations[0]);
-
-  THRUST_INDEX_TYPE_DISPATCH(
-    status,
-    doit_step<T>,
-    num_items,
-    (allocations[1], temp_storage_bytes, first, num_items_fixed, binary_op, d_result, stream));
-  cuda_cub::throw_on_error(status, "extrema failed on 2nd step");
-
-  status = cuda_cub::synchronize(policy);
-  cuda_cub::throw_on_error(status, "extrema failed to synchronize");
-
-  T result = cuda_cub::get_value(policy, d_result);
-
-  return result;
+  return first + get_value(policy, index_ptr);
 }
 
-template <template <class, class, class> class ArgFunctor, class Derived, class ItemsIt, class BinaryPred>
-ItemsIt THRUST_RUNTIME_FUNCTION
-element(execution_policy<Derived>& policy, ItemsIt first, ItemsIt last, BinaryPred binary_pred)
+template <typename F>
+struct swap_args : F
 {
-  if (first == last)
+  template <typename... Ts>
+  _CCCL_HOST_DEVICE _CCCL_FORCEINLINE decltype(auto) operator()(Ts&&... args) const
   {
-    return last;
+    return F::operator()(::cuda::std::forward<Ts>(args)...);
   }
-
-  using InputType = thrust::detail::it_value_t<ItemsIt>;
-  using IndexType = thrust::detail::it_difference_t<ItemsIt>;
-
-  IndexType num_items = static_cast<IndexType>(::cuda::std::distance(first, last));
-
-  using iterator_tuple = tuple<ItemsIt, counting_iterator<IndexType>>;
-  using zip_iterator   = zip_iterator<iterator_tuple>;
-
-  iterator_tuple iter_tuple = thrust::make_tuple(first, counting_iterator<IndexType>(0));
-
-  using arg_min_t = ArgFunctor<InputType, IndexType, BinaryPred>;
-  using T         = tuple<InputType, IndexType>;
-
-  zip_iterator begin = make_zip_iterator(iter_tuple);
-
-  T result = extrema(policy, begin, num_items, arg_min_t(binary_pred), (T*) (nullptr));
-  return first + thrust::get<1>(result);
-}
-
+};
 } // namespace __extrema
 
-/// min element
-
 _CCCL_EXEC_CHECK_DISABLE
-template <class Derived, class ItemsIt, class BinaryPred>
+template <class Derived, class ItemsIt, class BinaryPred = ::cuda::std::less<>>
 ItemsIt _CCCL_HOST_DEVICE
-min_element(execution_policy<Derived>& policy, ItemsIt first, ItemsIt last, BinaryPred binary_pred)
+min_element(execution_policy<Derived>& policy, ItemsIt first, ItemsIt last, BinaryPred binary_pred = {})
 {
-  THRUST_CDP_DISPATCH((last = __extrema::element<__extrema::arg_min_f>(policy, first, last, binary_pred);),
-                      (last = thrust::min_element(cvt_to_seq(derived_cast(policy)), first, last, binary_pred);));
-  return last;
+  THRUST_CDP_DISPATCH((return __extrema::cub_min_element(policy, first, last, binary_pred);),
+                      (return thrust::min_element(cvt_to_seq(derived_cast(policy)), first, last, binary_pred);));
 }
-
-template <class Derived, class ItemsIt>
-ItemsIt _CCCL_HOST_DEVICE min_element(execution_policy<Derived>& policy, ItemsIt first, ItemsIt last)
-{
-  using value_type = thrust::detail::it_value_t<ItemsIt>;
-  return cuda_cub::min_element(policy, first, last, ::cuda::std::less<value_type>());
-}
-
-/// max element
 
 _CCCL_EXEC_CHECK_DISABLE
-template <class Derived, class ItemsIt, class BinaryPred>
+template <class Derived, class ItemsIt, class BinaryPred = ::cuda::std::less<>>
 ItemsIt _CCCL_HOST_DEVICE
-max_element(execution_policy<Derived>& policy, ItemsIt first, ItemsIt last, BinaryPred binary_pred)
+max_element(execution_policy<Derived>& policy, ItemsIt first, ItemsIt last, BinaryPred binary_pred = {})
 {
-  THRUST_CDP_DISPATCH((last = __extrema::element<__extrema::arg_max_f>(policy, first, last, binary_pred);),
-                      (last = thrust::max_element(cvt_to_seq(derived_cast(policy)), first, last, binary_pred);));
-  return last;
+  THRUST_CDP_DISPATCH((return __extrema::cub_min_element(policy, first, last, __extrema::swap_args{binary_pred});),
+                      (return thrust::max_element(cvt_to_seq(derived_cast(policy)), first, last, binary_pred);));
 }
-
-template <class Derived, class ItemsIt>
-ItemsIt _CCCL_HOST_DEVICE max_element(execution_policy<Derived>& policy, ItemsIt first, ItemsIt last)
-{
-  using value_type = thrust::detail::it_value_t<ItemsIt>;
-  return cuda_cub::max_element(policy, first, last, ::cuda::std::less<value_type>());
-}
-
-/// minmax element
 
 _CCCL_EXEC_CHECK_DISABLE
-template <class Derived, class ItemsIt, class BinaryPred>
+template <class Derived, class ItemsIt, class BinaryPred = ::cuda::std::less<>>
 pair<ItemsIt, ItemsIt> _CCCL_HOST_DEVICE
-minmax_element(execution_policy<Derived>& policy, ItemsIt first, ItemsIt last, BinaryPred binary_pred)
+minmax_element(execution_policy<Derived>& policy, ItemsIt first, ItemsIt last, BinaryPred binary_pred = {})
 {
-  auto ret = thrust::make_pair(last, last);
   if (first == last)
   {
-    return ret;
+    return make_pair(last, last);
   }
 
   THRUST_CDP_DISPATCH(
-    (using InputType = thrust::detail::it_value_t<ItemsIt>; using IndexType = thrust::detail::it_difference_t<ItemsIt>;
+    (using offset_t       = thrust::detail::it_difference_t<ItemsIt>;
+     const auto num_items = static_cast<offset_t>(::cuda::std::distance(first, last));
 
-     const auto num_items = static_cast<IndexType>(::cuda::std::distance(first, last));
+     using counting_it    = counting_iterator<offset_t>;
+     const auto zip_first = make_zip_iterator(first, first, counting_it{0}, counting_it{0});
 
-     using iterator_tuple = tuple<ItemsIt, counting_iterator<IndexType>>;
-     using zip_iterator   = zip_iterator<iterator_tuple>;
-
-     iterator_tuple iter_tuple = thrust::make_tuple(first, counting_iterator<IndexType>(0));
-
-     using arg_minmax_t   = __extrema::arg_minmax_f<InputType, IndexType, BinaryPred>;
-     using two_pairs_type = typename arg_minmax_t::two_pairs_type;
-     using duplicate_t    = typename arg_minmax_t::duplicate_tuple;
-     using transform_t    = transform_iterator<duplicate_t, zip_iterator, two_pairs_type, two_pairs_type>;
-
-     zip_iterator begin    = make_zip_iterator(iter_tuple);
-     two_pairs_type result = __extrema::extrema(
-       policy, transform_t(begin, duplicate_t()), num_items, arg_minmax_t(binary_pred), (two_pairs_type*) (nullptr));
-     ret = thrust::make_pair(first + get<1>(get<0>(result)), first + get<1>(get<1>(result)));),
+     // TODO(bgruber): the previous thrust implementation avoided creating an initial value. Should we bring this back?
+     // There is no reduction in CUB without init.
+     using value_t   = thrust::detail::it_value_t<ItemsIt>;
+     using tuple_t   = tuple<value_t, value_t, offset_t, offset_t>;
+     const auto func = __extrema::arg_minmax_f<BinaryPred>{binary_pred};
+     return thrust::cuda_cub::detail::reduce_n_impl(
+       policy,
+       zip_first,
+       num_items,
+       tuple_t{cub::FutureValue(first), cub::FutureValue(first), offset_t{0}, offset_t{0}},
+       func,
+       [&](execution_policy<Derived>& policy, const tuple_t* result_ptr) -> pair<ItemsIt, ItemsIt> {
+         // TODO(bgruber): I only want to download the offsets (element 2/3) and not the values (element 0/1), but how
+         // can I legally form a pointer to those tuple elements?
+         const auto result = get_value(policy, result_ptr);
+         return {first + get<2>(result), first + get<3>(result)};
+       });),
     // CDP Sequential impl:
-    (ret = thrust::minmax_element(cvt_to_seq(derived_cast(policy)), first, last, binary_pred);));
-  return ret;
-}
-
-template <class Derived, class ItemsIt>
-pair<ItemsIt, ItemsIt> _CCCL_HOST_DEVICE minmax_element(execution_policy<Derived>& policy, ItemsIt first, ItemsIt last)
-{
-  using value_type = thrust::detail::it_value_t<ItemsIt>;
-  return cuda_cub::minmax_element(policy, first, last, ::cuda::std::less<value_type>());
+    (return thrust::minmax_element(cvt_to_seq(derived_cast(policy)), first, last, binary_pred);));
 }
 
 } // namespace cuda_cub
 THRUST_NAMESPACE_END
-#endif

--- a/thrust/thrust/system/cuda/detail/reduce.h
+++ b/thrust/thrust/system/cuda/detail/reduce.h
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -49,13 +49,9 @@
 #  include <thrust/detail/raw_reference_cast.h>
 #  include <thrust/detail/temporary_array.h>
 #  include <thrust/distance.h>
-#  include <thrust/functional.h>
 #  include <thrust/system/cuda/detail/cdp_dispatch.h>
-#  include <thrust/system/cuda/detail/core/agent_launcher.h>
-#  include <thrust/system/cuda/detail/dispatch.h>
 #  include <thrust/system/cuda/detail/execution_policy.h>
 #  include <thrust/system/cuda/detail/get_value.h>
-#  include <thrust/system/cuda/detail/make_unsigned_special.h>
 #  include <thrust/system/cuda/detail/util.h>
 
 #  include <cuda/std/cstdint>
@@ -82,532 +78,6 @@ void _CCCL_HOST_DEVICE reduce_into(
 
 namespace cuda_cub
 {
-
-namespace __reduce
-{
-
-template <bool>
-struct is_true : thrust::detail::false_type
-{};
-template <>
-struct is_true<true> : thrust::detail::true_type
-{};
-
-template <int _BLOCK_THREADS,
-          int _ITEMS_PER_THREAD                      = 1,
-          int _VECTOR_LOAD_LENGTH                    = 1,
-          cub::BlockReduceAlgorithm _BLOCK_ALGORITHM = cub::BLOCK_REDUCE_RAKING,
-          cub::CacheLoadModifier _LOAD_MODIFIER      = cub::LOAD_DEFAULT,
-          cub::GridMappingStrategy _GRID_MAPPING     = cub::GRID_MAPPING_DYNAMIC>
-struct PtxPolicy
-{
-  enum
-  {
-    BLOCK_THREADS      = _BLOCK_THREADS,
-    ITEMS_PER_THREAD   = _ITEMS_PER_THREAD,
-    VECTOR_LOAD_LENGTH = _VECTOR_LOAD_LENGTH,
-    ITEMS_PER_TILE     = _BLOCK_THREADS * _ITEMS_PER_THREAD
-  };
-
-  static const cub::BlockReduceAlgorithm BLOCK_ALGORITHM = _BLOCK_ALGORITHM;
-  static const cub::CacheLoadModifier LOAD_MODIFIER      = _LOAD_MODIFIER;
-  static const cub::GridMappingStrategy GRID_MAPPING     = _GRID_MAPPING;
-}; // struct PtxPolicy
-
-template <class, class>
-struct Tuning;
-
-template <class T>
-struct Tuning<core::detail::sm52, T>
-{
-  enum
-  {
-    // Relative size of T type to a 4-byte word
-    SCALE_FACTOR_4B = (sizeof(T) + 3) / 4,
-    // Relative size of T type to a 1-byte word
-    SCALE_FACTOR_1B = sizeof(T),
-  };
-
-  // ReducePolicy1B (GTX Titan: 228.7 GB/s @ 192M 1B items)
-  using ReducePolicy1B =
-    PtxPolicy<128,
-              (((24 / Tuning::SCALE_FACTOR_1B) > (1)) ? (24 / Tuning::SCALE_FACTOR_1B) : (1)),
-              4,
-              cub::BLOCK_REDUCE_WARP_REDUCTIONS,
-              cub::LOAD_LDG,
-              cub::GRID_MAPPING_DYNAMIC>;
-
-  // ReducePolicy4B types (GTX Titan: 255.1 GB/s @ 48M 4B items)
-  using ReducePolicy4B =
-    PtxPolicy<256,
-              (((20 / Tuning::SCALE_FACTOR_4B) > (1)) ? (20 / Tuning::SCALE_FACTOR_4B) : (1)),
-              4,
-              cub::BLOCK_REDUCE_WARP_REDUCTIONS,
-              cub::LOAD_LDG,
-              cub::GRID_MAPPING_DYNAMIC>;
-
-  using type = ::cuda::std::conditional_t<(sizeof(T) < 4), ReducePolicy1B, ReducePolicy4B>;
-}; // Tuning sm52
-
-template <class InputIt, class OutputIt, class T, class Size, class ReductionOp>
-struct ReduceAgent
-{
-  using UnsignedSize = typename detail::make_unsigned_special<Size>::type;
-
-  template <class Arch>
-  struct PtxPlan : Tuning<Arch, T>::type
-  {
-    // we need this type definition to indicate "specialize_plan" metafunction
-    // that this PtxPlan may have specializations for different Arch
-    // via Tuning<Arch,T> type.
-    //
-    using tuning = Tuning<Arch, T>;
-
-    using Vector      = cub::CubVector<T, PtxPlan::VECTOR_LOAD_LENGTH>;
-    using LoadIt      = cub::detail::try_make_cache_modified_iterator_t<PtxPlan::LOAD_MODIFIER, InputIt>;
-    using BlockReduce = cub::BlockReduce<T, PtxPlan::BLOCK_THREADS, PtxPlan::BLOCK_ALGORITHM, 1, 1>;
-
-    using VectorLoadIt = cub::CacheModifiedInputIterator<PtxPlan::LOAD_MODIFIER, Vector, Size>;
-
-    struct TempStorage
-    {
-      typename BlockReduce::TempStorage reduce;
-      //
-      Size dequeue_offset;
-    }; // struct TempStorage
-
-  }; // struct PtxPlan
-
-  // Reduction need additional information which is not covered in
-  // default core::AgentPlan. We thus inherit from core::AgentPlan
-  // and add additional member fields that are needed.
-  // Other algorithms, e.g. merge, may not need additional information,
-  // and may use AgentPlan directly, instead of defining their own Plan type.
-  //
-  struct Plan : core::detail::AgentPlan
-  {
-    cub::GridMappingStrategy grid_mapping;
-
-    THRUST_RUNTIME_FUNCTION Plan() {}
-
-    template <class P>
-    THRUST_RUNTIME_FUNCTION Plan(P)
-        : core::detail::AgentPlan(P())
-        , grid_mapping(P::GRID_MAPPING)
-    {}
-  };
-
-  // this specialized PtxPlan for a device-compiled Arch
-  // ptx_plan type *must* only be used from device code
-  // Its use from host code will result in *undefined behaviour*
-  //
-  using ptx_plan = typename core::detail::specialize_plan_msvc10_war<PtxPlan>::type::type;
-
-  using TempStorage  = typename ptx_plan::TempStorage;
-  using Vector       = typename ptx_plan::Vector;
-  using LoadIt       = typename ptx_plan::LoadIt;
-  using BlockReduce  = typename ptx_plan::BlockReduce;
-  using VectorLoadIt = typename ptx_plan::VectorLoadIt;
-
-  enum
-  {
-    ITEMS_PER_THREAD   = ptx_plan::ITEMS_PER_THREAD,
-    BLOCK_THREADS      = ptx_plan::BLOCK_THREADS,
-    ITEMS_PER_TILE     = ptx_plan::ITEMS_PER_TILE,
-    VECTOR_LOAD_LENGTH = ptx_plan::VECTOR_LOAD_LENGTH,
-
-    ATTEMPT_VECTORIZATION = (VECTOR_LOAD_LENGTH > 1) && (ITEMS_PER_THREAD % VECTOR_LOAD_LENGTH == 0)
-                         && ::cuda::std::is_pointer<InputIt>::value
-                         && ::cuda::std::is_arithmetic<typename ::cuda::std::remove_cv<T>>::value
-  };
-
-  struct impl
-  {
-    //---------------------------------------------------------------------
-    // Per thread data
-    //---------------------------------------------------------------------
-
-    TempStorage& storage;
-    InputIt input_it;
-    LoadIt load_it;
-    ReductionOp reduction_op;
-
-    //---------------------------------------------------------------------
-    // Constructor
-    //---------------------------------------------------------------------
-
-    _CCCL_DEVICE_API _CCCL_FORCEINLINE impl(TempStorage& storage_, InputIt input_it_, ReductionOp reduction_op_)
-        : storage(storage_)
-        , input_it(input_it_)
-        , load_it(cub::detail::try_make_cache_modified_iterator<ptx_plan::LOAD_MODIFIER>(input_it))
-        , reduction_op(reduction_op_)
-    {}
-
-    //---------------------------------------------------------------------
-    // Utility
-    //---------------------------------------------------------------------
-
-    // Whether or not the input is aligned with the vector type
-    // (specialized for types we can vectorize)
-    //
-    template <class Iterator>
-    static _CCCL_DEVICE_API _CCCL_FORCEINLINE bool
-    is_aligned(Iterator d_in, thrust::detail::true_type /* can_vectorize */)
-    {
-      return ::cuda::std::is_sufficiently_aligned<alignof(Vector)>(d_in);
-    }
-
-    // Whether or not the input is aligned with the vector type
-    // (specialized for types we cannot vectorize)
-    //
-    template <class Iterator>
-    static _CCCL_DEVICE_API _CCCL_FORCEINLINE bool is_aligned(Iterator, thrust::detail::false_type /* can_vectorize */)
-    {
-      return false;
-    }
-
-    //---------------------------------------------------------------------
-    // Tile processing
-    //---------------------------------------------------------------------
-
-    // Consume a full tile of input (non-vectorized)
-    //
-    template <int IS_FIRST_TILE>
-    _CCCL_DEVICE_API _CCCL_FORCEINLINE void consume_tile(
-      T& thread_aggregate,
-      Size block_offset,
-      int /*valid_items*/,
-      thrust::detail::true_type /* is_full_tile */,
-      thrust::detail::false_type /* can_vectorize */)
-    {
-      T items[ITEMS_PER_THREAD];
-
-      // Load items in striped fashion
-      cub::LoadDirectStriped<BLOCK_THREADS>(threadIdx.x, load_it + block_offset, items);
-
-      // Reduce items within each thread stripe
-      thread_aggregate = (IS_FIRST_TILE) ? cub::ThreadReduce(items, reduction_op)
-                                         : cub::ThreadReduce(items, reduction_op, thread_aggregate);
-    }
-
-    // Consume a full tile of input (vectorized)
-    //
-    template <int IS_FIRST_TILE>
-    _CCCL_DEVICE_API _CCCL_FORCEINLINE void consume_tile(
-      T& thread_aggregate,
-      Size block_offset,
-      int /*valid_items*/,
-      thrust::detail::true_type /* is_full_tile */,
-      thrust::detail::true_type /* can_vectorize */)
-    {
-      // Alias items as an array of VectorT and load it in striped fashion
-      enum
-      {
-        WORDS = ITEMS_PER_THREAD / VECTOR_LOAD_LENGTH
-      };
-
-      T items[ITEMS_PER_THREAD];
-
-      Vector* vec_items = reinterpret_cast<Vector*>(items);
-
-      // Vector Input iterator wrapper type (for applying cache modifier)
-      T* d_in_unqualified = const_cast<T*>(input_it) + block_offset + (threadIdx.x * VECTOR_LOAD_LENGTH);
-      VectorLoadIt vec_load_it(reinterpret_cast<Vector*>(d_in_unqualified));
-
-      _CCCL_PRAGMA_UNROLL_FULL()
-      for (int i = 0; i < WORDS; ++i)
-      {
-        vec_items[i] = vec_load_it[BLOCK_THREADS * i];
-      }
-
-      // Reduce items within each thread stripe
-      thread_aggregate = (IS_FIRST_TILE) ? cub::ThreadReduce(items, reduction_op)
-                                         : cub::ThreadReduce(items, reduction_op, thread_aggregate);
-    }
-
-    // Consume a partial tile of input
-    //
-    template <int IS_FIRST_TILE, class CAN_VECTORIZE>
-    _CCCL_DEVICE_API _CCCL_FORCEINLINE void consume_tile(
-      T& thread_aggregate,
-      Size block_offset,
-      int valid_items,
-      thrust::detail::false_type /* is_full_tile */,
-      CAN_VECTORIZE)
-    {
-      // Partial tile
-      int thread_offset = threadIdx.x;
-
-      // Read first item
-      if ((IS_FIRST_TILE) && (thread_offset < valid_items))
-      {
-        thread_aggregate = load_it[block_offset + thread_offset];
-        thread_offset += BLOCK_THREADS;
-      }
-
-      // Continue reading items (block-striped)
-      while (thread_offset < valid_items)
-      {
-        thread_aggregate =
-          reduction_op(thread_aggregate, thrust::raw_reference_cast(load_it[block_offset + thread_offset]));
-        thread_offset += BLOCK_THREADS;
-      }
-    }
-
-    //---------------------------------------------------------------
-    // Consume a contiguous segment of tiles
-    //---------------------------------------------------------------------
-
-    // Reduce a contiguous segment of input tiles
-    //
-    template <class CAN_VECTORIZE>
-    _CCCL_DEVICE_API _CCCL_FORCEINLINE T
-    consume_range_impl(Size block_offset, Size block_end, CAN_VECTORIZE can_vectorize)
-    {
-      T thread_aggregate;
-
-      if (block_offset + ITEMS_PER_TILE > block_end)
-      {
-        // First tile isn't full (not all threads have valid items)
-        int valid_items = block_end - block_offset;
-        consume_tile<true>(thread_aggregate, block_offset, valid_items, thrust::detail::false_type(), can_vectorize);
-        return BlockReduce(storage.reduce).Reduce(thread_aggregate, reduction_op, valid_items);
-      }
-
-      // At least one full block
-      consume_tile<true>(thread_aggregate, block_offset, ITEMS_PER_TILE, thrust::detail::true_type(), can_vectorize);
-      block_offset += ITEMS_PER_TILE;
-
-      // Consume subsequent full tiles of input
-      while (block_offset + ITEMS_PER_TILE <= block_end)
-      {
-        consume_tile<false>(thread_aggregate, block_offset, ITEMS_PER_TILE, thrust::detail::true_type(), can_vectorize);
-        block_offset += ITEMS_PER_TILE;
-      }
-
-      // Consume a partially-full tile
-      if (block_offset < block_end)
-      {
-        int valid_items = block_end - block_offset;
-        consume_tile<false>(thread_aggregate, block_offset, valid_items, thrust::detail::false_type(), can_vectorize);
-      }
-
-      // Compute block-wide reduction (all threads have valid items)
-      return BlockReduce(storage.reduce).Reduce(thread_aggregate, reduction_op);
-    }
-
-    // Reduce a contiguous segment of input tiles
-    //
-    _CCCL_DEVICE_API _CCCL_FORCEINLINE T consume_range(Size block_offset, Size block_end)
-    {
-      using attempt_vec = is_true<ATTEMPT_VECTORIZATION>;
-      using path_a      = is_true<true && ATTEMPT_VECTORIZATION>;
-      using path_b      = is_true<false && ATTEMPT_VECTORIZATION>;
-
-      return is_aligned(input_it + block_offset, attempt_vec())
-             ? consume_range_impl(block_offset, block_end, path_a())
-             : consume_range_impl(block_offset, block_end, path_b());
-    }
-
-    // Reduce a contiguous segment of input tiles
-    //
-    _CCCL_DEVICE_API _CCCL_FORCEINLINE T consume_tiles(
-      Size /*num_items*/,
-      cub::GridEvenShare<Size>& even_share,
-      cub::GridQueue<UnsignedSize>& /*queue*/,
-      thrust::detail::integral_constant<cub::GridMappingStrategy, cub::GRID_MAPPING_RAKE> /*is_rake*/)
-    {
-      using attempt_vec = is_true<ATTEMPT_VECTORIZATION>;
-      using path_a      = is_true<true && ATTEMPT_VECTORIZATION>;
-      using path_b      = is_true<false && ATTEMPT_VECTORIZATION>;
-
-      // Initialize even-share descriptor for this thread block
-      even_share.template BlockInit<ITEMS_PER_TILE, cub::GRID_MAPPING_RAKE>();
-
-      return is_aligned(input_it, attempt_vec())
-             ? consume_range_impl(even_share.block_offset, even_share.block_end, path_a())
-             : consume_range_impl(even_share.block_offset, even_share.block_end, path_b());
-    }
-
-    //---------------------------------------------------------------------
-    // Dynamically consume tiles
-    //---------------------------------------------------------------------
-
-    // Dequeue and reduce tiles of items as part of a inter-block reduction
-    //
-    template <class CAN_VECTORIZE>
-    _CCCL_DEVICE_API _CCCL_FORCEINLINE T
-    consume_tiles_impl(Size num_items, cub::GridQueue<UnsignedSize> queue, CAN_VECTORIZE can_vectorize)
-    {
-      // We give each thread block at least one tile of input.
-      T thread_aggregate;
-      Size block_offset    = blockIdx.x * ITEMS_PER_TILE;
-      Size even_share_base = gridDim.x * ITEMS_PER_TILE;
-
-      if (block_offset + ITEMS_PER_TILE > num_items)
-      {
-        // First tile isn't full (not all threads have valid items)
-        int valid_items = num_items - block_offset;
-        consume_tile<true>(thread_aggregate, block_offset, valid_items, thrust::detail::false_type(), can_vectorize);
-        return BlockReduce(storage.reduce).Reduce(thread_aggregate, reduction_op, valid_items);
-      }
-
-      // Consume first full tile of input
-      consume_tile<true>(thread_aggregate, block_offset, ITEMS_PER_TILE, thrust::detail::true_type(), can_vectorize);
-
-      if (num_items > even_share_base)
-      {
-        // Dequeue a tile of items
-        if (threadIdx.x == 0)
-        {
-          storage.dequeue_offset = queue.Drain(ITEMS_PER_TILE) + even_share_base;
-        }
-
-        __syncthreads();
-
-        // Grab tile offset and check if we're done with full tiles
-        block_offset = storage.dequeue_offset;
-
-        // Consume more full tiles
-        while (block_offset + ITEMS_PER_TILE <= num_items)
-        {
-          consume_tile<false>(
-            thread_aggregate, block_offset, ITEMS_PER_TILE, thrust::detail::true_type(), can_vectorize);
-
-          __syncthreads();
-
-          // Dequeue a tile of items
-          if (threadIdx.x == 0)
-          {
-            storage.dequeue_offset = queue.Drain(ITEMS_PER_TILE) + even_share_base;
-          }
-
-          __syncthreads();
-
-          // Grab tile offset and check if we're done with full tiles
-          block_offset = storage.dequeue_offset;
-        }
-
-        // Consume partial tile
-        if (block_offset < num_items)
-        {
-          int valid_items = num_items - block_offset;
-          consume_tile<false>(thread_aggregate, block_offset, valid_items, thrust::detail::false_type(), can_vectorize);
-        }
-      }
-
-      // Compute block-wide reduction (all threads have valid items)
-      return BlockReduce(storage.reduce).Reduce(thread_aggregate, reduction_op);
-    }
-
-    // Dequeue and reduce tiles of items as part of a inter-block reduction
-    //
-    _CCCL_DEVICE_API _CCCL_FORCEINLINE T consume_tiles(
-      Size num_items,
-      cub::GridEvenShare<Size>& /*even_share*/,
-      cub::GridQueue<UnsignedSize>& queue,
-      thrust::detail::integral_constant<cub::GridMappingStrategy, cub::GRID_MAPPING_DYNAMIC>)
-    {
-      using attempt_vec = is_true<ATTEMPT_VECTORIZATION>;
-      using path_a      = is_true<true && ATTEMPT_VECTORIZATION>;
-      using path_b      = is_true<false && ATTEMPT_VECTORIZATION>;
-
-      return is_aligned(input_it, attempt_vec())
-             ? consume_tiles_impl(num_items, queue, path_a())
-             : consume_tiles_impl(num_items, queue, path_b());
-    }
-  }; // struct impl
-
-  //---------------------------------------------------------------------
-  // Agent entry points
-  //---------------------------------------------------------------------
-
-  // single tile reduce entry point
-  //
-  THRUST_AGENT_ENTRY(InputIt input_it, OutputIt output_it, Size num_items, ReductionOp reduction_op, char* shmem)
-  {
-    TempStorage& storage = *reinterpret_cast<TempStorage*>(shmem);
-
-    if (num_items == 0)
-    {
-      return;
-    }
-
-    T block_aggregate = impl(storage, input_it, reduction_op).consume_range((Size) 0, num_items);
-
-    if (threadIdx.x == 0)
-    {
-      *output_it = block_aggregate;
-    }
-  }
-
-  // single tile reduce entry point
-  //
-  THRUST_AGENT_ENTRY(InputIt input_it, OutputIt output_it, Size num_items, ReductionOp reduction_op, T init, char* shmem)
-  {
-    TempStorage& storage = *reinterpret_cast<TempStorage*>(shmem);
-
-    if (num_items == 0)
-    {
-      if (threadIdx.x == 0)
-      {
-        *output_it = init;
-      }
-      return;
-    }
-
-    T block_aggregate = impl(storage, input_it, reduction_op).consume_range((Size) 0, num_items);
-
-    if (threadIdx.x == 0)
-    {
-      *output_it = reduction_op(init, block_aggregate);
-    }
-  }
-
-  THRUST_AGENT_ENTRY(
-    InputIt input_it,
-    OutputIt output_it,
-    Size num_items,
-    cub::GridEvenShare<Size> even_share,
-    cub::GridQueue<UnsignedSize> queue,
-    ReductionOp reduction_op,
-    char* shmem)
-  {
-    TempStorage& storage = *reinterpret_cast<TempStorage*>(shmem);
-
-    using grid_mapping = thrust::detail::integral_constant<cub::GridMappingStrategy, ptx_plan::GRID_MAPPING>;
-
-    T block_aggregate =
-      impl(storage, input_it, reduction_op).consume_tiles(num_items, even_share, queue, grid_mapping());
-
-    if (threadIdx.x == 0)
-    {
-      output_it[blockIdx.x] = block_aggregate;
-    }
-  }
-}; // struct ReduceAgent
-
-template <class Size>
-struct DrainAgent
-{
-  using UnsignedSize = typename detail::make_unsigned_special<Size>::type;
-
-  template <class Arch>
-  struct PtxPlan : PtxPolicy<1>
-  {};
-  using ptx_plan = core::detail::specialize_plan<PtxPlan>;
-
-  //---------------------------------------------------------------------
-  // Agent entry point
-  //---------------------------------------------------------------------
-
-  THRUST_AGENT_ENTRY(cub::GridQueue<UnsignedSize> grid_queue, Size num_items, char* /*shmem*/)
-  {
-    grid_queue.FillAndResetDrain(num_items);
-  }
-}; // struct DrainAgent;
-} // namespace __reduce
-
 namespace detail
 {
 
@@ -630,30 +100,19 @@ THRUST_RUNTIME_FUNCTION size_t get_reduce_n_temporary_storage_size(
   return tmp_size;
 }
 
-template <typename Derived, typename InputIt, typename Size, typename T, typename BinaryOp>
-THRUST_RUNTIME_FUNCTION T
-reduce_n_impl(execution_policy<Derived>& policy, InputIt first, Size num_items, T init, BinaryOp binary_op)
+template <typename Derived, typename InputIt, typename Size, typename T, typename BinaryOp, typename GetValue>
+THRUST_RUNTIME_FUNCTION auto reduce_n_impl(
+  execution_policy<Derived>& policy, InputIt first, Size num_items, T init, BinaryOp binary_op, GetValue get_value)
 {
-  cudaStream_t stream = cuda_cub::stream(policy);
-  cudaError_t status;
+  const cudaStream_t stream = cuda_cub::stream(policy);
 
-  // Determine temporary device storage requirements.
-
+  // We allocate both the temporary storage needed for the algorithm, and a `T` to store the result. The array was
+  // dynamically allocated, so we assume that it's suitably aligned for any type of data.
+  // `malloc`/`cudaMalloc`/`new`/`std::allocator` make this guarantee.
   size_t tmp_size = get_reduce_n_temporary_storage_size(policy, first, num_items, init, binary_op);
-
-  // Allocate temporary storage.
-
-  // We allocate both the temporary storage needed for the algorithm, and a `T`
-  // to store the result.
-  //
-  // The array was dynamically allocated, so we assume that it's suitably
-  // aligned for any type of data. `malloc`/`cudaMalloc`/`new`/`std::allocator`
-  // make this guarantee.
-
   thrust::detail::temporary_array<std::uint8_t, Derived> tmp(policy, tmp_size + sizeof(T));
 
-  // Run reduction.
-
+  cudaError_t status;
   T* ret_ptr    = thrust::detail::aligned_reinterpret_cast<T*>(tmp.data().get());
   void* tmp_ptr = static_cast<void*>((tmp.data() + sizeof(T)).get());
   THRUST_INDEX_TYPE_DISPATCH(
@@ -663,30 +122,20 @@ reduce_n_impl(execution_policy<Derived>& policy, InputIt first, Size num_items, 
     (tmp_ptr, tmp_size, first, ret_ptr, num_items_fixed, binary_op, init, stream));
   cuda_cub::throw_on_error(status, "after reduce invocation");
 
-  // Synchronize the stream and get the value.
-
-  status = cuda_cub::synchronize(policy);
-  cuda_cub::throw_on_error(status, "reduce failed to synchronize");
-  return thrust::cuda_cub::get_value(policy, thrust::detail::aligned_reinterpret_cast<T*>(tmp.data().get()));
+  cuda_cub::throw_on_error(cuda_cub::synchronize(policy), "reduce failed to synchronize");
+  return get_value(policy, ret_ptr);
 }
 
 template <typename Derived, typename InputIt, typename Size, typename OutputIt, typename T, typename BinaryOp>
 THRUST_RUNTIME_FUNCTION void reduce_n_into_impl(
   execution_policy<Derived>& policy, InputIt first, Size num_items, OutputIt output, T init, BinaryOp binary_op)
 {
-  cudaStream_t stream = cuda_cub::stream(policy);
-  cudaError_t status;
-
-  // Determine temporary device storage requirements.
+  const cudaStream_t stream = cuda_cub::stream(policy);
 
   size_t tmp_size = get_reduce_n_temporary_storage_size(policy, first, num_items, init, binary_op);
-
-  // Allocate temporary storage.
-
   thrust::detail::temporary_array<std::uint8_t, Derived> tmp(policy, tmp_size);
 
-  // Run reduction.
-
+  cudaError_t status;
   void* tmp_ptr = thrust::raw_pointer_cast(tmp.data());
   THRUST_INDEX_TYPE_DISPATCH(
     status,
@@ -695,12 +144,9 @@ THRUST_RUNTIME_FUNCTION void reduce_n_into_impl(
     (tmp_ptr, tmp_size, first, output, num_items_fixed, binary_op, init, stream));
   cuda_cub::throw_on_error(status, "after reduce invocation");
 
-  // Synchronize the stream and get the value.
-
   status = cuda_cub::synchronize_optional(policy);
   cuda_cub::throw_on_error(status, "reduce failed to synchronize");
 }
-
 } // namespace detail
 
 //-------------------------
@@ -713,7 +159,8 @@ _CCCL_HOST_DEVICE T
 reduce_n(execution_policy<Derived>& policy, InputIt first, Size num_items, T init, BinaryOp binary_op)
 {
   THRUST_CDP_DISPATCH(
-    (init = thrust::cuda_cub::detail::reduce_n_impl(policy, first, num_items, init, binary_op);),
+    (init = thrust::cuda_cub::detail::reduce_n_impl(
+       policy, first, num_items, init, binary_op, &get_value<Derived, const T*>);),
     (init = thrust::reduce(cvt_to_seq(derived_cast(policy)), first, first + num_items, init, binary_op);));
   return init;
 }


### PR DESCRIPTION
Fixes #1626

`thrust.bench.reduce.basic.base` on RTX 5090
```
# base

## [0] NVIDIA GeForce RTX 5090

|  T{ct}  |  Elements  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|------------|------------|-------------|------------|-------------|-----------|---------|----------|
|   I8    |    2^16    |  18.996 us |       9.69% |  18.976 us |       7.08% | -0.020 us |  -0.10% |   SAME   |
|   I8    |    2^20    |  21.213 us |      10.46% |  20.692 us |       6.91% | -0.521 us |  -2.46% |   SAME   |
|   I8    |    2^24    |  38.706 us |       4.53% |  38.294 us |       4.14% | -0.412 us |  -1.06% |   SAME   |
|   I8    |    2^28    | 235.330 us |       0.90% | 234.404 us |       0.76% | -0.926 us |  -0.39% |   SAME   |
|   I16   |    2^16    |  18.491 us |       9.88% |  18.110 us |       7.43% | -0.381 us |  -2.06% |   SAME   |
|   I16   |    2^20    |  21.037 us |      10.49% |  20.769 us |       8.16% | -0.268 us |  -1.27% |   SAME   |
|   I16   |    2^24    |  43.850 us |       2.66% |  43.891 us |       2.63% |  0.041 us |   0.09% |   SAME   |
|   I16   |    2^28    | 368.571 us |       0.89% | 370.061 us |       3.76% |  1.490 us |   0.40% |   SAME   |
|   I32   |    2^16    |  19.128 us |      14.85% |  19.000 us |       9.60% | -0.128 us |  -0.67% |   SAME   |
|   I32   |    2^20    |  22.113 us |       7.64% |  22.448 us |       9.29% |  0.335 us |   1.52% |   SAME   |
|   I32   |    2^24    |  65.135 us |       3.37% |  66.471 us |       7.21% |  1.336 us |   2.05% |   SAME   |
|   I32   |    2^28    | 691.652 us |       0.52% | 691.844 us |       0.42% |  0.192 us |   0.03% |   SAME   |
|   I64   |    2^16    |  20.190 us |       7.42% |  20.795 us |       7.30% |  0.605 us |   2.99% |   SAME   |
|   I64   |    2^20    |  26.892 us |       3.10% |  27.530 us |       5.01% |  0.638 us |   2.37% |   SAME   |
|   I64   |    2^24    | 108.388 us |       1.93% | 108.820 us |       1.53% |  0.431 us |   0.40% |   SAME   |
|   I64   |    2^28    |   1.328 ms |       0.19% |   1.327 ms |       0.19% | -0.612 us |  -0.05% |   SAME   |
|  I128   |    2^16    |  20.705 us |      25.83% |  20.381 us |       7.45% | -0.324 us |  -1.56% |   SAME   |
|  I128   |    2^20    |  32.301 us |       6.55% |  32.129 us |       4.53% | -0.172 us |  -0.53% |   SAME   |
|  I128   |    2^24    | 199.346 us |       1.07% | 200.923 us |       1.24% |  1.577 us |   0.79% |   SAME   |
|  I128   |    2^28    |   2.597 ms |       0.13% |   2.599 ms |       0.15% |  1.824 us |   0.07% |   SAME   |
|   F32   |    2^16    |  19.672 us |       9.66% |  19.637 us |       7.84% | -0.035 us |  -0.18% |   SAME   |
|   F32   |    2^20    |  21.911 us |       6.59% |  21.860 us |       6.58% | -0.051 us |  -0.23% |   SAME   |
|   F32   |    2^24    |  64.753 us |       2.92% |  64.713 us |       2.61% | -0.040 us |  -0.06% |   SAME   |
|   F32   |    2^28    | 687.966 us |       0.30% | 689.294 us |       0.33% |  1.328 us |   0.19% |   SAME   |
|   F64   |    2^16    |  22.964 us |       4.34% |  23.073 us |       5.25% |  0.109 us |   0.48% |   SAME   |
|   F64   |    2^20    |  28.493 us |       4.50% |  28.488 us |       4.24% | -0.005 us |  -0.02% |   SAME   |
|   F64   |    2^24    | 109.701 us |       1.61% | 109.534 us |       1.49% | -0.167 us |  -0.15% |   SAME   |
|   F64   |    2^28    |   1.333 ms |       0.37% |   1.332 ms |       0.30% | -0.987 us |  -0.07% |   SAME   |
```