### PR TITLE
Add cub::DeviceReduce::Sum Env-based API

### DIFF
--- a/cub/cub/device/device_reduce.cuh
+++ b/cub/cub/device/device_reduce.cuh
@@ -601,6 +601,10 @@ public:
 
     using tuning_t = _CUDA_STD_EXEC::__query_result_or_t<EnvT, _CUDA_EXEC::__get_tuning_t, _CUDA_STD_EXEC::env<>>;
 
+    using OutputT = cub::detail::non_void_value_t<OutputIteratorT, cub::detail::it_value_t<InputIteratorT>>;
+
+    using InitT = OutputT;
+
     // Query the required temporary storage size
     cudaError_t error = reduce_impl<tuning_t>(
       d_temp_storage,
@@ -609,7 +613,7 @@ public:
       d_out,
       num_items,
       ::cuda::std::plus<>{},
-      0,
+      InitT{}, // zero-initialize
       determinism_t{},
       stream.get());
     if (error != cudaSuccess)
@@ -632,7 +636,7 @@ public:
       d_out,
       num_items,
       ::cuda::std::plus<>{},
-      0,
+      InitT{}, // zero-initialize
       determinism_t{},
       stream.get());
 

--- a/cub/cub/device/device_reduce.cuh
+++ b/cub/cub/device/device_reduce.cuh
@@ -521,6 +521,81 @@ public:
     }
   }
 
+  template <typename InputIteratorT,
+            typename OutputIteratorT,
+            typename NumItemsT,
+            typename EnvT = ::cuda::std::execution::env<>>
+  CUB_RUNTIME_FUNCTION static cudaError_t
+  Sum(InputIteratorT d_in, OutputIteratorT d_out, NumItemsT num_items, EnvT env = {})
+  {
+    _CCCL_NVTX_RANGE_SCOPE("cub::DeviceReduce::Sum");
+
+    static_assert(!_CUDA_STD_EXEC::__queryable_with<EnvT, _CUDA_EXEC::determinism::__get_determinism_t>,
+                  "Determinism should be used inside requires to have an effect.");
+    using requirements_t =
+      _CUDA_STD_EXEC::__query_result_or_t<EnvT, _CUDA_EXEC::__get_requirements_t, _CUDA_STD_EXEC::env<>>;
+    using determinism_t =
+      _CUDA_STD_EXEC::__query_result_or_t<requirements_t, //
+                                          _CUDA_EXEC::determinism::__get_determinism_t,
+                                          _CUDA_EXEC::determinism::run_to_run_t>;
+
+    // Query relevant properties from the environment
+    auto stream = _CUDA_STD_EXEC::__query_or(env, ::cuda::get_stream, ::cuda::stream_ref{});
+    auto mr     = _CUDA_STD_EXEC::__query_or(env, ::cuda::mr::__get_memory_resource, detail::device_memory_resource{});
+
+    void* d_temp_storage      = nullptr;
+    size_t temp_storage_bytes = 0;
+
+    using tuning_t = _CUDA_STD_EXEC::__query_result_or_t<EnvT, _CUDA_EXEC::__get_tuning_t, _CUDA_STD_EXEC::env<>>;
+
+    // Query the required temporary storage size
+    cudaError_t error = reduce_impl<tuning_t>(
+      d_temp_storage,
+      temp_storage_bytes,
+      d_in,
+      d_out,
+      num_items,
+      ::cuda::std::plus<>{},
+      0,
+      determinism_t{},
+      stream.get());
+    if (error != cudaSuccess)
+    {
+      return error;
+    }
+
+    // TODO(gevtushenko): use uninitialized buffer when it's available
+    error = CubDebug(detail::temporary_storage::allocate_async(d_temp_storage, temp_storage_bytes, mr, stream));
+    if (error != cudaSuccess)
+    {
+      return error;
+    }
+
+    // Run the algorithm
+    error = reduce_impl<tuning_t>(
+      d_temp_storage,
+      temp_storage_bytes,
+      d_in,
+      d_out,
+      num_items,
+      ::cuda::std::plus<>{},
+      0,
+      determinism_t{},
+      stream.get());
+
+    // Try to deallocate regardless of the error to avoid memory leaks
+    cudaError_t deallocate_error =
+      CubDebug(detail::temporary_storage::deallocate_async(d_temp_storage, temp_storage_bytes, mr, stream));
+
+    if (error != cudaSuccess)
+    {
+      // Reduction error takes precedence over deallocation error since it happens first
+      return error;
+    }
+
+    return deallocate_error;
+  }
+
   //! @rst
   //! Computes a device-wide sum using the addition (``+``) operator.
   //!

