### PR TITLE
Add load-bearing semicolon for MSVC in openMP sort

### DIFF
--- a/thrust/thrust/system/omp/detail/sort.inl
+++ b/thrust/thrust/system/omp/detail/sort.inl
@@ -130,7 +130,7 @@ void stable_sort(
 
     THRUST_PRAGMA_OMP(barrier)
 
-    // XXX For some reason, MSVC 2015 yields an error unless we include this meaningless semicolon here
+    // #5020: For some reason, MSVC may yield an error unless we include this meaningless semicolon here
     ;
 
     IndexType nseg = decomp.size();
@@ -159,6 +159,9 @@ void stable_sort(
       h *= 2;
 
       THRUST_PRAGMA_OMP(barrier)
+
+      // #5020: For some reason, MSVC may yield an error unless we include this meaningless semicolon here
+      ;
     }
   }
 #endif // THRUST_DEVICE_COMPILER_IS_OMP_CAPABLE
@@ -214,7 +217,7 @@ void stable_sort_by_key(
 
     THRUST_PRAGMA_OMP(barrier)
 
-    // XXX For some reason, MSVC 2015 yields an error unless we include this meaningless semicolon here
+    // #5020: For some reason, MSVC may yield an error unless we include this meaningless semicolon here
     ;
 
     IndexType nseg = decomp.size();
@@ -248,6 +251,9 @@ void stable_sort_by_key(
       h *= 2;
 
       THRUST_PRAGMA_OMP(barrier)
+
+      // #5020: For some reason, MSVC may yield an error unless we include this meaningless semicolon here
+      ;
     }
   }
 #endif // THRUST_DEVICE_COMPILER_IS_OMP_CAPABLE


### PR DESCRIPTION
Fixes [BUG]: Can't compile use of thrust::omp::par execution policy with CUDA 12.8 and MSVC 2022 #5020
