### PR TITLE
[CUDAX] Migrate copy and fill to use driver API and add driver stack checks in memory_resource and async_buffer tests

### DIFF
--- a/cudax/include/cuda/experimental/__algorithm/copy.cuh
+++ b/cudax/include/cuda/experimental/__algorithm/copy.cuh
@@ -44,14 +44,7 @@ void __copy_bytes_impl(stream_ref __stream, _CUDA_VSTD::span<_SrcTy> __src, _CUD
     _CUDA_VSTD::__throw_invalid_argument("Copy destination is too small to fit the source data");
   }
 
-  _CCCL_TRY_CUDA_API(
-    ::cudaMemcpyAsync,
-    "Failed to perform a copy",
-    __dst.data(),
-    __src.data(),
-    __src.size_bytes(),
-    cudaMemcpyDefault,
-    __stream.get());
+  __detail::driver::memcpyAsync(__dst.data(), __src.data(), __src.size_bytes(), __stream.get());
 }
 
 //! @brief Launches a bytewise memory copy from source to destination into the provided stream.

--- a/cudax/include/cuda/experimental/__algorithm/fill.cuh
+++ b/cudax/include/cuda/experimental/__algorithm/fill.cuh
@@ -38,8 +38,7 @@ void __fill_bytes_impl(stream_ref __stream, _CUDA_VSTD::span<_DstTy, _DstSize> _
   static_assert(_CUDA_VSTD::is_trivially_copyable_v<_DstTy>);
 
   // TODO do a host callback if not device accessible?
-  _CCCL_TRY_CUDA_API(
-    ::cudaMemsetAsync, "Failed to perform a fill", __dst.data(), __value, __dst.size_bytes(), __stream.get());
+  __detail::driver::memsetAsync(__dst.data(), __value, __dst.size_bytes(), __stream.get());
 }
 
 //! @brief Launches an operation to bytewise fill the memory into the provided stream.

--- a/cudax/include/cuda/experimental/__container/async_buffer.cuh
+++ b/cudax/include/cuda/experimental/__container/async_buffer.cuh
@@ -175,14 +175,7 @@ private:
 
     static_assert(_CUDA_VSTD::contiguous_iterator<_Iter>, "Non contiguous iterators are not supported");
     // TODO use batched memcpy for non-contiguous iterators, it allows to specify stream ordered access
-    _CCCL_TRY_CUDA_API(
-      ::cudaMemcpyAsync,
-      "cudax::async_buffer::__copy_cross: failed to copy data",
-      __dest,
-      _CUDA_VSTD::to_address(__first),
-      sizeof(_Tp) * __count,
-      ::cudaMemcpyDefault,
-      __buf_.stream().get());
+    __detail::driver::memcpyAsync(__dest, _CUDA_VSTD::to_address(__first), sizeof(_Tp) * __count, __buf_.stream().get());
   }
 
   //! @brief Value-initializes elements in the range `[__first, __first + __count)`.
@@ -646,13 +639,10 @@ template <typename _BufferTo, typename _BufferFrom>
 void __copy_cross_buffers(stream_ref __stream, _BufferTo& __to, const _BufferFrom& __from)
 {
   __stream.wait(__from.stream());
-  _CCCL_TRY_CUDA_API(
-    ::cudaMemcpyAsync,
-    "make_async_buffer: failed to copy data",
+  __detail::driver::memcpyAsync(
     __to.__unwrapped_begin(),
     __from.__unwrapped_begin(),
     sizeof(typename _BufferTo::value_type) * __from.size(),
-    cudaMemcpyKind::cudaMemcpyDefault,
     __stream.get());
 }
 

--- a/cudax/include/cuda/experimental/__stream/internal_streams.cuh
+++ b/cudax/include/cuda/experimental/__stream/internal_streams.cuh
@@ -31,7 +31,7 @@ namespace cuda::experimental
 {
 //! @brief internal stream used for memory allocations, no real blocking work
 //! should ever be pushed into it
-inline ::cuda::stream_ref __cccl_allocation_stream()
+inline ::cuda::experimental::stream_ref __cccl_allocation_stream()
 {
   static ::cuda::experimental::stream __stream{device_ref{0}};
   return __stream;

--- a/cudax/include/cuda/experimental/__utility/driver_api.cuh
+++ b/cudax/include/cuda/experimental/__utility/driver_api.cuh
@@ -259,6 +259,25 @@ inline CUcontext ctxFromGreenCtx(CUgreenCtx green_ctx)
 }
 
 #endif // CUDART_VERSION >= 12050
+
+inline void memcpyAsync(void* dst, const void* src, size_t count, CUstream stream)
+{
+  static auto driver_fn = CUDAX_GET_DRIVER_FUNCTION(cuMemcpyAsync);
+  call_driver_fn(
+    driver_fn,
+    "Failed to perform a memcpy",
+    reinterpret_cast<CUdeviceptr>(dst),
+    reinterpret_cast<CUdeviceptr>(src),
+    count,
+    stream);
+}
+
+inline void memsetAsync(void* dst, int value, size_t count, CUstream stream)
+{
+  static auto driver_fn = CUDAX_GET_DRIVER_FUNCTION(cuMemsetD8Async);
+  call_driver_fn(driver_fn, "Failed to perform a memset", reinterpret_cast<CUdeviceptr>(dst), value, count, stream);
+}
+
 } // namespace cuda::experimental::__detail::driver
 
 #undef CUDAX_GET_DRIVER_FUNCTION

--- a/cudax/include/cuda/experimental/__utility/driver_api.cuh
+++ b/cudax/include/cuda/experimental/__utility/driver_api.cuh
@@ -272,7 +272,7 @@ inline void memcpyAsync(void* dst, const void* src, size_t count, CUstream strea
     stream);
 }
 
