### PR TITLE
[CUDAX] Refactor arch traits to be more structured and support arch-specific targets

### DIFF
--- a/cudax/include/cuda/experimental/__device/all_devices.cuh
+++ b/cudax/include/cuda/experimental/__device/all_devices.cuh
@@ -198,7 +198,7 @@ inline const ::std::vector<device>& all_devices::__devices()
 //! * device_ref
 inline constexpr __detail::all_devices devices{};
 
-inline const arch_traits_t& device_ref::arch_traits() const
+inline const arch::traits_t& device_ref::arch_traits() const
 {
   return devices[get()].arch_traits();
 }

--- a/cudax/include/cuda/experimental/__device/arch_traits.cuh
+++ b/cudax/include/cuda/experimental/__device/arch_traits.cuh
@@ -31,81 +31,107 @@
 namespace cuda::experimental
 {
 
-namespace __detail
+namespace arch
 {
-struct arch_common_traits
+
+inline constexpr int __special_id_multiplier = 100000;
+
+// @brief Architecture identifier
+// This type identifies an architecture. It has more possible entries than just numeric values of the compute
+// capability. For example, sm_90 and sm_90a have the same compute capability, but the identifier is different.
+enum class id : int
+{
+  sm_60   = 60,
+  sm_61   = 61,
+  sm_70   = 70,
+  sm_75   = 75,
+  sm_80   = 80,
+  sm_86   = 86,
+  sm_89   = 89,
+  sm_90   = 90,
+  sm_100  = 100,
+  sm_103  = 103,
+  sm_120  = 120,
+  sm_90a  = 90 * __special_id_multiplier,
+  sm_100a = 100 * __special_id_multiplier,
+  sm_103a = 103 * __special_id_multiplier,
+  sm_120a = 120 * __special_id_multiplier,
+};
+
+// @brief Architecture traits
+// This type contains information about an architecture that is constant across devices of that architecture.
+struct traits_t
 {
   // Maximum number of threads per block
-  static constexpr int max_threads_per_block = 1024;
+  const int max_threads_per_block = 1024;
 
   // Maximum x-dimension of a block
-  static constexpr int max_block_dim_x = 1024;
+  const int max_block_dim_x = 1024;
 
   // Maximum y-dimension of a block
-  static constexpr int max_block_dim_y = 1024;
+  const int max_block_dim_y = 1024;
 
   // Maximum z-dimension of a block
-  static constexpr int max_block_dim_z = 64;
+  const int max_block_dim_z = 64;
 
   // Maximum x-dimension of a grid
-  static constexpr int max_grid_dim_x = cuda::std::numeric_limits<int>::max();
+  const int max_grid_dim_x = cuda::std::numeric_limits<int>::max();
 
   // Maximum y-dimension of a grid
-  static constexpr int max_grid_dim_y = 64 * 1024 - 1;
+  const int max_grid_dim_y = 64 * 1024 - 1;
 
   // Maximum z-dimension of a grid
-  static constexpr int max_grid_dim_z = 64 * 1024 - 1;
+  const int max_grid_dim_z = 64 * 1024 - 1;
 
   // Maximum amount of shared memory available to a thread block in bytes
-  static constexpr int max_shared_memory_per_block = 48 * 1024;
+  const int max_shared_memory_per_block = 48 * 1024;
 
   // Memory available on device for __constant__ variables in a CUDA C kernel in bytes
-  static constexpr int total_constant_memory = 64 * 1024;
+  const int total_constant_memory = 64 * 1024;
 
   // Warp size in threads
-  static constexpr int warp_size = 32;
+  const int warp_size = 32;
 
   // Maximum number of concurrent grids on the device
-  static constexpr int max_resident_grids = 128;
+  const int max_resident_grids = 128;
 
   // true if the device can concurrently copy memory between host and device
   // while executing a kernel, or false if not
-  static constexpr bool gpu_overlap = true;
+  const bool gpu_overlap = true;
 
   // true if the device can map host memory into CUDA address space
-  static constexpr bool can_map_host_memory = true;
+  const bool can_map_host_memory = true;
 
   // true if the device supports executing multiple kernels within the same
   // context simultaneously, or false if not. It is not guaranteed that multiple
   // kernels will be resident on the device concurrently so this feature should
   // not be relied upon for correctness.
-  static constexpr bool concurrent_kernels = true;
+  const bool concurrent_kernels = true;
 
   // true if the device supports stream priorities, or false if not
-  static constexpr bool stream_priorities_supported = true;
+  const bool stream_priorities_supported = true;
 
   // true if device supports caching globals in L1 cache, false if not
-  static constexpr bool global_l1_cache_supported = true;
+  const bool global_l1_cache_supported = true;
 
   // true if device supports caching locals in L1 cache, false if not
-  static constexpr bool local_l1_cache_supported = true;
+  const bool local_l1_cache_supported = true;
 
   // TODO: We might want to have these per-arch
   // Maximum number of 32-bit registers available to a thread block
-  static constexpr int max_registers_per_block = 64 * 1024;
+  const int max_registers_per_block = 64 * 1024;
 
   // Maximum number of 32-bit registers available to a multiprocessor; this
   // number is shared by all thread blocks simultaneously resident on a
   // multiprocessor
-  static constexpr int max_registers_per_multiprocessor = 64 * 1024;
+  const int max_registers_per_multiprocessor = 64 * 1024;
 
   // Maximum number of 32-bit registers available to a thread
-  static constexpr int max_registers_per_thread = 255;
-};
-} // namespace __detail
+  const int max_registers_per_thread = 255;
 
-struct arch_traits_t : public __detail::arch_common_traits
-{
+  // Identifier for the architecture
+  id id;
+
   // Major compute capability version number
   int compute_capability_major;
 
@@ -151,365 +177,441 @@ struct arch_traits_t : public __detail::arch_common_traits
 
   // true if architecture supports tensor memory access instructions
   bool tma_supported;
+
+  constexpr bool operator==(const traits_t& other) const = default;
 };
 
-namespace __detail
+// @brief Architecture type
+// This type is a template that represents an architecture. It also contains the traits for that architecture.
+template <id _Id>
+struct type;
+
+template <>
+struct type<id::sm_60>
 {
+  static constexpr traits_t traits = []() constexpr {
+    traits_t __traits{};
+    __traits.id                                   = id::sm_60;
+    __traits.compute_capability_major             = 6;
+    __traits.compute_capability_minor             = 0;
+    __traits.compute_capability                   = 60;
+    __traits.max_shared_memory_per_multiprocessor = 64 * 1024;
+    __traits.max_blocks_per_multiprocessor        = 32;
+    __traits.max_threads_per_multiprocessor       = 2048;
+    __traits.max_warps_per_multiprocessor         = __traits.max_threads_per_multiprocessor / __traits.warp_size;
+    __traits.reserved_shared_memory_per_block     = 0;
+    __traits.max_shared_memory_per_block_optin    = 48 * 1024;
 
-inline constexpr arch_traits_t sm_600_traits = []() constexpr {
-  arch_traits_t __traits{};
-  __traits.compute_capability_major             = 6;
-  __traits.compute_capability_minor             = 0;
-  __traits.compute_capability                   = 600;
-  __traits.max_shared_memory_per_multiprocessor = 64 * 1024;
-  __traits.max_blocks_per_multiprocessor        = 32;
-  __traits.max_threads_per_multiprocessor       = 2048;
-  __traits.max_warps_per_multiprocessor =
-    __traits.max_threads_per_multiprocessor / __detail::arch_common_traits::warp_size;
-  __traits.reserved_shared_memory_per_block  = 0;
-  __traits.max_shared_memory_per_block_optin = 48 * 1024;
+    __traits.cluster_supported  = false;
+    __traits.redux_intrinisic   = false;
+    __traits.elect_intrinsic    = false;
+    __traits.cp_async_supported = false;
+    __traits.tma_supported      = false;
+    return __traits;
+  }();
+};
+using sm_60 = type<id::sm_60>;
 
-  __traits.cluster_supported  = false;
-  __traits.redux_intrinisic   = false;
-  __traits.elect_intrinsic    = false;
-  __traits.cp_async_supported = false;
-  __traits.tma_supported      = false;
-
-  return __traits;
-}();
-
-inline constexpr arch_traits_t sm_610_traits = []() constexpr {
-  arch_traits_t __traits{};
-  __traits.compute_capability_major             = 6;
-  __traits.compute_capability_minor             = 1;
-  __traits.compute_capability                   = 610;
-  __traits.max_shared_memory_per_multiprocessor = 96 * 1024;
-  __traits.max_blocks_per_multiprocessor        = 32;
-  __traits.max_threads_per_multiprocessor       = 2048;
-  __traits.max_warps_per_multiprocessor =
-    __traits.max_threads_per_multiprocessor / __detail::arch_common_traits::warp_size;
-  __traits.reserved_shared_memory_per_block  = 0;
-  __traits.max_shared_memory_per_block_optin = 48 * 1024;
-
-  __traits.cluster_supported  = false;
-  __traits.redux_intrinisic   = false;
-  __traits.elect_intrinsic    = false;
-  __traits.cp_async_supported = false;
-  __traits.tma_supported      = false;
-
-  return __traits;
-}();
-
-inline constexpr arch_traits_t sm_700_traits = []() constexpr {
-  arch_traits_t __traits{};
-  __traits.compute_capability_major             = 7;
-  __traits.compute_capability_minor             = 0;
-  __traits.compute_capability                   = 700;
-  __traits.max_shared_memory_per_multiprocessor = 96 * 1024;
-  __traits.max_blocks_per_multiprocessor        = 32;
-  __traits.max_threads_per_multiprocessor       = 2048;
-  __traits.max_warps_per_multiprocessor =
-    __traits.max_threads_per_multiprocessor / __detail::arch_common_traits::warp_size;
-  __traits.reserved_shared_memory_per_block = 0;
-  __traits.max_shared_memory_per_block_optin =
-    __traits.max_shared_memory_per_multiprocessor - __traits.reserved_shared_memory_per_block;
-
-  __traits.cluster_supported  = false;
-  __traits.redux_intrinisic   = false;
-  __traits.elect_intrinsic    = false;
-  __traits.cp_async_supported = false;
-  __traits.tma_supported      = false;
-
-  return __traits;
-}();
-
-inline constexpr arch_traits_t sm_750_traits = []() constexpr {
-  arch_traits_t __traits{};
-  __traits.compute_capability_major             = 7;
-  __traits.compute_capability_minor             = 5;
-  __traits.compute_capability                   = 750;
-  __traits.max_shared_memory_per_multiprocessor = 64 * 1024;
-  __traits.max_blocks_per_multiprocessor        = 16;
-  __traits.max_threads_per_multiprocessor       = 1024;
-  __traits.max_warps_per_multiprocessor =
-    __traits.max_threads_per_multiprocessor / __detail::arch_common_traits::warp_size;
-  __traits.reserved_shared_memory_per_block = 0;
-  __traits.max_shared_memory_per_block_optin =
-    __traits.max_shared_memory_per_multiprocessor - __traits.reserved_shared_memory_per_block;
-
-  __traits.cluster_supported  = false;
-  __traits.redux_intrinisic   = false;
-  __traits.elect_intrinsic    = false;
-  __traits.cp_async_supported = false;
-  __traits.tma_supported      = false;
-
-  return __traits;
-}();
-
-inline constexpr arch_traits_t sm_800_traits = []() constexpr {
-  arch_traits_t __traits{};
-  __traits.compute_capability_major             = 8;
-  __traits.compute_capability_minor             = 0;
-  __traits.compute_capability                   = 800;
-  __traits.max_shared_memory_per_multiprocessor = 164 * 1024;
-  __traits.max_blocks_per_multiprocessor        = 32;
-  __traits.max_threads_per_multiprocessor       = 2048;
-  __traits.max_warps_per_multiprocessor =
-    __traits.max_threads_per_multiprocessor / __detail::arch_common_traits::warp_size;
-  __traits.reserved_shared_memory_per_block = 1024;
-  __traits.max_shared_memory_per_block_optin =
-    __traits.max_shared_memory_per_multiprocessor - __traits.reserved_shared_memory_per_block;
-
-  __traits.cluster_supported  = false;
-  __traits.redux_intrinisic   = true;
-  __traits.elect_intrinsic    = false;
-  __traits.cp_async_supported = true;
-  __traits.tma_supported      = false;
-
-  return __traits;
-}();
-
-inline constexpr arch_traits_t sm_860_traits = []() constexpr {
-  arch_traits_t __traits{};
-  __traits.compute_capability_major             = 8;
-  __traits.compute_capability_minor             = 6;
-  __traits.compute_capability                   = 860;
-  __traits.max_shared_memory_per_multiprocessor = 100 * 1024;
-  __traits.max_blocks_per_multiprocessor        = 16;
-  __traits.max_threads_per_multiprocessor       = 1536;
-  __traits.max_warps_per_multiprocessor =
-    __traits.max_threads_per_multiprocessor / __detail::arch_common_traits::warp_size;
-  __traits.reserved_shared_memory_per_block = 1024;
-  __traits.max_shared_memory_per_block_optin =
-    __traits.max_shared_memory_per_multiprocessor - __traits.reserved_shared_memory_per_block;
-
-  __traits.cluster_supported  = false;
-  __traits.redux_intrinisic   = true;
-  __traits.elect_intrinsic    = false;
-  __traits.cp_async_supported = true;
-  __traits.tma_supported      = false;
-
-  return __traits;
-}();
-
-inline constexpr arch_traits_t sm_890_traits = []() constexpr {
-  arch_traits_t __traits{};
-  __traits.compute_capability_major             = 8;
-  __traits.compute_capability_minor             = 9;
-  __traits.compute_capability                   = 890;
-  __traits.max_shared_memory_per_multiprocessor = 100 * 1024;
-  __traits.max_blocks_per_multiprocessor        = 24;
-  __traits.max_threads_per_multiprocessor       = 1536;
-  __traits.max_warps_per_multiprocessor =
-    __traits.max_threads_per_multiprocessor / __detail::arch_common_traits::warp_size;
-  __traits.reserved_shared_memory_per_block = 1024;
-  __traits.max_shared_memory_per_block_optin =
-    __traits.max_shared_memory_per_multiprocessor - __traits.reserved_shared_memory_per_block;
-
-  __traits.cluster_supported  = false;
-  __traits.redux_intrinisic   = true;
-  __traits.elect_intrinsic    = false;
-  __traits.cp_async_supported = true;
-  __traits.tma_supported      = false;
-
-  return __traits;
-}();
-
-inline constexpr arch_traits_t sm_900_traits = []() constexpr {
-  arch_traits_t __traits{};
-  __traits.compute_capability_major             = 9;
-  __traits.compute_capability_minor             = 0;
-  __traits.compute_capability                   = 900;
-  __traits.max_shared_memory_per_multiprocessor = 228 * 1024;
-  __traits.max_blocks_per_multiprocessor        = 32;
-  __traits.max_threads_per_multiprocessor       = 2048;
-  __traits.max_warps_per_multiprocessor =
-    __traits.max_threads_per_multiprocessor / __detail::arch_common_traits::warp_size;
-  __traits.reserved_shared_memory_per_block = 1024;
-  __traits.max_shared_memory_per_block_optin =
-    __traits.max_shared_memory_per_multiprocessor - __traits.reserved_shared_memory_per_block;
-
-  __traits.cluster_supported  = true;
-  __traits.redux_intrinisic   = true;
-  __traits.elect_intrinsic    = true;
-  __traits.cp_async_supported = true;
-  __traits.tma_supported      = true;
-
-  return __traits;
-}();
-
-inline constexpr arch_traits_t sm_1000_traits = []() constexpr {
-  arch_traits_t __traits{};
-  __traits.compute_capability_major             = 10;
-  __traits.compute_capability_minor             = 0;
-  __traits.compute_capability                   = 1000;
-  __traits.max_shared_memory_per_multiprocessor = 228 * 1024;
-  __traits.max_blocks_per_multiprocessor        = 32;
-  __traits.max_threads_per_multiprocessor       = 2048;
-  __traits.max_warps_per_multiprocessor =
-    __traits.max_threads_per_multiprocessor / __detail::arch_common_traits::warp_size;
-  __traits.reserved_shared_memory_per_block = 1024;
-  __traits.max_shared_memory_per_block_optin =
-    __traits.max_shared_memory_per_multiprocessor - __traits.reserved_shared_memory_per_block;
-
-  __traits.cluster_supported  = true;
-  __traits.redux_intrinisic   = true;
-  __traits.elect_intrinsic    = true;
-  __traits.cp_async_supported = true;
-  __traits.tma_supported      = true;
-
-  return __traits;
-}();
-
-inline constexpr arch_traits_t sm_1030_traits = []() constexpr {
-  arch_traits_t __traits            = sm_1000_traits;
-  __traits.compute_capability_major = 10;
-  __traits.compute_capability_minor = 3;
-  __traits.compute_capability       = 1030;
-  return __traits;
-}();
-
-inline constexpr arch_traits_t sm_1200_traits = []() constexpr {
-  arch_traits_t __traits{};
-  __traits.compute_capability_major             = 12;
-  __traits.compute_capability_minor             = 0;
-  __traits.compute_capability                   = 1200;
-  __traits.max_shared_memory_per_multiprocessor = 100 * 1024;
-  __traits.max_blocks_per_multiprocessor        = 32;
-  __traits.max_threads_per_multiprocessor       = 1536;
-  __traits.max_warps_per_multiprocessor =
-    __traits.max_threads_per_multiprocessor / __detail::arch_common_traits::warp_size;
-  __traits.reserved_shared_memory_per_block = 1024;
-  __traits.max_shared_memory_per_block_optin =
-    __traits.max_shared_memory_per_multiprocessor - __traits.reserved_shared_memory_per_block;
-
-  __traits.cluster_supported  = true;
-  __traits.redux_intrinisic   = true;
-  __traits.elect_intrinsic    = true;
-  __traits.cp_async_supported = true;
-  __traits.tma_supported      = true;
-
-  return __traits;
-}();
-
-inline constexpr unsigned int __highest_known_arch = 1200;
-
-} // namespace __detail
-
-//! @brief Retrieve architecture traits of the specified architecture
-//!
-//! @param __sm_version Compute capability in 100 * major + 10 * minor format for which the architecture traits are
-//! requested
-//!
-//! @throws cuda_error if the requested architecture is unknown
-_CCCL_HOST_DEVICE inline constexpr arch_traits_t arch_traits(unsigned int __sm_version)
+template <>
+struct type<id::sm_61>
 {
-  switch (__sm_version)
+  static constexpr traits_t traits = []() constexpr {
+    traits_t __traits{};
+    __traits.id                                   = id::sm_61;
+    __traits.compute_capability_major             = 6;
+    __traits.compute_capability_minor             = 1;
+    __traits.compute_capability                   = 61;
+    __traits.max_shared_memory_per_multiprocessor = 96 * 1024;
+    __traits.max_blocks_per_multiprocessor        = 32;
+    __traits.max_threads_per_multiprocessor       = 2048;
+    __traits.max_warps_per_multiprocessor         = __traits.max_threads_per_multiprocessor / __traits.warp_size;
+    __traits.reserved_shared_memory_per_block     = 0;
+    __traits.max_shared_memory_per_block_optin    = 48 * 1024;
+
+    __traits.cluster_supported  = false;
+    __traits.redux_intrinisic   = false;
+    __traits.elect_intrinsic    = false;
+    __traits.cp_async_supported = false;
+    __traits.tma_supported      = false;
+    return __traits;
+  }();
+};
+using sm_61 = type<id::sm_61>;
+
+template <>
+struct type<id::sm_70>
+{
+  static constexpr traits_t traits = []() constexpr {
+    traits_t __traits{};
+    __traits.id                                   = id::sm_70;
+    __traits.compute_capability_major             = 7;
+    __traits.compute_capability_minor             = 0;
+    __traits.compute_capability                   = 70;
+    __traits.max_shared_memory_per_multiprocessor = 96 * 1024;
+    __traits.max_blocks_per_multiprocessor        = 32;
+    __traits.max_threads_per_multiprocessor       = 2048;
+    __traits.max_warps_per_multiprocessor         = __traits.max_threads_per_multiprocessor / __traits.warp_size;
+    __traits.reserved_shared_memory_per_block     = 0;
+    __traits.max_shared_memory_per_block_optin =
+      __traits.max_shared_memory_per_multiprocessor - __traits.reserved_shared_memory_per_block;
+
+    __traits.cluster_supported  = false;
+    __traits.redux_intrinisic   = false;
+    __traits.elect_intrinsic    = false;
+    __traits.cp_async_supported = false;
+    __traits.tma_supported      = false;
+    return __traits;
+  }();
+};
+using sm_70 = type<id::sm_70>;
+
+template <>
+struct type<id::sm_75>
+{
+  static constexpr traits_t traits = []() constexpr {
+    traits_t __traits{};
+    __traits.id                                   = id::sm_75;
+    __traits.compute_capability_major             = 7;
+    __traits.compute_capability_minor             = 5;
+    __traits.compute_capability                   = 75;
+    __traits.max_shared_memory_per_multiprocessor = 64 * 1024;
+    __traits.max_blocks_per_multiprocessor        = 16;
+    __traits.max_threads_per_multiprocessor       = 1024;
+    __traits.max_warps_per_multiprocessor         = __traits.max_threads_per_multiprocessor / __traits.warp_size;
+    __traits.reserved_shared_memory_per_block     = 0;
+    __traits.max_shared_memory_per_block_optin =
+      __traits.max_shared_memory_per_multiprocessor - __traits.reserved_shared_memory_per_block;
+
+    __traits.cluster_supported  = false;
+    __traits.redux_intrinisic   = false;
+    __traits.elect_intrinsic    = false;
+    __traits.cp_async_supported = false;
+    __traits.tma_supported      = false;
+    return __traits;
+  }();
+};
+using sm_75 = type<id::sm_75>;
+
+template <>
+struct type<id::sm_80>
+{
+  static constexpr traits_t traits = []() constexpr {
+    traits_t __traits{};
+    __traits.id                                   = id::sm_80;
+    __traits.compute_capability_major             = 8;
+    __traits.compute_capability_minor             = 0;
+    __traits.compute_capability                   = 80;
+    __traits.max_shared_memory_per_multiprocessor = 164 * 1024;
+    __traits.max_blocks_per_multiprocessor        = 32;
+    __traits.max_threads_per_multiprocessor       = 2048;
+    __traits.max_warps_per_multiprocessor         = __traits.max_threads_per_multiprocessor / __traits.warp_size;
+    __traits.reserved_shared_memory_per_block     = 1024;
+    __traits.max_shared_memory_per_block_optin =
+      __traits.max_shared_memory_per_multiprocessor - __traits.reserved_shared_memory_per_block;
+
+    __traits.cluster_supported  = false;
+    __traits.redux_intrinisic   = true;
+    __traits.elect_intrinsic    = false;
+    __traits.cp_async_supported = true;
+    __traits.tma_supported      = false;
+    return __traits;
+  }();
+};
+using sm_80 = type<id::sm_80>;
+
+template <>
+struct type<id::sm_86>
+{
+  static constexpr traits_t traits = []() constexpr {
+    traits_t __traits{};
+    __traits.id                                   = id::sm_86;
+    __traits.compute_capability_major             = 8;
+    __traits.compute_capability_minor             = 6;
+    __traits.compute_capability                   = 86;
+    __traits.max_shared_memory_per_multiprocessor = 100 * 1024;
+    __traits.max_blocks_per_multiprocessor        = 16;
+    __traits.max_threads_per_multiprocessor       = 1536;
+    __traits.max_warps_per_multiprocessor         = __traits.max_threads_per_multiprocessor / __traits.warp_size;
+    __traits.reserved_shared_memory_per_block     = 1024;
+    __traits.max_shared_memory_per_block_optin =
+      __traits.max_shared_memory_per_multiprocessor - __traits.reserved_shared_memory_per_block;
+
+    __traits.cluster_supported  = false;
+    __traits.redux_intrinisic   = true;
+    __traits.elect_intrinsic    = false;
+    __traits.cp_async_supported = true;
+    __traits.tma_supported      = false;
+    return __traits;
+  }();
+};
+using sm_86 = type<id::sm_86>;
+
+template <>
+struct type<id::sm_89>
+{
+  static constexpr traits_t traits = []() constexpr {
+    traits_t __traits{};
+    __traits.id                                   = id::sm_89;
+    __traits.compute_capability_major             = 8;
+    __traits.compute_capability_minor             = 9;
+    __traits.compute_capability                   = 89;
+    __traits.max_shared_memory_per_multiprocessor = 100 * 1024;
+    __traits.max_blocks_per_multiprocessor        = 24;
+    __traits.max_threads_per_multiprocessor       = 1536;
+    __traits.max_warps_per_multiprocessor         = __traits.max_threads_per_multiprocessor / __traits.warp_size;
+    __traits.reserved_shared_memory_per_block     = 1024;
+    __traits.max_shared_memory_per_block_optin =
+      __traits.max_shared_memory_per_multiprocessor - __traits.reserved_shared_memory_per_block;
+
+    __traits.cluster_supported  = false;
+    __traits.redux_intrinisic   = true;
+    __traits.elect_intrinsic    = false;
+    __traits.cp_async_supported = true;
+    __traits.tma_supported      = false;
+    return __traits;
+  }();
+};
+using sm_89 = type<id::sm_89>;
+
+template <>
+struct type<id::sm_90>
+{
+  static constexpr traits_t traits = []() constexpr {
+    traits_t __traits{};
+    __traits.id                                   = id::sm_90;
+    __traits.compute_capability_major             = 9;
+    __traits.compute_capability_minor             = 0;
+    __traits.compute_capability                   = 90;
+    __traits.max_shared_memory_per_multiprocessor = 228 * 1024;
+    __traits.max_blocks_per_multiprocessor        = 32;
+    __traits.max_threads_per_multiprocessor       = 2048;
+    __traits.max_warps_per_multiprocessor         = __traits.max_threads_per_multiprocessor / __traits.warp_size;
+    __traits.reserved_shared_memory_per_block     = 1024;
+    __traits.max_shared_memory_per_block_optin =
+      __traits.max_shared_memory_per_multiprocessor - __traits.reserved_shared_memory_per_block;
+
+    __traits.cluster_supported  = true;
+    __traits.redux_intrinisic   = true;
+    __traits.elect_intrinsic    = true;
+    __traits.cp_async_supported = true;
+    __traits.tma_supported      = true;
+    return __traits;
+  }();
+};
+using sm_90 = type<id::sm_90>;
+
+// No sm_90a specific fields for now.
+template <>
+struct type<id::sm_90a> : type<id::sm_90>
+{};
+using sm_90a = type<id::sm_90a>;
+
+template <>
+struct type<id::sm_100>
+{
+  static constexpr traits_t traits = []() constexpr {
+    traits_t __traits{};
+    __traits.id                                   = id::sm_100;
+    __traits.compute_capability_major             = 10;
+    __traits.compute_capability_minor             = 0;
+    __traits.compute_capability                   = 100;
+    __traits.max_shared_memory_per_multiprocessor = 228 * 1024;
+    __traits.max_blocks_per_multiprocessor        = 32;
+    __traits.max_threads_per_multiprocessor       = 2048;
+    __traits.max_warps_per_multiprocessor         = __traits.max_threads_per_multiprocessor / __traits.warp_size;
+    __traits.reserved_shared_memory_per_block     = 1024;
+    __traits.max_shared_memory_per_block_optin =
+      __traits.max_shared_memory_per_multiprocessor - __traits.reserved_shared_memory_per_block;
+
+    __traits.cluster_supported  = true;
+    __traits.redux_intrinisic   = true;
+    __traits.elect_intrinsic    = true;
+    __traits.cp_async_supported = true;
+    __traits.tma_supported      = true;
+    return __traits;
+  }();
+};
+using sm_100 = type<id::sm_100>;
+
+template <>
+struct type<id::sm_100a> : type<id::sm_100>
+{};
+using sm_100a = type<id::sm_100a>;
+
+template <>
+struct type<id::sm_103>
+{
+  static constexpr traits_t traits = []() constexpr {
+    traits_t __traits                 = sm_100::traits;
+    __traits.id                       = id::sm_103;
+    __traits.compute_capability_major = 10;
+    __traits.compute_capability_minor = 3;
+    __traits.compute_capability       = 103;
+
+    return __traits;
+  }();
+};
+using sm_103 = type<id::sm_103>;
+
+template <>
+struct type<id::sm_103a> : type<id::sm_103>
+{};
+using sm_103a = type<id::sm_103a>;
+
+template <>
+struct type<id::sm_120>
+{
+  static constexpr traits_t traits = []() constexpr {
+    traits_t __traits{};
+    __traits.id                                   = id::sm_120;
+    __traits.compute_capability_major             = 12;
+    __traits.compute_capability_minor             = 0;
+    __traits.compute_capability                   = 120;
+    __traits.max_shared_memory_per_multiprocessor = 100 * 1024;
+    __traits.max_blocks_per_multiprocessor        = 32;
+    __traits.max_threads_per_multiprocessor       = 1536;
+    __traits.max_warps_per_multiprocessor         = __traits.max_threads_per_multiprocessor / __traits.warp_size;
+    __traits.reserved_shared_memory_per_block     = 1024;
+    __traits.max_shared_memory_per_block_optin =
+      __traits.max_shared_memory_per_multiprocessor - __traits.reserved_shared_memory_per_block;
+
+    __traits.cluster_supported  = true;
+    __traits.redux_intrinisic   = true;
+    __traits.elect_intrinsic    = true;
+    __traits.cp_async_supported = true;
+    __traits.tma_supported      = true;
+    return __traits;
+  }();
+};
+using sm_120 = type<id::sm_120>;
+
+template <>
+struct type<id::sm_120a> : type<id::sm_120>
+{};
+using sm_120a = type<id::sm_120a>;
+
+inline constexpr int __highest_known_arch = 120;
+
+_CCCL_HOST_DEVICE constexpr inline traits_t traits_for_id(id __id)
+{
+  switch (__id)
   {
-    case 600:
-      return __detail::sm_600_traits;
-    case 610:
-      return __detail::sm_610_traits;
-    case 700:
-      return __detail::sm_700_traits;
-    case 750:
-      return __detail::sm_750_traits;
-    case 800:
-      return __detail::sm_800_traits;
-    case 860:
-      return __detail::sm_860_traits;
-    case 890:
-      return __detail::sm_890_traits;
-    case 900:
-      return __detail::sm_900_traits;
-    case 1000:
-      return __detail::sm_1000_traits;
-    case 1030:
-      return __detail::sm_1030_traits;
-    case 1200:
-      return __detail::sm_1200_traits;
+    case id::sm_60:
+      return arch::sm_60::traits;
+    case id::sm_61:
+      return arch::sm_61::traits;
+    case id::sm_70:
+      return arch::sm_70::traits;
+    case id::sm_75:
+      return arch::sm_75::traits;
+    case id::sm_80:
+      return arch::sm_80::traits;
+    case id::sm_86:
+      return arch::sm_86::traits;
+    case id::sm_89:
+      return arch::sm_89::traits;
+    case id::sm_90:
+      return arch::sm_90::traits;
+    case id::sm_90a:
+      return arch::sm_90a::traits;
+    case id::sm_100:
+      return arch::sm_100::traits;
+    case id::sm_100a:
+      return arch::sm_100a::traits;
+    case id::sm_103:
+      return arch::sm_103::traits;
+    case id::sm_103a:
+      return arch::sm_103a::traits;
+    case id::sm_120:
+      return arch::sm_120::traits;
+    case id::sm_120a:
+      return arch::sm_120a::traits;
     default:
       __throw_cuda_error(cudaErrorInvalidValue, "Traits requested for an unknown architecture");
       break;
   }
 }
 
