### PR TITLE
Move math builtins into the respective header file

### DIFF
--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -90,59 +90,11 @@
 #  define _CCCL_BUILTIN_ARRAY_EXTENT(...) __array_extent(__VA_ARGS__)
 #endif // _CCCL_HAS_BUILTIN(__array_extent)
 
-#if _CCCL_CHECK_BUILTIN(builtin_acos) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_ACOSF(...) __builtin_acosf(__VA_ARGS__)
-#  define _CCCL_BUILTIN_ACOS(...)  __builtin_acos(__VA_ARGS__)
-#  define _CCCL_BUILTIN_ACOSL(...) __builtin_acosl(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(builtin_acos)
-
-#if _CCCL_CUDA_COMPILER(CLANG)
-#  undef _CCCL_BUILTIN_ACOSF
-#  undef _CCCL_BUILTIN_ACOS
-#  undef _CCCL_BUILTIN_ACOSL
-#endif // _CCCL_CUDA_COMPILER(CLANG)
-
-#if _CCCL_CHECK_BUILTIN(builtin_acosh) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_ACOSHF(...) __builtin_acoshf(__VA_ARGS__)
-#  define _CCCL_BUILTIN_ACOSH(...)  __builtin_acosh(__VA_ARGS__)
-#  define _CCCL_BUILTIN_ACOSHL(...) __builtin_acoshl(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(builtin_acosh)
-
-#if _CCCL_CUDA_COMPILER(CLANG)
-#  undef _CCCL_BUILTIN_ACOSHF
-#  undef _CCCL_BUILTIN_ACOSH
-#  undef _CCCL_BUILTIN_ACOSHL
-#endif // _CCCL_CUDA_COMPILER(CLANG)
-
 // nvhpc has a bug where it supports __builtin_addressof but does not mark it via _CCCL_CHECK_BUILTIN
 #if _CCCL_CHECK_BUILTIN(builtin_addressof) || _CCCL_COMPILER(GCC, >=, 7) || _CCCL_COMPILER(MSVC) \
   || _CCCL_COMPILER(NVHPC)
 #  define _CCCL_BUILTIN_ADDRESSOF(...) __builtin_addressof(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(builtin_addressof)
-
-#if _CCCL_CHECK_BUILTIN(builtin_asin) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_ASINF(...) __builtin_asinf(__VA_ARGS__)
-#  define _CCCL_BUILTIN_ASIN(...)  __builtin_asin(__VA_ARGS__)
-#  define _CCCL_BUILTIN_ASINL(...) __builtin_asinl(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(builtin_asin)
-
-#if _CCCL_CUDA_COMPILER(CLANG)
-#  undef _CCCL_BUILTIN_ASINF
-#  undef _CCCL_BUILTIN_ASIN
-#  undef _CCCL_BUILTIN_ASINL
-#endif // _CCCL_CUDA_COMPILER(CLANG)
-
-#if _CCCL_CHECK_BUILTIN(builtin_asinh) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_ASINHF(...) __builtin_asinhf(__VA_ARGS__)
-#  define _CCCL_BUILTIN_ASINH(...)  __builtin_asinh(__VA_ARGS__)
-#  define _CCCL_BUILTIN_ASINHL(...) __builtin_asinhl(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(builtin_asin)
-
-#if _CCCL_CUDA_COMPILER(CLANG)
-#  undef _CCCL_BUILTIN_ASINHF
-#  undef _CCCL_BUILTIN_ASINH
-#  undef _CCCL_BUILTIN_ASINHL
-#endif // _CCCL_CUDA_COMPILER(CLANG)
 
 #if _CCCL_CHECK_BUILTIN(builtin_assume) || _CCCL_COMPILER(CLANG) || _CCCL_COMPILER(NVHPC)
 #  define _CCCL_BUILTIN_ASSUME(...) __builtin_assume(__VA_ARGS__)
@@ -157,42 +109,6 @@
 #if _CCCL_HAS_BUILTIN(__builtin_assume_aligned) || _CCCL_COMPILER(MSVC, >=, 19, 23) || _CCCL_COMPILER(GCC)
 #  define _CCCL_BUILTIN_ASSUME_ALIGNED(...) __builtin_assume_aligned(__VA_ARGS__)
 #endif // _CCCL_HAS_BUILTIN(__builtin_assume_aligned)
-
-#if _CCCL_CHECK_BUILTIN(builtin_atan) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_ATANF(...) __builtin_atanf(__VA_ARGS__)
-#  define _CCCL_BUILTIN_ATAN(...)  __builtin_atan(__VA_ARGS__)
-#  define _CCCL_BUILTIN_ATANL(...) __builtin_atanl(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(builtin_atan)
-
-#if _CCCL_CUDA_COMPILER(CLANG)
-#  undef _CCCL_BUILTIN_ATANF
-#  undef _CCCL_BUILTIN_ATAN
-#  undef _CCCL_BUILTIN_ATANL
-#endif // _CCCL_CUDA_COMPILER(CLANG)
-
-#if _CCCL_CHECK_BUILTIN(builtin_atan2) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_ATAN2F(...) __builtin_atan2f(__VA_ARGS__)
-#  define _CCCL_BUILTIN_ATAN2(...)  __builtin_atan2(__VA_ARGS__)
-#  define _CCCL_BUILTIN_ATAN2L(...) __builtin_atan2l(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(builtin_atan2)
-
-#if _CCCL_CUDA_COMPILER(CLANG)
-#  undef _CCCL_BUILTIN_ATAN2F
-#  undef _CCCL_BUILTIN_ATAN2
-#  undef _CCCL_BUILTIN_ATAN2L
-#endif // _CCCL_CUDA_COMPILER(CLANG)
-
-#if _CCCL_CHECK_BUILTIN(builtin_atanh) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_ATANHF(...) __builtin_atanhf(__VA_ARGS__)
-#  define _CCCL_BUILTIN_ATANH(...)  __builtin_atanh(__VA_ARGS__)
-#  define _CCCL_BUILTIN_ATANHL(...) __builtin_atanhl(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(builtin_atanh)
-
-#if _CCCL_CUDA_COMPILER(CLANG)
-#  undef _CCCL_BUILTIN_ATANHF
-#  undef _CCCL_BUILTIN_ATANH
-#  undef _CCCL_BUILTIN_ATANHL
-#endif // _CCCL_CUDA_COMPILER(CLANG)
 
 // MSVC supports __builtin_bit_cast from 19.25 on
 #if _CCCL_CHECK_BUILTIN(builtin_bit_cast) || _CCCL_COMPILER(MSVC, >, 19, 25)
@@ -282,25 +198,6 @@
 #  define _CCCL_BUILTIN_BITREVERSE64(...) __builtin_bitreverse64(__VA_ARGS__)
 #endif
 
-#if _CCCL_CHECK_BUILTIN(builtin_cbrt) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_CBRTF(...) __builtin_cbrtf(__VA_ARGS__)
-#  define _CCCL_BUILTIN_CBRT(...)  __builtin_cbrt(__VA_ARGS__)
-#  define _CCCL_BUILTIN_CBRTL(...) __builtin_cbrtl(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(builtin_cbrt)
-
-// clang-cuda fails with fatal error: error in backend: Undefined external symbol "cbrt"
-#if _CCCL_CUDA_COMPILER(CLANG)
-#  undef _CCCL_BUILTIN_CBRTF
-#  undef _CCCL_BUILTIN_CBRT
-#  undef _CCCL_BUILTIN_CBRTL
-#endif // _CCCL_CUDA_COMPILER(CLANG)
-
-#if _CCCL_CHECK_BUILTIN(builtin_ceil) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_CEILF(...) __builtin_ceilf(__VA_ARGS__)
-#  define _CCCL_BUILTIN_CEIL(...)  __builtin_ceil(__VA_ARGS__)
-#  define _CCCL_BUILTIN_CEILL(...) __builtin_ceill(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(builtin_ceil)
-
 #if _CCCL_HAS_BUILTIN(__builtin_COLUMN) || _CCCL_COMPILER(MSVC, >=, 19, 27)
 #  define _CCCL_BUILTIN_COLUMN() __builtin_COLUMN()
 #else // ^^^ _CCCL_HAS_BUILTIN(__builtin_COLUMN) ^^^ / vvv !_CCCL_HAS_BUILTIN(__builtin_COLUMN) vvv
@@ -311,149 +208,15 @@
 #  define _CCCL_BUILTIN_CONSTANT_P(...) __builtin_constant_p(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(builtin_constant_p)
 
