### PR TITLE
Optimize `cuda::minimum/maximum` for `float`, `double`, `__half`, `__nv_bfloat16`, `__float128`

### DIFF
--- a/libcudacxx/include/cuda/__functional/minimum.h
+++ b/libcudacxx/include/cuda/__functional/minimum.h
@@ -21,7 +21,12 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+
 #include <cuda/std/__type_traits/common_type.h>
+#include <cuda/std/__type_traits/is_constant_evaluated.h>
+#include <cuda/std/__type_traits/is_same.h>
 
 #include <cuda/std/__cccl/prologue.h>
 
@@ -34,6 +39,31 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT minimum
   [[nodiscard]] _CCCL_API constexpr _Tp operator()(const _Tp& __lhs, const _Tp& __rhs) const
     noexcept(noexcept((__lhs < __rhs) ? __lhs : __rhs))
   {
+    if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
+    {
+      if constexpr (_CUDA_VSTD::is_same_v<_Tp, float>)
+      {
+        NV_IF_TARGET(NV_IS_DEVICE, (return ::fminf(__lhs, __rhs);))
+      }
+      else if constexpr (_CUDA_VSTD::is_same_v<_Tp, double>)
+      {
+        NV_IF_TARGET(NV_IS_DEVICE, (return ::fmin(__lhs, __rhs);))
+      }
+      else if constexpr (_CUDA_VSTD::is_same_v<_Tp, __half>)
+      {
+        NV_IF_TARGET(NV_PROVIDES_SM_53, (return ::__hmin(__lhs, __rhs);))
+      }
+      else if constexpr (_CUDA_VSTD::is_same_v<_Tp, __nv_bfloat16>)
+      {
+        NV_IF_TARGET(NV_PROVIDES_SM_80, (return ::__hmin(__lhs, __rhs);))
+      }
+#if _CCCL_HAS_FLOAT128()
+      else if constexpr (_CUDA_VSTD::is_same_v<_Tp, __float128>)
+      {
+        NV_IF_TARGET(NV_PROVIDES_SM_80, (return ::__nv_fp128_fmin(__lhs, __rhs);))
+      }
+#endif
+    }
     return (__lhs < __rhs) ? __lhs : __rhs;
   }
 };

--- a/libcudacxx/test/libcudacxx/cuda/functional/maximum.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/functional/maximum.pass.cpp
@@ -32,12 +32,31 @@ __host__ __device__ constexpr bool test()
          test<int>(1, 0, 1) && //
          test<int>(0, 0, 0) && //
          test<int>(-1, 1, 1) && //
-         test<char>('a', 'b', 'b');
+         test<char>('a', 'b', 'b') && //
+         test<float>(1.0f, 2.0f, 2.0f) && //
+         test<double>(1.0f, 2.0f, 2.0f)
+#if _CCCL_HAS_FLOAT128()
+      && test<__float128>(__float128(1.0f), __float128(2.0f), __float128(2.0f))
+#endif
+    ;
+}
+
+__host__ __device__ bool runtime_test()
+{
+  return true
+#if _CCCL_HAS_NVFP16
+      && test<__half>(__half(1.0f), __half(2.0f), __half(2.0f))
+#endif
+#if _CCCL_HAS_NVBF16()
+      && test<__nv_bfloat16>(__nv_bfloat16(1.0f), __nv_bfloat16(2.0f), __nv_bfloat16(2.0f))
+#endif
+    ;
 }
 
 int main(int, char**)
 {
   assert(test());
-  static_assert(test(), "");
+  assert(runtime_test());
+  static_assert(test());
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/cuda/functional/minimum.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/functional/minimum.pass.cpp
@@ -32,12 +32,31 @@ __host__ __device__ constexpr bool test()
          test<int>(1, 0, 0) && //
          test<int>(0, 0, 0) && //
          test<int>(-1, 1, -1) && //
-         test<char>('a', 'b', 'a');
+         test<char>('a', 'b', 'a') && //
+         test<float>(1.0f, 2.0f, 1.0f) && //
+         test<double>(1.0f, 2.0f, 1.0f)
+#if _CCCL_HAS_FLOAT128()
+      && test<__float128>(__float128(1.0f), __float128(2.0f), __float128(1.0f))
+#endif
+    ;
+}
+
+__host__ __device__ bool runtime_test()
+{
+  return true
+#if _CCCL_HAS_NVFP16
+      && test<__half>(__half(1.0f), __half(2.0f), __half(1.0f))
+#endif
+#if _CCCL_HAS_NVBF16()
+      && test<__nv_bfloat16>(__nv_bfloat16(1.0f), __nv_bfloat16(2.0f), __nv_bfloat16(1.0f))
+#endif
+    ;
 }
 
 int main(int, char**)
 {
-  test();
-  static_assert(test(), "");
+  assert(test());
+  assert(runtime_test());
+  static_assert(test());
   return 0;
 }


### PR DESCRIPTION
## Description

`cuda::minimum/maximum` is implemented as `a < b ? a : b`. On the other hand, it produces non-optimal code for device code.
This PR adds the specializations for `float`, `double`, `__half`, `__nv_bfloat16`, `__float128`.

I was tempted to add support for vector types but the semantic is ambiguous, e.g. 
`a.x < b.x ? a : (a.y < b.y ? a : b)` or 
`T{a.x < b.x ? a.x, a.y < b.y ? a.y : b.y}`