### PR TITLE
fix the syntax for Catch2 test tags for `cudax::execution`

### DIFF
--- a/cudax/test/execution/env.cu
+++ b/cudax/test/execution/env.cu
@@ -45,14 +45,14 @@ struct test_resource
   friend void get_property(const test_resource&, cuda::mr::device_accessible) noexcept {}
 };
 
-C2H_TEST("env_t is queryable for all properties we want", "[execution, env]")
+C2H_TEST("env_t is queryable for all properties we want", "[execution][env]")
 {
   STATIC_REQUIRE(cuda::std::execution::__queryable_with<env_t, cuda::get_stream_t>);
   STATIC_REQUIRE(cuda::std::execution::__queryable_with<env_t, cuda::mr::get_memory_resource_t>);
   STATIC_REQUIRE(cuda::std::execution::__queryable_with<env_t, cudax::execution::get_execution_policy_t>);
 }
 
-C2H_TEST("env_t is default constructible", "[execution, env]")
+C2H_TEST("env_t is default constructible", "[execution][env]")
 {
   env_t env{cudax::device_memory_resource{cudax::device_ref{0}}};
   CHECK(env.query(cuda::get_stream) == ::cuda::experimental::__detail::__invalid_stream);
@@ -60,7 +60,7 @@ C2H_TEST("env_t is default constructible", "[execution, env]")
   CHECK(env.query(cuda::mr::get_memory_resource) == cudax::device_memory_resource{cudax::device_ref{0}});
 }
 
-C2H_TEST("env_t is constructible from an any_resource", "[execution, env]")
+C2H_TEST("env_t is constructible from an any_resource", "[execution][env]")
 {
   const cudax::any_async_resource<cuda::mr::device_accessible> mr{test_resource{}};
 
@@ -91,7 +91,7 @@ C2H_TEST("env_t is constructible from an any_resource", "[execution, env]")
   }
 }
 
-C2H_TEST("env_t is constructible from an any_resource passed as an rvalue", "[execution, env]")
+C2H_TEST("env_t is constructible from an any_resource passed as an rvalue", "[execution][env]")
 {
   SECTION("Passing an any_resource")
   {
@@ -124,7 +124,7 @@ C2H_TEST("env_t is constructible from an any_resource passed as an rvalue", "[ex
   }
 }
 
-C2H_TEST("env_t is constructible from a resource", "[execution, env]")
+C2H_TEST("env_t is constructible from a resource", "[execution][env]")
 {
   test_resource mr{};
 
@@ -155,7 +155,7 @@ C2H_TEST("env_t is constructible from a resource", "[execution, env]")
   }
 }
 
-C2H_TEST("env_t is constructible from a resource passed as an rvalue", "[execution, env]")
+C2H_TEST("env_t is constructible from a resource passed as an rvalue", "[execution][env]")
 {
   SECTION("Passing an any_resource")
   {
@@ -205,7 +205,7 @@ struct some_env_t
     return policy_;
   }
 };
-C2H_TEST("env_t is constructible from a suitable env", "[execution, env]")
+C2H_TEST("env_t is constructible from a suitable env", "[execution][env]")
 {
   some_env_t other_env{};
   env_t env{other_env};
@@ -239,7 +239,7 @@ struct bad_env_t
     return policy_;
   }
 };
