### PR TITLE
make the stream sender adaptor work with non-visitable senders

### DIFF
--- a/cudax/include/cuda/experimental/__execution/stream/adaptor.cuh
+++ b/cudax/include/cuda/experimental/__execution/stream/adaptor.cuh
@@ -393,7 +393,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __sndr_t
     return __attrs_t<_Sndr>{&__sndr_};
   }
 
-  _CCCL_NO_UNIQUE_ADDRESS __adapted_t<tag_of_t<_Sndr>> __tag_;
+  _CCCL_NO_UNIQUE_ADDRESS __adapted_t<__stream::__tag_of_t<_Sndr>> __tag_;
   stream_ref __stream_;
   _Sndr __sndr_;
 };

--- a/cudax/include/cuda/experimental/__execution/stream/domain.cuh
+++ b/cudax/include/cuda/experimental/__execution/stream/domain.cuh
@@ -34,6 +34,21 @@ namespace cuda::experimental::execution
 namespace __stream
 {
 template <class _Tag>
+struct __tag_t
+{};
+
+struct __unknown_sender_t
+{};
+
+_CCCL_API auto __tag_of(_CUDA_VSTD::__ignore_t) -> __unknown_sender_t;
+
+template <class _Sndr>
+_CCCL_API auto __tag_of(const _Sndr& __sndr) -> tag_of_t<_Sndr>;
+
+template <class _Sndr>
+using __tag_of_t = decltype(__stream::__tag_of(declval<_Sndr>()));
+
+template <class _Tag>
 struct __adapted_t
 {};
 

--- a/cudax/include/cuda/experimental/__execution/stream/domain.cuh
+++ b/cudax/include/cuda/experimental/__execution/stream/domain.cuh
@@ -37,10 +37,10 @@ template <class _Tag>
 struct __tag_t
 {};
 
-struct __unknown_sender_t
+struct __no_tag_t
 {};
 
-_CCCL_API auto __tag_of(_CUDA_VSTD::__ignore_t) -> __unknown_sender_t;
+_CCCL_API auto __tag_of(_CUDA_VSTD::__ignore_t) -> __no_tag_t;
 
 template <class _Sndr>
 _CCCL_API auto __tag_of(const _Sndr& __sndr) -> tag_of_t<_Sndr>;

--- a/cudax/include/cuda/experimental/__execution/stream/sync_wait.cuh
+++ b/cudax/include/cuda/experimental/__execution/stream/sync_wait.cuh
@@ -55,7 +55,7 @@ struct __sync_wait_t
 
 private:
   template <class _Sndr, class _Env>
-  struct __state_t
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __state_t
   {
     using __values_t = typename sync_wait_t::__state_t<_Sndr, _Env>::__values_t;
     using __errors_t = typename sync_wait_t::__state_t<_Sndr, _Env>::__errors_t;


### PR DESCRIPTION
## Description

the stream scheduler works by adapting senders to the stream domain so that their operation states are in managed memory, and so that completion is executed on the device.

there are two types of senders: those that can be introspected and those that can't. if a sender can be introspected, it makes available its tag type. for instance, the sender `just()` has a tag type of `just_t`. if a sender cannot be introspected, it does not make a tag type available.

the stream sender adaptor is currently assuming that all senders are introspect-able. this is a mistake. this pr changes the stream sender adaptor to work with senders that cannot be introspected.

note: the test for this fix is currently on an `if(false)` branch because it uses `starts_on`, and `starts_on` is currently broken for the stream scheduler. a future pr will fix `starts_on` and enable this test.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
