### PR TITLE
fix `let_value` and friends to work when the function returns a dependent sender

### DIFF
--- a/cudax/include/cuda/experimental/__execution/read_env.cuh
+++ b/cudax/include/cuda/experimental/__execution/read_env.cuh
@@ -52,7 +52,7 @@ private:
 
     _Rcvr __rcvr_;
 
-    _CCCL_API constexpr explicit __opstate_t(_Rcvr __rcvr)
+    _CCCL_API constexpr explicit __opstate_t(_Rcvr __rcvr) noexcept
         : __rcvr_(static_cast<_Rcvr&&>(__rcvr))
     {}
 
@@ -119,22 +119,17 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT read_env_t::__sndr_t
                                           _WITH_QUERY(_Query),
                                           _WITH_ENVIRONMENT(_Env)>();
     }
-    else if constexpr (__nothrow_callable<_Query, _Env>)
-    {
-      return completion_signatures<set_value_t(_CUDA_VSTD::__call_result_t<_Query, _Env>)>{};
-    }
     else
     {
-      return completion_signatures<set_value_t(_CUDA_VSTD::__call_result_t<_Query, _Env>),
-                                   set_error_t(::std::exception_ptr)>{};
+      return completion_signatures<set_value_t(_CUDA_VSTD::__call_result_t<_Query, _Env>)>{}
+           + __eptr_completion_if<!__nothrow_callable<_Query, _Env>>();
     }
 
     _CCCL_UNREACHABLE();
   }
 
   template <class _Rcvr>
-  [[nodiscard]] _CCCL_API constexpr auto connect(_Rcvr __rcvr) const noexcept(__nothrow_movable<_Rcvr>)
-    -> __opstate_t<_Rcvr, _Query>
+  [[nodiscard]] _CCCL_API constexpr auto connect(_Rcvr __rcvr) const noexcept -> __opstate_t<_Rcvr, _Query>
   {
     return __opstate_t<_Rcvr, _Query>{static_cast<_Rcvr&&>(__rcvr)};
   }


### PR DESCRIPTION
## Description

a dependent sender is one that needs an environment to compute its completion signatures. for example, `read_env(get_stop_token)` is a sender that will read the current stop token out of the receiver's environment and pass it back to the receiver in a call to `set_value`.

the following code exposed a couple of bugs in the `let_value` implementation having to do with dependent senders. 

```c++
  auto sndr     = ex::write_env(ex::just() | ex::let_value([] {
                              return ex::read_env(test_query);
                            }),
                            ex::prop{test_query, 42});
```

this pr fixes the issues causing the above expression to fail, and adds this case as a new `let_value` test.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