-#if _CCCL_CHECK_BUILTIN(builtin_copysign) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_COPYSIGNF(...) __builtin_copysignf(__VA_ARGS__)
-#  define _CCCL_BUILTIN_COPYSIGN(...)  __builtin_copysign(__VA_ARGS__)
-#  define _CCCL_BUILTIN_COPYSIGNL(...) __builtin_copysignl(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(builtin_copysign)
-
-#if _CCCL_CHECK_BUILTIN(builtin_cos) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_COSF(...) __builtin_cosf(__VA_ARGS__)
-#  define _CCCL_BUILTIN_COS(...)  __builtin_cos(__VA_ARGS__)
-#  define _CCCL_BUILTIN_COSL(...) __builtin_cosl(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(builtin_cos)
-
-#if _CCCL_CUDA_COMPILER(CLANG)
-#  undef _CCCL_BUILTIN_COSF
-#  undef _CCCL_BUILTIN_COS
-#  undef _CCCL_BUILTIN_COSL
-#endif // _CCCL_CUDA_COMPILER(CLANG)
-
-#if _CCCL_CHECK_BUILTIN(builtin_cosh) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_COSHF(...) __builtin_coshf(__VA_ARGS__)
-#  define _CCCL_BUILTIN_COSH(...)  __builtin_cosh(__VA_ARGS__)
-#  define _CCCL_BUILTIN_COSHL(...) __builtin_coshl(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(builtin_cosh)
-
-#if _CCCL_CUDA_COMPILER(CLANG)
-#  undef _CCCL_BUILTIN_COSHF
-#  undef _CCCL_BUILTIN_COSH
-#  undef _CCCL_BUILTIN_COSHL
-#endif // _CCCL_CUDA_COMPILER(CLANG)
-
-#if _CCCL_CHECK_BUILTIN(builtin_exp) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_EXPF(...) __builtin_expf(__VA_ARGS__)
-#  define _CCCL_BUILTIN_EXP(...)  __builtin_exp(__VA_ARGS__)
-#  define _CCCL_BUILTIN_EXPL(...) __builtin_expl(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(builtin_exp)
-
-// clang-cuda fails with fatal error: error in backend: Undefined external symbol "expf"
-#if _CCCL_CUDA_COMPILER(CLANG)
-#  undef _CCCL_BUILTIN_EXPF
-#  undef _CCCL_BUILTIN_EXP
-#  undef _CCCL_BUILTIN_EXPL
-#endif // _CCCL_CUDA_COMPILER(CLANG)
-
-#if _CCCL_CHECK_BUILTIN(builtin_exp2) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_EXP2F(...) __builtin_exp2f(__VA_ARGS__)
-#  define _CCCL_BUILTIN_EXP2(...)  __builtin_exp2(__VA_ARGS__)
-#  define _CCCL_BUILTIN_EXP2L(...) __builtin_exp2l(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(builtin_exp2)
-
-// clang-cuda fails with fatal error: error in backend: Undefined external symbol "exp2"
-#if _CCCL_CUDA_COMPILER(CLANG)
-#  undef _CCCL_BUILTIN_EXP2F
-#  undef _CCCL_BUILTIN_EXP2
-#  undef _CCCL_BUILTIN_EXP2L
-#endif // _CCCL_CUDA_COMPILER(CLANG)
-
-#if _CCCL_CHECK_BUILTIN(builtin_expm1) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_EXPM1F(...) __builtin_expm1f(__VA_ARGS__)
-#  define _CCCL_BUILTIN_EXPM1(...)  __builtin_expm1(__VA_ARGS__)
-#  define _CCCL_BUILTIN_EXPM1L(...) __builtin_expm1l(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(builtin_expm1)
-
-// clang-cuda fails with fatal error: error in backend: Undefined external symbol "expm1"
-#if _CCCL_CUDA_COMPILER(CLANG)
-#  undef _CCCL_BUILTIN_EXPM1F
-#  undef _CCCL_BUILTIN_EXPM1
-#  undef _CCCL_BUILTIN_EXPM1L
-#endif // _CCCL_CUDA_COMPILER(CLANG)
-
 #if _CCCL_CHECK_BUILTIN(builtin_expect) || _CCCL_COMPILER(MSVC) || _CCCL_COMPILER(GCC)
 #  define _CCCL_BUILTIN_EXPECT(...) __builtin_expect(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(builtin_expect)
-
-#if _CCCL_CHECK_BUILTIN(builtin_fabs) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_FABSF(...) __builtin_fabsf(__VA_ARGS__)
-#  define _CCCL_BUILTIN_FABS(...)  __builtin_fabs(__VA_ARGS__)
-#  define _CCCL_BUILTIN_FABSL(...) __builtin_fabsl(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(builtin_fabs)
-
-#if _CCCL_CHECK_BUILTIN(builtin_floor) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_FLOORF(...) __builtin_floorf(__VA_ARGS__)
-#  define _CCCL_BUILTIN_FLOOR(...)  __builtin_floor(__VA_ARGS__)
-#  define _CCCL_BUILTIN_FLOORL(...) __builtin_floorl(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(builtin_floor)
-
-#if _CCCL_CHECK_BUILTIN(builtin_fma) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_FMAF(...) __builtin_fmaf(__VA_ARGS__)
-#  define _CCCL_BUILTIN_FMA(...)  __builtin_fma(__VA_ARGS__)
-#  define _CCCL_BUILTIN_FMAL(...) __builtin_fmal(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(builtin_fmax)
-
-#if _CCCL_CHECK_BUILTIN(builtin_fmax) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_FMAXF(...) __builtin_fmaxf(__VA_ARGS__)
-#  define _CCCL_BUILTIN_FMAX(...)  __builtin_fmax(__VA_ARGS__)
-#  define _CCCL_BUILTIN_FMAXL(...) __builtin_fmaxl(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(builtin_fmax)
-
-#if _CCCL_CHECK_BUILTIN(builtin_fmin) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_FMINF(...) __builtin_fminf(__VA_ARGS__)
-#  define _CCCL_BUILTIN_FMIN(...)  __builtin_fmin(__VA_ARGS__)
-#  define _CCCL_BUILTIN_FMINL(...) __builtin_fminl(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(builtin_fmin)
-
-#if _CCCL_CHECK_BUILTIN(builtin_fmod) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_FMODF(...) __builtin_fmodf(__VA_ARGS__)
-#  define _CCCL_BUILTIN_FMOD(...)  __builtin_fmod(__VA_ARGS__)
-#  define _CCCL_BUILTIN_FMODL(...) __builtin_fmodl(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(builtin_fmod)
-
-// clang-cuda fails with fatal error: error in backend: Undefined external symbol "modf"
-#if _CCCL_CUDA_COMPILER(CLANG)
-#  undef _CCCL_BUILTIN_FMODF
-#  undef _CCCL_BUILTIN_FMOD
-#  undef _CCCL_BUILTIN_FMODL
-#endif // _CCCL_CUDA_COMPILER(CLANG)
 
 #if _CCCL_HAS_BUILTIN(__builtin_FILE) || _CCCL_COMPILER(GCC) || _CCCL_COMPILER(MSVC, >=, 19, 27)
 #  define _CCCL_BUILTIN_FILE() __builtin_FILE()
 #else // ^^^ _CCCL_HAS_BUILTIN(__builtin_FILE) ^^^ / vvv !_CCCL_HAS_BUILTIN(__builtin_FILE) vvv
 #  define _CCCL_BUILTIN_FILE() __FILE__
 #endif // !_CCCL_HAS_BUILTIN(__builtin_LINE)
-
-#if _CCCL_CHECK_BUILTIN(builtin_fpclassify) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_FPCLASSIFY(...) __builtin_fpclassify(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(builtin_fpclassify)
-
-// nvcc does not implement __builtin_fpclassify
-#if _CCCL_CUDA_COMPILER(NVCC)
-#  undef _CCCL_BUILTIN_FPCLASSIFY
-#endif // _CCCL_CUDA_COMPILER(NVCC)
-
-#if _CCCL_CHECK_BUILTIN(builtin_frexp) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_FREXPF(...) __builtin_frexpf(__VA_ARGS__)
-#  define _CCCL_BUILTIN_FREXP(...)  __builtin_frexp(__VA_ARGS__)
-#  define _CCCL_BUILTIN_FREXPL(...) __builtin_frexpl(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(builtin_frexp)
-
-// clang-cuda fails with fatal error: error in backend: Undefined external symbol "frexp"
-#if _CCCL_CUDA_COMPILER(CLANG)
-#  undef _CCCL_BUILTIN_FREXPF
-#  undef _CCCL_BUILTIN_FREXP
-#  undef _CCCL_BUILTIN_FREXPL
-#endif // _CCCL_CUDA_COMPILER(CLANG)
 
 #if _CCCL_HAS_BUILTIN(__builtin_FUNCTION) || _CCCL_COMPILER(GCC) || _CCCL_COMPILER(MSVC, >=, 19, 27)
 #  define _CCCL_BUILTIN_FUNCTION() __builtin_FUNCTION()
@@ -486,18 +249,6 @@
 #  endif // _CCCL_CUDA_COMPILER(NVCC)
 #endif // _CCCL_HAS_FLOAT128()
 
-#if _CCCL_CHECK_BUILTIN(builtin_hypot) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_HYPOTF(...) __builtin_hypotf(__VA_ARGS__)
-#  define _CCCL_BUILTIN_HYPOT(...)  __builtin_hypot(__VA_ARGS__)
-#  define _CCCL_BUILTIN_HYPOTL(...) __builtin_hypotl(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(builtin_hypot)
-
-#if _CCCL_CUDA_COMPILER(CLANG)
-#  undef _CCCL_BUILTIN_HYPOTF
-#  undef _CCCL_BUILTIN_HYPOT
-#  undef _CCCL_BUILTIN_HYPOTL
-#endif // _CCCL_CUDA_COMPILER(CLANG)
-
 #if _CCCL_CHECK_BUILTIN(builtin_is_constant_evaluated) || _CCCL_COMPILER(GCC, >=, 9) || _CCCL_COMPILER(MSVC, >, 19, 24)
 #  define _CCCL_BUILTIN_IS_CONSTANT_EVALUATED(...) __builtin_is_constant_evaluated(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(builtin_is_constant_evaluated)
@@ -522,126 +273,15 @@
 // __is_pointer_interconvertible_with_class(_S, _MPtr)
 #endif // ^^^ _CCCL_COMPILER(MSVC, >=, 19, 29) ^^^
 
-#if _CCCL_CHECK_BUILTIN(builtin_isfinite) || _CCCL_COMPILER(GCC) || _CCCL_COMPILER(NVRTC, >, 12, 2)
-#  define _CCCL_BUILTIN_ISFINITE(...) __builtin_isfinite(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(isfinite)
-
-#if _CCCL_CHECK_BUILTIN(builtin_isinf) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_ISINF(...) __builtin_isinf(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(isinf)
-
-#if _CCCL_CHECK_BUILTIN(builtin_isnan) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_ISNAN(...) __builtin_isnan(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(isnan)
-
-#if _CCCL_CHECK_BUILTIN(builtin_isnormal) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_ISNORMAL(...) __builtin_isnormal(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(isnormal)
-
-// nvcc does not implement __builtin_isnormal
-#if _CCCL_CUDA_COMPILER(NVCC)
-#  undef _CCCL_BUILTIN_ISNORMAL
-#endif // _CCCL_CUDA_COMPILER(NVCC)
-
 #if _CCCL_CHECK_BUILTIN(builtin_launder) || _CCCL_COMPILER(GCC, >=, 7)
 #  define _CCCL_BUILTIN_LAUNDER(...) __builtin_launder(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(builtin_launder) && gcc >= 7
