### PR TITLE
add the `bulk`, `bulk_chunked`, and `bulk_unchunked` sender adaptors

### DIFF
--- a/cudax/include/cuda/experimental/__execution/bulk.cuh
+++ b/cudax/include/cuda/experimental/__execution/bulk.cuh
@@ -1,0 +1,479 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __CUDAX_EXECUTION_BULK
+#define __CUDAX_EXECUTION_BULK
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__concepts/arithmetic.h>
+#include <cuda/std/__concepts/same_as.h>
+#include <cuda/std/__tuple_dir/ignore.h>
+#include <cuda/std/__type_traits/is_callable.h>
+#include <cuda/std/__type_traits/is_same.h>
+#include <cuda/std/__type_traits/is_void.h>
+#include <cuda/std/__utility/forward_like.h>
+
+#include <cuda/experimental/__execution/concepts.cuh>
+#include <cuda/experimental/__execution/domain.cuh>
+#include <cuda/experimental/__execution/exception.cuh>
+#include <cuda/experimental/__execution/fwd.cuh>
+#include <cuda/experimental/__execution/get_completion_signatures.cuh>
+#include <cuda/experimental/__execution/policy.cuh>
+#include <cuda/experimental/__execution/queries.cuh>
+#include <cuda/experimental/__execution/rcvr_ref.cuh>
+#include <cuda/experimental/__execution/transform_sender.cuh>
+#include <cuda/experimental/__execution/type_traits.cuh>
+#include <cuda/experimental/__launch/configuration.cuh>
+
+#include <cuda/experimental/__execution/prologue.cuh>
+
+_CCCL_DIAG_PUSH
+_CCCL_DIAG_SUPPRESS_MSVC(4702) // warning: unreachable code
+
+namespace cuda::experimental::execution
+{
+template <class _Policy, class _Shape, class _Fn>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT __bulk_state_t
+{
+  _CCCL_NO_UNIQUE_ADDRESS _Policy __policy_;
+  _Shape __shape_;
+  _Fn __fn_;
+};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// attributes for bulk senders
+template <class _Sndr, class _Shape>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT __bulk_attrs_t
+{
+  _CCCL_HOST_API constexpr auto query(get_launch_config_t) const noexcept
+  {
+    constexpr int __block_threads = 256;
+    const int __grid_blocks       = (static_cast<int>(__shape_) + __block_threads - 1) / __block_threads;
+    return experimental::make_config(block_dims<__block_threads>, grid_dims(__grid_blocks));
+  }
+
+  _CCCL_TEMPLATE(class _Query)
+  _CCCL_REQUIRES(__forwarding_query<_Query> _CCCL_AND __queryable_with<env_of_t<_Sndr>, _Query>)
+  _CCCL_API constexpr auto query(_Query) const noexcept(__nothrow_queryable_with<env_of_t<_Sndr>, _Query>)
+    -> decltype(auto)
+  {
+    return execution::get_env(__sndr_).query(_Query{});
+  }
+
+  _Shape __shape_;
+  const _Sndr& __sndr_;
+};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// generic bulk utilities
+template <class _BulkTag>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT __bulk_t
+{
+  // This is a function object that is used to transform the value completion signatures
+  // of a bulk sender's child operation. It does type checking and "throws" if the bulk
+  // function is not callable with the value datums of the predecessor.
+  template <class _Shape, class _Fn>
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __transform_value_completion_fn
+  {
+    template <class... _Ts>
+    [[nodiscard]] _CCCL_API _CCCL_CONSTEVAL auto operator()() const
+    {
+      // The function objects passed to the "chunked" and "unchunked" flavors of bulk have
+      // different signatures, so we need to type-check them separately.
+      if constexpr (_BulkTag::__is_chunked())
+      {
+        if constexpr (_CUDA_VSTD::__is_callable_v<_Fn&, _Shape, _Shape, _Ts&...>)
+        {
+          return completion_signatures<set_value_t(_Ts...)>{}
+               + __eptr_completion_if<!__nothrow_callable<_Fn&, _Shape, _Shape, _Ts&...>>();
+        }
+        else
+        {
+          return invalid_completion_signature<_WHERE(_IN_ALGORITHM, _BulkTag),
+                                              _WHAT(_FUNCTION_IS_NOT_CALLABLE),
+                                              _WITH_FUNCTION(_Fn&),
+                                              _WITH_ARGUMENTS(_Shape, _Shape, _Ts & ...)>();
+        }
+      }
+      else if constexpr (_CUDA_VSTD::__is_callable_v<_Fn&, _Shape, _Ts&...>)
+      {
+        return completion_signatures<set_value_t(_Ts...)>{}
+             + __eptr_completion_if<!__nothrow_callable<_Fn&, _Shape, _Ts&...>>();
+      }
+      else
+      {
+        return invalid_completion_signature<_WHERE(_IN_ALGORITHM, _BulkTag),
+                                            _WHAT(_FUNCTION_IS_NOT_CALLABLE),
+                                            _WITH_FUNCTION(_Fn&),
+                                            _WITH_ARGUMENTS(_Shape, _Ts & ...)>();
+      }
+    }
+  };
+
+  // This is the base operation state for bulk senders. It provides the common
+  // functionality for all bulk senders, such as starting the operation, setting errors,
+  // and getting the environment. The bulk operation state types inherit from this and
+  // provide the implementation for `set_value`.
+  template <class _CvSndr, class _Rcvr, class _Shape, class _Fn>
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __opstate_t
+  {
+    using operation_state_concept = operation_state_t;
+    using __derived_opstate_t     = typename _BulkTag::template __opstate_t<_CvSndr, _Rcvr, _Shape, _Fn>;
+    static_assert(!_CUDA_VSTD::is_same_v<__derived_opstate_t, __opstate_t>,
+                  "The derived operation state must not be the same as the base operation state");
+    using __rcvr_t = __rcvr_ref_t<__derived_opstate_t, __fwd_env_t<env_of_t<_Rcvr>>>;
+
+    _CCCL_API constexpr explicit __opstate_t(_CvSndr&& __sndr, _Rcvr __rcvr, _Shape __shape, _Fn __fn)
+        : __rcvr_{static_cast<_Rcvr&&>(__rcvr)}
+        , __shape_{__shape}
+        , __fn_{static_cast<_Fn&&>(__fn)}
+        , __opstate_{
+            execution::connect(static_cast<_CvSndr&&>(__sndr), __ref_rcvr(*static_cast<__derived_opstate_t*>(this)))}
+    {}
+
+    _CCCL_IMMOVABLE_OPSTATE(__opstate_t);
+
+    _CCCL_API constexpr void start() noexcept
+    {
+      execution::start(__opstate_);
+    }
+
+    template <class _Error>
+    _CCCL_API constexpr void set_error(_Error&& __err) noexcept
+    {
+      execution::set_error(static_cast<_Rcvr&&>(__rcvr_), static_cast<_Error&&>(__err));
+    }
+
+    _CCCL_API constexpr void set_stopped() noexcept
+    {
+      execution::set_stopped(static_cast<_Rcvr&&>(__rcvr_));
+    }
+
+    [[nodiscard]] _CCCL_TRIVIAL_API constexpr auto get_env() const noexcept -> __fwd_env_t<env_of_t<_Rcvr>>
+    {
+      return __fwd_env(execution::get_env(__rcvr_));
+    }
+
+    _Rcvr __rcvr_;
+    _Shape __shape_;
+    _Fn __fn_;
+    connect_result_t<_CvSndr, __rcvr_t> __opstate_;
+  };
+
+  // This is the sender type for the three bulk algorithms.
+  template <class _Sndr, class _Policy, class _Shape, class _Fn>
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __sndr_t
+  {
+    using sender_concept = sender_t;
+
+    // Look in _BulkTag (bulk_t, bulk_chunked_t, or bulk_unchunked_t) for the derived
+    // operation state type.
+    template <class _CvSndr, class _Rcvr>
+    using __opstate_t = typename _BulkTag::template __opstate_t<_CvSndr, _Rcvr, _Shape, _Fn>;
+
+    template <class _Self, class... _Env>
+    [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL auto get_completion_signatures()
+    {
+      _CUDAX_LET_COMPLETIONS(
+        auto(__child_completions) = execution::get_child_completion_signatures<_Self, _Sndr, _Env...>())
+      {
+        return transform_completion_signatures(__child_completions, __transform_value_completion_fn<_Shape, _Fn>{});
+      }
+    }
+
+    // The bulk algorithm lowers to a bulk_chunked sender. The bulk sender itself should
+    // not have `connect` functions, shince they should never be called. Hence, we
+    // constrain these functions with !same_as<_BulkTag, bulk_t>.
+    _CCCL_TEMPLATE(class _Rcvr)
+    _CCCL_REQUIRES((!_CUDA_VSTD::same_as<_BulkTag, bulk_t>) )
+    [[nodiscard]] _CCCL_API constexpr auto connect(_Rcvr __rcvr) && -> __opstate_t<_Sndr, _Rcvr>
+    {
+      return __opstate_t<_Sndr, _Rcvr>{
+        static_cast<_Sndr&&>(__sndr_),
+        static_cast<_Rcvr&&>(__rcvr),
+        __state_.__shape_,
+        static_cast<_Fn&&>(__state_.__fn_)};
+    }
+
+    _CCCL_TEMPLATE(class _Rcvr)
+    _CCCL_REQUIRES((!_CUDA_VSTD::same_as<_BulkTag, bulk_t>) )
+    [[nodiscard]] _CCCL_API constexpr auto connect(_Rcvr __rcvr) const& -> __opstate_t<const _Sndr&, _Rcvr>
+    {
+      return __opstate_t<const _Sndr&, _Rcvr>{__sndr_, static_cast<_Rcvr&&>(__rcvr), __state_.__shape_, __state_.__fn_};
+    }
+
+    [[nodiscard]] _CCCL_API constexpr auto get_env() const noexcept -> __bulk_attrs_t<_Sndr, _Shape>
+    {
+      return {__state_.__shape_, __sndr_};
+    }
+
+    _CCCL_NO_UNIQUE_ADDRESS _BulkTag __tag_;
+    __bulk_state_t<_Policy, _Shape, _Fn> __state_;
+    _Sndr __sndr_;
+  };
+
+  template <class _Policy, class _Shape, class _Fn>
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __closure_t : __bulk_state_t<_Policy, _Shape, _Fn>
+  {
+    template <class _Sndr>
+    _CCCL_TRIVIAL_API friend constexpr auto operator|(_Sndr&& __sndr, __closure_t __self)
+    {
+      using __domain_t = __early_domain_of_t<_Sndr>;
+      using __sndr_t   = __bulk_t::__sndr_t<_Sndr, _Policy, _Shape, _Fn>;
+      return transform_sender(__domain_t{},
+                              __sndr_t{{}, static_cast<__closure_t&&>(__self), static_cast<_Sndr&&>(__sndr)});
+    }
+  };
+
+  // This function call operator is the entry point for the bulk algorithms. It takes a
+  // predecessor sender, a policy, a shape, and a function, and returns a sender that can
+  // be connected to a receiver.
+  template <class _Sndr, class _Policy, class _Shape, class _Fn>
+  _CCCL_API auto operator()(_Sndr&& __sndr, _Policy __policy, _Shape __shape, _Fn __fn) const
+  {
+    static_assert(__is_sender<_Sndr>);
+    static_assert(_CUDA_VSTD::integral<_Shape>);
+    static_assert(is_execution_policy_v<_Policy>);
+
+    using __domain_t = __early_domain_of_t<_Sndr>;
+    using __sndr_t   = __bulk_t::__sndr_t<_Sndr, _Policy, _Shape, _Fn>;
+
+    if constexpr (!dependent_sender<_Sndr>)
+    {
+      __assert_valid_completion_signatures(get_completion_signatures<__sndr_t>());
+    }
+
+    return transform_sender(__domain_t{},
+                            __sndr_t{{}, {__policy, __shape, static_cast<_Fn&&>(__fn)}, static_cast<_Sndr&&>(__sndr)});
+  }
+
+  // This function call operator creates a sender adaptor closure object that can appear
+  // on the right-hand side of a pipe operator, like: sndr | bulk(par, shape, fn).
+  template <class _Policy, class _Shape, class _Fn>
+  _CCCL_TRIVIAL_API auto operator()(_Policy __policy, _Shape __shape, _Fn __fn) const
+    -> __closure_t<_Policy, _Shape, _Fn>
+  {
+    static_assert(_CUDA_VSTD::integral<_Shape>);
+    static_assert(is_execution_policy_v<_Policy>);
+    return {__policy, __shape, static_cast<_Fn&&>(__fn)};
+  }
+};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// bulk_chunked
+struct _CCCL_TYPE_VISIBILITY_DEFAULT bulk_chunked_t : __bulk_t<bulk_chunked_t>
+{
+  template <class _CvSndr, class _Rcvr, class _Shape, class _Fn>
+  using __base_opstate_t = __bulk_t::__opstate_t<_CvSndr, _Rcvr, _Shape, _Fn>;
+
+  // This is the operation state for the bulk_chunked sender. It provides the
+  // implementation for `set_value` that calls the function with the begin and end shapes,
+  // and the value results of the predecessor.
+  template <class _CvSndr, class _Rcvr, class _Shape, class _Fn>
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __opstate_t : __base_opstate_t<_CvSndr, _Rcvr, _Shape, _Fn>
+  {
+    _CCCL_API constexpr explicit __opstate_t(_CvSndr&& __sndr, _Rcvr __rcvr, _Shape __shape, _Fn __fn)
+        : __base_opstate_t<_CvSndr, _Rcvr, _Shape, _Fn>{
+            static_cast<_CvSndr&&>(__sndr), static_cast<_Rcvr&&>(__rcvr), __shape, static_cast<_Fn&&>(__fn)}
+    {}
+
+    _CCCL_EXEC_CHECK_DISABLE
+    template <class... _Values>
+    _CCCL_API void set_value(_Values&&... __values) noexcept
+    {
+      _CUDAX_TRY( //
+        ({
+          this->__fn_(_Shape(0), _Shape(this->__shape_), __values...);
+          execution::set_value(static_cast<_Rcvr&&>(this->__rcvr_), static_cast<_Values&&>(__values)...);
+        }),
+        _CUDAX_CATCH(...) //
+        ({
+          if constexpr (!__nothrow_callable<_Fn&, _Shape, _Shape, _Values&...>)
+          {
+            execution::set_error(static_cast<_Rcvr&&>(this->__rcvr_), ::std::current_exception());
+          }
+        }))
+    }
+  };
+
+  _CCCL_API static constexpr bool __is_chunked() noexcept
+  {
+    return true;
+  }
+};
+
+_CCCL_GLOBAL_CONSTANT auto bulk_chunked = bulk_chunked_t{};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// bulk_unchunked
+struct _CCCL_TYPE_VISIBILITY_DEFAULT bulk_unchunked_t : __bulk_t<bulk_unchunked_t>
+{
+  template <class _CvSndr, class _Rcvr, class _Shape, class _Fn>
+  using __base_opstate_t = __bulk_t::__opstate_t<_CvSndr, _Rcvr, _Shape, _Fn>;
+
+  // This is the operation state for the bulk_unchunked sender. It provides the
+  // implementation for `set_value` that calls the function repeatedly with an index and
+  // the value results of the predecessor. The index is monotonically increasing from 0 to
+  // the shape minus one.
+  template <class _CvSndr, class _Rcvr, class _Shape, class _Fn>
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __opstate_t : __base_opstate_t<_CvSndr, _Rcvr, _Shape, _Fn>
+  {
+    _CCCL_API constexpr explicit __opstate_t(_CvSndr&& __sndr, _Rcvr __rcvr, _Shape __shape, _Fn __fn)
+        : __base_opstate_t<_CvSndr, _Rcvr, _Shape, _Fn>{
+            static_cast<_CvSndr&&>(__sndr), static_cast<_Rcvr&&>(__rcvr), __shape, static_cast<_Fn&&>(__fn)}
+    {
+      __check_forward_progress(__sndr);
+    }
+
+    _CCCL_API static constexpr void __check_forward_progress(_CvSndr& __sndr)
+    {
+      if constexpr (_CUDA_VSTD::__is_callable_v<get_completion_scheduler_t<set_value_t>, env_of_t<_CvSndr>>)
+      {
+        // If the scheduler is queryable, we can check the forward progress guarantee to
+        // make sure the user hasn't asked the default implementation to do something that
+        // it cannot do.
+        using __sched_t = _CUDA_VSTD::__call_result_t<get_completion_scheduler_t<set_value_t>, env_of_t<_CvSndr>>;
+        if constexpr (__statically_queryable_with<__sched_t, get_forward_progress_guarantee_t>)
+        {
+          constexpr auto __guarantee = __sched_t::query(get_forward_progress_guarantee);
+          static_assert(__guarantee != forward_progress_guarantee::concurrent,
+                        "The default implementation cannot provide the concurrent progress guarantee");
+        }
+        else
+        {
+          const auto __guarantee =
+            get_forward_progress_guarantee(get_completion_scheduler<set_value_t>(execution::get_env(__sndr)));
+          _CCCL_ASSERT(__guarantee != forward_progress_guarantee::concurrent,
+                       "The default implementation cannot provide the concurrent progress guarantee");
+        }
+      }
+    }
+
+    _CCCL_EXEC_CHECK_DISABLE
+    template <class... _Values>
+    _CCCL_API void set_value(_Values&&... __values) noexcept
+    {
+      _CUDAX_TRY( //
+        ({
+          for (_Shape __index{}; __index != this->__shape_; ++__index)
+          {
+            this->__fn_(_Shape(__index), __values...);
+          }
+          execution::set_value(static_cast<_Rcvr&&>(this->__rcvr_), static_cast<_Values&&>(__values)...);
+        }),
+        _CUDAX_CATCH(...) //
+        ({
+          if constexpr (!__nothrow_callable<_Fn&, _Shape, _Values&...>)
+          {
+            execution::set_error(static_cast<_Rcvr&&>(this->__rcvr_), ::std::current_exception());
+          }
+        }))
+    }
+  };
+
+  // The bulk_unchunked algorithm is different from the other bulk algorithms in that it
+  // does not take an execution policy, so we must hide the base class's `operator()` that
+  // takes a policy with an overload that does not take a policy.
+  template <class _Sndr, class _Shape, class _Fn>
+  [[nodiscard]] _CCCL_TRIVIAL_API constexpr auto operator()(_Sndr&& __sndr, _Shape __shape, _Fn __fn) const
+  {
+    return this->__bulk_t::operator()(static_cast<_Sndr&&>(__sndr), par, __shape, static_cast<_Fn&&>(__fn));
+  }
+
+  template <class _Shape, class _Fn>
+  [[nodiscard]] _CCCL_TRIVIAL_API constexpr auto operator()(_Shape __shape, _Fn __fn) const
+  {
+    return this->__bulk_t::operator()(par, __shape, static_cast<_Fn&&>(__fn));
+  }
+
+  _CCCL_API static constexpr bool __is_chunked() noexcept
+  {
+    return false;
+  }
+};
+
+_CCCL_GLOBAL_CONSTANT auto bulk_unchunked = bulk_unchunked_t{};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// bulk
+struct _CCCL_TYPE_VISIBILITY_DEFAULT bulk_t : __bulk_t<bulk_t>
+{
+  // This is a function adaptor that transforms a `bulk` function that takes a single
+  // shape to a `bulk_chunked` function that takes a begin and end shape.
+  template <class _Shape, class _Fn>
+  struct __bulk_chunked_fn
+  {
+    _CCCL_EXEC_CHECK_DISABLE
+    template <class... _Ts>
+    _CCCL_TRIVIAL_API auto operator()(_Shape __begin, _Shape __end, _Ts&&... __values) noexcept(
+      __nothrow_callable<_Fn&, _Shape, decltype(__values)&...>)
+    {
+      for (; __begin != __end; ++__begin)
+      {
+        // Pass a copy of `__begin` to the function so it can't do anything funny with it.
+        __fn_(_Shape(__begin), __values...);
+      }
+    }
+
+    _Fn __fn_;
+  };
+
+  // This function is called when `connect` is called on a `bulk` sender. It transforms
+  // the `bulk` sender into a `bulk_chunked` sender.
+  template <class _Sndr>
+  _CCCL_API static auto transform_sender(_Sndr&& __sndr, _CUDA_VSTD::__ignore_t)
+  {
+    static_assert(_CUDA_VSTD::is_same_v<tag_of_t<_Sndr>, bulk_t>);
+    auto& [__tag, __data, __child]  = __sndr;
+    auto& [__policy, __shape, __fn] = __data;
+
+    using __chunked_fn_t = __bulk_chunked_fn<decltype(__shape), decltype(__fn)>;
+
+    // Lower `bulk` to `bulk_chunked`. If `bulk_chunked` has a late customization, we will
+    // see the customization.
+    return bulk_chunked(_CUDA_VSTD::forward_like<_Sndr>(__child),
+                        __policy,
+                        __shape,
+                        __chunked_fn_t{_CUDA_VSTD::forward_like<_Sndr>(__fn)});
+  }
+
+  _CCCL_API static constexpr bool __is_chunked() noexcept
+  {
+    return false;
+  }
+};
+
+_CCCL_GLOBAL_CONSTANT auto bulk = bulk_t{};
+
+template <class _Sndr, class _Policy, class _Shape, class _Fn>
+inline constexpr size_t structured_binding_size<__bulk_t<bulk_t>::__sndr_t<_Sndr, _Policy, _Shape, _Fn>> = 3;
+
+template <class _Sndr, class _Policy, class _Shape, class _Fn>
+inline constexpr size_t structured_binding_size<__bulk_t<bulk_chunked_t>::__sndr_t<_Sndr, _Policy, _Shape, _Fn>> = 3;
+
+template <class _Sndr, class _Policy, class _Shape, class _Fn>
+inline constexpr size_t structured_binding_size<__bulk_t<bulk_unchunked_t>::__sndr_t<_Sndr, _Policy, _Shape, _Fn>> = 3;
+
+} // namespace cuda::experimental::execution
+
+_CCCL_DIAG_POP
+
+#include <cuda/experimental/__execution/epilogue.cuh>
+
+#endif // __CUDAX_EXECUTION_BULK

--- a/cudax/include/cuda/experimental/__execution/env.cuh
+++ b/cudax/include/cuda/experimental/__execution/env.cuh
@@ -24,11 +24,13 @@
 #include <cuda/__memory_resource/get_memory_resource.h>
 #include <cuda/__memory_resource/properties.h>
 #include <cuda/__stream/get_stream.h>
+#include <cuda/std/__concepts/concept_macros.h>
 #include <cuda/std/__execution/env.h>
 #include <cuda/std/__tuple_dir/ignore.h>
 #include <cuda/std/__type_traits/conditional.h>
 #include <cuda/std/__type_traits/is_nothrow_move_constructible.h>
 #include <cuda/std/__type_traits/is_same.h>
+#include <cuda/std/__type_traits/remove_cvref.h>
 #include <cuda/std/__utility/move.h>
 #include <cuda/std/cstdint>
 
@@ -44,6 +46,13 @@ namespace cuda::experimental
 {
 namespace execution
 {
+template <class _Env, class _Query>
+_CCCL_CONCEPT __statically_queryable_with = //
+  _CCCL_REQUIRES_EXPR((_Env, _Query)) //
+  ( //
+    (_CUDA_VSTD::remove_cvref_t<_Env>::query(_Query{})) //
+  );
+
 // For senders that adapt other senders, the attribute queries are forwarded. __fwd_env_
 // is a utility that forwards queries to a given environment.
 template <class _Env>

--- a/cudax/include/cuda/experimental/__execution/fwd.cuh
+++ b/cudax/include/cuda/experimental/__execution/fwd.cuh
@@ -162,6 +162,8 @@ struct starts_on_t;
 struct continues_on_t;
 struct schedule_from_t;
 struct bulk_t;
+struct bulk_chunked_t;
+struct bulk_unchunked_t;
 
 // sender consumer algorithms:
 struct sync_wait_t;
@@ -205,7 +207,7 @@ template <class _Sndr>
 using tag_of_t _CCCL_NODEBUG_ALIAS = decltype(__detail::__tag_of_v<_Sndr>());
 
 template <class _Sndr, class _Tag>
-_CCCL_CONCEPT __sender_for = _CCCL_REQUIRES_EXPR((_Sndr, _Tag))(_Same_as(_Tag) tag_of_t<_Sndr>{});
+_CCCL_CONCEPT sender_for = _CCCL_REQUIRES_EXPR((_Sndr, _Tag))(_Same_as(_Tag) tag_of_t<_Sndr>{});
 
 namespace __detail
 {

--- a/cudax/include/cuda/experimental/__execution/queries.cuh
+++ b/cudax/include/cuda/experimental/__execution/queries.cuh
@@ -195,11 +195,14 @@ _CCCL_GLOBAL_CONSTANT struct get_forward_progress_guarantee_t
 {
   _CCCL_EXEC_CHECK_DISABLE
   template <class _Sch>
-  [[nodiscard]] _CCCL_API auto operator()(const _Sch& __sch) const noexcept
+  [[nodiscard]] _CCCL_API constexpr auto operator()([[maybe_unused]] const _Sch& __sch) const noexcept
+    -> forward_progress_guarantee
   {
     if constexpr (__queryable_with<_Sch, get_forward_progress_guarantee_t>)
     {
       static_assert(noexcept(__sch.query(*this)));
+      static_assert(_CUDA_VSTD::is_same_v<decltype(__sch.query(*this)), forward_progress_guarantee>,
+                    "The get_forward_progress_guarantee query must return a forward_progress_guarantee enum value.");
       return __sch.query(*this);
     }
     else
@@ -229,6 +232,11 @@ _CCCL_GLOBAL_CONSTANT struct get_launch_config_t
     {
       return experimental::make_config(grid_dims<1>, block_dims<1>);
     }
+  }
+
+  static constexpr bool query(forwarding_query_t) noexcept
+  {
+    return true;
   }
 } get_launch_config{};
 

--- a/cudax/include/cuda/experimental/__execution/stream/adaptor.cuh
+++ b/cudax/include/cuda/experimental/__execution/stream/adaptor.cuh
@@ -21,15 +21,10 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/atomic>
-#include <cuda/std/__exception/cuda_error.h>
-#include <cuda/std/__memory/addressof.h>
+#include <cuda/std/__concepts/concept_macros.h>
 #include <cuda/std/__memory/unique_ptr.h>
-#include <cuda/std/__tuple_dir/ignore.h>
 #include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/__type_traits/remove_cvref.h>
-#include <cuda/std/__type_traits/remove_reference.h>
-#include <cuda/std/__type_traits/type_list.h>
 #include <cuda/std/__utility/pod_tuple.h>
 
 #include <cuda/experimental/__detail/utility.cuh>
@@ -51,7 +46,24 @@
 _CCCL_DIAG_PUSH
 _CCCL_DIAG_SUPPRESS_GCC("-Wattributes")
 
-namespace cuda::experimental::execution::__stream
+// This header provides a sender adaptor that adapts a non-stream sender to a stream
+// sender. The adaptor does several things:
+//
+// 1. It ensures that the stream_domain is used for sender transformations.
+// 2. It takes the launch configuration from the child sender and puts it into the
+//    environment of the inner receiver used to connect the child sender.
+// 3. It connects the child sender to the inner receiver, which will write the child's
+//    results into a variant that is in managed memory.
+// 4. It creates the child operation state in managed memory.
+// 5. It starts the child operation on the host, which causes the predecessor kernels to
+//    be launched in order.
+// 6. It launches a completion kernel on the stream to read the results out of the variant
+//    and send them to the outer receiver. The launch configuration is read from the outer
+//    receiver's environment.
+
+namespace cuda::experimental::execution
+{
+namespace __stream
 {
 template <class _Rcvr>
 struct __completion_fn
@@ -77,52 +89,82 @@ struct __results_visitor
   _Rcvr& __rcvr_;
 };
 
+// __state_t lives in managed memory. It stores everything the operation state needs,
+// besides the child operation state.
 template <class _Rcvr, class _Variant>
-struct __state_t
+struct __state_base_t
 {
   _Rcvr __rcvr_;
   _Variant __results_;
-  stream_ref __stream_;
   bool __complete_inline_;
 };
 
+template <class _Rcvr, class _Config, class _Variant>
+struct __state_t : __state_base_t<_Rcvr, _Variant>
+{
+  _Config __launch_config_;
+};
+
+// remove any exception_ptr error completion from the completion signatures, and replace it
+// with a cudaError_t error completion.
 template <class _Completions>
-_CCCL_API static constexpr auto __with_cuda_error(_Completions __completions) noexcept
+_CCCL_API constexpr auto __with_cuda_error(_Completions __completions) noexcept
 {
   return __completions - __eptr_completion() + completion_signatures<set_error_t(cudaError_t)>{};
 }
 
-template <class _Rcvr, class _Variant>
-__launch_bounds__(1) __global__ void __host_complete_fn(__state_t<_Rcvr, _Variant>* __state)
+template <class _Config>
+using __dims_of_t = decltype(_Config::dims);
+
+// This kernel forwards the results from the child sender to the receiver of the parent
+// sender. The receiver is where most algorithms do their work, so we want the receiver to
+// tell us how to launch the kernel that completes it. Thus, the launch configuration is
+// read from the outer receiver's environment.
+template <int _BlockThreads, class _Rcvr, class _Variant>
+_CCCL_VISIBILITY_HIDDEN __launch_bounds__(_BlockThreads) __global__
+  void __completion_kernel(__state_base_t<_Rcvr, _Variant>* __state)
 {
   _Variant::__visit(__results_visitor<_Rcvr>{__state->__rcvr_}, __state->__results_);
 }
 
-template <class _Env>
+// This is the environment of the inner receiver that is used to connect the child sender.
+template <class _Env, class _Config>
 struct __env_t
 {
-  template <class _Query>
+  _CCCL_TEMPLATE(class _Query)
+  _CCCL_REQUIRES(__queryable_with<_Env, _Query>)
   [[nodiscard]] _CCCL_API constexpr auto query(_Query) const noexcept(__nothrow_queryable_with<_Env, _Query>)
     -> __query_result_t<_Env, _Query>
   {
     return __env_.query(_Query{});
   }
 
+  // Use the default domain when connecting the child sender to the inner receiver. We
+  // want senders on device to behave like senders on the host by default. We will further
+  // customize those algorithms that need to do something different on device, like
+  // `bulk`, `when_all`, and `let_value`.
   [[nodiscard]] _CCCL_API static constexpr auto query(get_domain_t) noexcept -> default_domain
   {
     return default_domain{};
   }
 
+  [[nodiscard]] _CCCL_API constexpr auto query(get_launch_config_t) const noexcept -> _Config
+  {
+    return __launch_config_;
+  }
+
   _Env __env_;
+  _CCCL_NO_UNIQUE_ADDRESS _Config __launch_config_;
 };
 
-template <class _Rcvr, class _Variant>
+// This is the inner receiver that is used to connect the child sender.
+template <class _Rcvr, class _Config, class _Variant>
 struct __rcvr_t
 {
   template <class _Tag, class... _Args>
   _CCCL_API void __complete(_Tag, _Args&&... __args) noexcept
   {
-    if (__state_->__complete_inline_)
+    if (__state_->__complete_inline_) // TODO: untested
     {
       _Tag{}(static_cast<_Rcvr&&>(__state_->__rcvr_), static_cast<_Args&&>(__args)...);
     }
@@ -142,6 +184,7 @@ struct __rcvr_t
   template <class _Error>
   _CCCL_TRIVIAL_API constexpr void set_error(_Error&& __err) noexcept
   {
+    // Map any exception_ptr error completions to cudaErrorUnknown:
     if constexpr (_CUDA_VSTD::is_same_v<_CUDA_VSTD::remove_cvref_t<_Error>, ::std::exception_ptr>)
     {
       __complete(execution::set_error, cudaErrorUnknown);
@@ -157,23 +200,13 @@ struct __rcvr_t
     __complete(execution::set_stopped);
   }
 
-  _CCCL_API constexpr auto get_env() const noexcept -> __env_t<env_of_t<_Rcvr>>
+  _CCCL_API constexpr auto get_env() const noexcept -> __env_t<env_of_t<_Rcvr>, _Config>
   {
-    return {execution::get_env(__state_->__rcvr_)};
+    return {execution::get_env(__state_->__rcvr_), __state_->__launch_config_};
   }
 
-  __state_t<_Rcvr, _Variant>* __state_;
+  __state_t<_Rcvr, _Config, _Variant>* __state_;
 };
-
-template <class _Sndr>
-_CCCL_HOST_API auto __bulk_launch_config(const _Sndr& __sndr) noexcept
-{
-  constexpr int __block             = 256;
-  auto&& [__tag, __params, __child] = __sndr;
-  auto&& [__shape, __fn]            = __params;
-  const int __grid                  = (static_cast<int>(__shape) + __block - 1) / __block;
-  return experimental::make_config(block_dims<__block>, grid_dims(__grid));
-}
 
 template <class _CvSndr, class _Rcvr>
 struct __opstate_t
@@ -181,11 +214,11 @@ struct __opstate_t
   using operation_state_concept = operation_state_t;
 
   _CCCL_API constexpr explicit __opstate_t(_CvSndr&& __sndr, _Rcvr __rcvr, stream_ref __stream)
-      : __launch_config_{get_launch_config(get_env(__sndr))}
+      : __stream_{__stream}
   {
     NV_IF_TARGET(NV_IS_HOST,
-                 (__host_make_state(static_cast<_CvSndr&&>(__sndr), static_cast<_Rcvr&&>(__rcvr), __stream);),
-                 (__device_make_state(static_cast<_CvSndr&&>(__sndr), static_cast<_Rcvr&&>(__rcvr), __stream);));
+                 (__host_make_state(static_cast<_CvSndr&&>(__sndr), static_cast<_Rcvr&&>(__rcvr));),
+                 (__device_make_state(static_cast<_CvSndr&&>(__sndr), static_cast<_Rcvr&&>(__rcvr));));
   }
 
   _CCCL_IMMOVABLE_OPSTATE(__opstate_t);
@@ -203,87 +236,117 @@ struct __opstate_t
   }
 
 private:
-  using __child_completions_t = completion_signatures_of_t<_CvSndr, __env_t<env_of_t<_Rcvr>>>;
+  using __sndr_config_t       = _CUDA_VSTD::__call_result_t<get_launch_config_t, env_of_t<_CvSndr>>;
+  using __rcvr_config_t       = _CUDA_VSTD::__call_result_t<get_launch_config_t, env_of_t<_Rcvr>>;
+  using __env_t               = __stream::__env_t<env_of_t<_Rcvr>, __sndr_config_t>;
+  using __child_completions_t = completion_signatures_of_t<_CvSndr, __env_t>;
   using __completions_t       = decltype(__stream::__with_cuda_error(__child_completions_t{}));
   using __results_t = typename __completions_t::template __transform_q<_CUDA_VSTD::__decayed_tuple, __variant>;
+  using __rcvr_t    = __stream::__rcvr_t<_Rcvr, __sndr_config_t, __results_t>;
 
-  _CCCL_HOST_API void __host_make_state(_CvSndr&& __sndr, _Rcvr __rcvr, stream_ref __stream)
+  _CCCL_HOST_API void __host_make_state(_CvSndr&& __sndr, _Rcvr __rcvr)
   {
     // If *this is already in device or managed memory, then we can avoid a separate
     // allocation.
     if (auto const __attrs = execution::__get_pointer_attributes(this); __attrs.type == ::cudaMemoryTypeManaged)
     {
-      __state_.template __emplace<__state_t>(static_cast<_CvSndr&&>(__sndr), static_cast<_Rcvr&&>(__rcvr), __stream);
+      __state_.template __emplace<__state_t>(static_cast<_CvSndr&&>(__sndr), static_cast<_Rcvr&&>(__rcvr));
     }
     else
     {
-      __state_.__emplace(__managed_box<__state_t>::__make_unique(
-        static_cast<_CvSndr&&>(__sndr), static_cast<_Rcvr&&>(__rcvr), __stream));
+      __state_.__emplace(
+        __managed_box<__state_t>::__make_unique(static_cast<_CvSndr&&>(__sndr), static_cast<_Rcvr&&>(__rcvr)));
     }
   }
 
-  _CCCL_DEVICE_API void __device_make_state(_CvSndr&& __sndr, _Rcvr __rcvr, stream_ref __stream)
+  _CCCL_DEVICE_API void __device_make_state(_CvSndr&& __sndr, _Rcvr __rcvr)
   {
-    __state_.template __emplace<__state_t>(static_cast<_CvSndr&&>(__sndr), static_cast<_Rcvr&&>(__rcvr), __stream);
+    __state_.template __emplace<__state_t>(static_cast<_CvSndr&&>(__sndr), static_cast<_Rcvr&&>(__rcvr));
   }
 
   _CCCL_HOST_API void __host_start() noexcept
   {
-    auto& __state       = __get_state();
-    auto const __stream = __state.__state_.__stream_.get();
+    auto& __state = __get_state();
 
-    _CCCL_ASSERT(execution::__get_pointer_attributes(&__state.__state_).type == ::cudaMemoryTypeManaged,
-                 "stream scheduler's operation state must be allocated in managed memory");
-    // start the child operation state on the host and launch a kernel to pass the results
-    // to the receiver.
+    // Read the launch configuration passed to us by the parent operation. When we launch
+    // the completion kernel, we will be completing the parent's receiver, so we must let
+    // the receiver tell us how to launch the kernel.
+    auto const __launch_config    = get_launch_config(execution::get_env(__state.__state_.__rcvr_));
+    using __launch_dims_t         = decltype(__launch_config.dims);
+    constexpr int __block_threads = __launch_dims_t::static_count(experimental::thread, experimental::block);
+    int const __grid_blocks       = __launch_config.dims.count(experimental::block, experimental::grid);
+    static_assert(__block_threads != cuda::std::dynamic_extent);
+
+    // Start the child operation state. This will launch kernels for all the predecessors
+    // of this operation.
     execution::start(__state.__opstate_);
-    auto __status =
-      __detail::launch_impl(__stream, __launch_config_, &__host_complete_fn<_Rcvr, __results_t>, &__state.__state_);
-    if (__status != cudaSuccess)
+
+    // printf("Launching completion kernel for %s with %d block threads and %d grid blocks\n",
+    //        __name,
+    //        __block_threads,
+    //        __grid_blocks);
+
+    // launch a kernel to pass the results to the receiver.
+    __completion_kernel<__block_threads><<<__grid_blocks, __block_threads, 0, __stream_.get()>>>(&__state.__state_);
+
+    // Check for errors in the kernel launch.
+    if (auto __status = cudaGetLastError(); __status != cudaSuccess)
     {
-      execution::set_error(static_cast<_Rcvr&&>(__state.__state_.__rcvr_), __status);
+      execution::set_error(static_cast<_Rcvr&&>(__state.__state_.__rcvr_), cudaError_t(__status));
     }
   }
 
+  // TODO: untested
   _CCCL_DEVICE_API void __device_start() noexcept
   {
-    [[maybe_unused]] auto* const __complete_fn = &__host_complete_fn<_Rcvr, __results_t>;
-    auto& __state                              = __get_state();
-    __state.__state_.__complete_inline_        = true;
+    using __launch_dims_t         = __dims_of_t<__rcvr_config_t>;
+    constexpr int __block_threads = __launch_dims_t::static_count(experimental::thread, experimental::block);
+    auto& __state                 = __get_state();
+
+    // without the following, the kernel in __host_start will fail to launch with
+    // cudaErrorInvalidDeviceFunction.
+    ::__cccl_unused(&__completion_kernel<__block_threads, _Rcvr, __results_t>);
+    __state.__state_.__complete_inline_ = true;
     execution::start(__state.__opstate_);
   }
 
+  // This is the part of the operation state that is stored in managed memory.
   struct __state_t
   {
-    _CCCL_HOST_API explicit __state_t(_CvSndr&& __sndr, _Rcvr __rcvr, stream_ref __stream)
-        : __state_{static_cast<_Rcvr&&>(__rcvr), {}, __stream, false}
-        , __opstate_(connect(static_cast<_CvSndr&&>(__sndr), __rcvr_t<_Rcvr, __results_t>{&__state_}))
+    _CCCL_HOST_API constexpr explicit __state_t(_CvSndr&& __sndr, _Rcvr __rcvr)
+        : __state_{{static_cast<_Rcvr&&>(__rcvr), {}, false}, get_launch_config(execution::get_env(__sndr))}
+        , __opstate_(execution::connect(static_cast<_CvSndr&&>(__sndr), __rcvr_t{&__state_}))
     {}
 
-    __stream::__state_t<_Rcvr, __results_t> __state_;
-    connect_result_t<_CvSndr, __rcvr_t<_Rcvr, __results_t>> __opstate_;
+    __stream::__state_t<_Rcvr, __sndr_config_t, __results_t> __state_;
+    connect_result_t<_CvSndr, __rcvr_t> __opstate_;
   };
 
   // Return a reference to the state for this operation, whether it is stored in-situ or
   // in dyncamically-allocated managed memory.
-  _CCCL_API auto __get_state() noexcept -> __state_t&
+  [[nodiscard]] _CCCL_API constexpr auto __get_state() noexcept -> __state_t&
   {
     return __state_.__index() == 0 ? __state_.template __get<0>() : __state_.template __get<1>()->__value;
   }
 
-  using __launch_config_t _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::__call_result_t<get_launch_config_t, env_of_t<_CvSndr>>;
-  __launch_config_t __launch_config_{};
+  stream_ref __stream_;
   __variant<__state_t, _CUDA_VSTD::unique_ptr<__managed_box<__state_t>>> __state_{};
 };
 
 template <class _Sndr>
 struct __attrs_t
 {
+  // This makes sure that when `connect` calls `transform_sender`, it will use the stream
+  // domain to find a customization.
   [[nodiscard]] _CCCL_TRIVIAL_API static constexpr auto query(get_domain_late_t) noexcept -> stream_domain
   {
     return {};
   }
 
+  // This forwards even non-forwarding queries. A stream sender adaptor is not an ordinary
+  // sender adaptor, like `then` or `let_value`. A stream sender adaptor is an
+  // implementation detail that is not visible to the user. It should be as transparent as
+  // possible.
   _CCCL_TEMPLATE(class _Query)
   _CCCL_REQUIRES(__queryable_with<env_of_t<_Sndr>, _Query>)
   [[nodiscard]] _CCCL_API constexpr auto query(_Query) const noexcept(__nothrow_queryable_with<env_of_t<_Sndr>, _Query>)
@@ -295,6 +358,7 @@ struct __attrs_t
   const _Sndr* __sndr_;
 };
 
+// This is the sender adaptor that adapts a non-stream sender to a stream sender.
 template <class _Sndr>
 struct __sndr_t
 {
@@ -303,62 +367,62 @@ struct __sndr_t
   template <class _Self, class _Env>
   [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL auto get_completion_signatures() noexcept
   {
-    using __cv_sndr_t _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::__copy_cvref_t<_Self, _Sndr>;
-    _CUDAX_LET_COMPLETIONS(auto(__completions) = execution::get_completion_signatures<__cv_sndr_t, __env_t<_Env>>())
+    using __cv_sndr_t _CCCL_NODEBUG_ALIAS     = _CUDA_VSTD::__copy_cvref_t<_Self, _Sndr>;
+    using __sndr_config_t _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::__call_result_t<get_launch_config_t, env_of_t<_Sndr>>;
+    using __env_t                             = __stream::__env_t<_Env, __sndr_config_t>;
+    _CUDAX_LET_COMPLETIONS(auto(__completions) = execution::get_completion_signatures<__cv_sndr_t, __env_t>())
     {
-      return __with_cuda_error(__completions);
+      return __stream::__with_cuda_error(__completions);
     }
   }
 
   template <class _Rcvr>
   [[nodiscard]] _CCCL_API constexpr auto connect(_Rcvr __rcvr) && -> __opstate_t<_Sndr, _Rcvr>
   {
-    return __opstate_t<_Sndr, _Rcvr>(
-      static_cast<_Sndr&&>(__state_.__sndr_), static_cast<_Rcvr&&>(__rcvr), __state_.__stream_);
+    return __opstate_t<_Sndr, _Rcvr>(static_cast<_Sndr&&>(__sndr_), static_cast<_Rcvr&&>(__rcvr), __stream_);
   }
 
   template <class _Rcvr>
   [[nodiscard]] _CCCL_API constexpr auto connect(_Rcvr __rcvr) const& -> __opstate_t<const _Sndr&, _Rcvr>
   {
-    return __opstate_t<const _Sndr&, _Rcvr>(__state_.__sndr_, static_cast<_Rcvr&&>(__rcvr), __state_.__stream_);
+    return __opstate_t<const _Sndr&, _Rcvr>(__sndr_, static_cast<_Rcvr&&>(__rcvr), __stream_);
   }
 
   [[nodiscard]] _CCCL_API constexpr auto get_env() const noexcept -> __attrs_t<_Sndr>
   {
-    return __attrs_t<_Sndr>{&__state_.__sndr_};
+    return __attrs_t<_Sndr>{&__sndr_};
   }
 
-  // By having just one data member, this sender does not look like one that can be
-  // introspected, transformed, or visited.
-  struct __state_t
-  {
-    stream_ref __stream_;
-    _Sndr __sndr_;
-  } __state_;
+  _CCCL_NO_UNIQUE_ADDRESS __adapted_t<tag_of_t<_Sndr>> __tag_;
+  stream_ref __stream_;
+  _Sndr __sndr_;
 };
 
 template <class _Sndr>
 _CCCL_API constexpr auto __adapt(_Sndr __sndr, stream_ref __stream) -> decltype(auto)
 {
+  // Ensure that we are not trying to adapt a sender that is already adapted.
   if constexpr (__is_specialization_of_v<_Sndr, __sndr_t>)
   {
-    return _Sndr(static_cast<_Sndr&&>(__sndr));
+    return static_cast<_Sndr>(static_cast<_Sndr&&>(__sndr)); // passthrough
   }
   else
   {
-    return __sndr_t<_Sndr>{{__stream, static_cast<_Sndr&&>(__sndr)}};
+    return __sndr_t<_Sndr>{{}, __stream, static_cast<_Sndr&&>(__sndr)};
   }
 }
 
 template <class _Sndr>
 _CCCL_API constexpr auto __adapt(_Sndr __sndr) -> decltype(auto)
 {
-  return __stream::__adapt(static_cast<_Sndr&&>(__sndr), get_stream(get_env(__sndr)));
+  return __stream::__adapt(static_cast<_Sndr&&>(__sndr), get_stream(execution::get_env(__sndr)));
 }
+} // namespace __stream
 
 template <class _Sndr>
-_CCCL_API void __adapt(__sndr_t<_Sndr>, stream_ref) = delete;
-} // namespace cuda::experimental::execution::__stream
+inline constexpr size_t structured_binding_size<__stream::__sndr_t<_Sndr>> = 3;
+
+} // namespace cuda::experimental::execution
 
 _CCCL_DIAG_POP
 

--- a/cudax/include/cuda/experimental/__execution/stream/adaptor.cuh
+++ b/cudax/include/cuda/experimental/__execution/stream/adaptor.cuh
@@ -275,7 +275,7 @@ private:
     using __launch_dims_t         = decltype(__launch_config.dims);
     constexpr int __block_threads = __launch_dims_t::static_count(experimental::thread, experimental::block);
     int const __grid_blocks       = __launch_config.dims.count(experimental::block, experimental::grid);
-    static_assert(__block_threads != cuda::std::dynamic_extent);
+    static_assert(__block_threads != ::cuda::std::dynamic_extent);
 
     // Start the child operation state. This will launch kernels for all the predecessors
     // of this operation.

--- a/cudax/include/cuda/experimental/__execution/stream/bulk.cuh
+++ b/cudax/include/cuda/experimental/__execution/stream/bulk.cuh
@@ -1,0 +1,195 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __CUDAX_EXECUTION_STREAM_BULK
+#define __CUDAX_EXECUTION_STREAM_BULK
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__tuple_dir/ignore.h>
+#include <cuda/std/__utility/forward_like.h>
+
+#include <cuda/experimental/__execution/bulk.cuh>
+#include <cuda/experimental/__execution/cpos.cuh>
+#include <cuda/experimental/__execution/policy.cuh>
+#include <cuda/experimental/__execution/stream/domain.cuh>
+
+#include <cuda_runtime_api.h>
+
+#include <cuda/experimental/__execution/prologue.cuh>
+
+namespace cuda::experimental::execution
+{
+template <>
+struct stream_domain::__apply_t<bulk_chunked_t> : __bulk_t<__apply_t<bulk_chunked_t>>
+{
+  template <class _CvSndr, class _Rcvr, class _Shape, class _Fn>
+  using __base_opstate_t = __bulk_t<__apply_t<bulk_chunked_t>>::__opstate_t<_CvSndr, _Rcvr, _Shape, _Fn>;
+
+  template <class _CvSndr, class _Rcvr, class _Shape, class _Fn>
+  struct __opstate_t : __base_opstate_t<_CvSndr, _Rcvr, _Shape, _Fn>
+  {
+    _CCCL_API constexpr explicit __opstate_t(_CvSndr&& __sndr, _Rcvr __rcvr, _Shape __shape, _Fn __fn)
+        : __base_opstate_t<_CvSndr, _Rcvr, _Shape, _Fn>{
+            static_cast<_CvSndr&&>(__sndr), static_cast<_Rcvr&&>(__rcvr), __shape, static_cast<_Fn&&>(__fn)}
+    {}
+
+    // We permit this `set_value` function to be called multiple times, once for each
+    // thread in the block.
+    template <class... _Values>
+    _CCCL_DEVICE_API void set_value(_Values&&... __values) noexcept
+    {
+      const _Shape __tid = threadIdx.x + blockIdx.x * blockDim.x;
+
+      if (__tid < this->__shape_)
+      {
+        if constexpr (__is_specialization_of_v<_Fn, bulk_t::__bulk_chunked_fn>)
+        {
+          // If the chunked function was adapted from an unchunked function, we can call
+          // the unchunked functions directly.
+          this->__fn_.__fn_(_Shape(__tid), __values...);
+        }
+        else
+        {
+          // Otherwise, we call the function with the half-open range [__tid, __tid + 1)
+          // to process a single element.
+          this->__fn_(_Shape(__tid), _Shape(__tid + 1), __values...);
+        }
+      }
+
+      __syncthreads();
+
+      // Only call the downstream receiver once, after all threads have processed their
+      // elements.
+      if (__tid == 0)
+      {
+        execution::set_value(static_cast<_Rcvr&&>(this->__rcvr_), static_cast<_Values&&>(__values)...);
+      }
+    }
+  };
+
+  // This function is called when the `bulk_chunked` CPO calls `transform_sender` with a
+  // domain argument of stream_domain. It adapts a `bulk_chunked` sender to the stream
+  // domain.
+  template <class _Sndr>
+  _CCCL_API constexpr auto operator()(_Sndr&& __sndr) const
+  {
+    // Decompose the bulk sender into its components:
+    auto& [__tag, __state, __child] = __sndr;
+    auto& [__policy, __shape, __fn] = __state;
+
+    using __sndr_t = __bulk_t::__sndr_t<decltype(__child), decltype(__policy), decltype(__shape), decltype(__fn)>;
+    return __stream::__adapt(__sndr_t{
+      {}, {__policy, __shape, _CUDA_VSTD::forward_like<_Sndr>(__fn)}, _CUDA_VSTD::forward_like<_Sndr>(__child)});
+  }
+
+  _CCCL_API static constexpr bool __is_chunked() noexcept
+  {
+    return true;
+  }
+};
+
+template <>
+struct stream_domain::__apply_t<bulk_unchunked_t> : __bulk_t<__apply_t<bulk_unchunked_t>>
+{
+  template <class _CvSndr, class _Rcvr, class _Shape, class _Fn>
+  using __base_opstate_t = __bulk_t<__apply_t<bulk_unchunked_t>>::__opstate_t<_CvSndr, _Rcvr, _Shape, _Fn>;
+
+  template <class _CvSndr, class _Rcvr, class _Shape, class _Fn>
+  struct __opstate_t : __base_opstate_t<_CvSndr, _Rcvr, _Shape, _Fn>
+  {
+    _CCCL_API constexpr explicit __opstate_t(_CvSndr&& __sndr, _Rcvr __rcvr, _Shape __shape, _Fn __fn)
+        : __base_opstate_t<_CvSndr, _Rcvr, _Shape, _Fn>{
+            static_cast<_CvSndr&&>(__sndr), static_cast<_Rcvr&&>(__rcvr), __shape, static_cast<_Fn&&>(__fn)}
+    {}
+
+    // We permit this `set_value` function to be called multiple times, once for each
+    // thread in the block.
+    template <class... _Values>
+    _CCCL_DEVICE_API void set_value(_Values&&... __values) noexcept
+    {
+      const _Shape __tid = threadIdx.x + blockIdx.x * blockDim.x;
+
+      if (__tid < this->__shape_)
+      {
+        this->__fn_(_Shape(__tid), __values...);
+      }
+
+      __syncthreads();
+
+      // Only call the downstream receiver once, after all threads have processed their
+      // elements.
+      if (__tid == 0)
+      {
+        execution::set_value(static_cast<_Rcvr&&>(this->__rcvr_), static_cast<_Values&&>(__values)...);
+      }
+    }
+  };
+
+  // This function is called when the `bulk_unchunked` CPO calls `transform_sender` with a
+  // domain argument of stream_domain. It adapts a `bulk_unchunked` sender to the stream
+  // domain.
+  template <class _Sndr>
+  _CCCL_API constexpr auto operator()(_Sndr&& __sndr) const
+  {
+    // Decompose the bulk sender into its components:
+    auto& [__tag, __state, __child] = __sndr;
+    auto& [__policy, __shape, __fn] = __state;
+
+    using __sndr_t = __bulk_t::__sndr_t<decltype(__child), decltype(__policy), decltype(__shape), decltype(__fn)>;
+    return __stream::__adapt(__sndr_t{
+      {}, {__policy, __shape, _CUDA_VSTD::forward_like<_Sndr>(__fn)}, _CUDA_VSTD::forward_like<_Sndr>(__child)});
+  }
+
+  _CCCL_API static constexpr bool __is_chunked() noexcept
+  {
+    return false;
+  }
+};
+
+template <>
+struct stream_domain::__apply_t<bulk_t>
+{
+  template <class _Sndr>
+  _CCCL_API constexpr auto operator()(_Sndr&& __sndr) const -> decltype(auto)
+  {
+    // This converts a bulk sender into a bulk_chunked sender, which will then be
+    // further transformed by the __apply_t<bulk_chunked_t> specialization above.
+    return bulk.transform_sender(static_cast<_Sndr&&>(__sndr), env{});
+  }
+};
+
+template <class _Sndr, class _Policy, class _Shape, class _Fn>
+inline constexpr size_t
+  structured_binding_size<__bulk_t<stream_domain::__apply_t<bulk_chunked_t>>::__sndr_t<_Sndr, _Policy, _Shape, _Fn>> =
+    3;
+
+template <class _Sndr, class _Policy, class _Shape, class _Fn>
+inline constexpr size_t
+  structured_binding_size<__bulk_t<stream_domain::__apply_t<bulk_unchunked_t>>::__sndr_t<_Sndr, _Policy, _Shape, _Fn>> =
+    3;
+
+template <class _Sndr, class _Policy, class _Shape, class _Fn>
+inline constexpr size_t
+  structured_binding_size<__bulk_t<stream_domain::__apply_t<bulk_t>>::__sndr_t<_Sndr, _Policy, _Shape, _Fn>> = 3;
+
+} // namespace cuda::experimental::execution
+
+#include <cuda/experimental/__execution/epilogue.cuh>
+
+#endif // __CUDAX_EXECUTION_STREAM_BULK

--- a/cudax/include/cuda/experimental/__execution/stream/domain.cuh
+++ b/cudax/include/cuda/experimental/__execution/stream/domain.cuh
@@ -33,6 +33,10 @@ namespace cuda::experimental::execution
 {
 namespace __stream
 {
+template <class _Tag>
+struct __adapted_t
+{};
+
 // Forward declaration of the __adapt function
 template <class _Sndr>
 _CCCL_API constexpr auto __adapt(_Sndr, stream_ref) -> decltype(auto);
@@ -43,10 +47,10 @@ _CCCL_API constexpr auto __adapt(_Sndr) -> decltype(auto);
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // stream domain
-struct stream_domain : default_domain
+struct stream_domain
 {
   _CUDAX_SEMI_PRIVATE :
-  struct __default_apply_t
+  struct __apply_adapt_t
   {
     template <class _Sndr>
     _CCCL_API constexpr auto operator()(_Sndr&& __sndr) const
@@ -55,8 +59,17 @@ struct stream_domain : default_domain
     }
   };
 
+  struct __apply_passthru_t
+  {
+    template <class _Sndr>
+    _CCCL_API constexpr auto operator()(_Sndr&& __sndr, _CUDA_VSTD::__ignore_t = {}) const -> _Sndr
+    {
+      return static_cast<_Sndr&&>(__sndr);
+    }
+  };
+
   template <class _Tag>
-  struct __apply_t : __default_apply_t
+  struct __apply_t : __apply_adapt_t
   {};
 
 public:

--- a/cudax/include/cuda/experimental/__execution/stream/scheduler.cuh
+++ b/cudax/include/cuda/experimental/__execution/stream/scheduler.cuh
@@ -22,6 +22,7 @@
 #endif // no system header
 
 #include <cuda/__stream/get_stream.h>
+#include <cuda/std/__concepts/concept_macros.h>
 
 #include <cuda/experimental/__execution/completion_signatures.cuh>
 #include <cuda/experimental/__execution/cpos.cuh>
@@ -36,12 +37,16 @@
 
 #include <cuda/experimental/__execution/prologue.cuh>
 
+_CCCL_DIAG_PUSH
+_CCCL_DIAG_SUPPRESS_GCC("-Wattributes")
+
 namespace cuda::experimental
 {
 namespace execution
 {
-template <class _Tag, class _Rcvr, class... _Args>
-__launch_bounds__(1) __global__ static void __stream_complete(_Tag, _Rcvr* __rcvr, _Args... __args)
+template <int _BlockThreads, class _Tag, class _Rcvr, class... _Args>
+_CCCL_VISIBILITY_HIDDEN __launch_bounds__(_BlockThreads) __global__
+  void __stream_complete(_Tag, _Rcvr* __rcvr, _Args... __args)
 {
   _Tag{}(static_cast<_Rcvr&&>(*__rcvr), static_cast<_Args&&>(__args)...);
 }
@@ -107,18 +112,37 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT stream_scheduler
   private:
     _CCCL_HOST_API void __host_start() noexcept
     {
-      __stream_complete<<<1, 1, 0, __stream_.get()>>>(set_value, &__rcvr_);
+      // Read the launch configuration passed to us by the parent operation. When we launch
+      // the completion kernel, we will be completing the parent's receiver, so we must let
+      // the receiver tell us how to launch the kernel.
+      auto const __launch_dims      = get_launch_config(execution::get_env(__rcvr_)).dims;
+      constexpr int __block_threads = decltype(__launch_dims)::static_count(experimental::thread, experimental::block);
+      int const __grid_blocks       = __launch_dims.count(experimental::block, experimental::grid);
+      static_assert(__block_threads != cuda::std::dynamic_extent);
+
+      // printf("Launching completion kernel for stream_scheduler with %d block threads and %d grid blocks\n",
+      //        __block_threads,
+      //        __grid_blocks);
+
+      // Launch the kernel that completes the receiver with the launch configuration from
+      // the receiver.
+      __stream_complete<__block_threads><<<__grid_blocks, __block_threads, 0, __stream_.get()>>>(set_value, &__rcvr_);
+
       if (auto __status = cudaGetLastError(); __status != cudaSuccess)
       {
         execution::set_error(static_cast<_Rcvr&&>(__rcvr_), cudaError_t(__status));
       }
     }
 
+    // TODO: untested
     _CCCL_DEVICE_API void __device_start() noexcept
     {
+      using __launch_dims_t         = decltype(get_launch_config(execution::get_env(__rcvr_)).dims);
+      constexpr int __block_threads = __launch_dims_t::static_count(experimental::thread, experimental::block);
+
       // without the following, the kernel in __host_start will fail to launch with
       // cudaErrorInvalidDeviceFunction.
-      [[maybe_unused]] auto __ignore = &__stream_complete<set_value_t, _Rcvr>;
+      ::__cccl_unused(&__stream_complete<__block_threads, set_value_t, _Rcvr>);
       execution::set_value(static_cast<_Rcvr&&>(__rcvr_));
     }
 
@@ -214,6 +238,8 @@ _CCCL_HOST_API inline auto stream_ref::schedule() const noexcept
 }
 
 } // namespace cuda::experimental
+
+_CCCL_DIAG_POP
 
 #include <cuda/experimental/__execution/epilogue.cuh>
 

--- a/cudax/include/cuda/experimental/__execution/stream/scheduler.cuh
+++ b/cudax/include/cuda/experimental/__execution/stream/scheduler.cuh
@@ -118,7 +118,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT stream_scheduler
       auto const __launch_dims      = get_launch_config(execution::get_env(__rcvr_)).dims;
       constexpr int __block_threads = decltype(__launch_dims)::static_count(experimental::thread, experimental::block);
       int const __grid_blocks       = __launch_dims.count(experimental::block, experimental::grid);
-      static_assert(__block_threads != cuda::std::dynamic_extent);
+      static_assert(__block_threads != ::cuda::std::dynamic_extent);
 
       // printf("Launching completion kernel for stream_scheduler with %d block threads and %d grid blocks\n",
       //        __block_threads,

--- a/cudax/include/cuda/experimental/__execution/stream/sync_wait.cuh
+++ b/cudax/include/cuda/experimental/__execution/stream/sync_wait.cuh
@@ -21,6 +21,8 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/std/__utility/move.h>
+
 #include <cuda/experimental/__execution/stream/domain.cuh>
 #include <cuda/experimental/__execution/sync_wait.cuh>
 #include <cuda/experimental/__execution/utility.cuh>

--- a/cudax/include/cuda/experimental/__execution/stream_context.cuh
+++ b/cudax/include/cuda/experimental/__execution/stream_context.cuh
@@ -23,6 +23,7 @@
 
 // IWYU pragma: begin_exports
 #include <cuda/experimental/__execution/stream/adaptor.cuh>
+#include <cuda/experimental/__execution/stream/bulk.cuh>
 #include <cuda/experimental/__execution/stream/context.cuh>
 #include <cuda/experimental/__execution/stream/continues_on.cuh>
 #include <cuda/experimental/__execution/stream/domain.cuh>

--- a/cudax/include/cuda/experimental/__execution/sync_wait.cuh
+++ b/cudax/include/cuda/experimental/__execution/sync_wait.cuh
@@ -172,7 +172,7 @@ struct sync_wait_t
       }
       else if constexpr (_CUDA_VSTD::is_same_v<_Error, cudaError_t>)
       {
-        cuda::__throw_cuda_error(__err, "sync_wait failed with cudaError_t");
+        ::cuda::__throw_cuda_error(__err, "sync_wait failed with cudaError_t");
       }
       else
       {

--- a/cudax/include/cuda/experimental/__execution/sync_wait.cuh
+++ b/cudax/include/cuda/experimental/__execution/sync_wait.cuh
@@ -21,6 +21,7 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/std/__exception/cuda_error.h>
 #include <cuda/std/__type_traits/always_false.h>
 #include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/__type_traits/type_identity.h>
@@ -159,15 +160,19 @@ struct sync_wait_t
   struct __throw_error_fn
   {
     template <class _Error>
-    _CCCL_HOST_API void operator()(_Error&& __err) const
+    _CCCL_HOST_API void operator()(_Error __err) const
     {
-      if constexpr (_CUDA_VSTD::is_same_v<_CUDA_VSTD::remove_cvref_t<_Error>, ::std::exception_ptr>)
+      if constexpr (_CUDA_VSTD::is_same_v<_Error, ::std::exception_ptr>)
       {
         ::std::rethrow_exception(static_cast<_Error&&>(__err));
       }
-      else if constexpr (_CUDA_VSTD::is_same_v<_CUDA_VSTD::remove_cvref_t<_Error>, ::std::error_code>)
+      else if constexpr (_CUDA_VSTD::is_same_v<_Error, ::std::error_code>)
       {
-        throw ::std::system_error(static_cast<_Error&&>(__err));
+        throw ::std::system_error(__err);
+      }
+      else if constexpr (_CUDA_VSTD::is_same_v<_Error, cudaError_t>)
+      {
+        cuda::__throw_cuda_error(__err, "sync_wait failed with cudaError_t");
       }
       else
       {

--- a/cudax/include/cuda/experimental/execution.cuh
+++ b/cudax/include/cuda/experimental/execution.cuh
@@ -13,6 +13,7 @@
 
 // IWYU pragma: begin_exports
 #include <cuda/experimental/__execution/apply_sender.cuh>
+#include <cuda/experimental/__execution/bulk.cuh>
 #include <cuda/experimental/__execution/completion_signatures.cuh>
 #include <cuda/experimental/__execution/conditional.cuh>
 #include <cuda/experimental/__execution/continues_on.cuh>

--- a/cudax/test/CMakeLists.txt
+++ b/cudax/test/CMakeLists.txt
@@ -80,6 +80,7 @@ foreach(cn_target IN LISTS cudax_TARGETS)
     execution/env.cu
     execution/policies/policies.cu
     execution/policies/get_execution_policy.cu
+    execution/test_bulk.cu
     execution/test_concepts.cu
     execution/test_completion_signatures.cu
     execution/test_conditional.cu

--- a/cudax/test/execution/common/checked_receiver.cuh
+++ b/cudax/test/execution/common/checked_receiver.cuh
@@ -12,6 +12,8 @@
 
 #include <cuda/experimental/execution.cuh>
 
+#include <exception>
+
 #include "testing.cuh"
 
 namespace
@@ -69,7 +71,7 @@ struct checked_value_receiver
 template <class... Values>
 _CCCL_HOST_DEVICE checked_value_receiver(Values...) -> checked_value_receiver<Values...>;
 
-template <class Error>
+template <class Error = ::std::exception_ptr>
 struct checked_error_receiver
 {
   using receiver_concept = cudax_async::receiver_t;

--- a/cudax/test/execution/common/error_scheduler.cuh
+++ b/cudax/test/execution/common/error_scheduler.cuh
@@ -97,6 +97,7 @@ public:
       : _err(static_cast<Error&&>(err))
   {}
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_HOST_DEVICE sndr_t schedule() const noexcept
   {
     return {_err};

--- a/cudax/test/execution/common/inline_scheduler.cuh
+++ b/cudax/test/execution/common/inline_scheduler.cuh
@@ -18,14 +18,20 @@ namespace
 {
 //! Scheduler that returns a sender that always completes inline
 //! (successfully).
+template <class Domain = cudax_async::default_domain>
 struct inline_scheduler
 {
 private:
-  struct _env_t
+  struct _attrs_t
   {
     _CCCL_HOST_DEVICE auto query(cudax_async::get_completion_scheduler_t<cudax_async::set_value_t>) const noexcept
     {
       return inline_scheduler{};
+    }
+
+    _CCCL_HOST_DEVICE static constexpr auto query(cudax_async::get_domain_t) noexcept -> Domain
+    {
+      return {};
     }
   };
 
@@ -61,7 +67,7 @@ public:
       return {{}, static_cast<Rcvr&&>(rcvr)};
     }
 
-    _CCCL_HOST_DEVICE _env_t get_env() const noexcept
+    _CCCL_HOST_DEVICE _attrs_t get_env() const noexcept
     {
       return {};
     }
@@ -70,6 +76,11 @@ public:
   inline_scheduler() = default;
 
   _CCCL_HOST_DEVICE _sndr_t schedule() const noexcept
+  {
+    return {};
+  }
+
+  _CCCL_HOST_DEVICE static auto query(cudax_async::get_domain_t) noexcept -> Domain
   {
     return {};
   }

--- a/cudax/test/execution/test_bulk.cu
+++ b/cudax/test/execution/test_bulk.cu
@@ -1,0 +1,1110 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//                         Copyright (c) 2022 Lucian Radu Teodorescu
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/__algorithm/fill_n.h>
+#include <cuda/std/__exception/terminate.h>
+#include <cuda/std/__numeric/iota.h>
+#include <cuda/std/array>
+
+#include <cuda/experimental/execution.cuh>
+
+#include "common/checked_receiver.cuh"
+#include "common/error_scheduler.cuh"
+#include "common/inline_scheduler.cuh"
+#include "common/utility.cuh"
+#include "testing.cuh" // IWYU pragma: keep
+
+namespace ex = cuda::experimental::execution;
+
+#if !defined(__CUDA_ARCH__)
+using _exception_ptr = ::std::exception_ptr;
+#else
+struct _exception_ptr
+{};
+#endif
+
+namespace
+{
+template <class Shape, int N>
+_CCCL_HOST_DEVICE void function(Shape i, int (*counter)[N])
+{
+  (*counter)[i]++;
+}
+
+template <class Shape, int N>
+_CCCL_HOST_DEVICE void function_range(Shape b, Shape e, int (*counter)[N])
+{
+  while (b != e)
+  {
+    (*counter)[b++]++;
+  }
+}
+
+template <class Shape>
+struct function_object_t
+{
+  int* counter_;
+
+  _CCCL_HOST_DEVICE void operator()(Shape i)
+  {
+    counter_[i]++;
+  }
+};
+
+template <class Shape>
+struct function_object_range_t
+{
+  int* counter_;
+
+  _CCCL_HOST_DEVICE void operator()(Shape b, Shape e)
+  {
+    while (b != e)
+    {
+      counter_[b++]++;
+    }
+  }
+};
+
+struct ignore_lvalue_ref
+{
+  template <class T>
+  _CCCL_HOST_DEVICE ignore_lvalue_ref(T&) noexcept
+  {
+    // Do nothing, just ignore the value
+  }
+};
+} // anonymous namespace
+
+void bulk_returns_a_sender()
+{
+  auto sndr = ex::bulk(ex::just(19), ex::par, 8, [] _CCCL_HOST_DEVICE(int, int) {});
+  STATIC_REQUIRE(ex::sender<decltype(sndr)>);
+  (void) sndr;
+}
+
+void bulk_chunked_returns_a_sender()
+{
+  auto sndr = ex::bulk_chunked(ex::just(19), ex::par, 8, [] _CCCL_HOST_DEVICE(int, int, int) {});
+  STATIC_REQUIRE(ex::sender<decltype(sndr)>);
+  (void) sndr;
+}
+
+void bulk_unchunked_returns_a_sender()
+{
+  auto sndr = ex::bulk_unchunked(ex::just(19), 8, [] _CCCL_HOST_DEVICE(int, int) {});
+  STATIC_REQUIRE(ex::sender<decltype(sndr)>);
+  (void) sndr;
+}
+
+void bulk_with_environment_returns_a_sender()
+{
+  auto sndr = ex::bulk(ex::just(19), ex::par, 8, [] _CCCL_HOST_DEVICE(int, int) {});
+  STATIC_REQUIRE(ex::sender_in<decltype(sndr), ex::env<>>);
+  (void) sndr;
+}
+
+void bulk_chunked_with_environment_returns_a_sender()
+{
+  auto sndr = ex::bulk_chunked(ex::just(19), ex::par, 8, [] _CCCL_HOST_DEVICE(int, int, int) {});
+  STATIC_REQUIRE(ex::sender_in<decltype(sndr), ex::env<>>);
+  (void) sndr;
+}
+
+void bulk_unchunked_with_environment_returns_a_sender()
+{
+  auto sndr = ex::bulk_unchunked(ex::just(19), 8, [] _CCCL_HOST_DEVICE(int, int) {});
+  STATIC_REQUIRE(ex::sender_in<decltype(sndr), ex::env<>>);
+  (void) sndr;
+}
+
+void bulk_can_be_piped()
+{
+  auto sndr = ex::just() //
+            | ex::bulk(ex::par, 42, [] _CCCL_HOST_DEVICE(int) {});
+  (void) sndr;
+}
+
+void bulk_chunked_can_be_piped()
+{
+  auto sndr = ex::just() //
+            | ex::bulk_chunked(ex::par, 42, [] _CCCL_HOST_DEVICE(int, int) {});
+  (void) sndr;
+}
+
+void bulk_unchunked_can_be_piped()
+{
+  auto sndr = ex::just() //
+            | ex::bulk_unchunked(42, [] _CCCL_HOST_DEVICE(int) {});
+  (void) sndr;
+}
+
+void bulk_keeps_values_type_from_input_sender()
+{
+  constexpr int n = 42;
+  check_value_types<types<>>(ex::just() //
+                             | ex::bulk(ex::par, n, [] _CCCL_HOST_DEVICE(int) {}));
+  check_value_types<types<double>>(ex::just(4.2) //
+                                   | ex::bulk(ex::par, n, [] _CCCL_HOST_DEVICE(int, double) {}));
+  check_value_types<types<double, string>>(ex::just(4.2, string{}) //
+                                           | ex::bulk(ex::par, n, [] _CCCL_HOST_DEVICE(int, double, string) {}));
+}
+
+void bulk_chunked_keeps_values_type_from_input_sender()
+{
+  constexpr int n = 42;
+  check_value_types<types<>>(ex::just() //
+                             | ex::bulk_chunked(ex::par, n, [] _CCCL_HOST_DEVICE(int, int) {}));
+  check_value_types<types<double>>(ex::just(4.2) //
+                                   | ex::bulk_chunked(ex::par, n, [] _CCCL_HOST_DEVICE(int, int, double) {}));
+  check_value_types<types<double, string>>(
+    ex::just(4.2, string{}) | ex::bulk_chunked(ex::par, n, [] _CCCL_HOST_DEVICE(int, int, double, string) {}));
+}
+
+void bulk_unchunked_keeps_values_type_from_input_sender()
+{
+  constexpr int n = 42;
+  check_value_types<types<>>(ex::just() //
+                             | ex::bulk_unchunked(n, [] _CCCL_HOST_DEVICE(int) {}));
+  check_value_types<types<double>>(ex::just(4.2) //
+                                   | ex::bulk_unchunked(n, [] _CCCL_HOST_DEVICE(int, double) {}));
+  check_value_types<types<double, string>>(ex::just(4.2, string{}) //
+                                           | ex::bulk_unchunked(n, [] _CCCL_HOST_DEVICE(int, double, string) {}));
+}
+
+void bulk_keeps_error_types_from_input_sender()
+{
+#if !_CCCL_COMPILER(MSVC)
+  constexpr int n = 42;
+  inline_scheduler sched1{};
+  error_scheduler<_exception_ptr> sched2{};
+  error_scheduler<int> sched3{43};
+
+  // MSVCBUG https://developercommunity.visualstudio.com/t/noexcept-expression-in-lambda-template-n/10718680
+  check_error_types<>(ex::just() //
+                      | ex::continues_on(sched1) //
+                      | ex::bulk(ex::par, n, [] _CCCL_HOST_DEVICE(int) noexcept {}));
+  check_error_types<_exception_ptr>(
+    ex::just() //
+    | ex::continues_on(sched2) //
+    | ex::bulk(ex::par, n, [] _CCCL_HOST_DEVICE(int) noexcept {}));
+  check_error_types<int>(ex::just_error(n) //
+                         | ex::bulk(ex::par, n, [] _CCCL_HOST_DEVICE(int) noexcept {}));
+  check_error_types<int>(
+    ex::just() //
+    | ex::continues_on(sched3) //
+    | ex::bulk(ex::par, n, [] _CCCL_HOST_DEVICE(int) noexcept {}));
+#  if !defined(__CUDA_ARCH__)
+  check_error_types<::std::exception_ptr, int>(
+    ex::just() //
+    | ex::continues_on(sched3) //
+    | ex::bulk(ex::par, n, [](int) {
+        throw std::logic_error{"err"};
+      }));
+#  else
+  check_error_types<int>(
+    ex::just() //
+    | ex::continues_on(sched3) //
+    | ex::bulk(ex::par, n, [] _CCCL_HOST_DEVICE(int) {
+        cuda::std::__cccl_terminate();
+      }));
+#  endif
+#endif
+}
+
+void bulk_chunked_keeps_error_types_from_input_sender()
+{
+  constexpr int n = 42;
+  inline_scheduler sched1{};
+  error_scheduler<_exception_ptr> sched2{};
+  error_scheduler<int> sched3{43};
+
+  check_error_types<>(ex::just() //
+                      | ex::continues_on(sched1) //
+                      | ex::bulk_chunked(ex::par, n, [] _CCCL_HOST_DEVICE(int, int) noexcept {}));
+  check_error_types<_exception_ptr>(
+    ex::just() //
+    | ex::continues_on(sched2) //
+    | ex::bulk_chunked(ex::par, n, [] _CCCL_HOST_DEVICE(int, int) noexcept {}));
+  check_error_types<int>(ex::just_error(n) //
+                         | ex::bulk_chunked(ex::par, n, [] _CCCL_HOST_DEVICE(int, int) noexcept {}));
+  check_error_types<int>(
+    ex::just() //
+    | ex::continues_on(sched3) //
+    | ex::bulk_chunked(ex::par, n, [] _CCCL_HOST_DEVICE(int, int) noexcept {}));
+#if !defined(__CUDA_ARCH__)
+  check_error_types<::std::exception_ptr, int>(
+    ex::just() //
+    | ex::continues_on(sched3) //
+    | ex::bulk_chunked(ex::par, n, [](int, int) {
+        throw std::logic_error{"err"};
+      }));
+#else
+  check_error_types<int>(
+    ex::just() //
+    | ex::continues_on(sched3) //
+    | ex::bulk_chunked(ex::par, n, [] _CCCL_HOST_DEVICE(int, int) {
+        cuda::std::__cccl_terminate();
+      }));
+#endif
+}
+
+void bulk_unchunked_keeps_error_types_from_input_sender()
+{
+  constexpr int n = 42;
+  inline_scheduler sched1{};
+  error_scheduler<_exception_ptr> sched2{};
+  error_scheduler<int> sched3{43};
+
+  check_error_types<>(ex::just() //
+                      | ex::continues_on(sched1) //
+                      | ex::bulk_unchunked(n, [] _CCCL_HOST_DEVICE(int) noexcept {}));
+  check_error_types<_exception_ptr>(
+    ex::just() //
+    | ex::continues_on(sched2) //
+    | ex::bulk_unchunked(n, [] _CCCL_HOST_DEVICE(int) noexcept {}));
+  check_error_types<int>(ex::just_error(n) //
+                         | ex::bulk_unchunked(n, [] _CCCL_HOST_DEVICE(int) noexcept {}));
+  check_error_types<int>(
+    ex::just() //
+    | ex::continues_on(sched3) //
+    | ex::bulk_unchunked(n, [] _CCCL_HOST_DEVICE(int) noexcept {}));
+#if !defined(__CUDA_ARCH__)
+  check_error_types<::std::exception_ptr, int>(
+    ex::just() //
+    | ex::continues_on(sched3) //
+    | ex::bulk_unchunked(n, [](int) {
+        throw std::logic_error{"err"};
+      }));
+#else
+  check_error_types<int>(
+    ex::just() //
+    | ex::continues_on(sched3) //
+    | ex::bulk_unchunked(n, [] _CCCL_HOST_DEVICE(int) {
+        cuda::std::__cccl_terminate();
+      }));
+#endif
+}
+
+void bulk_can_be_used_with_a_function()
+{
+  constexpr int n = 9;
+  int counter1[n]{};
+  _CUDA_VSTD::fill_n(counter1, n, 0);
+
+  auto sndr = ex::just(&counter1) //
+            | ex::bulk(ex::par, n, function<int, n>);
+  auto op = ex::connect(cuda::std::move(sndr), checked_value_receiver{&counter1});
+  ex::start(op);
+
+  for (int i : counter1)
+  {
+    CHECK(i == 1);
+  }
+}
+
+void bulk_chunked_can_be_used_with_a_function()
+{
+  constexpr int n = 9;
+  int counter2[n]{};
+  _CUDA_VSTD::fill_n(counter2, n, 0);
+
+  auto sndr = ex::just(&counter2) //
+            | ex::bulk_chunked(ex::par, n, function_range<int, n>);
+  auto op = ex::connect(cuda::std::move(sndr), checked_value_receiver{&counter2});
+  ex::start(op);
+
+  for (int i = 0; i < n; i++)
+  {
+    CHECK(counter2[i] == 1);
+  }
+}
+
+void bulk_unchunked_can_be_used_with_a_function()
+{
+  constexpr int n = 9;
+  int counter3[n]{};
+  _CUDA_VSTD::fill_n(counter3, n, 0);
+
+  auto sndr = ex::just(&counter3) //
+            | ex::bulk_unchunked(n, function<int, n>);
+  auto op = ex::connect(cuda::std::move(sndr), checked_value_receiver{&counter3});
+  ex::start(op);
+
+  for (int i = 0; i < n; i++)
+  {
+    CHECK(counter3[i] == 1);
+  }
+}
+
+void bulk_can_be_used_with_a_function_object()
+{
+  constexpr int n = 9;
+  int counter[n]{0};
+  function_object_t<int> fn{counter};
+
+  auto sndr = ex::just() //
+            | ex::bulk(ex::par, n, fn);
+  auto op = ex::connect(cuda::std::move(sndr), checked_value_receiver{});
+  ex::start(op);
+
+  for (int i : counter)
+  {
+    CHECK(i == 1);
+  }
+}
+
+void bulk_chunked_can_be_used_with_a_function_object()
+{
+  constexpr int n = 9;
+  int counter[n]{0};
+  function_object_range_t<int> fn{counter};
+
+  auto sndr = ex::just() //
+            | ex::bulk_chunked(ex::par, n, fn);
+  auto op = ex::connect(cuda::std::move(sndr), checked_value_receiver{});
+  ex::start(op);
+
+  for (int i = 0; i < n; i++)
+  {
+    CHECK(counter[i] == 1);
+  }
+}
+
+void bulk_unchunked_can_be_used_with_a_function_object()
+{
+  constexpr int n = 9;
+  int counter[n]{0};
+  function_object_t<int> fn{counter};
+
+  auto sndr = ex::just() //
+            | ex::bulk_unchunked(n, fn);
+  auto op = ex::connect(cuda::std::move(sndr), checked_value_receiver{});
+  ex::start(op);
+
+  for (int i = 0; i < n; i++)
+  {
+    CHECK(counter[i] == 1);
+  }
+}
+
+#if !defined(__CUDA_ARCH__)
+void bulk_can_be_used_with_a_lambda()
+{
+  constexpr int n = 9;
+  int counter[n]{0};
+
+  auto sndr = ex::just() //
+            | ex::bulk(ex::par, n, [&](int i) {
+                counter[i]++;
+              });
+  auto op = ex::connect(cuda::std::move(sndr), checked_value_receiver{});
+  ex::start(op);
+
+  for (int i : counter)
+  {
+    CHECK(i == 1);
+  }
+}
+
+void bulk_chunked_can_be_used_with_a_lambda()
+{
+  constexpr int n = 9;
+  int counter[n]{0};
+
+  auto sndr = ex::just() //
+            | ex::bulk_chunked(ex::par, n, [&](int b, int e) {
+                while (b < e)
+                {
+                  counter[b++]++;
+                }
+              });
+  auto op = ex::connect(cuda::std::move(sndr), checked_value_receiver{});
+  ex::start(op);
+
+  for (int i = 0; i < n; i++)
+  {
+    CHECK(counter[i] == 1);
+  }
+}
+
+void bulk_unchunked_can_be_used_with_a_lambda()
+{
+  constexpr int n = 9;
+  int counter[n]{0};
+
+  auto sndr = ex::just() //
+            | ex::bulk_unchunked(n, [&](int i) {
+                counter[i]++;
+              });
+  auto op = ex::connect(cuda::std::move(sndr), checked_value_receiver{});
+  ex::start(op);
+
+  for (int i = 0; i < n; i++)
+  {
+    CHECK(counter[i] == 1);
+  }
+}
+#endif // !defined(__CUDA_ARCH__)
+
+void bulk_works_with_all_standard_execution_policies()
+{
+  auto snd1 = ex::just() //
+            | ex::bulk(ex::seq, 9, [] _CCCL_HOST_DEVICE(int) {});
+  auto snd2 = ex::just() //
+            | ex::bulk(ex::par, 9, [] _CCCL_HOST_DEVICE(int) {});
+  auto snd3 = ex::just() //
+            | ex::bulk(ex::par_unseq, 9, [] _CCCL_HOST_DEVICE(int) {});
+  auto snd4 = ex::just() //
+            | ex::bulk(ex::unseq, 9, [] _CCCL_HOST_DEVICE(int) {});
+
+  STATIC_REQUIRE(ex::sender<decltype(snd1)>);
+  STATIC_REQUIRE(ex::sender<decltype(snd2)>);
+  STATIC_REQUIRE(ex::sender<decltype(snd3)>);
+  STATIC_REQUIRE(ex::sender<decltype(snd4)>);
+  (void) snd1;
+  (void) snd2;
+  (void) snd3;
+  (void) snd4;
+}
+
+void bulk_chunked_works_with_all_standard_execution_policies()
+{
+  auto snd1 = ex::just() //
+            | ex::bulk_chunked(ex::seq, 9, [] _CCCL_HOST_DEVICE(int, int) {});
+  auto snd2 = ex::just() //
+            | ex::bulk_chunked(ex::par, 9, [] _CCCL_HOST_DEVICE(int, int) {});
+  auto snd3 = ex::just() //
+            | ex::bulk_chunked(ex::par_unseq, 9, [] _CCCL_HOST_DEVICE(int, int) {});
+  auto snd4 = ex::just() //
+            | ex::bulk_chunked(ex::unseq, 9, [] _CCCL_HOST_DEVICE(int, int) {});
+
+  STATIC_REQUIRE(ex::sender<decltype(snd1)>);
+  STATIC_REQUIRE(ex::sender<decltype(snd2)>);
+  STATIC_REQUIRE(ex::sender<decltype(snd3)>);
+  STATIC_REQUIRE(ex::sender<decltype(snd4)>);
+  (void) snd1;
+  (void) snd2;
+  (void) snd3;
+  (void) snd4;
+}
+
+void bulk_forwards_values()
+{
+  constexpr int n            = 9;
+  constexpr int magic_number = 42;
+  int counter[n]{0};
+
+  auto sndr = ex::just(magic_number, &counter) //
+            | ex::bulk(ex::par, n, [](int i, int val, int(*counter)[n]) {
+                if (val == magic_number)
+                {
+                  (*counter)[i]++;
+                }
+              });
+  auto op = ex::connect(cuda::std::move(sndr), checked_value_receiver{magic_number, &counter});
+  ex::start(op);
+
+  for (int i : counter)
+  {
+    CHECK(i == 1);
+  }
+}
+
+void bulk_chunked_forwards_values()
+{
+  constexpr int n            = 9;
+  constexpr int magic_number = 42;
+  int counter[n]{0};
+
+  auto sndr = ex::just(magic_number) //
+            | ex::bulk_chunked(ex::par, n, [&](int b, int e, int val) {
+                if (val == magic_number)
+                {
+                  while (b < e)
+                  {
+                    counter[b++]++;
+                  }
+                }
+              });
+  auto op = ex::connect(cuda::std::move(sndr), checked_value_receiver{magic_number});
+  ex::start(op);
+
+  for (int i = 0; i < n; i++)
+  {
+    CHECK(counter[i] == 1);
+  }
+}
+
+void bulk_unchunked_forwards_values()
+{
+  constexpr int n            = 9;
+  constexpr int magic_number = 42;
+  int counter[n]{0};
+
+  auto sndr = ex::just(magic_number) //
+            | ex::bulk_unchunked(n, [&](int i, int val) {
+                if (val == magic_number)
+                {
+                  counter[i]++;
+                }
+              });
+  auto op = ex::connect(cuda::std::move(sndr), checked_value_receiver{magic_number});
+  ex::start(op);
+
+  for (int i = 0; i < n; i++)
+  {
+    CHECK(counter[i] == 1);
+  }
+}
+
+constexpr std::size_t n = 9;
+
+void bulk_forwards_values_that_can_be_taken_by_reference()
+{
+  _CUDA_VSTD::array<int, n> vals{};
+  _CUDA_VSTD::array<int, n> vals_expected{};
+  _CUDA_VSTD::iota(vals_expected.begin(), vals_expected.end(), 0);
+
+  auto sndr = ex::just(cuda::std::move(vals)) //
+            | ex::bulk(ex::par, n, [&](std::size_t i, _CUDA_VSTD::array<int, n>& vals) {
+                vals[i] = static_cast<int>(i);
+              });
+  auto op = ex::connect(cuda::std::move(sndr), checked_value_receiver{vals_expected});
+  ex::start(op);
+}
+
+void bulk_chunked_forwards_values_that_can_be_taken_by_reference()
+{
+  _CUDA_VSTD::array<int, n> vals{};
+  _CUDA_VSTD::array<int, n> vals_expected{};
+  _CUDA_VSTD::iota(vals_expected.begin(), vals_expected.end(), 0);
+
+  auto sndr = ex::just(cuda::std::move(vals)) //
+            | ex::bulk_chunked(ex::par, n, [&](std::size_t b, std::size_t e, _CUDA_VSTD::array<int, n>& vals) {
+                for (; b != e; ++b)
+                {
+                  vals[b] = static_cast<int>(b);
+                }
+              });
+  auto op = ex::connect(cuda::std::move(sndr), checked_value_receiver{vals_expected});
+  ex::start(op);
+}
+
+void bulk_unchunked_forwards_values_that_can_be_taken_by_reference()
+{
+  _CUDA_VSTD::array<int, n> vals{};
+  _CUDA_VSTD::array<int, n> vals_expected{};
+  _CUDA_VSTD::iota(vals_expected.begin(), vals_expected.end(), 0);
+
+  auto sndr = ex::just(cuda::std::move(vals)) //
+            | ex::bulk_unchunked(n, [&](std::size_t i, _CUDA_VSTD::array<int, n>& vals) {
+                vals[i] = static_cast<int>(i);
+              });
+  auto op = ex::connect(cuda::std::move(sndr), checked_value_receiver{vals_expected});
+  ex::start(op);
+}
+
+void bulk_cannot_be_used_to_change_the_value_type()
+{
+  constexpr int magic_number = 42;
+  constexpr int n            = 2;
+
+  auto sndr = ex::just(magic_number) //
+            | ex::bulk(ex::par, n, [] _CCCL_HOST_DEVICE(int, int) {
+                return function_object_t<int>{nullptr};
+              });
+
+  auto op = ex::connect(cuda::std::move(sndr), checked_value_receiver{magic_number});
+  ex::start(op);
+}
+
+void bulk_chunked_cannot_be_used_to_change_the_value_type()
+{
+  constexpr int magic_number = 42;
+  constexpr int n            = 2;
+
+  auto sndr = ex::just(magic_number) //
+            | ex::bulk_chunked(ex::par, n, [] _CCCL_HOST_DEVICE(int, int, int) {
+                return function_object_range_t<int>{nullptr};
+              });
+
+  auto op = ex::connect(cuda::std::move(sndr), checked_value_receiver{magic_number});
+  ex::start(op);
+}
+
+void bulk_unchunked_cannot_be_used_to_change_the_value_type()
+{
+  constexpr int magic_number = 42;
+  constexpr int n            = 2;
+
+  auto sndr = ex::just(magic_number) //
+            | ex::bulk_unchunked(n, [] _CCCL_HOST_DEVICE(int, int) {
+                return function_object_t<int>{nullptr};
+              });
+
+  auto op = ex::connect(cuda::std::move(sndr), checked_value_receiver{magic_number});
+  ex::start(op);
+}
+
+#if _CCCL_HAS_EXCEPTIONS() && !defined(__CUDA_ARCH__)
+void bulk_can_throw_and_set_error_will_be_called()
+{
+  constexpr int n = 2;
+
+  auto sndr = ex::just() //
+            | ex::bulk(ex::par, n, [](int) -> int {
+                throw std::logic_error{"err"};
+              });
+  auto op = ex::connect(cuda::std::move(sndr), checked_error_receiver{});
+  ex::start(op);
+}
+
+void bulk_chunked_can_throw_and_set_error_will_be_called()
+{
+  constexpr int n = 2;
+
+  auto sndr = ex::just() //
+            | ex::bulk_chunked(ex::par, n, [](int, int) -> int {
+                throw std::logic_error{"err"};
+              });
+  auto op = ex::connect(cuda::std::move(sndr), checked_error_receiver{});
+  ex::start(op);
+}
+
+void bulk_unchunked_can_throw_and_set_error_will_be_called()
+{
+  constexpr int n = 2;
+
+  auto sndr = ex::just() //
+            | ex::bulk_unchunked(n, [](int) -> int {
+                throw std::logic_error{"err"};
+              });
+  auto op = ex::connect(cuda::std::move(sndr), checked_error_receiver{});
+  ex::start(op);
+}
+#endif // _CCCL_HAS_EXCEPTIONS() && !defined(__CUDA_ARCH__)
+
+void bulk_function_is_not_called_on_error()
+{
+  constexpr int n = 2;
+  int called{};
+
+  auto sndr = ex::just_error(string{"err"}) //
+            | ex::bulk(ex::par, n, [&called](int) {
+                called++;
+              });
+  auto op = ex::connect(cuda::std::move(sndr), checked_error_receiver{string{"err"}});
+  ex::start(op);
+}
+
+void bulk_chunked_function_is_not_called_on_error()
+{
+  constexpr int n = 2;
+  int called{};
+
+  auto sndr = ex::just_error(string{"err"}) //
+            | ex::bulk_chunked(ex::par, n, [&called](int, int) {
+                called++;
+              });
+  auto op = ex::connect(cuda::std::move(sndr), checked_error_receiver{string{"err"}});
+  ex::start(op);
+}
+
+void bulk_unchunked_function_is_not_called_on_error()
+{
+  constexpr int n = 2;
+  int called{};
+
+  auto sndr = ex::just_error(string{"err"}) //
+            | ex::bulk_unchunked(n, [&called](int) {
+                called++;
+              });
+  auto op = ex::connect(cuda::std::move(sndr), checked_error_receiver{string{"err"}});
+  ex::start(op);
+}
+
+void bulk_function_in_not_called_on_stop()
+{
+  constexpr int n = 2;
+  int called{};
+
+  auto sndr = ex::just_stopped() //
+            | ex::bulk(ex::par, n, [&called](int) {
+                called++;
+              });
+  auto op = ex::connect(cuda::std::move(sndr), checked_stopped_receiver{});
+  ex::start(op);
+}
+
+void bulk_chunked_function_in_not_called_on_stop()
+{
+  constexpr int n = 2;
+  int called{};
+
+  auto sndr = ex::just_stopped() //
+            | ex::bulk_chunked(ex::par, n, [&called](int, int) {
+                called++;
+              });
+  auto op = ex::connect(cuda::std::move(sndr), checked_stopped_receiver{});
+  ex::start(op);
+}
+
+void bulk_unchunked_function_in_not_called_on_stop()
+{
+  constexpr int n = 2;
+  int called{};
+
+  auto sndr = ex::just_stopped() //
+            | ex::bulk_unchunked(n, [&called](int) {
+                called++;
+              });
+  auto op = ex::connect(cuda::std::move(sndr), checked_stopped_receiver{});
+  ex::start(op);
+}
+
+void default_bulk_works_with_non_default_constructible_types()
+{
+  auto s = ex::just(non_default_constructible{42}) //
+         | ex::bulk(ex::par, 1, [] _CCCL_HOST_DEVICE(int, ignore_lvalue_ref) {});
+  ex::sync_wait(cuda::std::move(s));
+}
+
+void default_bulk_chunked_works_with_non_default_constructible_types()
+{
+  auto s = ex::just(non_default_constructible{42}) //
+         | ex::bulk_chunked(ex::par, 1, [] _CCCL_HOST_DEVICE(int, int, ignore_lvalue_ref) {});
+  ex::sync_wait(cuda::std::move(s));
+}
+
+void default_bulk_unchunked_works_with_non_default_constructible_types()
+{
+  auto s = ex::just(non_default_constructible{42}) //
+         | ex::bulk_unchunked(1, [] _CCCL_HOST_DEVICE(int, ignore_lvalue_ref) {});
+  ex::sync_wait(cuda::std::move(s));
+}
+
+#if !defined(__CUDA_ARCH__)
+// TODO: modify these tests to work on device as well
+struct my_domain
+{
+  _CCCL_TEMPLATE(class Sender, class... Env)
+  _CCCL_REQUIRES(ex::sender_for<Sender, ex::bulk_chunked_t>)
+  static auto transform_sender(Sender, const Env&...)
+  {
+    return ex::just(string{"hijacked"});
+  }
+};
+
+void late_customizing_bulk_chunked_also_changes_the_behavior_of_bulk()
+{
+  bool called{false};
+  // The customization will return a different value
+  inline_scheduler<my_domain> sched;
+  auto sndr = ex::just(string{"hello"}) //
+            | ex::continues_on(sched) //
+            | ex::bulk(ex::par, 1, [&called](int, string) {
+                called = true;
+              });
+  wait_for_value(cuda::std::move(sndr), string{"hijacked"});
+  REQUIRE_FALSE(called);
+}
+
+struct my_domain2
+{
+  _CCCL_TEMPLATE(class Sender, class... Env)
+  _CCCL_REQUIRES(ex::sender_for<Sender, ex::bulk_t>)
+  static auto transform_sender(Sender, const Env&...)
+  {
+    return ex::just(string{"hijacked"});
+  }
+};
+
+void bulk_can_be_customized_independently_of_bulk_chunked()
+{
+  bool called{false};
+  // The customization will return a different value
+  inline_scheduler<my_domain2> sched;
+  auto sndr = ex::just(string{"hello"}) //
+            | ex::continues_on(sched) //
+            | ex::bulk(ex::par, 1, [&called](int, string) {
+                called = true;
+              });
+  wait_for_value(cuda::std::move(sndr), string{"hijacked"});
+  REQUIRE_FALSE(called);
+
+  // bulk_chunked will still use the default implementation
+  auto snd2 = ex::just(string{"hello"}) //
+            | ex::continues_on(sched) | ex::bulk_chunked(ex::par, 1, [&called](int, int, string) {
+                called = true;
+              });
+  wait_for_value(cuda::std::move(snd2), string{"hello"});
+  REQUIRE(called);
+}
+#endif // !defined(__CUDA_ARCH__)
+
+namespace
+{
+C2H_TEST("bulk returns a sender", "[adaptors][bulk]")
+{
+  bulk_returns_a_sender();
+}
+
+C2H_TEST("bulk_chunked returns a sender", "[adaptors][bulk]")
+{
+  bulk_chunked_returns_a_sender();
+}
+
+C2H_TEST("bulk_unchunked returns a sender", "[adaptors][bulk]")
+{
+  bulk_unchunked_returns_a_sender();
+}
+
+C2H_TEST("bulk with environment returns a sender", "[adaptors][bulk]")
+{
+  bulk_with_environment_returns_a_sender();
+}
+
+C2H_TEST("bulk_chunked with environment returns a sender", "[adaptors][bulk]")
+{
+  bulk_chunked_with_environment_returns_a_sender();
+}
+
+C2H_TEST("bulk_unchunked with environment returns a sender", "[adaptors][bulk]")
+{
+  bulk_unchunked_with_environment_returns_a_sender();
+}
+
+C2H_TEST("bulk can be piped", "[adaptors][bulk]")
+{
+  bulk_can_be_piped();
+}
+
+C2H_TEST("bulk_chunked can be piped", "[adaptors][bulk]")
+{
+  bulk_chunked_can_be_piped();
+}
+
+C2H_TEST("bulk_unchunked can be piped", "[adaptors][bulk]")
+{
+  bulk_unchunked_can_be_piped();
+}
+
+C2H_TEST("bulk keeps values_type from input sender", "[adaptors][bulk]")
+{
+  bulk_keeps_values_type_from_input_sender();
+}
+
+C2H_TEST("bulk_chunked keeps values_type from input sender", "[adaptors][bulk]")
+{
+  bulk_chunked_keeps_values_type_from_input_sender();
+}
+
+C2H_TEST("bulk_unchunked keeps values_type from input sender", "[adaptors][bulk]")
+{
+  bulk_unchunked_keeps_values_type_from_input_sender();
+}
+
+C2H_TEST("bulk keeps error_types from input sender", "[adaptors][bulk]")
+{
+  bulk_keeps_error_types_from_input_sender();
+}
+
+C2H_TEST("bulk_chunked keeps error_types from input sender", "[adaptors][bulk]")
+{
+  bulk_chunked_keeps_error_types_from_input_sender();
+}
+
+C2H_TEST("bulk_unchunked keeps error_types from input sender", "[adaptors][bulk]")
+{
+  bulk_unchunked_keeps_error_types_from_input_sender();
+}
+
+C2H_TEST("bulk can be used with a function", "[adaptors][bulk]")
+{
+  bulk_can_be_used_with_a_function();
+}
+
+C2H_TEST("bulk_chunked can be used with a function", "[adaptors][bulk]")
+{
+  bulk_chunked_can_be_used_with_a_function();
+}
+
+C2H_TEST("bulk_unchunked can be used with a function", "[adaptors][bulk]")
+{
+  bulk_unchunked_can_be_used_with_a_function();
+}
+
+C2H_TEST("bulk can be used with a function object", "[adaptors][bulk]")
+{
+  bulk_can_be_used_with_a_function_object();
+}
+
+C2H_TEST("bulk_chunked can be used with a function object", "[adaptors][bulk]")
+{
+  bulk_chunked_can_be_used_with_a_function_object();
+}
+
+C2H_TEST("bulk_unchunked can be used with a function object", "[adaptors][bulk]")
+{
+  bulk_unchunked_can_be_used_with_a_function_object();
+}
+
+#if !defined(__CUDA_ARCH__)
+C2H_TEST("bulk can be used with a lambda", "[adaptors][bulk]")
+{
+  bulk_can_be_used_with_a_lambda();
+}
+
+C2H_TEST("bulk_chunked can be used with a lambda", "[adaptors][bulk]")
+{
+  bulk_chunked_can_be_used_with_a_lambda();
+}
+
+C2H_TEST("bulk_unchunked can be used with a lambda", "[adaptors][bulk]")
+{
+  bulk_unchunked_can_be_used_with_a_lambda();
+}
+#endif // !defined(__CUDA_ARCH__)
+
+C2H_TEST("bulk works with all standard execution policies", "[adaptors][bulk]")
+{
+  bulk_works_with_all_standard_execution_policies();
+}
+
+C2H_TEST("bulk_chunked works with all standard execution policies", "[adaptors][bulk]")
+{
+  bulk_chunked_works_with_all_standard_execution_policies();
+}
+
+C2H_TEST("bulk forwards values", "[adaptors][bulk]")
+{
+  bulk_forwards_values();
+}
+
+C2H_TEST("bulk_chunked forwards values", "[adaptors][bulk]")
+{
+  bulk_chunked_forwards_values();
+}
+
+C2H_TEST("bulk_unchunked forwards values", "[adaptors][bulk]")
+{
+  bulk_unchunked_forwards_values();
+}
+
+C2H_TEST("bulk forwards values that can be taken by reference", "[adaptors][bulk]")
+{
+  bulk_forwards_values_that_can_be_taken_by_reference();
+}
+
+C2H_TEST("bulk_chunked forwards values that can be taken by reference", "[adaptors][bulk]")
+{
+  bulk_chunked_forwards_values_that_can_be_taken_by_reference();
+}
+
+C2H_TEST("bulk_unchunked forwards values that can be taken by reference", "[adaptors][bulk]")
+{
+  bulk_unchunked_forwards_values_that_can_be_taken_by_reference();
+}
+
+C2H_TEST("bulk cannot be used to change the value type", "[adaptors][bulk]")
+{
+  bulk_cannot_be_used_to_change_the_value_type();
+}
+
+C2H_TEST("bulk_chunked cannot be used to change the value type", "[adaptors][bulk]")
+{
+  bulk_chunked_cannot_be_used_to_change_the_value_type();
+}
+
+C2H_TEST("bulk_unchunked cannot be used to change the value type", "[adaptors][bulk]")
+{
+  bulk_unchunked_cannot_be_used_to_change_the_value_type();
+}
+
+#if _CCCL_HAS_EXCEPTIONS() && !defined(__CUDA_ARCH__)
+C2H_TEST("bulk can throw, and set_error will be called", "[adaptors][bulk]")
+{
+  bulk_can_throw_and_set_error_will_be_called();
+}
+
+C2H_TEST("bulk_chunked can throw, and set_error will be called", "[adaptors][bulk]")
+{
+  bulk_chunked_can_throw_and_set_error_will_be_called();
+}
+
+C2H_TEST("bulk_unchunked can throw, and set_error will be called", "[adaptors][bulk]")
+{
+  bulk_unchunked_can_throw_and_set_error_will_be_called();
+}
+#endif // _CCCL_HAS_EXCEPTIONS() && !defined(__CUDA_ARCH__)
+
+C2H_TEST("bulk function is not called on error", "[adaptors][bulk]")
+{
+  bulk_function_is_not_called_on_error();
+}
+
+C2H_TEST("bulk_chunked function is not called on error", "[adaptors][bulk]")
+{
+  bulk_chunked_function_is_not_called_on_error();
+}
+
+C2H_TEST("bulk_unchunked function is not called on error", "[adaptors][bulk]")
+{
+  bulk_unchunked_function_is_not_called_on_error();
+}
+
+C2H_TEST("bulk function in not called on stop", "[adaptors][bulk]")
+{
+  bulk_function_in_not_called_on_stop();
+}
+
+C2H_TEST("bulk_chunked function in not called on stop", "[adaptors][bulk]")
+{
+  bulk_chunked_function_in_not_called_on_stop();
+}
+
+C2H_TEST("bulk_unchunked function in not called on stop", "[adaptors][bulk]")
+{
+  bulk_unchunked_function_in_not_called_on_stop();
+}
+
+C2H_TEST("default bulk works with non_default constructible types", "[adaptors][bulk]")
+{
+  default_bulk_works_with_non_default_constructible_types();
+}
+
+C2H_TEST("default bulk_chunked works with non_default constructible types", "[adaptors][bulk]")
+{
+  default_bulk_chunked_works_with_non_default_constructible_types();
+}
+
+C2H_TEST("default bulk_unchunked works with non_default constructible types", "[adaptors][bulk]")
+{
+  default_bulk_unchunked_works_with_non_default_constructible_types();
+}
+
+#if !defined(__CUDA_ARCH__)
+// TODO: modify these tests to work on device as well
+struct my_domain
+{};
+
+C2H_TEST("late customizing bulk_chunked also changes the behavior of bulk", "[adaptors][then]")
+{
+  late_customizing_bulk_chunked_also_changes_the_behavior_of_bulk();
+}
+
+C2H_TEST("bulk can be customized, independently of bulk_chunked", "[adaptors][then]")
+{
+  bulk_can_be_customized_independently_of_bulk_chunked();
+}
+#endif // !defined(__CUDA_ARCH__)
+
+} // namespace

--- a/cudax/test/execution/test_concepts.cu
+++ b/cudax/test/execution/test_concepts.cu
@@ -82,5 +82,5 @@ C2H_TEST("tests for the sender concepts", "[concepts]")
   static_assert(async::sender<read_env_t>);
   static_assert(!async::sender_in<read_env_t>);
   static_assert(!async::sender_in<read_env_t, async::env<>>);
-  static_assert(async::sender_in<read_env_t, async::prop<async::get_scheduler_t, inline_scheduler>>);
+  static_assert(async::sender_in<read_env_t, async::prop<async::get_scheduler_t, inline_scheduler<>>>);
 }

--- a/cudax/test/execution/test_continues_on.cu
+++ b/cudax/test/execution/test_continues_on.cu
@@ -23,7 +23,7 @@ namespace
 {
 C2H_TEST("continues_on simple example", "[adaptors][continues_on]")
 {
-  auto snd = cudax_async::continues_on(cudax_async::just(13), inline_scheduler{});
+  auto snd = cudax_async::continues_on(cudax_async::just(13), inline_scheduler<>{});
   auto op  = cudax_async::connect(std::move(snd), checked_value_receiver{13});
   cudax_async::start(op);
   // The receiver checks if we receive the right value
@@ -121,7 +121,7 @@ C2H_TEST("continues_on works when changing threads", "[adaptors][continues_on]")
 
 C2H_TEST("continues_on can be called with rvalue ref scheduler", "[adaptors][continues_on]")
 {
-  auto snd = cudax_async::continues_on(cudax_async::just(13), inline_scheduler{});
+  auto snd = cudax_async::continues_on(cudax_async::just(13), inline_scheduler<>{});
   auto op  = cudax_async::connect(std::move(snd), checked_value_receiver{13});
   cudax_async::start(op);
   // The receiver checks if we receive the right value
@@ -129,7 +129,7 @@ C2H_TEST("continues_on can be called with rvalue ref scheduler", "[adaptors][con
 
 C2H_TEST("continues_on can be called with const ref scheduler", "[adaptors][continues_on]")
 {
-  const inline_scheduler sched;
+  const inline_scheduler<> sched;
   auto snd = cudax_async::continues_on(cudax_async::just(13), sched);
   auto op  = cudax_async::connect(std::move(snd), checked_value_receiver{13});
   cudax_async::start(op);
@@ -138,7 +138,7 @@ C2H_TEST("continues_on can be called with const ref scheduler", "[adaptors][cont
 
 C2H_TEST("continues_on can be called with ref scheduler", "[adaptors][continues_on]")
 {
-  inline_scheduler sched;
+  inline_scheduler<> sched;
   auto snd = cudax_async::continues_on(cudax_async::just(13), sched);
   auto op  = cudax_async::connect(std::move(snd), checked_value_receiver{13});
   cudax_async::start(op);
@@ -175,7 +175,7 @@ C2H_TEST("continues_on forwards set_stopped calls", "[adaptors][continues_on]")
 
 C2H_TEST("continues_on has the values_type corresponding to the given values", "[adaptors][continues_on]")
 {
-  inline_scheduler sched{};
+  inline_scheduler<> sched{};
 
   check_value_types<types<int>>(cudax_async::continues_on(cudax_async::just(1), sched));
   check_value_types<types<int, double>>(cudax_async::continues_on(cudax_async::just(3, 0.14), sched));
@@ -185,7 +185,7 @@ C2H_TEST("continues_on has the values_type corresponding to the given values", "
 
 C2H_TEST("continues_on keeps error_types from scheduler's sender", "[adaptors][continues_on]")
 {
-  inline_scheduler sched1{};
+  inline_scheduler<> sched1{};
   error_scheduler<std::error_code> sched2{std::make_error_code(std::errc::invalid_argument)};
   error_scheduler<int> sched3{43};
 
@@ -197,7 +197,7 @@ C2H_TEST("continues_on keeps error_types from scheduler's sender", "[adaptors][c
 C2H_TEST("continues_on sends an exception_ptr if value types are potentially throwing when copied",
          "[adaptors][continues_on]")
 {
-  inline_scheduler sched{};
+  inline_scheduler<> sched{};
 
 #if !defined(__CUDA_ARCH__)
   check_error_types<std::exception_ptr>(cudax_async::continues_on(cudax_async::just(potentially_throwing{}), sched));
@@ -209,7 +209,7 @@ C2H_TEST("continues_on sends an exception_ptr if value types are potentially thr
 
 C2H_TEST("continues_on keeps sends_stopped from scheduler's sender", "[adaptors][continues_on]")
 {
-  inline_scheduler sched1{};
+  inline_scheduler<> sched1{};
   error_scheduler<error_code> sched2{error_code{std::errc::invalid_argument}};
   stopped_scheduler sched3{};
 

--- a/cudax/test/execution/test_stream_context.cu
+++ b/cudax/test/execution/test_stream_context.cu
@@ -12,11 +12,17 @@
 #include <cuda/experimental/execution.cuh>
 
 // Then include the test helpers
+#include <thrust/equal.h>
+
+#include <cuda/experimental/container.cuh>
+
 #include <nv/target>
 
 #include "testing.cuh" // IWYU pragma: keep
 
 _CCCL_NV_DIAG_SUPPRESS(177) // function "_is_on_device" was declared but never referenced
+
+namespace ex = cuda::experimental::execution;
 
 namespace
 {
@@ -41,34 +47,34 @@ struct _say_hello
 
 void stream_context_test1()
 {
-  cudax_async::stream_context ctx{cuda::experimental::device_ref{0}};
+  ex::stream_context ctx{cuda::experimental::device_ref{0}};
   auto sched = ctx.get_scheduler();
 
-  auto sndr = cudax_async::schedule(sched) //
-            | cudax_async::then([] __host__ __device__() noexcept -> bool {
+  auto sndr = ex::schedule(sched) //
+            | ex::then([] __host__ __device__() noexcept -> bool {
                 return _is_on_device();
               });
 
-  auto [on_device] = cudax_async::sync_wait(std::move(sndr)).value();
+  auto [on_device] = ex::sync_wait(std::move(sndr)).value();
   CHECK(on_device);
 }
 
 void stream_context_test2()
 {
-  cudax_async::thread_context tctx;
-  cudax_async::stream_context sctx{cuda::experimental::device_ref{0}};
+  ex::thread_context tctx;
+  ex::stream_context sctx{cuda::experimental::device_ref{0}};
   auto sch = sctx.get_scheduler();
 
   auto start = //
-    cudax_async::schedule(sch) // begin work on the GPU
-    | cudax_async::then(_say_hello{42}) // enqueue a function object on the GPU
-    | cudax_async::then([] __device__(int i) noexcept -> int { // enqueue a lambda on the GPU
+    ex::schedule(sch) // begin work on the GPU
+    | ex::then(_say_hello{42}) // enqueue a function object on the GPU
+    | ex::then([] __device__(int i) noexcept -> int { // enqueue a lambda on the GPU
         CUDAX_CHECK(_is_on_device());
         printf("Hello again from lambda on device! i = %d\n", i);
         return i + 1;
       })
-    | cudax_async::continues_on(tctx.get_scheduler()) // continue work on the CPU
-    | cudax_async::then([] __host__ __device__(int i) noexcept -> int { // run a lambda on the CPU
+    | ex::continues_on(tctx.get_scheduler()) // continue work on the CPU
+    | ex::then([] __host__ __device__(int i) noexcept -> int { // run a lambda on the CPU
         CUDAX_CHECK(!_is_on_device());
         NV_IF_TARGET(NV_IS_HOST,
                      (printf("Hello from lambda on host! i = %d\n", i);),
@@ -76,28 +82,28 @@ void stream_context_test2()
         return i;
       });
 
-  // run the cudax_async, wait for it to finish, and get the result
-  auto [i] = cudax_async::sync_wait(std::move(start)).value();
+  // run the ex, wait for it to finish, and get the result
+  auto [i] = ex::sync_wait(std::move(start)).value();
   CHECK(i == 43);
   printf("All done on the host! result = %d\n", i);
 }
 
 void stream_ref_as_scheduler()
 {
-  cudax_async::thread_context tctx;
+  ex::thread_context tctx;
   cudax::stream sctx{cuda::experimental::device_ref{0}};
   auto sch = sctx.get_scheduler();
 
   auto start = //
-    cudax_async::schedule(sch) // begin work on the GPU
-    | cudax_async::then(_say_hello{42}) // enqueue a function object on the GPU
-    | cudax_async::then([] __device__(int i) noexcept -> int { // enqueue a lambda on the GPU
+    ex::schedule(sch) // begin work on the GPU
+    | ex::then(_say_hello{42}) // enqueue a function object on the GPU
+    | ex::then([] __device__(int i) noexcept -> int { // enqueue a lambda on the GPU
         CUDAX_CHECK(_is_on_device());
         printf("Hello again from lambda on device! i = %d\n", i);
         return i + 1;
       })
-    | cudax_async::continues_on(tctx.get_scheduler()) // continue work on the CPU
-    | cudax_async::then([] __host__ __device__(int i) noexcept -> int { // run a lambda on the CPU
+    | ex::continues_on(tctx.get_scheduler()) // continue work on the CPU
+    | ex::then([] __host__ __device__(int i) noexcept -> int { // run a lambda on the CPU
         CUDAX_CHECK(!_is_on_device());
         NV_IF_TARGET(NV_IS_HOST,
                      (printf("Hello from lambda on host! i = %d\n", i);),
@@ -105,10 +111,43 @@ void stream_ref_as_scheduler()
         return i;
       });
 
-  // run the cudax_async, wait for it to finish, and get the result
-  auto [i] = cudax_async::sync_wait(std::move(start)).value();
+  // run the ex, wait for it to finish, and get the result
+  auto [i] = ex::sync_wait(std::move(start)).value();
   CHECK(i == 43);
   printf("All done on the host! result = %d\n", i);
+}
+
+void bulk_on_stream_scheduler()
+{
+  cuda::experimental::device_ref _dev{0};
+  cudax::stream sctx{_dev};
+  auto sch = sctx.get_scheduler();
+
+  using _env_t = cudax::env_t<cuda::mr::device_accessible>;
+  _env_t env{cudax::device_memory_resource{_dev}, cuda::get_stream(sch), ex::par_unseq};
+  cudax::async_device_buffer<int> buf{env, 10, 40}; // a device buffer of 10 integers, initialized to 40
+  cuda::std::span data{buf};
+
+  auto start = //
+    ex::schedule(sch) // begin work on the GPU
+    | ex::then([data] __host__ __device__() -> cuda::std::span<int> {
+        printf("Hello from lambda on device!\n");
+        return data;
+      })
+    // enqueue a bulk kernel on the GPU
+    | ex::bulk(ex::par_unseq, 10, [] __host__ __device__(int i, cuda::std::span<int> data) -> void {
+        printf("Hello from bulk kernel on device! i = %d\n", i);
+        CUDAX_CHECK(_is_on_device());
+        CUDAX_CHECK(i < data.size());
+        data[i] += 2;
+      });
+
+  cudax::async_device_buffer<int> expected{env, 10, 42}; // a device buffer of 10 integers, initialized to 42
+
+  // start the sender and wait for it to finish
+  auto [span] = ex::sync_wait(std::move(start)).value();
+
+  CHECK(thrust::equal(thrust::device, span.begin(), span.end(), expected.begin()));
 }
 
 // Test code is placed in separate functions to avoid an nvc++ issue with
@@ -128,5 +167,10 @@ C2H_TEST("a simple use of the stream context", "[context][stream]")
 C2H_TEST("use stream_ref as a scheduler", "[context][stream]")
 {
   REQUIRE_NOTHROW(stream_ref_as_scheduler());
+}
+
+C2H_TEST("launch a bulk kernel", "[context][stream]")
+{
+  REQUIRE_NOTHROW(bulk_on_stream_scheduler());
 }
 } // namespace


### PR DESCRIPTION
## Description

there isn't any point to a stream scheduler without an algorithm for processing elements in parallel. `bulk` is that algorithm in `std::execution`, and [P3481](https://wg21.link/p3481r3) extends this with `bulk_chunked` and `bulk_unchunked`. this PR ports the implementation for the `bulk` algorithms from stdexec and adds customizations for the new stream scheduler.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
