### PR TITLE
Implement `cudax::demangle`

### DIFF
--- a/cudax/include/cuda/experimental/__binutils/demangle.cuh
+++ b/cudax/include/cuda/experimental/__binutils/demangle.cuh
@@ -1,0 +1,100 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDAX___BINUTILS_DEMANGLE_CUH
+#define _CUDAX___BINUTILS_DEMANGLE_CUH
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#if _CCCL_HOSTED()
+
+#  include <cuda/std/__cstddef/types.h>
+#  include <cuda/std/__exception/exception_macros.h>
+#  include <cuda/std/__host_stdlib/new>
+#  include <cuda/std/__host_stdlib/stdexcept>
+#  include <cuda/std/__type_traits/always_false.h>
+#  include <cuda/std/cstdlib>
+#  include <cuda/std/string_view>
+
+#  include <string>
+
+#  include <cuda/std/__cccl/prologue.h>
+
+// Forward declare the __cu_demangle symbol defined in <nv_decode.h>.
+extern "C" char* __cu_demangle(const char*, char*, size_t*, int*);
+
+namespace cuda::experimental
+{
+// todo: make this function take cuda::std::cstring_view once P3655 is merged to C++29 and implemented in libcu++
+
+//! @brief Demangles a CUDA C++ mangled name.
+//!
+//! @param __name The mangled name to demangle.
+//!
+//! @return A \c std::string containing the demangled name.
+//!
+//! @throws \c std::bad_alloc if memory allocation fails.
+//! @throws \c std::runtime_error if the passed \c __name is not a valid mangled symbol.
+template <class _Dummy = void>
+[[nodiscard]] _CCCL_HOST_API ::std::string demangle([[maybe_unused]] ::cuda::std::string_view __name)
+{
+#  if !__has_include(<nv_decode.h>)
+  static_assert(::cuda::std::__always_false_v<_Dummy>,
+                "cuda::demangle requires the `cuxxfilt` package from the CUDA Toolkit.");
+  return {};
+#  else // ^^^ no cuxxfilt ^^^ / vvv has cuxxfilt vvv
+  // input must be zero-terminated, so we convert string_view to std::string
+  ::std::string __name_in{__name.data(), __name.size()};
+
+  int __status{};
+  char* __dname = ::__cu_demangle(__name_in.c_str(), nullptr, nullptr, &__status);
+
+  _CCCL_TRY
+  {
+    switch (__status)
+    {
+      case 0: {
+        ::std::string __ret{__dname};
+        ::cuda::std::free(__dname);
+        return __ret;
+      }
+      case -1:
+        _CCCL_THROW(::std::bad_alloc);
+      case -2:
+        _CCCL_THROW(::std::runtime_error, "invalid mangled name passed to cuda::demangle function");
+      case -3:
+        _CCCL_VERIFY(false, "cccl internal error - invalid argument passed to __cu_demangle");
+      default:
+        _CCCL_UNREACHABLE();
+    }
+  }
+  _CCCL_CATCH_ALL
+  {
+    // If an exception is thrown, free the allocated memory and rethrow the exception
+    ::cuda::std::free(__dname);
+    _CCCL_RETHROW;
+  }
+#  endif // ^^^ has cuxxfilt ^^^
+}
+} // namespace cuda::experimental
+
+#  include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CCCL_HOSTED()
+
+#endif // _CUDAX___BINUTILS_DEMANGLE_CUH

--- a/cudax/include/cuda/experimental/binutils.cuh
+++ b/cudax/include/cuda/experimental/binutils.cuh
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDAX_BINUTILS
+#define _CUDAX_BINUTILS
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/experimental/__binutils/demangle.cuh>
+
+#endif // _CUDAX_BINUTILS

--- a/cudax/test/CMakeLists.txt
+++ b/cudax/test/CMakeLists.txt
@@ -1,6 +1,17 @@
 cccl_get_c2h()
 cccl_get_cudatoolkit()
 
+# Find the cu++filt library.
+find_library(
+  cudax_cufilt_lib
+  "cufilt"
+  PATHS "${CUDAToolkit_LIBRARY_DIR}"
+  NO_DEFAULT_PATH
+)
+if (NOT cudax_cufilt_lib)
+  message(FATAL_ERROR "cudax: cu++filt library (libcufilt.a) not found.")
+endif()
+
 ## cudax_add_test
 #
 # Add a catch2 test executable and register it with ctest.
@@ -256,6 +267,15 @@ cudax_add_catch2_test(test_target coop.shuffle_down.threads_within_warp
 cudax_add_catch2_test(test_target coop.shuffle_up.threads_within_warp
     coop/shuffle_up/threads_within_warp.cu
 )
+
+# Disable cudax::demangle testing on windows, due to:
+#   error LNK2038: mismatch detected for 'RuntimeLibrary': value 'MT_StaticRelease' doesn't match value
+#                  'MD_DynamicRelease' in catch2_runner.cu.obj
+# This is caused by catch2_runner.cu.obj using dynamic runtime and cu++filt.lib using static runtime.
+if (NOT WIN32)
+  cudax_add_catch2_test(test_target demangle binutils/demangle.cu)
+  target_link_libraries(${test_target} PRIVATE ${cudax_cufilt_lib})
+endif()
 
 if (cudax_ENABLE_CUFILE)
   cudax_add_catch2_test(test_target cufile.driver_attributes

--- a/cudax/test/binutils/demangle.cu
+++ b/cudax/test/binutils/demangle.cu
@@ -1,0 +1,41 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/string_view>
+#include <cuda/std/type_traits>
+
+#include <cuda/experimental/binutils.cuh>
+
+#include <stdexcept>
+#include <string>
+
+#include "testing.cuh"
+
+C2H_TEST("cudax::demangle", "[binutils]")
+{
+  // 1. Test signature
+  static_assert(cuda::std::is_same_v<std::string, decltype(cudax::demangle(cuda::std::string_view{}))>);
+  static_assert(!noexcept(cudax::demangle(cuda::std::string_view{})));
+
+  // 2. Test positive case
+  {
+    constexpr auto real_mangled_name = "_ZN8clstmp01I5cls01E13clstmp01_mf01Ev";
+    const auto demangled             = cudax::demangle(real_mangled_name);
+    REQUIRE(demangled == "clstmp01<cls01>::clstmp01_mf01()");
+  }
+
+  // 3. Test error case
+  {
+#if _CCCL_HAS_EXCEPTIONS()
+    constexpr auto fake_mangled_name = "B@d_iDentiFier";
+    CHECK_THROWS_AS(((void) cudax::demangle(fake_mangled_name)), std::runtime_error);
+#endif // _CCCL_HAS_EXCEPTIONS()
+  }
+}


### PR DESCRIPTION
This PR introduces `demangle` function to `cuda::experimental`. It uses `__cu_demangle` function from `libcufilt.a` library which is required to be linked by the user when using this function.