-//! @brief Type representing a CUDA device architecture. It provides traits from arch_traits_t in form of static members
-template <unsigned int __SmVersion>
-struct arch : public __detail::arch_common_traits
+_CCCL_HOST_DEVICE constexpr inline id id_for_compute_capability(int compute_capability)
 {
-private:
-  static constexpr arch_traits_t __traits = arch_traits(__SmVersion);
-
-public:
-  static constexpr int compute_capability_major             = __traits.compute_capability_major;
-  static constexpr int compute_capability_minor             = __traits.compute_capability_minor;
-  static constexpr int compute_capability                   = __traits.compute_capability;
-  static constexpr int max_shared_memory_per_multiprocessor = __traits.max_shared_memory_per_multiprocessor;
-  static constexpr int max_warps_per_multiprocessor         = __traits.max_warps_per_multiprocessor;
-  static constexpr int max_blocks_per_multiprocessor        = __traits.max_blocks_per_multiprocessor;
-  static constexpr int max_threads_per_multiprocessor       = __traits.max_threads_per_multiprocessor;
-  static constexpr int reserved_shared_memory_per_block     = __traits.reserved_shared_memory_per_block;
-  static constexpr int max_shared_memory_per_block_optin    = __traits.max_shared_memory_per_block_optin;
-
-  static constexpr bool cluster_supported  = __traits.cluster_supported;
-  static constexpr bool redux_intrinisic   = __traits.redux_intrinisic;
-  static constexpr bool elect_intrinsic    = __traits.elect_intrinsic;
-  static constexpr bool cp_async_supported = __traits.cp_async_supported;
-  static constexpr bool tma_supported      = __traits.tma_supported;
-
-  constexpr operator arch_traits_t() const
+  if (compute_capability < 60 || compute_capability > __highest_known_arch)
   {
-    return __traits;
+    __throw_cuda_error(cudaErrorInvalidValue, "Compute capability out of range");
   }
-};
+  return static_cast<id>(compute_capability);
+}
+
+_CCCL_HOST_DEVICE constexpr inline traits_t traits_for_compute_capability(int compute_capability)
+{
+  return traits_for_id(id_for_compute_capability(compute_capability));
+}
+
+_CCCL_HOST_DEVICE constexpr inline id __special_id_for_compute_capability(int value)
+{
+  switch (value)
+  {
+    case 90:
+      return id::sm_90a;
+    case 100:
+      return id::sm_100a;
+    case 103:
+      return id::sm_103a;
+    case 120:
+      return id::sm_120a;
+    default:
+      __throw_cuda_error(cudaErrorInvalidValue, "Compute capability out of range");
+      break;
+  }
+}
 
 //! @brief Provides architecture traits of the architecture matching __CUDA_ARCH__ macro