-C2H_TEST("env_t is not constructible from a env missing queries", "[execution, env]")
+C2H_TEST("env_t is not constructible from a env missing queries", "[execution][env]")
 {
   STATIC_REQUIRE(cuda::std::is_constructible_v<env_t, bad_env_t<true, true, true>>);
   STATIC_REQUIRE(!cuda::std::is_constructible_v<env_t, bad_env_t<false, true, true>>);
@@ -247,7 +247,7 @@ C2H_TEST("env_t is not constructible from a env missing queries", "[execution, e
   STATIC_REQUIRE(!cuda::std::is_constructible_v<env_t, bad_env_t<true, true, false>>);
 }
 
-C2H_TEST("Can use query to construct various objects", "[execution, env]")
+C2H_TEST("Can use query to construct various objects", "[execution][env]")
 {
   SECTION("Can create an any_resource")
   {

--- a/cudax/test/execution/policies/get_execution_policy.cu
+++ b/cudax/test/execution/policies/get_execution_policy.cu
@@ -26,7 +26,7 @@ struct with_get_execution_policy_const_lvalue
   }
 };
 C2H_TEST("Can call get_execution_policy on a type with a get_execution_policy method that returns a const lvalue",
-         "[execution, policies]")
+         "[execution][policies]")
 {
   with_get_execution_policy_const_lvalue val{};
   auto&& res = cuda::experimental::execution::get_execution_policy(val);
@@ -44,7 +44,7 @@ struct with_get_execution_policy_rvalue
   }
 };
 C2H_TEST("Can call get_execution_policy on a type with a get_execution_policy method returns an rvalue",
-         "[execution, policies]")
+         "[execution][policies]")
 {
   with_get_execution_policy_rvalue val{};
   auto&& res = cuda::experimental::execution::get_execution_policy(val);
@@ -62,7 +62,7 @@ struct with_get_execution_policy_non_const
   }
 };
 C2H_TEST("Cannot call get_execution_policy on a type with a non-const get_execution_policy method",
-         "[execution, policies]")
+         "[execution][policies]")
 {
   STATIC_REQUIRE(!::cuda::std::is_invocable_v<cuda::experimental::execution::get_execution_policy_t,
                                               const with_get_execution_policy_non_const&>);
@@ -78,7 +78,7 @@ struct env_with_query_const_ref
   }
 };
 C2H_TEST("Can call get_execution_policy on an env with a get_execution_policy query that returns a const lvalue",
-         "[execution, policies]")
+         "[execution][policies]")
 {
   env_with_query_const_ref val{};
   auto&& res = cuda::experimental::execution::get_execution_policy(val);
@@ -96,7 +96,7 @@ struct env_with_query_rvalue
   }
 };
 C2H_TEST("Can call get_execution_policy on an env with a get_execution_policy query that returns an rvalue",
-         "[execution, policies]")
+         "[execution][policies]")
 {
   env_with_query_rvalue val{};
   auto&& res = cuda::experimental::execution::get_execution_policy(val);
@@ -113,7 +113,7 @@ struct env_with_query_non_const
     return pol_;
   }
 };
-C2H_TEST("Cannot call get_execution_policy on an env with a non-const query", "[execution, policies]")
+C2H_TEST("Cannot call get_execution_policy on an env with a non-const query", "[execution][policies]")
 {
   STATIC_REQUIRE(
     !::cuda::std::is_invocable_v<cuda::experimental::execution::get_execution_policy_t, const env_with_query_non_const&>);
@@ -133,7 +133,7 @@ struct env_with_query_and_method
     return pol_;
   }
 };
-C2H_TEST("Can call get_execution_policy on a type with both get_execution_policy and query", "[execution, policies]")
+C2H_TEST("Can call get_execution_policy on a type with both get_execution_policy and query", "[execution][policies]")
 {
   env_with_query_and_method val{};
   auto&& res = cuda::experimental::execution::get_execution_policy(val);

--- a/cudax/test/execution/policies/policies.cu
+++ b/cudax/test/execution/policies/policies.cu
@@ -19,7 +19,7 @@ namespace cudax = cuda::experimental;
 template <class T, class U>
 using is_same = cuda::std::is_same<cuda::std::remove_cvref_t<T>, U>;
 
-C2H_TEST("Execution policies", "[execution, policies]")
+C2H_TEST("Execution policies", "[execution][policies]")
 {
   namespace execution = cuda::experimental::execution;
   SECTION("Individual options")


### PR DESCRIPTION
## Description

the second argument to the `C2H_TEST` macro is a list of tags. those tags can be used to decide which tests to run. when a test has multiple tags, the correct syntax is `[tag1][tag2]`.

fix the places that are incorrectly specifying multiple tags like `[tag1, tag2]`.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
