### PR TITLE
Rebalance items per thread in LDGSTS/UBLKCP transform kernels

### DIFF
--- a/cub/cub/device/dispatch/dispatch_transform.cuh
+++ b/cub/cub/device/dispatch/dispatch_transform.cuh
@@ -186,6 +186,7 @@ struct dispatch_t<StableAddress,
     auto wrapped_policy     = detail::transform::MakeTransformPolicyWrapper(active_policy);
     const int block_threads = wrapped_policy.BlockThreads();
 
+// TODO(bgruber): this should probably be a ceil_div:
     const int items_per_thread_evenly_spread = static_cast<int>(
       (::cuda::std::min)(Offset{items_per_thread}, num_items / (sm_count * block_threads * max_occupancy)));
     const int items_per_thread_clamped = ::cuda::std::clamp(

--- a/cub/cub/device/dispatch/dispatch_transform.cuh
+++ b/cub/cub/device/dispatch/dispatch_transform.cuh
@@ -185,10 +185,9 @@ struct dispatch_t<StableAddress,
     auto wrapped_policy     = detail::transform::MakeTransformPolicyWrapper(active_policy);
     const int block_threads = wrapped_policy.BlockThreads();
 
-    // TODO(bgruber): this should probably be a ceil_div:
-    const int items_per_thread_evenly_spread = static_cast<int>(
-      (::cuda::std::min)(Offset{items_per_thread}, num_items / (sm_count * block_threads * max_occupancy)));
-    const int items_per_thread_clamped = ::cuda::std::clamp(
+    const int items_per_thread_evenly_spread = static_cast<int>((::cuda::std::min)(
+      Offset{items_per_thread}, ::cuda::ceil_div(num_items, sm_count * block_threads * max_occupancy)));
+    const int items_per_thread_clamped       = ::cuda::std::clamp(
       items_per_thread_evenly_spread, +wrapped_policy.MinItemsPerThread(), +wrapped_policy.MaxItemsPerThread());
     return items_per_thread_clamped;
   }

--- a/cub/cub/device/dispatch/dispatch_transform.cuh
+++ b/cub/cub/device/dispatch/dispatch_transform.cuh
@@ -121,10 +121,11 @@ _CCCL_HOST_DEVICE inline cuda_expected<int> get_max_shared_memory()
   return max_smem;
 }
 
-struct elem_counts
+struct async_config
 {
-  int elem_per_thread;
-  int tile_size;
+  int items_per_thread;
+  int max_occupancy;
+  int sm_count;
   int smem_size;
 };
 
@@ -177,62 +178,87 @@ struct dispatch_t<StableAddress,
   KernelSource kernel_source             = {};
   KernelLauncherFactory launcher_factory = {};
 
+  // Reduces the items_per_thread when necessary to generate enough blocks to reach the maximum occupancy.
+  template <typename ActivePolicy>
+  CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE int
+  spread_out_items_per_thread(ActivePolicy active_policy, int items_per_thread, int sm_count, int max_occupancy)
+  {
+    auto wrapped_policy     = detail::transform::MakeTransformPolicyWrapper(active_policy);
+    const int block_threads = wrapped_policy.BlockThreads();
+
+    const int items_per_thread_evenly_spread = static_cast<int>(
+      (::cuda::std::min)(Offset{items_per_thread}, num_items / (sm_count * block_threads * max_occupancy)));
+    const int items_per_thread_clamped = ::cuda::std::clamp(
+      items_per_thread_evenly_spread, +wrapped_policy.MinItemsPerThread(), +wrapped_policy.MaxItemsPerThread());
+    return items_per_thread_clamped;
+  }
+
   template <typename ActivePolicy, typename SMemFunc>
   CUB_RUNTIME_FUNCTION _CCCL_VISIBILITY_HIDDEN _CCCL_FORCEINLINE auto
