### PR TITLE
get the `starts_on` algorithm working with the stream scheduler

### DIFF
--- a/cudax/include/cuda/experimental/__execution/domain.cuh
+++ b/cudax/include/cuda/experimental/__execution/domain.cuh
@@ -168,6 +168,11 @@ struct get_domain_override_t
   {
     return {};
   }
+
+  [[nodiscard]] static _CCCL_API constexpr auto query(forwarding_query_t) noexcept -> bool
+  {
+    return false;
+  }
 };
 
 _CCCL_GLOBAL_CONSTANT get_domain_override_t get_domain_override{};

--- a/cudax/include/cuda/experimental/__execution/fwd.cuh
+++ b/cudax/include/cuda/experimental/__execution/fwd.cuh
@@ -198,8 +198,15 @@ extern __fn_ptr_t<_Tag> __tag_of_v;
 template <class _Sndr>
 using tag_of_t _CCCL_NODEBUG_ALIAS = decltype(__detail::__tag_of_v<_Sndr>());
 
+template <class _Sndr, class... _Tag>
+inline constexpr bool __sender_for_v = _CCCL_REQUIRES_EXPR((_Sndr, variadic _Tag))(tag_of_t<_Sndr>{});
+
 template <class _Sndr, class _Tag>
-_CCCL_CONCEPT sender_for = _CCCL_REQUIRES_EXPR((_Sndr, _Tag))(_Same_as(_Tag) tag_of_t<_Sndr>{});
+inline constexpr bool __sender_for_v<_Sndr, _Tag> =
+  _CCCL_REQUIRES_EXPR((_Sndr, _Tag))(_Same_as(_Tag) tag_of_t<_Sndr>{});
+
+template <class _Sndr, class... _Tag>
+_CCCL_CONCEPT sender_for = __sender_for_v<_Sndr, _Tag...>;
 
 namespace __detail
 {

--- a/cudax/include/cuda/experimental/__execution/rcvr_with_env.cuh
+++ b/cudax/include/cuda/experimental/__execution/rcvr_with_env.cuh
@@ -60,8 +60,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __rcvr_with_env_t : _Rcvr
       // forwarding a get_domain query to the parent receiver's environment.
       static_assert(!_CUDA_VSTD::is_same_v<_Query, get_domain_t> || !__queryable_with<_Env, get_scheduler_t>,
                     "_Env specifies a scheduler but not a domain.");
-      return __rcvr_->__base().query(_Query{});
-      // return execution::get_env(__rcvr_->__base()).query(_Query{});
+      return execution::get_env(__rcvr_->__base()).query(_Query{});
     }
 
     __rcvr_with_env_t const* __rcvr_;

