### PR TITLE
Simplify the type of `write_env`'s receiver and make `write_env` pipeable

### DIFF
--- a/cudax/include/cuda/experimental/__execution/env.cuh
+++ b/cudax/include/cuda/experimental/__execution/env.cuh
@@ -53,8 +53,69 @@ _CCCL_CONCEPT __statically_queryable_with = //
     (_CUDA_VSTD::remove_cvref_t<_Env>::query(_Query{})) //
   );
 
-// For senders that adapt other senders, the attribute queries are forwarded. __fwd_env_
-// is a utility that forwards queries to a given environment.
+template <class _Env>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT __fwd_env_;
+
+//! \brief __env_ref_ is a utility that builds a queryable object from a reference
+//! to another queryable object.
+template <class _Env>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT __env_ref_
+{
+  _CCCL_TEMPLATE(class _Query)
+  _CCCL_REQUIRES(__queryable_with<_Env, _Query>)
+  [[nodiscard]] _CCCL_API constexpr auto query(_Query) const noexcept(__nothrow_queryable_with<_Env, _Query>)
+    -> __query_result_t<_Env, _Query>
+  {
+    return __env_.query(_Query{});
+  }
+
+  _Env const& __env_;
+};
+
+namespace __detail
+{
+struct _CCCL_TYPE_VISIBILITY_DEFAULT __env_ref_fn
+{
+  [[nodiscard]] _CCCL_TRIVIAL_API constexpr auto operator()(env<>) const noexcept -> env<>
+  {
+    return {};
+  }
+
+  _CCCL_TEMPLATE(class _Env, class = _Env*) // not considered if _Env is a reference type
+  _CCCL_REQUIRES((!__is_specialization_of_v<_Env, __fwd_env_>) )
+  [[nodiscard]] _CCCL_TRIVIAL_API constexpr auto operator()(_Env&& __env) const noexcept -> _Env
+  {
+    return static_cast<_Env&&>(__env);
+  }
+
+  template <class _Env>
+  [[nodiscard]] _CCCL_TRIVIAL_API constexpr auto operator()(const _Env& __env) const noexcept -> __env_ref_<_Env>
+  {
+    return __env_ref_<_Env>{__env};
+  }
+
+  template <class _Env>
+  [[nodiscard]] _CCCL_TRIVIAL_API constexpr auto operator()(__env_ref_<_Env> __env) const noexcept -> __env_ref_<_Env>
+  {
+    return __env;
+  }
+
+  template <class _Env>
+  [[nodiscard]] _CCCL_TRIVIAL_API constexpr auto operator()(const __fwd_env_<_Env>& __env) const noexcept
+    -> __fwd_env_<_Env const&>
+  {
+    return __fwd_env_<_Env const&>{__env.__env_};
+  }
+};
+} // namespace __detail
+
+template <class _Env>
+using __env_ref_t _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::__call_result_t<__detail::__env_ref_fn, _Env>;
+
+_CCCL_GLOBAL_CONSTANT __detail::__env_ref_fn __env_ref{};
+
+//! \brief __fwd_env_ is a utility that forwards queries to a given queryable object
+//! provided those queries that satisfy the __forwarding_query concept.
 template <class _Env>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __fwd_env_
 {
@@ -79,6 +140,13 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __fwd_env_fn
   }
 
   template <class _Env>
