### PR TITLE
rename the `get_domain_late` query to `get_domain_override` per WG21

### DIFF
--- a/cudax/include/cuda/experimental/__execution/domain.cuh
+++ b/cudax/include/cuda/experimental/__execution/domain.cuh
@@ -157,18 +157,18 @@ struct get_domain_t
 _CCCL_GLOBAL_CONSTANT get_domain_t get_domain{};
 
 // Used by the schedule_from and continues_on senders
-struct get_domain_late_t
+struct get_domain_override_t
 {
   _CCCL_EXEC_CHECK_DISABLE
   template <class _Env>
   [[nodiscard]] _CCCL_API constexpr auto operator()(const _Env&) const noexcept
-    -> __query_result_t<_Env, get_domain_late_t>
+    -> __query_result_t<_Env, get_domain_override_t>
   {
     return {};
   }
 };
 
-_CCCL_GLOBAL_CONSTANT get_domain_late_t get_domain_late{};
+_CCCL_GLOBAL_CONSTANT get_domain_override_t get_domain_override{};
 
 namespace __detail
 {
@@ -194,9 +194,9 @@ _CCCL_TRIVIAL_API constexpr auto __get_domain_late() noexcept
   // If the sender is a continues_on or schedule_from sender, we check with the sender for
   // its domain. If it does not provide one, we fall back to using the domain from the
   // receiver's environment.
-  if constexpr (__queryable_with<env_of_t<_Sndr>, get_domain_late_t>)
+  if constexpr (__queryable_with<env_of_t<_Sndr>, get_domain_override_t>)
   {
-    using __late_domain_t _CCCL_NODEBUG_ALIAS = __query_result_t<env_of_t<_Sndr>, get_domain_late_t>;
+    using __late_domain_t _CCCL_NODEBUG_ALIAS = __query_result_t<env_of_t<_Sndr>, get_domain_override_t>;
     return _CUDA_VSTD::_If<_CUDA_VSTD::is_same_v<__late_domain_t, __nil>, __env_domain_t, __late_domain_t>{};
   }
   else

--- a/cudax/include/cuda/experimental/__execution/fwd.cuh
+++ b/cudax/include/cuda/experimental/__execution/fwd.cuh
@@ -178,7 +178,7 @@ struct get_forward_progress_guarantee_t;
 template <class _Tag>
 struct get_completion_scheduler_t;
 struct get_domain_t;
-struct get_domain_late_t;
+struct get_domain_override_t;
 
 // get_forward_progress_guarantee:
 enum class forward_progress_guarantee

--- a/cudax/include/cuda/experimental/__execution/schedule_from.cuh
+++ b/cudax/include/cuda/experimental/__execution/schedule_from.cuh
@@ -106,13 +106,13 @@ struct __transfer_sndr_t
     // the sender.
     _CCCL_TEMPLATE(class _LateDomain = __late_domain_t)
     _CCCL_REQUIRES((!_CUDA_VSTD::same_as<_LateDomain, __nil>) )
-    [[nodiscard]] _CCCL_API static constexpr auto query(get_domain_late_t) noexcept -> _LateDomain
+    [[nodiscard]] _CCCL_API static constexpr auto query(get_domain_override_t) noexcept -> _LateDomain
     {
       return {};
     }
 
-    // The following overload will not be considered when _Query is get_domain_late_t
-    // because get_domain_late_t is not a forwarding query.
+    // The following overload will not be considered when _Query is get_domain_override_t
+    // because get_domain_override_t is not a forwarding query.
     _CCCL_TEMPLATE(class _Query)
     _CCCL_REQUIRES(__forwarding_query<_Query> _CCCL_AND __queryable_with<env_of_t<_Sndr>, _Query>)
     [[nodiscard]] _CCCL_API constexpr auto query(_Query) const

--- a/cudax/include/cuda/experimental/__execution/stream/adaptor.cuh
+++ b/cudax/include/cuda/experimental/__execution/stream/adaptor.cuh
@@ -338,7 +338,7 @@ struct __attrs_t
 {
   // This makes sure that when `connect` calls `transform_sender`, it will use the stream
   // domain to find a customization.
-  [[nodiscard]] _CCCL_TRIVIAL_API static constexpr auto query(get_domain_late_t) noexcept -> stream_domain
+  [[nodiscard]] _CCCL_TRIVIAL_API static constexpr auto query(get_domain_override_t) noexcept -> stream_domain
   {
     return {};
   }

--- a/cudax/include/cuda/experimental/__execution/stream/scheduler.cuh
+++ b/cudax/include/cuda/experimental/__execution/stream/scheduler.cuh
@@ -78,7 +78,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT stream_scheduler
       return {};
     }
 
-    [[nodiscard]] _CCCL_TRIVIAL_API static constexpr auto query(get_domain_late_t) noexcept -> stream_domain
+    [[nodiscard]] _CCCL_TRIVIAL_API static constexpr auto query(get_domain_override_t) noexcept -> stream_domain
     {
       return {};
     }


### PR DESCRIPTION
## Description

this is a simple rename of the query `get_domain_late` to `get_domain_override` as requested by the C++ Committee.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