--- a/cudax/include/cuda/experimental/__execution/starts_on.cuh
+++ b/cudax/include/cuda/experimental/__execution/starts_on.cuh
@@ -41,6 +41,54 @@
 
 namespace cuda::experimental::execution
 {
+//! \brief Execution algorithm that starts a given sender on a specified scheduler.
+//!
+//! The `starts_on` algorithm takes a scheduler and a sender, and returns a new sender
+//! that, when connected and started, will first schedule work on the provided scheduler,
+//! and then start the original sender on that scheduler's execution context.
+//!
+//! This algorithm is particularly useful for ensuring that a chain of work begins
+//! execution on a specific execution context, such as a particular GPU stream or thread
+//! pool.
+//!
+//! \details The operation proceeds in two phases:
+//! 1. **Scheduling Phase**: The algorithm first calls `schedule()` on the provided
+//!    scheduler to obtain a sender that represents scheduling work on that scheduler's
+//!    execution context.
+//! 2. **Execution Phase**: Once the scheduling operation completes successfully, the
+//!    original sender is started on the scheduler's execution context.
+//!
+//! The resulting sender's completion signatures are derived from both the scheduler's
+//! `schedule()` sender and the original sender. Error and stopped signals from either
+//! operation are propagated to the final receiver.
+//!
+//! \tparam _Sch A scheduler type that satisfies the `scheduler` concept
+//! \tparam _Sndr A sender type that satisfies the `sender` concept
+//!
+//! \param __sch The scheduler on which the sender should start execution
+//! \param __sndr The sender to be started on the scheduler's execution context
+//!
+//! \return A sender that, when started, will first schedule on `__sch` and then execute
+//!         `__sndr`
+//!
+//! \note The returned sender's environment includes the provided scheduler as the current
+//!       scheduler, allowing nested senders to query and use the same execution context.
+//!
+//! \note This implementation follows the C++26 standard specification for
+//!       `std::execution::starts_on` as defined in [exec.starts.on].
+//!
+//! Example usage:
+//! \code
+//! auto work = cuda::experimental::execution::just(42)
+//!           | cuda::experimental::execution::then([](int x) { return x * 2; });
+//!
+//! auto scheduled_work = cuda::experimental::execution::starts_on(some_scheduler, work);
+//! \endcode
+//!
+//! \see schedule
+//! \see scheduler
+//! \see sender
+//! \see receiver
 struct starts_on_t
 {
   _CUDAX_SEMI_PRIVATE :

--- a/cudax/include/cuda/experimental/__execution/stream/adaptor.cuh
+++ b/cudax/include/cuda/experimental/__execution/stream/adaptor.cuh
@@ -33,6 +33,7 @@
 #include <cuda/experimental/__execution/stream/domain.cuh>
 #include <cuda/experimental/__execution/utility.cuh>
 #include <cuda/experimental/__execution/variant.cuh>
+#include <cuda/experimental/__execution/visit.cuh>
 #include <cuda/experimental/__launch/configuration.cuh>
 #include <cuda/experimental/__launch/launch.cuh>
 #include <cuda/experimental/__stream/stream_ref.cuh>
@@ -124,6 +125,7 @@ template <int _BlockThreads, class _Rcvr, class _Variant>
 _CCCL_VISIBILITY_HIDDEN __launch_bounds__(_BlockThreads) __global__
   void __completion_kernel(__state_base_t<_Rcvr, _Variant>* __state)
 {
+  _CCCL_ASSERT(__state->__results_.__index() != __npos, "__completion_kernel called with empty results");
   _Variant::__visit(__results_visitor<_Rcvr>{__state->__rcvr_}, __state->__results_);
 }
 
@@ -139,13 +141,11 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __env_t
     return __env_.query(_Query{});
   }
 
-  // Use the default domain when connecting the child sender to the inner receiver. We
-  // want senders on device to behave like senders on the host by default. We will further
-  // customize those algorithms that need to do something different on device, like
-  // `bulk`, `when_all`, and `let_value`.
-  [[nodiscard]] _CCCL_API static constexpr auto query(get_domain_t) noexcept -> default_domain
+  // This query is used to tell transform_sender that the child sender has been adapted to
+  // the stream domain.
+  [[nodiscard]] _CCCL_API static constexpr auto query(__stream::__adapted_t) noexcept -> _CUDA_VSTD::__ignore_t
   {
-    return default_domain{};
+    return {};
   }
 
   [[nodiscard]] _CCCL_API constexpr auto query(get_launch_config_t) const noexcept -> _Config
@@ -208,13 +208,13 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __rcvr_t
   __state_t<_Rcvr, _Config, _Variant>* __state_;
 };
 