--- a/cub/cub/device/device_reduce.cuh
+++ b/cub/cub/device/device_reduce.cuh
@@ -521,6 +521,59 @@ public:
     }
   }
 
+  //! @rst
+  //! Computes a device-wide sum using the addition (``+``) operator.
+  //!
+  //! - Uses ``0`` as the initial value of the reduction.
+  //! - Does not support ``+`` operators that are non-commutative.
+  //! - Provides "run-to-run" determinism for pseudo-associative reduction
+  //!   (e.g., addition of floating point types) on the same GPU device.
+  //!   However, results for pseudo-associative reduction may be inconsistent
+  //!   from one device to a another device of a different compute-capability
+  //!   because CUB can employ different tile-sizing for different architectures.
+  //!   To request "gpu-to-gpu" determinism, pass `cuda::execution::require(cuda::execution::determinism::gpu_to_gpu)`
+  //!   as the `env` parameter.
+  //! - The range ``[d_in, d_in + num_items)`` shall not overlap ``d_out``.
+  //!
+  //! Snippet
+  //! +++++++++++++++++++++++++++++++++++++++++++++
+  //!
+  //! The code snippet below illustrates a user-defined min-reduction of a
+  //! device vector of ``int`` data elements.
+  //!
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_reduce_env_api.cu
+  //!     :language: c++
+  //!     :dedent:
+  //!     :start-after: example-begin sum-env-determinism
+  //!     :end-before: example-end sum-env-determinism
+  //!
+  //! @endrst
+  //!
+  //! @tparam InputIteratorT
+  //!   **[inferred]** Random-access input iterator type for reading input items @iterator
+  //!
+  //! @tparam OutputIteratorT
+  //!   **[inferred]** Output iterator type for recording the reduced aggregate @iterator
+  //!
+  //! @tparam NumItemsT
+  //!   **[inferred]** Type of num_items
+  //!
+  //! @tparam EnvT
+  //!   **[inferred]** Execution environment type. Default is `cuda::std::execution::env<>`.
+  //!
+  //! @param[in] d_in
+  //!   Pointer to the input sequence of data items
+  //!
+  //! @param[out] d_out
+  //!   Pointer to the output aggregate
+  //!
+  //! @param[in] num_items
+  //!   Total number of input items (i.e., length of `d_in`)
+  //!
+  //! @param[in] env
+  //!   @rst
+  //!   **[optional]** Execution environment. Default is `cuda::std::execution::env{}`.
+  //!   @endrst
   template <typename InputIteratorT,
             typename OutputIteratorT,
             typename NumItemsT,
@@ -600,7 +653,7 @@ public:
   //! Computes a device-wide sum using the addition (``+``) operator.
   //!
   //! - Uses ``0`` as the initial value of the reduction.
-  //! - Does not support ``+`` operators that are non-commutative..
+  //! - Does not support ``+`` operators that are non-commutative.
   //! - Provides "run-to-run" determinism for pseudo-associative reduction
   //!   (e.g., addition of floating point types) on the same GPU device.
   //!   However, results for pseudo-associative reduction may be inconsistent

--- a/cub/test/catch2_test_device_reduce_env.cu
+++ b/cub/test/catch2_test_device_reduce_env.cu
@@ -312,7 +312,6 @@ C2H_TEST("Device sum uses environment", "[reduce][device]", requirements)
   auto d_in             = thrust::make_constant_iterator(1.0f);
   auto d_out            = thrust::device_vector<accumulator_t>(1);
 
