### PR TITLE
[EXPERIMENT] Try to remove `__device__` from _CCCL_GLOBAL_CONSTANT

### DIFF
--- a/libcudacxx/include/cuda/std/__cccl/dialect.h
+++ b/libcudacxx/include/cuda/std/__cccl/dialect.h
@@ -109,7 +109,7 @@
 
 // We need to treat host and device separately
 #if _CCCL_DEVICE_COMPILATION() && !_CCCL_CUDA_COMPILER(NVHPC)
-#  define _CCCL_GLOBAL_CONSTANT _CCCL_DEVICE constexpr
+#  define _CCCL_GLOBAL_CONSTANT constexpr
 #else // ^^^ _CCCL_DEVICE_COMPILATION() && !_CCCL_CUDA_COMPILER(NVHPC) ^^^ /
       // vvv !_CCCL_DEVICE_COMPILATION() || _CCCL_CUDA_COMPILER(NVHPC) vvv
 #  define _CCCL_GLOBAL_CONSTANT inline constexpr


### PR DESCRIPTION
## Description

Using `__device__ constexpr` causes a compilation error with MSVC that prevents `<cuda/std/numbers>` usage.
This PR tries the experiment of removing  `__device__`