### PR TITLE
nvcc-12.0 seems happier with `__host__ __device__` lambdas

### DIFF
--- a/cudax/test/execution/test_stream_context.cu
+++ b/cudax/test/execution/test_stream_context.cu
@@ -45,7 +45,7 @@ void stream_context_test1()
   auto sched = ctx.get_scheduler();
 
   auto sndr = cudax_async::schedule(sched) //
-            | cudax_async::then([] __device__() noexcept -> bool {
+            | cudax_async::then([] __host__ __device__() noexcept -> bool {
                 return _is_on_device();
               });
 


### PR DESCRIPTION
## Description

the stream scheduler tests are failing in CI again, but only for CTK 12.0. at least locally, changing the test to use a `__host__ __device__` lambda instead of a `__device__` lambda seems to fix the problem. fingers crossed it works in CI too.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
