### PR TITLE
fix visibility problem in `invoke`, correct the spelling of "invocable" globally

### DIFF
--- a/cub/cub/device/dispatch/dispatch_merge.cuh
+++ b/cub/cub/device/dispatch/dispatch_merge.cuh
@@ -120,7 +120,7 @@ __launch_bounds__(
 {
   // the merge agent loads keys into a local array of KeyIt1::value_type, on which the comparisons are performed
   using key_t = it_value_t<KeyIt1>;
-  static_assert(::cuda::std::__invokable<CompareOp, key_t, key_t>::value,
+  static_assert(::cuda::std::__invocable<CompareOp, key_t, key_t>::value,
                 "Comparison operator cannot compare two keys");
   static_assert(::cuda::std::is_convertible_v<typename ::cuda::std::__invoke_of<CompareOp, key_t, key_t>::type, bool>,
                 "Comparison operator must be convertible to bool");

--- a/cub/cub/device/dispatch/dispatch_reduce_deterministic.cuh
+++ b/cub/cub/device/dispatch/dispatch_reduce_deterministic.cuh
@@ -67,8 +67,8 @@ namespace detail
 namespace rfa
 {
 
-template <typename Invokable, typename InputT>
-using transformed_input_t = _CUDA_VSTD::decay_t<typename _CUDA_VSTD::__invoke_of<Invokable, InputT>::type>;
+template <typename Invocable, typename InputT>
+using transformed_input_t = _CUDA_VSTD::decay_t<typename _CUDA_VSTD::__invoke_of<Invocable, InputT>::type>;
 
 template <typename InitT, typename InputIteratorT, typename TransformOpT>
 using accum_t =

--- a/docs/libcudacxx/extended_api/work_stealing.rst
+++ b/docs/libcudacxx/extended_api/work_stealing.rst
@@ -33,7 +33,7 @@ For better performance, extract the shared thread-block prologue and epilogue ou
 **Mandates**:
 
    - ``ThreadBlockRank`` equals the rank of the thread block: ``1``, ``2``, or ``3`` for one-dimensional, two-dimensional, and three-dimensional thread blocks, respectively.
-   - ``is_invokable_r_v<UnaryFunction, void, dim3>`` is true.
+   - ``is_invocable_r_v<UnaryFunction, void, dim3>`` is true.
 
 **Preconditions**:
 

--- a/libcudacxx/include/cuda/std/__functional/bind.h
+++ b/libcudacxx/include/cuda/std/__functional/bind.h
@@ -155,21 +155,21 @@ __mu(_Ti& __ti, _Uj&)
 template <class _Ti, bool IsReferenceWrapper, bool IsBindEx, bool IsPh, class _TupleUj>
 struct __mu_return_impl;
 
-template <bool _Invokable, class _Ti, class... _Uj>
-struct __mu_return_invokable // false
+template <bool _Invocable, class _Ti, class... _Uj>
+struct __mu_return_invocable // false
 {
   using type = __nat;
 };
 
 template <class _Ti, class... _Uj>
-struct __mu_return_invokable<true, _Ti, _Uj...>
+struct __mu_return_invocable<true, _Ti, _Uj...>
 {
   using type = typename __invoke_of<_Ti&, _Uj...>::type;
 };
 
 template <class _Ti, class... _Uj>
 struct __mu_return_impl<_Ti, false, true, false, tuple<_Uj...>>
-    : public __mu_return_invokable<__invokable<_Ti&, _Uj...>::value, _Ti, _Uj...>
+    : public __mu_return_invocable<__invocable<_Ti&, _Uj...>::value, _Ti, _Uj...>
 {};
 
 template <class _Ti, class _TupleUj>
@@ -209,13 +209,13 @@ struct __is_valid_bind_return
 template <class _Fp, class... _BoundArgs, class _TupleUj>
 struct __is_valid_bind_return<_Fp, tuple<_BoundArgs...>, _TupleUj>
 {
-  static const bool value = __invokable<_Fp, typename __mu_return<_BoundArgs, _TupleUj>::type...>::value;
+  static const bool value = __invocable<_Fp, typename __mu_return<_BoundArgs, _TupleUj>::type...>::value;
 };
 
 template <class _Fp, class... _BoundArgs, class _TupleUj>
 struct __is_valid_bind_return<_Fp, const tuple<_BoundArgs...>, _TupleUj>
 {
-  static const bool value = __invokable<_Fp, typename __mu_return<const _BoundArgs, _TupleUj>::type...>::value;
+  static const bool value = __invocable<_Fp, typename __mu_return<const _BoundArgs, _TupleUj>::type...>::value;
 };
 
 template <class _Fp, class _BoundArgs, class _TupleUj, bool = __is_valid_bind_return<_Fp, _BoundArgs, _TupleUj>::value>

--- a/libcudacxx/include/cuda/std/__functional/function.h
+++ b/libcudacxx/include/cuda/std/__functional/function.h
@@ -995,7 +995,7 @@ class _CCCL_TYPE_VISIBILITY_DEFAULT function<_Rp(_ArgTypes...)>
 
   __func __f_;
 
-  template <class _Fp, bool = _And<_IsNotSame<remove_cvref_t<_Fp>, function>, __invokable<_Fp, _ArgTypes...>>::value>
+  template <class _Fp, bool = _And<_IsNotSame<remove_cvref_t<_Fp>, function>, __invocable<_Fp, _ArgTypes...>>::value>
   struct __callable;
   template <class _Fp>
   struct __callable<_Fp, true>

--- a/libcudacxx/include/cuda/std/__functional/hash.h
+++ b/libcudacxx/include/cuda/std/__functional/hash.h
@@ -628,7 +628,7 @@ template <class _Key, class _Hash>
 using __check_hash_requirements _CCCL_NODEBUG_ALIAS =
   integral_constant<bool,
                     is_copy_constructible<_Hash>::value && is_move_constructible<_Hash>::value
-                      && __invokable_r<size_t, _Hash, _Key const&>::value>;
+                      && __invocable_r<size_t, _Hash, _Key const&>::value>;
 
 template <class _Key, class _Hash = hash<_Key>>
 using __has_enabled_hash _CCCL_NODEBUG_ALIAS =

--- a/libcudacxx/include/cuda/std/__functional/invoke.h
+++ b/libcudacxx/include/cuda/std/__functional/invoke.h
@@ -392,9 +392,9 @@ __invoke(_Fp&& __f, _Args&&... __args) noexcept(noexcept(static_cast<_Fp&&>(__f)
   return static_cast<_Fp&&>(__f)(static_cast<_Args&&>(__args)...);
 }
 
-// __invokable
+// __invocable
 template <class _Ret, class _Fp, class... _Args>
-struct __invokable_r
+struct __invocable_r
 {
   template <class _XFp, class... _XArgs>
   _CCCL_API inline static decltype(_CUDA_VSTD::__invoke(_CUDA_VSTD::declval<_XFp>(), _CUDA_VSTD::declval<_XArgs>()...))
@@ -413,18 +413,18 @@ struct __invokable_r
   static const bool value = type::value;
 };
 template <class _Fp, class... _Args>
-using __invokable = __invokable_r<void, _Fp, _Args...>;
+using __invocable = __invocable_r<void, _Fp, _Args...>;
 
-template <bool _IsInvokable, bool _IsCVVoid, class _Ret, class _Fp, class... _Args>
-struct __nothrow_invokable_r_imp
+template <bool _IsInvocable, bool _IsCVVoid, class _Ret, class _Fp, class... _Args>
+struct __nothrow_invocable_r_imp
 {
   static const bool value = false;
 };
 
 template <class _Ret, class _Fp, class... _Args>
-struct __nothrow_invokable_r_imp<true, false, _Ret, _Fp, _Args...>
+struct __nothrow_invocable_r_imp<true, false, _Ret, _Fp, _Args...>
 {
-  using _ThisT = __nothrow_invokable_r_imp;
+  using _ThisT = __nothrow_invocable_r_imp;
 
   template <class _Tp>
   _CCCL_API inline static void __test_noexcept(_Tp) noexcept;
@@ -434,21 +434,21 @@ struct __nothrow_invokable_r_imp<true, false, _Ret, _Fp, _Args...>
 };
 
 template <class _Ret, class _Fp, class... _Args>
-struct __nothrow_invokable_r_imp<true, true, _Ret, _Fp, _Args...>
+struct __nothrow_invocable_r_imp<true, true, _Ret, _Fp, _Args...>
 {
   static const bool value = noexcept(_CUDA_VSTD::__invoke(_CUDA_VSTD::declval<_Fp>(), _CUDA_VSTD::declval<_Args>()...));
 };
 
 template <class _Ret, class _Fp, class... _Args>
-using __nothrow_invokable_r =
-  __nothrow_invokable_r_imp<__invokable_r<_Ret, _Fp, _Args...>::value, is_void<_Ret>::value, _Ret, _Fp, _Args...>;
+using __nothrow_invocable_r =
+  __nothrow_invocable_r_imp<__invocable_r<_Ret, _Fp, _Args...>::value, is_void<_Ret>::value, _Ret, _Fp, _Args...>;
 
 template <class _Fp, class... _Args>
-using __nothrow_invokable = __nothrow_invokable_r_imp<__invokable<_Fp, _Args...>::value, true, void, _Fp, _Args...>;
+using __nothrow_invocable = __nothrow_invocable_r_imp<__invocable<_Fp, _Args...>::value, true, void, _Fp, _Args...>;
 
 template <class _Fp, class... _Args>
-struct __invoke_of
-    : public enable_if<__invokable<_Fp, _Args...>::value, typename __invokable_r<void, _Fp, _Args...>::_Result>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT __invoke_of //
+    : public enable_if<__invocable<_Fp, _Args...>::value, typename __invocable_r<void, _Fp, _Args...>::_Result>
 {
 #if _CCCL_CUDA_COMPILER(NVCC) && defined(__CUDACC_EXTENDED_LAMBDA__) && !_CCCL_DEVICE_COMPILATION()
 #  if _CCCL_CUDACC_BELOW(12, 3)
@@ -493,11 +493,11 @@ struct __invoke_void_return_wrapper<_Ret, true>
 // is_invocable
 
 template <class _Fn, class... _Args>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_invocable : integral_constant<bool, __invokable<_Fn, _Args...>::value>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_invocable : integral_constant<bool, __invocable<_Fn, _Args...>::value>
 {};
 
 template <class _Ret, class _Fn, class... _Args>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_invocable_r : integral_constant<bool, __invokable_r<_Ret, _Fn, _Args...>::value>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_invocable_r : integral_constant<bool, __invocable_r<_Ret, _Fn, _Args...>::value>
 {};
 
 template <class _Fn, class... _Args>
@@ -509,13 +509,13 @@ inline constexpr bool is_invocable_r_v = is_invocable_r<_Ret, _Fn, _Args...>::va
 // is_nothrow_invocable
 
 template <class _Fn, class... _Args>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_nothrow_invocable
-    : integral_constant<bool, __nothrow_invokable<_Fn, _Args...>::value>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT
+is_nothrow_invocable : integral_constant<bool, __nothrow_invocable<_Fn, _Args...>::value>
 {};
 
 template <class _Ret, class _Fn, class... _Args>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_nothrow_invocable_r
-    : integral_constant<bool, __nothrow_invokable_r<_Ret, _Fn, _Args...>::value>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT
+is_nothrow_invocable_r : integral_constant<bool, __nothrow_invocable_r<_Ret, _Fn, _Args...>::value>
 {};
 
 template <class _Fn, class... _Args>
@@ -548,8 +548,8 @@ _CCCL_API constexpr _Ret invoke_r(_Fn&& __f,
 }
 
 /// The type of intermediate accumulator (according to P2322R6)
-template <typename Invokable, typename InputT, typename InitT = InputT>
-using __accumulator_t = typename decay<typename _CUDA_VSTD::__invoke_of<Invokable, InitT, InputT>::type>::type;
+template <typename Invocable, typename InputT, typename InitT = InputT>
+using __accumulator_t = typename decay<typename _CUDA_VSTD::__invoke_of<Invocable, InitT, InputT>::type>::type;
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__functional/invoke.h
+++ b/libcudacxx/include/cuda/std/__functional/invoke.h
@@ -509,13 +509,13 @@ inline constexpr bool is_invocable_r_v = is_invocable_r<_Ret, _Fn, _Args...>::va
 // is_nothrow_invocable
 
 template <class _Fn, class... _Args>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT
-is_nothrow_invocable : integral_constant<bool, __nothrow_invocable<_Fn, _Args...>::value>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_nothrow_invocable
+    : integral_constant<bool, __nothrow_invocable<_Fn, _Args...>::value>
 {};
 
 template <class _Ret, class _Fn, class... _Args>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT
-is_nothrow_invocable_r : integral_constant<bool, __nothrow_invocable_r<_Ret, _Fn, _Args...>::value>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_nothrow_invocable_r
+    : integral_constant<bool, __nothrow_invocable_r<_Ret, _Fn, _Args...>::value>
 {};
 
 template <class _Fn, class... _Args>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,6 @@ extend-select = ["I"]
 skip = "./.git,./build,./CITATION.md"
 # ignore short words, and typename parameters like OffsetT
 ignore-regex = "\\b(.{1,4}|[A-Z]\\w*T)\\b"
-ignore-words-list = "inout,imovable,optionN,aCount,quitted,Invokable,countr,unexpect,numer,euclidian,couldn,OffsetT,FromM"
+ignore-words-list = "inout,imovable,optionN,aCount,quitted,Invocable,countr,unexpect,numer,euclidian,couldn,OffsetT,FromM"
 builtin = "clear"
 quiet-level = 3


### PR DESCRIPTION
## Description

i recently hit this compiler error:

```
/home/coder/cccl/lib/cmake/libcudacxx/../../../libcudacxx/include/cuda/std/__functional/invoke.h:450:8: err
or: ‘cuda::std::__4::__invoke_of<const cuda::experimental::execution::get_completion_scheduler_t<cuda::experi
mental::execution::set_value_t>&, cuda::experimental::execution::__bulk::__attrs_t<cuda::experimental::execut
ion::continues_on_t::__sndr_t<_GLOBAL__N__bebcd1eb_12_test_bulk_cu_5a368d64::inline_scheduler<my_domain>, cud
a::experimental::execution::just_t::__sndr_t<string> >, int> >’ declared with greater visibility than its bas
e ‘cuda::std::__4::enable_if<true, _GLOBAL__N__bebcd1eb_12_test_bulk_cu_5a368d64::inline_scheduler<my_domain>
>’ [-Werror=attributes]
    450 | struct __invoke_of
        |        ^~~~~~~~~~~
```

this is easily fixable by using `_CCCL_TYPE_VISIBILITY_DEFAULT` on the `__invoke_of` struct.

while looking into this issue, i noticed that there are a lot of misspellings of "invocable" in our codebase. this pr fixes that as a drive-by.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
