### PR TITLE
avoid return type deduction in the execution queries

### DIFF
--- a/cudax/include/cuda/experimental/__execution/domain.cuh
+++ b/cudax/include/cuda/experimental/__execution/domain.cuh
@@ -22,6 +22,7 @@
 #endif // no system header
 
 #include <cuda/std/__execution/env.h>
+#include <cuda/std/__functional/compose.h>
 #include <cuda/std/__tuple_dir/ignore.h>
 #include <cuda/std/__type_traits/decay.h>
 #include <cuda/std/__type_traits/is_callable.h>
@@ -52,8 +53,16 @@ using _CUDA_STD_EXEC::__query_result_t;
 using _CUDA_STD_EXEC::__queryable_with;
 
 using _CUDA_STD_EXEC::__query_or;
-using _CUDA_STD_EXEC::__query_result_or_t;
+// TODO: Remove this alias once https://github.com/NVIDIA/cccl/pull/5109 is merged.
+// using _CUDA_STD_EXEC::__query_result_or_t;
+template <class _Env, class _Query, class _Default>
+using __query_result_or_t _CCCL_NODEBUG_ALIAS =
+  decltype(__query_or(_CUDA_VSTD::declval<_Env>(), _CUDA_VSTD::declval<_Query>(), _CUDA_VSTD::declval<_Default>()));
 // NOLINTEND(misc-unused-using-decls)
+
+template <class _Env, class _Query, bool _Default>
+_CCCL_CONCEPT __nothrow_queryable_with_or =
+  bool(__queryable_with<_Env, _Query> ? __nothrow_queryable_with<_Env, _Query> : _Default);
 
 template <class _DomainOrTag, class... _Args>
 using __apply_sender_result_t _CCCL_NODEBUG_ALIAS = decltype(_DomainOrTag{}.apply_sender(declval<_Args>()...));
