### PR TITLE
[CUDAX] Add an event constructor taking a device_ref

### DIFF
--- a/cudax/include/cuda/experimental/__event/event.cuh
+++ b/cudax/include/cuda/experimental/__event/event.cuh
@@ -62,6 +62,14 @@ public:
     record(__stream);
   }
 
+  //! @brief Construct a new `event` object with timing disabled. The event can only be recorded on streams from the
+  //! specified device.
+  //!
+  //! @throws cuda_error if the event creation fails.
+  explicit event(device_ref __device, flags __flags = flags::none)
+      : event(__device, static_cast<unsigned int>(__flags) | cudaEventDisableTiming)
+  {}
+
   //! @brief Construct a new `event` object into the moved-from state.
   //!
   //! @post `get()` returns `cudaEvent_t()`.
@@ -155,6 +163,14 @@ private:
       : event_ref(::cudaEvent_t{})
   {
     [[maybe_unused]] __ensure_current_device __dev_setter(__stream);
+    _CCCL_TRY_CUDA_API(
+      ::cudaEventCreateWithFlags, "Failed to create CUDA event", &__event_, static_cast<unsigned int>(__flags));
+  }
+
+  explicit event(device_ref __device, unsigned int __flags)
+      : event_ref(::cudaEvent_t{})
+  {
+    [[maybe_unused]] __ensure_current_device __dev_setter(__device);
     _CCCL_TRY_CUDA_API(
       ::cudaEventCreateWithFlags, "Failed to create CUDA event", &__event_, static_cast<unsigned int>(__flags));
   }

--- a/cudax/include/cuda/experimental/__event/timed_event.cuh
+++ b/cudax/include/cuda/experimental/__event/timed_event.cuh
@@ -49,6 +49,14 @@ public:
     record(__stream);
   }
 
+  //! @brief Construct a new `timed_event` object with the specified flags. The event can only be recorded on streams
+  //! from the specified device.
+  //!
+  //! @throws cuda_error if the event creation fails.
+  explicit timed_event(device_ref __device, flags __flags = flags::none)
+      : event(__device, static_cast<unsigned int>(__flags))
+  {}
+
   //! @brief Construct a new `timed_event` object into the moved-from state.
   //!
   //! @post `get()` returns `cudaEvent_t()`.

--- a/cudax/test/event/event_smoke.cu
+++ b/cudax/test/event/event_smoke.cu
@@ -94,6 +94,17 @@ C2H_CCCLRT_TEST("can construct an event with a stream_ref", "[event]")
   CUDAX_REQUIRE(ev.get() != ::cudaEvent_t{});
 }
 
+C2H_CCCLRT_TEST("can construct an event with a device_ref", "[event]")
+{
+  cudax::device_ref device{0};
+  cudax::event ev(device);
+  CUDAX_REQUIRE(ev.get() != ::cudaEvent_t{});
+  cudax::stream stream{device};
+  ev.record(stream);
+  ev.sync();
+  CUDAX_REQUIRE(ev.is_done());
+}
+
 C2H_CCCLRT_TEST("can wait on an event", "[event]")
 {
   cudax::stream stream{cudax::device_ref{0}};


### PR DESCRIPTION
Currently event can only be constructed with a stream and it comes pre-recorded into that stream. This PR adds an event constructor taking `device_ref` to produce an event not recorded to any stream.
Hopefully in the future it would be possible to create an event not tied to a specific device, but until then construction from `device_ref` is the best we can do.