### PR TITLE
Refactor around `thrust::vector`

### DIFF
--- a/thrust/thrust/detail/type_traits/is_thrust_pointer.h
+++ b/thrust/thrust/detail/type_traits/is_thrust_pointer.h
@@ -52,8 +52,7 @@ struct pointer_raw_pointer : pointer_traits_detail::pointer_raw_pointer_impl<T>
 // this could be a lot better, but for our purposes, it's probably
 // sufficient just to check if pointer_raw_pointer<T> has meaning
 template <typename T>
-struct is_thrust_pointer : is_metafunction_defined<pointer_raw_pointer<T>>
-{};
+inline constexpr bool is_thrust_pointer_v = is_metafunction_defined<pointer_raw_pointer<T>>::value;
 
 } // namespace detail
 

--- a/thrust/thrust/detail/type_traits/pointer_traits.h
+++ b/thrust/thrust/detail/type_traits/pointer_traits.h
@@ -306,14 +306,14 @@ struct is_void_pointer_system_convertible
 // avoid inspecting traits of the arguments if they aren't known to be pointers
 template <typename FromPtr, typename ToPtr>
 struct lazy_is_pointer_convertible
-    : thrust::detail::eval_if<is_thrust_pointer<FromPtr>::value && is_thrust_pointer<ToPtr>::value,
+    : thrust::detail::eval_if<is_thrust_pointer_v<FromPtr> && is_thrust_pointer_v<ToPtr>,
                               is_pointer_convertible<FromPtr, ToPtr>,
                               ::cuda::std::type_identity<thrust::detail::false_type>>
 {};
 
 template <typename FromPtr, typename ToPtr>
 struct lazy_is_void_pointer_system_convertible
-    : thrust::detail::eval_if<is_thrust_pointer<FromPtr>::value && is_thrust_pointer<ToPtr>::value,
+    : thrust::detail::eval_if<is_thrust_pointer_v<FromPtr> && is_thrust_pointer_v<ToPtr>,
                               is_void_pointer_system_convertible<FromPtr, ToPtr>,
                               ::cuda::std::type_identity<thrust::detail::false_type>>
 {};

--- a/thrust/thrust/detail/vector_base.h
+++ b/thrust/thrust/detail/vector_base.h
@@ -525,13 +525,6 @@ protected:
   size_type m_size;
 
 private:
-  // these methods resolve the ambiguity of the constructor template of form (Iterator, Iterator)
-  template <typename IteratorOrIntegralType>
-  void init_dispatch(IteratorOrIntegralType begin, IteratorOrIntegralType end, false_type);
-
-  template <typename IteratorOrIntegralType>
-  void init_dispatch(IteratorOrIntegralType n, IteratorOrIntegralType value, true_type);
-
   template <typename InputIterator>
   void range_init(InputIterator first, InputIterator last);
 
@@ -558,14 +551,6 @@ private:
   // this method performs insertion from a range
   template <typename InputIterator>
   void copy_insert(iterator position, InputIterator first, InputIterator last);
-
-  // these methods resolve the ambiguity of the assign() template of form (InputIterator, InputIterator)
-  template <typename InputIterator>
-  void assign_dispatch(InputIterator first, InputIterator last, false_type);
-
-  // these methods resolve the ambiguity of the assign() template of form (InputIterator, InputIterator)
-  template <typename Integral>
-  void assign_dispatch(Integral n, Integral x, true_type);
 
   // this method performs assignment from a range
   template <typename InputIterator>

--- a/thrust/thrust/system/cuda/detail/internal/copy_device_to_device.h
+++ b/thrust/thrust/system/cuda/detail/internal/copy_device_to_device.h
@@ -40,12 +40,12 @@
 #if _CCCL_HAS_CUDA_COMPILER()
 #  include <thrust/system/cuda/config.h>
 
-#  include <thrust/distance.h>
-#  include <thrust/functional.h>
 #  include <thrust/system/cuda/detail/execution_policy.h>
 #  include <thrust/system/cuda/detail/transform.h>
 #  include <thrust/system/cuda/detail/util.h>
 #  include <thrust/type_traits/is_trivially_relocatable.h>
+
+#  include <cuda/std/iterator>
 
 THRUST_NAMESPACE_BEGIN
 namespace cuda_cub