-template <class _CvSndr, class _Rcvr>
+template <class _CvSndr, class _Rcvr, class _GetStream>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __opstate_t
 {
   using operation_state_concept = operation_state_t;
 
-  _CCCL_API constexpr explicit __opstate_t(_CvSndr&& __sndr, _Rcvr __rcvr, stream_ref __stream)
-      : __stream_{__stream}
+  _CCCL_API constexpr explicit __opstate_t(_CvSndr&& __sndr, _Rcvr __rcvr, _GetStream __get_stream)
+      : __stream_{__get_stream(__sndr, execution::get_env(__rcvr))}
   {
     NV_IF_TARGET(NV_IS_HOST,
                  (__host_make_state(static_cast<_CvSndr&&>(__sndr), static_cast<_Rcvr&&>(__rcvr));),
@@ -333,7 +333,10 @@ private:
   __variant<__state_t, _CUDA_VSTD::unique_ptr<__managed_box<__state_t>>> __state_{};
 };
 
-template <class _Sndr>
+template <class _Sndr, class _GetStream>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT __sndr_t;
+
+template <class _Sndr, class _GetStream>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __attrs_t
 {
   // This makes sure that when `connect` calls `transform_sender`, it will use the stream
@@ -341,6 +344,15 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __attrs_t
   [[nodiscard]] _CCCL_TRIVIAL_API static constexpr auto query(get_domain_override_t) noexcept -> stream_domain
   {
     return {};
+  }
+
+  // If the child sender knows how to provide a stream, make it available via the stream
+  // adapter's attributes.
+  _CCCL_TEMPLATE(class _GetStream2 = _GetStream)
+  _CCCL_REQUIRES(_CUDA_VSTD::__is_callable_v<_GetStream2, _Sndr, env<>>)
+  [[nodiscard]] _CCCL_API constexpr auto query(get_stream_t) const noexcept -> stream_ref
+  {
+    return __sndr_.__get_stream_(__sndr_.__sndr_, env{});
   }
 
   // This forwards even non-forwarding queries. A stream sender adaptor is not an ordinary
@@ -352,14 +364,14 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __attrs_t
   [[nodiscard]] _CCCL_API constexpr auto query(_Query) const noexcept(__nothrow_queryable_with<env_of_t<_Sndr>, _Query>)
     -> __query_result_t<env_of_t<_Sndr>, _Query>
   {
-    return execution::get_env(*__sndr_).query(_Query{});
+    return execution::get_env(__sndr_.__sndr_).query(_Query{});
   }
 
-  const _Sndr* __sndr_;
+  const __sndr_t<_Sndr, _GetStream>& __sndr_;
 };
 
 // This is the sender adaptor that adapts a non-stream sender to a stream sender.
-template <class _Sndr>
+template <class _Sndr, class _GetStream>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __sndr_t
 {
   using sender_concept = sender_t;
@@ -377,51 +389,37 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __sndr_t
   }
 
   template <class _Rcvr>
-  [[nodiscard]] _CCCL_API constexpr auto connect(_Rcvr __rcvr) && -> __opstate_t<_Sndr, _Rcvr>
+  [[nodiscard]] _CCCL_API constexpr auto connect(_Rcvr __rcvr) && -> __opstate_t<_Sndr, _Rcvr, _GetStream>
   {
-    return __opstate_t<_Sndr, _Rcvr>(static_cast<_Sndr&&>(__sndr_), static_cast<_Rcvr&&>(__rcvr), __stream_);
+    return __opstate_t<_Sndr, _Rcvr, _GetStream>(
+      static_cast<_Sndr&&>(__sndr_), static_cast<_Rcvr&&>(__rcvr), __get_stream_);
   }
 
   template <class _Rcvr>
-  [[nodiscard]] _CCCL_API constexpr auto connect(_Rcvr __rcvr) const& -> __opstate_t<const _Sndr&, _Rcvr>
+  [[nodiscard]] _CCCL_API constexpr auto connect(_Rcvr __rcvr) const& -> __opstate_t<const _Sndr&, _Rcvr, _GetStream>
   {
-    return __opstate_t<const _Sndr&, _Rcvr>(__sndr_, static_cast<_Rcvr&&>(__rcvr), __stream_);
+    return __opstate_t<const _Sndr&, _Rcvr, _GetStream>(__sndr_, static_cast<_Rcvr&&>(__rcvr), __get_stream_);
   }
 
-  [[nodiscard]] _CCCL_API constexpr auto get_env() const noexcept -> __attrs_t<_Sndr>
+  [[nodiscard]] _CCCL_API constexpr auto get_env() const noexcept -> __attrs_t<_Sndr, _GetStream>
   {
-    return __attrs_t<_Sndr>{&__sndr_};
+    return __attrs_t<_Sndr, _GetStream>{*this};
   }
 
-  _CCCL_NO_UNIQUE_ADDRESS __adapted_t<__stream::__tag_of_t<_Sndr>> __tag_;
-  stream_ref __stream_;
+  _CCCL_NO_UNIQUE_ADDRESS __tag_t<__stream::__tag_of_t<_Sndr>> __tag_;
+  _CCCL_NO_UNIQUE_ADDRESS _GetStream __get_stream_;
   _Sndr __sndr_;
 };
 
-template <class _Sndr>
-_CCCL_API constexpr auto __adapt(_Sndr __sndr, [[maybe_unused]] stream_ref __stream)
+template <class _Sndr, class _GetStream>
+_CCCL_API constexpr auto __adapt(_Sndr&& __sndr, _GetStream __get_stream) noexcept(__nothrow_decay_copyable<_Sndr>)
 {
-  // Ensure that we are not trying to adapt a sender that is already adapted.
-  if constexpr (__is_specialization_of_v<_Sndr, __sndr_t>)
-  {
-    return static_cast<_Sndr>(static_cast<_Sndr&&>(__sndr)); // passthrough
-  }
-  else
-  {
-    return __sndr_t<_Sndr>{{}, __stream, static_cast<_Sndr&&>(__sndr)};
-  }
-}
-
-template <class _Sndr>
-_CCCL_API constexpr auto __adapt(_Sndr __sndr)
-{
-  auto __stream = get_stream(execution::get_env(__sndr));
-  return __stream::__adapt(static_cast<_Sndr&&>(__sndr), __stream);
+  return __sndr_t<_Sndr, _GetStream>{{}, __get_stream, static_cast<_Sndr&&>(__sndr)};
 }
 } // namespace __stream
 
-template <class _Sndr>
-inline constexpr size_t structured_binding_size<__stream::__sndr_t<_Sndr>> = 3;
+template <class _Sndr, class _GetStream>
+inline constexpr size_t structured_binding_size<__stream::__sndr_t<_Sndr, _GetStream>> = 3;
 
 } // namespace cuda::experimental::execution
 

--- a/cudax/include/cuda/experimental/__execution/stream/bulk.cuh
+++ b/cudax/include/cuda/experimental/__execution/stream/bulk.cuh
@@ -88,7 +88,7 @@ struct __bulk_chunked_t : execution::__bulk_t<__bulk_chunked_t>
   // domain argument of stream_domain. It adapts a `bulk_chunked` sender to the stream
   // domain.
   template <class _Sndr>
