### PR TITLE
Replace CG by TMA copy in bulk copy fallback path

### DIFF
--- a/cub/cub/device/dispatch/kernels/transform.cuh
+++ b/cub/cub/device/dispatch/kernels/transform.cuh
@@ -580,7 +580,7 @@ _CCCL_DEVICE void bulk_copy_maybe_unaligned(
         src_ptr + head_bytes,
         aligned_bytes_to_copy,
         &bar);
-      total_copied += bytes_to_copy;
+      total_copied += aligned_bytes_to_copy;
     }
   }
 

--- a/cub/cub/device/dispatch/kernels/transform.cuh
+++ b/cub/cub/device/dispatch/kernels/transform.cuh
@@ -550,7 +550,7 @@ _CCCL_DEVICE void bulk_copy_maybe_unaligned(
   char* dst_ptr       = static_cast<char*>(dst);
 
   // handle tiny copies to simplify head/tail bytes computations below
-  if (bytes_to_copy < bulk_copy_size_multiple)
+  if (bytes_to_copy < BulkCopyAlignment)
   {
     if (threadIdx.x < bytes_to_copy)
     {

--- a/cub/cub/device/dispatch/kernels/transform.cuh
+++ b/cub/cub/device/dispatch/kernels/transform.cuh
@@ -565,6 +565,7 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
       int smem_offset                    = 0;
       ::cuda::std::uint32_t total_copied = 0;
 
+      // turning this lambda into a function does not change SASS
       auto bulk_copy_tile = [&](auto aligned_ptr) {
         using T = typename decltype(aligned_ptr)::value_type;
         static_assert(alignof(T) <= bulk_copy_alignment, "");
@@ -602,6 +603,7 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
     // use all threads to schedule an async_memcpy
     int smem_offset = 0;
 
+    // turning this lambda into a function does not change SASS
     auto bulk_copy_tile_fallback = [&](auto aligned_ptr) {
       using T      = typename decltype(aligned_ptr)::value_type;
       const T* src = aligned_ptr.ptr_to_elements() + offset;

--- a/cub/cub/device/dispatch/kernels/transform.cuh
+++ b/cub/cub/device/dispatch/kernels/transform.cuh
@@ -578,7 +578,7 @@ _CCCL_DEVICE void bulk_copy_maybe_unaligned(
         ::cuda::ptx::space_global,
         dst_ptr + head_bytes,
         src_ptr + head_bytes,
-        bytes_to_copy,
+        aligned_bytes_to_copy,
         &bar);
       total_copied += bytes_to_copy;
     }

--- a/cub/cub/device/dispatch/kernels/transform.cuh
+++ b/cub/cub/device/dispatch/kernels/transform.cuh
@@ -584,13 +584,23 @@ _CCCL_DEVICE void bulk_copy_maybe_unaligned(
     }
   }
 
+  // ahendriksen: we perform both loads first and then both writes. this reduces the total latency
+  char head_byte, tail_byte;
   if (threadIdx.x < head_bytes)
   {
-    dst_ptr[threadIdx.x] = src_ptr[threadIdx.x];
+    head_byte = src_ptr[threadIdx.x];
   }
   if (threadIdx.x < tail_bytes)
   {
-    dst_ptr[bytes_to_copy - tail_bytes + threadIdx.x] = src_ptr[bytes_to_copy - tail_bytes + threadIdx.x];
+    tail_byte = src_ptr[bytes_to_copy - tail_bytes + threadIdx.x];
+  }
+  if (threadIdx.x < head_bytes)
+  {
+    dst_ptr[threadIdx.x] = head_byte;
+  }
+  if (threadIdx.x < tail_bytes)
+  {
+    dst_ptr[bytes_to_copy - tail_bytes + threadIdx.x] = tail_byte;
   }
 }
 

--- a/cub/cub/device/dispatch/kernels/transform.cuh
+++ b/cub/cub/device/dispatch/kernels/transform.cuh
@@ -573,7 +573,13 @@ _CCCL_DEVICE void bulk_copy_maybe_unaligned(
       _CCCL_ASSERT(::cuda::std::bit_cast<uintptr_t>(src_ptr + head_bytes) % BulkCopyAlignment == 0, "");
       _CCCL_ASSERT(aligned_bytes_to_copy % bulk_copy_size_multiple == 0, "");
 
-      ::cuda::ptx::cp_async_bulk(::cuda::ptx::space_cluster, ::cuda::ptx::space_global, dst, src, bytes_to_copy, &bar);
+      ::cuda::ptx::cp_async_bulk(
+        ::cuda::ptx::space_cluster,
+        ::cuda::ptx::space_global,
+        dst_ptr + head_bytes,
+        src_ptr + head_bytes,
+        bytes_to_copy,
+        &bar);
       total_copied += bytes_to_copy;
     }
   }


### PR DESCRIPTION
- [x] Merge before: #4976
- [x] Unit tests pass on a Hopper or Blackwell machine

This also drops the last use of cooperative_groups in CUB DeviceTransform.

Benchmark on B200:
```
# mul

## [0] NVIDIA B200

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |       Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|------------|---------|----------|
|   I8    |      I32      |      2^16      |   7.638 us |      10.75% |   6.156 us |       8.64% |  -1.481 us | -19.39% |   FAST   |
|   I8    |      I32      |      2^20      |   7.998 us |       4.01% |   6.769 us |      11.62% |  -1.228 us | -15.36% |   FAST   |
|   I8    |      I32      |      2^24      |  16.181 us |       2.13% |  14.179 us |       2.63% |  -2.001 us | -12.37% |   FAST   |
|   I8    |      I32      |      2^28      | 132.860 us |       0.34% | 123.017 us |       0.48% |  -9.844 us |  -7.41% |   FAST   |
|   I8    |      I64      |      2^16      |   7.649 us |       9.52% |   6.413 us |      10.56% |  -1.236 us | -16.16% |   FAST   |
|   I8    |      I64      |      2^20      |   7.997 us |       3.85% |   6.883 us |      11.88% |  -1.114 us | -13.92% |   FAST   |
|   I8    |      I64      |      2^24      |  16.171 us |       2.40% |  14.216 us |       2.84% |  -1.954 us | -12.09% |   FAST   |
|   I8    |      I64      |      2^28      | 135.067 us |       0.17% | 124.755 us |       0.25% | -10.313 us |  -7.64% |   FAST   |
|   I16   |      I32      |      2^16      |   6.396 us |       9.54% |   5.973 us |       6.02% |  -0.424 us |  -6.62% |   FAST   |
|   I16   |      I32      |      2^20      |   7.312 us |      11.81% |   6.724 us |      10.74% |  -0.588 us |  -8.05% |   SAME   |
|   I16   |      I32      |      2^24      |  18.413 us |       2.87% |  17.416 us |       4.96% |  -0.997 us |  -5.41% |   FAST   |
|   I16   |      I32      |      2^28      | 188.638 us |       0.37% | 167.895 us |       0.30% | -20.743 us | -11.00% |   FAST   |
|   I16   |      I64      |      2^16      |   6.450 us |      10.17% |   5.950 us |       6.26% |  -0.500 us |  -7.75% |   FAST   |
|   I16   |      I64      |      2^20      |   7.289 us |      11.82% |   6.765 us |      10.92% |  -0.524 us |  -7.18% |   SAME   |
|   I16   |      I64      |      2^24      |  18.212 us |       2.09% |  17.555 us |       4.68% |  -0.657 us |  -3.61% |   FAST   |
|   I16   |      I64      |      2^28      | 182.178 us |       0.19% | 170.071 us |       0.38% | -12.107 us |  -6.65% |   FAST   |
|   F32   |      I32      |      2^16      |   5.951 us |       5.34% |   5.909 us |       5.62% |  -0.042 us |  -0.71% |   SAME   |
|   F32   |      I32      |      2^20      |   7.615 us |      10.05% |   7.552 us |       9.81% |  -0.064 us |  -0.83% |   SAME   |
|   F32   |      I32      |      2^24      |  25.840 us |       3.31% |  25.859 us |       3.16% |   0.019 us |   0.07% |   SAME   |
|   F32   |      I32      |      2^28      | 313.338 us |       0.33% | 313.597 us |       0.33% |   0.259 us |   0.08% |   SAME   |
|   F32   |      I64      |      2^16      |   5.941 us |       5.27% |   5.916 us |       5.49% |  -0.025 us |  -0.42% |   SAME   |
|   F32   |      I64      |      2^20      |   7.669 us |       9.31% |   7.451 us |      10.81% |  -0.218 us |  -2.85% |   SAME   |
|   F32   |      I64      |      2^24      |  26.167 us |       2.63% |  26.092 us |       2.66% |  -0.075 us |  -0.29% |   SAME   |
|   F32   |      I64      |      2^28      | 313.380 us |       0.31% | 313.473 us |       0.31% |   0.093 us |   0.03% |   SAME   |
|   F64   |      I32      |      2^16      |   5.936 us |       5.39% |   5.914 us |       5.62% |  -0.021 us |  -0.36% |   SAME   |
|   F64   |      I32      |      2^20      |   8.368 us |       7.15% |   8.367 us |       7.70% |  -0.000 us |  -0.00% |   SAME   |
|   F64   |      I32      |      2^24      |  45.488 us |       1.98% |  45.632 us |       2.06% |   0.144 us |   0.32% |   SAME   |
|   F64   |      I32      |      2^28      | 620.668 us |       0.23% | 620.794 us |       0.22% |   0.126 us |   0.02% |   SAME   |
|   F64   |      I64      |      2^16      |   5.956 us |       5.20% |   5.930 us |       5.50% |  -0.026 us |  -0.44% |   SAME   |
|   F64   |      I64      |      2^20      |   8.349 us |       6.78% |   8.392 us |       7.57% |   0.043 us |   0.52% |   SAME   |
|   F64   |      I64      |      2^24      |  45.777 us |       2.17% |  45.768 us |       2.13% |  -0.009 us |  -0.02% |   SAME   |
|   F64   |      I64      |      2^28      | 620.638 us |       0.22% | 620.888 us |       0.22% |   0.251 us |   0.04% |   SAME   |
|  I128   |      I32      |      2^16      |   5.984 us |       5.70% |   5.911 us |       6.05% |  -0.074 us |  -1.23% |   SAME   |
|  I128   |      I32      |      2^20      |  10.884 us |       7.42% |  10.962 us |       7.15% |   0.078 us |   0.72% |   SAME   |
|  I128   |      I32      |      2^24      |  83.794 us |       0.86% |  83.801 us |       0.80% |   0.007 us |   0.01% |   SAME   |
|  I128   |      I32      |      2^28      |   1.236 ms |       0.14% |   1.236 ms |       0.15% |   0.194 us |   0.02% |   SAME   |
|  I128   |      I64      |      2^16      |   6.139 us |       9.97% |   6.035 us |       8.62% |  -0.104 us |  -1.70% |   SAME   |
|  I128   |      I64      |      2^20      |  10.932 us |       7.42% |  10.976 us |       7.37% |   0.044 us |   0.40% |   SAME   |
|  I128   |      I64      |      2^24      |  83.876 us |       0.73% |  83.802 us |       0.77% |  -0.074 us |  -0.09% |   SAME   |
|  I128   |      I64      |      2^28      |   1.236 ms |       0.15% |   1.236 ms |       0.15% |   0.074 us |   0.01% |   SAME   |

# add

## [0] NVIDIA B200

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |       Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|------------|---------|----------|
|   I8    |      I32      |      2^16      |   7.796 us |       8.32% |   6.306 us |      12.32% |  -1.490 us | -19.11% |   FAST   |
|   I8    |      I32      |      2^20      |   7.977 us |       4.65% |   6.624 us |      10.55% |  -1.353 us | -16.96% |   FAST   |
|   I8    |      I32      |      2^24      |  17.933 us |       3.99% |  16.130 us |       2.10% |  -1.804 us | -10.06% |   FAST   |
|   I8    |      I32      |      2^28      | 155.759 us |       0.39% | 148.479 us |       0.66% |  -7.279 us |  -4.67% |   FAST   |
|   I8    |      I64      |      2^16      |   7.336 us |      11.70% |   5.979 us |       6.69% |  -1.357 us | -18.49% |   FAST   |
|   I8    |      I64      |      2^20      |   7.962 us |       4.43% |   6.615 us |      10.60% |  -1.347 us | -16.92% |   FAST   |
|   I8    |      I64      |      2^24      |  16.971 us |       4.66% |  16.163 us |       2.03% |  -0.808 us |  -4.76% |   FAST   |
|   I8    |      I64      |      2^28      | 154.553 us |       0.62% | 151.558 us |       0.31% |  -2.996 us |  -1.94% |   FAST   |
|   I16   |      I32      |      2^16      |   6.491 us |      10.61% |   5.882 us |       5.58% |  -0.609 us |  -9.38% |   FAST   |
|   I16   |      I32      |      2^20      |   7.886 us |       5.85% |   7.543 us |      10.01% |  -0.343 us |  -4.35% |   SAME   |
|   I16   |      I32      |      2^24      |  23.712 us |       3.67% |  22.385 us |       1.99% |  -1.327 us |  -5.59% |   FAST   |
|   I16   |      I32      |      2^28      | 259.584 us |       0.32% | 250.035 us |       0.30% |  -9.549 us |  -3.68% |   FAST   |
|   I16   |      I64      |      2^16      |   6.344 us |       9.89% |   5.875 us |       5.97% |  -0.469 us |  -7.40% |   FAST   |
|   I16   |      I64      |      2^20      |   7.929 us |       4.41% |   7.472 us |      10.09% |  -0.456 us |  -5.76% |   FAST   |
|   I16   |      I64      |      2^24      |  23.798 us |       3.60% |  22.524 us |       2.27% |  -1.274 us |  -5.36% |   FAST   |
|   I16   |      I64      |      2^28      | 264.200 us |       0.23% | 253.396 us |       0.33% | -10.804 us |  -4.09% |   FAST   |
|   F32   |      I32      |      2^16      |   5.972 us |       5.38% |   5.906 us |       5.87% |  -0.066 us |  -1.11% |   SAME   |
|   F32   |      I32      |      2^20      |   7.978 us |       4.39% |   8.032 us |       4.50% |   0.054 us |   0.68% |   SAME   |
|   F32   |      I32      |      2^24      |  36.664 us |       1.00% |  36.495 us |       1.53% |  -0.169 us |  -0.46% |   SAME   |
|   F32   |      I32      |      2^28      | 454.553 us |       0.05% | 453.647 us |       0.23% |  -0.906 us |  -0.20% |   FAST   |
|   F32   |      I64      |      2^16      |   5.976 us |       5.97% |   5.932 us |       5.44% |  -0.043 us |  -0.72% |   SAME   |
|   F32   |      I64      |      2^20      |   8.013 us |       4.65% |   7.995 us |       4.76% |  -0.018 us |  -0.22% |   SAME   |
|   F32   |      I64      |      2^24      |  36.667 us |       0.97% |  36.646 us |       1.27% |  -0.021 us |  -0.06% |   SAME   |
|   F32   |      I64      |      2^28      | 454.962 us |       0.18% | 454.342 us |       0.13% |  -0.620 us |  -0.14% |   FAST   |
|   F64   |      I32      |      2^16      |   5.952 us |       5.89% |   5.961 us |       5.52% |   0.009 us |   0.16% |   SAME   |
|   F64   |      I32      |      2^20      |  10.022 us |       3.38% |  10.022 us |       3.75% |  -0.001 us |  -0.01% |   SAME   |
|   F64   |      I32      |      2^24      |  65.355 us |       0.68% |  65.234 us |       0.86% |  -0.121 us |  -0.18% |   SAME   |
|   F64   |      I32      |      2^28      | 905.185 us |       0.18% | 907.897 us |       0.21% |   2.711 us |   0.30% |   SLOW   |
|   F64   |      I64      |      2^16      |   5.951 us |       5.56% |   5.925 us |       6.03% |  -0.026 us |  -0.43% |   SAME   |
|   F64   |      I64      |      2^20      |  10.076 us |       3.48% |   9.994 us |       3.53% |  -0.081 us |  -0.81% |   SAME   |
|   F64   |      I64      |      2^24      |  65.435 us |       0.65% |  65.329 us |       0.70% |  -0.107 us |  -0.16% |   SAME   |
|   F64   |      I64      |      2^28      | 903.595 us |       0.19% | 906.505 us |       0.21% |   2.910 us |   0.32% |   SLOW   |
|  I128   |      I32      |      2^16      |   6.043 us |       6.31% |   5.999 us |       6.23% |  -0.044 us |  -0.72% |   SAME   |
|  I128   |      I32      |      2^20      |  14.141 us |       2.45% |  14.088 us |       2.45% |  -0.053 us |  -0.38% |   SAME   |
|  I128   |      I32      |      2^24      | 120.718 us |       0.35% | 120.672 us |       0.47% |  -0.046 us |  -0.04% |   SAME   |
|  I128   |      I32      |      2^28      |   1.807 ms |       0.10% |   1.811 ms |       0.13% |   3.279 us |   0.18% |   SLOW   |
|  I128   |      I64      |      2^16      |   6.174 us |      10.24% |   6.150 us |      10.66% |  -0.024 us |  -0.39% |   SAME   |
|  I128   |      I64      |      2^20      |  14.158 us |       2.42% |  14.075 us |       2.64% |  -0.083 us |  -0.58% |   SAME   |
|  I128   |      I64      |      2^24      | 120.793 us |       0.39% | 120.637 us |       0.38% |  -0.156 us |  -0.13% |   SAME   |
|  I128   |      I64      |      2^28      |   1.806 ms |       0.12% |   1.809 ms |       0.13% |   2.882 us |   0.16% |   SLOW   |

# triad

## [0] NVIDIA B200

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |       Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|------------|---------|----------|
|   I8    |      I32      |      2^16      |   7.408 us |      11.79% |   6.232 us |      11.15% |  -1.175 us | -15.87% |   FAST   |
|   I8    |      I32      |      2^20      |   7.955 us |       4.17% |   6.710 us |      10.93% |  -1.246 us | -15.66% |   FAST   |
|   I8    |      I32      |      2^24      |  18.445 us |       2.60% |  16.396 us |       3.39% |  -2.049 us | -11.11% |   FAST   |
|   I8    |      I32      |      2^28      | 172.607 us |       0.55% | 161.278 us |       0.48% | -11.329 us |  -6.56% |   FAST   |
|   I8    |      I64      |      2^16      |   6.924 us |      12.11% |   6.031 us |       6.08% |  -0.893 us | -12.89% |   FAST   |
|   I8    |      I64      |      2^20      |   7.956 us |       4.01% |   6.856 us |      11.12% |  -1.100 us | -13.82% |   FAST   |
|   I8    |      I64      |      2^24      |  18.753 us |       3.84% |  16.553 us |       3.82% |  -2.200 us | -11.73% |   FAST   |
|   I8    |      I64      |      2^28      | 188.372 us |       0.23% | 163.704 us |       0.13% | -24.667 us | -13.10% |   FAST   |
|   I16   |      I32      |      2^16      |   6.394 us |       9.77% |   5.940 us |       5.33% |  -0.454 us |  -7.10% |   FAST   |
|   I16   |      I32      |      2^20      |   7.910 us |       5.03% |   7.568 us |       9.78% |  -0.341 us |  -4.31% |   SAME   |
|   I16   |      I32      |      2^24      |  24.903 us |       2.99% |  22.802 us |       3.08% |  -2.101 us |  -8.44% |   FAST   |
|   I16   |      I32      |      2^28      | 278.567 us |       0.19% | 250.192 us |       0.33% | -28.375 us | -10.19% |   FAST   |
|   I16   |      I64      |      2^16      |   6.401 us |      10.43% |   5.908 us |       5.67% |  -0.492 us |  -7.69% |   FAST   |
|   I16   |      I64      |      2^20      |   7.934 us |       4.87% |   7.651 us |       9.30% |  -0.283 us |  -3.57% |   SAME   |
|   I16   |      I64      |      2^24      |  24.221 us |       2.29% |  22.930 us |       3.24% |  -1.291 us |  -5.33% |   FAST   |
|   I16   |      I64      |      2^28      | 252.027 us |       0.27% | 252.433 us |       0.36% |   0.406 us |   0.16% |   SAME   |
|   F32   |      I32      |      2^16      |   5.979 us |       5.74% |   5.902 us |       5.74% |  -0.076 us |  -1.28% |   SAME   |
|   F32   |      I32      |      2^20      |   8.008 us |       4.57% |   7.959 us |       4.37% |  -0.049 us |  -0.61% |   SAME   |
|   F32   |      I32      |      2^24      |  36.715 us |       0.99% |  36.668 us |       0.99% |  -0.047 us |  -0.13% |   SAME   |
|   F32   |      I32      |      2^28      | 454.444 us |       0.10% | 453.032 us |       0.19% |  -1.412 us |  -0.31% |   FAST   |
|   F32   |      I64      |      2^16      |   5.969 us |       5.79% |   5.928 us |       5.39% |  -0.041 us |  -0.69% |   SAME   |
|   F32   |      I64      |      2^20      |   7.977 us |       4.39% |   7.979 us |       4.67% |   0.002 us |   0.03% |   SAME   |
|   F32   |      I64      |      2^24      |  36.752 us |       1.06% |  36.675 us |       0.98% |  -0.078 us |  -0.21% |   SAME   |
|   F32   |      I64      |      2^28      | 454.533 us |       0.04% | 453.798 us |       0.20% |  -0.735 us |  -0.16% |   FAST   |
|   F64   |      I32      |      2^16      |   5.914 us |       5.54% |   5.933 us |       5.41% |   0.019 us |   0.31% |   SAME   |
|   F64   |      I32      |      2^20      |  10.170 us |       4.46% |  10.178 us |       4.46% |   0.008 us |   0.08% |   SAME   |
|   F64   |      I32      |      2^24      |  64.337 us |       1.48% |  64.122 us |       1.38% |  -0.215 us |  -0.33% |   SAME   |
|   F64   |      I32      |      2^28      | 903.785 us |       0.29% | 906.797 us |       0.25% |   3.012 us |   0.33% |   SLOW   |
|   F64   |      I64      |      2^16      |   5.954 us |       5.34% |   5.935 us |       5.48% |  -0.020 us |  -0.33% |   SAME   |
|   F64   |      I64      |      2^20      |  10.187 us |       4.50% |  10.132 us |       4.33% |  -0.055 us |  -0.54% |   SAME   |
|   F64   |      I64      |      2^24      |  65.171 us |       0.94% |  64.962 us |       1.13% |  -0.210 us |  -0.32% |   SAME   |
|   F64   |      I64      |      2^28      | 901.310 us |       0.34% | 905.455 us |       0.24% |   4.145 us |   0.46% |   SLOW   |
|  I128   |      I32      |      2^16      |   6.028 us |       6.40% |   6.013 us |       6.39% |  -0.015 us |  -0.25% |   SAME   |
|  I128   |      I32      |      2^20      |  14.123 us |       2.27% |  14.099 us |       2.51% |  -0.024 us |  -0.17% |   SAME   |
|  I128   |      I32      |      2^24      | 120.622 us |       0.31% | 120.429 us |       0.49% |  -0.193 us |  -0.16% |   SAME   |
|  I128   |      I32      |      2^28      |   1.811 ms |       0.15% |   1.814 ms |       0.11% |   2.734 us |   0.15% |   SLOW   |
|  I128   |      I64      |      2^16      |   6.177 us |      10.41% |   6.192 us |      10.60% |   0.015 us |   0.24% |   SAME   |
|  I128   |      I64      |      2^20      |  14.122 us |       2.22% |  14.091 us |       2.49% |  -0.031 us |  -0.22% |   SAME   |
|  I128   |      I64      |      2^24      | 120.652 us |       0.27% | 120.568 us |       0.30% |  -0.083 us |  -0.07% |   SAME   |
|  I128   |      I64      |      2^28      |   1.809 ms |       0.16% |   1.813 ms |       0.11% |   4.017 us |   0.22% |   SLOW   |

# nstream

## [0] NVIDIA B200

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |       Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|------------|---------|----------|
|   I8    |      I32      |      2^16      |   7.444 us |      11.81% |   6.219 us |      11.85% |  -1.225 us | -16.46% |   FAST   |
|   I8    |      I32      |      2^20      |   7.967 us |       4.04% |   7.115 us |      11.75% |  -0.851 us | -10.68% |   FAST   |
|   I8    |      I32      |      2^24      |  22.007 us |       3.20% |  20.363 us |       2.32% |  -1.644 us |  -7.47% |   FAST   |
|   I8    |      I32      |      2^28      | 230.197 us |       0.43% | 225.106 us |       0.14% |  -5.091 us |  -2.21% |   FAST   |
|   I8    |      I64      |      2^16      |   7.559 us |      10.41% |   6.003 us |       6.10% |  -1.556 us | -20.58% |   FAST   |
|   I8    |      I64      |      2^20      |   8.037 us |       4.29% |   7.264 us |      11.24% |  -0.773 us |  -9.62% |   FAST   |
|   I8    |      I64      |      2^24      |  21.246 us |       4.14% |  20.472 us |       2.46% |  -0.775 us |  -3.65% |   FAST   |
|   I8    |      I64      |      2^28      | 213.003 us |       0.24% | 229.229 us |       0.12% |  16.226 us |   7.62% |   SLOW   |
|   I16   |      I32      |      2^16      |   6.739 us |      12.36% |   5.930 us |       5.62% |  -0.810 us | -12.01% |   FAST   |
|   I16   |      I32      |      2^20      |   8.170 us |       6.04% |   7.945 us |       4.28% |  -0.225 us |  -2.75% |   SAME   |
|   I16   |      I32      |      2^24      |  29.767 us |       3.16% |  28.121 us |       2.47% |  -1.646 us |  -5.53% |   FAST   |
|   I16   |      I32      |      2^28      | 356.758 us |       0.25% | 343.862 us |       0.18% | -12.896 us |  -3.61% |   FAST   |
|   I16   |      I64      |      2^16      |   7.425 us |      11.14% |   5.924 us |       5.81% |  -1.502 us | -20.23% |   FAST   |
|   I16   |      I64      |      2^20      |   8.085 us |       5.98% |   7.939 us |       4.12% |  -0.146 us |  -1.81% |   SAME   |
|   I16   |      I64      |      2^24      |  29.166 us |       2.78% |  28.435 us |       1.20% |  -0.731 us |  -2.51% |   FAST   |
|   I16   |      I64      |      2^28      | 327.902 us |       0.25% | 342.087 us |       0.22% |  14.185 us |   4.33% |   SLOW   |
|   F32   |      I32      |      2^16      |   6.032 us |       6.44% |   5.917 us |       5.57% |  -0.115 us |  -1.91% |   SAME   |
|   F32   |      I32      |      2^20      |   8.883 us |       9.00% |   8.905 us |       8.79% |   0.022 us |   0.25% |   SAME   |
|   F32   |      I32      |      2^24      |  47.124 us |       1.19% |  46.971 us |       0.94% |  -0.154 us |  -0.33% |   SAME   |
|   F32   |      I32      |      2^28      | 604.561 us |       0.14% | 602.026 us |       0.06% |  -2.535 us |  -0.42% |   FAST   |
|   F32   |      I64      |      2^16      |   6.009 us |       6.61% |   5.928 us |       5.61% |  -0.081 us |  -1.35% |   SAME   |
|   F32   |      I64      |      2^20      |   8.968 us |       9.20% |   8.887 us |       8.86% |  -0.081 us |  -0.91% |   SAME   |
|   F32   |      I64      |      2^24      |  47.283 us |       1.44% |  47.013 us |       1.05% |  -0.270 us |  -0.57% |   SAME   |
|   F32   |      I64      |      2^28      | 606.143 us |       0.07% | 603.278 us |       0.16% |  -2.865 us |  -0.47% |   FAST   |
|   F64   |      I32      |      2^16      |   6.010 us |       6.62% |   5.966 us |       5.85% |  -0.045 us |  -0.74% |   SAME   |
|   F64   |      I32      |      2^20      |  12.026 us |       2.86% |  12.019 us |       3.35% |  -0.007 us |  -0.06% |   SAME   |
|   F64   |      I32      |      2^24      |  84.448 us |       1.06% |  84.437 us |       1.07% |  -0.011 us |  -0.01% |   SAME   |
|   F64   |      I32      |      2^28      |   1.185 ms |       0.08% |   1.185 ms |       0.07% |   0.180 us |   0.02% |   SAME   |
|   F64   |      I64      |      2^16      |   6.001 us |       6.51% |   5.990 us |       5.80% |  -0.011 us |  -0.18% |   SAME   |
|   F64   |      I64      |      2^20      |  12.035 us |       2.83% |  12.036 us |       3.04% |   0.001 us |   0.01% |   SAME   |
|   F64   |      I64      |      2^24      |  84.649 us |       1.08% |  84.575 us |       1.11% |  -0.074 us |  -0.09% |   SAME   |
|   F64   |      I64      |      2^28      |   1.185 ms |       0.08% |   1.185 ms |       0.07% |   0.195 us |   0.02% |   SAME   |
|  I128   |      I32      |      2^16      |   6.290 us |       8.82% |   6.273 us |       9.75% |  -0.017 us |  -0.27% |   SAME   |
|  I128   |      I32      |      2^20      |  16.593 us |       3.71% |  16.715 us |       4.33% |   0.123 us |   0.74% |   SAME   |
|  I128   |      I32      |      2^24      | 157.167 us |       0.51% | 157.175 us |       0.45% |   0.007 us |   0.00% |   SAME   |
|  I128   |      I32      |      2^28      |   2.359 ms |       0.05% |   2.359 ms |       0.05% |   0.076 us |   0.00% |   SAME   |
|  I128   |      I64      |      2^16      |   6.559 us |      12.57% |   6.529 us |      12.33% |  -0.031 us |  -0.47% |   SAME   |
|  I128   |      I64      |      2^20      |  16.748 us |       4.35% |  16.604 us |       3.90% |  -0.144 us |  -0.86% |   SAME   |
|  I128   |      I64      |      2^24      | 157.211 us |       0.45% | 157.170 us |       0.48% |  -0.041 us |  -0.03% |   SAME   |
|  I128   |      I64      |      2^28      |   2.359 ms |       0.05% |   2.359 ms |       0.05% |   0.399 us |   0.02% |   SAME   |
```

Benchmark on H200:
```
# mul

## [0] NVIDIA H200

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-----------|---------|----------|
|   I8    |      I32      |      2^16      |   5.041 us |       2.59% |   4.916 us |       2.38% | -0.124 us |  -2.47% |   FAST   |
|   I8    |      I32      |      2^20      |   5.571 us |       2.75% |   5.568 us |       2.99% | -0.004 us |  -0.07% |   SAME   |
|   I8    |      I32      |      2^24      |  14.583 us |       2.02% |  14.532 us |       1.97% | -0.051 us |  -0.35% |   SAME   |
|   I8    |      I32      |      2^28      | 140.910 us |       0.54% | 140.742 us |       0.54% | -0.169 us |  -0.12% |   SAME   |
|   I8    |      I64      |      2^16      |   5.117 us |       2.79% |   5.006 us |       2.73% | -0.111 us |  -2.17% |   SAME   |
|   I8    |      I64      |      2^20      |   5.550 us |       2.58% |   5.516 us |       3.05% | -0.034 us |  -0.62% |   SAME   |
|   I8    |      I64      |      2^24      |  14.643 us |       1.90% |  14.550 us |       2.07% | -0.093 us |  -0.63% |   SAME   |
|   I8    |      I64      |      2^28      | 141.643 us |       0.54% | 141.559 us |       0.55% | -0.084 us |  -0.06% |   SAME   |
|   I16   |      I32      |      2^16      |   4.594 us |       2.57% |   4.598 us |       3.23% |  0.005 us |   0.10% |   SAME   |
|   I16   |      I32      |      2^20      |   5.694 us |       2.86% |   5.706 us |       3.20% |  0.012 us |   0.22% |   SAME   |
|   I16   |      I32      |      2^24      |  21.488 us |       2.29% |  21.448 us |       2.36% | -0.040 us |  -0.19% |   SAME   |
|   I16   |      I32      |      2^28      | 253.575 us |       0.39% | 253.611 us |       0.38% |  0.036 us |   0.01% |   SAME   |
|   I16   |      I64      |      2^16      |   4.663 us |       2.82% |   4.646 us |       2.83% | -0.018 us |  -0.38% |   SAME   |
|   I16   |      I64      |      2^20      |   5.756 us |       3.10% |   5.792 us |       2.93% |  0.036 us |   0.63% |   SAME   |
|   I16   |      I64      |      2^24      |  21.416 us |       2.37% |  21.494 us |       2.27% |  0.078 us |   0.36% |   SAME   |
|   I16   |      I64      |      2^28      | 253.742 us |       0.38% | 253.823 us |       0.38% |  0.081 us |   0.03% |   SAME   |
|   F32   |      I32      |      2^16      |   4.485 us |       2.96% |   4.565 us |       3.01% |  0.080 us |   1.78% |   SAME   |
|   F32   |      I32      |      2^20      |   6.455 us |       3.26% |   6.546 us |       2.32% |  0.091 us |   1.41% |   SAME   |
|   F32   |      I32      |      2^24      |  36.885 us |       1.87% |  36.987 us |       1.93% |  0.102 us |   0.28% |   SAME   |
|   F32   |      I32      |      2^28      | 508.699 us |       0.19% | 509.003 us |       0.18% |  0.304 us |   0.06% |   SAME   |
|   F32   |      I64      |      2^16      |   4.587 us |       3.75% |   4.637 us |       4.04% |  0.050 us |   1.10% |   SAME   |
|   F32   |      I64      |      2^20      |   6.511 us |       3.48% |   6.573 us |       2.56% |  0.062 us |   0.95% |   SAME   |
|   F32   |      I64      |      2^24      |  36.709 us |       1.95% |  36.829 us |       1.98% |  0.120 us |   0.33% |   SAME   |
|   F32   |      I64      |      2^28      | 508.565 us |       0.18% | 508.897 us |       0.19% |  0.333 us |   0.07% |   SAME   |
|   F64   |      I32      |      2^16      |   4.563 us |       3.58% |   4.758 us |       3.13% |  0.195 us |   4.28% |   SLOW   |
|   F64   |      I32      |      2^20      |   8.623 us |       2.91% |   8.758 us |       2.75% |  0.135 us |   1.56% |   SAME   |
|   F64   |      I32      |      2^24      |  67.605 us |       1.10% |  67.716 us |       1.08% |  0.110 us |   0.16% |   SAME   |
|   F64   |      I32      |      2^28      |   1.011 ms |       0.13% |   1.011 ms |       0.11% |  0.458 us |   0.05% |   SAME   |
|   F64   |      I64      |      2^16      |   4.640 us |       4.25% |   4.715 us |       4.75% |  0.075 us |   1.63% |   SAME   |
|   F64   |      I64      |      2^20      |   8.713 us |       3.06% |   8.753 us |       3.16% |  0.041 us |   0.47% |   SAME   |
|   F64   |      I64      |      2^24      |  67.612 us |       1.12% |  67.666 us |       1.07% |  0.054 us |   0.08% |   SAME   |
|   F64   |      I64      |      2^28      |   1.011 ms |       0.13% |   1.011 ms |       0.12% |  0.525 us |   0.05% |   SAME   |
|  I128   |      I32      |      2^16      |   4.967 us |       3.90% |   4.996 us |       5.10% |  0.029 us |   0.58% |   SAME   |
|  I128   |      I32      |      2^20      |  13.003 us |       2.75% |  13.071 us |       2.49% |  0.068 us |   0.52% |   SAME   |
|  I128   |      I32      |      2^24      | 132.870 us |       0.63% | 132.935 us |       0.67% |  0.066 us |   0.05% |   SAME   |
|  I128   |      I32      |      2^28      |   2.052 ms |       0.08% |   2.052 ms |       0.08% |  0.093 us |   0.00% |   SAME   |
|  I128   |      I64      |      2^16      |   5.087 us |       3.42% |   4.939 us |       3.86% | -0.148 us |  -2.90% |   SAME   |
|  I128   |      I64      |      2^20      |  12.991 us |       2.51% |  12.965 us |       2.67% | -0.026 us |  -0.20% |   SAME   |
|  I128   |      I64      |      2^24      | 134.354 us |       0.65% | 134.347 us |       0.65% | -0.006 us |  -0.00% |   SAME   |
|  I128   |      I64      |      2^28      |   2.055 ms |       0.31% |   2.055 ms |       0.39% | -0.183 us |  -0.01% |   SAME   |

# add

## [0] NVIDIA H200

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-----------|---------|----------|
|   I8    |      I32      |      2^16      |   5.040 us |       3.54% |   4.773 us |       3.06% | -0.267 us |  -5.29% |   FAST   |
|   I8    |      I32      |      2^20      |   5.969 us |       3.41% |   5.745 us |       3.09% | -0.224 us |  -3.75% |   FAST   |
|   I8    |      I32      |      2^24      |  19.456 us |       2.09% |  19.168 us |       1.91% | -0.289 us |  -1.48% |   SAME   |
|   I8    |      I32      |      2^28      | 201.868 us |       0.45% | 198.857 us |       0.55% | -3.010 us |  -1.49% |   FAST   |
|   I8    |      I64      |      2^16      |   4.990 us |       2.92% |   4.736 us |       2.92% | -0.254 us |  -5.10% |   FAST   |
|   I8    |      I64      |      2^20      |   6.004 us |       2.62% |   5.830 us |       2.51% | -0.174 us |  -2.90% |   FAST   |
|   I8    |      I64      |      2^24      |  19.112 us |       1.93% |  18.710 us |       2.00% | -0.402 us |  -2.10% |   FAST   |
|   I8    |      I64      |      2^28      | 205.752 us |       0.16% | 198.805 us |       0.23% | -6.947 us |  -3.38% |   FAST   |
|   I16   |      I32      |      2^16      |   4.713 us |       2.62% |   4.656 us |       2.71% | -0.057 us |  -1.20% |   SAME   |
|   I16   |      I32      |      2^20      |   6.548 us |       3.79% |   6.558 us |       2.74% |  0.009 us |   0.14% |   SAME   |
|   I16   |      I32      |      2^24      |  30.136 us |       1.87% |  30.109 us |       1.89% | -0.027 us |  -0.09% |   SAME   |
|   I16   |      I32      |      2^28      | 372.093 us |       0.21% | 371.495 us |       0.22% | -0.598 us |  -0.16% |   SAME   |
|   I16   |      I64      |      2^16      |   4.677 us |       3.70% |   4.633 us |       3.09% | -0.044 us |  -0.95% |   SAME   |
|   I16   |      I64      |      2^20      |   6.539 us |       2.77% |   6.578 us |       3.46% |  0.039 us |   0.60% |   SAME   |
|   I16   |      I64      |      2^24      |  30.334 us |       1.84% |  30.261 us |       1.87% | -0.073 us |  -0.24% |   SAME   |
|   I16   |      I64      |      2^28      | 372.933 us |       0.22% | 372.270 us |       0.21% | -0.663 us |  -0.18% |   SAME   |
|   F32   |      I32      |      2^16      |   4.671 us |       2.96% |   4.665 us |       2.69% | -0.006 us |  -0.13% |   SAME   |
|   F32   |      I32      |      2^20      |   7.840 us |       1.93% |   7.991 us |       2.85% |  0.152 us |   1.93% |   SAME   |
|   F32   |      I32      |      2^24      |  52.672 us |       1.39% |  52.743 us |       1.40% |  0.071 us |   0.13% |   SAME   |
|   F32   |      I32      |      2^28      | 730.827 us |       0.11% | 730.912 us |       0.12% |  0.085 us |   0.01% |   SAME   |
|   F32   |      I64      |      2^16      |   4.707 us |       4.58% |   4.763 us |       4.80% |  0.055 us |   1.18% |   SAME   |
|   F32   |      I64      |      2^20      |   7.866 us |       2.24% |   7.966 us |       2.91% |  0.100 us |   1.27% |   SAME   |
|   F32   |      I64      |      2^24      |  52.745 us |       1.38% |  52.766 us |       1.38% |  0.021 us |   0.04% |   SAME   |
|   F32   |      I64      |      2^28      | 731.262 us |       0.11% | 730.928 us |       0.11% | -0.335 us |  -0.05% |   SAME   |
|   F64   |      I32      |      2^16      |   4.812 us |       3.48% |   4.909 us |       3.54% |  0.096 us |   2.00% |   SAME   |
|   F64   |      I32      |      2^20      |  11.017 us |       2.69% |  11.113 us |       2.72% |  0.097 us |   0.88% |   SAME   |
|   F64   |      I32      |      2^24      |  97.557 us |       0.48% |  97.671 us |       0.44% |  0.114 us |   0.12% |   SAME   |
|   F64   |      I32      |      2^28      |   1.466 ms |       0.11% |   1.467 ms |       0.11% |  0.326 us |   0.02% |   SAME   |
|   F64   |      I64      |      2^16      |   4.997 us |       4.31% |   5.018 us |       4.53% |  0.022 us |   0.43% |   SAME   |
|   F64   |      I64      |      2^20      |  11.050 us |       2.57% |  11.170 us |       2.71% |  0.120 us |   1.08% |   SAME   |
|   F64   |      I64      |      2^24      |  97.436 us |       0.36% |  97.689 us |       0.44% |  0.252 us |   0.26% |   SAME   |
|   F64   |      I64      |      2^28      |   1.466 ms |       0.11% |   1.466 ms |       0.11% |  0.406 us |   0.03% |   SAME   |
|  I128   |      I32      |      2^16      |   5.448 us |       4.39% |   5.539 us |       4.89% |  0.091 us |   1.67% |   SAME   |
|  I128   |      I32      |      2^20      |  17.335 us |       2.11% |  17.470 us |       2.27% |  0.135 us |   0.78% |   SAME   |
|  I128   |      I32      |      2^24      | 188.575 us |       0.22% | 188.450 us |       0.32% | -0.125 us |  -0.07% |   SAME   |
|  I128   |      I32      |      2^28      |   2.929 ms |       0.07% |   2.930 ms |       0.07% |  0.604 us |   0.02% |   SAME   |
|  I128   |      I64      |      2^16      |   5.284 us |       3.48% |   5.332 us |       3.74% |  0.048 us |   0.91% |   SAME   |
|  I128   |      I64      |      2^20      |  17.572 us |       2.35% |  17.649 us |       2.26% |  0.077 us |   0.44% |   SAME   |
|  I128   |      I64      |      2^24      | 190.702 us |       0.18% | 190.415 us |       0.36% | -0.288 us |  -0.15% |   SAME   |
|  I128   |      I64      |      2^28      |   2.933 ms |       0.38% |   2.936 ms |       0.42% |  2.589 us |   0.09% |   SAME   |

# triad

## [0] NVIDIA H200

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-----------|---------|----------|
|   I8    |      I32      |      2^16      |   4.954 us |       3.26% |   4.824 us |       3.30% | -0.131 us |  -2.63% |   SAME   |
|   I8    |      I32      |      2^20      |   5.970 us |       3.09% |   5.906 us |       3.34% | -0.064 us |  -1.07% |   SAME   |
|   I8    |      I32      |      2^24      |  19.712 us |       1.91% |  19.460 us |       1.82% | -0.252 us |  -1.28% |   SAME   |
|   I8    |      I32      |      2^28      | 209.414 us |       0.20% | 206.285 us |       0.12% | -3.129 us |  -1.49% |   FAST   |
|   I8    |      I64      |      2^16      |   4.959 us |       2.84% |   4.858 us |       3.11% | -0.101 us |  -2.04% |   SAME   |
|   I8    |      I64      |      2^20      |   5.957 us |       3.18% |   5.911 us |       3.83% | -0.047 us |  -0.78% |   SAME   |
|   I8    |      I64      |      2^24      |  19.844 us |       2.55% |  19.349 us |       1.78% | -0.495 us |  -2.49% |   FAST   |
|   I8    |      I64      |      2^28      | 211.026 us |       0.21% | 206.240 us |       0.14% | -4.786 us |  -2.27% |   FAST   |
|   I16   |      I32      |      2^16      |   4.624 us |       3.15% |   4.625 us |       3.09% |  0.001 us |   0.02% |   SAME   |
|   I16   |      I32      |      2^20      |   6.510 us |       3.06% |   6.575 us |       2.57% |  0.065 us |   1.00% |   SAME   |
|   I16   |      I32      |      2^24      |  30.654 us |       1.84% |  30.642 us |       1.85% | -0.012 us |  -0.04% |   SAME   |
|   I16   |      I32      |      2^28      | 373.934 us |       0.21% | 373.435 us |       0.21% | -0.499 us |  -0.13% |   SAME   |
|   I16   |      I64      |      2^16      |   4.641 us |       3.53% |   4.638 us |       3.00% | -0.003 us |  -0.07% |   SAME   |
|   I16   |      I64      |      2^20      |   6.529 us |       3.16% |   6.646 us |       2.61% |  0.117 us |   1.79% |   SAME   |
|   I16   |      I64      |      2^24      |  30.692 us |       1.83% |  30.753 us |       1.84% |  0.061 us |   0.20% |   SAME   |
|   I16   |      I64      |      2^28      | 374.795 us |       0.21% | 374.305 us |       0.21% | -0.490 us |  -0.13% |   SAME   |
|   F32   |      I32      |      2^16      |   4.572 us |       2.67% |   4.672 us |       3.04% |  0.101 us |   2.20% |   SAME   |
|   F32   |      I32      |      2^20      |   7.766 us |       2.14% |   7.914 us |       2.89% |  0.148 us |   1.90% |   SAME   |
|   F32   |      I32      |      2^24      |  53.107 us |       1.35% |  53.159 us |       1.37% |  0.052 us |   0.10% |   SAME   |
|   F32   |      I32      |      2^28      | 731.313 us |       0.12% | 731.558 us |       0.14% |  0.245 us |   0.03% |   SAME   |
|   F32   |      I64      |      2^16      |   4.771 us |       4.30% |   4.710 us |       4.06% | -0.061 us |  -1.27% |   SAME   |
|   F32   |      I64      |      2^20      |   7.915 us |       2.83% |   7.910 us |       2.84% | -0.006 us |  -0.07% |   SAME   |
|   F32   |      I64      |      2^24      |  53.254 us |       1.35% |  53.192 us |       1.38% | -0.062 us |  -0.12% |   SAME   |
|   F32   |      I64      |      2^28      | 731.523 us |       0.11% | 731.380 us |       0.12% | -0.143 us |  -0.02% |   SAME   |
|   F64   |      I32      |      2^16      |   4.908 us |       3.92% |   4.926 us |       3.69% |  0.018 us |   0.37% |   SAME   |
|   F64   |      I32      |      2^20      |  11.202 us |       2.47% |  11.235 us |       2.64% |  0.034 us |   0.30% |   SAME   |
|   F64   |      I32      |      2^24      |  97.639 us |       0.46% |  97.715 us |       0.40% |  0.075 us |   0.08% |   SAME   |
|   F64   |      I32      |      2^28      |   1.467 ms |       0.10% |   1.467 ms |       0.10% |  0.114 us |   0.01% |   SAME   |
|   F64   |      I64      |      2^16      |   5.004 us |       4.39% |   4.984 us |       4.42% | -0.020 us |  -0.41% |   SAME   |
|   F64   |      I64      |      2^20      |  11.265 us |       2.60% |  11.266 us |       2.65% |  0.000 us |   0.00% |   SAME   |
|   F64   |      I64      |      2^24      |  97.728 us |       0.39% |  97.728 us |       0.44% | -0.000 us |  -0.00% |   SAME   |
|   F64   |      I64      |      2^28      |   1.466 ms |       0.10% |   1.467 ms |       0.10% |  0.272 us |   0.02% |   SAME   |
|  I128   |      I32      |      2^16      |   5.577 us |       4.07% |   5.416 us |       4.07% | -0.161 us |  -2.88% |   SAME   |
|  I128   |      I32      |      2^20      |  17.642 us |       2.24% |  17.668 us |       2.15% |  0.026 us |   0.15% |   SAME   |
|  I128   |      I32      |      2^24      | 188.755 us |       0.30% | 188.426 us |       0.34% | -0.330 us |  -0.17% |   SAME   |
|  I128   |      I32      |      2^28      |   2.933 ms |       0.06% |   2.933 ms |       0.06% |  0.235 us |   0.01% |   SAME   |
|  I128   |      I64      |      2^16      |   5.426 us |       3.79% |   5.319 us |       3.55% | -0.107 us |  -1.98% |   SAME   |
|  I128   |      I64      |      2^20      |  17.564 us |       2.41% |  17.514 us |       2.24% | -0.050 us |  -0.29% |   SAME   |
|  I128   |      I64      |      2^24      | 190.538 us |       0.37% | 190.626 us |       0.36% |  0.087 us |   0.05% |   SAME   |
|  I128   |      I64      |      2^28      |   2.932 ms |       0.41% |   2.933 ms |       0.41% |  1.106 us |   0.04% |   SAME   |

# nstream

## [0] NVIDIA H200

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-----------|---------|----------|
|   I8    |      I32      |      2^16      |   5.052 us |       3.48% |   4.750 us |       3.68% | -0.301 us |  -5.97% |   FAST   |
|   I8    |      I32      |      2^20      |   6.320 us |       3.53% |   6.191 us |       4.82% | -0.128 us |  -2.03% |   SAME   |
|   I8    |      I32      |      2^24      |  23.600 us |       2.14% |  23.070 us |       1.88% | -0.530 us |  -2.25% |   FAST   |
|   I8    |      I32      |      2^28      | 267.733 us |       0.34% | 261.517 us |       0.35% | -6.215 us |  -2.32% |   FAST   |
|   I8    |      I64      |      2^16      |   5.000 us |       3.53% |   4.699 us |       3.49% | -0.301 us |  -6.01% |   FAST   |
|   I8    |      I64      |      2^20      |   6.276 us |       2.94% |   6.168 us |       2.40% | -0.108 us |  -1.72% |   SAME   |
|   I8    |      I64      |      2^24      |  23.127 us |       1.88% |  22.986 us |       2.03% | -0.141 us |  -0.61% |   SAME   |
|   I8    |      I64      |      2^28      | 267.619 us |       0.35% | 261.213 us |       0.36% | -6.406 us |  -2.39% |   FAST   |
|   I16   |      I32      |      2^16      |   4.734 us |       3.01% |   4.676 us |       2.89% | -0.058 us |  -1.23% |   SAME   |
|   I16   |      I32      |      2^20      |   7.220 us |       2.14% |   7.189 us |       2.48% | -0.030 us |  -0.42% |   SAME   |
|   I16   |      I32      |      2^24      |  38.586 us |       1.71% |  38.462 us |       1.70% | -0.125 us |  -0.32% |   SAME   |
|   I16   |      I32      |      2^28      | 497.134 us |       0.10% | 493.943 us |       0.11% | -3.191 us |  -0.64% |   FAST   |
|   I16   |      I64      |      2^16      |   4.775 us |       3.42% |   4.693 us |       2.48% | -0.082 us |  -1.72% |   SAME   |
|   I16   |      I64      |      2^20      |   7.397 us |       4.19% |   7.190 us |       2.62% | -0.207 us |  -2.80% |   FAST   |
|   I16   |      I64      |      2^24      |  38.700 us |       1.68% |  38.442 us |       1.75% | -0.257 us |  -0.67% |   SAME   |
|   I16   |      I64      |      2^28      | 501.303 us |       0.08% | 495.680 us |       0.10% | -5.623 us |  -1.12% |   FAST   |
|   F32   |      I32      |      2^16      |   4.749 us |       3.27% |   4.754 us |       3.52% |  0.005 us |   0.10% |   SAME   |
|   F32   |      I32      |      2^20      |   9.350 us |       2.78% |   9.378 us |       2.62% |  0.028 us |   0.30% |   SAME   |
|   F32   |      I32      |      2^24      |  68.766 us |       0.99% |  68.725 us |       1.01% | -0.041 us |  -0.06% |   SAME   |
|   F32   |      I32      |      2^28      | 969.484 us |       0.09% | 968.923 us |       0.09% | -0.560 us |  -0.06% |   SAME   |
|   F32   |      I64      |      2^16      |   4.818 us |       3.54% |   4.815 us |       3.97% | -0.003 us |  -0.07% |   SAME   |
|   F32   |      I64      |      2^20      |   9.361 us |       2.54% |   9.356 us |       2.48% | -0.005 us |  -0.05% |   SAME   |
|   F32   |      I64      |      2^24      |  68.284 us |       1.02% |  68.213 us |       1.02% | -0.071 us |  -0.10% |   SAME   |
|   F32   |      I64      |      2^28      | 971.171 us |       0.08% | 969.574 us |       0.09% | -1.597 us |  -0.16% |   FAST   |
|   F64   |      I32      |      2^16      |   4.993 us |       3.31% |   5.076 us |       3.63% |  0.084 us |   1.67% |   SAME   |
|   F64   |      I32      |      2^20      |  13.723 us |       2.39% |  13.723 us |       2.33% | -0.000 us |  -0.00% |   SAME   |
|   F64   |      I32      |      2^24      | 127.982 us |       0.58% | 128.161 us |       0.59% |  0.178 us |   0.14% |   SAME   |
|   F64   |      I32      |      2^28      |   1.930 ms |       0.04% |   1.929 ms |       0.04% | -0.446 us |  -0.02% |   SAME   |
|   F64   |      I64      |      2^16      |   5.192 us |       4.77% |   5.177 us |       4.45% | -0.015 us |  -0.29% |   SAME   |
|   F64   |      I64      |      2^20      |  13.764 us |       2.31% |  13.691 us |       2.33% | -0.073 us |  -0.53% |   SAME   |
|   F64   |      I64      |      2^24      | 128.024 us |       0.58% | 128.323 us |       0.60% |  0.298 us |   0.23% |   SAME   |
|   F64   |      I64      |      2^28      |   1.931 ms |       0.04% |   1.930 ms |       0.04% | -1.090 us |  -0.06% |   FAST   |
|  I128   |      I32      |      2^16      |   5.764 us |       4.34% |   5.912 us |       4.05% |  0.148 us |   2.57% |   SAME   |
|  I128   |      I32      |      2^20      |  21.617 us |       1.99% |  21.739 us |       2.01% |  0.122 us |   0.56% |   SAME   |
|  I128   |      I32      |      2^24      | 248.009 us |       0.37% | 248.026 us |       0.35% |  0.016 us |   0.01% |   SAME   |
|  I128   |      I32      |      2^28      |   3.860 ms |       0.04% |   3.861 ms |       0.04% |  0.749 us |   0.02% |   SAME   |
|  I128   |      I64      |      2^16      |   5.650 us |       3.22% |   5.773 us |       3.81% |  0.123 us |   2.18% |   SAME   |
|  I128   |      I64      |      2^20      |  21.831 us |       2.12% |  22.026 us |       2.11% |  0.195 us |   0.90% |   SAME   |
|  I128   |      I64      |      2^24      | 250.699 us |       0.36% | 250.798 us |       0.36% |  0.099 us |   0.04% |   SAME   |
|  I128   |      I64      |      2^28      |   3.861 ms |       0.30% |   3.861 ms |       0.29% |  0.085 us |   0.00% |   SAME   |
```


Benchmark on GH200:

```
# mul

## [0] NVIDIA GH200 480GB

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-----------|---------|----------|
|   I8    |      I32      |      2^16      |   4.937 us |       2.13% |   4.957 us |       3.50% |  0.020 us |   0.41% |   SAME   |
|   I8    |      I32      |      2^20      |   5.530 us |       2.35% |   5.589 us |       2.44% |  0.059 us |   1.07% |   SAME   |
|   I8    |      I32      |      2^24      |  15.712 us |       1.53% |  15.745 us |       1.75% |  0.033 us |   0.21% |   SAME   |
|   I8    |      I32      |      2^28      | 155.248 us |       0.44% | 155.299 us |       0.45% |  0.051 us |   0.03% |   SAME   |
|   I8    |      I64      |      2^16      |   5.119 us |       2.49% |   5.074 us |       2.30% | -0.044 us |  -0.87% |   SAME   |
|   I8    |      I64      |      2^20      |   5.534 us |       2.56% |   5.606 us |       2.25% |  0.072 us |   1.30% |   SAME   |
|   I8    |      I64      |      2^24      |  15.715 us |       1.80% |  15.868 us |       1.98% |  0.152 us |   0.97% |   SAME   |
|   I8    |      I64      |      2^28      | 155.994 us |       0.42% | 155.902 us |       0.41% | -0.091 us |  -0.06% |   SAME   |
|   I16   |      I32      |      2^16      |   4.633 us |       3.01% |   4.644 us |       2.08% |  0.011 us |   0.23% |   SAME   |
|   I16   |      I32      |      2^20      |   5.819 us |       2.60% |   5.906 us |       2.62% |  0.087 us |   1.50% |   SAME   |
|   I16   |      I32      |      2^24      |  24.118 us |       1.70% |  24.186 us |       1.53% |  0.068 us |   0.28% |   SAME   |
|   I16   |      I32      |      2^28      | 296.670 us |       0.18% | 297.056 us |       0.17% |  0.385 us |   0.13% |   SAME   |
|   I16   |      I64      |      2^16      |   4.638 us |       2.29% |   4.658 us |       2.62% |  0.020 us |   0.43% |   SAME   |
|   I16   |      I64      |      2^20      |   5.861 us |       2.80% |   5.964 us |       2.30% |  0.103 us |   1.76% |   SAME   |
|   I16   |      I64      |      2^24      |  23.987 us |       1.56% |  24.106 us |       1.50% |  0.120 us |   0.50% |   SAME   |
|   I16   |      I64      |      2^28      | 296.706 us |       0.17% | 296.789 us |       0.19% |  0.083 us |   0.03% |   SAME   |
|   F32   |      I32      |      2^16      |   4.680 us |       3.86% |   4.466 us |       2.77% | -0.214 us |  -4.57% |   FAST   |
|   F32   |      I32      |      2^20      |   6.875 us |       2.89% |   6.691 us |       2.67% | -0.184 us |  -2.68% |   FAST   |
|   F32   |      I32      |      2^24      |  42.134 us |       1.34% |  42.167 us |       1.38% |  0.033 us |   0.08% |   SAME   |
|   F32   |      I32      |      2^28      | 590.153 us |       0.13% | 590.350 us |       0.12% |  0.197 us |   0.03% |   SAME   |
|   F32   |      I64      |      2^16      |   4.662 us |       3.14% |   4.461 us |       2.49% | -0.201 us |  -4.31% |   FAST   |
|   F32   |      I64      |      2^20      |   7.023 us |       2.67% |   6.853 us |       2.92% | -0.171 us |  -2.43% |   SAME   |
|   F32   |      I64      |      2^24      |  42.281 us |       1.33% |  42.163 us |       1.36% | -0.118 us |  -0.28% |   SAME   |
|   F32   |      I64      |      2^28      | 590.061 us |       0.13% | 590.489 us |       0.13% |  0.428 us |   0.07% |   SAME   |
|   F64   |      I32      |      2^16      |   4.740 us |       3.24% |   4.566 us |       2.53% | -0.174 us |  -3.67% |   FAST   |
|   F64   |      I32      |      2^20      |   9.600 us |       2.43% |   9.461 us |       2.67% | -0.139 us |  -1.45% |   SAME   |
|   F64   |      I32      |      2^24      |  78.531 us |       0.70% |  78.419 us |       0.69% | -0.112 us |  -0.14% |   SAME   |
|   F64   |      I32      |      2^28      |   1.176 ms |       0.07% |   1.176 ms |       0.07% | -0.032 us |  -0.00% |   SAME   |
|   F64   |      I64      |      2^16      |   4.777 us |       3.50% |   4.559 us |       2.27% | -0.218 us |  -4.57% |   FAST   |
|   F64   |      I64      |      2^20      |   9.595 us |       2.27% |   9.402 us |       2.39% | -0.193 us |  -2.01% |   SAME   |
|   F64   |      I64      |      2^24      |  78.626 us |       0.70% |  78.322 us |       0.72% | -0.304 us |  -0.39% |   SAME   |
|   F64   |      I64      |      2^28      |   1.176 ms |       0.08% |   1.176 ms |       0.08% |  0.290 us |   0.02% |   SAME   |
|  I128   |      I32      |      2^16      |   5.134 us |       2.73% |   4.979 us |       3.84% | -0.155 us |  -3.02% |   FAST   |
|  I128   |      I32      |      2^20      |  14.414 us |       2.41% |  14.231 us |       2.06% | -0.182 us |  -1.26% |   SAME   |
|  I128   |      I32      |      2^24      | 151.767 us |       0.49% | 151.747 us |       0.49% | -0.020 us |  -0.01% |   SAME   |
|  I128   |      I32      |      2^28      |   2.348 ms |       0.05% |   2.348 ms |       0.05% |  0.157 us |   0.01% |   SAME   |
|  I128   |      I64      |      2^16      |   5.138 us |       3.33% |   4.939 us |       2.41% | -0.199 us |  -3.88% |   FAST   |
|  I128   |      I64      |      2^20      |  14.502 us |       2.02% |  14.415 us |       2.21% | -0.087 us |  -0.60% |   SAME   |
|  I128   |      I64      |      2^24      | 152.405 us |       0.46% | 152.003 us |       0.47% | -0.401 us |  -0.26% |   SAME   |
|  I128   |      I64      |      2^28      |   2.350 ms |       0.06% |   2.350 ms |       0.06% | -0.111 us |  -0.00% |   SAME   |

# add

## [0] NVIDIA GH200 480GB

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-----------|---------|----------|
|   I8    |      I32      |      2^16      |   5.035 us |       2.42% |   4.599 us |       1.90% | -0.436 us |  -8.67% |   FAST   |
|   I8    |      I32      |      2^20      |   6.223 us |       2.26% |   5.869 us |       1.97% | -0.354 us |  -5.68% |   FAST   |
|   I8    |      I32      |      2^24      |  21.117 us |       1.45% |  20.911 us |       1.48% | -0.206 us |  -0.97% |   SAME   |
|   I8    |      I32      |      2^28      | 225.739 us |       0.24% | 224.930 us |       0.25% | -0.808 us |  -0.36% |   FAST   |
|   I8    |      I64      |      2^16      |   5.006 us |       2.48% |   4.663 us |       2.53% | -0.343 us |  -6.85% |   FAST   |
|   I8    |      I64      |      2^20      |   6.243 us |       2.36% |   5.928 us |       3.05% | -0.315 us |  -5.05% |   FAST   |
|   I8    |      I64      |      2^24      |  21.178 us |       1.46% |  20.834 us |       1.59% | -0.344 us |  -1.62% |   FAST   |
|   I8    |      I64      |      2^28      | 227.677 us |       0.27% | 225.162 us |       0.27% | -2.515 us |  -1.10% |   FAST   |
|   I16   |      I32      |      2^16      |   4.810 us |       2.59% |   4.590 us |       2.88% | -0.221 us |  -4.58% |   FAST   |
|   I16   |      I32      |      2^20      |   7.069 us |       2.51% |   7.032 us |       2.89% | -0.037 us |  -0.52% |   SAME   |
|   I16   |      I32      |      2^24      |  34.380 us |       1.35% |  34.143 us |       1.27% | -0.237 us |  -0.69% |   SAME   |
|   I16   |      I32      |      2^28      | 436.501 us |       0.15% | 436.757 us |       0.15% |  0.256 us |   0.06% |   SAME   |
|   I16   |      I64      |      2^16      |   4.738 us |       2.70% |   4.604 us |       2.35% | -0.134 us |  -2.83% |   FAST   |
|   I16   |      I64      |      2^20      |   7.217 us |       2.26% |   6.793 us |       2.25% | -0.424 us |  -5.87% |   FAST   |
|   I16   |      I64      |      2^24      |  34.322 us |       1.25% |  34.340 us |       1.26% |  0.018 us |   0.05% |   SAME   |
|   I16   |      I64      |      2^28      | 436.656 us |       0.15% | 436.818 us |       0.15% |  0.162 us |   0.04% |   SAME   |
|   F32   |      I32      |      2^16      |   4.741 us |       2.45% |   4.604 us |       3.07% | -0.137 us |  -2.88% |   FAST   |
|   F32   |      I32      |      2^20      |   8.514 us |       2.25% |   8.595 us |       2.35% |  0.080 us |   0.94% |   SAME   |
|   F32   |      I32      |      2^24      |  61.417 us |       0.84% |  61.162 us |       0.81% | -0.254 us |  -0.41% |   SAME   |
|   F32   |      I32      |      2^28      | 864.523 us |       0.08% | 864.934 us |       0.08% |  0.411 us |   0.05% |   SAME   |
|   F32   |      I64      |      2^16      |   4.715 us |       2.71% |   4.723 us |       2.70% |  0.008 us |   0.16% |   SAME   |
|   F32   |      I64      |      2^20      |   8.562 us |       2.45% |   8.798 us |       2.08% |  0.236 us |   2.75% |   SLOW   |
|   F32   |      I64      |      2^24      |  61.130 us |       0.84% |  61.177 us |       0.84% |  0.048 us |   0.08% |   SAME   |
|   F32   |      I64      |      2^28      | 865.577 us |       0.08% | 865.323 us |       0.08% | -0.254 us |  -0.03% |   SAME   |
|   F64   |      I32      |      2^16      |   4.919 us |       2.55% |   4.931 us |       2.43% |  0.013 us |   0.26% |   SAME   |
|   F64   |      I32      |      2^20      |  12.643 us |       2.11% |  12.761 us |       1.98% |  0.118 us |   0.93% |   SAME   |
|   F64   |      I32      |      2^24      | 114.671 us |       0.42% | 114.457 us |       0.45% | -0.214 us |  -0.19% |   SAME   |
|   F64   |      I32      |      2^28      |   1.727 ms |       0.06% |   1.727 ms |       0.06% |  0.140 us |   0.01% |   SAME   |
|   F64   |      I64      |      2^16      |   4.994 us |       2.45% |   5.079 us |       2.72% |  0.085 us |   1.69% |   SAME   |
|   F64   |      I64      |      2^20      |  12.465 us |       2.11% |  12.647 us |       2.31% |  0.182 us |   1.46% |   SAME   |
|   F64   |      I64      |      2^24      | 114.489 us |       0.43% | 114.372 us |       0.43% | -0.117 us |  -0.10% |   SAME   |
|   F64   |      I64      |      2^28      |   1.726 ms |       0.06% |   1.726 ms |       0.06% | -0.078 us |  -0.00% |   SAME   |
|  I128   |      I32      |      2^16      |   5.455 us |       2.36% |   5.530 us |       2.34% |  0.075 us |   1.38% |   SAME   |
|  I128   |      I32      |      2^20      |  19.921 us |       1.73% |  19.945 us |       1.83% |  0.024 us |   0.12% |   SAME   |
|  I128   |      I32      |      2^24      | 221.837 us |       0.27% | 221.786 us |       0.27% | -0.050 us |  -0.02% |   SAME   |
|  I128   |      I32      |      2^28      |   3.451 ms |       0.05% |   3.451 ms |       0.05% | -0.160 us |  -0.00% |   SAME   |
|  I128   |      I64      |      2^16      |   5.451 us |       2.21% |   5.503 us |       2.84% |  0.052 us |   0.95% |   SAME   |
|  I128   |      I64      |      2^20      |  20.069 us |       1.69% |  20.061 us |       1.85% | -0.009 us |  -0.04% |   SAME   |
|  I128   |      I64      |      2^24      | 221.668 us |       0.27% | 221.775 us |       0.29% |  0.107 us |   0.05% |   SAME   |
|  I128   |      I64      |      2^28      |   3.450 ms |       0.05% |   3.451 ms |       0.05% |  0.418 us |   0.01% |   SAME   |

# triad

## [0] NVIDIA GH200 480GB

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-----------|---------|----------|
|   I8    |      I32      |      2^16      |   4.985 us |       2.21% |   4.791 us |       2.35% | -0.194 us |  -3.89% |   FAST   |
|   I8    |      I32      |      2^20      |   6.257 us |       1.85% |   6.212 us |       2.67% | -0.045 us |  -0.72% |   SAME   |
|   I8    |      I32      |      2^24      |  21.409 us |       1.37% |  21.301 us |       1.41% | -0.108 us |  -0.51% |   SAME   |
|   I8    |      I32      |      2^28      | 229.149 us |       0.27% | 227.683 us |       0.26% | -1.465 us |  -0.64% |   FAST   |
|   I8    |      I64      |      2^16      |   5.004 us |       2.18% |   4.778 us |       2.50% | -0.226 us |  -4.52% |   FAST   |
|   I8    |      I64      |      2^20      |   6.275 us |       2.29% |   6.173 us |       2.70% | -0.102 us |  -1.63% |   SAME   |
|   I8    |      I64      |      2^24      |  21.296 us |       1.40% |  21.154 us |       1.47% | -0.142 us |  -0.67% |   SAME   |
|   I8    |      I64      |      2^28      | 230.900 us |       0.27% | 228.161 us |       0.26% | -2.738 us |  -1.19% |   FAST   |
|   I16   |      I32      |      2^16      |   4.810 us |       3.18% |   4.680 us |       2.71% | -0.130 us |  -2.71% |   FAST   |
|   I16   |      I32      |      2^20      |   6.943 us |       2.29% |   7.074 us |       2.36% |  0.131 us |   1.88% |   SAME   |
|   I16   |      I32      |      2^24      |  34.568 us |       1.21% |  35.159 us |       1.17% |  0.591 us |   1.71% |   SLOW   |
|   I16   |      I32      |      2^28      | 436.983 us |       0.14% | 436.775 us |       0.15% | -0.208 us |  -0.05% |   SAME   |
|   I16   |      I64      |      2^16      |   4.747 us |       2.67% |   4.715 us |       2.67% | -0.032 us |  -0.68% |   SAME   |
|   I16   |      I64      |      2^20      |   7.106 us |       2.58% |   7.103 us |       2.06% | -0.003 us |  -0.04% |   SAME   |
|   I16   |      I64      |      2^24      |  34.733 us |       1.16% |  34.913 us |       1.19% |  0.181 us |   0.52% |   SAME   |
|   I16   |      I64      |      2^28      | 436.832 us |       0.14% | 437.312 us |       0.15% |  0.480 us |   0.11% |   SAME   |
|   F32   |      I32      |      2^16      |   4.653 us |       3.05% |   4.735 us |       3.20% |  0.082 us |   1.76% |   SAME   |
|   F32   |      I32      |      2^20      |   8.475 us |       2.66% |   8.716 us |       2.89% |  0.242 us |   2.85% |   SLOW   |
|   F32   |      I32      |      2^24      |  61.302 us |       0.81% |  61.379 us |       0.82% |  0.077 us |   0.13% |   SAME   |
|   F32   |      I32      |      2^28      | 864.556 us |       0.08% | 864.609 us |       0.08% |  0.054 us |   0.01% |   SAME   |
|   F32   |      I64      |      2^16      |   4.824 us |       2.49% |   4.622 us |       2.17% | -0.202 us |  -4.19% |   FAST   |
|   F32   |      I64      |      2^20      |   8.630 us |       2.30% |   8.589 us |       2.16% | -0.041 us |  -0.47% |   SAME   |
|   F32   |      I64      |      2^24      |  61.154 us |       0.82% |  61.181 us |       0.85% |  0.026 us |   0.04% |   SAME   |
|   F32   |      I64      |      2^28      | 865.039 us |       0.07% | 864.493 us |       0.08% | -0.547 us |  -0.06% |   SAME   |
|   F64   |      I32      |      2^16      |   4.972 us |       2.37% |   4.829 us |       2.21% | -0.143 us |  -2.88% |   FAST   |
|   F64   |      I32      |      2^20      |  12.459 us |       2.04% |  12.621 us |       1.95% |  0.162 us |   1.30% |   SAME   |
|   F64   |      I32      |      2^24      | 114.290 us |       0.43% | 114.624 us |       0.45% |  0.334 us |   0.29% |   SAME   |
|   F64   |      I32      |      2^28      |   1.727 ms |       0.06% |   1.726 ms |       0.06% | -0.261 us |  -0.02% |   SAME   |
|   F64   |      I64      |      2^16      |   5.022 us |       2.48% |   4.859 us |       2.17% | -0.163 us |  -3.25% |   FAST   |
|   F64   |      I64      |      2^20      |  12.594 us |       2.08% |  12.543 us |       2.08% | -0.050 us |  -0.40% |   SAME   |
|   F64   |      I64      |      2^24      | 114.640 us |       0.46% | 114.456 us |       0.43% | -0.185 us |  -0.16% |   SAME   |
|   F64   |      I64      |      2^28      |   1.726 ms |       0.06% |   1.726 ms |       0.06% | -0.248 us |  -0.01% |   SAME   |
|  I128   |      I32      |      2^16      |   5.633 us |       2.74% |   5.435 us |       2.73% | -0.197 us |  -3.51% |   FAST   |
|  I128   |      I32      |      2^20      |  19.950 us |       1.76% |  20.011 us |       1.95% |  0.062 us |   0.31% |   SAME   |
|  I128   |      I32      |      2^24      | 221.863 us |       0.27% | 221.894 us |       0.28% |  0.031 us |   0.01% |   SAME   |
|  I128   |      I32      |      2^28      |   3.450 ms |       0.05% |   3.449 ms |       0.05% | -0.265 us |  -0.01% |   SAME   |
|  I128   |      I64      |      2^16      |   5.690 us |       2.95% |   5.527 us |       2.87% | -0.162 us |  -2.85% |   SAME   |
|  I128   |      I64      |      2^20      |  20.337 us |       1.74% |  20.145 us |       1.68% | -0.192 us |  -0.94% |   SAME   |
|  I128   |      I64      |      2^24      | 222.039 us |       0.27% | 221.993 us |       0.28% | -0.046 us |  -0.02% |   SAME   |
|  I128   |      I64      |      2^28      |   3.450 ms |       0.04% |   3.450 ms |       0.05% | -0.119 us |  -0.00% |   SAME   |

# nstream

## [0] NVIDIA GH200 480GB

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-----------|---------|----------|
|   I8    |      I32      |      2^16      |   5.073 us |       3.09% |   4.605 us |       2.42% | -0.468 us |  -9.22% |   FAST   |
|   I8    |      I32      |      2^20      |   6.652 us |       1.79% |   6.364 us |       1.85% | -0.288 us |  -4.33% |   FAST   |
|   I8    |      I32      |      2^24      |  25.748 us |       1.33% |  25.855 us |       1.23% |  0.107 us |   0.42% |   SAME   |
|   I8    |      I32      |      2^28      | 297.502 us |       0.14% | 296.162 us |       0.14% | -1.340 us |  -0.45% |   FAST   |
|   I8    |      I64      |      2^16      |   5.071 us |       2.82% |   4.633 us |       3.41% | -0.437 us |  -8.63% |   FAST   |
|   I8    |      I64      |      2^20      |   6.590 us |       1.98% |   6.379 us |       1.99% | -0.210 us |  -3.19% |   FAST   |
|   I8    |      I64      |      2^24      |  25.822 us |       1.34% |  25.710 us |       1.18% | -0.112 us |  -0.43% |   SAME   |
|   I8    |      I64      |      2^28      | 298.088 us |       0.14% | 296.394 us |       0.13% | -1.694 us |  -0.57% |   FAST   |
|   I16   |      I32      |      2^16      |   4.839 us |       2.83% |   4.575 us |       2.38% | -0.263 us |  -5.44% |   FAST   |
|   I16   |      I32      |      2^20      |   7.847 us |       2.26% |   7.792 us |       2.85% | -0.056 us |  -0.71% |   SAME   |
|   I16   |      I32      |      2^24      |  43.912 us |       1.00% |  44.137 us |       0.94% |  0.225 us |   0.51% |   SAME   |
|   I16   |      I32      |      2^28      | 576.304 us |       0.10% | 576.156 us |       0.09% | -0.148 us |  -0.03% |   SAME   |
|   I16   |      I64      |      2^16      |   4.848 us |       2.70% |   4.596 us |       2.40% | -0.252 us |  -5.19% |   FAST   |
|   I16   |      I64      |      2^20      |   7.872 us |       2.20% |   7.654 us |       2.23% | -0.218 us |  -2.77% |   FAST   |
|   I16   |      I64      |      2^24      |  43.871 us |       1.02% |  43.985 us |       1.02% |  0.114 us |   0.26% |   SAME   |
|   I16   |      I64      |      2^28      | 576.610 us |       0.09% | 576.442 us |       0.09% | -0.168 us |  -0.03% |   SAME   |
|   F32   |      I32      |      2^16      |   4.864 us |       3.59% |   4.688 us |       2.03% | -0.176 us |  -3.62% |   FAST   |
|   F32   |      I32      |      2^20      |  10.281 us |       1.97% |  10.158 us |       1.93% | -0.122 us |  -1.19% |   SAME   |
|   F32   |      I32      |      2^24      |  79.406 us |       0.57% |  79.242 us |       0.60% | -0.164 us |  -0.21% |   SAME   |
|   F32   |      I32      |      2^28      |   1.141 ms |       0.05% |   1.141 ms |       0.05% | -0.202 us |  -0.02% |   SAME   |
|   F32   |      I64      |      2^16      |   4.913 us |       2.61% |   4.728 us |       2.26% | -0.185 us |  -3.76% |   FAST   |
|   F32   |      I64      |      2^20      |  10.329 us |       2.24% |  10.118 us |       1.95% | -0.211 us |  -2.04% |   FAST   |
|   F32   |      I64      |      2^24      |  79.466 us |       0.58% |  79.249 us |       0.59% | -0.218 us |  -0.27% |   SAME   |
|   F32   |      I64      |      2^28      |   1.142 ms |       0.05% |   1.141 ms |       0.05% | -0.549 us |  -0.05% |   SAME   |
|   F64   |      I32      |      2^16      |   5.162 us |       2.26% |   5.239 us |       2.28% |  0.077 us |   1.49% |   SAME   |
|   F64   |      I32      |      2^20      |  15.387 us |       1.78% |  15.202 us |       1.67% | -0.185 us |  -1.20% |   SAME   |
|   F64   |      I32      |      2^24      | 150.217 us |       0.39% | 150.137 us |       0.39% | -0.080 us |  -0.05% |   SAME   |
|   F64   |      I32      |      2^28      |   2.273 ms |       0.02% |   2.273 ms |       0.02% | -0.102 us |  -0.00% |   SAME   |
|   F64   |      I64      |      2^16      |   5.206 us |       2.70% |   5.201 us |       2.14% | -0.005 us |  -0.10% |   SAME   |
|   F64   |      I64      |      2^20      |  15.387 us |       1.84% |  15.572 us |       1.73% |  0.185 us |   1.20% |   SAME   |
|   F64   |      I64      |      2^24      | 150.458 us |       0.40% | 150.150 us |       0.40% | -0.308 us |  -0.20% |   SAME   |
|   F64   |      I64      |      2^28      |   2.274 ms |       0.03% |   2.273 ms |       0.03% | -0.776 us |  -0.03% |   FAST   |
|  I128   |      I32      |      2^16      |   5.936 us |       2.21% |   6.066 us |       3.13% |  0.130 us |   2.19% |   SAME   |
|  I128   |      I32      |      2^20      |  24.856 us |       1.55% |  24.843 us |       1.16% | -0.013 us |  -0.05% |   SAME   |
|  I128   |      I32      |      2^24      | 291.601 us |       0.19% | 291.688 us |       0.17% |  0.088 us |   0.03% |   SAME   |
|  I128   |      I32      |      2^28      |   4.541 ms |       0.02% |   4.541 ms |       0.02% | -0.253 us |  -0.01% |   SAME   |
|  I128   |      I64      |      2^16      |   6.055 us |       2.09% |   6.012 us |       2.49% | -0.043 us |  -0.71% |   SAME   |
|  I128   |      I64      |      2^20      |  24.719 us |       1.48% |  24.758 us |       1.50% |  0.038 us |   0.16% |   SAME   |
|  I128   |      I64      |      2^24      | 291.778 us |       0.18% | 291.754 us |       0.16% | -0.024 us |  -0.01% |   SAME   |
|  I128   |      I64      |      2^28      |   4.541 ms |       0.02% |   4.541 ms |       0.02% | -0.112 us |  -0.00% |   SAME   |
```

<details>
  <summary>Old results for switching the fallback to `memcpy_async`</summary>

Benchmark on B200. Lots of solid gains, especially on small data types. A few regressions though.
```
# mul

## [0] NVIDIA B200

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |       Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|------------|---------|----------|
|   I8    |      I32      |      2^16      |   7.717 us |       9.56% |   6.106 us |       7.82% |  -1.611 us | -20.87% |   FAST   |
|   I8    |      I32      |      2^20      |   8.004 us |       3.74% |   6.803 us |      11.60% |  -1.201 us | -15.00% |   FAST   |
|   I8    |      I32      |      2^24      |  16.200 us |       1.99% |  14.232 us |       2.58% |  -1.968 us | -12.15% |   FAST   |
|   I8    |      I32      |      2^28      | 132.719 us |       0.45% | 124.636 us |       0.34% |  -8.082 us |  -6.09% |   FAST   |
|   I8    |      I64      |      2^16      |   7.790 us |       7.81% |   6.876 us |      12.59% |  -0.914 us | -11.73% |   FAST   |
|   I8    |      I64      |      2^20      |   8.005 us |       3.79% |   7.912 us |       5.74% |  -0.093 us |  -1.16% |   SAME   |
|   I8    |      I64      |      2^24      |  16.136 us |       2.46% |  14.659 us |       4.76% |  -1.476 us |  -9.15% |   FAST   |
|   I8    |      I64      |      2^28      | 135.045 us |       0.15% | 125.823 us |       0.80% |  -9.221 us |  -6.83% |   FAST   |
|   I16   |      I32      |      2^16      |   6.535 us |      10.92% |   5.978 us |       5.84% |  -0.557 us |  -8.53% |   FAST   |
|   I16   |      I32      |      2^20      |   7.496 us |      10.43% |   6.689 us |      11.06% |  -0.807 us | -10.77% |   FAST   |
|   I16   |      I32      |      2^24      |  18.409 us |       2.71% |  17.667 us |       4.66% |  -0.742 us |  -4.03% |   FAST   |
|   I16   |      I32      |      2^28      | 188.503 us |       0.32% | 171.869 us |       0.18% | -16.634 us |  -8.82% |   FAST   |
|   I16   |      I64      |      2^16      |   6.523 us |      11.04% |   6.013 us |       6.88% |  -0.509 us |  -7.81% |   FAST   |
|   I16   |      I64      |      2^20      |   7.464 us |      10.80% |   6.900 us |      11.65% |  -0.564 us |  -7.55% |   SAME   |
|   I16   |      I64      |      2^24      |  18.193 us |       2.33% |  17.968 us |       3.52% |  -0.225 us |  -1.24% |   SAME   |
|   I16   |      I64      |      2^28      | 182.147 us |       0.16% | 171.897 us |       0.12% | -10.250 us |  -5.63% |   FAST   |
|   F32   |      I32      |      2^16      |   5.983 us |       4.93% |   5.905 us |       5.42% |  -0.078 us |  -1.31% |   SAME   |
|   F32   |      I32      |      2^20      |   7.687 us |       8.88% |   7.634 us |       8.91% |  -0.052 us |  -0.68% |   SAME   |
|   F32   |      I32      |      2^24      |  25.933 us |       3.13% |  25.910 us |       2.95% |  -0.023 us |  -0.09% |   SAME   |
|   F32   |      I32      |      2^28      | 313.463 us |       0.31% | 313.575 us |       0.31% |   0.112 us |   0.04% |   SAME   |
|   F32   |      I64      |      2^16      |   5.931 us |       5.37% |   5.913 us |       5.31% |  -0.018 us |  -0.30% |   SAME   |
|   F32   |      I64      |      2^20      |   7.625 us |       9.64% |   7.669 us |       9.11% |   0.043 us |   0.57% |   SAME   |
|   F32   |      I64      |      2^24      |  26.210 us |       2.40% |  26.242 us |       2.22% |   0.032 us |   0.12% |   SAME   |
|   F32   |      I64      |      2^28      | 313.486 us |       0.32% | 313.400 us |       0.32% |  -0.086 us |  -0.03% |   SAME   |
|   F64   |      I32      |      2^16      |   5.954 us |       5.08% |   5.943 us |       5.43% |  -0.011 us |  -0.19% |   SAME   |
|   F64   |      I32      |      2^20      |   8.365 us |       7.34% |   8.423 us |       7.69% |   0.058 us |   0.69% |   SAME   |
|   F64   |      I32      |      2^24      |  45.651 us |       2.12% |  45.627 us |       2.07% |  -0.024 us |  -0.05% |   SAME   |
|   F64   |      I32      |      2^28      | 620.523 us |       0.23% | 620.557 us |       0.21% |   0.034 us |   0.01% |   SAME   |
|   F64   |      I64      |      2^16      |   5.967 us |       5.04% |   5.921 us |       5.62% |  -0.046 us |  -0.77% |   SAME   |
|   F64   |      I64      |      2^20      |   8.383 us |       7.68% |   8.414 us |       7.69% |   0.031 us |   0.37% |   SAME   |
|   F64   |      I64      |      2^24      |  45.775 us |       2.20% |  45.784 us |       2.14% |   0.009 us |   0.02% |   SAME   |
|   F64   |      I64      |      2^28      | 620.506 us |       0.20% | 620.532 us |       0.21% |   0.025 us |   0.00% |   SAME   |
|  I128   |      I32      |      2^16      |   5.966 us |       5.24% |   5.947 us |       5.07% |  -0.019 us |  -0.31% |   SAME   |
|  I128   |      I32      |      2^20      |  10.973 us |       7.60% |  11.029 us |       7.45% |   0.057 us |   0.52% |   SAME   |
|  I128   |      I32      |      2^24      |  83.787 us |       0.83% |  83.760 us |       0.85% |  -0.027 us |  -0.03% |   SAME   |
|  I128   |      I32      |      2^28      |   1.235 ms |       0.14% |   1.235 ms |       0.14% |   0.082 us |   0.01% |   SAME   |
|  I128   |      I64      |      2^16      |   6.093 us |       9.55% |   6.072 us |       9.90% |  -0.021 us |  -0.35% |   SAME   |
|  I128   |      I64      |      2^20      |  10.978 us |       7.34% |  10.935 us |       7.30% |  -0.042 us |  -0.39% |   SAME   |
|  I128   |      I64      |      2^24      |  83.808 us |       0.73% |  83.864 us |       0.73% |   0.056 us |   0.07% |   SAME   |
|  I128   |      I64      |      2^28      |   1.235 ms |       0.14% |   1.235 ms |       0.14% |  -0.327 us |  -0.03% |   SAME   |

# add

## [0] NVIDIA B200

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-----------|---------|----------|
|   I8    |      I32      |      2^16      |   8.042 us |       4.11% |   6.314 us |      12.10% | -1.728 us | -21.49% |   FAST   |
|   I8    |      I32      |      2^20      |   7.974 us |       4.19% |   6.619 us |      10.81% | -1.354 us | -16.98% |   FAST   |
|   I8    |      I32      |      2^24      |  17.879 us |       4.18% |  16.165 us |       2.19% | -1.714 us |  -9.58% |   FAST   |
|   I8    |      I32      |      2^28      | 155.656 us |       0.33% | 155.648 us |       0.00% | -0.008 us |  -0.00% |   ????   |
|   I8    |      I64      |      2^16      |   7.543 us |      10.44% |   6.055 us |       7.11% | -1.488 us | -19.73% |   FAST   |
|   I8    |      I64      |      2^20      |   7.970 us |       4.06% |   6.747 us |      11.10% | -1.223 us | -15.35% |   FAST   |
|   I8    |      I64      |      2^24      |  16.954 us |       4.88% |  16.325 us |       2.70% | -0.630 us |  -3.71% |   FAST   |
|   I8    |      I64      |      2^28      | 154.259 us |       0.62% | 156.169 us |       0.59% |  1.910 us |   1.24% |   SLOW   |
|   I16   |      I32      |      2^16      |   6.568 us |      11.54% |   5.901 us |       5.40% | -0.667 us | -10.16% |   FAST   |
|   I16   |      I32      |      2^20      |   8.010 us |       4.18% |   7.616 us |       9.30% | -0.395 us |  -4.93% |   FAST   |
|   I16   |      I32      |      2^24      |  23.685 us |       3.84% |  22.467 us |       2.30% | -1.217 us |  -5.14% |   FAST   |
|   I16   |      I32      |      2^28      | 259.483 us |       0.33% | 255.464 us |       0.33% | -4.018 us |  -1.55% |   FAST   |
|   I16   |      I64      |      2^16      |   6.413 us |      10.40% |   5.931 us |       5.32% | -0.482 us |  -7.52% |   FAST   |
|   I16   |      I64      |      2^20      |   7.943 us |       3.95% |   7.766 us |       7.86% | -0.177 us |  -2.23% |   SAME   |
|   I16   |      I64      |      2^24      |  23.776 us |       3.63% |  23.041 us |       3.32% | -0.735 us |  -3.09% |   SAME   |
|   I16   |      I64      |      2^28      | 264.133 us |       0.19% | 259.206 us |       0.38% | -4.927 us |  -1.87% |   FAST   |
|   F32   |      I32      |      2^16      |   5.977 us |       5.20% |   5.895 us |       5.66% | -0.082 us |  -1.37% |   SAME   |
|   F32   |      I32      |      2^20      |   8.045 us |       4.02% |   7.951 us |       4.46% | -0.095 us |  -1.18% |   SAME   |
|   F32   |      I32      |      2^24      |  36.690 us |       0.90% |  36.581 us |       1.31% | -0.109 us |  -0.30% |   SAME   |
|   F32   |      I32      |      2^28      | 454.550 us |       0.04% | 454.123 us |       0.18% | -0.427 us |  -0.09% |   FAST   |
|   F32   |      I64      |      2^16      |   5.958 us |       5.12% |   5.897 us |       5.51% | -0.061 us |  -1.02% |   SAME   |
|   F32   |      I64      |      2^20      |   8.027 us |       4.45% |   8.015 us |       4.43% | -0.013 us |  -0.16% |   SAME   |
|   F32   |      I64      |      2^24      |  36.680 us |       0.97% |  36.641 us |       1.01% | -0.039 us |  -0.11% |   SAME   |
|   F32   |      I64      |      2^28      | 454.849 us |       0.16% | 454.552 us |       0.07% | -0.297 us |  -0.07% |   SAME   |
|   F64   |      I32      |      2^16      |   5.911 us |       5.44% |   5.955 us |       4.99% |  0.043 us |   0.73% |   SAME   |
|   F64   |      I32      |      2^20      |  10.018 us |       3.39% |   9.975 us |       3.17% | -0.043 us |  -0.43% |   SAME   |
|   F64   |      I32      |      2^24      |  65.340 us |       0.71% |  65.280 us |       0.81% | -0.060 us |  -0.09% |   SAME   |
|   F64   |      I32      |      2^28      | 905.374 us |       0.20% | 907.578 us |       0.22% |  2.203 us |   0.24% |   SLOW   |
|   F64   |      I64      |      2^16      |   5.959 us |       5.29% |   5.939 us |       5.40% | -0.020 us |  -0.34% |   SAME   |
|   F64   |      I64      |      2^20      |  10.024 us |       3.25% |  10.007 us |       3.39% | -0.017 us |  -0.17% |   SAME   |
|   F64   |      I64      |      2^24      |  65.430 us |       0.66% |  65.394 us |       0.67% | -0.036 us |  -0.06% |   SAME   |
|   F64   |      I64      |      2^28      | 903.571 us |       0.19% | 905.971 us |       0.21% |  2.400 us |   0.27% |   SLOW   |
|  I128   |      I32      |      2^16      |   6.042 us |       5.99% |   6.037 us |       6.25% | -0.005 us |  -0.09% |   SAME   |
|  I128   |      I32      |      2^20      |  14.133 us |       2.21% |  14.117 us |       2.22% | -0.017 us |  -0.12% |   SAME   |
|  I128   |      I32      |      2^24      | 120.699 us |       0.35% | 120.683 us |       0.42% | -0.016 us |  -0.01% |   SAME   |
|  I128   |      I32      |      2^28      |   1.807 ms |       0.11% |   1.810 ms |       0.13% |  2.631 us |   0.15% |   SLOW   |
|  I128   |      I64      |      2^16      |   6.221 us |      11.16% |   6.258 us |      11.54% |  0.037 us |   0.60% |   SAME   |
|  I128   |      I64      |      2^20      |  14.139 us |       2.23% |  14.117 us |       2.22% | -0.022 us |  -0.16% |   SAME   |
|  I128   |      I64      |      2^24      | 120.785 us |       0.40% | 120.712 us |       0.39% | -0.074 us |  -0.06% |   SAME   |
|  I128   |      I64      |      2^28      |   1.807 ms |       0.11% |   1.809 ms |       0.12% |  2.292 us |   0.13% |   SLOW   |

# triad

## [0] NVIDIA B200

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |       Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|------------|---------|----------|
|   I8    |      I32      |      2^16      |   7.523 us |      11.20% |   6.313 us |      12.77% |  -1.210 us | -16.08% |   FAST   |
|   I8    |      I32      |      2^20      |   7.942 us |       4.13% |   6.749 us |      11.56% |  -1.194 us | -15.03% |   FAST   |
|   I8    |      I32      |      2^24      |  18.407 us |       2.49% |  17.081 us |       5.03% |  -1.327 us |  -7.21% |   FAST   |
|   I8    |      I32      |      2^28      | 172.297 us |       0.45% | 163.890 us |       0.36% |  -8.408 us |  -4.88% |   FAST   |
|   I8    |      I64      |      2^16      |   7.016 us |      12.20% |   6.051 us |       7.03% |  -0.965 us | -13.76% |   FAST   |
|   I8    |      I64      |      2^20      |   7.987 us |       3.67% |   7.138 us |      11.75% |  -0.849 us | -10.62% |   FAST   |
|   I8    |      I64      |      2^24      |  18.826 us |       4.07% |  17.741 us |       4.36% |  -1.085 us |  -5.76% |   FAST   |
|   I8    |      I64      |      2^28      | 188.342 us |       0.20% | 167.862 us |       0.21% | -20.480 us | -10.87% |   FAST   |
|   I16   |      I32      |      2^16      |   6.337 us |       9.44% |   5.948 us |       5.01% |  -0.390 us |  -6.15% |   FAST   |
|   I16   |      I32      |      2^20      |   7.971 us |       4.05% |   7.586 us |       9.39% |  -0.385 us |  -4.84% |   FAST   |
|   I16   |      I32      |      2^24      |  24.868 us |       2.89% |  23.082 us |       3.50% |  -1.786 us |  -7.18% |   FAST   |
|   I16   |      I32      |      2^28      | 278.467 us |       0.14% | 257.252 us |       0.36% | -21.215 us |  -7.62% |   FAST   |
|   I16   |      I64      |      2^16      |   6.451 us |      10.50% |   5.896 us |       5.53% |  -0.555 us |  -8.61% |   FAST   |
|   I16   |      I64      |      2^20      |   7.983 us |       4.05% |   7.926 us |       4.43% |  -0.057 us |  -0.72% |   SAME   |
|   I16   |      I64      |      2^24      |  24.225 us |       2.29% |  23.879 us |       3.35% |  -0.346 us |  -1.43% |   SAME   |
|   I16   |      I64      |      2^28      | 251.922 us |       0.21% | 260.817 us |       0.39% |   8.896 us |   3.53% |   SLOW   |
|   F32   |      I32      |      2^16      |   5.980 us |       5.35% |   5.920 us |       5.59% |  -0.060 us |  -1.00% |   SAME   |
|   F32   |      I32      |      2^20      |   8.015 us |       4.14% |   7.958 us |       4.29% |  -0.057 us |  -0.71% |   SAME   |
|   F32   |      I32      |      2^24      |  36.709 us |       0.94% |  36.600 us |       0.86% |  -0.110 us |  -0.30% |   SAME   |
|   F32   |      I32      |      2^28      | 454.414 us |       0.11% | 453.347 us |       0.22% |  -1.067 us |  -0.23% |   FAST   |
|   F32   |      I64      |      2^16      |   5.963 us |       5.10% |   5.911 us |       5.55% |  -0.052 us |  -0.86% |   SAME   |
|   F32   |      I64      |      2^20      |   7.955 us |       4.02% |   8.005 us |       4.68% |   0.049 us |   0.62% |   SAME   |
|   F32   |      I64      |      2^24      |  36.727 us |       1.08% |  36.709 us |       1.13% |  -0.018 us |  -0.05% |   SAME   |
|   F32   |      I64      |      2^28      | 454.527 us |       0.04% | 454.510 us |       0.04% |  -0.017 us |  -0.00% |   SAME   |
|   F64   |      I32      |      2^16      |   5.955 us |       5.31% |   5.931 us |       5.04% |  -0.025 us |  -0.42% |   SAME   |
|   F64   |      I32      |      2^20      |  10.140 us |       3.91% |  10.140 us |       4.78% |   0.000 us |   0.00% |   SAME   |
|   F64   |      I32      |      2^24      |  64.440 us |       1.40% |  64.184 us |       1.44% |  -0.256 us |  -0.40% |   SAME   |
|   F64   |      I32      |      2^28      | 904.071 us |       0.27% | 906.335 us |       0.26% |   2.264 us |   0.25% |   SAME   |
|   F64   |      I64      |      2^16      |   5.949 us |       5.48% |   5.926 us |       5.20% |  -0.024 us |  -0.40% |   SAME   |
|   F64   |      I64      |      2^20      |  10.200 us |       4.76% |  10.166 us |       4.84% |  -0.034 us |  -0.33% |   SAME   |
|   F64   |      I64      |      2^24      |  65.145 us |       0.90% |  65.068 us |       1.10% |  -0.078 us |  -0.12% |   SAME   |
|   F64   |      I64      |      2^28      | 901.378 us |       0.35% | 904.837 us |       0.26% |   3.459 us |   0.38% |   SLOW   |
|  I128   |      I32      |      2^16      |   6.067 us |       5.00% |   6.012 us |       6.28% |  -0.055 us |  -0.91% |   SAME   |
|  I128   |      I32      |      2^20      |  14.191 us |       2.02% |  14.116 us |       2.26% |  -0.075 us |  -0.53% |   SAME   |
|  I128   |      I32      |      2^24      | 120.680 us |       0.27% | 120.520 us |       0.41% |  -0.159 us |  -0.13% |   SAME   |
|  I128   |      I32      |      2^28      |   1.811 ms |       0.15% |   1.813 ms |       0.10% |   2.479 us |   0.14% |   SLOW   |
|  I128   |      I64      |      2^16      |   6.288 us |      11.60% |   6.256 us |      11.59% |  -0.032 us |  -0.50% |   SAME   |
|  I128   |      I64      |      2^20      |  14.134 us |       2.17% |  14.102 us |       2.39% |  -0.032 us |  -0.23% |   SAME   |
|  I128   |      I64      |      2^24      | 120.701 us |       0.32% | 120.594 us |       0.27% |  -0.107 us |  -0.09% |   SAME   |
|  I128   |      I64      |      2^28      |   1.809 ms |       0.17% |   1.812 ms |       0.12% |   3.384 us |   0.19% |   SLOW   |

# nstream

## [0] NVIDIA B200

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |       Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|------------|---------|----------|
|   I8    |      I32      |      2^16      |   7.481 us |      11.47% |   6.297 us |      12.53% |  -1.184 us | -15.83% |   FAST   |
|   I8    |      I32      |      2^20      |   8.001 us |       3.74% |   7.159 us |      11.66% |  -0.843 us | -10.53% |   FAST   |
|   I8    |      I32      |      2^24      |  21.970 us |       3.34% |  20.551 us |       3.02% |  -1.419 us |  -6.46% |   FAST   |
|   I8    |      I32      |      2^28      | 229.946 us |       0.40% | 229.234 us |       0.11% |  -0.712 us |  -0.31% |   FAST   |
|   I8    |      I64      |      2^16      |   7.519 us |      10.63% |   5.999 us |       6.15% |  -1.520 us | -20.22% |   FAST   |
|   I8    |      I64      |      2^20      |   7.965 us |       4.22% |   7.471 us |      10.50% |  -0.493 us |  -6.19% |   FAST   |
|   I8    |      I64      |      2^24      |  21.212 us |       4.15% |  20.951 us |       3.88% |  -0.260 us |  -1.23% |   SAME   |
|   I8    |      I64      |      2^28      | 212.908 us |       0.17% | 231.289 us |       0.09% |  18.381 us |   8.63% |   SLOW   |
|   I16   |      I32      |      2^16      |   6.799 us |      11.91% |   5.887 us |       5.58% |  -0.912 us | -13.41% |   FAST   |
|   I16   |      I32      |      2^20      |   8.062 us |       4.80% |   7.921 us |       4.01% |  -0.141 us |  -1.74% |   SAME   |
|   I16   |      I32      |      2^24      |  29.697 us |       3.17% |  28.386 us |       1.42% |  -1.311 us |  -4.41% |   FAST   |
|   I16   |      I32      |      2^28      | 356.953 us |       0.27% | 346.717 us |       0.28% | -10.236 us |  -2.87% |   FAST   |
|   I16   |      I64      |      2^16      |   7.533 us |      10.73% |   5.913 us |       5.58% |  -1.620 us | -21.50% |   FAST   |
|   I16   |      I64      |      2^20      |   8.244 us |       6.24% |   7.972 us |       3.96% |  -0.272 us |  -3.30% |   SAME   |
|   I16   |      I64      |      2^24      |  29.158 us |       2.77% |  28.558 us |       1.52% |  -0.600 us |  -2.06% |   FAST   |
|   I16   |      I64      |      2^28      | 327.977 us |       0.26% | 357.386 us |       0.28% |  29.409 us |   8.97% |   SLOW   |
|   F32   |      I32      |      2^16      |   6.026 us |       5.58% |   5.932 us |       5.69% |  -0.094 us |  -1.57% |   SAME   |
|   F32   |      I32      |      2^20      |   8.888 us |       9.29% |   8.887 us |       9.05% |  -0.001 us |  -0.02% |   SAME   |
|   F32   |      I32      |      2^24      |  47.138 us |       1.17% |  46.983 us |       0.99% |  -0.154 us |  -0.33% |   SAME   |
|   F32   |      I32      |      2^28      | 604.427 us |       0.13% | 603.502 us |       0.15% |  -0.925 us |  -0.15% |   FAST   |
|   F32   |      I64      |      2^16      |   6.047 us |       6.03% |   5.962 us |       5.88% |  -0.085 us |  -1.40% |   SAME   |
|   F32   |      I64      |      2^20      |   8.910 us |       9.51% |   9.016 us |       9.00% |   0.105 us |   1.18% |   SAME   |
|   F32   |      I64      |      2^24      |  47.296 us |       1.37% |  47.193 us |       1.34% |  -0.103 us |  -0.22% |   SAME   |
|   F32   |      I64      |      2^28      | 606.141 us |       0.05% | 605.454 us |       0.15% |  -0.687 us |  -0.11% |   FAST   |
|   F64   |      I32      |      2^16      |   6.035 us |       4.95% |   5.973 us |       5.38% |  -0.062 us |  -1.02% |   SAME   |
|   F64   |      I32      |      2^20      |  12.071 us |       2.88% |  12.017 us |       3.11% |  -0.054 us |  -0.44% |   SAME   |
|   F64   |      I32      |      2^24      |  84.476 us |       1.03% |  84.479 us |       1.04% |   0.003 us |   0.00% |   SAME   |
|   F64   |      I32      |      2^28      |   1.185 ms |       0.08% |   1.185 ms |       0.07% |   0.121 us |   0.01% |   SAME   |
|   F64   |      I64      |      2^16      |   6.011 us |       5.86% |   5.967 us |       6.06% |  -0.044 us |  -0.74% |   SAME   |
|   F64   |      I64      |      2^20      |  12.074 us |       2.60% |  12.071 us |       2.68% |  -0.003 us |  -0.03% |   SAME   |
|   F64   |      I64      |      2^24      |  84.640 us |       1.10% |  84.631 us |       1.09% |  -0.009 us |  -0.01% |   SAME   |
|   F64   |      I64      |      2^28      |   1.185 ms |       0.08% |   1.185 ms |       0.07% |   0.320 us |   0.03% |   SAME   |
|  I128   |      I32      |      2^16      |   6.250 us |       9.54% |   6.228 us |       9.58% |  -0.022 us |  -0.35% |   SAME   |
|  I128   |      I32      |      2^20      |  16.720 us |       4.43% |  16.638 us |       4.11% |  -0.082 us |  -0.49% |   SAME   |
|  I128   |      I32      |      2^24      | 157.213 us |       0.45% | 157.146 us |       0.49% |  -0.066 us |  -0.04% |   SAME   |
|  I128   |      I32      |      2^28      |   2.358 ms |       0.05% |   2.359 ms |       0.04% |   0.200 us |   0.01% |   SAME   |
|  I128   |      I64      |      2^16      |   6.549 us |      13.05% |   6.629 us |      13.28% |   0.080 us |   1.22% |   SAME   |
|  I128   |      I64      |      2^20      |  16.684 us |       4.11% |  16.714 us |       4.38% |   0.031 us |   0.18% |   SAME   |
|  I128   |      I64      |      2^24      | 157.251 us |       0.44% | 157.192 us |       0.48% |  -0.059 us |  -0.04% |   SAME   |
|  I128   |      I64      |      2^28      |   2.358 ms |       0.05% |   2.359 ms |       0.05% |   0.188 us |   0.01% |   SAME   |
```

On GH200:
```
# mul

## [0] NVIDIA GH200 480GB

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-----------|---------|----------|
|   I8    |      I32      |      2^16      |   4.937 us |       2.13% |   4.938 us |       2.22% |  0.001 us |   0.03% |   SAME   |
|   I8    |      I32      |      2^20      |   5.530 us |       2.35% |   5.549 us |       2.36% |  0.019 us |   0.34% |   SAME   |
|   I8    |      I32      |      2^24      |  15.712 us |       1.53% |  15.745 us |       1.67% |  0.033 us |   0.21% |   SAME   |
|   I8    |      I32      |      2^28      | 155.248 us |       0.44% | 155.974 us |       0.43% |  0.727 us |   0.47% |   SLOW   |
|   I8    |      I64      |      2^16      |   5.119 us |       2.49% |   5.049 us |       1.99% | -0.069 us |  -1.36% |   SAME   |
|   I8    |      I64      |      2^20      |   5.534 us |       2.56% |   5.583 us |       2.53% |  0.049 us |   0.88% |   SAME   |
|   I8    |      I64      |      2^24      |  15.715 us |       1.80% |  15.846 us |       1.78% |  0.130 us |   0.83% |   SAME   |
|   I8    |      I64      |      2^28      | 155.994 us |       0.42% | 156.568 us |       0.43% |  0.574 us |   0.37% |   SAME   |
|   I16   |      I32      |      2^16      |   4.633 us |       3.01% |   4.627 us |       2.49% | -0.006 us |  -0.14% |   SAME   |
|   I16   |      I32      |      2^20      |   5.819 us |       2.60% |   5.944 us |       2.51% |  0.126 us |   2.16% |   SAME   |
|   I16   |      I32      |      2^24      |  24.118 us |       1.70% |  24.203 us |       1.69% |  0.085 us |   0.35% |   SAME   |
|   I16   |      I32      |      2^28      | 296.670 us |       0.18% | 297.012 us |       0.17% |  0.341 us |   0.11% |   SAME   |
|   I16   |      I64      |      2^16      |   4.638 us |       2.29% |   4.689 us |       3.19% |  0.051 us |   1.11% |   SAME   |
|   I16   |      I64      |      2^20      |   5.861 us |       2.80% |   5.951 us |       2.76% |  0.089 us |   1.52% |   SAME   |
|   I16   |      I64      |      2^24      |  23.987 us |       1.56% |  24.205 us |       1.76% |  0.218 us |   0.91% |   SAME   |
|   I16   |      I64      |      2^28      | 296.706 us |       0.17% | 296.981 us |       0.18% |  0.275 us |   0.09% |   SAME   |
|   F32   |      I32      |      2^16      |   4.680 us |       3.86% |   4.636 us |       2.67% | -0.044 us |  -0.94% |   SAME   |
|   F32   |      I32      |      2^20      |   6.875 us |       2.89% |   6.948 us |       3.04% |  0.073 us |   1.06% |   SAME   |
|   F32   |      I32      |      2^24      |  42.134 us |       1.34% |  42.272 us |       1.34% |  0.138 us |   0.33% |   SAME   |
|   F32   |      I32      |      2^28      | 590.153 us |       0.13% | 590.523 us |       0.11% |  0.371 us |   0.06% |   SAME   |
|   F32   |      I64      |      2^16      |   4.662 us |       3.14% |   4.643 us |       2.76% | -0.019 us |  -0.42% |   SAME   |
|   F32   |      I64      |      2^20      |   7.023 us |       2.67% |   7.054 us |       2.58% |  0.030 us |   0.43% |   SAME   |
|   F32   |      I64      |      2^24      |  42.281 us |       1.33% |  42.401 us |       1.30% |  0.119 us |   0.28% |   SAME   |
|   F32   |      I64      |      2^28      | 590.061 us |       0.13% | 590.418 us |       0.12% |  0.357 us |   0.06% |   SAME   |
|   F64   |      I32      |      2^16      |   4.740 us |       3.24% |   4.766 us |       2.73% |  0.026 us |   0.54% |   SAME   |
|   F64   |      I32      |      2^20      |   9.600 us |       2.43% |   9.643 us |       2.27% |  0.043 us |   0.45% |   SAME   |
|   F64   |      I32      |      2^24      |  78.531 us |       0.70% |  78.795 us |       0.70% |  0.263 us |   0.34% |   SAME   |
|   F64   |      I32      |      2^28      |   1.176 ms |       0.07% |   1.176 ms |       0.08% |  0.241 us |   0.02% |   SAME   |
|   F64   |      I64      |      2^16      |   4.777 us |       3.50% |   4.757 us |       2.30% | -0.020 us |  -0.42% |   SAME   |
|   F64   |      I64      |      2^20      |   9.595 us |       2.27% |   9.618 us |       2.46% |  0.023 us |   0.24% |   SAME   |
|   F64   |      I64      |      2^24      |  78.626 us |       0.70% |  78.844 us |       0.69% |  0.218 us |   0.28% |   SAME   |
|   F64   |      I64      |      2^28      |   1.176 ms |       0.08% |   1.176 ms |       0.07% |  0.302 us |   0.03% |   SAME   |
|  I128   |      I32      |      2^16      |   5.134 us |       2.73% |   5.341 us |       5.68% |  0.207 us |   4.04% |   SLOW   |
|  I128   |      I32      |      2^20      |  14.414 us |       2.41% |  14.431 us |       2.09% |  0.017 us |   0.12% |   SAME   |
|  I128   |      I32      |      2^24      | 151.767 us |       0.49% | 152.058 us |       0.46% |  0.291 us |   0.19% |   SAME   |
|  I128   |      I32      |      2^28      |   2.348 ms |       0.05% |   2.349 ms |       0.06% |  0.570 us |   0.02% |   SAME   |
|  I128   |      I64      |      2^16      |   5.138 us |       3.33% |   5.142 us |       3.39% |  0.004 us |   0.08% |   SAME   |
|  I128   |      I64      |      2^20      |  14.502 us |       2.02% |  14.731 us |       2.14% |  0.228 us |   1.57% |   SAME   |
|  I128   |      I64      |      2^24      | 152.405 us |       0.46% | 152.712 us |       0.45% |  0.307 us |   0.20% |   SAME   |
|  I128   |      I64      |      2^28      |   2.350 ms |       0.06% |   2.350 ms |       0.05% | -0.135 us |  -0.01% |   SAME   |

# add

## [0] NVIDIA GH200 480GB

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-----------|---------|----------|
|   I8    |      I32      |      2^16      |   5.035 us |       2.42% |   4.824 us |       3.45% | -0.211 us |  -4.19% |   FAST   |
|   I8    |      I32      |      2^20      |   6.223 us |       2.26% |   6.055 us |       2.01% | -0.168 us |  -2.70% |   FAST   |
|   I8    |      I32      |      2^24      |  21.117 us |       1.45% |  21.084 us |       1.49% | -0.033 us |  -0.16% |   SAME   |
|   I8    |      I32      |      2^28      | 225.739 us |       0.24% | 224.863 us |       0.23% | -0.876 us |  -0.39% |   FAST   |
|   I8    |      I64      |      2^16      |   5.006 us |       2.48% |   4.817 us |       1.84% | -0.189 us |  -3.78% |   FAST   |
|   I8    |      I64      |      2^20      |   6.243 us |       2.36% |   6.136 us |       3.10% | -0.108 us |  -1.72% |   SAME   |
|   I8    |      I64      |      2^24      |  21.178 us |       1.46% |  20.975 us |       1.53% | -0.202 us |  -0.95% |   SAME   |
|   I8    |      I64      |      2^28      | 227.677 us |       0.27% | 225.553 us |       0.25% | -2.124 us |  -0.93% |   FAST   |
|   I16   |      I32      |      2^16      |   4.810 us |       2.59% |   4.780 us |       2.34% | -0.030 us |  -0.63% |   SAME   |
|   I16   |      I32      |      2^20      |   7.069 us |       2.51% |   7.283 us |       3.23% |  0.215 us |   3.04% |   SLOW   |
|   I16   |      I32      |      2^24      |  34.380 us |       1.35% |  34.498 us |       1.24% |  0.119 us |   0.35% |   SAME   |
|   I16   |      I32      |      2^28      | 436.501 us |       0.15% | 437.071 us |       0.15% |  0.570 us |   0.13% |   SAME   |
|   I16   |      I64      |      2^16      |   4.738 us |       2.70% |   4.742 us |       2.57% |  0.003 us |   0.07% |   SAME   |
|   I16   |      I64      |      2^20      |   7.217 us |       2.26% |   7.108 us |       2.78% | -0.109 us |  -1.51% |   SAME   |
|   I16   |      I64      |      2^24      |  34.322 us |       1.25% |  34.788 us |       1.26% |  0.466 us |   1.36% |   SLOW   |
|   I16   |      I64      |      2^28      | 436.656 us |       0.15% | 437.163 us |       0.14% |  0.508 us |   0.12% |   SAME   |
|   F32   |      I32      |      2^16      |   4.741 us |       2.45% |   4.755 us |       2.64% |  0.014 us |   0.30% |   SAME   |
|   F32   |      I32      |      2^20      |   8.514 us |       2.25% |   8.577 us |       2.76% |  0.062 us |   0.73% |   SAME   |
|   F32   |      I32      |      2^24      |  61.417 us |       0.84% |  60.995 us |       0.82% | -0.421 us |  -0.69% |   SAME   |
|   F32   |      I32      |      2^28      | 864.523 us |       0.08% | 864.796 us |       0.08% |  0.272 us |   0.03% |   SAME   |
|   F32   |      I64      |      2^16      |   4.715 us |       2.71% |   4.727 us |       2.31% |  0.012 us |   0.25% |   SAME   |
|   F32   |      I64      |      2^20      |   8.562 us |       2.45% |   8.750 us |       2.22% |  0.188 us |   2.19% |   SAME   |
|   F32   |      I64      |      2^24      |  61.130 us |       0.84% |  60.962 us |       0.82% | -0.168 us |  -0.27% |   SAME   |
|   F32   |      I64      |      2^28      | 865.577 us |       0.08% | 865.215 us |       0.08% | -0.362 us |  -0.04% |   SAME   |
|   F64   |      I32      |      2^16      |   4.919 us |       2.55% |   4.953 us |       2.79% |  0.035 us |   0.71% |   SAME   |
|   F64   |      I32      |      2^20      |  12.643 us |       2.11% |  12.711 us |       2.14% |  0.068 us |   0.54% |   SAME   |
|   F64   |      I32      |      2^24      | 114.671 us |       0.42% | 114.368 us |       0.42% | -0.303 us |  -0.26% |   SAME   |
|   F64   |      I32      |      2^28      |   1.727 ms |       0.06% |   1.727 ms |       0.06% | -0.124 us |  -0.01% |   SAME   |
|   F64   |      I64      |      2^16      |   4.994 us |       2.45% |   5.014 us |       2.38% |  0.020 us |   0.40% |   SAME   |
|   F64   |      I64      |      2^20      |  12.465 us |       2.11% |  12.497 us |       2.09% |  0.032 us |   0.25% |   SAME   |
|   F64   |      I64      |      2^24      | 114.489 us |       0.43% | 114.457 us |       0.45% | -0.032 us |  -0.03% |   SAME   |
|   F64   |      I64      |      2^28      |   1.726 ms |       0.06% |   1.726 ms |       0.06% | -0.153 us |  -0.01% |   SAME   |
|  I128   |      I32      |      2^16      |   5.455 us |       2.36% |   5.518 us |       2.14% |  0.063 us |   1.16% |   SAME   |
|  I128   |      I32      |      2^20      |  19.921 us |       1.73% |  19.808 us |       1.68% | -0.113 us |  -0.57% |   SAME   |
|  I128   |      I32      |      2^24      | 221.837 us |       0.27% | 221.812 us |       0.27% | -0.024 us |  -0.01% |   SAME   |
|  I128   |      I32      |      2^28      |   3.451 ms |       0.05% |   3.450 ms |       0.05% | -0.544 us |  -0.02% |   SAME   |
|  I128   |      I64      |      2^16      |   5.451 us |       2.21% |   5.537 us |       2.33% |  0.086 us |   1.58% |   SAME   |
|  I128   |      I64      |      2^20      |  20.069 us |       1.69% |  20.027 us |       1.70% | -0.042 us |  -0.21% |   SAME   |
|  I128   |      I64      |      2^24      | 221.668 us |       0.27% | 221.558 us |       0.28% | -0.110 us |  -0.05% |   SAME   |
|  I128   |      I64      |      2^28      |   3.450 ms |       0.05% |   3.450 ms |       0.05% |  0.121 us |   0.00% |   SAME   |

# triad

## [0] NVIDIA GH200 480GB

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-----------|---------|----------|
|   I8    |      I32      |      2^16      |   4.985 us |       2.21% |   4.758 us |       2.33% | -0.227 us |  -4.56% |   FAST   |
|   I8    |      I32      |      2^20      |   6.257 us |       1.85% |   6.103 us |       1.94% | -0.154 us |  -2.47% |   FAST   |
|   I8    |      I32      |      2^24      |  21.409 us |       1.37% |  21.282 us |       1.51% | -0.128 us |  -0.60% |   SAME   |
|   I8    |      I32      |      2^28      | 229.149 us |       0.27% | 227.697 us |       0.26% | -1.452 us |  -0.63% |   FAST   |
|   I8    |      I64      |      2^16      |   5.004 us |       2.18% |   4.770 us |       2.26% | -0.235 us |  -4.69% |   FAST   |
|   I8    |      I64      |      2^20      |   6.275 us |       2.29% |   6.136 us |       1.94% | -0.139 us |  -2.22% |   FAST   |
|   I8    |      I64      |      2^24      |  21.296 us |       1.40% |  21.342 us |       1.53% |  0.047 us |   0.22% |   SAME   |
|   I8    |      I64      |      2^28      | 230.900 us |       0.27% | 228.483 us |       0.27% | -2.417 us |  -1.05% |   FAST   |
|   I16   |      I32      |      2^16      |   4.810 us |       3.18% |   4.681 us |       2.16% | -0.129 us |  -2.68% |   FAST   |
|   I16   |      I32      |      2^20      |   6.943 us |       2.29% |   6.971 us |       2.06% |  0.028 us |   0.40% |   SAME   |
|   I16   |      I32      |      2^24      |  34.568 us |       1.21% |  34.521 us |       1.25% | -0.047 us |  -0.14% |   SAME   |
|   I16   |      I32      |      2^28      | 436.983 us |       0.14% | 437.306 us |       0.14% |  0.323 us |   0.07% |   SAME   |
|   I16   |      I64      |      2^16      |   4.747 us |       2.67% |   4.749 us |       2.53% |  0.002 us |   0.04% |   SAME   |
|   I16   |      I64      |      2^20      |   7.106 us |       2.58% |   7.145 us |       2.55% |  0.039 us |   0.55% |   SAME   |
|   I16   |      I64      |      2^24      |  34.733 us |       1.16% |  34.979 us |       1.18% |  0.247 us |   0.71% |   SAME   |
|   I16   |      I64      |      2^28      | 436.832 us |       0.14% | 437.749 us |       0.14% |  0.917 us |   0.21% |   SLOW   |
|   F32   |      I32      |      2^16      |   4.653 us |       3.05% |   4.679 us |       2.27% |  0.026 us |   0.55% |   SAME   |
|   F32   |      I32      |      2^20      |   8.475 us |       2.66% |   8.599 us |       2.27% |  0.124 us |   1.46% |   SAME   |
|   F32   |      I32      |      2^24      |  61.302 us |       0.81% |  60.836 us |       0.79% | -0.466 us |  -0.76% |   SAME   |
|   F32   |      I32      |      2^28      | 864.556 us |       0.08% | 864.409 us |       0.08% | -0.147 us |  -0.02% |   SAME   |
|   F32   |      I64      |      2^16      |   4.824 us |       2.49% |   4.822 us |       2.59% | -0.002 us |  -0.04% |   SAME   |
|   F32   |      I64      |      2^20      |   8.630 us |       2.30% |   8.782 us |       2.17% |  0.152 us |   1.76% |   SAME   |
|   F32   |      I64      |      2^24      |  61.154 us |       0.82% |  61.398 us |       0.82% |  0.244 us |   0.40% |   SAME   |
|   F32   |      I64      |      2^28      | 865.039 us |       0.07% | 864.854 us |       0.08% | -0.185 us |  -0.02% |   SAME   |
|   F64   |      I32      |      2^16      |   4.972 us |       2.37% |   5.000 us |       2.53% |  0.028 us |   0.57% |   SAME   |
|   F64   |      I32      |      2^20      |  12.459 us |       2.04% |  12.785 us |       2.04% |  0.326 us |   2.62% |   SLOW   |
|   F64   |      I32      |      2^24      | 114.290 us |       0.43% | 114.550 us |       0.42% |  0.260 us |   0.23% |   SAME   |
|   F64   |      I32      |      2^28      |   1.727 ms |       0.06% |   1.727 ms |       0.06% |  0.025 us |   0.00% |   SAME   |
|   F64   |      I64      |      2^16      |   5.022 us |       2.48% |   5.033 us |       2.26% |  0.011 us |   0.22% |   SAME   |
|   F64   |      I64      |      2^20      |  12.594 us |       2.08% |  12.671 us |       2.01% |  0.077 us |   0.61% |   SAME   |
|   F64   |      I64      |      2^24      | 114.640 us |       0.46% | 114.725 us |       0.44% |  0.085 us |   0.07% |   SAME   |
|   F64   |      I64      |      2^28      |   1.726 ms |       0.06% |   1.727 ms |       0.06% |  0.113 us |   0.01% |   SAME   |
|  I128   |      I32      |      2^16      |   5.633 us |       2.74% |   5.600 us |       2.96% | -0.032 us |  -0.57% |   SAME   |
|  I128   |      I32      |      2^20      |  19.950 us |       1.76% |  20.073 us |       1.84% |  0.124 us |   0.62% |   SAME   |
|  I128   |      I32      |      2^24      | 221.863 us |       0.27% | 222.005 us |       0.28% |  0.142 us |   0.06% |   SAME   |
|  I128   |      I32      |      2^28      |   3.450 ms |       0.05% |   3.449 ms |       0.05% | -0.316 us |  -0.01% |   SAME   |
|  I128   |      I64      |      2^16      |   5.690 us |       2.95% |   5.702 us |       2.36% |  0.013 us |   0.22% |   SAME   |
|  I128   |      I64      |      2^20      |  20.337 us |       1.74% |  20.354 us |       1.82% |  0.017 us |   0.08% |   SAME   |
|  I128   |      I64      |      2^24      | 222.039 us |       0.27% | 222.021 us |       0.27% | -0.018 us |  -0.01% |   SAME   |
|  I128   |      I64      |      2^28      |   3.450 ms |       0.04% |   3.451 ms |       0.05% |  0.403 us |   0.01% |   SAME   |

# nstream

## [0] NVIDIA GH200 480GB

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-----------|---------|----------|
|   I8    |      I32      |      2^16      |   5.073 us |       3.09% |   4.836 us |       2.79% | -0.237 us |  -4.67% |   FAST   |
|   I8    |      I32      |      2^20      |   6.652 us |       1.79% |   6.564 us |       2.24% | -0.087 us |  -1.31% |   SAME   |
|   I8    |      I32      |      2^24      |  25.748 us |       1.33% |  26.045 us |       1.32% |  0.298 us |   1.16% |   SAME   |
|   I8    |      I32      |      2^28      | 297.502 us |       0.14% | 296.731 us |       0.13% | -0.771 us |  -0.26% |   FAST   |
|   I8    |      I64      |      2^16      |   5.071 us |       2.82% |   4.832 us |       2.64% | -0.239 us |  -4.71% |   FAST   |
|   I8    |      I64      |      2^20      |   6.590 us |       1.98% |   6.628 us |       2.65% |  0.038 us |   0.58% |   SAME   |
|   I8    |      I64      |      2^24      |  25.822 us |       1.34% |  26.075 us |       1.32% |  0.253 us |   0.98% |   SAME   |
|   I8    |      I64      |      2^28      | 298.088 us |       0.14% | 296.881 us |       0.12% | -1.207 us |  -0.40% |   FAST   |
|   I16   |      I32      |      2^16      |   4.839 us |       2.83% |   4.744 us |       3.41% | -0.094 us |  -1.95% |   SAME   |
|   I16   |      I32      |      2^20      |   7.847 us |       2.26% |   7.834 us |       1.99% | -0.013 us |  -0.16% |   SAME   |
|   I16   |      I32      |      2^24      |  43.912 us |       1.00% |  43.995 us |       0.98% |  0.083 us |   0.19% |   SAME   |
|   I16   |      I32      |      2^28      | 576.304 us |       0.10% | 576.326 us |       0.09% |  0.022 us |   0.00% |   SAME   |
|   I16   |      I64      |      2^16      |   4.848 us |       2.70% |   4.817 us |       2.43% | -0.031 us |  -0.64% |   SAME   |
|   I16   |      I64      |      2^20      |   7.872 us |       2.20% |   7.908 us |       1.98% |  0.036 us |   0.46% |   SAME   |
|   I16   |      I64      |      2^24      |  43.871 us |       1.02% |  44.143 us |       1.01% |  0.272 us |   0.62% |   SAME   |
|   I16   |      I64      |      2^28      | 576.610 us |       0.09% | 577.579 us |       0.09% |  0.969 us |   0.17% |   SLOW   |
|   F32   |      I32      |      2^16      |   4.864 us |       3.59% |   4.845 us |       2.46% | -0.019 us |  -0.40% |   SAME   |
|   F32   |      I32      |      2^20      |  10.281 us |       1.97% |  10.249 us |       1.77% | -0.031 us |  -0.31% |   SAME   |
|   F32   |      I32      |      2^24      |  79.406 us |       0.57% |  79.697 us |       0.57% |  0.291 us |   0.37% |   SAME   |
|   F32   |      I32      |      2^28      |   1.141 ms |       0.05% |   1.141 ms |       0.05% |  0.028 us |   0.00% |   SAME   |
|   F32   |      I64      |      2^16      |   4.913 us |       2.61% |   4.913 us |       2.26% | -0.000 us |  -0.01% |   SAME   |
|   F32   |      I64      |      2^20      |  10.329 us |       2.24% |  10.285 us |       2.06% | -0.044 us |  -0.43% |   SAME   |
|   F32   |      I64      |      2^24      |  79.466 us |       0.58% |  79.516 us |       0.57% |  0.049 us |   0.06% |   SAME   |
|   F32   |      I64      |      2^28      |   1.142 ms |       0.05% |   1.142 ms |       0.05% | -0.065 us |  -0.01% |   SAME   |
|   F64   |      I32      |      2^16      |   5.162 us |       2.26% |   5.141 us |       2.41% | -0.021 us |  -0.41% |   SAME   |
|   F64   |      I32      |      2^20      |  15.387 us |       1.78% |  15.341 us |       1.93% | -0.046 us |  -0.30% |   SAME   |
|   F64   |      I32      |      2^24      | 150.217 us |       0.39% | 150.415 us |       0.39% |  0.198 us |   0.13% |   SAME   |
|   F64   |      I32      |      2^28      |   2.273 ms |       0.02% |   2.273 ms |       0.02% |  0.602 us |   0.03% |   SLOW   |
|   F64   |      I64      |      2^16      |   5.206 us |       2.70% |   5.217 us |       2.07% |  0.011 us |   0.21% |   SAME   |
|   F64   |      I64      |      2^20      |  15.387 us |       1.84% |  15.457 us |       1.91% |  0.070 us |   0.46% |   SAME   |
|   F64   |      I64      |      2^24      | 150.458 us |       0.40% | 150.293 us |       0.39% | -0.165 us |  -0.11% |   SAME   |
|   F64   |      I64      |      2^28      |   2.274 ms |       0.03% |   2.274 ms |       0.03% |  0.138 us |   0.01% |   SAME   |
|  I128   |      I32      |      2^16      |   5.936 us |       2.21% |   5.977 us |       1.99% |  0.041 us |   0.69% |   SAME   |
|  I128   |      I32      |      2^20      |  24.856 us |       1.55% |  24.858 us |       1.52% |  0.002 us |   0.01% |   SAME   |
|  I128   |      I32      |      2^24      | 291.601 us |       0.19% | 291.756 us |       0.16% |  0.155 us |   0.05% |   SAME   |
|  I128   |      I32      |      2^28      |   4.541 ms |       0.02% |   4.541 ms |       0.02% |  0.010 us |   0.00% |   SAME   |
|  I128   |      I64      |      2^16      |   6.055 us |       2.09% |   6.113 us |       2.16% |  0.058 us |   0.96% |   SAME   |
|  I128   |      I64      |      2^20      |  24.719 us |       1.48% |  24.854 us |       1.60% |  0.135 us |   0.54% |   SAME   |
|  I128   |      I64      |      2^24      | 291.778 us |       0.18% | 291.755 us |       0.18% | -0.023 us |  -0.01% |   SAME   |
|  I128   |      I64      |      2^28      |   4.541 ms |       0.02% |   4.542 ms |       0.02% |  0.108 us |   0.00% |   SAME   |
```

</details>