@@ -138,16 +147,10 @@ struct get_domain_t
 {
   _CCCL_EXEC_CHECK_DISABLE
   template <class _Env>
-  [[nodiscard]] _CCCL_API constexpr auto operator()(const _Env&) const noexcept
+  [[nodiscard]] _CCCL_TRIVIAL_API constexpr auto operator()(const _Env&) const noexcept
     -> _CUDA_VSTD::decay_t<__query_result_t<_Env, get_domain_t>>
   {
     return {};
-  }
-
-  // NOT TO SPEC: return default_domain if the environment does not provide a domain.
-  [[nodiscard]] _CCCL_API constexpr auto operator()(_CUDA_VSTD::__ignore_t) const noexcept
-  {
-    return default_domain{};
   }
 
   _CCCL_TRIVIAL_API static constexpr auto query(forwarding_query_t) noexcept
@@ -163,13 +166,13 @@ struct get_domain_override_t
 {
   _CCCL_EXEC_CHECK_DISABLE
   template <class _Env>
-  [[nodiscard]] _CCCL_API constexpr auto operator()(const _Env&) const noexcept
+  [[nodiscard]] _CCCL_TRIVIAL_API constexpr auto operator()(const _Env&) const noexcept
     -> _CUDA_VSTD::decay_t<__query_result_t<_Env, get_domain_override_t>>
   {
     return {};
   }
 
-  [[nodiscard]] static _CCCL_API constexpr auto query(forwarding_query_t) noexcept -> bool
+  [[nodiscard]] _CCCL_TRIVIAL_API static constexpr auto query(forwarding_query_t) noexcept -> bool
   {
     return false;
   }
@@ -179,13 +182,14 @@ _CCCL_GLOBAL_CONSTANT get_domain_override_t get_domain_override{};
 
 namespace __detail
 {
-template <class _Env, class _GetScheduler, class _Default>
-_CCCL_API auto __domain_of_fn(const _Env& __env, _GetScheduler, _Default) noexcept -> decltype(__query_or(
-  __env, get_domain, __query_or(__query_or(__env, _GetScheduler{}, __nil{}), get_domain, _Default{})));
-
+// Returns the type of the first expression that is well-formed:
+// - get_domain(env)
+// - get_domain(_GetScheduler{}(env))
+// - _Default{}
 template <class _Env, class _GetScheduler, class _Default = default_domain>
-using __domain_of_t =
-  decltype(__detail::__domain_of_fn(declval<_Env>(), declval<_GetScheduler>(), declval<_Default>()));
+using __domain_of_t = _CUDA_VSTD::decay_t<_CUDA_VSTD::__call_result_t<
+  __first_callable<get_domain_t, _CUDA_VSTD::__compose_t<get_domain_t, _GetScheduler>, __always<_Default>>,
+  _Env>>;
 
 template <class _Sndr, class _Default = default_domain>
 _CCCL_TRIVIAL_API constexpr auto __get_domain_early() noexcept
@@ -196,19 +200,15 @@ _CCCL_TRIVIAL_API constexpr auto __get_domain_early() noexcept
 template <class _Sndr, class _Env, class _Default = default_domain>
 _CCCL_TRIVIAL_API constexpr auto __get_domain_late() noexcept
 {
-  using __env_domain_t _CCCL_NODEBUG_ALIAS = __domain_of_t<_Env, get_scheduler_t, _Default>;
-
-  // If the sender is a continues_on or schedule_from sender, we check with the sender for
-  // its domain. If it does not provide one, we fall back to using the domain from the
-  // receiver's environment.
+  // Check if the sender's attributes has a get_domain_override query. If so, use that.
+  // Otherwise, we fall back to using the domain from the receiver's environment.
   if constexpr (__queryable_with<env_of_t<_Sndr>, get_domain_override_t>)
   {
-    using __late_domain_t _CCCL_NODEBUG_ALIAS = __query_result_t<env_of_t<_Sndr>, get_domain_override_t>;
-    return _CUDA_VSTD::_If<_CUDA_VSTD::is_same_v<__late_domain_t, __nil>, __env_domain_t, __late_domain_t>{};
+    return _CUDA_VSTD::decay_t<__query_result_t<env_of_t<_Sndr>, get_domain_override_t>>{};
   }
   else
   {
-    return __env_domain_t{};
+    return __domain_of_t<_Env, get_scheduler_t, _Default>{};
   }
 }
 } // namespace __detail

--- a/cudax/include/cuda/experimental/__execution/env.cuh
+++ b/cudax/include/cuda/experimental/__execution/env.cuh
@@ -180,7 +180,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __sch_env_t
 
   [[nodiscard]] _CCCL_API static constexpr auto query(get_domain_t) noexcept
   {
-    return _CUDA_VSTD::__call_result_t<get_domain_t, _Sch>{};
+    return __query_result_or_t<_Sch, get_domain_t, default_domain>{};
   }
 
   _Sch __sch_;

--- a/cudax/include/cuda/experimental/__execution/on.cuh
+++ b/cudax/include/cuda/experimental/__execution/on.cuh
@@ -193,7 +193,8 @@ public:
   _CCCL_REQUIRES(__is_sender<_Sndr>)
   _CCCL_TRIVIAL_API constexpr auto operator()(_Sch __sch, _Sndr __sndr) const
   {
-    return execution::transform_sender(get_domain(__sch), __sndr_t<_Sch, _Sndr>{{}, __sch, __sndr});
+    using __domain_t = __query_result_or_t<_Sch, get_domain_t, default_domain>;
+    return execution::transform_sender(__domain_t{}, __sndr_t<_Sch, _Sndr>{{}, __sch, __sndr});
   }
 
   _CCCL_TEMPLATE(class _Sch, class _Closure)

--- a/cudax/include/cuda/experimental/__execution/schedule_from.cuh
+++ b/cudax/include/cuda/experimental/__execution/schedule_from.cuh
@@ -343,7 +343,8 @@ public:
     static_assert(__is_sender<_Sndr>);
     static_assert(__is_scheduler<_Sch>);
     // schedule_from always dispatches based on the domain of the scheduler
-    return transform_sender(get_domain(__sch), __sndr_t<_Sch, _Sndr>{{{}, __sch, static_cast<_Sndr&&>(__sndr)}});
+    using __domain_t = __query_result_or_t<_Sch, get_domain_t, default_domain>;
+    return transform_sender(__domain_t{}, __sndr_t<_Sch, _Sndr>{{{}, __sch, static_cast<_Sndr&&>(__sndr)}});
   }
 };
 