-  _CCCL_API constexpr auto operator()(_Sndr&& __sndr) const
+  _CCCL_API constexpr auto operator()(_Sndr&& __sndr, _CUDA_VSTD::__ignore_t) const
   {
     // Decompose the bulk sender into its components:
     auto& [__tag, __state, __child] = __sndr;
@@ -151,7 +151,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __bulk_unchunked_t : execution::__bulk_t<__
   // domain argument of stream_domain. It adapts a `bulk_unchunked` sender to the stream
   // domain.
   template <class _Sndr>
-  _CCCL_API constexpr auto operator()(_Sndr&& __sndr) const
+  _CCCL_API constexpr auto operator()(_Sndr&& __sndr, _CUDA_VSTD::__ignore_t) const
   {
     // Decompose the bulk sender into its components:
     auto& [__tag, __state, __child] = __sndr;
@@ -185,10 +185,10 @@ struct __bulk_t : execution::__bulk_t<__bulk_t>
   {};
 
   template <class _Sndr>
-  _CCCL_API constexpr auto operator()(_Sndr&& __sndr) const -> decltype(auto)
+  _CCCL_API constexpr auto operator()(_Sndr&& __sndr, _CUDA_VSTD::__ignore_t) const -> decltype(auto)
   {
     // This converts a bulk sender into a bulk_chunked sender, which will then be
-    // further transformed by the __bulk_chunked_t above.
+    // further transformed by __bulk_chunked_t above.
     return bulk.transform_sender(static_cast<_Sndr&&>(__sndr), env{});
   }
 };

--- a/cudax/include/cuda/experimental/__execution/stream/continues_on.cuh
+++ b/cudax/include/cuda/experimental/__execution/stream/continues_on.cuh
@@ -43,9 +43,9 @@ namespace cuda::experimental::execution
 {
 namespace __stream
 {
-// Transition from the GPU to the CPU domain
 struct __continues_on_t
 {
+  // Transition from the GPU to the CPU domain
   template <class _Rcvr>
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __rcvr_t
   {
@@ -82,9 +82,9 @@ struct __continues_on_t
     using operation_state_concept = operation_state_t;
     using __env_t                 = __fwd_env_t<env_of_t<_Rcvr>>;
 
-    _CCCL_API constexpr explicit __opstate_t(_Sndr&& __sndr, _Rcvr __rcvr, stream_ref __stream)
+    _CCCL_API constexpr explicit __opstate_t(_Sndr&& __sndr, _Rcvr __rcvr)
         : __rcvr_(static_cast<_Rcvr&&>(__rcvr))
-        , __stream_(__stream)
+        , __stream_(__get_stream(__sndr, execution::get_env(__rcvr)))
         , __opstate_(execution::connect(static_cast<_Sndr&&>(__sndr), __rcvr_t<_Rcvr>{__rcvr_}))
     {}
 
@@ -127,13 +127,13 @@ struct __continues_on_t
     template <class _Rcvr>
     [[nodiscard]] _CCCL_API constexpr auto connect(_Rcvr __rcvr) && -> __opstate_t<_Sndr, _Rcvr>
     {
-      return __opstate_t<_Sndr, _Rcvr>{static_cast<_Sndr&&>(__sndr_), static_cast<_Rcvr&&>(__rcvr), __stream_};
+      return __opstate_t<_Sndr, _Rcvr>{static_cast<_Sndr&&>(__sndr_), static_cast<_Rcvr&&>(__rcvr)};
     }
 
     template <class _Rcvr>
     [[nodiscard]] _CCCL_API constexpr auto connect(_Rcvr __rcvr) const& -> __opstate_t<const _Sndr&, _Rcvr>
     {
-      return __opstate_t<const _Sndr&, _Rcvr>{__sndr_, static_cast<_Rcvr&&>(__rcvr), __stream_};
+      return __opstate_t<const _Sndr&, _Rcvr>{__sndr_, static_cast<_Rcvr&&>(__rcvr)};
     }
 
     [[nodiscard]] _CCCL_API constexpr auto get_env() const noexcept -> env_of_t<_Sndr>
@@ -142,19 +142,29 @@ struct __continues_on_t
     }
 
     _CCCL_NO_UNIQUE_ADDRESS __thunk_t __tag_;
-    stream_ref __stream_;
+    _CUDA_VSTD::__ignore_t __ignore_;
     _Sndr __sndr_;
   };
 
-  template <class _Sndr, class _Env>
-  [[nodiscard]] _CCCL_API auto operator()(_Sndr&& __sndr, const _Env&) const -> decltype(auto)
+  template <class _Sndr>
+  [[nodiscard]] _CCCL_API auto operator()(_Sndr&& __sndr, _CUDA_VSTD::__ignore_t) const
   {
     auto& [__tag, __sched, __child] = __sndr;
-    static_assert(__is_specialization_of_v<decltype(__child), __stream::__sndr_t>);
-    using __child_t = _CUDA_VSTD::__copy_cvref_t<_Sndr, decltype(__child)>;
+    using __child_t                 = _CUDA_VSTD::__copy_cvref_t<_Sndr, decltype(__child)>;
 
-    auto __stream = get_stream(get_env(__child));
-    return execution::schedule_from(__sched, __sndr_t<__child_t>{{}, __stream, static_cast<__child_t&&>(__child)});
+    // If the child sender has not already been adapted to be a stream sender,
+    // we adapt it now.
+    if constexpr (!__is_specialization_of_v<decltype(__child), __stream::__sndr_t>)
+    {
+      auto __adapted_sndr    = __stream::__adapt(static_cast<__child_t&&>(__child));
+      using __adapted_sndr_t = decltype(__adapted_sndr);
+      return execution::schedule_from(
+        __sched, __sndr_t<__adapted_sndr_t>{{}, {}, static_cast<__adapted_sndr_t&&>(__adapted_sndr)});
+    }
+    else
+    {
+      return execution::schedule_from(__sched, __sndr_t<decltype(__child)>{{}, {}, static_cast<__child_t&&>(__child)});
+    }
   }
 };
 } // namespace __stream
@@ -164,7 +174,7 @@ struct stream_domain::__apply_t<continues_on_t> : __stream::__continues_on_t
 {};
 
 template <class _Sndr>
-inline constexpr size_t structured_binding_size<stream_domain::__apply_t<continues_on_t>::__sndr_t<_Sndr>> = 3;
+inline constexpr size_t structured_binding_size<__stream::__continues_on_t::__sndr_t<_Sndr>> = 3;
 } // namespace cuda::experimental::execution
 
 #include <cuda/experimental/__execution/epilogue.cuh>