-  init_t init = 0;
   size_t expected_bytes_allocated{};
 
   // To check if a given algorithm implementation is used, we check if associated kernels are invoked.
@@ -359,8 +358,8 @@ C2H_TEST("Device sum uses environment", "[reduce][device]", requirements)
       using dispatch_t = cub::detail::
         DispatchReduceDeterministic<decltype(d_in), decltype(d_out.begin()), offset_t, init_t, transform_t, accumulator_t>;
 
-      REQUIRE(
-        cudaSuccess == dispatch_t::Dispatch(nullptr, expected_bytes_allocated, d_in, d_out.begin(), num_items, init));
+      REQUIRE(cudaSuccess
+              == dispatch_t::Dispatch(nullptr, expected_bytes_allocated, d_in, d_out.begin(), num_items, init_t{}));
 
       return cuda::std::array<void*, 3>{
         reinterpret_cast<void*>(

--- a/cub/test/catch2_test_device_reduce_env.cu
+++ b/cub/test/catch2_test_device_reduce_env.cu
@@ -178,7 +178,7 @@ C2H_TEST("Device sum can be tuned", "[reduce][device]", block_sizes)
   // We are expecting that `scan_tuning` is ignored
   auto env = cuda::execution::__tune(reduce_tuning<target_block_size>{}, scan_tuning{});
 
-  REQUIRE(cudaSuccess == cub::DeviceReduce::Reduce(d_in, d_out.begin(), num_items, env));
+  REQUIRE(cudaSuccess == cub::DeviceReduce::Sum(d_in, d_out.begin(), num_items, env));
   REQUIRE(d_out[0] == num_items);
 }
 #endif

--- a/cub/test/catch2_test_device_reduce_env.cu
+++ b/cub/test/catch2_test_device_reduce_env.cu
@@ -15,6 +15,7 @@ struct stream_registry_factory_t;
 #include "catch2_test_env_launch_helper.h"
 
 DECLARE_LAUNCH_WRAPPER(cub::DeviceReduce::Reduce, device_reduce);
+DECLARE_LAUNCH_WRAPPER(cub::DeviceReduce::Sum, device_reduce_sum);
 
 // %PARAM% TEST_LAUNCH lid 0:1:2
 
@@ -293,6 +294,113 @@ C2H_TEST("Device reduce uses environment", "[reduce][device]", requirements)
                           expected_allocation_size(expected_bytes_allocated)}; // temp storage size
 
   device_reduce(d_in, d_out.begin(), num_items, op_t{}, init, env);