--- a/cudax/include/cuda/experimental/__execution/starts_on.cuh
+++ b/cudax/include/cuda/experimental/__execution/starts_on.cuh
@@ -151,7 +151,7 @@ struct starts_on_t
 
     [[nodiscard]] _CCCL_API static constexpr auto query(get_domain_t) noexcept
     {
-      return _CUDA_VSTD::__call_result_t<get_domain_t, _Sch>{};
+      return __query_result_or_t<_Sch, get_domain_t, default_domain>{};
     }
 
     _CCCL_TEMPLATE(class _Query)
@@ -318,8 +318,9 @@ template <class _Sch, class _Sndr>
 [[nodiscard]] _CCCL_TRIVIAL_API constexpr auto starts_on_t::operator()(_Sch __sch, _Sndr __sndr) const
 {
   using __sndr_t _CCCL_NODEBUG_ALIAS = starts_on_t::__sndr_t<_Sch, _Sndr>;
+  using __domain_t                   = __query_result_or_t<_Sch, get_domain_t, default_domain>;
   return execution::transform_sender(
-    execution::get_domain(__sch), __sndr_t{{}, static_cast<_Sch&&>(__sch), static_cast<_Sndr&&>(__sndr)});
+    __domain_t{}, __sndr_t{{}, static_cast<_Sch&&>(__sch), static_cast<_Sndr&&>(__sndr)});
 }
 
 template <class _Sch, class _Sndr>

--- a/cudax/include/cuda/experimental/__execution/stream/domain.cuh
+++ b/cudax/include/cuda/experimental/__execution/stream/domain.cuh
@@ -60,10 +60,10 @@ template <class _Sndr, class _GetStream>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __sndr_t;
 
 _CCCL_GLOBAL_CONSTANT auto __get_stream_from_attrs =
-  __call_first{get_stream, _CUDA_VSTD::__compose(get_stream, get_completion_scheduler<set_value_t>)};
+  __first_callable{get_stream, _CUDA_VSTD::__compose(get_stream, get_completion_scheduler<set_value_t>)};
 
 _CCCL_GLOBAL_CONSTANT auto __get_stream_from_env =
-  __call_first{get_stream, _CUDA_VSTD::__compose(get_stream, get_scheduler)};
+  __first_callable{get_stream, _CUDA_VSTD::__compose(get_stream, get_scheduler)};
 
 using __get_stream_from_attrs_t = decltype(__get_stream_from_attrs);
 using __get_stream_from_env_t   = decltype(__get_stream_from_env);

--- a/cudax/include/cuda/experimental/__execution/utility.cuh
+++ b/cudax/include/cuda/experimental/__execution/utility.cuh
@@ -28,6 +28,7 @@
 #include <cuda/std/__new/bad_alloc.h>
 #include <cuda/std/__tuple_dir/ignore.h>
 #include <cuda/std/__type_traits/decay.h>
+#include <cuda/std/__type_traits/is_callable.h>
 #include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/__type_traits/type_list.h>
 #include <cuda/std/__utility/pod_tuple.h>
@@ -195,41 +196,80 @@ private:
   ~__managed_box() = default;
 };
 
-// Given a list of functions and a set of arguments, apply the first function that is
-// callable with those arguments.
+//! \brief A callable that wraps a set of functions and calls the first one that is
+//! callable with a given set of arguments.
 template <class... _Fns>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT __call_first