--- a/cudax/include/cuda/experimental/__execution/stream/domain.cuh
+++ b/cudax/include/cuda/experimental/__execution/stream/domain.cuh
@@ -21,10 +21,15 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/__stream/get_stream.h>
 #include <cuda/std/__concepts/concept_macros.h>
+#include <cuda/std/__functional/compose.h>
 #include <cuda/std/__type_traits/is_callable.h>
 
 #include <cuda/experimental/__execution/domain.cuh>
+#include <cuda/experimental/__execution/queries.cuh>
+#include <cuda/experimental/__execution/type_traits.cuh>
+#include <cuda/experimental/__execution/utility.cuh>
 #include <cuda/experimental/__stream/stream_ref.cuh>
 
 #include <cuda/experimental/__execution/prologue.cuh>
@@ -48,17 +53,48 @@ _CCCL_API auto __tag_of(const _Sndr& __sndr) -> tag_of_t<_Sndr>;
 template <class _Sndr>
 using __tag_of_t = decltype(__stream::__tag_of(declval<_Sndr>()));
 
-template <class _Tag>
 struct __adapted_t
 {};
 
-// Forward declaration of the __adapt function
-template <class _Sndr>
-_CCCL_API constexpr auto __adapt(_Sndr, stream_ref);
+template <class _Sndr, class _GetStream>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT __sndr_t;
 
-template <class _Sndr>
-_CCCL_API constexpr auto __adapt(_Sndr);
+_CCCL_GLOBAL_CONSTANT auto __get_stream_from_attrs =
+  __call_first{get_stream, _CUDA_VSTD::__compose(get_stream, get_completion_scheduler<set_value_t>)};
+
+_CCCL_GLOBAL_CONSTANT auto __get_stream_from_env =
+  __call_first{get_stream, _CUDA_VSTD::__compose(get_stream, get_scheduler)};
+
+using __get_stream_from_attrs_t = decltype(__get_stream_from_attrs);
+using __get_stream_from_env_t   = decltype(__get_stream_from_env);
+
+// Get the stream either the sender's attributes or from the receiver's environment.
+struct __get_stream_fn
+{
+  _CCCL_TEMPLATE(class _Sndr, class _Env)
+  _CCCL_REQUIRES((_CUDA_VSTD::__is_callable_v<__get_stream_from_attrs_t, env_of_t<_Sndr>>
+                  || _CUDA_VSTD::__is_callable_v<__get_stream_from_env_t, _Env>) )
+  _CCCL_API constexpr auto operator()(const _Sndr& __sndr, const _Env& __env) const noexcept -> stream_ref
+  {
+    if constexpr (_CUDA_VSTD::__is_callable_v<__get_stream_from_attrs_t, env_of_t<_Sndr>>)
+    {
+      // If the sender's attributes have a stream, use it.
+      return __get_stream_from_attrs(execution::get_env(__sndr));
+    }
+    else
+    {
+      // Otherwise, try to get the stream from the receiver's environment.
+      return __get_stream_from_env(__env);
+    }
+  }
+};
+
+// Forward declaration of the __adapt function
+template <class _Sndr, class _GetStream = __get_stream_fn>
+_CCCL_API constexpr auto __adapt(_Sndr&& __sndr, _GetStream = {}) noexcept(__nothrow_decay_copyable<_Sndr>);
 } // namespace __stream
