### PR TITLE
Test CI job times without `sccache` [DO NOT MERGE]

### DIFF
--- a/.github/actions/workflow-run-job-linux/action.yml
+++ b/.github/actions/workflow-run-job-linux/action.yml
@@ -149,6 +149,7 @@ runs:
           --env "CI=$CI" \
           --env "AWS_ROLE_ARN=" \
           --env "COMMAND=$COMMAND" \
+          --env "DISABLE_SCCACHE=1" \
           --env "SCCACHE_IDLE_TIMEOUT=0" \
           --env "GITHUB_ENV=$GITHUB_ENV" \
           --env "GITHUB_SHA=$GITHUB_SHA" \


### PR DESCRIPTION
Just opening this PR to test how long CI takes to build without `sccache`.