### PR TITLE
[CUDAX] Fix parentheses in one of the launch overloads

### DIFF
--- a/cudax/include/cuda/experimental/__launch/launch.cuh
+++ b/cudax/include/cuda/experimental/__launch/launch.cuh
@@ -208,7 +208,7 @@ _CCCL_CONCEPT work_submitter = graph_inserter<_Submitter> || _CUDA_VSTD::is_conv
 //! arguments to be passed into the kernel functor
 _CCCL_TEMPLATE(typename... _Args, typename... _Config, typename _Submitter, typename _Dimensions, typename _Kernel)
 _CCCL_REQUIRES(work_submitter<_Submitter>
-               && ((!::cuda::std::is_pointer_v<_Kernel>) || (!::cuda::std::is_function_v<_Kernel>) ))
+               && !(::cuda::std::is_pointer_v<_Kernel> || ::cuda::std::is_function_v<_Kernel>) )
 _CCCL_HOST_API auto launch(_Submitter&& __submitter,
                            const kernel_config<_Dimensions, _Config...>& __conf,
                            const _Kernel& __kernel,


### PR DESCRIPTION
When working on [https://github.com/NVIDIA/cccl/pull/5048#event-18288216972](url) it seems one of the requires conditions got wrong when parentheses were added, this PR fixes it