### PR TITLE
give `cudax::stream_ref` the opt-in for satisfying the `scheduler` concept

### DIFF
--- a/cudax/include/cuda/experimental/__stream/stream_ref.cuh
+++ b/cudax/include/cuda/experimental/__stream/stream_ref.cuh
@@ -46,6 +46,8 @@ static const ::cudaStream_t __invalid_stream = reinterpret_cast<cudaStream_t>(~0
 //! @brief A non-owning wrapper for cudaStream_t.
 struct stream_ref : ::cuda::stream_ref
 {
+  using scheduler_concept = execution::scheduler_t;
+
   stream_ref() = delete;
 
   //! @brief Wrap a native \c ::cudaStream_t in a \c stream_ref

--- a/cudax/test/execution/test_stream_context.cu
+++ b/cudax/test/execution/test_stream_context.cu
@@ -49,6 +49,7 @@ void stream_context_test1()
 {
   ex::stream_context ctx{cuda::experimental::device_ref{0}};
   auto sched = ctx.get_scheduler();
+  static_assert(ex::__is_scheduler<decltype(sched)>);
 
   auto sndr = ex::schedule(sched) //
             | ex::then([] __host__ __device__() noexcept -> bool {
@@ -93,6 +94,7 @@ void stream_ref_as_scheduler()
   ex::thread_context tctx;
   cudax::stream sctx{cuda::experimental::device_ref{0}};
   auto sch = sctx.get_scheduler();
+  static_assert(ex::__is_scheduler<decltype(sch)>);
 
   auto start = //
     ex::schedule(sch) // begin work on the GPU


### PR DESCRIPTION
## Description

pr #4952 gave `cudax::stream_ref` a `schedule()` member function, making it possible to use a `stream_ref` as a `std::execution`-style scheduler. but that pr forgot to give `stream_ref` the necessary opt-in -- a nested `scheduler_concept` alias -- to actually satisfy the `scheduler` concept.

this pr corrects the oversight and adds some tests that would have caught this.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
