### PR TITLE
Avoid usage of `_CCCL_NO_UNIQUE_ADDRESS` for cuda iterators

### DIFF
--- a/libcudacxx/include/cuda/__iterator/constant_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/constant_iterator.h
@@ -39,7 +39,7 @@ class constant_iterator
 private:
   static_assert(_CUDA_VSTD::__integer_like<_Index>, "The index type of cuda::constant_iterator must be integer-like!");
 
-  _CCCL_NO_UNIQUE_ADDRESS _CUDA_VRANGES::__movable_box<_Tp> __value_{_CUDA_VSTD::in_place};
+  _CUDA_VRANGES::__movable_box<_Tp> __value_{_CUDA_VSTD::in_place};
   _Index __index_ = 0;
 
 public:

--- a/libcudacxx/include/cuda/__iterator/strided_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/strided_iterator.h
@@ -52,8 +52,8 @@ private:
   static_assert(_CUDA_VSTD::__integer_like<_Stride> || _CUDA_VSTD::__integral_constant_like<_Stride>,
                 "The stride of a strided_iterator must either be an integer-like or integral-constant-like.");
 
-  _CCCL_NO_UNIQUE_ADDRESS _Iter __iter_{};
-  _CCCL_NO_UNIQUE_ADDRESS _Stride __stride_{};
+  _Iter __iter_{};
+  _Stride __stride_{};
 
   template <class, class>
   friend class strided_iterator;

--- a/libcudacxx/include/cuda/__iterator/tabulate_output_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/tabulate_output_iterator.h
@@ -110,7 +110,7 @@ template <class _Fn, class _Index>
 class tabulate_output_iterator
 {
 private:
-  _CCCL_NO_UNIQUE_ADDRESS _CUDA_VRANGES::__movable_box<_Fn> __func_;
+  _CUDA_VRANGES::__movable_box<_Fn> __func_;
   _Index __index_ = 0;
 
 public:

--- a/libcudacxx/include/cuda/__iterator/transform_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/transform_iterator.h
@@ -155,8 +155,8 @@ class transform_iterator : public __transform_iterator_category_base<_Iter, _Fn>
                 "cuda::transform_iterator requires that the return type of _Fn is referenceable");
 
 public:
-  _CCCL_NO_UNIQUE_ADDRESS _Iter __current_;
-  _CCCL_NO_UNIQUE_ADDRESS _CUDA_VRANGES::__movable_box<_Fn> __func_;
+  _Iter __current_;
+  _CUDA_VRANGES::__movable_box<_Fn> __func_;
 
   using iterator_concept = _CUDA_VSTD::conditional_t<
     _CUDA_VSTD::random_access_iterator<_Iter>,

--- a/libcudacxx/include/cuda/__iterator/transform_output_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/transform_output_iterator.h
@@ -55,7 +55,7 @@ private:
   template <class, class>
   friend class transform_output_iterator;
 
-  _CCCL_NO_UNIQUE_ADDRESS _Iter __iter_;
+  _Iter __iter_;
   _Fn& __func_;
 
   template <class _MaybeConstFn, class _Arg>
@@ -142,8 +142,8 @@ class transform_output_iterator
   static_assert(_CUDA_VSTD::is_object_v<_Fn>, "cuda::transform_output_iterator requires that _Fn is a function object");
 
 public:
-  _CCCL_NO_UNIQUE_ADDRESS _Iter __current_{};
-  _CCCL_NO_UNIQUE_ADDRESS _CUDA_VRANGES::__movable_box<_Fn> __func_{};
+  _Iter __current_{};
+  _CUDA_VRANGES::__movable_box<_Fn> __func_{};
 
   using _Cat = typename _CUDA_VSTD::iterator_traits<_Iter>::iterator_category;
 

--- a/libcudacxx/test/libcudacxx/cuda/iterators/tabulate_output_iterator/member_typedefs.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/tabulate_output_iterator/member_typedefs.compile.pass.cpp
@@ -28,10 +28,6 @@ __host__ __device__ void test()
 #if !_CCCL_ARCH(ARM64) // There are some compiler issues on arm compilers
     static_assert(cuda::std::output_iterator<Iter, int>);
 #endif // !_CCCL_ARCH(ARM64)
-
-#if _CCCL_HAS_ATTRIBUTE_NO_UNIQUE_ADDRESS()
-    static_assert(sizeof(Iter) == sizeof(cuda::std::ptrdiff_t));
-#endif // _CCCL_HAS_ATTRIBUTE_NO_UNIQUE_ADDRESS()
   }
 
   {
@@ -43,10 +39,6 @@ __host__ __device__ void test()
 #if !_CCCL_ARCH(ARM64) // There are some compiler issues on arm compilers
     static_assert(cuda::std::output_iterator<Iter, int>);
 #endif // !_CCCL_ARCH(ARM64)
-
-#if _CCCL_HAS_ATTRIBUTE_NO_UNIQUE_ADDRESS()
-    static_assert(sizeof(Iter) == sizeof(char));
-#endif // _CCCL_HAS_ATTRIBUTE_NO_UNIQUE_ADDRESS()
   }
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_output_iterator/member_typedefs.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_output_iterator/member_typedefs.compile.pass.cpp
@@ -29,10 +29,6 @@ __host__ __device__ void test()
     static_assert(cuda::std::same_as<Iter::value_type, void>);
     static_assert(cuda::std::same_as<Iter::difference_type, cuda::std::ptrdiff_t>);
     static_assert(cuda::std::output_iterator<Iter, int>);
-
-#if _CCCL_HAS_ATTRIBUTE_NO_UNIQUE_ADDRESS()
-    static_assert(sizeof(Iter) == sizeof(int*));
-#endif // _CCCL_HAS_ATTRIBUTE_NO_UNIQUE_ADDRESS()
   }
 
   {
@@ -44,10 +40,6 @@ __host__ __device__ void test()
     static_assert(cuda::std::same_as<Iter::value_type, void>);
     static_assert(cuda::std::same_as<Iter::difference_type, cuda::std::ptrdiff_t>);
     static_assert(cuda::std::output_iterator<Iter, int>);
-
-#if _CCCL_HAS_ATTRIBUTE_NO_UNIQUE_ADDRESS()
-    static_assert(sizeof(Iter) == sizeof(int*));
-#endif // _CCCL_HAS_ATTRIBUTE_NO_UNIQUE_ADDRESS()
   }
 }
 


### PR DESCRIPTION
We experienced memory corruption in an upcoming PR.

It turned out to be due toe usage of `_CCCL_NO_UNIQUE_ADDRESS` in `cuda::transform_iterator`

Until we are sure that there are no more issues, we need to drop any optimization here :(
