### PR TITLE
Port `std::modf` and `std::fmod`

### DIFF
--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -414,6 +414,19 @@
 #  define _CCCL_BUILTIN_FMINL(...) __builtin_fminl(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(builtin_fmin)
 
+#if _CCCL_CHECK_BUILTIN(builtin_fmod) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_FMODF(...) __builtin_fmodf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_FMOD(...)  __builtin_fmod(__VA_ARGS__)
+#  define _CCCL_BUILTIN_FMODL(...) __builtin_fmodl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_fmod)
+
+// clang-cuda fails with fatal error: error in backend: Undefined external symbol "modf"
+#if _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_FMODF
+#  undef _CCCL_BUILTIN_FMOD
+#  undef _CCCL_BUILTIN_FMODL
+#endif // _CCCL_CUDA_COMPILER(CLANG)
+
 #if _CCCL_HAS_BUILTIN(__builtin_FILE) || _CCCL_COMPILER(GCC) || _CCCL_COMPILER(MSVC, >=, 19, 27)
 #  define _CCCL_BUILTIN_FILE() __builtin_FILE()
 #else // ^^^ _CCCL_HAS_BUILTIN(__builtin_FILE) ^^^ / vvv !_CCCL_HAS_BUILTIN(__builtin_FILE) vvv
@@ -610,12 +623,24 @@
 #  define _CCCL_BUILTIN_LROUNDL(...) __builtin_lroundl(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(builtin_lround)
 
-// Below 11.7 nvcc treats the builtin as a host only function
 // clang-cuda fails with fatal error: error in backend: Undefined external symbol "lround"
 #if _CCCL_CUDA_COMPILER(CLANG)
 #  undef _CCCL_BUILTIN_LROUNDF
 #  undef _CCCL_BUILTIN_LROUND
 #  undef _CCCL_BUILTIN_LROUNDL
+#endif // _CCCL_CUDA_COMPILER(CLANG)
+
+#if _CCCL_CHECK_BUILTIN(builtin_modf) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_MODFF(...) __builtin_modff(__VA_ARGS__)
+#  define _CCCL_BUILTIN_MODF(...)  __builtin_modf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_MODFL(...) __builtin_modfl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_modf)
+
+// clang-cuda fails with fatal error: error in backend: Undefined external symbol "modf"
+#if _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_MODFF
+#  undef _CCCL_BUILTIN_MODF
+#  undef _CCCL_BUILTIN_MODFL
 #endif // _CCCL_CUDA_COMPILER(CLANG)
 
 #if _CCCL_CHECK_BUILTIN(builtin_nanf) || _CCCL_COMPILER(MSVC) || _CCCL_COMPILER(GCC, <, 10)

--- a/libcudacxx/include/cuda/std/__cmath/modulo.h
+++ b/libcudacxx/include/cuda/std/__cmath/modulo.h
@@ -85,14 +85,14 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 #if _LIBCUDACXX_HAS_NVFP16()
 [[nodiscard]] _CCCL_API inline __half fmod(__half __x, __half __y) noexcept
 {
-  return __float2half(_CUDA_VSTD::fmod(__half2float(__x), __half2float(__y)));
+  return ::__float2half(_CUDA_VSTD::fmod(::__half2float(__x), ::__half2float(__y)));
 }
 #endif // _LIBCUDACXX_HAS_NVFP16()
 
 #if _LIBCUDACXX_HAS_NVBF16()
 [[nodiscard]] _CCCL_API inline __nv_bfloat16 fmod(__nv_bfloat16 __x, __nv_bfloat16 __y) noexcept
 {
-  return __float2bfloat16(_CUDA_VSTD::fmod(__bfloat162float(__x), __bfloat162float(__y)));
+  return ::__float2bfloat16(_CUDA_VSTD::fmod(::__bfloat162float(__x), ::__bfloat162float(__y)));
 }
 #endif // _LIBCUDACXX_HAS_NVBF16()
 
@@ -100,7 +100,7 @@ template <class _A1, class _A2, enable_if_t<is_arithmetic_v<_A1> && is_arithmeti
 [[nodiscard]] _CCCL_API inline __promote_t<_A1, _A2> fmod(_A1 __x, _A2 __y) noexcept
 {
   using __result_type = __promote_t<_A1, _A2>;
-  static_assert(!(is_same_v<_A1, __result_type> && is_same_v<_A2, __result_type>), "");
+  static_assert(!(is_same_v<_A1, __result_type> && is_same_v<_A2, __result_type>) );
   return _CUDA_VSTD::fmod((__result_type) __x, (__result_type) __y);
 }
 