-_CCCL_DEVICE constexpr arch_traits_t current_arch()
+_CCCL_DEVICE constexpr arch::traits_t current_arch()
 {
   // fixme: this doesn't work with nvc++ -cuda
 #ifdef __CUDA_ARCH__
-  return arch_traits(__CUDA_ARCH__);
-#else
+#  ifdef __CUDA_ARCH_SPECIFIC__
+  return arch::traits_for_id(__special_id_for_compute_capability(__CUDA_ARCH_SPECIFIC__ / 10));
+#  else
+  return arch::traits_for_compute_capability(__CUDA_ARCH__ / 10);
+#  endif // __CUDA_ARCH_SPECIFIC__
+#else // __CUDA_ARCH__
   // Should be unreachable in __device__ function
-  return arch_traits_t{};
-#endif
+  return arch::traits_t{};
+#endif // __CUDA_ARCH__
 }
 
-namespace __detail
+[[nodiscard]] inline constexpr arch::traits_t
+__arch_traits_might_be_unknown(int __device, unsigned int __compute_capability)
 {
-[[nodiscard]] inline constexpr arch_traits_t __arch_traits_might_be_unknown(int __device, unsigned int __arch)
-{
-  if (__arch <= __highest_known_arch)
+  if (__compute_capability <= arch::__highest_known_arch)
   {
-    return arch_traits(__arch);
+    return arch::traits_for_compute_capability(__compute_capability);
   }
   else
   {
     // If the architecture is unknown, we need to craft the arch_traits from attributes
-    arch_traits_t __traits{};
-    __traits.compute_capability_major = __arch / 100;
-    __traits.compute_capability_minor = (__arch / 10) % 10;
-    __traits.compute_capability       = __arch;
+    arch::traits_t __traits{};
+    __traits.compute_capability_major = __compute_capability / 10;
+    __traits.compute_capability_minor = __compute_capability % 10;
+    __traits.compute_capability       = __compute_capability;
     __traits.max_shared_memory_per_multiprocessor =
       __detail::__device_attrs::max_shared_memory_per_multiprocessor(__device);
-    __traits.max_blocks_per_multiprocessor  = __detail::__device_attrs::max_blocks_per_multiprocessor(__device);
-    __traits.max_threads_per_multiprocessor = __detail::__device_attrs::max_threads_per_multiprocessor(__device);
-    __traits.max_warps_per_multiprocessor =
-      __traits.max_threads_per_multiprocessor / __detail::arch_common_traits::warp_size;
+    __traits.max_blocks_per_multiprocessor    = __detail::__device_attrs::max_blocks_per_multiprocessor(__device);
+    __traits.max_threads_per_multiprocessor   = __detail::__device_attrs::max_threads_per_multiprocessor(__device);
+    __traits.max_warps_per_multiprocessor     = __traits.max_threads_per_multiprocessor / __traits.warp_size;
     __traits.reserved_shared_memory_per_block = __detail::__device_attrs::reserved_shared_memory_per_block(__device);
     __traits.max_shared_memory_per_block_optin =
       __traits.max_shared_memory_per_multiprocessor - __traits.reserved_shared_memory_per_block;
 
-    __traits.cluster_supported  = __arch >= 900;
-    __traits.redux_intrinisic   = __arch >= 800;
-    __traits.elect_intrinsic    = __arch >= 900;
-    __traits.cp_async_supported = __arch >= 800;
-    __traits.tma_supported      = __arch >= 900;
+    __traits.cluster_supported  = __compute_capability >= 90;
+    __traits.redux_intrinisic   = __compute_capability >= 80;
+    __traits.elect_intrinsic    = __compute_capability >= 90;
+    __traits.cp_async_supported = __compute_capability >= 80;
+    __traits.tma_supported      = __compute_capability >= 90;
     return __traits;
   }
 }
-} // namespace __detail
+} // namespace arch
 
 } // namespace cuda::experimental
 