@@ -58,38 +58,29 @@ transform(execution_policy<Derived>& policy, InputIt first, InputIt last, Output
 namespace __copy
 {
 template <class Derived, class InputIt, class OutputIt>
-OutputIt THRUST_RUNTIME_FUNCTION device_to_device(
-  execution_policy<Derived>& policy, InputIt first, InputIt last, OutputIt result, thrust::detail::true_type)
-{
-  using InputTy = thrust::detail::it_value_t<InputIt>;
-  const auto n  = ::cuda::std::distance(first, last);
-  if (n > 0)
-  {
-    cudaError status;
-    status = trivial_copy_device_to_device(
-      policy,
-      reinterpret_cast<InputTy*>(thrust::raw_pointer_cast(&*result)),
-      reinterpret_cast<InputTy const*>(thrust::raw_pointer_cast(&*first)),
-      n);
-    cuda_cub::throw_on_error(status, "__copy:: D->D: failed");
-  }
-
-  return result + n;
-}
-
-template <class Derived, class InputIt, class OutputIt>
-OutputIt THRUST_RUNTIME_FUNCTION device_to_device(
-  execution_policy<Derived>& policy, InputIt first, InputIt last, OutputIt result, thrust::detail::false_type)
-{
-  return cuda_cub::transform(policy, first, last, result, ::cuda::std::identity{});
-}
-
-template <class Derived, class InputIt, class OutputIt>
 OutputIt THRUST_RUNTIME_FUNCTION
 device_to_device(execution_policy<Derived>& policy, InputIt first, InputIt last, OutputIt result)
 {
-  return device_to_device(
-    policy, first, last, result, typename is_indirectly_trivially_relocatable_to<InputIt, OutputIt>::type());
+  if constexpr (is_indirectly_trivially_relocatable_to<InputIt, OutputIt>::value)
+  {
+    using InputTy = thrust::detail::it_value_t<InputIt>;
+    const auto n  = ::cuda::std::distance(first, last);
+    if (n > 0)
+    {
+      const cudaError status = trivial_copy_device_to_device(
+        policy,
+        reinterpret_cast<InputTy*>(thrust::raw_pointer_cast(&*result)),
+        reinterpret_cast<InputTy const*>(thrust::raw_pointer_cast(&*first)),
+        n);
+      cuda_cub::throw_on_error(status, "__copy:: D->D: failed");
+    }
+
+    return result + n;
+  }
+  else
+  {
+    return cuda_cub::transform(policy, first, last, result, ::cuda::std::identity{});
+  }
 }
 } // namespace __copy
 

--- a/thrust/thrust/type_traits/is_contiguous_iterator.h
+++ b/thrust/thrust/type_traits/is_contiguous_iterator.h
@@ -161,7 +161,7 @@ template <typename Iterator>
 struct is_contiguous_iterator_impl
     : integral_constant<
         bool,
-        ::cuda::std::contiguous_iterator<Iterator> || is_thrust_pointer<Iterator>::value
+        ::cuda::std::contiguous_iterator<Iterator> || is_thrust_pointer_v<Iterator>
           || is_libcxx_wrap_iter<Iterator>::value || is_libstdcxx_normal_iterator<Iterator>::value
           || is_msvc_contiguous_iterator<Iterator>::value || proclaim_contiguous_iterator<Iterator>::value>
 {};

--- a/thrust/thrust/type_traits/is_contiguous_iterator.h
+++ b/thrust/thrust/type_traits/is_contiguous_iterator.h
@@ -44,46 +44,6 @@ THRUST_NAMESPACE_BEGIN
 /*! \addtogroup type_traits Type Traits
  *  \{
  */
-
-/*! \cond
- */
-
-namespace detail
-{
-
-template <typename Iterator>
-struct is_contiguous_iterator_impl;
-
-} // namespace detail
-
-/*! \endcond
- */
-
-/*! \brief <a href="https://en.cppreference.com/w/cpp/named_req/UnaryTypeTrait"><i>UnaryTypeTrait</i></a>
- *  that returns \c true_type if \c Iterator satisfies
- *  <a href="https://en.cppreference.com/w/cpp/named_req/ContiguousIterator">ContiguousIterator</a>,
- *  aka it points to elements that are contiguous in memory, and \c false_type
- *  otherwise.
- *
- * \see is_contiguous_iterator_v
- * \see proclaim_contiguous_iterator
- * \see THRUST_PROCLAIM_CONTIGUOUS_ITERATOR
- */
-template <typename Iterator>
-using is_contiguous_iterator = detail::is_contiguous_iterator_impl<Iterator>;
-
-/*! \brief <tt>constexpr bool</tt> that is \c true if \c Iterator satisfies
- *  <a href="https://en.cppreference.com/w/cpp/named_req/ContiguousIterator">ContiguousIterator</a>,
- *  aka it points to elements that are contiguous in memory, and \c false
- *  otherwise.
- *
- * \see is_contiguous_iterator
- * \see proclaim_contiguous_iterator
- * \see THRUST_PROCLAIM_CONTIGUOUS_ITERATOR
- */
-template <typename Iterator>
-constexpr bool is_contiguous_iterator_v = is_contiguous_iterator<Iterator>::value;
-
 /*! \brief Customization point that can be customized to indicate that an
  *  iterator type \c Iterator satisfies
  *  <a href="https://en.cppreference.com/w/cpp/named_req/ContiguousIterator">ContiguousIterator</a>,
@@ -116,60 +76,71 @@ struct proclaim_contiguous_iterator : false_type
 
 namespace detail
 {
-
 template <typename Iterator>
-struct is_libcxx_wrap_iter : false_type
-{};
+inline constexpr bool is_libcxx_wrap_iter_v = false;
 
 #if defined(_LIBCPP_VERSION)
 template <typename Iterator>
-struct is_libcxx_wrap_iter<
+inline constexpr bool is_libcxx_wrap_iter_v<
 #  if _LIBCPP_VERSION < 14000
   _VSTD::__wrap_iter<Iterator>
 #  else
   std::__wrap_iter<Iterator>
 #  endif
-  > : true_type
-{};
+  > = true;
 #endif
 
 template <typename Iterator>
-struct is_libstdcxx_normal_iterator : false_type
-{};
+inline constexpr bool is_libstdcxx_normal_iterator_v = false;
 
 #if defined(__GLIBCXX__)
 template <typename Iterator, typename Container>
-struct is_libstdcxx_normal_iterator<::__gnu_cxx::__normal_iterator<Iterator, Container>> : true_type
-{};
+inline constexpr bool is_libstdcxx_normal_iterator_v<::__gnu_cxx::__normal_iterator<Iterator, Container>> = true;
 #endif
 
 #if _CCCL_COMPILER(MSVC)
-
 template <typename Iterator>
-struct is_msvc_contiguous_iterator : ::cuda::std::is_pointer<::std::_Unwrapped_t<Iterator>>
-{};
-
+inline constexpr bool is_msvc_contiguous_iterator_v = ::cuda::std::is_pointer_v<::std::_Unwrapped_t<Iterator>>;
 #else
-
 template <typename Iterator>
-struct is_msvc_contiguous_iterator : false_type
-{};
-
+inline constexpr bool is_msvc_contiguous_iterator_v = false;
 #endif
 
 template <typename Iterator>
-struct is_contiguous_iterator_impl
-    : integral_constant<
-        bool,
-        ::cuda::std::contiguous_iterator<Iterator> || is_thrust_pointer_v<Iterator>
-          || is_libcxx_wrap_iter<Iterator>::value || is_libstdcxx_normal_iterator<Iterator>::value
-          || is_msvc_contiguous_iterator<Iterator>::value || proclaim_contiguous_iterator<Iterator>::value>
-{};
+inline constexpr bool is_contiguous_iterator_impl_v =
+  ::cuda::std::contiguous_iterator<Iterator> || is_thrust_pointer_v<Iterator> || is_libcxx_wrap_iter_v<Iterator>
+  || is_libstdcxx_normal_iterator_v<Iterator> || is_msvc_contiguous_iterator_v<Iterator>
+  || proclaim_contiguous_iterator<Iterator>::value;
 
 } // namespace detail
 
 /*! \endcond
  */
+
+/*! \brief <a href="https://en.cppreference.com/w/cpp/named_req/UnaryTypeTrait"><i>UnaryTypeTrait</i></a>
+ *  that returns \c true_type if \c Iterator satisfies
+ *  <a href="https://en.cppreference.com/w/cpp/named_req/ContiguousIterator">ContiguousIterator</a>,
+ *  aka it points to elements that are contiguous in memory, and \c false_type
+ *  otherwise.
+ *
+ * \see is_contiguous_iterator_v
+ * \see proclaim_contiguous_iterator
+ * \see THRUST_PROCLAIM_CONTIGUOUS_ITERATOR
+ */
+template <typename Iterator>
+using is_contiguous_iterator = ::cuda::std::bool_constant<detail::is_contiguous_iterator_impl_v<Iterator>>;
+
+/*! \brief <tt>constexpr bool</tt> that is \c true if \c Iterator satisfies
+ *  <a href="https://en.cppreference.com/w/cpp/named_req/ContiguousIterator">ContiguousIterator</a>,
+ *  aka it points to elements that are contiguous in memory, and \c false
+ *  otherwise.
+ *
+ * \see is_contiguous_iterator
+ * \see proclaim_contiguous_iterator
+ * \see THRUST_PROCLAIM_CONTIGUOUS_ITERATOR
+ */
+template <typename Iterator>
+constexpr bool is_contiguous_iterator_v = detail::is_contiguous_iterator_impl_v<Iterator>;
 
 ///////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
This PR tries to avoid some template instantiations around `thrust::vector`.