### PR TITLE
Parse and merge devcontainer feature metadata in `launch.sh`

### DIFF
--- a/.devcontainer/cccl-entrypoint.sh
+++ b/.devcontainer/cccl-entrypoint.sh
@@ -8,49 +8,27 @@ devcontainer-utils-post-create-command;
 devcontainer-utils-init-git;
 devcontainer-utils-post-attach-command;
 
-if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
-    echo "::group::Installing ca-certificates..."
-fi
-if ! sudo apt-get install -y ca-certificates; then
+if ! dpkg -s ca-certificates > /dev/null 2>&1; then
+    if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
+        echo "::group::Installing ca-certificates..."
+    fi
     sudo apt-get update
+    # Install or upgrade ca-certificates
     sudo apt-get install -y ca-certificates
+    if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
+        echo "::endgroup::"
+    fi
 fi
+
+if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
+    echo "::group::Updating ca-certificates..."
+fi
+sudo update-ca-certificates
 if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
     echo "::endgroup::"
 fi
 
 cd /home/coder/cccl/
-
-# Check if docker CLI is available, and if not, install docker-outside-of-docker feature if specified in devcontainer.json
-if ! command -v docker >/dev/null 2>&1; then
-    # Find the devcontainer.json file (search up from current dir)
-    search_dir="$(pwd)"
-    found_json=""
-    while [[ "$search_dir" != "/" ]]; do
-        if [[ -f "$search_dir/.devcontainer/devcontainer.json" ]]; then
-            found_json="$search_dir/.devcontainer/devcontainer.json"
-            break
-        fi
-        search_dir="$(dirname "$search_dir")"
-    done
-    if [[ -n "$found_json" ]] && grep -q 'docker-outside-of-docker' "$found_json"; then
-        echo "Installing docker-outside-of-docker feature..."
-        git clone --depth=1 https://github.com/devcontainers/features.git /tmp/features
-        cd /tmp/features/src/docker-outside-of-docker
-        chmod +x install.sh
-        sudo SOURCE_SOCKET=/var/run/docker.sock TARGET_SOCKET=/var/run/docker.sock MOBY=false ./install.sh || { echo "docker-outside-of-docker install failed"; exit 1; }
-        cd -
-
-        # Install nvidia-container-toolkit
-        curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg \
-        && curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
-            sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
-            sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
-        sudo sed -i -e '/experimental/ s/^#//g' /etc/apt/sources.list.d/nvidia-container-toolkit.list
-        sudo apt-get update
-        sudo apt-get install -y nvidia-container-toolkit
-    fi
-fi
 
 if test $# -gt 0; then
     exec "$@";

--- a/.devcontainer/cuda12.0-gcc10/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc10/devcontainer.json
@@ -13,7 +13,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse; else docker volume create cccl-build; docker volume create cccl-wheelhouse; fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build >/dev/null; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse >/dev/null; else docker volume create cccl-build >/dev/null; docker volume create cccl-wheelhouse >/dev/null; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",
@@ -28,8 +28,8 @@
     "CCCL_CUDA_EXTENDED": "false",
     "HOST_WORKSPACE": "${localWorkspaceFolder}"
   },