@@ -158,7 +158,9 @@ template <class _A1, class _A2, enable_if_t<is_arithmetic_v<_A1> && is_arithmeti
 {
   const __half __integral_part = _CUDA_VSTD::trunc(__x);
   *__y                         = __integral_part;
-  return ::__heq(__integral_part, __x) ? _CUDA_VSTD::copysign(__float2half(0.0f), __x) : ::__hsub(__x, __integral_part);
+  return ::__heq(__integral_part, __x)
+         ? _CUDA_VSTD::copysign(::__float2half(0.0f), __x)
+         : ::__hsub(__x, __integral_part);
 }
 #endif // _LIBCUDACXX_HAS_NVFP16()
 
@@ -168,7 +170,7 @@ template <class _A1, class _A2, enable_if_t<is_arithmetic_v<_A1> && is_arithmeti
   const __nv_bfloat16 __integral_part = _CUDA_VSTD::trunc(__x);
   *__y                                = __integral_part;
   return ::__heq(__integral_part, __x)
-         ? _CUDA_VSTD::copysign(__float2bfloat16(0.0f), __x)
+         ? _CUDA_VSTD::copysign(::__float2bfloat16(0.0f), __x)
          : ::__hsub(__x, __integral_part);
 }
 #endif // _LIBCUDACXX_HAS_NVBF16()

