### PR TITLE
`is_nothrow_destructible_v` should use the builtin when it is available

### DIFF
--- a/libcudacxx/include/cuda/std/__type_traits/is_nothrow_destructible.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_nothrow_destructible.h
@@ -40,6 +40,9 @@ template <class _Tp>
 struct is_nothrow_destructible : public integral_constant<bool, _CCCL_BUILTIN_IS_NOTHROW_DESTRUCTIBLE(_Tp)>
 {};
 
+template <class _Tp>
+inline constexpr bool is_nothrow_destructible_v = _CCCL_BUILTIN_IS_NOTHROW_DESTRUCTIBLE(_Tp);
+
 #else // ^^^ _CCCL_BUILTIN_IS_NOTHROW_DESTRUCTIBLE ^^^ / vvv !_CCCL_BUILTIN_IS_NOTHROW_DESTRUCTIBLE vvv
 
 template <class _Tp, bool = is_destructible<_Tp>::value>
@@ -67,10 +70,10 @@ template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT is_nothrow_destructible<_Tp&&> : public true_type
 {};
 
-#endif // !_CCCL_BUILTIN_IS_NOTHROW_DESTRUCTIBLE
-
 template <class _Tp>
 inline constexpr bool is_nothrow_destructible_v = is_nothrow_destructible<_Tp>::value;
+
+#endif // !_CCCL_BUILTIN_IS_NOTHROW_DESTRUCTIBLE
 
 _LIBCUDACXX_END_NAMESPACE_STD
 


### PR DESCRIPTION
## Description

`is_destructible_v` is using the builtin trait when it is available, but `is_nothrow_destructible_v` is not. this pr fixes the inconsistency.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