-  "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
-  "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
+  "workspaceFolder": "/home/coder/cccl",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/cccl,type=bind,consistency=consistent",
   "mounts": [
     "source=${localWorkspaceFolder}/.aws,target=/home/coder/.aws,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.cache,target=/home/coder/.cache,type=bind,consistency=consistent",

--- a/.devcontainer/cuda12.0-gcc10/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc10/devcontainer.json
@@ -1,6 +1,12 @@
 {
   "shutdownAction": "stopContainer",
   "image": "rapidsai/devcontainers:25.08-cpp-gcc10-cuda12.0",
+  "runArgs": [
+    "--init",
+    "--rm",
+    "--name",
+    "${localEnv:USER:anon}-${localWorkspaceFolderBasename}-cuda12.0-gcc10"
+  ],
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.0-gcc11/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc11/devcontainer.json
@@ -1,6 +1,12 @@
 {
   "shutdownAction": "stopContainer",
   "image": "rapidsai/devcontainers:25.08-cpp-gcc11-cuda12.0",
+  "runArgs": [
+    "--init",
+    "--rm",
+    "--name",
+    "${localEnv:USER:anon}-${localWorkspaceFolderBasename}-cuda12.0-gcc11"
+  ],
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.0-gcc11/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc11/devcontainer.json
@@ -13,7 +13,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse; else docker volume create cccl-build; docker volume create cccl-wheelhouse; fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build >/dev/null; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse >/dev/null; else docker volume create cccl-build >/dev/null; docker volume create cccl-wheelhouse >/dev/null; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",
@@ -28,8 +28,8 @@
     "CCCL_CUDA_EXTENDED": "false",
     "HOST_WORKSPACE": "${localWorkspaceFolder}"
   },
-  "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
-  "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
+  "workspaceFolder": "/home/coder/cccl",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/cccl,type=bind,consistency=consistent",
   "mounts": [
     "source=${localWorkspaceFolder}/.aws,target=/home/coder/.aws,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.cache,target=/home/coder/.cache,type=bind,consistency=consistent",

--- a/.devcontainer/cuda12.0-gcc12/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc12/devcontainer.json
@@ -1,6 +1,12 @@
 {
   "shutdownAction": "stopContainer",
   "image": "rapidsai/devcontainers:25.08-cpp-gcc12-cuda12.0",
+  "runArgs": [
+    "--init",
+    "--rm",
+    "--name",
+    "${localEnv:USER:anon}-${localWorkspaceFolderBasename}-cuda12.0-gcc12"
+  ],
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.0-gcc12/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc12/devcontainer.json
@@ -13,7 +13,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse; else docker volume create cccl-build; docker volume create cccl-wheelhouse; fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build >/dev/null; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse >/dev/null; else docker volume create cccl-build >/dev/null; docker volume create cccl-wheelhouse >/dev/null; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",
@@ -28,8 +28,8 @@
     "CCCL_CUDA_EXTENDED": "false",
     "HOST_WORKSPACE": "${localWorkspaceFolder}"
   },
-  "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
-  "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
+  "workspaceFolder": "/home/coder/cccl",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/cccl,type=bind,consistency=consistent",
   "mounts": [
     "source=${localWorkspaceFolder}/.aws,target=/home/coder/.aws,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.cache,target=/home/coder/.cache,type=bind,consistency=consistent",

--- a/.devcontainer/cuda12.0-gcc7/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc7/devcontainer.json
@@ -1,6 +1,12 @@
 {
   "shutdownAction": "stopContainer",
   "image": "rapidsai/devcontainers:25.08-cpp-gcc7-cuda12.0",
+  "runArgs": [
+    "--init",
+    "--rm",
+    "--name",
+    "${localEnv:USER:anon}-${localWorkspaceFolderBasename}-cuda12.0-gcc7"
+  ],
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.0-gcc7/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc7/devcontainer.json
@@ -13,7 +13,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse; else docker volume create cccl-build; docker volume create cccl-wheelhouse; fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build >/dev/null; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse >/dev/null; else docker volume create cccl-build >/dev/null; docker volume create cccl-wheelhouse >/dev/null; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",
@@ -28,8 +28,8 @@
     "CCCL_CUDA_EXTENDED": "false",
     "HOST_WORKSPACE": "${localWorkspaceFolder}"
   },
-  "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
-  "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
+  "workspaceFolder": "/home/coder/cccl",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/cccl,type=bind,consistency=consistent",
   "mounts": [
     "source=${localWorkspaceFolder}/.aws,target=/home/coder/.aws,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.cache,target=/home/coder/.cache,type=bind,consistency=consistent",

--- a/.devcontainer/cuda12.0-gcc8/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc8/devcontainer.json
@@ -1,6 +1,12 @@
 {
   "shutdownAction": "stopContainer",
   "image": "rapidsai/devcontainers:25.08-cpp-gcc8-cuda12.0",
+  "runArgs": [
+    "--init",
+    "--rm",
+    "--name",
+    "${localEnv:USER:anon}-${localWorkspaceFolderBasename}-cuda12.0-gcc8"
+  ],
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.0-gcc8/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc8/devcontainer.json
@@ -13,7 +13,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse; else docker volume create cccl-build; docker volume create cccl-wheelhouse; fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build >/dev/null; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse >/dev/null; else docker volume create cccl-build >/dev/null; docker volume create cccl-wheelhouse >/dev/null; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",
@@ -28,8 +28,8 @@
     "CCCL_CUDA_EXTENDED": "false",
     "HOST_WORKSPACE": "${localWorkspaceFolder}"
   },
-  "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
-  "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
+  "workspaceFolder": "/home/coder/cccl",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/cccl,type=bind,consistency=consistent",
   "mounts": [
     "source=${localWorkspaceFolder}/.aws,target=/home/coder/.aws,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.cache,target=/home/coder/.cache,type=bind,consistency=consistent",

--- a/.devcontainer/cuda12.0-gcc9/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc9/devcontainer.json
@@ -1,6 +1,12 @@
 {
   "shutdownAction": "stopContainer",
   "image": "rapidsai/devcontainers:25.08-cpp-gcc9-cuda12.0",
+  "runArgs": [
+    "--init",
+    "--rm",
+    "--name",
+    "${localEnv:USER:anon}-${localWorkspaceFolderBasename}-cuda12.0-gcc9"
+  ],
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.0-gcc9/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc9/devcontainer.json
@@ -13,7 +13,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse; else docker volume create cccl-build; docker volume create cccl-wheelhouse; fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build >/dev/null; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse >/dev/null; else docker volume create cccl-build >/dev/null; docker volume create cccl-wheelhouse >/dev/null; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",
@@ -28,8 +28,8 @@
     "CCCL_CUDA_EXTENDED": "false",
     "HOST_WORKSPACE": "${localWorkspaceFolder}"
   },
-  "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
-  "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
+  "workspaceFolder": "/home/coder/cccl",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/cccl,type=bind,consistency=consistent",
   "mounts": [
     "source=${localWorkspaceFolder}/.aws,target=/home/coder/.aws,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.cache,target=/home/coder/.cache,type=bind,consistency=consistent",

--- a/.devcontainer/cuda12.0-llvm14/devcontainer.json
+++ b/.devcontainer/cuda12.0-llvm14/devcontainer.json
@@ -13,7 +13,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse; else docker volume create cccl-build; docker volume create cccl-wheelhouse; fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build >/dev/null; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse >/dev/null; else docker volume create cccl-build >/dev/null; docker volume create cccl-wheelhouse >/dev/null; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",
@@ -28,8 +28,8 @@
     "CCCL_CUDA_EXTENDED": "false",
     "HOST_WORKSPACE": "${localWorkspaceFolder}"
   },
-  "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
-  "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
+  "workspaceFolder": "/home/coder/cccl",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/cccl,type=bind,consistency=consistent",
   "mounts": [
     "source=${localWorkspaceFolder}/.aws,target=/home/coder/.aws,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.cache,target=/home/coder/.cache,type=bind,consistency=consistent",

--- a/.devcontainer/cuda12.0-llvm14/devcontainer.json
+++ b/.devcontainer/cuda12.0-llvm14/devcontainer.json
@@ -1,6 +1,12 @@
 {
   "shutdownAction": "stopContainer",
   "image": "rapidsai/devcontainers:25.08-cpp-llvm14-cuda12.0",
+  "runArgs": [
+    "--init",
+    "--rm",
+    "--name",
+    "${localEnv:USER:anon}-${localWorkspaceFolderBasename}-cuda12.0-llvm14"
+  ],
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.9-gcc10/devcontainer.json
+++ b/.devcontainer/cuda12.9-gcc10/devcontainer.json
@@ -13,7 +13,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse; else docker volume create cccl-build; docker volume create cccl-wheelhouse; fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build >/dev/null; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse >/dev/null; else docker volume create cccl-build >/dev/null; docker volume create cccl-wheelhouse >/dev/null; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",
@@ -28,8 +28,8 @@
     "CCCL_CUDA_EXTENDED": "false",
     "HOST_WORKSPACE": "${localWorkspaceFolder}"
   },
-  "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
-  "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
+  "workspaceFolder": "/home/coder/cccl",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/cccl,type=bind,consistency=consistent",
   "mounts": [
     "source=${localWorkspaceFolder}/.aws,target=/home/coder/.aws,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.cache,target=/home/coder/.cache,type=bind,consistency=consistent",

--- a/.devcontainer/cuda12.9-gcc10/devcontainer.json
+++ b/.devcontainer/cuda12.9-gcc10/devcontainer.json
@@ -1,6 +1,12 @@
 {
   "shutdownAction": "stopContainer",
   "image": "rapidsai/devcontainers:25.08-cpp-gcc10-cuda12.9",
+  "runArgs": [
+    "--init",
+    "--rm",
+    "--name",
+    "${localEnv:USER:anon}-${localWorkspaceFolderBasename}-cuda12.9-gcc10"
+  ],
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.9-gcc11/devcontainer.json
+++ b/.devcontainer/cuda12.9-gcc11/devcontainer.json
@@ -1,6 +1,12 @@
 {
   "shutdownAction": "stopContainer",
   "image": "rapidsai/devcontainers:25.08-cpp-gcc11-cuda12.9",
+  "runArgs": [
+    "--init",
+    "--rm",
+    "--name",
+    "${localEnv:USER:anon}-${localWorkspaceFolderBasename}-cuda12.9-gcc11"
+  ],
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.9-gcc11/devcontainer.json
+++ b/.devcontainer/cuda12.9-gcc11/devcontainer.json
@@ -13,7 +13,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse; else docker volume create cccl-build; docker volume create cccl-wheelhouse; fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build >/dev/null; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse >/dev/null; else docker volume create cccl-build >/dev/null; docker volume create cccl-wheelhouse >/dev/null; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",
@@ -28,8 +28,8 @@
     "CCCL_CUDA_EXTENDED": "false",
     "HOST_WORKSPACE": "${localWorkspaceFolder}"
   },
-  "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
-  "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
+  "workspaceFolder": "/home/coder/cccl",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/cccl,type=bind,consistency=consistent",
   "mounts": [
     "source=${localWorkspaceFolder}/.aws,target=/home/coder/.aws,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.cache,target=/home/coder/.cache,type=bind,consistency=consistent",

--- a/.devcontainer/cuda12.9-gcc12/devcontainer.json
+++ b/.devcontainer/cuda12.9-gcc12/devcontainer.json
@@ -1,6 +1,12 @@
 {
   "shutdownAction": "stopContainer",
   "image": "rapidsai/devcontainers:25.08-cpp-gcc12-cuda12.9",
+  "runArgs": [
+    "--init",
+    "--rm",
+    "--name",
+    "${localEnv:USER:anon}-${localWorkspaceFolderBasename}-cuda12.9-gcc12"
+  ],
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.9-gcc12/devcontainer.json
+++ b/.devcontainer/cuda12.9-gcc12/devcontainer.json
@@ -13,7 +13,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse; else docker volume create cccl-build; docker volume create cccl-wheelhouse; fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build >/dev/null; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse >/dev/null; else docker volume create cccl-build >/dev/null; docker volume create cccl-wheelhouse >/dev/null; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",
@@ -28,8 +28,8 @@
     "CCCL_CUDA_EXTENDED": "false",
     "HOST_WORKSPACE": "${localWorkspaceFolder}"
   },
-  "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
-  "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
+  "workspaceFolder": "/home/coder/cccl",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/cccl,type=bind,consistency=consistent",
   "mounts": [
     "source=${localWorkspaceFolder}/.aws,target=/home/coder/.aws,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.cache,target=/home/coder/.cache,type=bind,consistency=consistent",

--- a/.devcontainer/cuda12.9-gcc13/devcontainer.json
+++ b/.devcontainer/cuda12.9-gcc13/devcontainer.json
@@ -1,6 +1,12 @@
 {
   "shutdownAction": "stopContainer",
   "image": "rapidsai/devcontainers:25.08-cpp-gcc13-cuda12.9",
+  "runArgs": [
+    "--init",
+    "--rm",
+    "--name",
+    "${localEnv:USER:anon}-${localWorkspaceFolderBasename}-cuda12.9-gcc13"
+  ],
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.9-gcc13/devcontainer.json
+++ b/.devcontainer/cuda12.9-gcc13/devcontainer.json
@@ -13,7 +13,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse; else docker volume create cccl-build; docker volume create cccl-wheelhouse; fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build >/dev/null; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse >/dev/null; else docker volume create cccl-build >/dev/null; docker volume create cccl-wheelhouse >/dev/null; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",
@@ -28,8 +28,8 @@
     "CCCL_CUDA_EXTENDED": "false",
     "HOST_WORKSPACE": "${localWorkspaceFolder}"
   },
-  "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
-  "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
+  "workspaceFolder": "/home/coder/cccl",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/cccl,type=bind,consistency=consistent",
   "mounts": [
     "source=${localWorkspaceFolder}/.aws,target=/home/coder/.aws,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.cache,target=/home/coder/.cache,type=bind,consistency=consistent",

--- a/.devcontainer/cuda12.9-gcc7/devcontainer.json
+++ b/.devcontainer/cuda12.9-gcc7/devcontainer.json
@@ -1,6 +1,12 @@
 {
   "shutdownAction": "stopContainer",
   "image": "rapidsai/devcontainers:25.08-cpp-gcc7-cuda12.9",
+  "runArgs": [
+    "--init",
+    "--rm",
+    "--name",
+    "${localEnv:USER:anon}-${localWorkspaceFolderBasename}-cuda12.9-gcc7"
+  ],
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.9-gcc7/devcontainer.json
+++ b/.devcontainer/cuda12.9-gcc7/devcontainer.json
@@ -13,7 +13,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse; else docker volume create cccl-build; docker volume create cccl-wheelhouse; fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build >/dev/null; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse >/dev/null; else docker volume create cccl-build >/dev/null; docker volume create cccl-wheelhouse >/dev/null; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",
@@ -28,8 +28,8 @@
     "CCCL_CUDA_EXTENDED": "false",
     "HOST_WORKSPACE": "${localWorkspaceFolder}"
   },
-  "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
-  "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
+  "workspaceFolder": "/home/coder/cccl",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/cccl,type=bind,consistency=consistent",
   "mounts": [
     "source=${localWorkspaceFolder}/.aws,target=/home/coder/.aws,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.cache,target=/home/coder/.cache,type=bind,consistency=consistent",

--- a/.devcontainer/cuda12.9-gcc8/devcontainer.json
+++ b/.devcontainer/cuda12.9-gcc8/devcontainer.json
@@ -1,6 +1,12 @@
 {
   "shutdownAction": "stopContainer",
   "image": "rapidsai/devcontainers:25.08-cpp-gcc8-cuda12.9",
+  "runArgs": [
+    "--init",
+    "--rm",
+    "--name",
+    "${localEnv:USER:anon}-${localWorkspaceFolderBasename}-cuda12.9-gcc8"
+  ],
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.9-gcc8/devcontainer.json
+++ b/.devcontainer/cuda12.9-gcc8/devcontainer.json
@@ -13,7 +13,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse; else docker volume create cccl-build; docker volume create cccl-wheelhouse; fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build >/dev/null; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse >/dev/null; else docker volume create cccl-build >/dev/null; docker volume create cccl-wheelhouse >/dev/null; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",
@@ -28,8 +28,8 @@
     "CCCL_CUDA_EXTENDED": "false",
     "HOST_WORKSPACE": "${localWorkspaceFolder}"
   },
-  "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
-  "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
+  "workspaceFolder": "/home/coder/cccl",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/cccl,type=bind,consistency=consistent",
   "mounts": [
     "source=${localWorkspaceFolder}/.aws,target=/home/coder/.aws,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.cache,target=/home/coder/.cache,type=bind,consistency=consistent",

--- a/.devcontainer/cuda12.9-gcc9/devcontainer.json
+++ b/.devcontainer/cuda12.9-gcc9/devcontainer.json
@@ -1,6 +1,12 @@
 {
   "shutdownAction": "stopContainer",
   "image": "rapidsai/devcontainers:25.08-cpp-gcc9-cuda12.9",
+  "runArgs": [
+    "--init",
+    "--rm",
+    "--name",
+    "${localEnv:USER:anon}-${localWorkspaceFolderBasename}-cuda12.9-gcc9"
+  ],
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.9-gcc9/devcontainer.json
+++ b/.devcontainer/cuda12.9-gcc9/devcontainer.json
@@ -13,7 +13,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse; else docker volume create cccl-build; docker volume create cccl-wheelhouse; fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build >/dev/null; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse >/dev/null; else docker volume create cccl-build >/dev/null; docker volume create cccl-wheelhouse >/dev/null; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",
@@ -28,8 +28,8 @@
     "CCCL_CUDA_EXTENDED": "false",
     "HOST_WORKSPACE": "${localWorkspaceFolder}"
   },
-  "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
-  "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
+  "workspaceFolder": "/home/coder/cccl",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/cccl,type=bind,consistency=consistent",
   "mounts": [
     "source=${localWorkspaceFolder}/.aws,target=/home/coder/.aws,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.cache,target=/home/coder/.cache,type=bind,consistency=consistent",

--- a/.devcontainer/cuda12.9-llvm14/devcontainer.json
+++ b/.devcontainer/cuda12.9-llvm14/devcontainer.json
@@ -1,6 +1,12 @@
 {
   "shutdownAction": "stopContainer",
   "image": "rapidsai/devcontainers:25.08-cpp-llvm14-cuda12.9",
+  "runArgs": [
+    "--init",
+    "--rm",
+    "--name",
+    "${localEnv:USER:anon}-${localWorkspaceFolderBasename}-cuda12.9-llvm14"
+  ],
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.9-llvm14/devcontainer.json
+++ b/.devcontainer/cuda12.9-llvm14/devcontainer.json
@@ -13,7 +13,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse; else docker volume create cccl-build; docker volume create cccl-wheelhouse; fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build >/dev/null; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse >/dev/null; else docker volume create cccl-build >/dev/null; docker volume create cccl-wheelhouse >/dev/null; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",
@@ -28,8 +28,8 @@
     "CCCL_CUDA_EXTENDED": "false",
     "HOST_WORKSPACE": "${localWorkspaceFolder}"
   },
-  "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
-  "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
+  "workspaceFolder": "/home/coder/cccl",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/cccl,type=bind,consistency=consistent",
   "mounts": [
     "source=${localWorkspaceFolder}/.aws,target=/home/coder/.aws,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.cache,target=/home/coder/.cache,type=bind,consistency=consistent",

--- a/.devcontainer/cuda12.9-llvm15/devcontainer.json
+++ b/.devcontainer/cuda12.9-llvm15/devcontainer.json
@@ -1,6 +1,12 @@
 {
   "shutdownAction": "stopContainer",
   "image": "rapidsai/devcontainers:25.08-cpp-llvm15-cuda12.9",
+  "runArgs": [
+    "--init",
+    "--rm",
+    "--name",
+    "${localEnv:USER:anon}-${localWorkspaceFolderBasename}-cuda12.9-llvm15"
+  ],
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.9-llvm15/devcontainer.json
+++ b/.devcontainer/cuda12.9-llvm15/devcontainer.json
@@ -13,7 +13,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse; else docker volume create cccl-build; docker volume create cccl-wheelhouse; fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build >/dev/null; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse >/dev/null; else docker volume create cccl-build >/dev/null; docker volume create cccl-wheelhouse >/dev/null; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",
@@ -28,8 +28,8 @@
     "CCCL_CUDA_EXTENDED": "false",
     "HOST_WORKSPACE": "${localWorkspaceFolder}"
   },
-  "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
-  "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
+  "workspaceFolder": "/home/coder/cccl",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/cccl,type=bind,consistency=consistent",
   "mounts": [
     "source=${localWorkspaceFolder}/.aws,target=/home/coder/.aws,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.cache,target=/home/coder/.cache,type=bind,consistency=consistent",

--- a/.devcontainer/cuda12.9-llvm16/devcontainer.json
+++ b/.devcontainer/cuda12.9-llvm16/devcontainer.json
@@ -13,7 +13,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse; else docker volume create cccl-build; docker volume create cccl-wheelhouse; fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build >/dev/null; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse >/dev/null; else docker volume create cccl-build >/dev/null; docker volume create cccl-wheelhouse >/dev/null; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",
@@ -28,8 +28,8 @@
     "CCCL_CUDA_EXTENDED": "false",
     "HOST_WORKSPACE": "${localWorkspaceFolder}"
   },
-  "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
-  "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
+  "workspaceFolder": "/home/coder/cccl",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/cccl,type=bind,consistency=consistent",
   "mounts": [
     "source=${localWorkspaceFolder}/.aws,target=/home/coder/.aws,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.cache,target=/home/coder/.cache,type=bind,consistency=consistent",

--- a/.devcontainer/cuda12.9-llvm16/devcontainer.json
+++ b/.devcontainer/cuda12.9-llvm16/devcontainer.json
@@ -1,6 +1,12 @@
 {
   "shutdownAction": "stopContainer",
   "image": "rapidsai/devcontainers:25.08-cpp-llvm16-cuda12.9",
+  "runArgs": [
+    "--init",
+    "--rm",
+    "--name",
+    "${localEnv:USER:anon}-${localWorkspaceFolderBasename}-cuda12.9-llvm16"
+  ],
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.9-llvm17/devcontainer.json
+++ b/.devcontainer/cuda12.9-llvm17/devcontainer.json
@@ -1,6 +1,12 @@
 {
   "shutdownAction": "stopContainer",
   "image": "rapidsai/devcontainers:25.08-cpp-llvm17-cuda12.9",
+  "runArgs": [
+    "--init",
+    "--rm",
+    "--name",
+    "${localEnv:USER:anon}-${localWorkspaceFolderBasename}-cuda12.9-llvm17"
+  ],
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.9-llvm17/devcontainer.json
+++ b/.devcontainer/cuda12.9-llvm17/devcontainer.json
@@ -13,7 +13,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse; else docker volume create cccl-build; docker volume create cccl-wheelhouse; fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build >/dev/null; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse >/dev/null; else docker volume create cccl-build >/dev/null; docker volume create cccl-wheelhouse >/dev/null; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",
@@ -28,8 +28,8 @@
     "CCCL_CUDA_EXTENDED": "false",
     "HOST_WORKSPACE": "${localWorkspaceFolder}"
   },
-  "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
-  "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
+  "workspaceFolder": "/home/coder/cccl",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/cccl,type=bind,consistency=consistent",
   "mounts": [
     "source=${localWorkspaceFolder}/.aws,target=/home/coder/.aws,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.cache,target=/home/coder/.cache,type=bind,consistency=consistent",

--- a/.devcontainer/cuda12.9-llvm18/devcontainer.json
+++ b/.devcontainer/cuda12.9-llvm18/devcontainer.json
@@ -1,6 +1,12 @@
 {
   "shutdownAction": "stopContainer",
   "image": "rapidsai/devcontainers:25.08-cpp-llvm18-cuda12.9",
+  "runArgs": [
+    "--init",
+    "--rm",
+    "--name",
+    "${localEnv:USER:anon}-${localWorkspaceFolderBasename}-cuda12.9-llvm18"
+  ],
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.9-llvm18/devcontainer.json
+++ b/.devcontainer/cuda12.9-llvm18/devcontainer.json
@@ -13,7 +13,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse; else docker volume create cccl-build; docker volume create cccl-wheelhouse; fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build >/dev/null; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse >/dev/null; else docker volume create cccl-build >/dev/null; docker volume create cccl-wheelhouse >/dev/null; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",
@@ -28,8 +28,8 @@
     "CCCL_CUDA_EXTENDED": "false",
     "HOST_WORKSPACE": "${localWorkspaceFolder}"
   },
-  "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
-  "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
+  "workspaceFolder": "/home/coder/cccl",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/cccl,type=bind,consistency=consistent",
   "mounts": [
     "source=${localWorkspaceFolder}/.aws,target=/home/coder/.aws,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.cache,target=/home/coder/.cache,type=bind,consistency=consistent",

--- a/.devcontainer/cuda12.9-llvm19/devcontainer.json
+++ b/.devcontainer/cuda12.9-llvm19/devcontainer.json
@@ -1,6 +1,12 @@
 {
   "shutdownAction": "stopContainer",
   "image": "rapidsai/devcontainers:25.08-cpp-llvm19-cuda12.9",
+  "runArgs": [
+    "--init",
+    "--rm",
+    "--name",
+    "${localEnv:USER:anon}-${localWorkspaceFolderBasename}-cuda12.9-llvm19"
+  ],
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.9-llvm19/devcontainer.json
+++ b/.devcontainer/cuda12.9-llvm19/devcontainer.json
@@ -13,7 +13,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse; else docker volume create cccl-build; docker volume create cccl-wheelhouse; fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build >/dev/null; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse >/dev/null; else docker volume create cccl-build >/dev/null; docker volume create cccl-wheelhouse >/dev/null; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",
@@ -28,8 +28,8 @@
     "CCCL_CUDA_EXTENDED": "false",
     "HOST_WORKSPACE": "${localWorkspaceFolder}"
   },
-  "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
-  "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
+  "workspaceFolder": "/home/coder/cccl",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/cccl,type=bind,consistency=consistent",
   "mounts": [
     "source=${localWorkspaceFolder}/.aws,target=/home/coder/.aws,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.cache,target=/home/coder/.cache,type=bind,consistency=consistent",

--- a/.devcontainer/cuda12.9-nvhpc25.5/devcontainer.json
+++ b/.devcontainer/cuda12.9-nvhpc25.5/devcontainer.json
@@ -6,13 +6,14 @@
     "--rm",
     "--name",
     "${localEnv:USER:anon}-${localWorkspaceFolderBasename}-cuda12.9-nvhpc25.5"
+  ],
   "hostRequirements": {
     "gpu": "optional"
   },
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse; else docker volume create cccl-build; docker volume create cccl-wheelhouse; fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build >/dev/null; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse >/dev/null; else docker volume create cccl-build >/dev/null; docker volume create cccl-wheelhouse >/dev/null; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",
@@ -27,8 +28,8 @@
     "CCCL_CUDA_EXTENDED": "false",
     "HOST_WORKSPACE": "${localWorkspaceFolder}"
   },
-  "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
-  "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
+  "workspaceFolder": "/home/coder/cccl",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/cccl,type=bind,consistency=consistent",
   "mounts": [
     "source=${localWorkspaceFolder}/.aws,target=/home/coder/.aws,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.cache,target=/home/coder/.cache,type=bind,consistency=consistent",

--- a/.devcontainer/cuda12.9-nvhpc25.5/devcontainer.json
+++ b/.devcontainer/cuda12.9-nvhpc25.5/devcontainer.json
@@ -1,6 +1,11 @@
 {
   "shutdownAction": "stopContainer",
   "image": "rapidsai/devcontainers:25.08-cpp-nvhpc25.5",
+  "runArgs": [
+    "--init",
+    "--rm",
+    "--name",
+    "${localEnv:USER:anon}-${localWorkspaceFolderBasename}-cuda12.9-nvhpc25.5"
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.9ext-gcc13/devcontainer.json
+++ b/.devcontainer/cuda12.9ext-gcc13/devcontainer.json
@@ -13,7 +13,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse; else docker volume create cccl-build; docker volume create cccl-wheelhouse; fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build >/dev/null; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse >/dev/null; else docker volume create cccl-build >/dev/null; docker volume create cccl-wheelhouse >/dev/null; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",
@@ -28,8 +28,8 @@
     "CCCL_CUDA_EXTENDED": "true",
     "HOST_WORKSPACE": "${localWorkspaceFolder}"
   },
-  "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
-  "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
+  "workspaceFolder": "/home/coder/cccl",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/cccl,type=bind,consistency=consistent",
   "mounts": [
     "source=${localWorkspaceFolder}/.aws,target=/home/coder/.aws,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.cache,target=/home/coder/.cache,type=bind,consistency=consistent",

--- a/.devcontainer/cuda12.9ext-gcc13/devcontainer.json
+++ b/.devcontainer/cuda12.9ext-gcc13/devcontainer.json
@@ -1,6 +1,12 @@
 {
   "shutdownAction": "stopContainer",
   "image": "rapidsai/devcontainers:25.08-cpp-gcc13-cuda12.9ext",
+  "runArgs": [
+    "--init",
+    "--rm",
+    "--name",
+    "${localEnv:USER:anon}-${localWorkspaceFolderBasename}-cuda12.9ext-gcc13"
+  ],
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,12 @@
 {
   "shutdownAction": "stopContainer",
   "image": "rapidsai/devcontainers:25.08-cpp-gcc13-cuda12.9",
+  "runArgs": [
+    "--init",
+    "--rm",
+    "--name",
+    "${localEnv:USER:anon}-${localWorkspaceFolderBasename}-cuda12.9-gcc13"
+  ],
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,7 @@
   "initializeCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse; else docker volume create cccl-build; docker volume create cccl-wheelhouse; fi;"
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}; mkdir -m 0755 -p ${localWorkspaceFolder}/{build,wheelhouse}; if test -z ${localEnv:WSLENV}; then docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/build --opt o=bind cccl-build >/dev/null; docker volume create --driver local --opt type=none --opt device=${localWorkspaceFolder}/wheelhouse --opt o=bind cccl-wheelhouse >/dev/null; else docker volume create cccl-build >/dev/null; docker volume create cccl-wheelhouse >/dev/null; fi;"
   ],
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",
@@ -28,8 +28,8 @@
     "CCCL_CUDA_EXTENDED": "false",
     "HOST_WORKSPACE": "${localWorkspaceFolder}"
   },
-  "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
-  "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
+  "workspaceFolder": "/home/coder/cccl",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/cccl,type=bind,consistency=consistent",
   "mounts": [
     "source=${localWorkspaceFolder}/.aws,target=/home/coder/.aws,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.cache,target=/home/coder/.cache,type=bind,consistency=consistent",

--- a/.devcontainer/launch.py
+++ b/.devcontainer/launch.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+
+###
+# Parses and merges the devcontainer.json metadata with the feature metadata
+# from the devcontainer.json image's "devcontainer.metadata" label.
+#
+# Prints the relevant fields as eval-friendly shell variable declarations.
+#
+# Example:
+# python3 .devcontainer/launch.py .devcontainer/devcontainer.json
+###
+
+import functools
+import json
+import pathlib
+import os
+import re
+import subprocess
+import sys
+
+localWorkspaceFolder = str(pathlib.Path(os.path.dirname(os.path.realpath(__file__))).parent)
+localWorkspaceFolderBasename = os.path.basename(localWorkspaceFolder)
+containerWorkspaceFolder = ""
+containerWorkspaceFolderBasename = ""
+
+def inline_vars(val):
+    val = inline_local_workspace_folder(val)
+    val = inline_local_workspace_folder_basename(val)
+    val = inline_container_workspace_folder(val)
+    val = inline_container_workspace_folder_basename(val)
+    val = inline_shell_variables(val)
+    return val
+
+def inline_local_workspace_folder(val):
+    return re.sub(r"\$\{localWorkspaceFolder\}", localWorkspaceFolder, val)
+
+def inline_local_workspace_folder_basename(val):
+    return re.sub(r"\$\{localWorkspaceFolderBasename\}", localWorkspaceFolderBasename, val)
+
+def inline_container_workspace_folder(val):
+    return re.sub(r"\$\{containerWorkspaceFolder\}", containerWorkspaceFolder, val)
+
+def inline_container_workspace_folder_basename(val):
+    return re.sub(r"\$\{containerWorkspaceFolderBasename\}", containerWorkspaceFolderBasename, val)
+
+def inline_shell_variables(val):
+    return re.sub(r"\$\{localEnv:([^\:]*):?(.*)\}", r'${\1:-\2}', val)
+
+def flat_dict(list_of_dicts):
+    return functools.reduce(lambda x, y: {**x, **y}, list_of_dicts, dict())
+
+def flat_list(list_of_lists):
+    return functools.reduce(list.__add__, list_of_lists, list())
+
+def dict_list(map_):
+    return [f'{k}={v}' for k, v in map_.items()]
+
+def json_lookup(map_, path):
+    for key in path:
+        if key in map_:
+            map_ = map_[key]
+        else:
+            return None
+    return map_
+
+def load_devcontainer_json(path):
+    with open(path, "r") as devcontainer_file:
+        return json.load(devcontainer_file)
+
+def load_devcontainer_meta(tag):
+    return json.loads(json.loads(subprocess.check_output(
+        ["docker", "inspect", "--type", "image", "--format", r"{{json .Config.Labels}}", tag],
+        text=True
+    ))["devcontainer.metadata"])
+
+def normalize_mount(mount):
+    if isinstance(mount, dict):
+        # {"source": "/var/run/docker.sock", "target": "/var/run/docker-host.sock", "type": "bind"} ->
+        # 'source="/var/run/docker.sock",target="/var/run/docker-host.sock",type="bind"'
+        mount_ary = []
+        for k, v in mount.items():
+            mount_ary += [f'{k}={v}']
+        return r','.join(mount_ary)
+    return mount
+
+def bash_str(name, string):
+    return f'declare {name}="{inline_vars(string)}"'
+
+def bash_list(name, ary):
+    ary = [inline_vars(x) for x in ary]
+    if len(ary) == 0:
+        ary = ""
+    else:
+        ary = f'"{r'" "'.join(ary)}"'
+    return f'declare -a {name}=({ary})'
+
+def bash_dict(name, ary):
+    ary = [inline_vars(x) for x in ary]
+    if len(ary) == 0:
+        ary = ""
+    else:
+        ary = f'"{r'" "'.join(ary)}"'
+    return f'declare -A {name}="({ary})"'
+
+def bash_list_of_commands(name, arys):
+    # Wrap each initializeCommand in quotes so they're not all
+    # expanded into elements of the bash array
+    return bash_list(name, [f"'{r"' '".join(xs)}'" for xs in arys])
+
+# Load the devcontainer.json
+devcontainer_json = load_devcontainer_json(sys.argv[1])
+containerWorkspaceFolder = inline_vars(devcontainer_json.get("workspaceFolder", "/home/coder/cccl"))
+containerWorkspaceFolderBasename = os.path.basename(containerWorkspaceFolder)
+# The feature metadata first, then devcontainer.json
+devcontainer_meta = load_devcontainer_meta(devcontainer_json["image"]) + [devcontainer_json]
+
+print(bash_str("DOCKER_IMAGE", devcontainer_json["image"]))
+print(bash_str("WORKSPACE_FOLDER", containerWorkspaceFolder))
+print(bash_str("REMOTE_USER", [x["remoteUser"] for x in devcontainer_meta if "remoteUser" in x][-1]))
+
+gpu_request = json_lookup(devcontainer_json, ["hostRequirements", "gpu"])
+if gpu_request is None or gpu_request is False:
+    print(bash_list("GPU_REQUEST", []))
+if gpu_request is True:
+    print(bash_list("GPU_REQUEST", ["--gpus", "all"]))
+elif gpu_request == "optional":
+    try:
+        subprocess.check_output("command -v nvidia-container-runtime", shell=True)
+        print(bash_list("GPU_REQUEST", ["--gpus", "all"]))
+    except Exception as e:
+        print(bash_list("GPU_REQUEST", []))
+
+print(bash_list("ENTRYPOINTS", [
+    x["entrypoint"] for x in devcontainer_meta if "entrypoint" in x
+]))
+
+cap_add = flat_list([
+    ["--cap-add", cap] for cap in list(set(flat_list([
+        x["capAdd"] for x in devcontainer_meta if "capAdd" in x
+    ])))
+])
+
+# print(bash_list("CAP_ADD", flat_list([
+#     ["--cap-add", cap] for cap in list(set(flat_list([
+#         x["capAdd"] for x in devcontainer_meta if "capAdd" in x
+#     ])))
+# ])))
+
+secopts = flat_list([
+    ["--security-opt", opt] for opt in list(set(flat_list([
+        x["securityOpt"] for x in devcontainer_meta if "securityOpt" in x
+    ])))
+])
+
+# print(bash_list("SECOPTS", flat_list([
+#     ["--security-opt", opt] for opt in list(set(flat_list([
+#         x["securityOpt"] for x in devcontainer_meta if "securityOpt" in x
+#     ])))
+# ])))
+
+print(bash_list("RUN_ARGS",
+    flat_list([
+        x["runArgs"] for x in devcontainer_meta if "runArgs" in x
+    ]) +
+    cap_add +
+    secopts +
+    ["--workdir", containerWorkspaceFolder]
+))
+
+print(bash_list_of_commands("INITIALIZE_COMMANDS", [
+    x["initializeCommand"] for x in devcontainer_meta if "initializeCommand" in x
+]))
+
+print(bash_list("ENV_VARS", flat_list([
+    ["--env", x] for x in dict_list(flat_dict([
+        x["containerEnv"] for x in devcontainer_meta if "containerEnv" in x
+    ]))
+])))
+
+print(bash_list("MOUNTS", flat_list([
+    ["--mount", normalize_mount(m)] for m in flat_list(
+        [
+            x["mounts"] for x in devcontainer_meta if "mounts" in x
+        ] +
+        [
+            [devcontainer_json["workspaceMount"]] if "workspaceMount" in devcontainer_json else []
+        ]
+    )
+])))

--- a/.devcontainer/launch.sh
+++ b/.devcontainer/launch.sh
@@ -111,83 +111,24 @@ launch_docker() {
     local -;
     set -euo pipefail
 
-    inline_vars() {
-        cat - \
-        `# inline local workspace folder` \
-      | sed "s@\${localWorkspaceFolder}@$(pwd)@g" \
-        `# inline local workspace folder basename` \
-      | sed "s@\${localWorkspaceFolderBasename}@$(basename "$(pwd)")@g" \
-        `# inline container workspace folder` \
-      | sed "s@\${containerWorkspaceFolder}@${WORKSPACE_FOLDER:-}@g" \
-        `# inline container workspace folder basename` \
-      | sed "s@\${containerWorkspaceFolderBasename}@$(basename "${WORKSPACE_FOLDER:-}")@g" \
-        `# translate local envvars to shell syntax` \
-      | sed -r 's/\$\{localEnv:([^\:]*):?(.*)\}/${\1:-\2}/g'
-    }
-
-    args_to_path() {
-        local -a keys=("${@}")
-        keys=("${keys[@]/#/[}")
-        keys=("${keys[@]/%/]}")
-        echo "$(IFS=; echo "${keys[*]}")"
-    }
-
-    json_string() {
-        python3 -c "import json,sys; print(json.load(sys.stdin)$(args_to_path "${@}"))" 2>/dev/null | inline_vars
-    }
-
-    json_array() {
-        python3 -c "import json,sys; [print(f'\"{x}\"') for x in json.load(sys.stdin)$(args_to_path "${@}")]" 2>/dev/null | inline_vars
-    }
-
-    json_map() {
-        python3 -c "import json,sys; [print(f'{k}=\"{v}\"') for k,v in json.load(sys.stdin)$(args_to_path "${@}").items()]" 2>/dev/null | inline_vars
-    }
-
-    devcontainer_metadata_json() {
-        docker inspect --type image --format '{{json .Config.Labels}}' "$DOCKER_IMAGE" \
-      | json_string '"devcontainer.metadata"'
-    }
-
     ###
     # Read relevant values from devcontainer.json
     ###
 
-    local devcontainer_json="${path}/devcontainer.json";
+    # Read and merge the devcontainer feature and `devcontainer.json` metadata
+    # Introduces the `DOCKER_IMAGE`, `ENTRYPOINTS`, `ENV_VARS`, `GPU_REQUEST`,
+    # `INITIALIZE_COMMANDS`, `MOUNTS`, `REMOTE_USER`, `RUN_ARGS`, and
+    # `WORKSPACE_FOLDER` variables
+    source <(python3 .devcontainer/launch.py "${path}/devcontainer.json")
 
-    # Read image
-    local DOCKER_IMAGE="$(json_string '"image"' < "${devcontainer_json}")"
-    # Always pull the latest copy of the image
-    if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
-        echo "::group::Pulling Docker image ${DOCKER_IMAGE}"
-    fi
-    docker pull "$DOCKER_IMAGE"
-    if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
-        echo "::endgroup::"
-    fi
+    ###
+    # Run the initialize command(s) before starting the container
+    ###
 
-    # Read workspaceFolder
-    local WORKSPACE_FOLDER="$(json_string '"workspaceFolder"' < "${devcontainer_json}")"
-    # Read remoteUser
-    local REMOTE_USER="$(json_string '"remoteUser"' < "${devcontainer_json}")"
-    # If remoteUser isn't in our devcontainer.json, read it from the image's "devcontainer.metadata" label
-    if test -z "${REMOTE_USER:-}"; then
-        REMOTE_USER="$(devcontainer_metadata_json | json_string "-1" '"remoteUser"')"
-    fi
-    # Read runArgs
-    local -a RUN_ARGS="($(json_array '"runArgs"' < "${devcontainer_json}"))"
-    # Read initializeCommand
-    local -a INITIALIZE_COMMAND="($(json_array '"initializeCommand"' < "${devcontainer_json}"))"
-    # Read containerEnv
-    local -a ENV_VARS="($(json_map '"containerEnv"' < "${devcontainer_json}" | sed -r 's/(.*)=(.*)/--env \1=\2/'))"
-    # Read mounts
-    local -a MOUNTS="($(
-        tee < "${devcontainer_json}"          \
-            1>/dev/null                       \
-            >(json_array '"mounts"')          \
-            >(json_string '"workspaceMount"') \
-      | xargs -r -I% echo --mount '%'
-    ))"
+    local init_cmd;
+    for init_cmd in "${INITIALIZE_COMMANDS[@]}"; do
+        eval "${init_cmd}"
+    done
 
     ###
     # Update run arguments and container environment variables
@@ -198,39 +139,31 @@ launch_docker() {
         RUN_ARGS+=("-it")
     fi
 
-    for flag in rm init; do
-        if [[ " ${RUN_ARGS[*]} " != *" --${flag} "* ]]; then
-            RUN_ARGS+=("--${flag}")
-        fi
-    done
-
     # Prefer the user-provided --gpus argument
     if test -n "${gpu_request:-}"; then
         RUN_ARGS+=(--gpus "${gpu_request}")
     else
         # Otherwise read and infer from hostRequirements.gpu
-        local GPU_REQUEST="$(json_string '"hostRequirements"' '"gpu"' < "${devcontainer_json}")"
-        if test "${GPU_REQUEST:-false}" = true; then
-            RUN_ARGS+=(--gpus all)
-        elif test "${GPU_REQUEST:-false}" = optional && \
-             command -v nvidia-container-runtime >/dev/null 2>&1; then
-            RUN_ARGS+=(--gpus all)
-        fi
+        RUN_ARGS+=("${GPU_REQUEST[@]}")
     fi
 
-    RUN_ARGS+=(--workdir "${WORKSPACE_FOLDER:-/home/coder/cccl}")
-
     if test -n "${REMOTE_USER:-}"; then
-        ENV_VARS+=(--env NEW_UID="$(id -u)")
-        ENV_VARS+=(--env NEW_GID="$(id -g)")
-        ENV_VARS+=(--env REMOTE_USER="$REMOTE_USER")
-        RUN_ARGS+=(-u root:root)
-        RUN_ARGS+=(--entrypoint "${WORKSPACE_FOLDER:-/home/coder/cccl}/.devcontainer/docker-entrypoint.sh")
+        case "${REMOTE_USER:-}" in
+            root)
+                RUN_ARGS+=(-u root:root)
+                ;;
+            *)
+                RUN_ARGS+=(-u root:root)
+                ENV_VARS+=(--env NEW_UID="$(id -u)")
+                ENV_VARS+=(--env NEW_GID="$(id -g)")
+                ENV_VARS+=(--env REMOTE_USER="$REMOTE_USER")
+                ENTRYPOINTS+=("${WORKSPACE_FOLDER}/.devcontainer/docker-entrypoint.sh")
+                ;;
+        esac
     fi
 
     if test -n "${SSH_AUTH_SOCK:-}" && test -e "${SSH_AUTH_SOCK:-}"; then
         ENV_VARS+=(--env "SSH_AUTH_SOCK=/tmp/ssh-auth-sock")
-        ENV_VARS+=(--env "HOST_WORKSPACE=$(pwd)")
         MOUNTS+=(--mount "source=${SSH_AUTH_SOCK},target=/tmp/ssh-auth-sock,type=bind")
     fi
 
@@ -239,17 +172,9 @@ launch_docker() {
         MOUNTS+=("${volumes[@]}")
     fi
 
-    # mount /var/run/docker.sock
-    MOUNTS+=(--mount "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind")
-
     # Append user-provided envvars
     if test -v env_vars && test ${#env_vars[@]} -gt 0; then
         ENV_VARS+=("${env_vars[@]}")
-    fi
-
-    # Run the initialize command before starting the container
-    if test "${#INITIALIZE_COMMAND[@]}" -gt 0; then
-        eval "${INITIALIZE_COMMAND[*]@Q}"
     fi
 
     exec docker run \
@@ -257,6 +182,7 @@ launch_docker() {
         "${ENV_VARS[@]}" \
         "${MOUNTS[@]}" \
         "${DOCKER_IMAGE}" \
+        "${ENTRYPOINTS[@]}" \
         "$@"
 }
 

--- a/.github/workflows/build-rapids.yml
+++ b/.github/workflows/build-rapids.yml
@@ -174,6 +174,7 @@ jobs:
             --docker \
             --cuda ${{matrix.cuda}} \
             --host rapids-conda \
+            --env "CI=$CI" \
             --env "CCCL_TAG=${CCCL_TAG}" \
             --env "CCCL_VERSION=${CCCL_VERSION}" \
             --env "AWS_ROLE_ARN=" \
@@ -182,6 +183,7 @@ jobs:
             --env "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" \
             --env "AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN" \
             --env "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" \
+            --env "GITHUB_ACTIONS=$GITHUB_ACTIONS" \
             --env "GITHUB_SHA=$GITHUB_SHA" \
             --env "GITHUB_REF_NAME=$GITHUB_REF_NAME" \
             --env "GITHUB_REPOSITORY=$GITHUB_REPOSITORY" \

--- a/ci/rapids/cuda12.8-conda/devcontainer.json
+++ b/ci/rapids/cuda12.8-conda/devcontainer.json
@@ -14,7 +14,7 @@
   ],
   "containerEnv": {
     "CI": "${localEnv:CI}",
-    "CUDAARCHS": "70-real",
+    "CUDAARCHS": "75-real",
     "CUDA_VERSION": "12.8",
     "DEFAULT_CONDA_ENV": "rapids",
     "PYTHONSAFEPATH": "1",

--- a/ci/rapids/cuda12.8-conda/devcontainer.json
+++ b/ci/rapids/cuda12.8-conda/devcontainer.json
@@ -1,6 +1,7 @@
 {
   "image": "rapidsai/devcontainers:25.08-cpp-mambaforge-ubuntu22.04",
   "runArgs": [
+    "--init",
     "--rm",
     "--name",
     "${localEnv:USER:anon}-${localWorkspaceFolderBasename}-rapids-25.08-cuda12.8-conda"

--- a/ci/rapids/cuda12.8-conda/devcontainer.json
+++ b/ci/rapids/cuda12.8-conda/devcontainer.json
@@ -43,8 +43,8 @@
   "initializeCommand": ["/bin/bash", "-c", "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config} ${localWorkspaceFolder}/ci/rapids/.{conda,log/devcontainer-utils} ${localWorkspaceFolder}/ci/rapids/.repos/{rmm,kvikio,ucxx,cudf,raft,cuvs,cuml,cugraph,cugraph-gnn}"],
   "postCreateCommand": ["/bin/bash", "-c", "if [ ${CI:-false} = 'false' ]; then . /home/coder/cccl/ci/rapids/post-create-command.sh; fi"],
   "postAttachCommand": ["/bin/bash", "-c", "if [ ${CODESPACES:-false} = 'true' ]; then . devcontainer-utils-post-attach-command; fi"],
-  "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
-  "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
+  "workspaceFolder": "/home/coder/cccl",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/cccl,type=bind,consistency=consistent",
   "mounts": [
     "source=${localWorkspaceFolder}/.aws,target=/home/coder/.aws,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/.cache,target=/home/coder/.cache,type=bind,consistency=consistent",


### PR DESCRIPTION
Branched from https://github.com/NVIDIA/cccl/pull/5072

Refactors `launch.sh` to parse and merge the `devcontainer.json` metadata with the feature metadata from the devcontainer's image labels.

The feature metadata can be queried from an image with `docker inspect`:
```shell
docker inspect --type image --format '{{json .Config.Labels}}' rapidsai/devcontainers:25.08-cpp-gcc13-cuda12.9 | jq -r '.["devcontainer.metadata"]'
```

Features can define additional properties, like `mounts`, that should be set when running an image. This PR ensures the relevant properties are parsed from the image label and merged with the values in `devcontainer.json`.

It also ensures devcontainers have names so it's easier to tell what they are in `docker ps`.