### PR TITLE
Add work stealing to DeviceTransform

### DIFF
--- a/cub/cub/device/dispatch/kernels/transform.cuh
+++ b/cub/cub/device/dispatch/kernels/transform.cuh
@@ -679,8 +679,9 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
 
   const int tile_size = block_threads * num_elem_per_thread;
 
-  const bool bulk_cp_thread = threadIdx.x == 0;
-  const bool work_id_thread = threadIdx.x == 32;
+  const bool elected        = ptx::elect_sync(~0);
+  const bool bulk_cp_thread = elected && threadIdx.x < 32;
+  const bool work_id_thread = elected && threadIdx.x >= 32;
   if (bulk_cp_thread)
   {
     ptx::mbarrier_init(&bar_bulk_cp, 1);

--- a/cub/cub/device/dispatch/tuning/tuning_transform.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_transform.cuh
@@ -231,7 +231,8 @@ bulk_copy_dyn_smem_for_tile_size(ItValueSizesAlignments it_value_sizes_alignment
     tile_padding = ::cuda::std::max(tile_padding, static_cast<int>(vt_alignment));
   }
 
-  int smem_size = tile_padding; // for the barrier and padding
+  int smem_size = ::cuda::round_up(sizeof(uint64_t) * 2 + sizeof(uint4), tile_padding); // barriers, work id, and
+                                                                                        // padding
   for (auto&& [vt_size, _] : it_value_sizes_alignments)
   {
     smem_size += tile_padding + static_cast<int>(vt_size) * tile_size;


### PR DESCRIPTION
Fixes: #5100

Benchmark on B200:
```
# mul

## [0] NVIDIA B200

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-----------|---------|----------|
|   I8    |      I32      |      2^16      |   5.712 us |      12.35% |   5.916 us |       7.26% |  0.204 us |   3.58% |   SAME   |
|   I8    |      I32      |      2^20      |   6.028 us |       5.91% |   6.399 us |       9.77% |  0.371 us |   6.15% |   SLOW   |
|   I8    |      I32      |      2^24      |  14.140 us |       2.15% |  14.487 us |       3.98% |  0.347 us |   2.46% |   SLOW   |
|   I8    |      I32      |      2^28      | 122.136 us |       0.69% | 119.439 us |       0.71% | -2.698 us |  -2.21% |   FAST   |
|   I8    |      I64      |      2^16      |   5.555 us |      13.11% |   5.887 us |       5.74% |  0.332 us |   5.98% |   SLOW   |
|   I8    |      I64      |      2^20      |   6.063 us |       5.78% |   6.502 us |      10.28% |  0.439 us |   7.24% |   SLOW   |
|   I8    |      I64      |      2^24      |  14.096 us |       2.35% |  16.340 us |       2.87% |  2.243 us |  15.91% |   SLOW   |
|   I8    |      I64      |      2^28      | 122.899 us |       0.41% | 143.391 us |       0.37% | 20.491 us |  16.67% |   SLOW   |
|   I16   |      I32      |      2^16      |   5.485 us |      14.71% |   5.656 us |      12.31% |  0.170 us |   3.11% |   SAME   |
|   I16   |      I32      |      2^20      |   6.107 us |       6.79% |   6.589 us |      10.62% |  0.482 us |   7.89% |   SLOW   |
|   I16   |      I32      |      2^24      |  16.791 us |       4.61% |  16.591 us |       4.00% | -0.199 us |  -1.19% |   SAME   |
|   I16   |      I32      |      2^28      | 167.513 us |       0.42% | 160.063 us |       0.49% | -7.450 us |  -4.45% |   FAST   |
|   I16   |      I64      |      2^16      |   5.582 us |      13.59% |   5.928 us |       5.17% |  0.346 us |   6.20% |   SLOW   |
|   I16   |      I64      |      2^20      |   6.093 us |       6.94% |   6.642 us |      10.71% |  0.549 us |   9.01% |   SLOW   |
|   I16   |      I64      |      2^24      |  16.933 us |       4.70% |  16.801 us |       4.38% | -0.132 us |  -0.78% |   SAME   |
|   I16   |      I64      |      2^28      | 169.759 us |       0.29% | 163.761 us |       0.19% | -5.998 us |  -3.53% |   FAST   |
|   F32   |      I32      |      2^16      |   5.885 us |       7.00% |   5.973 us |       4.79% |  0.088 us |   1.49% |   SAME   |
|   F32   |      I32      |      2^20      |   7.389 us |      11.25% |   7.951 us |       4.79% |  0.563 us |   7.61% |   SLOW   |
|   F32   |      I32      |      2^24      |  25.455 us |       3.53% |  26.195 us |       2.58% |  0.740 us |   2.91% |   SLOW   |
|   F32   |      I32      |      2^28      | 313.359 us |       0.34% | 315.885 us |       0.32% |  2.526 us |   0.81% |   SLOW   |
|   F32   |      I64      |      2^16      |   5.453 us |      14.99% |   5.878 us |       7.39% |  0.425 us |   7.79% |   SLOW   |
|   F32   |      I64      |      2^20      |   7.514 us |      10.50% |   7.930 us |       5.56% |  0.415 us |   5.52% |   SAME   |
|   F32   |      I64      |      2^24      |  25.634 us |       3.41% |  26.316 us |       2.04% |  0.683 us |   2.66% |   SLOW   |
|   F32   |      I64      |      2^28      | 313.265 us |       0.31% | 315.804 us |       0.31% |  2.539 us |   0.81% |   SLOW   |
|   F64   |      I32      |      2^16      |   5.699 us |      11.53% |   5.961 us |       5.02% |  0.262 us |   4.60% |   SAME   |
|   F64   |      I32      |      2^20      |   8.048 us |       4.49% |   8.138 us |       5.27% |  0.090 us |   1.12% |   SAME   |
|   F64   |      I32      |      2^24      |  45.469 us |       1.97% |  46.110 us |       2.06% |  0.641 us |   1.41% |   SAME   |
|   F64   |      I32      |      2^28      | 620.538 us |       0.24% | 624.841 us |       0.20% |  4.303 us |   0.69% |   SLOW   |
|   F64   |      I64      |      2^16      |   5.697 us |      11.85% |   5.927 us |       5.31% |  0.231 us |   4.05% |   SAME   |
|   F64   |      I64      |      2^20      |   8.080 us |       4.86% |   8.167 us |       5.52% |  0.087 us |   1.08% |   SAME   |
|   F64   |      I64      |      2^24      |  45.533 us |       2.05% |  46.028 us |       2.09% |  0.495 us |   1.09% |   SAME   |
|   F64   |      I64      |      2^28      | 620.701 us |       0.22% | 624.575 us |       0.21% |  3.875 us |   0.62% |   SLOW   |
|  I128   |      I32      |      2^16      |   5.972 us |       4.78% |   5.968 us |       4.68% | -0.003 us |  -0.05% |   SAME   |
|  I128   |      I32      |      2^20      |  10.391 us |       6.01% |  10.639 us |       6.72% |  0.249 us |   2.39% |   SAME   |
|  I128   |      I32      |      2^24      |  83.600 us |       0.85% |  84.335 us |       1.04% |  0.735 us |   0.88% |   SLOW   |
|  I128   |      I32      |      2^28      |   1.236 ms |       0.15% |   1.243 ms |       0.14% |  7.772 us |   0.63% |   SLOW   |
|  I128   |      I64      |      2^16      |   5.953 us |       5.14% |   5.955 us |       5.02% |  0.002 us |   0.03% |   SAME   |
|  I128   |      I64      |      2^20      |  10.361 us |       5.41% |  10.667 us |       6.86% |  0.306 us |   2.95% |   SAME   |
|  I128   |      I64      |      2^24      |  83.674 us |       0.82% |  84.412 us |       1.05% |  0.738 us |   0.88% |   SLOW   |
|  I128   |      I64      |      2^28      |   1.235 ms |       0.14% |   1.243 ms |       0.14% |  7.754 us |   0.63% |   SLOW   |

# add

## [0] NVIDIA B200

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |       Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|------------|---------|----------|
|   I8    |      I32      |      2^16      |   5.867 us |       8.89% |   5.962 us |       4.97% |   0.095 us |   1.62% |   SAME   |
|   I8    |      I32      |      2^20      |   6.137 us |       6.47% |   6.569 us |      10.44% |   0.431 us |   7.03% |   SLOW   |
|   I8    |      I32      |      2^24      |  15.847 us |       4.55% |  15.833 us |       4.63% |  -0.015 us |  -0.09% |   SAME   |
|   I8    |      I32      |      2^28      | 147.365 us |       0.14% | 141.249 us |       0.17% |  -6.117 us |  -4.15% |   FAST   |
|   I8    |      I64      |      2^16      |   5.958 us |       5.63% |   5.977 us |       4.78% |   0.019 us |   0.32% |   SAME   |
|   I8    |      I64      |      2^20      |   6.155 us |       6.96% |   6.534 us |      10.17% |   0.380 us |   6.17% |   SAME   |
|   I8    |      I64      |      2^24      |  16.189 us |       1.90% |  16.377 us |       2.73% |   0.188 us |   1.16% |   SAME   |
|   I8    |      I64      |      2^28      | 150.343 us |       0.63% | 153.065 us |       0.55% |   2.721 us |   1.81% |   SLOW   |
|   I16   |      I32      |      2^16      |   5.957 us |       5.45% |   5.971 us |       4.87% |   0.014 us |   0.24% |   SAME   |
|   I16   |      I32      |      2^20      |   6.691 us |      11.34% |   7.523 us |      10.92% |   0.831 us |  12.42% |   SLOW   |
|   I16   |      I32      |      2^24      |  22.344 us |       1.50% |  22.332 us |       1.50% |  -0.012 us |  -0.05% |   SAME   |
|   I16   |      I32      |      2^28      | 246.406 us |       0.38% | 235.424 us |       0.08% | -10.982 us |  -4.46% |   FAST   |
|   I16   |      I64      |      2^16      |   5.874 us |       8.61% |   5.967 us |       4.89% |   0.093 us |   1.58% |   SAME   |
|   I16   |      I64      |      2^20      |   6.827 us |      12.05% |   7.520 us |      10.87% |   0.693 us |  10.15% |   SAME   |
|   I16   |      I64      |      2^24      |  22.349 us |       1.50% |  22.351 us |       1.44% |   0.002 us |   0.01% |   SAME   |
|   I16   |      I64      |      2^28      | 247.663 us |       0.16% | 235.437 us |       0.11% | -12.226 us |  -4.94% |   FAST   |
|   F32   |      I32      |      2^16      |   5.845 us |       8.35% |   5.973 us |       4.83% |   0.128 us |   2.19% |   SAME   |
|   F32   |      I32      |      2^20      |   8.014 us |       3.87% |   8.024 us |       3.99% |   0.010 us |   0.12% |   SAME   |
|   F32   |      I32      |      2^24      |  36.134 us |       2.29% |  36.293 us |       2.07% |   0.159 us |   0.44% |   SAME   |
|   F32   |      I32      |      2^28      | 453.427 us |       0.24% | 456.208 us |       0.35% |   2.780 us |   0.61% |   SLOW   |
|   F32   |      I64      |      2^16      |   5.981 us |       4.80% |   5.952 us |       5.20% |  -0.029 us |  -0.49% |   SAME   |
|   F32   |      I64      |      2^20      |   7.996 us |       3.72% |   8.028 us |       4.31% |   0.031 us |   0.39% |   SAME   |
|   F32   |      I64      |      2^24      |  36.333 us |       2.06% |  36.386 us |       1.95% |   0.053 us |   0.15% |   SAME   |
|   F32   |      I64      |      2^28      | 453.242 us |       0.22% | 455.485 us |       0.28% |   2.243 us |   0.49% |   SLOW   |
|   F64   |      I32      |      2^16      |   5.977 us |       4.91% |   5.962 us |       5.09% |  -0.015 us |  -0.25% |   SAME   |
|   F64   |      I32      |      2^20      |  10.033 us |       3.27% |  10.112 us |       3.13% |   0.079 us |   0.78% |   SAME   |
|   F64   |      I32      |      2^24      |  65.218 us |       0.88% |  65.258 us |       0.92% |   0.040 us |   0.06% |   SAME   |
|   F64   |      I32      |      2^28      | 908.869 us |       0.24% | 912.722 us |       0.21% |   3.853 us |   0.42% |   SLOW   |
|   F64   |      I64      |      2^16      |   5.962 us |       5.05% |   5.986 us |       4.61% |   0.024 us |   0.40% |   SAME   |
|   F64   |      I64      |      2^20      |  10.070 us |       2.99% |  10.088 us |       3.34% |   0.018 us |   0.18% |   SAME   |
|   F64   |      I64      |      2^24      |  65.350 us |       0.65% |  65.402 us |       0.68% |   0.052 us |   0.08% |   SAME   |
|   F64   |      I64      |      2^28      | 908.170 us |       0.22% | 912.434 us |       0.22% |   4.264 us |   0.47% |   SLOW   |
|  I128   |      I32      |      2^16      |   5.987 us |       4.84% |   5.988 us |       4.56% |   0.001 us |   0.01% |   SAME   |
|  I128   |      I32      |      2^20      |  14.167 us |       2.06% |  14.141 us |       2.18% |  -0.027 us |  -0.19% |   SAME   |
|  I128   |      I32      |      2^24      | 120.417 us |       0.78% | 121.276 us |       0.88% |   0.859 us |   0.71% |   SAME   |
|  I128   |      I32      |      2^28      |   1.812 ms |       0.16% |   1.816 ms |       0.16% |   4.086 us |   0.23% |   SLOW   |
|  I128   |      I64      |      2^16      |   6.002 us |       4.33% |   5.984 us |       5.52% |  -0.018 us |  -0.29% |   SAME   |
|  I128   |      I64      |      2^20      |  14.159 us |       2.24% |  14.180 us |       2.01% |   0.021 us |   0.15% |   SAME   |
|  I128   |      I64      |      2^24      | 120.541 us |       0.70% | 121.333 us |       0.87% |   0.793 us |   0.66% |   SAME   |
|  I128   |      I64      |      2^28      |   1.812 ms |       0.15% |   1.816 ms |       0.16% |   4.099 us |   0.23% |   SLOW   |

# triad

## [0] NVIDIA B200

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |       Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|------------|---------|----------|
|   I8    |      I32      |      2^16      |   5.880 us |       8.12% |   5.953 us |       5.06% |   0.072 us |   1.23% |   SAME   |
|   I8    |      I32      |      2^20      |   6.138 us |       7.17% |   6.576 us |      10.67% |   0.438 us |   7.13% |   SAME   |
|   I8    |      I32      |      2^24      |  16.236 us |       2.23% |  17.012 us |       4.75% |   0.777 us |   4.78% |   SLOW   |
|   I8    |      I32      |      2^28      | 159.747 us |       0.28% | 163.169 us |       0.54% |   3.422 us |   2.14% |   SLOW   |
|   I8    |      I64      |      2^16      |   5.968 us |       4.93% |   5.979 us |       4.63% |   0.011 us |   0.19% |   SAME   |
|   I8    |      I64      |      2^20      |   6.156 us |       7.14% |   6.585 us |      10.90% |   0.430 us |   6.98% |   SAME   |
|   I8    |      I64      |      2^24      |  16.289 us |       2.33% |  18.253 us |       1.62% |   1.964 us |  12.05% |   SLOW   |
|   I8    |      I64      |      2^28      | 162.319 us |       0.55% | 177.035 us |       0.55% |  14.716 us |   9.07% |   SLOW   |
|   I16   |      I32      |      2^16      |   5.827 us |       9.66% |   5.976 us |       4.82% |   0.149 us |   2.56% |   SAME   |
|   I16   |      I32      |      2^20      |   6.919 us |      12.92% |   7.637 us |       9.96% |   0.718 us |  10.38% |   SLOW   |
|   I16   |      I32      |      2^24      |  22.487 us |       1.93% |  22.339 us |       1.39% |  -0.148 us |  -0.66% |   SAME   |
|   I16   |      I32      |      2^28      | 245.919 us |       0.25% | 237.494 us |       0.12% |  -8.425 us |  -3.43% |   FAST   |
|   I16   |      I64      |      2^16      |   5.973 us |       4.84% |   5.979 us |       4.80% |   0.007 us |   0.11% |   SAME   |
|   I16   |      I64      |      2^20      |   7.129 us |      12.44% |   7.772 us |       8.47% |   0.644 us |   9.03% |   SLOW   |
|   I16   |      I64      |      2^24      |  22.572 us |       2.12% |  22.342 us |       1.41% |  -0.230 us |  -1.02% |   SAME   |
|   I16   |      I64      |      2^28      | 249.639 us |       0.20% | 238.155 us |       0.37% | -11.485 us |  -4.60% |   FAST   |
|   F32   |      I32      |      2^16      |   5.970 us |       4.84% |   5.964 us |       4.91% |  -0.005 us |  -0.09% |   SAME   |
|   F32   |      I32      |      2^20      |   8.014 us |       3.82% |   8.001 us |       3.74% |  -0.012 us |  -0.16% |   SAME   |
|   F32   |      I32      |      2^24      |  36.658 us |       1.09% |  36.673 us |       0.93% |   0.015 us |   0.04% |   SAME   |
|   F32   |      I32      |      2^28      | 452.689 us |       0.13% | 456.624 us |       0.43% |   3.935 us |   0.87% |   SLOW   |
|   F32   |      I64      |      2^16      |   5.989 us |       4.79% |   5.977 us |       4.84% |  -0.012 us |  -0.20% |   SAME   |
|   F32   |      I64      |      2^20      |   7.993 us |       3.78% |   8.005 us |       3.77% |   0.012 us |   0.15% |   SAME   |
|   F32   |      I64      |      2^24      |  36.696 us |       0.85% |  36.712 us |       0.81% |   0.016 us |   0.04% |   SAME   |
|   F32   |      I64      |      2^28      | 452.596 us |       0.09% | 455.425 us |       0.41% |   2.829 us |   0.63% |   SLOW   |
|   F64   |      I32      |      2^16      |   5.968 us |       4.90% |   5.978 us |       4.73% |   0.010 us |   0.17% |   SAME   |
|   F64   |      I32      |      2^20      |  10.062 us |       2.99% |  10.083 us |       3.16% |   0.021 us |   0.21% |   SAME   |
|   F64   |      I32      |      2^24      |  64.025 us |       1.43% |  64.839 us |       1.52% |   0.814 us |   1.27% |   SAME   |
|   F64   |      I32      |      2^28      | 906.965 us |       0.24% | 911.092 us |       0.22% |   4.127 us |   0.46% |   SLOW   |
|   F64   |      I64      |      2^16      |   5.995 us |       4.50% |   5.960 us |       5.01% |  -0.035 us |  -0.58% |   SAME   |
|   F64   |      I64      |      2^20      |  10.044 us |       3.19% |  10.060 us |       3.00% |   0.015 us |   0.15% |   SAME   |
|   F64   |      I64      |      2^24      |  64.661 us |       1.50% |  65.245 us |       1.28% |   0.584 us |   0.90% |   SAME   |
|   F64   |      I64      |      2^28      | 906.824 us |       0.25% | 911.089 us |       0.25% |   4.265 us |   0.47% |   SLOW   |
|  I128   |      I32      |      2^16      |   6.017 us |       4.82% |   6.019 us |       5.36% |   0.002 us |   0.03% |   SAME   |
|  I128   |      I32      |      2^20      |  14.182 us |       2.00% |  14.158 us |       2.06% |  -0.024 us |  -0.17% |   SAME   |
|  I128   |      I32      |      2^24      | 120.044 us |       0.73% | 120.642 us |       0.42% |   0.598 us |   0.50% |   SLOW   |
|  I128   |      I32      |      2^28      |   1.814 ms |       0.10% |   1.819 ms |       0.11% |   4.777 us |   0.26% |   SLOW   |
|  I128   |      I64      |      2^16      |   5.967 us |       4.92% |   6.006 us |       5.11% |   0.040 us |   0.66% |   SAME   |
|  I128   |      I64      |      2^20      |  14.174 us |       1.96% |  14.172 us |       2.15% |  -0.001 us |  -0.01% |   SAME   |
|  I128   |      I64      |      2^24      | 120.311 us |       0.62% | 120.712 us |       0.35% |   0.401 us |   0.33% |   SAME   |
|  I128   |      I64      |      2^28      |   1.814 ms |       0.11% |   1.819 ms |       0.10% |   4.683 us |   0.26% |   SLOW   |

# nstream

## [0] NVIDIA B200

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |       Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|------------|---------|----------|
|   I8    |      I32      |      2^16      |   5.996 us |       4.59% |   5.978 us |       4.84% |  -0.017 us |  -0.29% |   SAME   |
|   I8    |      I32      |      2^20      |   6.346 us |       9.02% |   6.929 us |      12.23% |   0.583 us |   9.19% |   SLOW   |
|   I8    |      I32      |      2^24      |  20.300 us |       1.70% |  18.823 us |       4.07% |  -1.477 us |  -7.28% |   FAST   |
|   I8    |      I32      |      2^28      | 222.271 us |       0.44% | 194.203 us |       0.34% | -28.068 us | -12.63% |   FAST   |
|   I8    |      I64      |      2^16      |   6.005 us |       4.51% |   5.993 us |       4.60% |  -0.012 us |  -0.19% |   SAME   |
|   I8    |      I64      |      2^20      |   6.369 us |       9.28% |   7.405 us |      11.57% |   1.036 us |  16.27% |   SLOW   |
|   I8    |      I64      |      2^24      |  20.354 us |       1.32% |  20.404 us |       2.14% |   0.050 us |   0.24% |   SAME   |
|   I8    |      I64      |      2^28      | 225.225 us |       0.16% | 217.801 us |       0.44% |  -7.424 us |  -3.30% |   FAST   |
|   I16   |      I32      |      2^16      |   5.969 us |       5.12% |   5.969 us |       4.85% |   0.001 us |   0.01% |   SAME   |
|   I16   |      I32      |      2^20      |   7.933 us |       6.09% |   7.998 us |       3.75% |   0.066 us |   0.83% |   SAME   |
|   I16   |      I32      |      2^24      |  27.534 us |       3.31% |  26.930 us |       2.75% |  -0.604 us |  -2.19% |   SAME   |
|   I16   |      I32      |      2^28      | 335.482 us |       0.23% | 308.890 us |       0.22% | -26.593 us |  -7.93% |   FAST   |
|   I16   |      I64      |      2^16      |   5.976 us |       4.89% |   5.985 us |       4.70% |   0.009 us |   0.15% |   SAME   |
|   I16   |      I64      |      2^20      |   7.929 us |       5.25% |   8.008 us |       3.75% |   0.079 us |   1.00% |   SAME   |
|   I16   |      I64      |      2^24      |  28.097 us |       2.72% |  27.115 us |       3.00% |  -0.982 us |  -3.49% |   FAST   |
|   I16   |      I64      |      2^28      | 339.547 us |       0.24% | 308.994 us |       0.18% | -30.553 us |  -9.00% |   FAST   |
|   F32   |      I32      |      2^16      |   5.948 us |       5.13% |   5.978 us |       5.11% |   0.030 us |   0.51% |   SAME   |
|   F32   |      I32      |      2^20      |   8.576 us |       8.17% |   8.995 us |       9.70% |   0.418 us |   4.88% |   SAME   |
|   F32   |      I32      |      2^24      |  46.788 us |       1.23% |  46.599 us |       1.56% |  -0.189 us |  -0.40% |   SAME   |
|   F32   |      I32      |      2^28      | 600.933 us |       0.16% | 599.915 us |       0.05% |  -1.017 us |  -0.17% |   FAST   |
|   F32   |      I64      |      2^16      |   5.972 us |       5.00% |   5.972 us |       5.38% |  -0.000 us |  -0.00% |   SAME   |
|   F32   |      I64      |      2^20      |   8.614 us |       8.75% |   9.112 us |       9.55% |   0.497 us |   5.77% |   SAME   |
|   F32   |      I64      |      2^24      |  46.852 us |       0.99% |  46.622 us |       1.47% |  -0.230 us |  -0.49% |   SAME   |
|   F32   |      I64      |      2^28      | 601.779 us |       0.11% | 599.978 us |       0.04% |  -1.801 us |  -0.30% |   FAST   |
|   F64   |      I32      |      2^16      |   5.985 us |       4.66% |   5.967 us |       5.12% |  -0.018 us |  -0.30% |   SAME   |
|   F64   |      I32      |      2^20      |  11.549 us |       7.04% |  12.083 us |       2.98% |   0.534 us |   4.62% |   SLOW   |
|   F64   |      I32      |      2^24      |  84.075 us |       0.82% |  84.343 us |       1.09% |   0.268 us |   0.32% |   SAME   |
|   F64   |      I32      |      2^28      |   1.185 ms |       0.08% |   1.186 ms |       0.06% |   0.489 us |   0.04% |   SAME   |
|   F64   |      I64      |      2^16      |   5.977 us |       4.88% |   5.972 us |       5.59% |  -0.005 us |  -0.08% |   SAME   |
|   F64   |      I64      |      2^20      |  11.541 us |       7.31% |  12.077 us |       2.76% |   0.537 us |   4.65% |   SLOW   |
|   F64   |      I64      |      2^24      |  84.115 us |       0.86% |  84.424 us |       1.07% |   0.309 us |   0.37% |   SAME   |
|   F64   |      I64      |      2^28      |   1.185 ms |       0.08% |   1.186 ms |       0.06% |   0.648 us |   0.05% |   SAME   |
|  I128   |      I32      |      2^16      |   6.041 us |       5.51% |   6.093 us |       7.39% |   0.053 us |   0.87% |   SAME   |
|  I128   |      I32      |      2^20      |  16.418 us |       2.88% |  16.572 us |       3.89% |   0.155 us |   0.94% |   SAME   |
|  I128   |      I32      |      2^24      | 156.611 us |       0.60% | 156.985 us |       0.62% |   0.374 us |   0.24% |   SAME   |
|  I128   |      I32      |      2^28      |   2.359 ms |       0.05% |   2.359 ms |       0.05% |   0.427 us |   0.02% |   SAME   |
|  I128   |      I64      |      2^16      |   6.082 us |       6.54% |   6.085 us |       6.80% |   0.003 us |   0.06% |   SAME   |
|  I128   |      I64      |      2^20      |  16.403 us |       2.74% |  16.589 us |       3.88% |   0.186 us |   1.13% |   SAME   |
|  I128   |      I64      |      2^24      | 156.757 us |       0.61% | 156.872 us |       0.58% |   0.116 us |   0.07% |   SAME   |
|  I128   |      I64      |      2^28      |   2.359 ms |       0.05% |   2.359 ms |       0.05% |   0.538 us |   0.02% |   SAME   |
```