-
-#if _CCCL_CHECK_BUILTIN(builtin_ldexp) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_LDEXPF(...) __builtin_ldexpf(__VA_ARGS__)
-#  define _CCCL_BUILTIN_LDEXP(...)  __builtin_ldexp(__VA_ARGS__)
-#  define _CCCL_BUILTIN_LDEXPL(...) __builtin_ldexpl(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(builtin_ldexp)
-
-// clang-cuda fails with fatal error: error in backend: Undefined external symbol "ldexp"
-#if _CCCL_CUDA_COMPILER(CLANG)
-#  undef _CCCL_BUILTIN_LDEXPF
-#  undef _CCCL_BUILTIN_LDEXP
-#  undef _CCCL_BUILTIN_LDEXPL
-#endif // _CCCL_CUDA_COMPILER(CLANG)
-
-#if _CCCL_CHECK_BUILTIN(builtin_lgamma) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_LGAMMAF(...) __builtin_lgammaf(__VA_ARGS__)
-#  define _CCCL_BUILTIN_LGAMMA(...)  __builtin_lgamma(__VA_ARGS__)
-#  define _CCCL_BUILTIN_LGAMMAL(...) __builtin_lgammal(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(builtin_lgamma)
-
-#if _CCCL_CUDA_COMPILER(CLANG)
-#  undef _CCCL_BUILTIN_LGAMMAF
-#  undef _CCCL_BUILTIN_LGAMMA
-#  undef _CCCL_BUILTIN_LGAMMAL
-#endif // _CCCL_CUDA_COMPILER(CLANG)
 
 #if _CCCL_HAS_BUILTIN(__builtin_LINE) || _CCCL_COMPILER(GCC) || _CCCL_COMPILER(MSVC, >=, 19, 27)
 #  define _CCCL_BUILTIN_LINE() __builtin_LINE()
 #else // ^^^ _CCCL_HAS_BUILTIN(__builtin_LINE) ^^^ / vvv !_CCCL_HAS_BUILTIN(__builtin_LINE) vvv
 #  define _CCCL_BUILTIN_LINE() __LINE__
 #endif // !_CCCL_HAS_BUILTIN(__builtin_LINE)
-
-#if _CCCL_CHECK_BUILTIN(builtin_llrint) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_LLRINTF(...) __builtin_llrintf(__VA_ARGS__)
-#  define _CCCL_BUILTIN_LLRINT(...)  __builtin_llrint(__VA_ARGS__)
-#  define _CCCL_BUILTIN_LLRINTL(...) __builtin_llrintl(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(builtin_llrint)
-
-// clang-cuda fails with fatal error: error in backend: Undefined external symbol "llrint"
-#if _CCCL_CUDA_COMPILER(CLANG)
-#  undef _CCCL_BUILTIN_LLRINTF
-#  undef _CCCL_BUILTIN_LLRINT
-#  undef _CCCL_BUILTIN_LLRINTL
-#endif // _CCCL_CUDA_COMPILER(CLANG)
-
-#if _CCCL_CHECK_BUILTIN(builtin_llround) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_LLROUNDF(...) __builtin_llroundf(__VA_ARGS__)
-#  define _CCCL_BUILTIN_LLROUND(...)  __builtin_llround(__VA_ARGS__)
-#  define _CCCL_BUILTIN_LLROUNDL(...) __builtin_llroundl(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(builtin_llround)
-
-// clang-cuda fails with fatal error: error in backend: Undefined external symbol "llround"
-#if _CCCL_CUDA_COMPILER(CLANG)
-#  undef _CCCL_BUILTIN_LLROUNDF
-#  undef _CCCL_BUILTIN_LLROUND
-#  undef _CCCL_BUILTIN_LLROUNDL
-#endif // _CCCL_CUDA_COMPILER(CLANG)
-
-#if _CCCL_CHECK_BUILTIN(builtin_lrint) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_LRINTF(...) __builtin_lrintf(__VA_ARGS__)
-#  define _CCCL_BUILTIN_LRINT(...)  __builtin_lrint(__VA_ARGS__)
-#  define _CCCL_BUILTIN_LRINTL(...) __builtin_lrintl(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(builtin_lrint)
-
-// clang-cuda fails with fatal error: error in backend: Undefined external symbol "lrint"
-#if _CCCL_CUDA_COMPILER(CLANG)
-#  undef _CCCL_BUILTIN_LRINTF
-#  undef _CCCL_BUILTIN_LRINT
-#  undef _CCCL_BUILTIN_LRINTL
-#endif // _CCCL_CUDA_COMPILER(CLANG)
-
-#if _CCCL_CHECK_BUILTIN(builtin_lround) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_LROUNDF(...) __builtin_lroundf(__VA_ARGS__)
-#  define _CCCL_BUILTIN_LROUND(...)  __builtin_lround(__VA_ARGS__)
-#  define _CCCL_BUILTIN_LROUNDL(...) __builtin_lroundl(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(builtin_lround)
-
-// clang-cuda fails with fatal error: error in backend: Undefined external symbol "lround"
-#if _CCCL_CUDA_COMPILER(CLANG)
-#  undef _CCCL_BUILTIN_LROUNDF
-#  undef _CCCL_BUILTIN_LROUND
-#  undef _CCCL_BUILTIN_LROUNDL
-#endif // _CCCL_CUDA_COMPILER(CLANG)
-
-#if _CCCL_CHECK_BUILTIN(builtin_modf) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_MODFF(...) __builtin_modff(__VA_ARGS__)
-#  define _CCCL_BUILTIN_MODF(...)  __builtin_modf(__VA_ARGS__)
-#  define _CCCL_BUILTIN_MODFL(...) __builtin_modfl(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(builtin_modf)
-
-// clang-cuda fails with fatal error: error in backend: Undefined external symbol "modf"
-#if _CCCL_CUDA_COMPILER(CLANG)
-#  undef _CCCL_BUILTIN_MODFF
-#  undef _CCCL_BUILTIN_MODF
-#  undef _CCCL_BUILTIN_MODFL
-#endif // _CCCL_CUDA_COMPILER(CLANG)
 
 #if _CCCL_CHECK_BUILTIN(builtin_nanf) || _CCCL_COMPILER(MSVC) || _CCCL_COMPILER(GCC, <, 10)
 #  define _CCCL_BUILTIN_NANF(...) __builtin_nanf(__VA_ARGS__)
@@ -693,110 +333,6 @@
 #  endif // _CCCL_CUDA_COMPILER(NVCC)
 #endif // _CCCL_HAS_FLOAT128()
 
-#if _CCCL_CHECK_BUILTIN(builtin_nearbyint) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_NEARBYINTF(...) __builtin_nearbyintf(__VA_ARGS__)
-#  define _CCCL_BUILTIN_NEARBYINT(...)  __builtin_nearbyint(__VA_ARGS__)
-#  define _CCCL_BUILTIN_NEARBYINTL(...) __builtin_nearbyintl(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(builtin_nearbyint)
-
-#if _CCCL_CHECK_BUILTIN(builtin_nextafter) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_NEXTAFTERF(...) __builtin_nextafterf(__VA_ARGS__)
-#  define _CCCL_BUILTIN_NEXTAFTER(...)  __builtin_nextafter(__VA_ARGS__)
-#  define _CCCL_BUILTIN_NEXTAFTERL(...) __builtin_nextafterl(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(builtin_nextafter)
-
-// clang-cuda fails with fatal error: error in backend: Undefined external symbol "nextafter"
-#if _CCCL_CUDA_COMPILER(CLANG)
-#  undef _CCCL_BUILTIN_NEXTAFTERF
-#  undef _CCCL_BUILTIN_NEXTAFTER
-#  undef _CCCL_BUILTIN_NEXTAFTERL
-#endif // _CCCL_CUDA_COMPILER(CLANG)
-
-#if _CCCL_CHECK_BUILTIN(builtin_nexttoward) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_NEXTTOWARDF(...) __builtin_nexttowardf(__VA_ARGS__)
-#  define _CCCL_BUILTIN_NEXTTOWARD(...)  __builtin_nexttoward(__VA_ARGS__)
-#  define _CCCL_BUILTIN_NEXTTOWARDL(...) __builtin_nexttowardl(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(builtin_nexttoward)
-
-#if _CCCL_CHECK_BUILTIN(builtin_log) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_LOGF(...) __builtin_logf(__VA_ARGS__)
-#  define _CCCL_BUILTIN_LOG(...)  __builtin_log(__VA_ARGS__)
-#  define _CCCL_BUILTIN_LOGL(...) __builtin_logl(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(builtin_log)
-
-// clang-cuda fails with fatal error: error in backend: Undefined external symbol "logf"
-#if _CCCL_CUDA_COMPILER(CLANG)
-#  undef _CCCL_BUILTIN_LOGF
-#  undef _CCCL_BUILTIN_LOG
-#  undef _CCCL_BUILTIN_LOGL
-#endif // _CCCL_CUDA_COMPILER(CLANG)
-
-#if _CCCL_CHECK_BUILTIN(builtin_log10) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_LOG10F(...) __builtin_log10f(__VA_ARGS__)
-#  define _CCCL_BUILTIN_LOG10(...)  __builtin_log10(__VA_ARGS__)
-#  define _CCCL_BUILTIN_LOG10L(...) __builtin_log10l(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(builtin_log10)
-
-// clang-cuda fails with fatal error: error in backend: Undefined external symbol "log10f"
-#if _CCCL_CUDA_COMPILER(CLANG)
-#  undef _CCCL_BUILTIN_LOG10F
-#  undef _CCCL_BUILTIN_LOG10
-#  undef _CCCL_BUILTIN_LOG10L
-#endif //  _CCCL_CUDA_COMPILER(CLANG)
-
-#if _CCCL_CHECK_BUILTIN(builtin_ilogb) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_ILOGBF(...) __builtin_ilogbf(__VA_ARGS__)
-#  define _CCCL_BUILTIN_ILOGB(...)  __builtin_ilogb(__VA_ARGS__)
-#  define _CCCL_BUILTIN_ILOGBL(...) __builtin_ilogbl(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(builtin_log10)
-
-// Below 11.7 nvcc treats the builtin as a host only function
-// clang-cuda fails with fatal error: error in backend: Undefined external symbol "ilogb"
-#if _CCCL_CUDA_COMPILER(CLANG)
-#  undef _CCCL_BUILTIN_ILOGBF
-#  undef _CCCL_BUILTIN_ILOGB
-#  undef _CCCL_BUILTIN_ILOGBL
-#endif // _CCCL_CUDA_COMPILER(CLANG)
-
-#if _CCCL_CHECK_BUILTIN(builtin_log1p) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_LOG1PF(...) __builtin_log1pf(__VA_ARGS__)
-#  define _CCCL_BUILTIN_LOG1P(...)  __builtin_log1p(__VA_ARGS__)
-#  define _CCCL_BUILTIN_LOG1PL(...) __builtin_log1pl(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(builtin_log1p)
-
-// clang-cuda fails with fatal error: error in backend: Undefined external symbol "log1p"
-#if _CCCL_CUDA_COMPILER(CLANG)
-#  undef _CCCL_BUILTIN_LOG1PF
-#  undef _CCCL_BUILTIN_LOG1P
-#  undef _CCCL_BUILTIN_LOG1PL
-#endif //  _CCCL_CUDA_COMPILER(CLANG)
-
-#if _CCCL_CHECK_BUILTIN(builtin_log2) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_LOG2F(...) __builtin_log2f(__VA_ARGS__)
-#  define _CCCL_BUILTIN_LOG2(...)  __builtin_log2(__VA_ARGS__)
-#  define _CCCL_BUILTIN_LOG2L(...) __builtin_log2l(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(builtin_log1)
-
-// clang-cuda fails with fatal error: error in backend: Undefined external symbol "log2f"
-#if _CCCL_CUDA_COMPILER(CLANG)
-#  undef _CCCL_BUILTIN_LOG2F
-#  undef _CCCL_BUILTIN_LOG2
-#  undef _CCCL_BUILTIN_LOG2L
-#endif // _CCCL_CUDA_COMPILER(CLANG)
-
-#if _CCCL_CHECK_BUILTIN(builtin_logb) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_LOGBF(...) __builtin_logbf(__VA_ARGS__)
-#  define _CCCL_BUILTIN_LOGB(...)  __builtin_logb(__VA_ARGS__)
-#  define _CCCL_BUILTIN_LOGBL(...) __builtin_logbl(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(builtin_log1)
-
-// clang-cuda fails with fatal error: error in backend: Undefined external symbol "logb"
-#if _CCCL_CUDA_COMPILER(CLANG)
-#  undef _CCCL_BUILTIN_LOGBF
-#  undef _CCCL_BUILTIN_LOGB
-#  undef _CCCL_BUILTIN_LOGBL
-#endif // _CCCL_CUDA_COMPILER(CLANG)
-
 #if _CCCL_CHECK_BUILTIN(builtin_memcmp) || _CCCL_COMPILER(GCC) || _CCCL_COMPILER(MSVC, >=, 19, 28)
 #  define _CCCL_BUILTIN_MEMCMP(...) __builtin_memcmp(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(builtin_memcmp) || _CCCL_COMPILER(GCC) || _CCCL_COMPILER(MSVC, >=, 19, 28)
