### PR TITLE
[Backport 3.0] Fix incorrect argument name in thrust openMP cmake file (#5004)

### DIFF
--- a/lib/cmake/thrust/thrust-config.cmake
+++ b/lib/cmake/thrust/thrust-config.cmake
@@ -632,11 +632,11 @@ endmacro()
 function(thrust_fixup_omp_target omp_target)
   get_target_property(opts ${omp_target} INTERFACE_COMPILE_OPTIONS)
   foreach (opt IN LISTS opts)
-    if (opts MATCHES "\\$<\\$<COMPILE_LANGUAGE:CXX>:SHELL:([^>]*)>")
+    if (opt MATCHES "\\$<\\$<COMPILE_LANGUAGE:CXX>:SHELL:([^>]*)>")
       target_compile_options(${omp_target} INTERFACE
         $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:SHELL:-Xcompiler=${CMAKE_MATCH_1}>
       )
-    elseif (opts MATCHES "\\$<\\$<COMPILE_LANGUAGE:CXX>:([^>]*)>")
+    elseif (opt MATCHES "\\$<\\$<COMPILE_LANGUAGE:CXX>:([^>]*)>")
       target_compile_options(${omp_target} INTERFACE
         $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:-Xcompiler=${CMAKE_MATCH_1}>
       )


### PR DESCRIPTION
Fixes #5002