+
+_CCCL_GLOBAL_CONSTANT auto __get_stream = __stream::__get_stream_fn{};
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // stream domain
@@ -67,8 +103,13 @@ struct stream_domain
   _CUDAX_SEMI_PRIVATE :
   struct __apply_adapt_t
   {
+    // This is the default apply function that adapts a sender to a stream sender.
+    // The constraint prevents this function from applying an adaptor to a sender
+    // that has already been adapted. The __stream::__adapted_t query is present
+    // only on receivers that come from an adapted sender.
     template <class _Sndr>
-    _CCCL_API constexpr auto operator()(_Sndr&& __sndr) const
+    _CCCL_API constexpr auto operator()(_Sndr&& __sndr, _CUDA_VSTD::__ignore_t) const
+      noexcept(__nothrow_decay_copyable<_Sndr>)
     {
       return __stream::__adapt(static_cast<_Sndr&&>(__sndr));
     }
@@ -77,7 +118,8 @@ struct stream_domain
   struct __apply_passthru_t
   {
     template <class _Sndr>
-    _CCCL_API constexpr auto operator()(_Sndr&& __sndr, _CUDA_VSTD::__ignore_t = {}) const -> _Sndr
+    _CCCL_API constexpr auto operator()(_Sndr&& __sndr, _CUDA_VSTD::__ignore_t) const noexcept(__nothrow_movable<_Sndr>)
+      -> _Sndr
     {
       return static_cast<_Sndr&&>(__sndr);
     }
@@ -87,24 +129,56 @@ struct stream_domain
   struct __apply_t : __apply_adapt_t
   {};
 
+  template <class _Sndr, class _Env>
+  _CCCL_API static constexpr auto __transform_strategy() noexcept
+  {
+    if constexpr (__queryable_with<_Env, __stream::__adapted_t>)
+    {
+      // The __stream::__adapted_t query is present only on receivers that come from an
+      // adapted sender. Therefore, _Sndr has already been adapted. Pass it through as is.
+      return __apply_passthru_t{};
+    }
+    else if constexpr (sender_for<_Sndr>)
+    {
+      // The sender has a tag type. Use the tag to determine the transformation to apply.
+      return __apply_t<tag_of_t<_Sndr>>{};
+    }
+    else
+    {
+      // Otherwise, _Sndr is an unknown sender type that has not yet been adapted to
+      // be a stream sender. Adapt it now.
+      return __apply_adapt_t{};
+    }
+  }
+
+  template <class _Sndr, class _Env>
+  using __transform_strategy_t = decltype(__transform_strategy<_Sndr, _Env>());
+
 public:
   _CCCL_TEMPLATE(class _Tag, class _Sndr, class... _Args)
   _CCCL_REQUIRES(_CUDA_VSTD::__is_callable_v<__apply_t<_Tag>, _Sndr, _Args...>)
-  _CCCL_TRIVIAL_HOST_API static constexpr auto apply_sender(_Tag, _Sndr&& __sndr, _Args&&... __args) noexcept(
-    _CUDA_VSTD::__is_nothrow_callable_v<__apply_t<_Tag>, _Sndr, _Args...>)
+  _CCCL_TRIVIAL_HOST_API static constexpr auto
+  apply_sender(_Tag, _Sndr&& __sndr, _Args&&... __args) noexcept(__nothrow_callable<__apply_t<_Tag>, _Sndr, _Args...>)
     -> _CUDA_VSTD::__call_result_t<__apply_t<_Tag>, _Sndr, _Args...>
   {
     return __apply_t<_Tag>{}(static_cast<_Sndr&&>(__sndr), static_cast<_Args&&>(__args)...);
   }
 
-  _CCCL_TEMPLATE(class _Sndr, class... _Env)
-  _CCCL_REQUIRES(_CUDA_VSTD::__is_callable_v<__apply_t<tag_of_t<_Sndr>>, _Sndr, const _Env&...>)
-  _CCCL_TRIVIAL_API static constexpr auto transform_sender(_Sndr&& __sndr, const _Env&... __env) noexcept(
-    _CUDA_VSTD::__is_nothrow_callable_v<__apply_t<tag_of_t<_Sndr>>, _Sndr, const _Env&...>) -> decltype(auto)
+  _CCCL_TEMPLATE(class _Sndr, class _Env)
+  _CCCL_REQUIRES(_CUDA_VSTD::__is_callable_v<__transform_strategy_t<_Sndr, _Env>, _Sndr, const _Env&>)
+  _CCCL_TRIVIAL_API static constexpr auto transform_sender(_Sndr&& __sndr, const _Env& __env) noexcept(
+    __nothrow_callable<__transform_strategy_t<_Sndr, _Env>, _Sndr, const _Env&>)
+    -> _CUDA_VSTD::__call_result_t<__transform_strategy_t<_Sndr, _Env>, _Sndr, const _Env&>
   {
-    return __apply_t<tag_of_t<_Sndr>>{}(static_cast<_Sndr&&>(__sndr), __env...);
+    return __transform_strategy_t<_Sndr, _Env>{}(static_cast<_Sndr&&>(__sndr), __env);
   }
 };
+
+// If a sender has already been adapted to a stream sender, it will have a tag that is a specialization of
+// __stream::__tag_t. In that case, we don't need to adapt it again, and we can just pass it through.
+template <class _Tag>
+struct stream_domain::__apply_t<__stream::__tag_t<_Tag>> : stream_domain::__apply_passthru_t
+{};
 
 } // namespace cuda::experimental::execution
 

