### PR TITLE
[CUDAX] Add sm_103 traits

### DIFF
--- a/cudax/include/cuda/experimental/__device/arch_traits.cuh
+++ b/cudax/include/cuda/experimental/__device/arch_traits.cuh
@@ -361,6 +361,14 @@ inline constexpr arch_traits_t sm_1000_traits = []() constexpr {
   return __traits;
 }();
 
+inline constexpr arch_traits_t sm_1030_traits = []() constexpr {
+  arch_traits_t __traits            = sm_1000_traits;
+  __traits.compute_capability_major = 10;
+  __traits.compute_capability_minor = 3;
+  __traits.compute_capability       = 1030;
+  return __traits;
+}();
+
 inline constexpr arch_traits_t sm_1200_traits = []() constexpr {
   arch_traits_t __traits{};
   __traits.compute_capability_major             = 12;
@@ -416,6 +424,8 @@ _CCCL_HOST_DEVICE inline constexpr arch_traits_t arch_traits(unsigned int __sm_v
       return __detail::sm_900_traits;
     case 1000:
       return __detail::sm_1000_traits;
+    case 1030:
+      return __detail::sm_1030_traits;
     case 1200:
       return __detail::sm_1200_traits;
     default:

--- a/cudax/test/device/arch_traits.cu
+++ b/cudax/test/device/arch_traits.cu
@@ -46,6 +46,9 @@ template __global__ void arch_specific_kernel_mock_do_not_launch<cudax::arch<800
 template __global__ void arch_specific_kernel_mock_do_not_launch<cudax::arch<860>>();
 template __global__ void arch_specific_kernel_mock_do_not_launch<cudax::arch<890>>();
 template __global__ void arch_specific_kernel_mock_do_not_launch<cudax::arch<900>>();
+template __global__ void arch_specific_kernel_mock_do_not_launch<cudax::arch<1000>>();
+template __global__ void arch_specific_kernel_mock_do_not_launch<cudax::arch<1030>>();
+template __global__ void arch_specific_kernel_mock_do_not_launch<cudax::arch<1200>>();
 
 template <unsigned int Arch>
 void constexpr compare_static_and_dynamic()
@@ -105,6 +108,9 @@ C2H_CCCLRT_TEST("Traits", "[device]")
   compare_static_and_dynamic<860>();
   compare_static_and_dynamic<890>();
   compare_static_and_dynamic<900>();
+  compare_static_and_dynamic<1000>();
+  compare_static_and_dynamic<1030>();
+  compare_static_and_dynamic<1200>();
 
   // Compare arch traits with attributes
   for (const cudax::device& dev : cudax::devices)


### PR DESCRIPTION
We need arch traits for sm_103. According to the table at https://docs.nvidia.com/cuda/cuda-c-programming-guide/#features-and-technical-specifications all sm_10X should have the same traits, so here we just copy sm_100 and update the number.

PR also adds some missing testing for newer arches