### PR TITLE
[cudax] Fix cudax compilation with gcc 9

### DIFF
--- a/cudax/include/cuda/experimental/__execution/stream/adaptor.cuh
+++ b/cudax/include/cuda/experimental/__execution/stream/adaptor.cuh
@@ -399,7 +399,7 @@ struct __sndr_t
 };
 
 template <class _Sndr>
-_CCCL_API constexpr auto __adapt(_Sndr __sndr, stream_ref __stream) -> decltype(auto)
+_CCCL_API constexpr auto __adapt(_Sndr __sndr, [[maybe_unused]] stream_ref __stream) -> decltype(auto)
 {
   // Ensure that we are not trying to adapt a sender that is already adapted.
   if constexpr (__is_specialization_of_v<_Sndr, __sndr_t>)

--- a/cudax/include/cuda/experimental/__launch/launch.cuh
+++ b/cudax/include/cuda/experimental/__launch/launch.cuh
@@ -207,8 +207,8 @@ _CCCL_CONCEPT work_submitter = graph_inserter<_Submitter> || _CUDA_VSTD::is_conv
 //! @param args
 //! arguments to be passed into the kernel functor
 _CCCL_TEMPLATE(typename... _Args, typename... _Config, typename _Submitter, typename _Dimensions, typename _Kernel)
-_CCCL_REQUIRES(work_submitter<_Submitter> && !::cuda::std::is_pointer_v<_Kernel>
-               && !::cuda::std::is_function_v<_Kernel>)
+_CCCL_REQUIRES(work_submitter<_Submitter>
+               && ((!::cuda::std::is_pointer_v<_Kernel>) || (!::cuda::std::is_function_v<_Kernel>) ))
 _CCCL_HOST_API auto launch(_Submitter&& __submitter,
                            const kernel_config<_Dimensions, _Config...>& __conf,
                            const _Kernel& __kernel,
@@ -280,7 +280,7 @@ _CCCL_HOST_API auto launch(_Submitter&& __submitter,
 //!
 _CCCL_TEMPLATE(
   typename... _ExpArgs, typename... _ActArgs, typename _Submitter, typename... _Config, typename _Dimensions)
-_CCCL_REQUIRES(work_submitter<_Submitter> && sizeof...(_ExpArgs) == sizeof...(_ActArgs))
+_CCCL_REQUIRES(work_submitter<_Submitter> && (sizeof...(_ExpArgs) == sizeof...(_ActArgs)))
 _CCCL_HOST_API auto launch(_Submitter&& __submitter,
                            const kernel_config<_Dimensions, _Config...>& __conf,
                            void (*__kernel)(kernel_config<_Dimensions, _Config...>, _ExpArgs...),
@@ -334,7 +334,7 @@ _CCCL_HOST_API auto launch(_Submitter&& __submitter,
 //! arguments to be passed into the kernel function
 _CCCL_TEMPLATE(
   typename... _ExpArgs, typename... _ActArgs, typename _Submitter, typename... _Config, typename _Dimensions)
-_CCCL_REQUIRES(work_submitter<_Submitter> && sizeof...(_ExpArgs) == sizeof...(_ActArgs))
+_CCCL_REQUIRES(work_submitter<_Submitter> && (sizeof...(_ExpArgs) == sizeof...(_ActArgs)))
 _CCCL_HOST_API auto launch(_Submitter&& __submitter,
                            const kernel_config<_Dimensions, _Config...>& __conf,
                            void (*__kernel)(_ExpArgs...),

--- a/cudax/include/cuda/experimental/__launch/launch.cuh
+++ b/cudax/include/cuda/experimental/__launch/launch.cuh
@@ -207,7 +207,8 @@ _CCCL_CONCEPT work_submitter = graph_inserter<_Submitter> || _CUDA_VSTD::is_conv
 //! @param args
 //! arguments to be passed into the kernel functor
 _CCCL_TEMPLATE(typename... _Args, typename... _Config, typename _Submitter, typename _Dimensions, typename _Kernel)
-_CCCL_REQUIRES(work_submitter<_Submitter> && !::cuda::std::is_pointer_v<_Kernel> && !::cuda::std::is_function_v<_Kernel>)
+_CCCL_REQUIRES(work_submitter<_Submitter> && !::cuda::std::is_pointer_v<_Kernel>
+               && !::cuda::std::is_function_v<_Kernel>)
 _CCCL_HOST_API auto launch(_Submitter&& __submitter,
                            const kernel_config<_Dimensions, _Config...>& __conf,
                            const _Kernel& __kernel,

--- a/cudax/include/cuda/experimental/__launch/launch.cuh
+++ b/cudax/include/cuda/experimental/__launch/launch.cuh
@@ -207,7 +207,7 @@ _CCCL_CONCEPT work_submitter = graph_inserter<_Submitter> || _CUDA_VSTD::is_conv
 //! @param args
 //! arguments to be passed into the kernel functor
 _CCCL_TEMPLATE(typename... _Args, typename... _Config, typename _Submitter, typename _Dimensions, typename _Kernel)
-_CCCL_REQUIRES(work_submitter<_Submitter>)
+_CCCL_REQUIRES(work_submitter<_Submitter> && !::cuda::std::is_pointer_v<_Kernel> && !::cuda::std::is_function_v<_Kernel>)
 _CCCL_HOST_API auto launch(_Submitter&& __submitter,
                            const kernel_config<_Dimensions, _Config...>& __conf,
                            const _Kernel& __kernel,
@@ -279,14 +279,12 @@ _CCCL_HOST_API auto launch(_Submitter&& __submitter,
 //!
 _CCCL_TEMPLATE(
   typename... _ExpArgs, typename... _ActArgs, typename _Submitter, typename... _Config, typename _Dimensions)
-_CCCL_REQUIRES(work_submitter<_Submitter>)
+_CCCL_REQUIRES(work_submitter<_Submitter> && sizeof...(_ExpArgs) == sizeof...(_ActArgs))
 _CCCL_HOST_API auto launch(_Submitter&& __submitter,
                            const kernel_config<_Dimensions, _Config...>& __conf,
                            void (*__kernel)(kernel_config<_Dimensions, _Config...>, _ExpArgs...),
                            _ActArgs&&... __args)
 {
-  static_assert(sizeof...(_ExpArgs) == sizeof...(_ActArgs),
-                "Number of kernel function arguments and number of arguments passed to the kernel function must match");
   __ensure_current_device __dev_setter{__submitter};
   return __launch_impl<kernel_config<_Dimensions, _Config...>, _ExpArgs...>(
     __forward_or_cast_to_stream_ref<_Submitter>(__submitter), //
@@ -335,14 +333,12 @@ _CCCL_HOST_API auto launch(_Submitter&& __submitter,
 //! arguments to be passed into the kernel function
 _CCCL_TEMPLATE(
   typename... _ExpArgs, typename... _ActArgs, typename _Submitter, typename... _Config, typename _Dimensions)
-_CCCL_REQUIRES(work_submitter<_Submitter>)
+_CCCL_REQUIRES(work_submitter<_Submitter> && sizeof...(_ExpArgs) == sizeof...(_ActArgs))
 _CCCL_HOST_API auto launch(_Submitter&& __submitter,
                            const kernel_config<_Dimensions, _Config...>& __conf,
                            void (*__kernel)(_ExpArgs...),
                            _ActArgs&&... __args)
 {
-  static_assert(sizeof...(_ExpArgs) == sizeof...(_ActArgs),
-                "Number of kernel function arguments and number of arguments passed to the kernel function must match");
   __ensure_current_device __dev_setter{__submitter};
   return __launch_impl<_ExpArgs...>(
     __forward_or_cast_to_stream_ref<_Submitter>(_CUDA_VSTD::forward<_Submitter>(__submitter)), //


### PR DESCRIPTION
It seems gcc9 is picky when it comes to ambiguous overload. This PR adds more template constraints to launch to make sure nothing stays ambiguous for gcc9. The downside is that the `static_assert` for the number of arguments was more readable in case of a mistake.

This change also adds `[[maybe_unused]]` to an argument of `__adapt`, it seems gcc9 didn't like that it was not used in one of the `if constexpr` branches.