+
+  REQUIRE(d_out[0] == num_items);
+}
+
+C2H_TEST("Device sum uses environment", "[reduce][device]", requirements)
+{
+  using determinism_t = c2h::get<0, TestType>;
+  using accumulator_t = float;
+  using op_t          = cuda::std::plus<>;
+  using num_items_t   = int;
+  using offset_t      = cub::detail::choose_offset_t<num_items_t>;
+  using transform_t   = ::cuda::std::identity;
+  using init_t        = accumulator_t;
+
+  num_items_t num_items = GENERATE(1 << 4, 1 << 24);
+  auto d_in             = thrust::make_constant_iterator(1.0f);
+  auto d_out            = thrust::device_vector<accumulator_t>(1);
+
+  init_t init = 0;
+  size_t expected_bytes_allocated{};
+
+  // To check if a given algorithm implementation is used, we check if associated kernels are invoked.
+  auto kernels = [&]() {
+    // TODO(gevtushenko): split `not_guaranteed` kernels once atomic reduce is merged
+    if constexpr (std::is_same_v<determinism_t, cuda::execution::determinism::run_to_run_t>
+                  || std::is_same_v<determinism_t, cuda::execution::determinism::not_guaranteed_t>)
+    {
+      REQUIRE(cudaSuccess == cub::DeviceReduce::Sum(nullptr, expected_bytes_allocated, d_in, d_out.begin(), num_items));
+
+      using policy_t = cub::detail::reduce::policy_hub<accumulator_t, offset_t, op_t>::MaxPolicy;
+      return cuda::std::array<void*, 3>{
+        reinterpret_cast<void*>(
+          cub::detail::reduce::DeviceReduceSingleTileKernel<
+            policy_t,
+            decltype(d_in),
+            decltype(d_out.begin()),
+            offset_t,
+            op_t,
+            init_t,
+            accumulator_t,
+            transform_t>),
+        reinterpret_cast<void*>(
+          cub::detail::reduce::DeviceReduceKernel<policy_t, decltype(d_in), offset_t, op_t, accumulator_t, transform_t>),
+        reinterpret_cast<void*>(
+          cub::detail::reduce::DeviceReduceSingleTileKernel<
+            policy_t,
+            accumulator_t*,
+            decltype(d_out.begin()),
+            int, // always used with int offset
+            op_t,
+            init_t,
+            accumulator_t>)};
+    }
+    else
+    {
+      using policy_t              = cub::detail::rfa::policy_hub<accumulator_t, offset_t, op_t>::MaxPolicy;
+      using deterministic_add_t   = cub::detail::rfa::deterministic_sum_t<accumulator_t>;
+      using reduction_op_t        = deterministic_add_t;
+      using deterministic_accum_t = deterministic_add_t::DeterministicAcc;
+      using output_it_t = thrust::transform_output_iterator<cub::detail::rfa::rfa_float_transform_t<accumulator_t>,
+                                                            decltype(d_out.begin())>;
+
+      using dispatch_t = cub::detail::
+        DispatchReduceDeterministic<decltype(d_in), decltype(d_out.begin()), offset_t, init_t, transform_t, accumulator_t>;
+
+      REQUIRE(
+        cudaSuccess == dispatch_t::Dispatch(nullptr, expected_bytes_allocated, d_in, d_out.begin(), num_items, init));
+
+      return cuda::std::array<void*, 3>{
+        reinterpret_cast<void*>(
+          cub::detail::reduce::DeterministicDeviceReduceSingleTileKernel<
+            policy_t,
+            decltype(d_in),
+            output_it_t,
+            offset_t,
+            reduction_op_t,
+            init_t,
+            deterministic_accum_t,
+            transform_t>),
+        reinterpret_cast<void*>(
+          cub::detail::reduce::DeterministicDeviceReduceKernel<
+            policy_t,
+            decltype(d_in),
+            offset_t,
+            reduction_op_t,
+            deterministic_accum_t,
+            transform_t>),
+        reinterpret_cast<void*>(
+          cub::detail::reduce::DeterministicDeviceReduceSingleTileKernel<
+            policy_t,
+            accumulator_t*,
+            output_it_t,
+            int, // always used with int offset
+            reduction_op_t,
+            init_t,
+            deterministic_accum_t,
+            transform_t>)};
+    }
+  }();
+
+  // Equivalent to `cuexec::require(cuexec::determinism::run_to_run)` and
+  //               `cuexec::require(cuexec::determinism::not_guaranteed)`
+  auto env = stdexec::env{cuda::execution::require(determinism_t{}), // determinism
+                          allowed_kernels(kernels), // allowed kernels for the given determinism
+                          expected_allocation_size(expected_bytes_allocated)}; // temp storage size
+
+  device_reduce_sum(d_in, d_out.begin(), num_items, env);
 
   REQUIRE(d_out[0] == num_items);
 }

--- a/cub/test/catch2_test_device_reduce_env_api.cu
+++ b/cub/test/catch2_test_device_reduce_env_api.cu
@@ -51,3 +51,38 @@ C2H_TEST("cub::DeviceReduce::Reduce accepts stream", "[reduce][env]")
 
   REQUIRE(output == expected);
 }