+struct _CCCL_TYPE_VISIBILITY_DEFAULT __first_callable
 {
-  template <class... _Args>
-  [[nodiscard]] _CCCL_TRIVIAL_API static constexpr auto __get_1st(const __call_first& __self) noexcept -> decltype(auto)
+private:
+  //! \brief Returns the first function that is callable with a given set of arguments.
+  template <class... _Args, class _Self>
+  [[nodiscard]] _CCCL_TRIVIAL_API static constexpr auto __get_1st(_Self&& __self) noexcept -> decltype(auto)
   {
     // NOLINTNEXTLINE (modernize-avoid-c-arrays)
-    constexpr bool __flags[] = {_CUDA_VSTD::__is_callable_v<const _Fns&, _Args...>..., false};
-    constexpr size_t __idx   = __find_pos(__flags, __flags + sizeof...(_Fns));
+    constexpr bool __flags[] = {
+      _CUDA_VSTD::__is_callable_v<_CUDA_VSTD::__copy_cvref_t<_Self, _Fns>, _Args...>..., false};
+    constexpr size_t __idx = execution::__find_pos(__flags, __flags + sizeof...(_Fns));
     if constexpr (__idx != __npos)
     {
-      return _CUDA_VSTD::__get<__idx>(__self.__fns_);
+      return _CUDA_VSTD::__get<__idx>(static_cast<_Self&&>(__self).__fns_);
     }
   }
 
-  template <class... _Args>
-  using __1st_fn_t _CCCL_NODEBUG_ALIAS = decltype(__call_first::__get_1st<_Args...>(declval<const __call_first&>()));
+  //! \brief Alias for the type of the first function that is callable with a given set of arguments.
+  template <class _Self, class... _Args>
+  using __1st_fn_t _CCCL_NODEBUG_ALIAS = decltype(__first_callable::__get_1st<_Args...>(declval<_Self>()));
 
+public:
+  //! \brief Calls the first function that is callable with a given set of arguments.
   _CCCL_EXEC_CHECK_DISABLE
-  _CCCL_TEMPLATE(class... _Args)
-  _CCCL_REQUIRES(_CUDA_VSTD::__is_callable_v<__1st_fn_t<_Args...>, _Args...>)
-  _CCCL_TRIVIAL_API constexpr auto operator()(_Args&&... __args) const
-    noexcept(_CUDA_VSTD::__is_nothrow_callable_v<__1st_fn_t<_Args...>, _Args...>)
-      -> _CUDA_VSTD::__call_result_t<__1st_fn_t<_Args...>, _Args...>
+  template <class... _Args>
+  _CCCL_TRIVIAL_API constexpr auto
+  operator()(_Args&&... __args) && noexcept(__nothrow_callable<__1st_fn_t<__first_callable, _Args...>, _Args...>)
+    -> _CUDA_VSTD::__call_result_t<__1st_fn_t<__first_callable, _Args...>, _Args...>
   {
-    return __call_first::__get_1st<_Args...>(*this)(static_cast<_Args&&>(__args)...);
+    return __first_callable::__get_1st<_Args...>(static_cast<__first_callable&&>(*this))(
+      static_cast<_Args&&>(__args)...);
+  }
+
+  //! \overload
+  _CCCL_EXEC_CHECK_DISABLE
+  template <class... _Args>
+  _CCCL_TRIVIAL_API constexpr auto operator()(_Args&&... __args) const& noexcept(
+    __nothrow_callable<__1st_fn_t<__first_callable const&, _Args...>, _Args...>)
+    -> _CUDA_VSTD::__call_result_t<__1st_fn_t<__first_callable const&, _Args...>, _Args...>
+  {
+    return __first_callable::__get_1st<_Args...>(*this)(static_cast<_Args&&>(__args)...);
   }
 
   _CUDA_VSTD::__tuple<_Fns...> __fns_;
 };
 
 template <class... _Fns>
-_CCCL_HOST_DEVICE __call_first(_Fns...) -> __call_first<_Fns...>;
+_CCCL_HOST_DEVICE __first_callable(_Fns...) -> __first_callable<_Fns...>;
+
+//! \brief A callable that always return a value of type _Ty, regardless of the arguments
+//! passed to it.
+template <class _Ty>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT __always
+{
+  template <class... _Args>
+  [[nodiscard]] _CCCL_TRIVIAL_API constexpr auto operator()(_Args&&...) && noexcept -> _Ty&&
+  {
+    return static_cast<_Ty&&>(__value);
+  }
+
+  template <class... _Args>
+  [[nodiscard]] _CCCL_TRIVIAL_API constexpr auto operator()(_Args&&...) const& noexcept -> _Ty const&
+  {
+    return __value;
+  }
+
+  _CCCL_NO_UNIQUE_ADDRESS _Ty __value{};
+};
+
+template <class _Ty>
+_CCCL_HOST_DEVICE __always(_Ty) -> __always<_Ty>;
 
 _CCCL_DIAG_PUSH
 _CCCL_DIAG_SUPPRESS_GCC("-Wnon-template-friend")


### PR DESCRIPTION
## Description

asking a function template for its result type when the function uses return type deduction causes the function template to be fully instantiated. that, in turn, can cause additional instantiations which, in some cases, can error because some type is not complete yet.

this is particularly an issue in std::execution-style environments as used by sender/receiver.

by explicitly declaring a function template's return type, it becomes possible to ask the function for its result type without causing the instantiation of the function template and the ensuing instantiations.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
