### PR TITLE
`sync_wait` should decay copy the value results

### DIFF
--- a/cudax/include/cuda/experimental/__execution/sync_wait.cuh
+++ b/cudax/include/cuda/experimental/__execution/sync_wait.cuh
@@ -23,6 +23,7 @@
 
 #include <cuda/std/__exception/cuda_error.h>
 #include <cuda/std/__type_traits/always_false.h>
+#include <cuda/std/__type_traits/decay.h>
 #include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/__type_traits/type_identity.h>
 #include <cuda/std/optional>
@@ -100,11 +101,14 @@ struct sync_wait_t
     __state_base_t<_Env>* __state_;
   };
 
+  template <class... _Ts>
+  using __decayed_tuple = _CUDA_VSTD::tuple<_CUDA_VSTD::decay_t<_Ts>...>;
+
   template <class _Sndr, class _Env>
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __state_t : __state_base_t<_Env>
   {
     using __completions_t _CCCL_NODEBUG_ALIAS = completion_signatures_of_t<_Sndr, __env_t<_Env>>;
-    using __values_t _CCCL_NODEBUG_ALIAS = __value_types<__completions_t, _CUDA_VSTD::tuple, _CUDA_VSTD::__type_self_t>;
+    using __values_t _CCCL_NODEBUG_ALIAS = __value_types<__completions_t, __decayed_tuple, _CUDA_VSTD::__type_self_t>;
     using __errors_t _CCCL_NODEBUG_ALIAS = __error_types<__completions_t, __decayed_variant>;
 
     _CUDA_VSTD::optional<__values_t>* __values_;


### PR DESCRIPTION
## Description

`execution::sync_wait` is [specified](https://eel.is/c++draft/exec#sync.wait-3) to decay-copy any values produced by the sender. this isn't happening currently in our implementation, which can potentially lead `sync_wait` to return a reference to a local.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
