### PR TITLE
avoid a mysterious codegen issue with llvm18 by simplifying the transform for the stream bulk senders

### DIFF
--- a/cudax/include/cuda/experimental/__execution/stream/adaptor.cuh
+++ b/cudax/include/cuda/experimental/__execution/stream/adaptor.cuh
@@ -399,7 +399,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __sndr_t
 };
 
 template <class _Sndr>
-_CCCL_API constexpr auto __adapt(_Sndr __sndr, [[maybe_unused]] stream_ref __stream) -> decltype(auto)
+_CCCL_API constexpr auto __adapt(_Sndr __sndr, [[maybe_unused]] stream_ref __stream)
 {
   // Ensure that we are not trying to adapt a sender that is already adapted.
   if constexpr (__is_specialization_of_v<_Sndr, __sndr_t>)
@@ -413,9 +413,10 @@ _CCCL_API constexpr auto __adapt(_Sndr __sndr, [[maybe_unused]] stream_ref __str
 }
 
 template <class _Sndr>
-_CCCL_API constexpr auto __adapt(_Sndr __sndr) -> decltype(auto)
+_CCCL_API constexpr auto __adapt(_Sndr __sndr)
 {
-  return __stream::__adapt(static_cast<_Sndr&&>(__sndr), get_stream(execution::get_env(__sndr)));
+  auto __stream = get_stream(execution::get_env(__sndr));
+  return __stream::__adapt(static_cast<_Sndr&&>(__sndr), __stream);
 }
 } // namespace __stream
 

--- a/cudax/include/cuda/experimental/__execution/stream/bulk.cuh
+++ b/cudax/include/cuda/experimental/__execution/stream/bulk.cuh
@@ -94,10 +94,15 @@ struct __bulk_chunked_t : execution::__bulk_t<__bulk_chunked_t>
     auto& [__tag, __state, __child] = __sndr;
     auto& [__policy, __shape, __fn] = __state;
 
-    using __sndr_t =
-      __bulk_chunked_t::__sndr_t<decltype(__child), decltype(__policy), decltype(__shape), decltype(__fn)>;
-    return __stream::__adapt(__sndr_t{
-      {{}, {__policy, __shape, _CUDA_VSTD::forward_like<_Sndr>(__fn)}, _CUDA_VSTD::forward_like<_Sndr>(__child)}});
+    using __policy_t  = decltype(__policy);
+    using __shape_t   = decltype(__shape);
+    using __fn_t      = decltype(__fn);
+    using __sndr_t    = __bulk_chunked_t::__sndr_t<decltype(__child), __policy_t, __shape_t, __fn_t>;
+    using __closure_t = __bulk_t::__closure_base_t<__policy_t, __shape_t, __fn_t>;
+
+    auto __closure  = __closure_t{__policy, __shape, _CUDA_VSTD::forward_like<_Sndr>(__fn)};
+    auto __new_sndr = __sndr_t{{{}, static_cast<__closure_t&&>(__closure), _CUDA_VSTD::forward_like<_Sndr>(__child)}};
+    return __stream::__adapt(static_cast<__sndr_t&&>(__new_sndr));
   }
 
   _CCCL_API static constexpr bool __is_chunked() noexcept
@@ -152,10 +157,15 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __bulk_unchunked_t : execution::__bulk_t<__
     auto& [__tag, __state, __child] = __sndr;
     auto& [__policy, __shape, __fn] = __state;
 
-    using __sndr_t =
-      __bulk_unchunked_t::__sndr_t<decltype(__child), decltype(__policy), decltype(__shape), decltype(__fn)>;
-    return __stream::__adapt(__sndr_t{
-      {{}, {__policy, __shape, _CUDA_VSTD::forward_like<_Sndr>(__fn)}}, _CUDA_VSTD::forward_like<_Sndr>(__child)});
+    using __policy_t  = decltype(__policy);
+    using __shape_t   = decltype(__shape);
+    using __fn_t      = decltype(__fn);
+    using __sndr_t    = __bulk_unchunked_t::__sndr_t<decltype(__child), __policy_t, __shape_t, __fn_t>;
+    using __closure_t = __bulk_t::__closure_base_t<__policy_t, __shape_t, __fn_t>;
+
+    auto __closure  = __closure_t{__policy, __shape, _CUDA_VSTD::forward_like<_Sndr>(__fn)};
+    auto __new_sndr = __sndr_t{{{}, static_cast<__closure_t&&>(__closure), _CUDA_VSTD::forward_like<_Sndr>(__child)}};
+    return __stream::__adapt(static_cast<__sndr_t&&>(__new_sndr));
   }
 
   _CCCL_API static constexpr bool __is_chunked() noexcept

--- a/cudax/include/cuda/experimental/__execution/stream/domain.cuh
+++ b/cudax/include/cuda/experimental/__execution/stream/domain.cuh
@@ -39,10 +39,10 @@ struct __adapted_t
 
 // Forward declaration of the __adapt function
 template <class _Sndr>
-_CCCL_API constexpr auto __adapt(_Sndr, stream_ref) -> decltype(auto);
+_CCCL_API constexpr auto __adapt(_Sndr, stream_ref);
 
 template <class _Sndr>
-_CCCL_API constexpr auto __adapt(_Sndr) -> decltype(auto);
+_CCCL_API constexpr auto __adapt(_Sndr);
 } // namespace __stream
 
 //////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Description

while working on something else, i started hitting a segfault while transforming a bulk sender into a bulk stream sender. the crash happened while doing nested aggregate initialization from locals introduced with a structured binding. everything looked ok in the debugger. i broke the initialization into several steps to narrow the problem down, and the crash went away.

i suspect an llvm18 codegen issue.

however, i did find some UB in my code; a possible use-after-move:

```c++
return __stream::__adapt(static_cast<_Sndr&&>(__sndr), get_stream(execution::get_env(__sndr)));
```

but this problem was not the source of the crash. this pr fixes the UB as well.


## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