@@ -819,138 +355,15 @@
 #  define _CCCL_BUILTIN_OPERATOR_NEW(...)    __builtin_operator_new(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(__builtin_operator_new) && _CCCL_CHECK_BUILTIN(__builtin_operator_delete)
 
-#if _CCCL_CHECK_BUILTIN(builtin_pow) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_POWF(...) __builtin_powf(__VA_ARGS__)
-#  define _CCCL_BUILTIN_POW(...)  __builtin_pow(__VA_ARGS__)
-#  define _CCCL_BUILTIN_POWL(...) __builtin_powl(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(builtin_pow)
-
-// clang-cuda fails with fatal error: error in backend: Undefined external symbol "pow"
-#if _CCCL_CUDA_COMPILER(CLANG)
-#  undef _CCCL_BUILTIN_POWF
-#  undef _CCCL_BUILTIN_POW
-#  undef _CCCL_BUILTIN_POWL
-#endif // _CCCL_CUDA_COMPILER(CLANG)
-
 #if _CCCL_CHECK_BUILTIN(builtin_prefetch) || _CCCL_COMPILER(GCC)
 #  define _CCCL_BUILTIN_PREFETCH(...) NV_IF_TARGET(NV_IS_HOST, __builtin_prefetch(__VA_ARGS__);)
 #else
 #  define _CCCL_BUILTIN_PREFETCH(...)
 #endif // _CCCL_CHECK_BUILTIN(builtin_prefetch)
 
-#if _CCCL_CHECK_BUILTIN(builtin_rint) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_RINTF(...) __builtin_rintf(__VA_ARGS__)
-#  define _CCCL_BUILTIN_RINT(...)  __builtin_rint(__VA_ARGS__)
-#  define _CCCL_BUILTIN_RINTL(...) __builtin_rintl(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(builtin_rint)
-
-#if _CCCL_CHECK_BUILTIN(builtin_round) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_ROUNDF(...) __builtin_roundf(__VA_ARGS__)
-#  define _CCCL_BUILTIN_ROUND(...)  __builtin_round(__VA_ARGS__)
-#  define _CCCL_BUILTIN_ROUNDL(...) __builtin_roundl(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(builtin_round)
-
-#if _CCCL_CHECK_BUILTIN(builtin_scalbln) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_SCALBLNF(...) __builtin_scalblnf(__VA_ARGS__)
-#  define _CCCL_BUILTIN_SCALBLN(...)  __builtin_scalbln(__VA_ARGS__)
-#  define _CCCL_BUILTIN_SCALBLNL(...) __builtin_scalblnl(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(builtin_scalbln)
-
-// clang-cuda fails with fatal error: error in backend: Undefined external symbol "scalblnf"
-#if _CCCL_CUDA_COMPILER(CLANG)
-#  undef _CCCL_BUILTIN_SCALBLNF
-#  undef _CCCL_BUILTIN_SCALBLN
-#  undef _CCCL_BUILTIN_SCALBLNL
-#endif // _CCCL_CUDA_COMPILER(CLANG)
-
-#if _CCCL_CHECK_BUILTIN(builtin_scalbn) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_SCALBNF(...) __builtin_scalbnf(__VA_ARGS__)
-#  define _CCCL_BUILTIN_SCALBN(...)  __builtin_scalbn(__VA_ARGS__)
-#  define _CCCL_BUILTIN_SCALBNL(...) __builtin_scalbnl(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(builtin_scalbn)
-
-// clang-cuda fails with fatal error: error in backend: Undefined external symbol "scalbnf"
-#if _CCCL_CUDA_COMPILER(CLANG)
-#  undef _CCCL_BUILTIN_SCALBNF
-#  undef _CCCL_BUILTIN_SCALBN
-#  undef _CCCL_BUILTIN_SCALBNL
-#endif // _CCCL_CUDA_COMPILER(CLANG)
-
 #if _CCCL_CHECK_BUILTIN(builtin_signbit) || _CCCL_COMPILER(GCC)
 #  define _CCCL_BUILTIN_SIGNBIT(...) __builtin_signbit(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(builtin_signbit)
-
-#if _CCCL_CHECK_BUILTIN(builtin_sin) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_SINF(...) __builtin_sinf(__VA_ARGS__)
-#  define _CCCL_BUILTIN_SIN(...)  __builtin_sin(__VA_ARGS__)
-#  define _CCCL_BUILTIN_SINL(...) __builtin_sinl(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(builtin_sin)
-
-#if _CCCL_CUDA_COMPILER(CLANG)
-#  undef _CCCL_BUILTIN_SINF
-#  undef _CCCL_BUILTIN_SIN
-#  undef _CCCL_BUILTIN_SINL
-#endif // _CCCL_CUDA_COMPILER(CLANG)
-
-#if _CCCL_CHECK_BUILTIN(builtin_sinh) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_SINHF(...) __builtin_sinhf(__VA_ARGS__)
-#  define _CCCL_BUILTIN_SINH(...)  __builtin_sinh(__VA_ARGS__)
-#  define _CCCL_BUILTIN_SINHL(...) __builtin_sinhl(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(builtin_sin)
-
-#if _CCCL_CUDA_COMPILER(CLANG)
-#  undef _CCCL_BUILTIN_SINHF
-#  undef _CCCL_BUILTIN_SINH
-#  undef _CCCL_BUILTIN_SINHL
-#endif // _CCCL_CUDA_COMPILER(CLANG)
-
-#if _CCCL_CHECK_BUILTIN(builtin_sqrt) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_SQRTF(...) __builtin_sqrtf(__VA_ARGS__)
-#  define _CCCL_BUILTIN_SQRT(...)  __builtin_sqrt(__VA_ARGS__)
-#  define _CCCL_BUILTIN_SQRTL(...) __builtin_sqrtl(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(builtin_sqrt)
-
-#if _CCCL_CHECK_BUILTIN(builtin_tan) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_TANF(...) __builtin_tanf(__VA_ARGS__)
-#  define _CCCL_BUILTIN_TAN(...)  __builtin_tan(__VA_ARGS__)
-#  define _CCCL_BUILTIN_TANL(...) __builtin_tanl(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(builtin_tan)
-
-#if _CCCL_CUDA_COMPILER(CLANG)
-#  undef _CCCL_BUILTIN_TANF
-#  undef _CCCL_BUILTIN_TAN
-#  undef _CCCL_BUILTIN_TANL
-#endif // _CCCL_CUDA_COMPILER(CLANG)
-
-#if _CCCL_CHECK_BUILTIN(builtin_tanh) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_TANHF(...) __builtin_tanhf(__VA_ARGS__)
-#  define _CCCL_BUILTIN_TANH(...)  __builtin_tanh(__VA_ARGS__)
-#  define _CCCL_BUILTIN_TANHL(...) __builtin_tanhl(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(builtin_tan)
-
-#if _CCCL_CUDA_COMPILER(CLANG)
-#  undef _CCCL_BUILTIN_TANHF
-#  undef _CCCL_BUILTIN_TANH
-#  undef _CCCL_BUILTIN_TANHL
-#endif // _CCCL_CUDA_COMPILER(CLANG)
-
-#if _CCCL_CHECK_BUILTIN(builtin_tgamma) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_TGAMMAF(...) __builtin_tgammaf(__VA_ARGS__)
-#  define _CCCL_BUILTIN_TGAMMA(...)  __builtin_tgamma(__VA_ARGS__)
-#  define _CCCL_BUILTIN_TGAMMAL(...) __builtin_tgammal(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(builtin_tgamma)
-
-#if _CCCL_CUDA_COMPILER(CLANG)
-#  undef _CCCL_BUILTIN_TGAMMAF
-#  undef _CCCL_BUILTIN_TGAMMA
-#  undef _CCCL_BUILTIN_TGAMMAL
-#endif // _CCCL_CUDA_COMPILER(CLANG)
-
-#if _CCCL_CHECK_BUILTIN(builtin_trunc) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_TRUNCF(...) __builtin_truncf(__VA_ARGS__)
-#  define _CCCL_BUILTIN_TRUNC(...)  __builtin_trunc(__VA_ARGS__)
-#  define _CCCL_BUILTIN_TRUNCL(...) __builtin_truncl(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(builtin_trunc)
 
 #if _CCCL_HAS_BUILTIN(__decay) && _CCCL_CUDA_COMPILER(CLANG)
 #  define _CCCL_BUILTIN_DECAY(...) __decay(__VA_ARGS__)

--- a/libcudacxx/include/cuda/std/__cmath/abs.h
+++ b/libcudacxx/include/cuda/std/__cmath/abs.h
@@ -39,6 +39,12 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 // fabs
 