--- a/cudax/include/cuda/experimental/__execution/stream/starts_on.cuh
+++ b/cudax/include/cuda/experimental/__execution/stream/starts_on.cuh
@@ -1,0 +1,104 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __CUDAX_EXECUTION_STREAM_STARTS_ON
+#define __CUDAX_EXECUTION_STREAM_STARTS_ON
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/__stream/get_stream.h>
+#include <cuda/std/__functional/compose.h>
+#include <cuda/std/__tuple_dir/ignore.h>
+#include <cuda/std/__utility/forward_like.h>
+
+#include <cuda/experimental/__execution/env.cuh>
+#include <cuda/experimental/__execution/starts_on.cuh>
+#include <cuda/experimental/__execution/stream/adaptor.cuh>
+#include <cuda/experimental/__execution/stream/domain.cuh>
+#include <cuda/experimental/__execution/write_env.cuh>
+
+#include <cuda/experimental/__execution/prologue.cuh>
+
+namespace cuda::experimental::execution
+{
+namespace __stream
+{
+struct __starts_on_t
+{
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __get_stream_fn
+  {
+    template <class _Sndr>
+    [[nodiscard]] _CCCL_API auto operator()(const _Sndr& __sndr, _CUDA_VSTD::__ignore_t) const
+    {
+      // __sndr is a write_env sender (see __mk_sndr_base below), which contains an
+      // environment that contains the stream scheduler, from which we can obtain the
+      // stream.
+      auto& [__ign0, __env, __ign1] = __sndr;
+      return cuda::get_stream(get_scheduler(__env));
+    }
+  };
+
+  template <class _Sch, class _Sndr>
+  [[nodiscard]] static _CCCL_API constexpr auto __mk_sndr_base(_Sch __sch, _Sndr&& __sndr)
+  {
+    // This is the implementation of the starts_on sender for the stream domain. _Sndr
+    // here is the child of the starts_on sender, and _Sch is the stream scheduler. We use
+    // write_env to let _Sndr and its children know that they are running on the stream
+    // scheduler. We construct the adaptor with a __get_stream_fn that knows how to obtain
+    // the stream from the write_env sender.
+    return __stream::__adapt(write_env(static_cast<_Sndr&&>(__sndr), __sch_env_t{__sch}), __get_stream_fn{});
+  }
+
+  template <class _Sch, class _Sndr>
+  using __sndr_base_t = decltype(__starts_on_t::__mk_sndr_base(declval<_Sch>(), declval<_Sndr>()));
+
+  template <class _Sch, class _Sndr>
+  using __with_sch_t = _CUDA_VSTD::__call_result_t<write_env_t, _Sndr, __sch_env_t<_Sch>>;
+
+  // Wrap the sender returned from __mk_sndr_base in a type that hides the complexity of
+  // the sender's type name. This results in more readable diagnostics.
+  template <class _Sch, class _Sndr>
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __sndr_t : __stream::__sndr_t<__with_sch_t<_Sch, _Sndr>, __get_stream_fn>
+  {
+    _CCCL_API explicit constexpr __sndr_t(_Sch __sch, _Sndr __sndr)
+        : __stream::__sndr_t<__with_sch_t<_Sch, _Sndr>, __get_stream_fn>{
+            {}, {}, write_env(static_cast<_Sndr&&>(__sndr), __sch_env_t{__sch})}
+    {}
+  };
+
+  // The connect cpo calls transform_sender, which is directed here for starts_on senders.
+  // It returns a custom sender that knows how to start the child sender on the specified
+  // stream.
+  template <class _Sndr>
+  [[nodiscard]] _CCCL_API auto operator()(_Sndr&& __sndr, _CUDA_VSTD::__ignore_t) const
+  {
+    auto& [__ign0, __sch, __child] = __sndr;
+    return __sndr_t{__sch, _CUDA_VSTD::forward_like<_Sndr>(__child)};
+  }
+};
+} // namespace __stream
+
+// Start work on the GPU
+template <>
+struct stream_domain::__apply_t<starts_on_t> : __stream::__starts_on_t
+{};
+} // namespace cuda::experimental::execution
+
+#include <cuda/experimental/__execution/epilogue.cuh>
+
+#endif // __CUDAX_EXECUTION_STREAM_STARTS_ON