--- a/libcudacxx/include/cuda/std/__cmath/modulo.h
+++ b/libcudacxx/include/cuda/std/__cmath/modulo.h
@@ -1,0 +1,180 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___CMATH_MODULO_H
+#define _LIBCUDACXX___CMATH_MODULO_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__cmath/copysign.h>
+#include <cuda/std/__cmath/rounding_functions.h>
+#include <cuda/std/__floating_point/nvfp_types.h>
+#include <cuda/std/__type_traits/enable_if.h>
+#include <cuda/std/__type_traits/is_arithmetic.h>
+#include <cuda/std/__type_traits/is_same.h>
+#include <cuda/std/__type_traits/promote.h>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_STD
+
+// fmod
+
+[[nodiscard]] _CCCL_API inline float fmod(float __x, float __y) noexcept
+{
+#if defined(_CCCL_BUILTIN_FMODF)
+  return _CCCL_BUILTIN_FMODF(__x, __y);
+#else // ^^^ _CCCL_BUILTIN_FMODF ^^^ / vvv !_CCCL_BUILTIN_FMODF vvv
+  return ::fmodf(__x, __y);
+#endif // ^^^ !_CCCL_BUILTIN_FMODF ^^^
+}
+
+[[nodiscard]] _CCCL_API inline float fmodf(float __x, float __y) noexcept
+{
+#if defined(_CCCL_BUILTIN_FMODF)
+  return _CCCL_BUILTIN_FMODF(__x, __y);
+#else // ^^^ _CCCL_BUILTIN_FMODF ^^^ / vvv !_CCCL_BUILTIN_FMODF vvv
+  return ::fmodf(__x, __y);
+#endif // ^^^ !_CCCL_BUILTIN_FMODF ^^^
+}
+
+[[nodiscard]] _CCCL_API inline double fmod(double __x, double __y) noexcept
+{
+#if defined(_CCCL_BUILTIN_FMOD)
+  return _CCCL_BUILTIN_FMOD(__x, __y);
+#else // ^^^ _CCCL_BUILTIN_FMOD ^^^ / vvv !_CCCL_BUILTIN_FMOD vvv
+  return ::fmod(__x, __y);
+#endif // ^^^ !_CCCL_BUILTIN_FMOD ^^^
+}
+
+#if _CCCL_HAS_LONG_DOUBLE()
+[[nodiscard]] _CCCL_API inline long double fmod(long double __x, long double __y) noexcept
+{
+#  if defined(_CCCL_BUILTIN_FMODL)
+  return _CCCL_BUILTIN_FMODL(__x, __y);
+#  else // ^^^ _CCCL_BUILTIN_FMODL ^^^ / vvv !_CCCL_BUILTIN_FMODL vvv
+  return ::fmodl(__x, __y);
+#  endif // ^^^ !_CCCL_BUILTIN_FMODL ^^^
+}
+
+[[nodiscard]] _CCCL_API inline long double fmodl(long double __x, long double __y) noexcept
+{
+#  if defined(_CCCL_BUILTIN_FMODL)
+  return _CCCL_BUILTIN_FMODL(__x, __y);
+#  else // ^^^ _CCCL_BUILTIN_FMODL ^^^ / vvv !_CCCL_BUILTIN_FMODL vvv
+  return ::fmodl(__x, __y);
+#  endif // ^^^ !_CCCL_BUILTIN_FMODL ^^^
+}
+#endif // _CCCL_HAS_LONG_DOUBLE()
+
+#if _LIBCUDACXX_HAS_NVFP16()
+[[nodiscard]] _CCCL_API inline __half fmod(__half __x, __half __y) noexcept
+{
+  return __float2half(_CUDA_VSTD::fmod(__half2float(__x), __half2float(__y)));
+}
+#endif // _LIBCUDACXX_HAS_NVFP16()
+
+#if _LIBCUDACXX_HAS_NVBF16()
+[[nodiscard]] _CCCL_API inline __nv_bfloat16 fmod(__nv_bfloat16 __x, __nv_bfloat16 __y) noexcept
+{
+  return __float2bfloat16(_CUDA_VSTD::fmod(__bfloat162float(__x), __bfloat162float(__y)));
+}
+#endif // _LIBCUDACXX_HAS_NVBF16()
+
+template <class _A1, class _A2, enable_if_t<is_arithmetic_v<_A1> && is_arithmetic_v<_A2>, int> = 0>
+[[nodiscard]] _CCCL_API inline __promote_t<_A1, _A2> fmod(_A1 __x, _A2 __y) noexcept
+{
+  using __result_type = __promote_t<_A1, _A2>;
+  static_assert(!(is_same_v<_A1, __result_type> && is_same_v<_A2, __result_type>), "");
+  return _CUDA_VSTD::fmod((__result_type) __x, (__result_type) __y);
+}
+
+// modf
+
+[[nodiscard]] _CCCL_API inline float modf(float __x, float* __y) noexcept
+{
+#if defined(_CCCL_BUILTIN_MODFF)
+  return _CCCL_BUILTIN_MODFF(__x, __y);
+#else // ^^^ _CCCL_BUILTIN_MODFF ^^^ / vvv !_CCCL_BUILTIN_MODFF vvv
+  return ::modff(__x, __y);
+#endif // ^^^ !_CCCL_BUILTIN_MODFF ^^^
+}
+
+[[nodiscard]] _CCCL_API inline float modff(float __x, float* __y) noexcept
+{
+#if defined(_CCCL_BUILTIN_MODFF)
+  return _CCCL_BUILTIN_MODFF(__x, __y);
+#else // ^^^ _CCCL_BUILTIN_MODFF ^^^ / vvv !_CCCL_BUILTIN_MODFF vvv
+  return ::modff(__x, __y);
+#endif // ^^^ !_CCCL_BUILTIN_MODFF ^^^
+}
+
+[[nodiscard]] _CCCL_API inline double modf(double __x, double* __y) noexcept
+{
+#if defined(_CCCL_BUILTIN_MODF)
+  return _CCCL_BUILTIN_MODF(__x, __y);
+#else // ^^^ _CCCL_BUILTIN_MODF ^^^ / vvv !_CCCL_BUILTIN_MODF vvv
+  return ::modf(__x, __y);
+#endif // ^^^ !_CCCL_BUILTIN_MODF ^^^
+}
+
+#if _CCCL_HAS_LONG_DOUBLE()
+[[nodiscard]] _CCCL_API inline long double modf(long double __x, long double* __y) noexcept
+{
+#  if defined(_CCCL_BUILTIN_MODFL)
+  return _CCCL_BUILTIN_MODFL(__x, __y);
+#  else // ^^^ _CCCL_BUILTIN_MODFL ^^^ / vvv !_CCCL_BUILTIN_MODFL vvv
+  return ::modfl(__x, __y);
+#  endif // ^^^ !_CCCL_BUILTIN_MODFL ^^^
+}
+
+[[nodiscard]] _CCCL_API inline long double modfl(long double __x, long double* __y) noexcept
+{
+#  if defined(_CCCL_BUILTIN_MODFL)
+  return _CCCL_BUILTIN_MODFL(__x, __y);
+#  else // ^^^ _CCCL_BUILTIN_MODFL ^^^ / vvv !_CCCL_BUILTIN_MODFL vvv
+  return ::modfl(__x, __y);
+#  endif // ^^^ !_CCCL_BUILTIN_MODFL ^^^
+}
+#endif // _CCCL_HAS_LONG_DOUBLE()
+
+#if _LIBCUDACXX_HAS_NVFP16()
+[[nodiscard]] _CCCL_API inline __half modf(__half __x, __half* __y) noexcept
+{
+  const __half __integral_part = _CUDA_VSTD::trunc(__x);
+  *__y                         = __integral_part;
+  return ::__heq(__integral_part, __x) ? _CUDA_VSTD::copysign(__float2half(0.0f), __x) : ::__hsub(__x, __integral_part);
+}
+#endif // _LIBCUDACXX_HAS_NVFP16()
+
+#if _LIBCUDACXX_HAS_NVBF16()
+[[nodiscard]] _CCCL_API inline __nv_bfloat16 modf(__nv_bfloat16 __x, __nv_bfloat16* __y) noexcept
+{
+  const __nv_bfloat16 __integral_part = _CUDA_VSTD::trunc(__x);
+  *__y                                = __integral_part;
+  return ::__heq(__integral_part, __x)
+         ? _CUDA_VSTD::copysign(__float2bfloat16(0.0f), __x)
+         : ::__hsub(__x, __integral_part);
+}
+#endif // _LIBCUDACXX_HAS_NVBF16()
+
+_LIBCUDACXX_END_NAMESPACE_STD
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _LIBCUDACXX___CMATH_MODULO_H

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/cmath
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/cmath
@@ -335,6 +335,7 @@ long double    truncl(long double x);
 #include <cuda/std/__cmath/lerp.h>
 #include <cuda/std/__cmath/logarithms.h>
 #include <cuda/std/__cmath/min_max.h>