+#if _CCCL_CHECK_BUILTIN(builtin_fabs) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_FABSF(...) __builtin_fabsf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_FABS(...)  __builtin_fabs(__VA_ARGS__)
+#  define _CCCL_BUILTIN_FABSL(...) __builtin_fabsl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_fabs)
+
 [[nodiscard]] _CCCL_API inline float fabs(float __x) noexcept
 {
 #if defined(_CCCL_BUILTIN_FABSF)

--- a/libcudacxx/include/cuda/std/__cmath/copysign.h
+++ b/libcudacxx/include/cuda/std/__cmath/copysign.h
@@ -40,6 +40,12 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+#if _CCCL_CHECK_BUILTIN(builtin_copysign) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_COPYSIGNF(...) __builtin_copysignf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_COPYSIGN(...)  __builtin_copysign(__VA_ARGS__)
+#  define _CCCL_BUILTIN_COPYSIGNL(...) __builtin_copysignl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_copysign)
+
 [[nodiscard]] _CCCL_API inline float copysign(float __x, float __y) noexcept
 {
 #if defined(_CCCL_BUILTIN_COPYSIGNF)

--- a/libcudacxx/include/cuda/std/__cmath/exponential_functions.h
+++ b/libcudacxx/include/cuda/std/__cmath/exponential_functions.h
@@ -40,6 +40,19 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 // exp
 
+#if _CCCL_CHECK_BUILTIN(builtin_exp) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_EXPF(...) __builtin_expf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_EXP(...)  __builtin_exp(__VA_ARGS__)
+#  define _CCCL_BUILTIN_EXPL(...) __builtin_expl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_exp)
+
+// clang-cuda fails with fatal error: error in backend: Undefined external symbol "expf"
+#if _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_EXPF
+#  undef _CCCL_BUILTIN_EXP
+#  undef _CCCL_BUILTIN_EXPL
+#endif // _CCCL_CUDA_COMPILER(CLANG)
+
 [[nodiscard]] _CCCL_API inline float exp(float __x) noexcept
 {
 #if defined(_CCCL_BUILTIN_EXPF)
@@ -129,6 +142,19 @@ template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> =
 
 // frexp
 
+#if _CCCL_CHECK_BUILTIN(builtin_frexp) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_FREXPF(...) __builtin_frexpf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_FREXP(...)  __builtin_frexp(__VA_ARGS__)
+#  define _CCCL_BUILTIN_FREXPL(...) __builtin_frexpl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_frexp)
+
+// clang-cuda fails with fatal error: error in backend: Undefined external symbol "frexp"
+#if _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_FREXPF
+#  undef _CCCL_BUILTIN_FREXP
+#  undef _CCCL_BUILTIN_FREXPL
+#endif // _CCCL_CUDA_COMPILER(CLANG)
+
 [[nodiscard]] _CCCL_API inline float frexp(float __x, int* __e) noexcept
 {
 #if defined(_CCCL_BUILTIN_FREXPF)
@@ -198,6 +224,19 @@ template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> =
 
 // ldexp
 
+#if _CCCL_CHECK_BUILTIN(builtin_ldexp) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_LDEXPF(...) __builtin_ldexpf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_LDEXP(...)  __builtin_ldexp(__VA_ARGS__)
+#  define _CCCL_BUILTIN_LDEXPL(...) __builtin_ldexpl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_ldexp)
+
+// clang-cuda fails with fatal error: error in backend: Undefined external symbol "ldexp"
+#if _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_LDEXPF
+#  undef _CCCL_BUILTIN_LDEXP
+#  undef _CCCL_BUILTIN_LDEXPL
+#endif // _CCCL_CUDA_COMPILER(CLANG)
+
 [[nodiscard]] _CCCL_API inline float ldexp(float __x, int __e) noexcept
 {
 #if defined(_CCCL_BUILTIN_LDEXPF)
@@ -266,6 +305,19 @@ template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> =
 }
 
 // exp2
+
+#if _CCCL_CHECK_BUILTIN(builtin_exp2) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_EXP2F(...) __builtin_exp2f(__VA_ARGS__)
+#  define _CCCL_BUILTIN_EXP2(...)  __builtin_exp2(__VA_ARGS__)
+#  define _CCCL_BUILTIN_EXP2L(...) __builtin_exp2l(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_exp2)
+
+// clang-cuda fails with fatal error: error in backend: Undefined external symbol "exp2"
+#if _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_EXP2F
+#  undef _CCCL_BUILTIN_EXP2
+#  undef _CCCL_BUILTIN_EXP2L
+#endif // _CCCL_CUDA_COMPILER(CLANG)
 
 [[nodiscard]] _CCCL_API inline float exp2(float __x) noexcept
 {
@@ -337,6 +389,19 @@ template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> =
 
 // expm1
 
+#if _CCCL_CHECK_BUILTIN(builtin_expm1) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_EXPM1F(...) __builtin_expm1f(__VA_ARGS__)
+#  define _CCCL_BUILTIN_EXPM1(...)  __builtin_expm1(__VA_ARGS__)
+#  define _CCCL_BUILTIN_EXPM1L(...) __builtin_expm1l(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_expm1)
+
+// clang-cuda fails with fatal error: error in backend: Undefined external symbol "expm1"
+#if _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_EXPM1F
+#  undef _CCCL_BUILTIN_EXPM1
+#  undef _CCCL_BUILTIN_EXPM1L
+#endif // _CCCL_CUDA_COMPILER(CLANG)
+
 [[nodiscard]] _CCCL_API inline float expm1(float __x) noexcept
 {
 #if defined(_CCCL_BUILTIN_EXPM1F)
@@ -405,6 +470,19 @@ template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> =
 }
 
 // scalbln
+
+#if _CCCL_CHECK_BUILTIN(builtin_scalbln) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_SCALBLNF(...) __builtin_scalblnf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_SCALBLN(...)  __builtin_scalbln(__VA_ARGS__)
+#  define _CCCL_BUILTIN_SCALBLNL(...) __builtin_scalblnl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_scalbln)
+
+// clang-cuda fails with fatal error: error in backend: Undefined external symbol "scalblnf"
+#if _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_SCALBLNF
+#  undef _CCCL_BUILTIN_SCALBLN
+#  undef _CCCL_BUILTIN_SCALBLNL
+#endif // _CCCL_CUDA_COMPILER(CLANG)
 
 [[nodiscard]] _CCCL_API inline float scalbln(float __x, long __y) noexcept
 {
@@ -475,6 +553,19 @@ template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> =
 
 // scalbn
 
+#if _CCCL_CHECK_BUILTIN(builtin_scalbn) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_SCALBNF(...) __builtin_scalbnf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_SCALBN(...)  __builtin_scalbn(__VA_ARGS__)
+#  define _CCCL_BUILTIN_SCALBNL(...) __builtin_scalbnl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_scalbn)
+
+// clang-cuda fails with fatal error: error in backend: Undefined external symbol "scalbnf"
+#if _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_SCALBNF
+#  undef _CCCL_BUILTIN_SCALBN
+#  undef _CCCL_BUILTIN_SCALBNL
+#endif // _CCCL_CUDA_COMPILER(CLANG)
+
 [[nodiscard]] _CCCL_API inline float scalbn(float __x, int __y) noexcept
 {
 #if defined(_CCCL_BUILTIN_SCALBNF)
@@ -543,6 +634,19 @@ template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> =
 }
 
 // pow
+
+#if _CCCL_CHECK_BUILTIN(builtin_pow) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_POWF(...) __builtin_powf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_POW(...)  __builtin_pow(__VA_ARGS__)
+#  define _CCCL_BUILTIN_POWL(...) __builtin_powl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_pow)
+
+// clang-cuda fails with fatal error: error in backend: Undefined external symbol "pow"
+#if _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_POWF
+#  undef _CCCL_BUILTIN_POW
+#  undef _CCCL_BUILTIN_POWL
+#endif // _CCCL_CUDA_COMPILER(CLANG)
 
 [[nodiscard]] _CCCL_API inline float pow(float __x, float __y) noexcept
 {

--- a/libcudacxx/include/cuda/std/__cmath/fma.h
+++ b/libcudacxx/include/cuda/std/__cmath/fma.h
@@ -33,6 +33,12 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 // fma
 
+#if _CCCL_CHECK_BUILTIN(builtin_fma) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_FMAF(...) __builtin_fmaf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_FMA(...)  __builtin_fma(__VA_ARGS__)
+#  define _CCCL_BUILTIN_FMAL(...) __builtin_fmal(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_fmax)
+
 [[nodiscard]] _CCCL_API inline float fma(float __x, float __y, float __z) noexcept
 {
 #if defined(_CCCL_BUILTIN_FMAF)

--- a/libcudacxx/include/cuda/std/__cmath/fpclassify.h
+++ b/libcudacxx/include/cuda/std/__cmath/fpclassify.h
@@ -58,6 +58,15 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+#if _CCCL_CHECK_BUILTIN(builtin_fpclassify) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_FPCLASSIFY(...) __builtin_fpclassify(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_fpclassify)
+
+// nvcc does not implement __builtin_fpclassify
+#if _CCCL_CUDA_COMPILER(NVCC)
+#  undef _CCCL_BUILTIN_FPCLASSIFY
+#endif // _CCCL_CUDA_COMPILER(NVCC)
+
 template <class _Tp>
 [[nodiscard]] _CCCL_API constexpr int __fpclassify_impl(_Tp __x) noexcept
 {

--- a/libcudacxx/include/cuda/std/__cmath/gamma.h
+++ b/libcudacxx/include/cuda/std/__cmath/gamma.h
@@ -38,6 +38,18 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 // lgamma
 
+#if _CCCL_CHECK_BUILTIN(builtin_lgamma) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_LGAMMAF(...) __builtin_lgammaf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_LGAMMA(...)  __builtin_lgamma(__VA_ARGS__)
+#  define _CCCL_BUILTIN_LGAMMAL(...) __builtin_lgammal(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_lgamma)
+
+#if _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_LGAMMAF
+#  undef _CCCL_BUILTIN_LGAMMA
+#  undef _CCCL_BUILTIN_LGAMMAL
+#endif // _CCCL_CUDA_COMPILER(CLANG)
+
 [[nodiscard]] _CCCL_API inline float lgamma(float __x) noexcept
 {
 #if defined(_CCCL_BUILTIN_LGAMMAF)
@@ -106,6 +118,18 @@ template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> =
 }
 
 // tgamma
+
+#if _CCCL_CHECK_BUILTIN(builtin_tgamma) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_TGAMMAF(...) __builtin_tgammaf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_TGAMMA(...)  __builtin_tgamma(__VA_ARGS__)
+#  define _CCCL_BUILTIN_TGAMMAL(...) __builtin_tgammal(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_tgamma)
+
+#if _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_TGAMMAF
+#  undef _CCCL_BUILTIN_TGAMMA
+#  undef _CCCL_BUILTIN_TGAMMAL
+#endif // _CCCL_CUDA_COMPILER(CLANG)
 
 [[nodiscard]] _CCCL_API inline float tgamma(float __x) noexcept
 {

--- a/libcudacxx/include/cuda/std/__cmath/hyperbolic_functions.h
+++ b/libcudacxx/include/cuda/std/__cmath/hyperbolic_functions.h
@@ -38,6 +38,18 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 // cosh
 
+#if _CCCL_CHECK_BUILTIN(builtin_cosh) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_COSHF(...) __builtin_coshf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_COSH(...)  __builtin_cosh(__VA_ARGS__)
+#  define _CCCL_BUILTIN_COSHL(...) __builtin_coshl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_cosh)
+
+#if _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_COSHF
+#  undef _CCCL_BUILTIN_COSH
+#  undef _CCCL_BUILTIN_COSHL
+#endif // _CCCL_CUDA_COMPILER(CLANG)
+
 [[nodiscard]] _CCCL_API inline float cosh(float __x) noexcept
 {
 #if defined(_CCCL_BUILTIN_COSHF)
@@ -107,6 +119,18 @@ template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> =
 
 // sinh
 
+#if _CCCL_CHECK_BUILTIN(builtin_sinh) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_SINHF(...) __builtin_sinhf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_SINH(...)  __builtin_sinh(__VA_ARGS__)
+#  define _CCCL_BUILTIN_SINHL(...) __builtin_sinhl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_sin)
+
+#if _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_SINHF
+#  undef _CCCL_BUILTIN_SINH
+#  undef _CCCL_BUILTIN_SINHL
+#endif // _CCCL_CUDA_COMPILER(CLANG)
+
 [[nodiscard]] _CCCL_API inline float sinh(float __x) noexcept
 {
 #if defined(_CCCL_BUILTIN_SINHF)
@@ -175,6 +199,18 @@ template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> =
 }
 
 // tanh
+
+#if _CCCL_CHECK_BUILTIN(builtin_tanh) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_TANHF(...) __builtin_tanhf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_TANH(...)  __builtin_tanh(__VA_ARGS__)
+#  define _CCCL_BUILTIN_TANHL(...) __builtin_tanhl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_tan)
+
+#if _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_TANHF
+#  undef _CCCL_BUILTIN_TANH
+#  undef _CCCL_BUILTIN_TANHL
+#endif // _CCCL_CUDA_COMPILER(CLANG)
 
 [[nodiscard]] _CCCL_API inline float tanh(float __x) noexcept
 {

--- a/libcudacxx/include/cuda/std/__cmath/hypot.h
+++ b/libcudacxx/include/cuda/std/__cmath/hypot.h
@@ -45,6 +45,18 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 // hypot
 
+#if _CCCL_CHECK_BUILTIN(builtin_hypot) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_HYPOTF(...) __builtin_hypotf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_HYPOT(...)  __builtin_hypot(__VA_ARGS__)
+#  define _CCCL_BUILTIN_HYPOTL(...) __builtin_hypotl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_hypot)
+
+#if _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_HYPOTF
+#  undef _CCCL_BUILTIN_HYPOT
+#  undef _CCCL_BUILTIN_HYPOTL
+#endif // _CCCL_CUDA_COMPILER(CLANG)
+
 [[nodiscard]] _CCCL_API inline float hypot(float __x, float __y) noexcept
 {
 #if defined(_CCCL_BUILTIN_HYPOTF)

--- a/libcudacxx/include/cuda/std/__cmath/inverse_hyperbolic_functions.h
+++ b/libcudacxx/include/cuda/std/__cmath/inverse_hyperbolic_functions.h
@@ -38,6 +38,18 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 // acosh
 
+#if _CCCL_CHECK_BUILTIN(builtin_acosh) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_ACOSHF(...) __builtin_acoshf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_ACOSH(...)  __builtin_acosh(__VA_ARGS__)
+#  define _CCCL_BUILTIN_ACOSHL(...) __builtin_acoshl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_acosh)
+
+#if _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_ACOSHF
+#  undef _CCCL_BUILTIN_ACOSH
+#  undef _CCCL_BUILTIN_ACOSHL
+#endif // _CCCL_CUDA_COMPILER(CLANG)
+
 [[nodiscard]] _CCCL_API inline float acosh(float __x) noexcept
 {
 #if defined(_CCCL_BUILTIN_ACOSHF)
@@ -107,6 +119,18 @@ template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> =
 
 // asinh
 
+#if _CCCL_CHECK_BUILTIN(builtin_asinh) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_ASINHF(...) __builtin_asinhf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_ASINH(...)  __builtin_asinh(__VA_ARGS__)
+#  define _CCCL_BUILTIN_ASINHL(...) __builtin_asinhl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_asin)
+
+#if _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_ASINHF
+#  undef _CCCL_BUILTIN_ASINH
+#  undef _CCCL_BUILTIN_ASINHL
+#endif // _CCCL_CUDA_COMPILER(CLANG)
+
 [[nodiscard]] _CCCL_API inline float asinh(float __x) noexcept
 {
 #if defined(_CCCL_BUILTIN_ASINHF)
@@ -175,6 +199,18 @@ template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> =
 }
 
 // atanh
+
+#if _CCCL_CHECK_BUILTIN(builtin_atanh) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_ATANHF(...) __builtin_atanhf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_ATANH(...)  __builtin_atanh(__VA_ARGS__)
+#  define _CCCL_BUILTIN_ATANHL(...) __builtin_atanhl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_atanh)
+
+#if _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_ATANHF
+#  undef _CCCL_BUILTIN_ATANH
+#  undef _CCCL_BUILTIN_ATANHL
+#endif // _CCCL_CUDA_COMPILER(CLANG)
 
 [[nodiscard]] _CCCL_API inline float atanh(float __x) noexcept
 {

--- a/libcudacxx/include/cuda/std/__cmath/inverse_trigonometric_functions.h
+++ b/libcudacxx/include/cuda/std/__cmath/inverse_trigonometric_functions.h
@@ -40,6 +40,18 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 // acos
 
+#if _CCCL_CHECK_BUILTIN(builtin_acos) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_ACOSF(...) __builtin_acosf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_ACOS(...)  __builtin_acos(__VA_ARGS__)
+#  define _CCCL_BUILTIN_ACOSL(...) __builtin_acosl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_acos)
+
+#if _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_ACOSF
+#  undef _CCCL_BUILTIN_ACOS
+#  undef _CCCL_BUILTIN_ACOSL
+#endif // _CCCL_CUDA_COMPILER(CLANG)
+
 [[nodiscard]] _CCCL_API inline float acos(float __x) noexcept
 {
 #if defined(_CCCL_BUILTIN_ACOSF)
@@ -108,6 +120,18 @@ template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> =
 }
 
 // asin
+
+#if _CCCL_CHECK_BUILTIN(builtin_asin) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_ASINF(...) __builtin_asinf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_ASIN(...)  __builtin_asin(__VA_ARGS__)
+#  define _CCCL_BUILTIN_ASINL(...) __builtin_asinl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_asin)
+
+#if _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_ASINF
+#  undef _CCCL_BUILTIN_ASIN
+#  undef _CCCL_BUILTIN_ASINL
+#endif // _CCCL_CUDA_COMPILER(CLANG)
 
 [[nodiscard]] _CCCL_API inline float asin(float __x) noexcept
 {
@@ -178,6 +202,18 @@ template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> =
 
 // atan
 
+#if _CCCL_CHECK_BUILTIN(builtin_atan) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_ATANF(...) __builtin_atanf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_ATAN(...)  __builtin_atan(__VA_ARGS__)
+#  define _CCCL_BUILTIN_ATANL(...) __builtin_atanl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_atan)
+
+#if _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_ATANF
+#  undef _CCCL_BUILTIN_ATAN
+#  undef _CCCL_BUILTIN_ATANL
+#endif // _CCCL_CUDA_COMPILER(CLANG)
+
 [[nodiscard]] _CCCL_API inline float atan(float __x) noexcept
 {
 #if defined(_CCCL_BUILTIN_ATANF)
@@ -246,6 +282,18 @@ template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> =
 }
 
 // atan2
+
+#if _CCCL_CHECK_BUILTIN(builtin_atan2) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_ATAN2F(...) __builtin_atan2f(__VA_ARGS__)
+#  define _CCCL_BUILTIN_ATAN2(...)  __builtin_atan2(__VA_ARGS__)
+#  define _CCCL_BUILTIN_ATAN2L(...) __builtin_atan2l(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_atan2)
+
+#if _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_ATAN2F
+#  undef _CCCL_BUILTIN_ATAN2
+#  undef _CCCL_BUILTIN_ATAN2L
+#endif // _CCCL_CUDA_COMPILER(CLANG)
 
 [[nodiscard]] _CCCL_API inline float atan2(float __x, float __y) noexcept
 {

--- a/libcudacxx/include/cuda/std/__cmath/isfinite.h
+++ b/libcudacxx/include/cuda/std/__cmath/isfinite.h
@@ -37,6 +37,10 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+#if _CCCL_CHECK_BUILTIN(builtin_isfinite) || _CCCL_COMPILER(GCC) || _CCCL_COMPILER(NVRTC, >, 12, 2)
+#  define _CCCL_BUILTIN_ISFINITE(...) __builtin_isfinite(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(isfinite)
+
 template <class _Tp>
 [[nodiscard]] _CCCL_API constexpr bool __isfinite_impl(_Tp __x) noexcept
 {

--- a/libcudacxx/include/cuda/std/__cmath/isinf.h
+++ b/libcudacxx/include/cuda/std/__cmath/isinf.h
@@ -38,6 +38,10 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+#if _CCCL_CHECK_BUILTIN(builtin_isinf) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_ISINF(...) __builtin_isinf(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(isinf)
+
 template <class _Tp>
 [[nodiscard]] _CCCL_API constexpr bool __isinf_impl(_Tp __x) noexcept
 {

--- a/libcudacxx/include/cuda/std/__cmath/isnan.h
+++ b/libcudacxx/include/cuda/std/__cmath/isnan.h
@@ -36,6 +36,10 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+#if _CCCL_CHECK_BUILTIN(builtin_isnan) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_ISNAN(...) __builtin_isnan(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(isnan)
+
 template <class _Tp>
 [[nodiscard]] _CCCL_API constexpr bool __isnan_impl(_Tp __x) noexcept
 {

--- a/libcudacxx/include/cuda/std/__cmath/isnormal.h
+++ b/libcudacxx/include/cuda/std/__cmath/isnormal.h
@@ -30,6 +30,15 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+#if _CCCL_CHECK_BUILTIN(builtin_isnormal) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_ISNORMAL(...) __builtin_isnormal(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(isnormal)
+
+// nvcc does not implement __builtin_isnormal
+#if _CCCL_CUDA_COMPILER(NVCC)
+#  undef _CCCL_BUILTIN_ISNORMAL
+#endif // _CCCL_CUDA_COMPILER(NVCC)
+
 [[nodiscard]] _CCCL_API constexpr bool isnormal(float __x) noexcept
 {
 #if defined(_CCCL_BUILTIN_ISNORMAL)

--- a/libcudacxx/include/cuda/std/__cmath/logarithms.h
+++ b/libcudacxx/include/cuda/std/__cmath/logarithms.h
@@ -39,6 +39,19 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 // log
 
+#if _CCCL_CHECK_BUILTIN(builtin_log) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_LOGF(...) __builtin_logf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_LOG(...)  __builtin_log(__VA_ARGS__)
+#  define _CCCL_BUILTIN_LOGL(...) __builtin_logl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_log)
+
+// clang-cuda fails with fatal error: error in backend: Undefined external symbol "logf"
+#if _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_LOGF
+#  undef _CCCL_BUILTIN_LOG
+#  undef _CCCL_BUILTIN_LOGL
+#endif // _CCCL_CUDA_COMPILER(CLANG)
+
 [[nodiscard]] _CCCL_API inline float log(float __x) noexcept
 {
 #if defined(_CCCL_BUILTIN_LOGF)
@@ -129,6 +142,19 @@ template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> =
 
 // log10
 
+#if _CCCL_CHECK_BUILTIN(builtin_log10) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_LOG10F(...) __builtin_log10f(__VA_ARGS__)
+#  define _CCCL_BUILTIN_LOG10(...)  __builtin_log10(__VA_ARGS__)
+#  define _CCCL_BUILTIN_LOG10L(...) __builtin_log10l(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_log10)
+
+// clang-cuda fails with fatal error: error in backend: Undefined external symbol "log10f"
+#if _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_LOG10F
+#  undef _CCCL_BUILTIN_LOG10
+#  undef _CCCL_BUILTIN_LOG10L
+#endif //  _CCCL_CUDA_COMPILER(CLANG)
+
 [[nodiscard]] _CCCL_API inline float log10(float __x) noexcept
 {
 #if defined(_CCCL_BUILTIN_LOG10F)
@@ -204,6 +230,20 @@ template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> =
 
 // ilogb
 
+#if _CCCL_CHECK_BUILTIN(builtin_ilogb) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_ILOGBF(...) __builtin_ilogbf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_ILOGB(...)  __builtin_ilogb(__VA_ARGS__)
+#  define _CCCL_BUILTIN_ILOGBL(...) __builtin_ilogbl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_log10)
+
+// Below 11.7 nvcc treats the builtin as a host only function
+// clang-cuda fails with fatal error: error in backend: Undefined external symbol "ilogb"
+#if _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_ILOGBF
+#  undef _CCCL_BUILTIN_ILOGB
+#  undef _CCCL_BUILTIN_ILOGBL
+#endif // _CCCL_CUDA_COMPILER(CLANG)
+
 [[nodiscard]] _CCCL_API inline int ilogb(float __x) noexcept
 {
 #if defined(_CCCL_BUILTIN_ILOGBF)
@@ -277,6 +317,19 @@ template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> =
 
 // log1p
 
+#if _CCCL_CHECK_BUILTIN(builtin_log1p) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_LOG1PF(...) __builtin_log1pf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_LOG1P(...)  __builtin_log1p(__VA_ARGS__)
+#  define _CCCL_BUILTIN_LOG1PL(...) __builtin_log1pl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_log1p)
+
+// clang-cuda fails with fatal error: error in backend: Undefined external symbol "log1p"
+#if _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_LOG1PF
+#  undef _CCCL_BUILTIN_LOG1P
+#  undef _CCCL_BUILTIN_LOG1PL
+#endif //  _CCCL_CUDA_COMPILER(CLANG)
+
 [[nodiscard]] _CCCL_API inline float log1p(float __x) noexcept
 {
 #if defined(_CCCL_BUILTIN_LOG1PF)
@@ -349,6 +402,19 @@ template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> =
 }
 
 // log2
+
+#if _CCCL_CHECK_BUILTIN(builtin_log2) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_LOG2F(...) __builtin_log2f(__VA_ARGS__)
+#  define _CCCL_BUILTIN_LOG2(...)  __builtin_log2(__VA_ARGS__)
+#  define _CCCL_BUILTIN_LOG2L(...) __builtin_log2l(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_log1)
+
+// clang-cuda fails with fatal error: error in backend: Undefined external symbol "log2f"
+#if _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_LOG2F
+#  undef _CCCL_BUILTIN_LOG2
+#  undef _CCCL_BUILTIN_LOG2L
+#endif // _CCCL_CUDA_COMPILER(CLANG)
 
 [[nodiscard]] _CCCL_API inline float log2(float __x) noexcept
 {
@@ -424,6 +490,19 @@ template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> =
 }
 
 // logb
+
+#if _CCCL_CHECK_BUILTIN(builtin_logb) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_LOGBF(...) __builtin_logbf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_LOGB(...)  __builtin_logb(__VA_ARGS__)
+#  define _CCCL_BUILTIN_LOGBL(...) __builtin_logbl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_log1)
+
+// clang-cuda fails with fatal error: error in backend: Undefined external symbol "logb"
+#if _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_LOGBF
+#  undef _CCCL_BUILTIN_LOGB
+#  undef _CCCL_BUILTIN_LOGBL
+#endif // _CCCL_CUDA_COMPILER(CLANG)
 
 [[nodiscard]] _CCCL_API inline float logb(float __x) noexcept
 {

--- a/libcudacxx/include/cuda/std/__cmath/min_max.h
+++ b/libcudacxx/include/cuda/std/__cmath/min_max.h
@@ -39,6 +39,12 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 // fmax
 
+#if _CCCL_CHECK_BUILTIN(builtin_fmax) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_FMAXF(...) __builtin_fmaxf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_FMAX(...)  __builtin_fmax(__VA_ARGS__)
+#  define _CCCL_BUILTIN_FMAXL(...) __builtin_fmaxl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_fmax)
+
 [[nodiscard]] _CCCL_API inline float fmax(float __x, float __y) noexcept
 {
 #if defined(_CCCL_BUILTIN_FMAX)
@@ -134,6 +140,12 @@ template <class _A1, class _A2, enable_if_t<_CCCL_TRAIT(is_arithmetic, _A1) && _
 }
 
 // fmin
+
+#if _CCCL_CHECK_BUILTIN(builtin_fmin) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_FMINF(...) __builtin_fminf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_FMIN(...)  __builtin_fmin(__VA_ARGS__)
+#  define _CCCL_BUILTIN_FMINL(...) __builtin_fminl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_fmin)
 
 [[nodiscard]] _CCCL_API inline float fmin(float __x, float __y) noexcept
 {

--- a/libcudacxx/include/cuda/std/__cmath/modulo.h
+++ b/libcudacxx/include/cuda/std/__cmath/modulo.h
@@ -35,6 +35,19 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 // fmod
 
+#if _CCCL_CHECK_BUILTIN(builtin_fmod) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_FMODF(...) __builtin_fmodf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_FMOD(...)  __builtin_fmod(__VA_ARGS__)
+#  define _CCCL_BUILTIN_FMODL(...) __builtin_fmodl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_fmod)
+
+// clang-cuda fails with fatal error: error in backend: Undefined external symbol "modf"
+#if _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_FMODF
+#  undef _CCCL_BUILTIN_FMOD
+#  undef _CCCL_BUILTIN_FMODL
+#endif // _CCCL_CUDA_COMPILER(CLANG)
+
 [[nodiscard]] _CCCL_API inline float fmod(float __x, float __y) noexcept
 {
 #if defined(_CCCL_BUILTIN_FMODF)
@@ -105,6 +118,19 @@ template <class _A1, class _A2, enable_if_t<is_arithmetic_v<_A1> && is_arithmeti
 }
 
 // modf
+
+#if _CCCL_CHECK_BUILTIN(builtin_modf) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_MODFF(...) __builtin_modff(__VA_ARGS__)
+#  define _CCCL_BUILTIN_MODF(...)  __builtin_modf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_MODFL(...) __builtin_modfl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_modf)
+
+// clang-cuda fails with fatal error: error in backend: Undefined external symbol "modf"
+#if _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_MODFF
+#  undef _CCCL_BUILTIN_MODF
+#  undef _CCCL_BUILTIN_MODFL
+#endif // _CCCL_CUDA_COMPILER(CLANG)
 
 [[nodiscard]] _CCCL_API inline float modf(float __x, float* __y) noexcept
 {

--- a/libcudacxx/include/cuda/std/__cmath/roots.h
+++ b/libcudacxx/include/cuda/std/__cmath/roots.h
@@ -36,6 +36,12 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 // sqrt
 
+#if _CCCL_CHECK_BUILTIN(builtin_sqrt) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_SQRTF(...) __builtin_sqrtf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_SQRT(...)  __builtin_sqrt(__VA_ARGS__)
+#  define _CCCL_BUILTIN_SQRTL(...) __builtin_sqrtl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_sqrt)
+
 [[nodiscard]] _CCCL_API inline float sqrt(float __x) noexcept
 {
 #if defined(_CCCL_BUILTIN_SQRTF)
@@ -105,6 +111,19 @@ template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> =
 }
 
 // cbrt
+
+#if _CCCL_CHECK_BUILTIN(builtin_cbrt) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_CBRTF(...) __builtin_cbrtf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_CBRT(...)  __builtin_cbrt(__VA_ARGS__)
+#  define _CCCL_BUILTIN_CBRTL(...) __builtin_cbrtl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_cbrt)
+
+// clang-cuda fails with fatal error: error in backend: Undefined external symbol "cbrt"
+#if _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_CBRTF
+#  undef _CCCL_BUILTIN_CBRT
+#  undef _CCCL_BUILTIN_CBRTL
+#endif // _CCCL_CUDA_COMPILER(CLANG)
 
 [[nodiscard]] _CCCL_API inline float cbrt(float __x) noexcept
 {

--- a/libcudacxx/include/cuda/std/__cmath/rounding_functions.h
+++ b/libcudacxx/include/cuda/std/__cmath/rounding_functions.h
@@ -39,6 +39,12 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 // ceil
 
+#if _CCCL_CHECK_BUILTIN(builtin_ceil) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_CEILF(...) __builtin_ceilf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_CEIL(...)  __builtin_ceil(__VA_ARGS__)
+#  define _CCCL_BUILTIN_CEILL(...) __builtin_ceill(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_ceil)
+
 [[nodiscard]] _CCCL_API inline float ceil(float __x) noexcept
 {
 #if defined(_CCCL_BUILTIN_CEILF)
@@ -107,6 +113,12 @@ template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> =
 }
 
 // floor
+
+#if _CCCL_CHECK_BUILTIN(builtin_floor) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_FLOORF(...) __builtin_floorf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_FLOOR(...)  __builtin_floor(__VA_ARGS__)
+#  define _CCCL_BUILTIN_FLOORL(...) __builtin_floorl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_floor)
 
 [[nodiscard]] _CCCL_API inline float floor(float __x) noexcept
 {
@@ -178,6 +190,19 @@ template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> =
 
 // llrint
 
+#if _CCCL_CHECK_BUILTIN(builtin_llrint) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_LLRINTF(...) __builtin_llrintf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_LLRINT(...)  __builtin_llrint(__VA_ARGS__)
+#  define _CCCL_BUILTIN_LLRINTL(...) __builtin_llrintl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_llrint)
+
+// clang-cuda fails with fatal error: error in backend: Undefined external symbol "llrint"
+#if _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_LLRINTF
+#  undef _CCCL_BUILTIN_LLRINT
+#  undef _CCCL_BUILTIN_LLRINTL
+#endif // _CCCL_CUDA_COMPILER(CLANG)
+
 _CCCL_API inline long long llrint(float __x) noexcept
 {
 #if defined(_CCCL_BUILTIN_LLRINTF)
@@ -246,6 +271,19 @@ _CCCL_API inline long long llrint(_Integer __x) noexcept
 }
 
 // llround
+
+#if _CCCL_CHECK_BUILTIN(builtin_llround) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_LLROUNDF(...) __builtin_llroundf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_LLROUND(...)  __builtin_llround(__VA_ARGS__)
+#  define _CCCL_BUILTIN_LLROUNDL(...) __builtin_llroundl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_llround)
+
+// clang-cuda fails with fatal error: error in backend: Undefined external symbol "llround"
+#if _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_LLROUNDF
+#  undef _CCCL_BUILTIN_LLROUND
+#  undef _CCCL_BUILTIN_LLROUNDL
+#endif // _CCCL_CUDA_COMPILER(CLANG)
 
 _CCCL_API inline long long llround(float __x) noexcept
 {
@@ -316,6 +354,19 @@ _CCCL_API inline long long llround(_Integer __x) noexcept
 
 // lrint
 
+#if _CCCL_CHECK_BUILTIN(builtin_lrint) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_LRINTF(...) __builtin_lrintf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_LRINT(...)  __builtin_lrint(__VA_ARGS__)
+#  define _CCCL_BUILTIN_LRINTL(...) __builtin_lrintl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_lrint)
+
+// clang-cuda fails with fatal error: error in backend: Undefined external symbol "lrint"
+#if _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_LRINTF
+#  undef _CCCL_BUILTIN_LRINT
+#  undef _CCCL_BUILTIN_LRINTL
+#endif // _CCCL_CUDA_COMPILER(CLANG)
+
 _CCCL_API inline long lrint(float __x) noexcept
 {
 #if defined(_CCCL_BUILTIN_LRINTF)
@@ -384,6 +435,19 @@ _CCCL_API inline long lrint(_Integer __x) noexcept
 }
 
 // lround
+
+#if _CCCL_CHECK_BUILTIN(builtin_lround) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_LROUNDF(...) __builtin_lroundf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_LROUND(...)  __builtin_lround(__VA_ARGS__)
+#  define _CCCL_BUILTIN_LROUNDL(...) __builtin_lroundl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_lround)
+
+// clang-cuda fails with fatal error: error in backend: Undefined external symbol "lround"
+#if _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_LROUNDF
+#  undef _CCCL_BUILTIN_LROUND
+#  undef _CCCL_BUILTIN_LROUNDL
+#endif // _CCCL_CUDA_COMPILER(CLANG)
 
 _CCCL_API inline long lround(float __x) noexcept
 {
@@ -454,6 +518,12 @@ _CCCL_API inline long lround(_Integer __x) noexcept
 
 // nearbyint
 
+#if _CCCL_CHECK_BUILTIN(builtin_nearbyint) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_NEARBYINTF(...) __builtin_nearbyintf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_NEARBYINT(...)  __builtin_nearbyint(__VA_ARGS__)
+#  define _CCCL_BUILTIN_NEARBYINTL(...) __builtin_nearbyintl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_nearbyint)
+
 [[nodiscard]] _CCCL_API inline float nearbyint(float __x) noexcept
 {
 #if defined(_CCCL_BUILTIN_NEARBYINTF)
@@ -522,6 +592,19 @@ template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> =
 }
 
 // nextafter
+
+#if _CCCL_CHECK_BUILTIN(builtin_nextafter) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_NEXTAFTERF(...) __builtin_nextafterf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_NEXTAFTER(...)  __builtin_nextafter(__VA_ARGS__)
+#  define _CCCL_BUILTIN_NEXTAFTERL(...) __builtin_nextafterl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_nextafter)
+
+// clang-cuda fails with fatal error: error in backend: Undefined external symbol "nextafter"
+#if _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_NEXTAFTERF
+#  undef _CCCL_BUILTIN_NEXTAFTER
+#  undef _CCCL_BUILTIN_NEXTAFTERL
+#endif // _CCCL_CUDA_COMPILER(CLANG)
 
 _CCCL_API inline float nextafter(float __x, float __y) noexcept
 {
@@ -594,6 +677,12 @@ _CCCL_API inline __promote_t<_A1, _A2> nextafter(_A1 __x, _A2 __y) noexcept
 
 // nexttoward
 
+#if _CCCL_CHECK_BUILTIN(builtin_nexttoward) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_NEXTTOWARDF(...) __builtin_nexttowardf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_NEXTTOWARD(...)  __builtin_nexttoward(__VA_ARGS__)
+#  define _CCCL_BUILTIN_NEXTTOWARDL(...) __builtin_nexttowardl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_nexttoward)
+
 #if _CCCL_HAS_LONG_DOUBLE()
 _CCCL_API inline float nexttoward(float __x, long double __y) noexcept
 {
@@ -662,6 +751,12 @@ _CCCL_API inline double nexttoward(_Integer __x, long double __y) noexcept
 #endif // _CCCL_HAS_LONG_DOUBLE()
 
 // rint
+
+#if _CCCL_CHECK_BUILTIN(builtin_rint) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_RINTF(...) __builtin_rintf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_RINT(...)  __builtin_rint(__VA_ARGS__)
+#  define _CCCL_BUILTIN_RINTL(...) __builtin_rintl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_rint)
 
 [[nodiscard]] _CCCL_API inline float rint(float __x) noexcept
 {
@@ -733,6 +828,12 @@ template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> =
 
 // round
 
+#if _CCCL_CHECK_BUILTIN(builtin_round) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_ROUNDF(...) __builtin_roundf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_ROUND(...)  __builtin_round(__VA_ARGS__)
+#  define _CCCL_BUILTIN_ROUNDL(...) __builtin_roundl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_round)
+
 [[nodiscard]] _CCCL_API inline float round(float __x) noexcept
 {
 #if defined(_CCCL_BUILTIN_ROUNDF)
@@ -801,6 +902,12 @@ template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> =
 }
 
 // trunc
+
+#if _CCCL_CHECK_BUILTIN(builtin_trunc) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_TRUNCF(...) __builtin_truncf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_TRUNC(...)  __builtin_trunc(__VA_ARGS__)
+#  define _CCCL_BUILTIN_TRUNCL(...) __builtin_truncl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_trunc)
 
 [[nodiscard]] _CCCL_API inline float trunc(float __x) noexcept
 {

--- a/libcudacxx/include/cuda/std/__cmath/trigonometric_functions.h
+++ b/libcudacxx/include/cuda/std/__cmath/trigonometric_functions.h
@@ -39,6 +39,18 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 // cos
 
+#if _CCCL_CHECK_BUILTIN(builtin_cos) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_COSF(...) __builtin_cosf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_COS(...)  __builtin_cos(__VA_ARGS__)
+#  define _CCCL_BUILTIN_COSL(...) __builtin_cosl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_cos)
+
+#if _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_COSF
+#  undef _CCCL_BUILTIN_COS
+#  undef _CCCL_BUILTIN_COSL
+#endif // _CCCL_CUDA_COMPILER(CLANG)
+
 [[nodiscard]] _CCCL_API inline float cos(float __x) noexcept
 {
 #if defined(_CCCL_BUILTIN_COSF)
@@ -125,6 +137,18 @@ template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> =
 }
 
 // sin
+
+#if _CCCL_CHECK_BUILTIN(builtin_sin) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_SINF(...) __builtin_sinf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_SIN(...)  __builtin_sin(__VA_ARGS__)
+#  define _CCCL_BUILTIN_SINL(...) __builtin_sinl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_sin)
+
+#if _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_SINF
+#  undef _CCCL_BUILTIN_SIN
+#  undef _CCCL_BUILTIN_SINL
+#endif // _CCCL_CUDA_COMPILER(CLANG)
 
 [[nodiscard]] _CCCL_API inline float sin(float __x) noexcept
 {
@@ -217,6 +241,18 @@ template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> =
 }
 
 // tan
+
+#if _CCCL_CHECK_BUILTIN(builtin_tan) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_TANF(...) __builtin_tanf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_TAN(...)  __builtin_tan(__VA_ARGS__)
+#  define _CCCL_BUILTIN_TANL(...) __builtin_tanl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_tan)
+
+#if _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_TANF
+#  undef _CCCL_BUILTIN_TAN
+#  undef _CCCL_BUILTIN_TANL
+#endif // _CCCL_CUDA_COMPILER(CLANG)
 
 [[nodiscard]] _CCCL_API inline float tan(float __x) noexcept
 {


### PR DESCRIPTION
We are collecting a ton of builtins that make the builtin header rather unwieldly, so move the math functions into their own file because they are the only place where they are actually used