-inline void memsetAsync(void* dst, int value, size_t count, CUstream stream)
+inline void memsetAsync(void* dst, uint8_t value, size_t count, CUstream stream)
 {
   static auto driver_fn = CUDAX_GET_DRIVER_FUNCTION(cuMemsetD8Async);
   call_driver_fn(driver_fn, "Failed to perform a memset", reinterpret_cast<CUdeviceptr>(dst), value, count, stream);

--- a/cudax/test/containers/async_buffer/access.cu
+++ b/cudax/test/containers/async_buffer/access.cu
@@ -31,7 +31,7 @@ using test_types = c2h::type_list<cuda::std::tuple<cuda::mr::host_accessible>,
 using test_types = c2h::type_list<cuda::std::tuple<cuda::mr::device_accessible>>;
 #endif
 
-C2H_TEST("cudax::async_buffer access", "[container][async_buffer]", test_types)
+C2H_CCCLRT_TEST("cudax::async_buffer access", "[container][async_buffer]", test_types)
 {
   using TestT           = c2h::get<0, TestType>;
   using Env             = typename extract_properties<TestT>::env;

--- a/cudax/test/containers/async_buffer/capacity.cu
+++ b/cudax/test/containers/async_buffer/capacity.cu
@@ -30,7 +30,7 @@ using test_types = c2h::type_list<cuda::std::tuple<cuda::mr::host_accessible>,
 using test_types = c2h::type_list<cuda::std::tuple<cuda::mr::device_accessible>>;
 #endif
 
-C2H_TEST("cudax::async_buffer capacity", "[container][async_buffer]", test_types)
+C2H_CCCLRT_TEST("cudax::async_buffer capacity", "[container][async_buffer]", test_types)
 {
   using TestT     = c2h::get<0, TestType>;
   using Env       = typename extract_properties<TestT>::env;

--- a/cudax/test/containers/async_buffer/constructor.cu
+++ b/cudax/test/containers/async_buffer/constructor.cu
@@ -31,7 +31,7 @@ using test_types = c2h::type_list<cuda::std::tuple<cuda::mr::host_accessible>,
 using test_types = c2h::type_list<cuda::std::tuple<cuda::mr::device_accessible>>;
 #endif
 
-C2H_TEST("cudax::async_buffer constructors", "[container][async_buffer]", test_types)
+C2H_CCCLRT_TEST("cudax::async_buffer constructors", "[container][async_buffer]", test_types)
 {
   using TestT    = c2h::get<0, TestType>;
   using Env      = typename extract_properties<TestT>::env;

--- a/cudax/test/containers/async_buffer/conversion.cu
+++ b/cudax/test/containers/async_buffer/conversion.cu
@@ -30,7 +30,7 @@ using test_types = c2h::type_list<cuda::std::tuple<cuda::mr::host_accessible>,
 using test_types = c2h::type_list<cuda::std::tuple<cuda::mr::device_accessible>>;
 #endif
 
-C2H_TEST("cudax::async_buffer conversion", "[container][async_buffer]", test_types)
+C2H_CCCLRT_TEST("cudax::async_buffer conversion", "[container][async_buffer]", test_types)
 {
   using TestT    = c2h::get<0, TestType>;
   using Env      = typename extract_properties<TestT>::env;

--- a/cudax/test/containers/async_buffer/copy.cu
+++ b/cudax/test/containers/async_buffer/copy.cu
@@ -30,7 +30,7 @@ using test_types = c2h::type_list<cuda::std::tuple<cuda::mr::host_accessible>,
 using test_types = c2h::type_list<cuda::std::tuple<cuda::mr::device_accessible>>;
 #endif
 
-C2H_TEST("cudax::async_buffer make_async_buffer", "[container][async_buffer]", test_types)
+C2H_CCCLRT_TEST("cudax::async_buffer make_async_buffer", "[container][async_buffer]", test_types)
 {
   using TestT    = c2h::get<0, TestType>;
   using Env      = typename extract_properties<TestT>::env;
@@ -150,7 +150,7 @@ C2H_TEST("cudax::async_buffer make_async_buffer", "[container][async_buffer]", t
   }
 }
 
-C2H_TEST("make_async_buffer variants", "[container][async_buffer]")
+C2H_CCCLRT_TEST("make_async_buffer variants", "[container][async_buffer]")
 {
   cudax::stream stream{cudax::device_ref{0}};
   cudax::env_t<cuda::mr::device_accessible, other_property> env{

--- a/cudax/test/containers/async_buffer/helper.h
+++ b/cudax/test/containers/async_buffer/helper.h
@@ -30,7 +30,7 @@ __device__ constexpr int device_data[] = {1, 42, 1337, 0, 12, -1};
 constexpr int host_data[]              = {1, 42, 1337, 0, 12, -1};
 
 template <class Buffer>
-constexpr bool equal_range(const Buffer& buf)
+bool equal_range(const Buffer& buf)
 {
   if constexpr (Buffer::__is_host_only)
   {
@@ -39,6 +39,7 @@ constexpr bool equal_range(const Buffer& buf)
   }
   else
   {
+    cuda::experimental::__ensure_current_device guard{cudax::device_ref{0}};
     return buf.size() == cuda::std::size(device_data)
         && thrust::equal(
              thrust::cuda::par.on(buf.stream().get()), buf.begin(), buf.end(), cuda::get_device_address(device_data[0]));
@@ -46,7 +47,7 @@ constexpr bool equal_range(const Buffer& buf)
 }
 
 template <bool HostOnly, class T>
-constexpr bool compare_value(const T& value, const T& expected)
+bool compare_value(const T& value, const T& expected)
 {
   if constexpr (HostOnly)
   {
@@ -54,6 +55,7 @@ constexpr bool compare_value(const T& value, const T& expected)
   }
   else
   {
+    cuda::experimental::__ensure_current_device guard{cudax::device_ref{0}};
     // copy the value to host
     T host_value;
     _CCCL_TRY_CUDA_API(
@@ -76,6 +78,7 @@ void assign_value(T& value, const T& input)
   }
   else
   {
+    cuda::experimental::__ensure_current_device guard{cudax::device_ref{0}};
     // copy the input to device
     _CCCL_TRY_CUDA_API(
       ::cudaMemcpy,
@@ -100,7 +103,7 @@ struct equal_to_value
 };
 
 template <class Buffer>
-constexpr bool equal_size_value(const Buffer& buf, const size_t size, const int value)
+bool equal_size_value(const Buffer& buf, const size_t size, const int value)
 {
   if constexpr (Buffer::__is_host_only)
   {
@@ -110,6 +113,7 @@ constexpr bool equal_size_value(const Buffer& buf, const size_t size, const int 
   }
   else
   {
+    cuda::experimental::__ensure_current_device guard{cudax::device_ref{0}};
     return buf.size() == size
         && thrust::equal(thrust::cuda::par.on(buf.stream().get()),
                          buf.begin(),
@@ -121,7 +125,7 @@ constexpr bool equal_size_value(const Buffer& buf, const size_t size, const int 
 
 // Helper function to compare two ranges
 template <class Range1, class Range2>
-constexpr bool equal_range(const Range1& range1, const Range2& range2)
+bool equal_range(const Range1& range1, const Range2& range2)
 {
   if constexpr (Range1::__is_host_only)
   {
@@ -130,6 +134,7 @@ constexpr bool equal_range(const Range1& range1, const Range2& range2)
   }
   else
   {
+    cuda::experimental::__ensure_current_device guard{cudax::device_ref{0}};
     return range1.size() == range2.size()
         && thrust::equal(thrust::cuda::par.on(range1.stream().get()), range1.begin(), range1.end(), range2.begin());
   }

--- a/cudax/test/containers/async_buffer/iterators.cu
+++ b/cudax/test/containers/async_buffer/iterators.cu
@@ -32,7 +32,7 @@ using test_types = c2h::type_list<cuda::std::tuple<cuda::mr::host_accessible>,
 using test_types = c2h::type_list<cuda::std::tuple<cuda::mr::device_accessible>>;
 #endif
 
-C2H_TEST("cudax::async_buffer iterators", "[container][async_buffer]", test_types)
+C2H_CCCLRT_TEST("cudax::async_buffer iterators", "[container][async_buffer]", test_types)
 {
   using TestT     = c2h::get<0, TestType>;
   using Env       = typename extract_properties<TestT>::env;

--- a/cudax/test/containers/async_buffer/properties.cu
+++ b/cudax/test/containers/async_buffer/properties.cu
@@ -29,7 +29,7 @@ using test_types = c2h::type_list<cuda::std::tuple<cuda::mr::host_accessible>,
 using test_types = c2h::type_list<cuda::std::tuple<cuda::mr::device_accessible>>;
 #endif
 
-C2H_TEST("cudax::async_buffer properties", "[container][async_buffer]", test_types)
+C2H_CCCLRT_TEST("cudax::async_buffer properties", "[container][async_buffer]", test_types)
 {
   using TestT                  = c2h::get<0, TestType>;
   using Buffer                 = typename extract_properties<TestT>::async_buffer;

--- a/cudax/test/containers/async_buffer/swap.cu
+++ b/cudax/test/containers/async_buffer/swap.cu
@@ -29,7 +29,7 @@ using test_types = c2h::type_list<cuda::std::tuple<cuda::mr::host_accessible>,
 using test_types = c2h::type_list<cuda::std::tuple<cuda::mr::device_accessible>>;
 #endif
 
-C2H_TEST("cudax::async_buffer swap", "[container][async_buffer]", test_types)
+C2H_CCCLRT_TEST("cudax::async_buffer swap", "[container][async_buffer]", test_types)
 {
   using TestT     = c2h::get<0, TestType>;
   using Env       = typename extract_properties<TestT>::env;

--- a/cudax/test/containers/async_buffer/transform.cu
+++ b/cudax/test/containers/async_buffer/transform.cu
@@ -77,7 +77,7 @@ struct add_kernel
   }
 };
 
-C2H_TEST("cudax::async_buffer launch transform", "[container][async_buffer]")
+C2H_CCCLRT_TEST("cudax::async_buffer launch transform", "[container][async_buffer]")
 {
   cudax::stream stream{cudax::device_ref{0}};
   cudax::env_t<cuda::mr::device_accessible> env{cudax::device_memory_resource{cudax::device_ref{0}}, stream};

--- a/cudax/test/memory_resource/device_memory_resource.cu
+++ b/cudax/test/memory_resource/device_memory_resource.cu
@@ -66,12 +66,10 @@ static bool ensure_export_handle(::cudaMemPool_t pool, const ::cudaMemAllocation
   return allocation_handle == ::cudaMemHandleTypeNone ? status == ::cudaErrorInvalidValue : status == ::cudaSuccess;
 }
 
-C2H_TEST("device_memory_resource construction", "[memory_resource]")
+C2H_CCCLRT_TEST("device_memory_resource construction", "[memory_resource]")
 {
-  int current_device{};
-  {
-    _CCCL_TRY_CUDA_API(::cudaGetDevice, "Failed to query current device with cudaGetDevice.", &current_device);
-  }
+  int current_device = 0;
+  cuda::experimental::__ensure_current_device guard{cudax::device_ref{current_device}};
 
   int driver_version = 0;
   {
@@ -217,8 +215,13 @@ static void ensure_device_ptr(void* ptr)
   CHECK(attributes.type == cudaMemoryTypeDevice);
 }
 
-C2H_TEST("device_memory_resource allocation", "[memory_resource]")
+C2H_CCCLRT_TEST("device_memory_resource allocation", "[memory_resource]")
 {
+  cudaStream_t raw_stream;
+  {
+    cuda::experimental::__ensure_current_device guard{cudax::device_ref{0}};
+    cudaStreamCreate(&raw_stream);
+  }
   cudax::device_memory_resource res{cudax::device_ref{0}};
 
   { // allocate / deallocate
@@ -238,9 +241,7 @@ C2H_TEST("device_memory_resource allocation", "[memory_resource]")
   }
 
   { // allocate_async / deallocate_async
-    cudaStream_t raw_stream;
-    cudaStreamCreate(&raw_stream);
-    cuda::stream_ref stream{raw_stream};
+    cuda::experimental::stream_ref stream{raw_stream};
 
     auto* ptr = res.allocate_async(42, stream);
     static_assert(cuda::std::is_same<decltype(ptr), void*>::value, "");
@@ -249,13 +250,10 @@ C2H_TEST("device_memory_resource allocation", "[memory_resource]")
     ensure_device_ptr(ptr);
 
     res.deallocate_async(ptr, 42, stream);
-    cudaStreamDestroy(raw_stream);
   }
 
   { // allocate_async / deallocate_async with alignment
-    cudaStream_t raw_stream;
-    cudaStreamCreate(&raw_stream);
-    cuda::stream_ref stream{raw_stream};
+    cuda::experimental::stream_ref stream{raw_stream};
 
     auto* ptr = res.allocate_async(42, 4, stream);
     static_assert(cuda::std::is_same<decltype(ptr), void*>::value, "");
@@ -264,7 +262,6 @@ C2H_TEST("device_memory_resource allocation", "[memory_resource]")
     ensure_device_ptr(ptr);
 
     res.deallocate_async(ptr, 42, 4, stream);
-    cudaStreamDestroy(raw_stream);
   }
 
 #if _CCCL_HAS_EXCEPTIONS()
@@ -300,15 +297,12 @@ C2H_TEST("device_memory_resource allocation", "[memory_resource]")
   { // allocate_async with too small alignment
     while (true)
     {
-      cudaStream_t raw_stream;
-      cudaStreamCreate(&raw_stream);
       try
       {
         [[maybe_unused]] auto* ptr = res.allocate_async(5, 42, raw_stream);
       }
       catch (std::invalid_argument&)
       {
-        cudaStreamDestroy(raw_stream);
         break;
       }
       CHECK(false);
@@ -318,21 +312,22 @@ C2H_TEST("device_memory_resource allocation", "[memory_resource]")
   { // allocate_async with non matching alignment
     while (true)
     {
-      cudaStream_t raw_stream;
-      cudaStreamCreate(&raw_stream);
       try
       {
         [[maybe_unused]] auto* ptr = res.allocate_async(5, 1337, raw_stream);
       }
       catch (std::invalid_argument&)
       {
-        cudaStreamDestroy(raw_stream);
         break;
       }
       CHECK(false);
     }
   }
 #endif // _CCCL_HAS_EXCEPTIONS()
+  {
+    cuda::experimental::__ensure_current_device guard{cudax::device_ref{0}};
+    cudaStreamDestroy(raw_stream);
+  }
 }
 
 enum class AccessibilityType
@@ -383,12 +378,10 @@ static_assert(!cuda::mr::async_resource_with<async_resource<AccessibilityType::H
 static_assert(cuda::mr::async_resource<async_resource<AccessibilityType::Device>>, "");
 static_assert(cuda::mr::async_resource_with<async_resource<AccessibilityType::Device>, cudax::device_accessible>, "");
 
-C2H_TEST("device_memory_resource comparison", "[memory_resource]")
+C2H_CCCLRT_TEST("device_memory_resource comparison", "[memory_resource]")
 {
-  int current_device{};
-  {
-    _CCCL_TRY_CUDA_API(::cudaGetDevice, "Failed to query current device with cudaGetDevice.", &current_device);
-  }
+  int current_device = 0;
+  cuda::experimental::__ensure_current_device guard{cudax::device_ref{current_device}};
 
   cudax::device_memory_resource first{cudax::device_ref{0}};
   { // comparison against a plain device_memory_resource
@@ -460,7 +453,7 @@ C2H_TEST("device_memory_resource comparison", "[memory_resource]")
   }
 }
 
-C2H_TEST("Async memory resource access", "")
+C2H_CCCLRT_TEST("Async memory resource access", "")
 {
   if (cudax::devices.size() > 1)
   {


### PR DESCRIPTION
This PR moves all calls to `cudaMemcpyAsync` and `cudaMemsetAsync` to use driver API instead.
It also adds driver stack checks to memory resource and containers tests and adjust the tests to properly leave empty driver stack