-  configure_async_kernel(int alignment, SMemFunc smem_for_tile_size) -> cuda_expected<
-    ::cuda::std::
-      tuple<THRUST_NS_QUALIFIER::cuda_cub::detail::triple_chevron, decltype(kernel_source.TransformKernel()), int>>
+  configure_async_kernel(int alignment, SMemFunc smem_for_tile_size)
+    -> cuda_expected<
+      ::cuda::std::
+        tuple<THRUST_NS_QUALIFIER::cuda_cub::detail::triple_chevron, decltype(kernel_source.TransformKernel()), int>>
   {
     // Benchmarking shows that even for a few iteration, this loop takes around 4-7 us, so should not be a concern.
     using policy_t              = typename ActivePolicy::algo_policy;
     constexpr int block_threads = policy_t::block_threads;
     _CCCL_ASSERT(block_threads % alignment == 0,
                  "block_threads needs to be a multiple of the copy alignment"); // then tile_size is a multiple
-    auto determine_element_counts = [&]() -> cuda_expected<elem_counts> {
+    auto determine_element_counts = [&]() -> cuda_expected<async_config> {
       const auto max_smem = get_max_shared_memory();
       if (!max_smem)
       {
         return ::cuda::std::unexpected<cudaError_t /* nvcc 12.0 fails CTAD here */>(max_smem.error());
       }
 
+      int sm_count = 0;
+      auto error   = CubDebug(launcher_factory.MultiProcessorCount(sm_count));
+      if (error != cudaSuccess)
+      {
+        return ::cuda::std::unexpected<cudaError_t /* nvcc 12.0 fails CTAD here */>(error);
+      }
+
       // Increase the number of output elements per thread until we reach the required bytes in flight. This computation
       // MUST NOT depend on any runtime state of the current API invocation (like num_items), since the result will be
       // cached.
-      elem_counts last_counts{};
-      for (int elem_per_thread = +policy_t::min_items_per_thread; elem_per_thread <= +policy_t::max_items_per_thread;
-           ++elem_per_thread)
+      async_config last_config{};
+      for (int items_per_thread = +policy_t::min_items_per_thread; items_per_thread <= +policy_t::max_items_per_thread;
+           ++items_per_thread)
       {
         // ensures the loop below runs at least once
         static_assert(policy_t::min_items_per_thread <= policy_t::max_items_per_thread);
 
-        const int tile_size = block_threads * elem_per_thread;
+        const int tile_size = block_threads * items_per_thread;
         const int smem_size = smem_for_tile_size(tile_size, alignment);
         if (smem_size > *max_smem)
         {
           // assert should be prevented by smem check in policy
-          _CCCL_ASSERT(last_counts.elem_per_thread > 0, "min_items_per_thread exceeds available shared memory");
-          return last_counts;
+          _CCCL_ASSERT(last_config.items_per_thread > 0, "min_items_per_thread exceeds available shared memory");
+          return last_config;
         }
 
         int max_occupancy = 0;
-        const auto error  = CubDebug(
+        error             = CubDebug(
           launcher_factory.MaxSmOccupancy(max_occupancy, kernel_source.TransformKernel(), block_threads, smem_size));
         if (error != cudaSuccess)
         {
           return ::cuda::std::unexpected<cudaError_t /* nvcc 12.0 fails CTAD here */>(error);
         }
 
+        const auto config = async_config{items_per_thread, max_occupancy, sm_count, smem_size};
+
         const int bytes_in_flight_SM = max_occupancy * tile_size * kernel_source.LoadedBytesPerIteration();
         if (ActivePolicy::min_bif <= bytes_in_flight_SM)
         {
-          return elem_counts{elem_per_thread, tile_size, smem_size};
+          return config;
         }
 
-        last_counts = elem_counts{elem_per_thread, tile_size, smem_size};
+        last_config = config;
       }
-      return last_counts;
+      return last_config;
     };
-    cuda_expected<elem_counts> config = [&]() {
+    cuda_expected<async_config> config = [&]() {
       NV_IF_TARGET(NV_IS_HOST,
                    (static auto cached_config = determine_element_counts(); return cached_config;),
                    (
@@ -243,16 +269,20 @@ struct dispatch_t<StableAddress,
     {
       return ::cuda::std::unexpected<cudaError_t /* nvcc 12.0 fails CTAD here */>(config.error());
     }
-    _CCCL_ASSERT(config->elem_per_thread > 0, "");
-    _CCCL_ASSERT(config->tile_size > 0, "");
-    _CCCL_ASSERT(config->tile_size % alignment == 0, "");
+    _CCCL_ASSERT(config->items_per_thread > 0, "");
+    _CCCL_ASSERT(config->items_per_thread > 0, "");
+    _CCCL_ASSERT((config->items_per_thread * block_threads) % alignment == 0, "");
     _CCCL_ASSERT((sizeof...(RandomAccessIteratorsIn) == 0) != (config->smem_size != 0), ""); // logical xor
 
-    const auto grid_dim = static_cast<unsigned int>(::cuda::ceil_div(num_items, Offset{config->tile_size}));
+    const int ipt =
+      spread_out_items_per_thread(ActivePolicy{}, config->items_per_thread, config->sm_count, config->max_occupancy);
+    const int tile_size = block_threads * ipt;
+
+    const auto grid_dim = static_cast<unsigned int>(::cuda::ceil_div(num_items, Offset{tile_size}));
     return ::cuda::std::make_tuple(
       launcher_factory(grid_dim, block_threads, config->smem_size, stream),
       kernel_source.TransformKernel(),
-      config->elem_per_thread);
+      config->items_per_thread);
   }
 
   template <typename ActivePolicy, typename SMemFunc, std::size_t... Is>
@@ -264,11 +294,11 @@ struct dispatch_t<StableAddress,
     {
       return ret.error();
     }
-    auto [launcher, kernel, elem_per_thread] = *ret;
+    auto [launcher, kernel, items_per_thread] = *ret;
     return launcher.doit(
       kernel,
       num_items,
-      elem_per_thread,
+      items_per_thread,
       false,
       op,
       THRUST_NS_QUALIFIER::try_unwrap_contiguous_iterator(out),
@@ -292,7 +322,7 @@ struct dispatch_t<StableAddress,
         return ::cuda::std::unexpected<cudaError_t /* nvcc 12.0 fails CTAD here */>(error);
       }
       int sm_count = 0;
-      error        = launcher_factory.MultiProcessorCount(sm_count);
+      error        = CubDebug(launcher_factory.MultiProcessorCount(sm_count));
       if (error != cudaSuccess)
       {
         return ::cuda::std::unexpected<cudaError_t /* nvcc 12.0 fails CTAD here */>(error);
@@ -351,7 +381,7 @@ struct dispatch_t<StableAddress,
           return wrapped_policy.ItemsPerThreadForVectorizedPath();
         }
       }
-      // otherwise, setup the prefetch kernel
+      // otherwise, set up the prefetch kernel
 
       auto loaded_bytes_per_iter = kernel_source.LoadedBytesPerIteration();
       // choose items per thread to reach minimum bytes in flight
@@ -360,14 +390,8 @@ struct dispatch_t<StableAddress,
           ? wrapped_policy.ItemsPerThreadNoInput()
           : ::cuda::ceil_div(wrapped_policy.MinBif(), config->max_occupancy * block_threads * loaded_bytes_per_iter);
 
-      // but also generate enough blocks for full occupancy to optimize small problem sizes, e.g., 2^16 or 2^20
-      // elements
-      const int items_per_thread_evenly_spread = static_cast<int>(
-        (::cuda::std::min) (Offset{items_per_thread},
-                            num_items / (config->sm_count * block_threads * config->max_occupancy)));
-      const int items_per_thread_clamped = ::cuda::std::clamp(
-        items_per_thread_evenly_spread, +wrapped_policy.MinItemsPerThread(), +wrapped_policy.MaxItemsPerThread());
-      return items_per_thread_clamped;
+      // but also generate enough blocks for full occupancy to optimize small problem sizes, e.g., 2^16/2^20 elements
+      return spread_out_items_per_thread(active_policy, items_per_thread, config->sm_count, config->max_occupancy);
     }();
     const int tile_size = block_threads * ipt;
     const auto grid_dim = static_cast<unsigned int>(::cuda::ceil_div(num_items, Offset{tile_size}));

--- a/cub/cub/device/dispatch/dispatch_transform.cuh
+++ b/cub/cub/device/dispatch/dispatch_transform.cuh
@@ -185,19 +185,19 @@ struct dispatch_t<StableAddress,
     auto wrapped_policy     = detail::transform::MakeTransformPolicyWrapper(active_policy);
     const int block_threads = wrapped_policy.BlockThreads();
 
-    const int items_per_thread_evenly_spread = static_cast<int>((::cuda::std::min)(
-      Offset{items_per_thread}, ::cuda::ceil_div(num_items, sm_count * block_threads * max_occupancy)));
-    const int items_per_thread_clamped       = ::cuda::std::clamp(
+    const int items_per_thread_evenly_spread = static_cast<int>(
+      (::cuda::std::min) (Offset{items_per_thread},
+                          ::cuda::ceil_div(num_items, sm_count * block_threads * max_occupancy)));
+    const int items_per_thread_clamped = ::cuda::std::clamp(
       items_per_thread_evenly_spread, +wrapped_policy.MinItemsPerThread(), +wrapped_policy.MaxItemsPerThread());
     return items_per_thread_clamped;
   }
 
   template <typename ActivePolicy, typename SMemFunc>
   CUB_RUNTIME_FUNCTION _CCCL_VISIBILITY_HIDDEN _CCCL_FORCEINLINE auto
-  configure_async_kernel(int alignment, SMemFunc smem_for_tile_size)
-    -> cuda_expected<
-      ::cuda::std::
-        tuple<THRUST_NS_QUALIFIER::cuda_cub::detail::triple_chevron, decltype(kernel_source.TransformKernel()), int>>
+  configure_async_kernel(int alignment, SMemFunc smem_for_tile_size) -> cuda_expected<
+    ::cuda::std::
+      tuple<THRUST_NS_QUALIFIER::cuda_cub::detail::triple_chevron, decltype(kernel_source.TransformKernel()), int>>
   {
     // Benchmarking shows that even for a few iteration, this loop takes around 4-7 us, so should not be a concern.
     using policy_t              = typename ActivePolicy::algo_policy;


### PR DESCRIPTION

This PR fixes a performance bug where CUB would just cache the kernel config for a small tile size (e.g. with items_per_thread == 1) and then retain that config also for large problem sizes. I therefore removed taking the problem size into account when choosing the items per thread.

However, the prefetch kernel does rebalance the chosen (and cached) items per thread again later to reach full occupancy, which is beneficial to small workloads. This PR implements the same logic now for the LDGSTS/UBLKCP kernels.

Only improvements on B300, especially for small problems of I8.

Strong improvements for small data types and small problem sizes on H200, but also a few regressions:
```
# mul

## [0] NVIDIA H200 NVL

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-----------|---------|----------|
|   I8    |      I32      |      2^16      |   5.397 us |       3.38% |   4.500 us |       2.70% | -0.897 us | -16.62% |   FAST   |
|   I8    |      I32      |      2^20      |   6.001 us |       3.86% |   5.581 us |       3.24% | -0.420 us |  -6.99% |   FAST   |
|   I8    |      I32      |      2^24      |  15.832 us |       2.57% |  15.863 us |       2.46% |  0.031 us |   0.20% |   SAME   |
|   I8    |      I32      |      2^28      | 154.749 us |       0.45% | 155.405 us |       0.50% |  0.657 us |   0.42% |   SAME   |
|   I8    |      I64      |      2^16      |   5.522 us |       3.56% |   4.682 us |       4.01% | -0.839 us | -15.20% |   FAST   |
|   I8    |      I64      |      2^20      |   6.029 us |       3.49% |   5.683 us |       4.28% | -0.346 us |  -5.73% |   FAST   |
|   I8    |      I64      |      2^24      |  15.823 us |       2.64% |  15.922 us |       2.54% |  0.099 us |   0.63% |   SAME   |
|   I8    |      I64      |      2^28      | 156.104 us |       0.48% | 156.364 us |       0.49% |  0.260 us |   0.17% |   SAME   |
|   I16   |      I32      |      2^16      |   5.045 us |       3.37% |   4.725 us |       3.92% | -0.320 us |  -6.35% |   FAST   |
|   I16   |      I32      |      2^20      |   6.264 us |       3.56% |   6.207 us |       3.10% | -0.057 us |  -0.91% |   SAME   |
|   I16   |      I32      |      2^24      |  22.637 us |       2.73% |  22.905 us |       2.52% |  0.268 us |   1.19% |   SAME   |
|   I16   |      I32      |      2^28      | 263.425 us |       0.44% | 263.379 us |       0.45% | -0.046 us |  -0.02% |   SAME   |
|   I16   |      I64      |      2^16      |   5.071 us |       4.07% |   4.782 us |       4.07% | -0.289 us |  -5.70% |   FAST   |
|   I16   |      I64      |      2^20      |   6.290 us |       3.78% |   6.222 us |       4.10% | -0.068 us |  -1.08% |   SAME   |
|   I16   |      I64      |      2^24      |  23.008 us |       2.63% |  22.924 us |       2.41% | -0.084 us |  -0.36% |   SAME   |
|   I16   |      I64      |      2^28      | 266.432 us |       0.42% | 266.419 us |       0.43% | -0.013 us |  -0.00% |   SAME   |
|   F32   |      I32      |      2^16      |   4.868 us |       4.00% |   4.754 us |       4.01% | -0.113 us |  -2.33% |   SAME   |
|   F32   |      I32      |      2^20      |   7.044 us |       3.57% |   7.181 us |       3.65% |  0.136 us |   1.94% |   SAME   |
|   F32   |      I32      |      2^24      |  38.340 us |       2.28% |  38.332 us |       2.33% | -0.009 us |  -0.02% |   SAME   |
|   F32   |      I32      |      2^28      | 527.645 us |       0.22% | 527.703 us |       0.22% |  0.057 us |   0.01% |   SAME   |
|   F32   |      I64      |      2^16      |   4.917 us |       4.22% |   4.782 us |       4.36% | -0.134 us |  -2.73% |   SAME   |
|   F32   |      I64      |      2^20      |   7.062 us |       3.21% |   7.209 us |       4.20% |  0.147 us |   2.08% |   SAME   |
|   F32   |      I64      |      2^24      |  38.416 us |       2.30% |  38.261 us |       2.35% | -0.154 us |  -0.40% |   SAME   |
|   F32   |      I64      |      2^28      | 527.526 us |       0.21% | 527.589 us |       0.22% |  0.064 us |   0.01% |   SAME   |
|   F64   |      I32      |      2^16      |   4.980 us |       4.96% |   4.886 us |       3.30% | -0.094 us |  -1.89% |   SAME   |
|   F64   |      I32      |      2^20      |   9.565 us |       4.20% |   9.487 us |       3.48% | -0.078 us |  -0.81% |   SAME   |
|   F64   |      I32      |      2^24      |  70.807 us |       1.34% |  70.745 us |       1.29% | -0.062 us |  -0.09% |   SAME   |
|   F64   |      I32      |      2^28      |   1.047 ms |       0.14% |   1.047 ms |       0.13% |  0.056 us |   0.01% |   SAME   |
|   F64   |      I64      |      2^16      |   5.009 us |       4.11% |   4.993 us |       4.55% | -0.016 us |  -0.31% |   SAME   |
|   F64   |      I64      |      2^20      |   9.568 us |       3.95% |   9.332 us |       1.80% | -0.236 us |  -2.47% |   FAST   |
|   F64   |      I64      |      2^24      |  70.682 us |       1.34% |  70.678 us |       1.33% | -0.005 us |  -0.01% |   SAME   |
|   F64   |      I64      |      2^28      |   1.047 ms |       0.15% |   1.047 ms |       0.14% | -0.044 us |  -0.00% |   SAME   |
|  I128   |      I32      |      2^16      |   5.406 us |       4.41% |   5.254 us |       4.94% | -0.152 us |  -2.81% |   SAME   |
|  I128   |      I32      |      2^20      |  13.938 us |       3.39% |  13.825 us |       3.29% | -0.113 us |  -0.81% |   SAME   |
|  I128   |      I32      |      2^24      | 138.428 us |       0.72% | 138.400 us |       0.71% | -0.028 us |  -0.02% |   SAME   |
|  I128   |      I32      |      2^28      |   2.128 ms |       0.08% |   2.128 ms |       0.08% | -0.106 us |  -0.00% |   SAME   |
|  I128   |      I64      |      2^16      |   5.336 us |       3.71% |   5.196 us |       3.94% | -0.140 us |  -2.63% |   SAME   |
|  I128   |      I64      |      2^20      |  13.764 us |       3.29% |  13.837 us |       3.41% |  0.073 us |   0.53% |   SAME   |
|  I128   |      I64      |      2^24      | 139.451 us |       1.17% | 139.464 us |       1.20% |  0.013 us |   0.01% |   SAME   |
|  I128   |      I64      |      2^28      |   2.128 ms |       0.09% |   2.128 ms |       0.08% | -0.037 us |  -0.00% |   SAME   |

# add

## [0] NVIDIA H200 NVL

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-----------|---------|----------|
|   I8    |      I32      |      2^16      |   5.139 us |       3.54% |   4.778 us |       4.15% | -0.361 us |  -7.02% |   FAST   |
|   I8    |      I32      |      2^20      |   6.154 us |       3.44% |   5.981 us |       4.30% | -0.173 us |  -2.81% |   SAME   |
|   I8    |      I32      |      2^24      |  20.458 us |       2.72% |  20.124 us |       2.66% | -0.333 us |  -1.63% |   SAME   |
|   I8    |      I32      |      2^28      | 210.742 us |       0.60% | 211.295 us |       0.56% |  0.552 us |   0.26% |   SAME   |
|   I8    |      I64      |      2^16      |   5.052 us |       3.48% |   4.711 us |       3.44% | -0.341 us |  -6.75% |   FAST   |
|   I8    |      I64      |      2^20      |   6.225 us |       3.48% |   6.116 us |       3.48% | -0.109 us |  -1.75% |   SAME   |
|   I8    |      I64      |      2^24      |  20.367 us |       2.67% |  20.247 us |       2.78% | -0.120 us |  -0.59% |   SAME   |
|   I8    |      I64      |      2^28      | 211.047 us |       0.22% | 211.341 us |       0.30% |  0.293 us |   0.14% |   SAME   |
|   I16   |      I32      |      2^16      |   4.970 us |       3.72% |   4.827 us |       4.50% | -0.143 us |  -2.89% |   SAME   |
|   I16   |      I32      |      2^20      |   7.047 us |       4.01% |   7.183 us |       4.42% |  0.136 us |   1.93% |   SAME   |
|   I16   |      I32      |      2^24      |  31.711 us |       2.22% |  31.748 us |       2.17% |  0.037 us |   0.12% |   SAME   |
|   I16   |      I32      |      2^28      | 386.820 us |       0.21% | 386.905 us |       0.21% |  0.084 us |   0.02% |   SAME   |
|   I16   |      I64      |      2^16      |   5.027 us |       3.78% |   4.842 us |       4.26% | -0.185 us |  -3.68% |   SAME   |
|   I16   |      I64      |      2^20      |   7.073 us |       3.71% |   7.065 us |       3.96% | -0.007 us |  -0.10% |   SAME   |
|   I16   |      I64      |      2^24      |  31.756 us |       2.26% |  31.788 us |       2.19% |  0.032 us |   0.10% |   SAME   |
|   I16   |      I64      |      2^28      | 387.707 us |       0.21% | 387.864 us |       0.19% |  0.157 us |   0.04% |   SAME   |
|   F32   |      I32      |      2^16      |   5.014 us |       3.25% |   4.929 us |       3.98% | -0.085 us |  -1.70% |   SAME   |
|   F32   |      I32      |      2^20      |   8.540 us |       4.06% |   8.945 us |       5.30% |  0.404 us |   4.73% |   SLOW   |
|   F32   |      I32      |      2^24      |  55.264 us |       1.55% |  55.348 us |       1.50% |  0.084 us |   0.15% |   SAME   |
|   F32   |      I32      |      2^28      | 756.205 us |       0.13% | 756.256 us |       0.13% |  0.051 us |   0.01% |   SAME   |
|   F32   |      I64      |      2^16      |   5.153 us |       3.97% |   5.123 us |       4.17% | -0.030 us |  -0.58% |   SAME   |
|   F32   |      I64      |      2^20      |   8.576 us |       4.59% |   8.962 us |       5.30% |  0.385 us |   4.49% |   SAME   |
|   F32   |      I64      |      2^24      |  55.302 us |       1.51% |  55.356 us |       1.51% |  0.054 us |   0.10% |   SAME   |
|   F32   |      I64      |      2^28      | 756.848 us |       0.13% | 756.879 us |       0.13% |  0.031 us |   0.00% |   SAME   |
|   F64   |      I32      |      2^16      |   5.530 us |       4.49% |   5.359 us |       3.93% | -0.171 us |  -3.10% |   SAME   |
|   F64   |      I32      |      2^20      |  12.172 us |       3.08% |  12.101 us |       3.29% | -0.070 us |  -0.58% |   SAME   |
|   F64   |      I32      |      2^24      | 101.596 us |       0.36% | 101.317 us |       0.43% | -0.278 us |  -0.27% |   SAME   |
|   F64   |      I32      |      2^28      |   1.510 ms |       0.10% |   1.510 ms |       0.10% | -0.088 us |  -0.01% |   SAME   |
|   F64   |      I64      |      2^16      |   5.426 us |       4.14% |   5.392 us |       4.38% | -0.035 us |  -0.64% |   SAME   |
|   F64   |      I64      |      2^20      |  12.192 us |       3.30% |  12.216 us |       3.38% |  0.024 us |   0.20% |   SAME   |
|   F64   |      I64      |      2^24      | 101.585 us |       0.34% | 101.341 us |       0.42% | -0.243 us |  -0.24% |   SAME   |
|   F64   |      I64      |      2^28      |   1.510 ms |       0.10% |   1.510 ms |       0.10% | -0.048 us |  -0.00% |   SAME   |
|  I128   |      I32      |      2^16      |   6.004 us |       4.63% |   6.077 us |       4.68% |  0.073 us |   1.22% |   SAME   |
|  I128   |      I32      |      2^20      |  18.937 us |       2.83% |  19.007 us |       2.88% |  0.069 us |   0.37% |   SAME   |
|  I128   |      I32      |      2^24      | 195.611 us |       0.35% | 195.713 us |       0.33% |  0.102 us |   0.05% |   SAME   |
|  I128   |      I32      |      2^28      |   3.017 ms |       0.06% |   3.017 ms |       0.06% | -0.160 us |  -0.01% |   SAME   |
|  I128   |      I64      |      2^16      |   5.758 us |       4.92% |   5.819 us |       4.46% |  0.061 us |   1.06% |   SAME   |
|  I128   |      I64      |      2^20      |  18.984 us |       3.23% |  18.878 us |       2.98% | -0.106 us |  -0.56% |   SAME   |
|  I128   |      I64      |      2^24      | 196.925 us |       1.16% | 197.107 us |       1.14% |  0.182 us |   0.09% |   SAME   |
|  I128   |      I64      |      2^28      |   3.017 ms |       0.06% |   3.017 ms |       0.06% | -0.209 us |  -0.01% |   SAME   |

# triad

## [0] NVIDIA H200 NVL

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-----------|---------|----------|
|   I8    |      I32      |      2^16      |   5.293 us |       3.84% |   4.877 us |       3.96% | -0.416 us |  -7.86% |   FAST   |
|   I8    |      I32      |      2^20      |   6.453 us |       3.79% |   6.217 us |       3.56% | -0.236 us |  -3.65% |   FAST   |
|   I8    |      I32      |      2^24      |  20.858 us |       2.81% |  20.919 us |       2.80% |  0.062 us |   0.30% |   SAME   |
|   I8    |      I32      |      2^28      | 220.103 us |       0.79% | 220.274 us |       0.74% |  0.171 us |   0.08% |   SAME   |
|   I8    |      I64      |      2^16      |   5.373 us |       3.22% |   4.814 us |       3.82% | -0.559 us | -10.40% |   FAST   |
|   I8    |      I64      |      2^20      |   6.521 us |       3.26% |   6.304 us |       3.90% | -0.217 us |  -3.33% |   FAST   |
|   I8    |      I64      |      2^24      |  20.865 us |       2.64% |  21.046 us |       2.69% |  0.180 us |   0.86% |   SAME   |
|   I8    |      I64      |      2^28      | 220.104 us |       0.31% | 220.634 us |       0.36% |  0.530 us |   0.24% |   SAME   |
|   I16   |      I32      |      2^16      |   5.201 us |       4.61% |   4.917 us |       3.83% | -0.284 us |  -5.46% |   FAST   |
|   I16   |      I32      |      2^20      |   7.316 us |       3.15% |   7.218 us |       3.97% | -0.098 us |  -1.34% |   SAME   |
|   I16   |      I32      |      2^24      |  32.364 us |       2.18% |  32.391 us |       2.15% |  0.027 us |   0.08% |   SAME   |
|   I16   |      I32      |      2^28      | 389.102 us |       0.19% | 389.151 us |       0.19% |  0.049 us |   0.01% |   SAME   |
|   I16   |      I64      |      2^16      |   5.183 us |       3.35% |   4.919 us |       3.67% | -0.263 us |  -5.08% |   FAST   |
|   I16   |      I64      |      2^20      |   7.299 us |       3.20% |   7.256 us |       3.73% | -0.043 us |  -0.59% |   SAME   |
|   I16   |      I64      |      2^24      |  32.375 us |       2.15% |  32.452 us |       2.18% |  0.078 us |   0.24% |   SAME   |
|   I16   |      I64      |      2^28      | 389.975 us |       0.19% | 389.990 us |       0.18% |  0.015 us |   0.00% |   SAME   |
|   F32   |      I32      |      2^16      |   5.124 us |       4.09% |   5.056 us |       4.09% | -0.068 us |  -1.32% |   SAME   |
|   F32   |      I32      |      2^20      |   8.797 us |       3.84% |   9.003 us |       5.38% |  0.207 us |   2.35% |   SAME   |
|   F32   |      I32      |      2^24      |  55.452 us |       1.56% |  55.497 us |       1.50% |  0.045 us |   0.08% |   SAME   |
|   F32   |      I32      |      2^28      | 756.090 us |       0.14% | 756.258 us |       0.13% |  0.167 us |   0.02% |   SAME   |
|   F32   |      I64      |      2^16      |   5.023 us |       3.82% |   4.975 us |       3.97% | -0.048 us |  -0.96% |   SAME   |
|   F32   |      I64      |      2^20      |   8.732 us |       4.18% |   8.701 us |       4.50% | -0.032 us |  -0.36% |   SAME   |
|   F32   |      I64      |      2^24      |  55.396 us |       1.53% |  55.477 us |       1.55% |  0.081 us |   0.15% |   SAME   |
|   F32   |      I64      |      2^28      | 756.336 us |       0.14% | 756.406 us |       0.13% |  0.070 us |   0.01% |   SAME   |
|   F64   |      I32      |      2^16      |   5.352 us |       4.58% |   5.236 us |       4.74% | -0.116 us |  -2.17% |   SAME   |
|   F64   |      I32      |      2^20      |  12.131 us |       3.32% |  12.155 us |       3.28% |  0.024 us |   0.19% |   SAME   |
|   F64   |      I32      |      2^24      | 101.875 us |       0.32% | 101.678 us |       0.35% | -0.198 us |  -0.19% |   SAME   |
|   F64   |      I32      |      2^28      |   1.511 ms |       0.09% |   1.511 ms |       0.10% |  0.109 us |   0.01% |   SAME   |
|   F64   |      I64      |      2^16      |   5.401 us |       3.97% |   5.300 us |       4.03% | -0.101 us |  -1.87% |   SAME   |
|   F64   |      I64      |      2^20      |  12.111 us |       3.32% |  12.174 us |       3.34% |  0.063 us |   0.52% |   SAME   |
|   F64   |      I64      |      2^24      | 101.906 us |       0.38% | 101.691 us |       0.37% | -0.215 us |  -0.21% |   SAME   |
|   F64   |      I64      |      2^28      |   1.511 ms |       0.10% |   1.511 ms |       0.09% | -0.131 us |  -0.01% |   SAME   |
|  I128   |      I32      |      2^16      |   5.894 us |       3.88% |   5.969 us |       4.58% |  0.074 us |   1.26% |   SAME   |
|  I128   |      I32      |      2^20      |  18.816 us |       2.93% |  18.915 us |       2.90% |  0.099 us |   0.53% |   SAME   |
|  I128   |      I32      |      2^24      | 194.883 us |       0.42% | 194.589 us |       0.42% | -0.294 us |  -0.15% |   SAME   |
|  I128   |      I32      |      2^28      |   3.021 ms |       0.06% |   3.021 ms |       0.06% | -0.208 us |  -0.01% |   SAME   |
|  I128   |      I64      |      2^16      |   5.676 us |       3.82% |   5.724 us |       4.80% |  0.048 us |   0.84% |   SAME   |
|  I128   |      I64      |      2^20      |  19.187 us |       2.81% |  18.851 us |       2.95% | -0.335 us |  -1.75% |   SAME   |
|  I128   |      I64      |      2^24      | 197.018 us |       1.14% | 196.985 us |       1.16% | -0.033 us |  -0.02% |   SAME   |
|  I128   |      I64      |      2^28      |   3.021 ms |       0.06% |   3.021 ms |       0.06% | -0.205 us |  -0.01% |   SAME   |

# nstream

## [0] NVIDIA H200 NVL

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-----------|---------|----------|
|   I8    |      I32      |      2^16      |   5.149 us |       3.36% |   4.871 us |       4.29% | -0.278 us |  -5.40% |   FAST   |
|   I8    |      I32      |      2^20      |   6.543 us |       3.58% |   6.529 us |       3.59% | -0.014 us |  -0.21% |   SAME   |
|   I8    |      I32      |      2^24      |  24.742 us |       2.67% |  24.688 us |       2.71% | -0.053 us |  -0.22% |   SAME   |
|   I8    |      I32      |      2^28      | 277.600 us |       0.71% | 277.556 us |       0.76% | -0.044 us |  -0.02% |   SAME   |
|   I8    |      I64      |      2^16      |   5.069 us |       3.28% |   4.825 us |       3.63% | -0.244 us |  -4.81% |   FAST   |
|   I8    |      I64      |      2^20      |   6.664 us |       3.20% |   6.542 us |       3.81% | -0.123 us |  -1.84% |   SAME   |
|   I8    |      I64      |      2^24      |  24.267 us |       2.64% |  24.460 us |       2.73% |  0.194 us |   0.80% |   SAME   |
|   I8    |      I64      |      2^28      | 277.489 us |       0.28% | 277.207 us |       0.28% | -0.282 us |  -0.10% |   SAME   |
|   I16   |      I32      |      2^16      |   5.039 us |       3.77% |   4.906 us |       4.11% | -0.133 us |  -2.64% |   SAME   |
|   I16   |      I32      |      2^20      |   7.800 us |       3.59% |   7.793 us |       4.06% | -0.007 us |  -0.09% |   SAME   |
|   I16   |      I32      |      2^24      |  40.218 us |       1.87% |  40.245 us |       1.86% |  0.027 us |   0.07% |   SAME   |
|   I16   |      I32      |      2^28      | 516.014 us |       0.13% | 516.109 us |       0.13% |  0.095 us |   0.02% |   SAME   |
|   I16   |      I64      |      2^16      |   5.026 us |       3.41% |   4.959 us |       3.58% | -0.067 us |  -1.33% |   SAME   |
|   I16   |      I64      |      2^20      |   7.829 us |       3.77% |   7.835 us |       3.97% |  0.006 us |   0.08% |   SAME   |
|   I16   |      I64      |      2^24      |  40.292 us |       1.82% |  40.289 us |       1.87% | -0.004 us |  -0.01% |   SAME   |
|   I16   |      I64      |      2^28      | 519.928 us |       0.14% | 519.966 us |       0.14% |  0.038 us |   0.01% |   SAME   |
|   F32   |      I32      |      2^16      |   5.146 us |       3.97% |   5.059 us |       4.22% | -0.087 us |  -1.69% |   SAME   |
|   F32   |      I32      |      2^20      |   9.878 us |       1.47% |  10.289 us |       3.45% |  0.411 us |   4.16% |   SLOW   |
|   F32   |      I32      |      2^24      |  71.033 us |       1.09% |  71.308 us |       1.05% |  0.275 us |   0.39% |   SAME   |
|   F32   |      I32      |      2^28      |   1.002 ms |       0.05% |   1.002 ms |       0.04% |  0.087 us |   0.01% |   SAME   |
|   F32   |      I64      |      2^16      |   5.150 us |       4.19% |   5.101 us |       4.13% | -0.049 us |  -0.95% |   SAME   |
|   F32   |      I64      |      2^20      |   9.897 us |       1.43% |  10.187 us |       1.39% |  0.289 us |   2.92% |   SLOW   |
|   F32   |      I64      |      2^24      |  71.135 us |       1.09% |  71.075 us |       1.07% | -0.060 us |  -0.08% |   SAME   |
|   F32   |      I64      |      2^28      |   1.004 ms |       0.04% |   1.004 ms |       0.04% | -0.016 us |  -0.00% |   SAME   |
|   F64   |      I32      |      2^16      |   5.581 us |       3.84% |   5.655 us |       4.25% |  0.074 us |   1.33% |   SAME   |
|   F64   |      I32      |      2^20      |  14.744 us |       3.02% |  14.933 us |       3.18% |  0.189 us |   1.28% |   SAME   |
|   F64   |      I32      |      2^24      | 132.777 us |       0.67% | 133.386 us |       0.65% |  0.609 us |   0.46% |   SAME   |
|   F64   |      I32      |      2^28      |   1.991 ms |       0.04% |   1.991 ms |       0.04% | -0.062 us |  -0.00% |   SAME   |
|   F64   |      I64      |      2^16      |   5.663 us |       4.65% |   5.704 us |       4.37% |  0.041 us |   0.72% |   SAME   |
|   F64   |      I64      |      2^20      |  14.752 us |       3.19% |  14.914 us |       3.24% |  0.162 us |   1.10% |   SAME   |
|   F64   |      I64      |      2^24      | 132.851 us |       0.65% | 133.511 us |       0.65% |  0.660 us |   0.50% |   SAME   |
|   F64   |      I64      |      2^28      |   1.993 ms |       0.04% |   1.993 ms |       0.03% | -0.106 us |  -0.01% |   SAME   |
|  I128   |      I32      |      2^16      |   6.456 us |       4.44% |   6.473 us |       5.00% |  0.017 us |   0.27% |   SAME   |
|  I128   |      I32      |      2^20      |  23.222 us |       2.60% |  23.162 us |       2.63% | -0.060 us |  -0.26% |   SAME   |
|  I128   |      I32      |      2^24      | 257.226 us |       0.35% | 257.088 us |       0.36% | -0.139 us |  -0.05% |   SAME   |
|  I128   |      I32      |      2^28      |   3.988 ms |       0.04% |   3.988 ms |       0.04% | -0.181 us |  -0.00% |   SAME   |
|  I128   |      I64      |      2^16      |   6.215 us |       4.13% |   6.217 us |       4.19% |  0.002 us |   0.04% |   SAME   |
|  I128   |      I64      |      2^20      |  23.421 us |       2.75% |  23.362 us |       2.72% | -0.059 us |  -0.25% |   SAME   |
|  I128   |      I64      |      2^24      | 259.004 us |       0.91% | 259.056 us |       0.93% |  0.053 us |   0.02% |   SAME   |
|  I128   |      I64      |      2^28      |   3.989 ms |       0.04% |   3.988 ms |       0.04% | -0.305 us |  -0.01% |   SAME   |

```