+
+C2H_TEST("cub::DeviceReduce::Sum accepts determinism requirements", "[reduce][env]")
+{
+  // TODO(gevtushenko): replace `run_to_run` with `gpu_to_gpu` once RFA unwraps contiguous iterators
+
+  // example-begin reduce-env-determinism
+  auto input  = c2h::device_vector<float>{0.0f, 1.0f, 2.0f, 3.0f};
+  auto output = c2h::device_vector<float>(1);
+
+  auto env = cuda::execution::require(cuda::execution::determinism::run_to_run);
+
+  cub::DeviceReduce::Sum(input.begin(), output.begin(), input.size(), env);
+
+  c2h::device_vector<float> expected{6.0f};
+  // example-end reduce-env-determinism
+
+  REQUIRE(output == expected);
+}
+
+C2H_TEST("cub::DeviceReduce::Sum accepts stream", "[reduce][env]")
+{
+  // example-begin reduce-env-sum-stream
+  auto input  = c2h::device_vector<float>{0.0f, 1.0f, 2.0f, 3.0f};
+  auto output = c2h::device_vector<float>(1);
+
+  cudaStream_t legacy_stream = 0;
+  cuda::stream_ref stream_ref{legacy_stream};
+
+  cub::DeviceReduce::Sum(input.begin(), output.begin(), input.size(), stream_ref);
+
+  c2h::device_vector<float> expected{6.0f};
+  // example-end reduce-env-stream
+
+  REQUIRE(output == expected);
+}

--- a/cub/test/catch2_test_device_reduce_env_api.cu
+++ b/cub/test/catch2_test_device_reduce_env_api.cu
@@ -72,7 +72,7 @@ C2H_TEST("cub::DeviceReduce::Sum accepts determinism requirements", "[reduce][en
 
 C2H_TEST("cub::DeviceReduce::Sum accepts stream", "[reduce][env]")
 {
-  // example-begin sum-env-sum-stream
+  // example-begin sum-env-stream
   auto input  = c2h::device_vector<float>{0.0f, 1.0f, 2.0f, 3.0f};
   auto output = c2h::device_vector<float>(1);
 

--- a/cub/test/catch2_test_device_reduce_env_api.cu
+++ b/cub/test/catch2_test_device_reduce_env_api.cu
@@ -56,7 +56,7 @@ C2H_TEST("cub::DeviceReduce::Sum accepts determinism requirements", "[reduce][en
 {
   // TODO(gevtushenko): replace `run_to_run` with `gpu_to_gpu` once RFA unwraps contiguous iterators
 
-  // example-begin reduce-env-determinism
+  // example-begin sum-env-determinism
   auto input  = c2h::device_vector<float>{0.0f, 1.0f, 2.0f, 3.0f};
   auto output = c2h::device_vector<float>(1);
 
@@ -65,14 +65,14 @@ C2H_TEST("cub::DeviceReduce::Sum accepts determinism requirements", "[reduce][en
   cub::DeviceReduce::Sum(input.begin(), output.begin(), input.size(), env);
 
   c2h::device_vector<float> expected{6.0f};
-  // example-end reduce-env-determinism
+  // example-end sum-env-determinism
 
   REQUIRE(output == expected);
 }
 
 C2H_TEST("cub::DeviceReduce::Sum accepts stream", "[reduce][env]")
 {
-  // example-begin reduce-env-sum-stream
+  // example-begin sum-env-sum-stream
   auto input  = c2h::device_vector<float>{0.0f, 1.0f, 2.0f, 3.0f};
   auto output = c2h::device_vector<float>(1);
 
@@ -82,7 +82,7 @@ C2H_TEST("cub::DeviceReduce::Sum accepts stream", "[reduce][env]")
   cub::DeviceReduce::Sum(input.begin(), output.begin(), input.size(), stream_ref);
 
   c2h::device_vector<float> expected{6.0f};
-  // example-end reduce-env-stream
+  // example-end sum-env-stream
 
   REQUIRE(output == expected);
 }


### PR DESCRIPTION
fixes #4960

Tracks work on `cub::DeviceReduce::Sum` env based API.