### PR TITLE
Avoid deprecated `cudaGetDriverEntryPoint`

### DIFF
--- a/libcudacxx/test/libcudacxx/cuda/barrier/cp_async_bulk_tensor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/barrier/cp_async_bulk_tensor.pass.cpp
@@ -140,6 +140,7 @@ __device__ void test(int base_i, int base_j)
 }
 
 #if !TEST_COMPILER(NVRTC)
+#  if _CCCL_CTK_BELOW(12, 5)
 PFN_cuTensorMapEncodeTiled get_cuTensorMapEncodeTiled()
 {
   void* driver_ptr = nullptr;
@@ -148,7 +149,18 @@ PFN_cuTensorMapEncodeTiled get_cuTensorMapEncodeTiled()
   assert(code == cudaSuccess && "Could not get driver API");
   return reinterpret_cast<PFN_cuTensorMapEncodeTiled>(driver_ptr);
 }
-#endif // ! TEST_COMPILER(NVRTC)
+#  else // ^^^ _CCCL_CTK_BELOW(12, 5) ^^^ / vvv _CCCL_CTK_AT_LEAST(12, 5) vvv
+PFN_cuTensorMapEncodeTiled_v12000 get_cuTensorMapEncodeTiled()
+{
+  void* driver_ptr = nullptr;
+  cudaDriverEntryPointQueryResult driver_status;
+  auto code =
+    cudaGetDriverEntryPointByVersion("cuTensorMapEncodeTiled", &driver_ptr, 12000, cudaEnableDefault, &driver_status);
+  assert(code == cudaSuccess && "Could not get driver API");
+  return reinterpret_cast<PFN_cuTensorMapEncodeTiled_v12000>(driver_ptr);
+}
+#  endif // _CCCL_CTK_AT_LEAST(12, 5)
+#endif // !TEST_COMPILER(NVRTC)
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/cuda/barrier/cp_async_bulk_tensor_generic.h
+++ b/libcudacxx/test/libcudacxx/cuda/barrier/cp_async_bulk_tensor_generic.h
@@ -253,6 +253,7 @@ test(cuda::std::array<uint32_t, num_dims> smem_coord,
 }
 
 #if !TEST_COMPILER(NVRTC)
+#  if _CCCL_CTK_BELOW(12, 5)
 PFN_cuTensorMapEncodeTiled get_cuTensorMapEncodeTiled()
 {
   void* driver_ptr = nullptr;
@@ -261,6 +262,17 @@ PFN_cuTensorMapEncodeTiled get_cuTensorMapEncodeTiled()
   assert(code == cudaSuccess && "Could not get driver API");
   return reinterpret_cast<PFN_cuTensorMapEncodeTiled>(driver_ptr);
 }
+#  else // ^^^ _CCCL_CTK_BELOW(12, 5) ^^^ / vvv _CCCL_CTK_AT_LEAST(12, 5) vvv
+PFN_cuTensorMapEncodeTiled_v12000 get_cuTensorMapEncodeTiled()
+{
+  void* driver_ptr = nullptr;
+  cudaDriverEntryPointQueryResult driver_status;
+  auto code =
+    cudaGetDriverEntryPointByVersion("cuTensorMapEncodeTiled", &driver_ptr, 12000, cudaEnableDefault, &driver_status);
+  assert(code == cudaSuccess && "Could not get driver API");
+  return reinterpret_cast<PFN_cuTensorMapEncodeTiled_v12000>(driver_ptr);
+}
+#  endif // _CCCL_CTK_AT_LEAST(12, 5)
 #endif // !TEST_COMPILER(NVRTC)
 
 #if !TEST_COMPILER(NVRTC)


### PR DESCRIPTION
The old `cudaGetDriverEntryPoint` API is going to be deprecated in a future release, so we need to replace it by the newer `cudaGetDriverEntryPointByVersion`, which however is only available in CTK 12.5

Furthermore the shorthand alias `PFN_cuTensorMapEncodeTiled` has been removed and we need to use the explicit versioned one, which currently is `PFN_cuTensorMapEncodeTiled_12000`

Fixes nvbug5341517