--- a/cudax/include/cuda/experimental/__execution/stream_context.cuh
+++ b/cudax/include/cuda/experimental/__execution/stream_context.cuh
@@ -30,6 +30,7 @@
 #include <cuda/experimental/__execution/stream/launch.cuh>
 #include <cuda/experimental/__execution/stream/let_value.cuh>
 #include <cuda/experimental/__execution/stream/sequence.cuh>
+#include <cuda/experimental/__execution/stream/starts_on.cuh>
 #include <cuda/experimental/__execution/stream/sync_wait.cuh>
 // IWYU pragma: end_exports
 

--- a/cudax/include/cuda/experimental/__execution/then.cuh
+++ b/cudax/include/cuda/experimental/__execution/then.cuh
@@ -41,6 +41,9 @@
 
 #include <cuda/experimental/__execution/prologue.cuh>
 
+_CCCL_DIAG_PUSH
+_CCCL_DIAG_SUPPRESS_MSVC(4702) // warning C4702: unreachable code
+
 namespace cuda::experimental::execution
 {
 namespace __upon
@@ -118,6 +121,7 @@ struct __upon_t
         }
         else
         {
+          // msvc warns that this is unreachable code, but it is reachable.
           execution::set_value(static_cast<_Rcvr&&>(__state_->__rcvr_),
                                static_cast<_Fn&&>(__state_->__fn_)(static_cast<_Ts&&>(__ts)...));
         }
@@ -396,6 +400,8 @@ _CCCL_GLOBAL_CONSTANT auto upon_error   = upon_error_t{};
 _CCCL_GLOBAL_CONSTANT auto upon_stopped = upon_stopped_t{};
 
 } // namespace cuda::experimental::execution
+
+_CCCL_DIAG_POP
 
 #include <cuda/experimental/__execution/epilogue.cuh>
 

--- a/cudax/include/cuda/experimental/__execution/write_env.cuh
+++ b/cudax/include/cuda/experimental/__execution/write_env.cuh
@@ -37,7 +37,7 @@
 
 namespace cuda::experimental::execution
 {
-struct _CCCL_TYPE_VISIBILITY_DEFAULT __write_env_t
+struct _CCCL_TYPE_VISIBILITY_DEFAULT write_env_t
 {
   _CUDAX_SEMI_PRIVATE :
   template <class _Rcvr, class _Sndr, class _Env>
@@ -72,7 +72,7 @@ public:
 };
 
 template <class _Sndr, class _Env>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT __write_env_t::__sndr_t
+struct _CCCL_TYPE_VISIBILITY_DEFAULT write_env_t::__sndr_t
 {
   using sender_concept _CCCL_NODEBUG_ALIAS = sender_t;
 
@@ -101,13 +101,13 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __write_env_t::__sndr_t
     return __fwd_env(execution::get_env(__sndr_));
   }
 
-  _CCCL_NO_UNIQUE_ADDRESS __write_env_t __tag_;
+  _CCCL_NO_UNIQUE_ADDRESS write_env_t __tag_;
   _Env __env_;
   _Sndr __sndr_;
 };
 
 template <class _Sndr, class _Env>
-_CCCL_TRIVIAL_API constexpr auto __write_env_t::operator()(_Sndr __sndr, _Env __env) const
+_CCCL_TRIVIAL_API constexpr auto write_env_t::operator()(_Sndr __sndr, _Env __env) const
 {
   // The write_env algorithm is not customizable by design; hence, we don't dispatch to
   // transform_sender like we do for other algorithms.
@@ -115,9 +115,9 @@ _CCCL_TRIVIAL_API constexpr auto __write_env_t::operator()(_Sndr __sndr, _Env __
 }
 
 template <class _Sndr, class _Env>
-inline constexpr size_t structured_binding_size<__write_env_t::__sndr_t<_Sndr, _Env>> = 3;
+inline constexpr size_t structured_binding_size<write_env_t::__sndr_t<_Sndr, _Env>> = 3;
 
-_CCCL_GLOBAL_CONSTANT __write_env_t write_env{};
+_CCCL_GLOBAL_CONSTANT write_env_t write_env{};
 } // namespace cuda::experimental::execution
 
 #include <cuda/experimental/__execution/epilogue.cuh>


### PR DESCRIPTION
## Description

the `starts_on` algorithm must be customized for the stream scheduler. the default implementation of `starts_on` would try to start the child operation from the device. that's bad because starting stream senders involves launching kernels, and that cannot be done from device.

this pr does a number of things:

* it changes the stream domain to use lazy customization of sender algorithms exclusively.
* it provides a stream domain transform for `starts_on` senders that correctly starts work on the requested stream.
* it looks both in the sender's attributes and in the receiver's environment when querying for the current stream.



## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