+  [[nodiscard]] _CCCL_TRIVIAL_API constexpr auto operator()(__env_ref_<_Env> __env) const noexcept
+    -> __fwd_env_<_Env const&>
+  {
+    return __fwd_env_<_Env const&>{__env.__env_};
+  }
+
+  template <class _Env>
   [[nodiscard]] _CCCL_TRIVIAL_API constexpr auto operator()(_Env&& __env) const noexcept(__nothrow_movable<_Env>)
     -> decltype(auto)
   {
@@ -100,6 +168,8 @@ using __fwd_env_t _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::__call_result_t<__detail::__
 
 _CCCL_GLOBAL_CONSTANT __detail::__fwd_env_fn __fwd_env{};
 
+//! \brief __sch_env_t is a utility that builds a queryable object from a scheduler. It
+//! defines the `get_scheduler` query and provides a default for the `get_domain` query.
 template <class _Sch>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __sch_env_t
 {

--- a/cudax/include/cuda/experimental/__execution/write_attrs.cuh
+++ b/cudax/include/cuda/experimental/__execution/write_attrs.cuh
@@ -35,6 +35,10 @@ struct write_attrs_t
   template <class _Sndr, class _Attrs>
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __sndr_t;
 
+  template <class _Attrs, class _SndrAttrs>
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __attrs_t : env<__env_ref_t<_Attrs const&>, __fwd_env_t<_SndrAttrs>>
+  {};
+
   template <class _Attrs>
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __closure_t
   {
@@ -108,7 +112,6 @@ template <class _Sndr, class _Attrs>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT write_attrs_t::__sndr_t
 {
   using sender_concept = sender_t;
-  using __attrs_t      = env<const _Attrs&, env_of_t<_Sndr>>;
 
   template <class _Self, class... _Env>
   [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL auto get_completion_signatures()
@@ -128,9 +131,9 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT write_attrs_t::__sndr_t
     return execution::connect(__sndr_, static_cast<_Rcvr&&>(_rcvr));
   }
 
-  [[nodiscard]] _CCCL_API constexpr auto get_env() const noexcept -> __attrs_t
+  [[nodiscard]] _CCCL_API constexpr auto get_env() const noexcept -> __attrs_t<_Attrs, env_of_t<_Sndr>>
   {
-    return {__attrs_, execution::get_env(__sndr_)};
+    return {{__env_ref(__attrs_), __fwd_env(execution::get_env(__sndr_))}};
   }
 
   _CCCL_NO_UNIQUE_ADDRESS write_attrs_t __tag_;

--- a/cudax/include/cuda/experimental/__execution/write_env.cuh
+++ b/cudax/include/cuda/experimental/__execution/write_env.cuh
@@ -40,14 +40,55 @@ namespace cuda::experimental::execution
 struct _CCCL_TYPE_VISIBILITY_DEFAULT write_env_t
 {
   _CUDAX_SEMI_PRIVATE :
+  template <class _Rcvr, class _Env>
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __state_t
+  {
+    _Rcvr __rcvr_;
+    _Env __env_;
+  };
+
+  template <class _Env, class... _RcvrEnv>
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __env_t : env<__env_ref_t<_Env const&>, __fwd_env_t<_RcvrEnv>...>
+  {};
+
+  template <class _Rcvr, class _Env>
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __rcvr_t
+  {
+    using receiver_concept = receiver_t;
+
+    template <class... _Ts>
+    _CCCL_API constexpr void set_value(_Ts&&... __ts) noexcept
+    {
+      execution::set_value(static_cast<_Rcvr&&>(__state_->__rcvr_), static_cast<_Ts&&>(__ts)...);
+    }
+
+    template <class _Error>
+    _CCCL_API constexpr void set_error(_Error&& __err) noexcept
+    {
+      execution::set_error(static_cast<_Rcvr&&>(__state_->__rcvr_), static_cast<_Error&&>(__err));
+    }
+
+    _CCCL_API constexpr void set_stopped() noexcept
+    {
+      execution::set_stopped(static_cast<_Rcvr&&>(__state_->__rcvr_));
+    }
+
+    [[nodiscard]] _CCCL_API constexpr auto get_env() const noexcept -> __env_t<_Env, env_of_t<_Rcvr>>
+    {
+      return {{__env_ref(__state_->__env_), __fwd_env(execution::get_env(__state_->__rcvr_))}};
+    }
+
+    __state_t<_Rcvr, _Env>* __state_;
+  };
+
   template <class _Rcvr, class _Sndr, class _Env>
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __opstate_t
   {
-    using operation_state_concept _CCCL_NODEBUG_ALIAS = operation_state_t;
+    using operation_state_concept = operation_state_t;
 
     _CCCL_API constexpr explicit __opstate_t(_Sndr&& __sndr, _Env __env, _Rcvr __rcvr)
-        : __env_rcvr_{static_cast<_Rcvr&&>(__rcvr), static_cast<_Env&&>(__env)}
-        , __opstate_(execution::connect(static_cast<_Sndr&&>(__sndr), __ref_rcvr(__env_rcvr_)))
+        : __state_{static_cast<_Rcvr&&>(__rcvr), static_cast<_Env&&>(__env)}
+        , __opstate_(execution::connect(static_cast<_Sndr&&>(__sndr), __rcvr_t<_Rcvr, _Env>{&__state_}))
     {}
 
     _CCCL_IMMOVABLE_OPSTATE(__opstate_t);
@@ -57,18 +98,34 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT write_env_t
       execution::start(__opstate_);
     }
 
-    __rcvr_with_env_t<_Rcvr, _Env> __env_rcvr_;
-    connect_result_t<_Sndr, __rcvr_ref_t<__rcvr_with_env_t<_Rcvr, _Env>>> __opstate_;
+    __state_t<_Rcvr, _Env> __state_;
+    connect_result_t<_Sndr, __rcvr_t<_Rcvr, _Env>> __opstate_;
   };
 
 public:
   template <class _Sndr, class _Env>
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __sndr_t;
 
+  template <class _Env>
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __closure_t;
+
   /// @brief Wraps one sender in another that modifies the execution
   /// environment by merging in the environment specified.
   template <class _Sndr, class _Env>
-  _CCCL_TRIVIAL_API constexpr auto operator()(_Sndr, _Env) const;
+  [[nodiscard]] _CCCL_TRIVIAL_API constexpr auto operator()(_Sndr __sndr, _Env __env) const
+  {
+    // The write_env algorithm is not customizable by design; hence, we don't dispatch to
+    // transform_sender like we do for other algorithms.
+    return __sndr_t<_Sndr, _Env>{{}, static_cast<_Env&&>(__env), static_cast<_Sndr&&>(__sndr)};
+  }
+
+  /// @brief Returns a closure that can be used with the pipe operator
+  /// to modify the execution environment.
+  template <class _Env>
+  [[nodiscard]] _CCCL_TRIVIAL_API constexpr auto operator()(_Env __env) const
+  {
+    return __closure_t<_Env>{static_cast<_Env&&>(__env)};
+  }
 };
 
 template <class _Sndr, class _Env>
@@ -76,11 +133,11 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT write_env_t::__sndr_t
 {
   using sender_concept _CCCL_NODEBUG_ALIAS = sender_t;
 
-  template <class _Self, class... _Env2>
+  template <class _Self, class... _RcvrEnv>
   [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL auto get_completion_signatures()
   {
     using _Child _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::__copy_cvref_t<_Self, _Sndr>;
-    return execution::get_completion_signatures<_Child, env<const _Env&, __fwd_env_t<_Env2>>...>();
+    return execution::get_completion_signatures<_Child, __env_t<_Env, _RcvrEnv...>>();
   }
 
   template <class _Rcvr>
@@ -106,18 +163,30 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT write_env_t::__sndr_t
   _Sndr __sndr_;
 };
 
-template <class _Sndr, class _Env>
-_CCCL_TRIVIAL_API constexpr auto write_env_t::operator()(_Sndr __sndr, _Env __env) const
+template <class _Env>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT write_env_t::__closure_t
 {
-  // The write_env algorithm is not customizable by design; hence, we don't dispatch to
-  // transform_sender like we do for other algorithms.
-  return __sndr_t<_Sndr, _Env>{{}, static_cast<_Env&&>(__env), static_cast<_Sndr&&>(__sndr)};
-}
+  template <class _Sndr>
+  [[nodiscard]] _CCCL_TRIVIAL_API constexpr auto operator()(_Sndr __sndr) const -> __sndr_t<_Sndr, _Env>
+  {
+    return __sndr_t<_Sndr, _Env>{{}, static_cast<_Env&&>(__env_), static_cast<_Sndr&&>(__sndr)};
+  }
+
+  template <class _Sndr>
+  [[nodiscard]] _CCCL_TRIVIAL_API friend constexpr auto operator|(_Sndr __sndr, __closure_t __self)
+    -> __sndr_t<_Sndr, _Env>
+  {
+    return __sndr_t<_Sndr, _Env>{{}, static_cast<_Env&&>(__self.__env_), static_cast<_Sndr&&>(__sndr)};
+  }
+
+  _Env __env_;
+};
 
 template <class _Sndr, class _Env>
 inline constexpr size_t structured_binding_size<write_env_t::__sndr_t<_Sndr, _Env>> = 3;
 
 _CCCL_GLOBAL_CONSTANT write_env_t write_env{};
+
 } // namespace cuda::experimental::execution
 
 #include <cuda/experimental/__execution/epilogue.cuh>

--- a/cudax/test/CMakeLists.txt
+++ b/cudax/test/CMakeLists.txt
@@ -94,6 +94,7 @@ foreach(cn_target IN LISTS cudax_TARGETS)
     execution/test_visit.cu
     execution/test_when_all.cu
     execution/test_write_attrs.cu
+    execution/test_write_env.cu
   )
   target_compile_options(${test_target} PRIVATE $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:--extended-lambda>)
   target_compile_options(${test_target} PRIVATE $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:--expt-relaxed-constexpr>)

--- a/cudax/test/execution/test_write_env.cu
+++ b/cudax/test/execution/test_write_env.cu
@@ -1,0 +1,98 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/experimental/execution.cuh>
+
+#include "common/checked_receiver.cuh"
+#include "common/utility.cuh"
+#include "testing.cuh"
+
+namespace ex = cuda::experimental::execution;
+
+namespace
+{
+// Custom domain for testing
+struct my_domain
+{};
+
+// Simple test query
+struct query1_t
+{
+  template <class Env>
+  _CCCL_API auto operator()(const Env& env) const noexcept -> decltype(env.query(*this))
+  {
+    return env.query(*this);
+  }
+};
+
+inline constexpr auto query1 = query1_t{};
+} // namespace
+
+C2H_TEST("write_env basic functionality", "[write_env][adaptors]")
+{
+  // Test that write_env wraps a sender and adds environment information
+  auto env  = ex::prop{query1, 42};
+  auto sndr = ex::write_env(ex::just(42), env);
+
+  auto op = ex::connect(std::move(sndr), checked_value_receiver{42});
+  ex::start(op);
+  // the receiver will check the result
+}
+
+C2H_TEST("write_env pipe syntax", "[write_env][adaptors]")
+{
+  // Test that write_env supports pipe syntax (sndr | write_env(env))
+  auto env  = ex::prop{query1, 42};
+  auto sndr = ex::just(42) | ex::write_env(env);
+
+  auto op = ex::connect(std::move(sndr), checked_value_receiver{42});
+  ex::start(op);
+  // the receiver will check the result
+}
+
+#if _CCCL_HOST_COMPILATION()
+C2H_TEST("write_env updates the receiver's environment", "[write_env][adaptors]")
+{
+  auto sndr = ex::just() | ex::let_value([]() {
+                return ex::read_env(query1);
+              })
+            | ex::write_env(ex::prop{query1, 42});
+
+  auto [result] = ex::sync_wait(std::move(sndr)).value();
+  CUDAX_CHECK(result == 42);
+}
+
+struct fake_allocator
+{};
+
+C2H_TEST("write_env does not hide the receiver's environment", "[write_env][adaptors]")
+{
+  auto sndr = ex::just() | ex::let_value([]() {
+                return ex::read_env(ex::get_allocator);
+              })
+            | ex::write_env(ex::prop{query1, 42});
+
+  auto env      = ex::prop{ex::get_allocator, fake_allocator{}};
+  auto [result] = ex::sync_wait(std::move(sndr), env).value();
+  STATIC_REQUIRE(std::is_same_v<decltype(result), fake_allocator>);
+}
+
+C2H_TEST("write_env prefers the passed env over the receiver's env", "[write_env][adaptors]")
+{
+  auto sndr = ex::just() | ex::let_value([]() {
+                return ex::read_env(query1);
+              })
+            | ex::write_env(ex::prop{query1, 42});
+
+  auto env      = ex::prop{query1, 100};
+  auto [result] = ex::sync_wait(std::move(sndr), env).value();
+  CUDAX_CHECK(result == 42);
+}
+#endif // _CCCL_HOST_COMPILATION()


### PR DESCRIPTION
## Description

#5065 refactored the sender algorithms to remove their receivers' dependence on the child sender's type, making type names dramatically shorter. that pr missed one algorithm: `write_env`. this pr finishes the job. it also makes `write_env` pipeable.

note to reviewers: the changes to `let_value` are the subject of #5105

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