--- a/cudax/include/cuda/experimental/__device/attributes.cuh
+++ b/cudax/include/cuda/experimental/__device/attributes.cuh
@@ -700,13 +700,13 @@ struct __device_attrs
 
 #endif // CUDART_VERSION >= 12020
 
-  // Combines major and minor compute capability in a 100 * major + 10 * minor format, allows to query full compute
-  // capability in a single query
+  // Combines major and minor compute capability in a 10 * major + minor format, allows to query full compute capability
+  // in a single query
   struct compute_capability_t
   {
     [[nodiscard]] int operator()(device_ref __dev_id) const
     {
-      return 100 * compute_capability_major(__dev_id) + 10 * compute_capability_minor(__dev_id);
+      return 10 * compute_capability_major(__dev_id) + compute_capability_minor(__dev_id);
     }
   };
   static constexpr compute_capability_t compute_capability{};

--- a/cudax/include/cuda/experimental/__device/device.cuh
+++ b/cudax/include/cuda/experimental/__device/device.cuh
@@ -86,7 +86,7 @@ public:
   //! that are shared by all devices belonging to given architecture.
   //!
   //! @return A reference to `arch_traits_t` object containing architecture traits of this device
-  const arch_traits_t& arch_traits() const noexcept
+  const arch::traits_t& arch_traits() const noexcept
   {
     return __traits;
   }