+#include <cuda/std/__cmath/modulo.h>
 #include <cuda/std/__cmath/roots.h>
 #include <cuda/std/__cmath/rounding_functions.h>
 #include <cuda/std/__cmath/signbit.h>
@@ -367,12 +368,6 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 using ::double_t;
 using ::float_t;
 
-using ::fmod;
-using ::fmodf;
-
-using ::modf;
-using ::modff;
-
 using ::erf;
 using ::erfc;
 using ::erfcf;
@@ -387,9 +382,6 @@ using ::remainder;
 using ::remainderf;
 using ::remquo;
 using ::remquof;
-
-using ::fmodl;
-using ::modfl;
 
 using ::erfcl;
 using ::erfl;

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/modulo.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/modulo.pass.cpp
@@ -1,0 +1,341 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cmath>
+
+#include <cuda/std/cassert>
+#include <cuda/std/cmath>
+#include <cuda/std/limits>
+#include <cuda/std/type_traits>
+
+#include "comparison.h"
+#include "test_macros.h"
+
+TEST_DIAG_SUPPRESS_MSVC(4244) // conversion from 'double' to 'float', possible loss of data
+TEST_DIAG_SUPPRESS_MSVC(4305) // 'argument': truncation from 'T' to 'float'
+TEST_DIAG_SUPPRESS_MSVC(4146) // unary minus operator applied to unsigned type, result still unsigned
+
+template <typename T>
+__host__ __device__ void test_fmod(T val)
+{
+  using ret = cuda::std::conditional_t<cuda::std::is_integral_v<T>, double, T>;
+  static_assert(cuda::std::is_same_v<decltype(cuda::std::fmod(T{}, T{})), ret>, "");
+
+  const T x = T(13.23456789);
+  const T y = T(3.456789123);
+
+  // The result has the same sign as the same sign as x
+  assert(eq(cuda::std::fmod(val, x), val));
+  assert(eq(cuda::std::fmod(-val, x), -val));
+
+  if constexpr (cuda::std::is_integral_v<T>)
+  {
+    assert(eq(cuda::std::fmod(x, y), T(1.0)));
+  }
+  else
+  {
+    // If x is ±0 and y is not zero, ±0 is returned.
+    assert(eq(cuda::std::fmod(val, x), val));
+    assert(eq(cuda::std::fmod(-val, x), -val));
+    assert(eq(cuda::std::fmod(val, -x), val));
+    assert(eq(cuda::std::fmod(-val, -x), -val));
+
+    assert(eq(cuda::std::fmod(val, cuda::std::numeric_limits<T>::infinity()), val));
+    assert(eq(cuda::std::fmod(-val, cuda::std::numeric_limits<T>::infinity()), -val));
+
+    // If x is ±∞ and y is not NaN, NaN is returned and FE_INVALID is raised.
+    assert(cuda::std::isnan(cuda::std::fmod(cuda::std::numeric_limits<T>::infinity(), val)));
+    assert(cuda::std::isnan(cuda::std::fmod(-cuda::std::numeric_limits<T>::infinity(), val)));
+    assert(cuda::std::isnan(cuda::std::fmod(cuda::std::numeric_limits<T>::infinity(), x)));
+    assert(cuda::std::isnan(cuda::std::fmod(-cuda::std::numeric_limits<T>::infinity(), x)));
+    assert(cuda::std::isnan(
+      cuda::std::fmod(cuda::std::numeric_limits<T>::infinity(), cuda::std::numeric_limits<T>::infinity())));
+    assert(cuda::std::isnan(
+      cuda::std::fmod(-cuda::std::numeric_limits<T>::infinity(), cuda::std::numeric_limits<T>::infinity())));
+
+    // If y is ±0 and x is not NaN, NaN is returned and FE_INVALID is raised.
+    assert(cuda::std::isnan(cuda::std::fmod(x, val)));
+    assert(cuda::std::isnan(cuda::std::fmod(-x, val)));
+
+    // If y is ±∞ and x is finite, x is returned.
+    assert(eq(cuda::std::fmod(x, cuda::std::numeric_limits<T>::infinity()), x));
+    assert(eq(cuda::std::fmod(x, -cuda::std::numeric_limits<T>::infinity()), x));
+    assert(eq(cuda::std::fmod(-x, cuda::std::numeric_limits<T>::infinity()), -x));
+    assert(eq(cuda::std::fmod(-x, -cuda::std::numeric_limits<T>::infinity()), -x));
+
+    // If y is ±0 and x is not NaN, NaN is returned and FE_INVALID is raised.
+    assert(cuda::std::isnan(cuda::std::fmod(x, cuda::std::numeric_limits<T>::quiet_NaN())));
+    assert(cuda::std::isnan(cuda::std::fmod(-x, cuda::std::numeric_limits<T>::quiet_NaN())));
+    assert(cuda::std::isnan(cuda::std::fmod(cuda::std::numeric_limits<T>::quiet_NaN(), x)));
+    assert(cuda::std::isnan(cuda::std::fmod(cuda::std::numeric_limits<T>::quiet_NaN(), -x)));
+    assert(cuda::std::isnan(cuda::std::fmod(x, cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::fmod(-x, cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::fmod(cuda::std::numeric_limits<T>::signaling_NaN(), x)));
+    assert(cuda::std::isnan(cuda::std::fmod(cuda::std::numeric_limits<T>::signaling_NaN(), -x)));
+    assert(cuda::std::isnan(
+      cuda::std::fmod(cuda::std::numeric_limits<T>::quiet_NaN(), cuda::std::numeric_limits<T>::quiet_NaN())));
+    assert(cuda::std::isnan(
+      cuda::std::fmod(cuda::std::numeric_limits<T>::quiet_NaN(), cuda::std::numeric_limits<T>::quiet_NaN())));
+
+    // Some random value
+    const T quotient = T(3.0);
+    assert(is_about(cuda::std::fmod(x, y), (x - quotient * y)));
+  }
+
+  if constexpr (cuda::std::is_same_v<T, float>)
+  {
+    // If x is ±0 and y is not zero, ±0 is returned.
+    assert(eq(cuda::std::fmodf(val, x), val));
+    assert(eq(cuda::std::fmodf(-val, x), -val));
+    assert(eq(cuda::std::fmodf(val, -x), val));
+    assert(eq(cuda::std::fmodf(-val, -x), -val));
+
+    assert(eq(cuda::std::fmodf(val, cuda::std::numeric_limits<T>::infinity()), val));
+    assert(eq(cuda::std::fmodf(-val, cuda::std::numeric_limits<T>::infinity()), -val));
+
+    // If x is ±∞ and y is not NaN, NaN is returned and FE_INVALID is raised.
+    assert(cuda::std::isnan(cuda::std::fmodf(cuda::std::numeric_limits<T>::infinity(), val)));
+    assert(cuda::std::isnan(cuda::std::fmodf(-cuda::std::numeric_limits<T>::infinity(), val)));
+    assert(cuda::std::isnan(cuda::std::fmodf(cuda::std::numeric_limits<T>::infinity(), x)));
+    assert(cuda::std::isnan(cuda::std::fmodf(-cuda::std::numeric_limits<T>::infinity(), x)));
+    assert(cuda::std::isnan(
+      cuda::std::fmodf(cuda::std::numeric_limits<T>::infinity(), cuda::std::numeric_limits<T>::infinity())));
+    assert(cuda::std::isnan(
+      cuda::std::fmodf(-cuda::std::numeric_limits<T>::infinity(), cuda::std::numeric_limits<T>::infinity())));
+
+    // If y is ±0 and x is not NaN, NaN is returned and FE_INVALID is raised.
+    assert(cuda::std::isnan(cuda::std::fmodf(x, val)));
+    assert(cuda::std::isnan(cuda::std::fmodf(-x, val)));
+
+    // If y is ±∞ and x is finite, x is returned.
+    assert(eq(cuda::std::fmodf(x, cuda::std::numeric_limits<T>::infinity()), x));
+    assert(eq(cuda::std::fmodf(x, -cuda::std::numeric_limits<T>::infinity()), x));
+    assert(eq(cuda::std::fmodf(-x, cuda::std::numeric_limits<T>::infinity()), -x));
+    assert(eq(cuda::std::fmodf(-x, -cuda::std::numeric_limits<T>::infinity()), -x));
+
+    // If y is ±0 and x is not NaN, NaN is returned and FE_INVALID is raised.
+    assert(cuda::std::isnan(cuda::std::fmodf(x, cuda::std::numeric_limits<T>::quiet_NaN())));
+    assert(cuda::std::isnan(cuda::std::fmodf(-x, cuda::std::numeric_limits<T>::quiet_NaN())));
+    assert(cuda::std::isnan(cuda::std::fmodf(cuda::std::numeric_limits<T>::quiet_NaN(), x)));
+    assert(cuda::std::isnan(cuda::std::fmodf(cuda::std::numeric_limits<T>::quiet_NaN(), -x)));
+    assert(cuda::std::isnan(cuda::std::fmodf(x, cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::fmodf(-x, cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::fmodf(cuda::std::numeric_limits<T>::signaling_NaN(), x)));
+    assert(cuda::std::isnan(cuda::std::fmodf(cuda::std::numeric_limits<T>::signaling_NaN(), -x)));
+    assert(cuda::std::isnan(
+      cuda::std::fmodf(cuda::std::numeric_limits<T>::quiet_NaN(), cuda::std::numeric_limits<T>::quiet_NaN())));
+    assert(cuda::std::isnan(
+      cuda::std::fmodf(cuda::std::numeric_limits<T>::quiet_NaN(), cuda::std::numeric_limits<T>::quiet_NaN())));
+
+    // Some random value
+    const T quotient = T(3.0);
+    assert(is_about(cuda::std::fmodf(x, y), (x - quotient * y)));
+  }
+#if _CCCL_HAS_LONG_DOUBLE()
+  else if constexpr (cuda::std::is_same_v<T, long double>)
+  {
+    // If x is ±0 and y is not zero, ±0 is returned.
+    assert(eq(cuda::std::fmodl(val, x), val));
+    assert(eq(cuda::std::fmodl(-val, x), -val));
+    assert(eq(cuda::std::fmodl(val, -x), val));
+    assert(eq(cuda::std::fmodl(-val, -x), -val));
+
+    assert(eq(cuda::std::fmodl(val, cuda::std::numeric_limits<T>::infinity()), val));
+    assert(eq(cuda::std::fmodl(-val, cuda::std::numeric_limits<T>::infinity()), -val));
+
+    // If x is ±∞ and y is not NaN, NaN is returned and FE_INVALID is raised.
+    assert(cuda::std::isnan(cuda::std::fmodl(cuda::std::numeric_limits<T>::infinity(), val)));
+    assert(cuda::std::isnan(cuda::std::fmodl(-cuda::std::numeric_limits<T>::infinity(), val)));
+    assert(cuda::std::isnan(cuda::std::fmodl(cuda::std::numeric_limits<T>::infinity(), x)));
+    assert(cuda::std::isnan(cuda::std::fmodl(-cuda::std::numeric_limits<T>::infinity(), x)));
+    assert(cuda::std::isnan(
+      cuda::std::fmodl(cuda::std::numeric_limits<T>::infinity(), cuda::std::numeric_limits<T>::infinity())));
+    assert(cuda::std::isnan(
+      cuda::std::fmodl(-cuda::std::numeric_limits<T>::infinity(), cuda::std::numeric_limits<T>::infinity())));
+
+    // If y is ±0 and x is not NaN, NaN is returned and FE_INVALID is raised.
+    assert(cuda::std::isnan(cuda::std::fmodl(x, val)));
+    assert(cuda::std::isnan(cuda::std::fmodl(-x, val)));
+
+    // If y is ±∞ and x is finite, x is returned.
+    assert(eq(cuda::std::fmodl(x, cuda::std::numeric_limits<T>::infinity()), x));
+    assert(eq(cuda::std::fmodl(x, -cuda::std::numeric_limits<T>::infinity()), x));
+    assert(eq(cuda::std::fmodl(-x, cuda::std::numeric_limits<T>::infinity()), -x));
+    assert(eq(cuda::std::fmodl(-x, -cuda::std::numeric_limits<T>::infinity()), -x));
+
+    // If y is ±0 and x is not NaN, NaN is returned and FE_INVALID is raised.
+    assert(cuda::std::isnan(cuda::std::fmodl(x, cuda::std::numeric_limits<T>::quiet_NaN())));
+    assert(cuda::std::isnan(cuda::std::fmodl(-x, cuda::std::numeric_limits<T>::quiet_NaN())));
+    assert(cuda::std::isnan(cuda::std::fmodl(cuda::std::numeric_limits<T>::quiet_NaN(), x)));
+    assert(cuda::std::isnan(cuda::std::fmodl(cuda::std::numeric_limits<T>::quiet_NaN(), -x)));
+    assert(cuda::std::isnan(cuda::std::fmodl(x, cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::fmodl(-x, cuda::std::numeric_limits<T>::signaling_NaN())));
+    assert(cuda::std::isnan(cuda::std::fmodl(cuda::std::numeric_limits<T>::signaling_NaN(), x)));
+    assert(cuda::std::isnan(cuda::std::fmodl(cuda::std::numeric_limits<T>::signaling_NaN(), -x)));
+    assert(cuda::std::isnan(
+      cuda::std::fmodl(cuda::std::numeric_limits<T>::quiet_NaN(), cuda::std::numeric_limits<T>::quiet_NaN())));
+    assert(cuda::std::isnan(
+      cuda::std::fmodl(cuda::std::numeric_limits<T>::quiet_NaN(), cuda::std::numeric_limits<T>::quiet_NaN())));
+
+    // Some random value
+    const T quotient = T(3.0);
+    assert(is_about(cuda::std::fmodl(x, y), (x - quotient * y)));
+  }
+#endif // _CCCL_HAS_LONG_DOUBLE()
+}
+
+template <typename T>
+__host__ __device__ void test_modf(T val)
+{
+  static_assert(cuda::std::is_same_v<decltype(cuda::std::modf(T{}, static_cast<T*>(nullptr))), T>, "");
+  {
+    // If num is ±0, ±0 is returned, and ±0 is stored in *iptr
+    T integral = cuda::std::numeric_limits<T>::infinity();
+    assert(eq(cuda::std::modf(val, &integral), val));
+    assert(eq(integral, val));
+
+    integral = cuda::std::numeric_limits<T>::infinity();
+    assert(eq(cuda::std::modf(-val, &integral), -val));
+    assert(eq(integral, -val));
+
+    // If num is ±∞, ±0 is returned, and ±∞ is stored in *iptr.
+    integral = T(-1.0);
+    assert(eq(cuda::std::modf(cuda::std::numeric_limits<T>::infinity(), &integral), val));
+    assert(eq(integral, cuda::std::numeric_limits<T>::infinity()));
+
+    // If num is NaN, NaN is returned, and NaN is stored in *iptr.
+    integral = T(-1.0);
+    assert(cuda::std::isnan(cuda::std::modf(cuda::std::numeric_limits<T>::quiet_NaN(), &integral)));
+    assert(cuda::std::isnan(integral));
+
+    integral = T(-1.0);
+    assert(cuda::std::isnan(cuda::std::modf(cuda::std::numeric_limits<T>::signaling_NaN(), &integral)));
+    assert(cuda::std::isnan(integral));
+
+    // some random value
+    integral         = cuda::std::numeric_limits<T>::infinity();
+    const T x        = T(12.3456789);
+    const T expected = x - T(12.0);
+    assert(is_about(cuda::std::modf(x, &integral), expected));
+    assert(eq(integral, T(12.0)));
+  }
+
+  if constexpr (cuda::std::is_same_v<T, float>)
+  {
+    // If num is ±0, ±0 is returned, and ±0 is stored in *iptr
+    T integral = cuda::std::numeric_limits<T>::infinity();
+    assert(eq(cuda::std::modff(val, &integral), val));
+    assert(eq(integral, val));
+
+    integral = cuda::std::numeric_limits<T>::infinity();
+    assert(eq(cuda::std::modff(-val, &integral), -val));
+    assert(eq(integral, -val));
+
+    // If num is ±∞, ±0 is returned, and ±∞ is stored in *iptr.
+    integral = T(-1.0);
+    assert(eq(cuda::std::modff(cuda::std::numeric_limits<T>::infinity(), &integral), val));
+    assert(eq(integral, cuda::std::numeric_limits<T>::infinity()));
+
+    // If num is NaN, NaN is returned, and NaN is stored in *iptr.
+    integral = T(-1.0);
+    assert(cuda::std::isnan(cuda::std::modff(cuda::std::numeric_limits<T>::quiet_NaN(), &integral)));
+    assert(cuda::std::isnan(integral));
+
+    integral = T(-1.0);
+    assert(cuda::std::isnan(cuda::std::modff(cuda::std::numeric_limits<T>::signaling_NaN(), &integral)));
+    assert(cuda::std::isnan(integral));
+
+    // some random value
+    integral         = cuda::std::numeric_limits<T>::infinity();
+    const T x        = T(12.3456789);
+    const T expected = x - T(12.0);
+    assert(is_about(cuda::std::modff(x, &integral), expected));
+    assert(eq(integral, T(12.0)));
+  }
+#if _CCCL_HAS_LONG_DOUBLE()
+  else if constexpr (cuda::std::is_same_v<T, long double>)
+  {
+    // If num is ±0, ±0 is returned, and ±0 is stored in *iptr
+    T integral = cuda::std::numeric_limits<T>::infinity();
+    assert(eq(cuda::std::modfl(val, &integral), val));
+    assert(eq(integral, val));
+
+    integral = cuda::std::numeric_limits<T>::infinity();
+    assert(eq(cuda::std::modfl(-val, &integral), -val));
+    assert(eq(integral, -val));
+
+    // If num is ±∞, ±0 is returned, and ±∞ is stored in *iptr.
+    integral = T(-1.0);
+    assert(eq(cuda::std::modfl(cuda::std::numeric_limits<T>::infinity(), &integral), val));
+    assert(eq(integral, cuda::std::numeric_limits<T>::infinity()));
+
+    // If num is NaN, NaN is returned, and NaN is stored in *iptr.
+    integral = T(-1.0);
+    assert(cuda::std::isnan(cuda::std::modfl(cuda::std::numeric_limits<T>::quiet_NaN(), &integral)));
+    assert(cuda::std::isnan(integral));
+
+    integral = T(-1.0);
+    assert(cuda::std::isnan(cuda::std::modfl(cuda::std::numeric_limits<T>::signaling_NaN(), &integral)));
+    assert(cuda::std::isnan(integral));
+
+    // some random value
+    integral         = cuda::std::numeric_limits<T>::infinity();
+    const T x        = T(12.3456789);
+    const T expected = x - T(12.0);
+    assert(is_about(cuda::std::modfl(x, &integral), expected));
+    assert(eq(integral, T(12.0)));
+  }
+#endif // _CCCL_HAS_LONG_DOUBLE()
+}
+
+template <typename T>
+__host__ __device__ void test(const T val)
+{
+  test_fmod<T>(val);
+  if constexpr (!cuda::std::is_integral_v<T>)
+  {
+    test_modf<T>(val);
+  }
+}
+
+__host__ __device__ void test(const float val)
+{
+  test<float>(val);
+  test<double>(val);
+#if _CCCL_HAS_LONG_DOUBLE()
+  test<long double>();
+#endif // _CCCL_HAS_LONG_DOUBLE()
+
+#if _LIBCUDACXX_HAS_NVFP16()
+  test<__half>(val);
+#endif // _LIBCUDACXX_HAS_NVFP16()
+#if _LIBCUDACXX_HAS_NVBF16()
+  test<__nv_bfloat16>(val);
+#endif // _LIBCUDACXX_HAS_NVBF16()
+
+  test<unsigned short>(static_cast<unsigned short>(val));
+  test<int>(static_cast<int>(val));
+  test<unsigned int>(static_cast<unsigned int>(val));
+  test<long>(static_cast<long>(val));
+  test<unsigned long>(static_cast<unsigned long>(val));
+  test<long long>(static_cast<long long>(val));
+  test<unsigned long long>(static_cast<unsigned long long>(val));
+}
+
+__global__ void test_global_kernel(float* val)
+{
+  test(*val);
+}
+
+int main(int, char**)
+{
+  volatile float val = 0.0f;
+  test(val);
+  return 0;
+}


### PR DESCRIPTION
This implements `std::modf` and `std::fmod`

We reuse the compiler builtins when possible and implement those functions for extended floating points