@@ -123,11 +123,11 @@ private:
   // TODO should this be a reference/pointer to the constexpr traits instances?
   //  Do we care about lazy init?
   //  We should have some of the attributes just return from the arch traits
-  arch_traits_t __traits;
+  arch::traits_t __traits;
 
   explicit device(int __id)
       : device_ref(__id)
-      , __traits(__detail::__arch_traits_might_be_unknown(__id, attributes::compute_capability(__id)))
+      , __traits(arch::__arch_traits_might_be_unknown(__id, attributes::compute_capability(__id)))
   {}
 
   // `device` objects are not movable or copyable.

--- a/cudax/include/cuda/experimental/__device/device_ref.cuh
+++ b/cudax/include/cuda/experimental/__device/device_ref.cuh
@@ -33,7 +33,10 @@
 namespace cuda::experimental
 {
 class device;
-struct arch_traits_t;
+namespace arch
+{
+struct traits_t;
+} // namespace arch
 
 namespace __detail
 {
@@ -152,7 +155,7 @@ public:
   //! that are shared by all devices belonging to given architecture.
   //!
   //! @return A reference to `arch_traits_t` object containing architecture traits of this device
-  const arch_traits_t& arch_traits() const;
+  const arch::traits_t& arch_traits() const;
 
   // TODO this might return some more complex type in the future
   // TODO we might want to include the calling device, depends on what we decide

--- a/cudax/test/device/arch_traits.cu
+++ b/cudax/test/device/arch_traits.cu
@@ -16,101 +16,106 @@ template <typename Arch>
 __global__ void arch_specific_kernel_mock_do_not_launch()
 {
   // I will try to pack something like this into an API
-  if constexpr (Arch::compute_capability != cudax::current_arch().compute_capability)
+  if constexpr (Arch::traits.compute_capability != cudax::arch::current_arch().compute_capability)
   {
     return;
   }
 
-  [[maybe_unused]] __shared__ int array[Arch::max_shared_memory_per_block / sizeof(int)];
+  [[maybe_unused]] __shared__ int array[Arch::traits.max_shared_memory_per_block / sizeof(int)];
 
   // constexpr is useless and I can't use intrinsics here :(
-  if constexpr (cudax::current_arch().cluster_supported)
+  if constexpr (cudax::arch::current_arch().cluster_supported)
   {
     [[maybe_unused]] int dummy;
     asm volatile("mov.u32 %0, %%cluster_ctarank;" : "=r"(dummy));
   }
-  if constexpr (cudax::current_arch().redux_intrinisic)
+  if constexpr (cudax::arch::current_arch().redux_intrinisic)
   {
     [[maybe_unused]] int dummy1 = 0, dummy2 = 0;
     asm volatile("redux.sync.add.s32 %0, %1, 0xffffffff;" : "=r"(dummy1) : "r"(dummy2));
   }
-  if constexpr (cudax::current_arch().cp_async_supported)
+  if constexpr (cudax::arch::current_arch().cp_async_supported)
   {
     asm volatile("cp.async.commit_group;");
   }
 }
 
-template __global__ void arch_specific_kernel_mock_do_not_launch<cudax::arch<700>>();
-template __global__ void arch_specific_kernel_mock_do_not_launch<cudax::arch<750>>();
-template __global__ void arch_specific_kernel_mock_do_not_launch<cudax::arch<800>>();
-template __global__ void arch_specific_kernel_mock_do_not_launch<cudax::arch<860>>();
-template __global__ void arch_specific_kernel_mock_do_not_launch<cudax::arch<890>>();
-template __global__ void arch_specific_kernel_mock_do_not_launch<cudax::arch<900>>();
-template __global__ void arch_specific_kernel_mock_do_not_launch<cudax::arch<1000>>();
-template __global__ void arch_specific_kernel_mock_do_not_launch<cudax::arch<1030>>();
-template __global__ void arch_specific_kernel_mock_do_not_launch<cudax::arch<1200>>();
+template __global__ void arch_specific_kernel_mock_do_not_launch<cudax::arch::sm_70>();
+template __global__ void arch_specific_kernel_mock_do_not_launch<cudax::arch::sm_75>();
+template __global__ void arch_specific_kernel_mock_do_not_launch<cudax::arch::sm_80>();
+template __global__ void arch_specific_kernel_mock_do_not_launch<cudax::arch::sm_86>();
+template __global__ void arch_specific_kernel_mock_do_not_launch<cudax::arch::sm_89>();
+template __global__ void arch_specific_kernel_mock_do_not_launch<cudax::arch::sm_90>();
+template __global__ void arch_specific_kernel_mock_do_not_launch<cudax::arch::sm_100>();
+template __global__ void arch_specific_kernel_mock_do_not_launch<cudax::arch::sm_103>();
+template __global__ void arch_specific_kernel_mock_do_not_launch<cudax::arch::sm_120>();
+template __global__ void arch_specific_kernel_mock_do_not_launch<cudax::arch::sm_90a>();
+template __global__ void arch_specific_kernel_mock_do_not_launch<cudax::arch::sm_100a>();
+template __global__ void arch_specific_kernel_mock_do_not_launch<cudax::arch::sm_103a>();
+template __global__ void arch_specific_kernel_mock_do_not_launch<cudax::arch::sm_120a>();
 
-template <unsigned int Arch>
+template <unsigned int ComputeCapability>
 void constexpr compare_static_and_dynamic()
 {
-  using StaticTraits                            = cudax::arch<Arch>;
-  constexpr cudax::arch_traits_t dynamic_traits = cudax::arch_traits(Arch);
+  using ArchType = cudax::arch::type<cudax::arch::id_for_compute_capability(ComputeCapability)>;
+  constexpr cudax::arch::traits_t dynamic_traits = cudax::arch::traits_for_compute_capability(ComputeCapability);
 
-  static_assert(sizeof(StaticTraits) == 1);
+  static_assert(sizeof(ArchType) == 1);
 
-  static_assert(StaticTraits::max_threads_per_block == dynamic_traits.max_threads_per_block);
-  static_assert(StaticTraits::max_block_dim_x == dynamic_traits.max_block_dim_x);
-  static_assert(StaticTraits::max_block_dim_y == dynamic_traits.max_block_dim_y);
-  static_assert(StaticTraits::max_block_dim_z == dynamic_traits.max_block_dim_z);
-  static_assert(StaticTraits::max_grid_dim_x == dynamic_traits.max_grid_dim_x);
-  static_assert(StaticTraits::max_grid_dim_y == dynamic_traits.max_grid_dim_y);
-  static_assert(StaticTraits::max_grid_dim_z == dynamic_traits.max_grid_dim_z);
+  static_assert(ArchType::traits == dynamic_traits);
+  static_assert(ArchType::traits.id == dynamic_traits.id);
+  static_assert(ArchType::traits.max_threads_per_block == dynamic_traits.max_threads_per_block);
+  static_assert(ArchType::traits.max_block_dim_x == dynamic_traits.max_block_dim_x);
+  static_assert(ArchType::traits.max_block_dim_y == dynamic_traits.max_block_dim_y);
+  static_assert(ArchType::traits.max_block_dim_z == dynamic_traits.max_block_dim_z);
+  static_assert(ArchType::traits.max_grid_dim_x == dynamic_traits.max_grid_dim_x);
+  static_assert(ArchType::traits.max_grid_dim_y == dynamic_traits.max_grid_dim_y);
+  static_assert(ArchType::traits.max_grid_dim_z == dynamic_traits.max_grid_dim_z);
 
-  static_assert(StaticTraits::warp_size == dynamic_traits.warp_size);
-  static_assert(StaticTraits::total_constant_memory == dynamic_traits.total_constant_memory);
-  static_assert(StaticTraits::max_resident_grids == dynamic_traits.max_resident_grids);
-  static_assert(StaticTraits::max_shared_memory_per_block == dynamic_traits.max_shared_memory_per_block);
-  static_assert(StaticTraits::gpu_overlap == dynamic_traits.gpu_overlap);
-  static_assert(StaticTraits::can_map_host_memory == dynamic_traits.can_map_host_memory);
-  static_assert(StaticTraits::concurrent_kernels == dynamic_traits.concurrent_kernels);
-  static_assert(StaticTraits::stream_priorities_supported == dynamic_traits.stream_priorities_supported);
-  static_assert(StaticTraits::global_l1_cache_supported == dynamic_traits.global_l1_cache_supported);
-  static_assert(StaticTraits::local_l1_cache_supported == dynamic_traits.local_l1_cache_supported);
-  static_assert(StaticTraits::max_registers_per_block == dynamic_traits.max_registers_per_block);
-  static_assert(StaticTraits::max_registers_per_multiprocessor == dynamic_traits.max_registers_per_multiprocessor);
-  static_assert(StaticTraits::max_registers_per_thread == dynamic_traits.max_registers_per_thread);
+  static_assert(ArchType::traits.warp_size == dynamic_traits.warp_size);
+  static_assert(ArchType::traits.total_constant_memory == dynamic_traits.total_constant_memory);
+  static_assert(ArchType::traits.max_resident_grids == dynamic_traits.max_resident_grids);
+  static_assert(ArchType::traits.max_shared_memory_per_block == dynamic_traits.max_shared_memory_per_block);
+  static_assert(ArchType::traits.gpu_overlap == dynamic_traits.gpu_overlap);
+  static_assert(ArchType::traits.can_map_host_memory == dynamic_traits.can_map_host_memory);
+  static_assert(ArchType::traits.concurrent_kernels == dynamic_traits.concurrent_kernels);
+  static_assert(ArchType::traits.stream_priorities_supported == dynamic_traits.stream_priorities_supported);
+  static_assert(ArchType::traits.global_l1_cache_supported == dynamic_traits.global_l1_cache_supported);
+  static_assert(ArchType::traits.local_l1_cache_supported == dynamic_traits.local_l1_cache_supported);
+  static_assert(ArchType::traits.max_registers_per_block == dynamic_traits.max_registers_per_block);
+  static_assert(ArchType::traits.max_registers_per_multiprocessor == dynamic_traits.max_registers_per_multiprocessor);
 
-  static_assert(StaticTraits::compute_capability_major == dynamic_traits.compute_capability_major);
-  static_assert(StaticTraits::compute_capability_minor == dynamic_traits.compute_capability_minor);
-  static_assert(StaticTraits::compute_capability == dynamic_traits.compute_capability);
+  static_assert(ArchType::traits.compute_capability == dynamic_traits.compute_capability);
+  static_assert(ArchType::traits.compute_capability_major == dynamic_traits.compute_capability_major);
+  static_assert(ArchType::traits.compute_capability_minor == dynamic_traits.compute_capability_minor);
+  static_assert(ArchType::traits.compute_capability == dynamic_traits.compute_capability);
   static_assert(
-    StaticTraits::max_shared_memory_per_multiprocessor == dynamic_traits.max_shared_memory_per_multiprocessor);
-  static_assert(StaticTraits::max_blocks_per_multiprocessor == dynamic_traits.max_blocks_per_multiprocessor);
-  static_assert(StaticTraits::max_warps_per_multiprocessor == dynamic_traits.max_warps_per_multiprocessor);
-  static_assert(StaticTraits::max_threads_per_multiprocessor == dynamic_traits.max_threads_per_multiprocessor);
-  static_assert(StaticTraits::reserved_shared_memory_per_block == dynamic_traits.reserved_shared_memory_per_block);
-  static_assert(StaticTraits::max_shared_memory_per_block_optin == dynamic_traits.max_shared_memory_per_block_optin);
-  static_assert(StaticTraits::cluster_supported == dynamic_traits.cluster_supported);
-  static_assert(StaticTraits::redux_intrinisic == dynamic_traits.redux_intrinisic);
-  static_assert(StaticTraits::elect_intrinsic == dynamic_traits.elect_intrinsic);
-  static_assert(StaticTraits::cp_async_supported == dynamic_traits.cp_async_supported);
-  static_assert(StaticTraits::tma_supported == dynamic_traits.tma_supported);
+    ArchType::traits.max_shared_memory_per_multiprocessor == dynamic_traits.max_shared_memory_per_multiprocessor);
+  static_assert(ArchType::traits.max_blocks_per_multiprocessor == dynamic_traits.max_blocks_per_multiprocessor);
+  static_assert(ArchType::traits.max_warps_per_multiprocessor == dynamic_traits.max_warps_per_multiprocessor);
+  static_assert(ArchType::traits.max_threads_per_multiprocessor == dynamic_traits.max_threads_per_multiprocessor);
+  static_assert(ArchType::traits.reserved_shared_memory_per_block == dynamic_traits.reserved_shared_memory_per_block);
+  static_assert(ArchType::traits.max_shared_memory_per_block_optin == dynamic_traits.max_shared_memory_per_block_optin);
+  static_assert(ArchType::traits.cluster_supported == dynamic_traits.cluster_supported);
+  static_assert(ArchType::traits.redux_intrinisic == dynamic_traits.redux_intrinisic);
+  static_assert(ArchType::traits.elect_intrinsic == dynamic_traits.elect_intrinsic);
+  static_assert(ArchType::traits.cp_async_supported == dynamic_traits.cp_async_supported);
+  static_assert(ArchType::traits.tma_supported == dynamic_traits.tma_supported);
 
-  constexpr cudax::arch_traits_t casted = StaticTraits{};
-  static_assert(casted.compute_capability == dynamic_traits.compute_capability);
+  static_assert(cudax::arch::type<ArchType::traits.id>::traits == ArchType::traits);
 }
 
 C2H_CCCLRT_TEST("Traits", "[device]")
 {
-  compare_static_and_dynamic<700>();
-  compare_static_and_dynamic<750>();
-  compare_static_and_dynamic<800>();
-  compare_static_and_dynamic<860>();
-  compare_static_and_dynamic<890>();
-  compare_static_and_dynamic<900>();
-  compare_static_and_dynamic<1000>();
-  compare_static_and_dynamic<1030>();
-  compare_static_and_dynamic<1200>();
+  compare_static_and_dynamic<70>();
+  compare_static_and_dynamic<75>();
+  compare_static_and_dynamic<80>();
+  compare_static_and_dynamic<86>();
+  compare_static_and_dynamic<89>();
+  compare_static_and_dynamic<90>();
+  compare_static_and_dynamic<100>();
+  compare_static_and_dynamic<103>();
+  compare_static_and_dynamic<120>();
 
   // Compare arch traits with attributes
   for (const cudax::device& dev : cudax::devices)


### PR DESCRIPTION
There is a bit of redundancy in arch traits right now, where there is `arch_traits_t` and the `arch` template is also a bit of a traits type templated on `__CUDA_ARCH__` values. We also don't have a good way to support arch-specific targets, because we are relying on compute capability values everywhere, which makes it hard to represent something like sm_90a.

This PR tries to shuffle things around and structure them better. It introduces `arch` namespace to avoid repeating that prefix on the names of all introduced APIs. `arch` namespace has three key components:

1. `id`, which is an enum meant to represent all different compilation targets, including the arch-specific targets. It is named to mimic the arch argument to nvcc `sm_90`, `sm_90a` etc. We could consider some different name as well, for example `compute_90` or something completely new.
2. `traits_t` which is the type with all the static architecture traits like shared memory size, compute capability etc. This type is also released from `device::arch_traits()` API for a given device.
3. `type` template that accepts `id` as a template argument. This is a type representation of a given architecture, which inside holds a static `traits_t` member. This way we don't have to duplicate the traits in this type, instead it has a member with the traits. There is a specialization of that type template for each valid architecture `id`. Each specialization also has a shorthand alias that follows the same naming as `id`, so `type<id::sm_90>` is aliased to just `sm_90`.
4. Outside of the `arch` namespace there is also a concept of compute capability, which is translatable to traits with `traits_for_compute_capability` or `id` with `id_for_compute_capability` constexpr functions. I decided to move to `major * 10 + minor` format, because I don't want `__CUDA_ARCH__` macro to be used with APIs accepting compute capability. Instead we offer `current_traits` function, which will return traits according to the current `__CUDA_ARCH__`. We could also provide an arch type alias for the current `__CUDA_ARCH__`, but because there is a host pass over device code, it could become problematic.

To sumarize:
`arch::id::sm_90` is an enum value of type `arch::id` that represents a given architecture.
`arch::sm_90` is a type that represents a given architecture.
`arch::sm_90::traits` is a static constexpr variable holding all traits of a given architecture.

One could argue that we don't need both a type and an enum for each architecture. I think there is value in having an enum type that can represent different architectures. With just the type representation, it would be impossible to have dynamic variable describing an architecture. We technically could only have the enum and a templated traits variable, but I think explicitly referring to a `arch::traits<arch::id::sm_90>` is worse than `arch::sm_90::traits`. I could be convinced otherwise.
It is possible `id` entries should be named differently from `type` specialization aliases, but I don't have a good idea how.

The structure selected was designed to work well for:
1. Get traits for a given device with:
`auto traits = device.arch_traits()`
2. Get traits for a given arch with
`auto traits = arch::sm_XY::traits`
3. Get traits for the current architecture in device code with:
`auto traits = arch::current_traits()`
This should return any architecture-specific target (like `sm_90a`) traits if enabled.
4. Template your code for a given architecture by accepting the architecture type as a template argument

It allows to do other things, but might need a few steps:
1. Store an architecture dynamically and get a traits for it later:
```
arch::id arch_id = arch::id::sm_90;
(...)
auto traits = arch::traits_for_id(arch_id);
```
2. Get the arch type from id:
```
using arch_type = arch::type<arch_id>;
```
3. Get id/traits from int compute capability:
```
auto traits = arch::traits_for_compute_capability(cc);
auto id      = arch::id_for_compute_capability(cc);
4. You can also get `id` from either type or traits, because `arch::traits_t` has an `id` member.

Finally this PR introduces `sm_90a`, `sm_100a`, `sm_103a` and `sm_120a` type and id to show how it fits into the new structure. For now we don't have any trait fields that would be different for those `a` architectures, but it should come in the future. There are also `sm_XYf` family targets that we probably need to add as well. We could also think about member aliases to link between `sm_100`, `sm_100a` and `sm_100f`, but that is also left for future changes.