### PR TITLE
Fix link to Python docs in cccl docs index page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,7 @@ CUDA Core Compute Libraries
    :maxdepth: 3
 
    cpp
-   :ref:`cccl-python-libraries`
+   python
 
 Welcome to the CUDA Core Compute Libraries (CCCL) where our mission is to
 make CUDA C++ and Python more delightful.

--- a/docs/python.rst
+++ b/docs/python.rst
@@ -1,0 +1,13 @@
+.. _cccl-python-libraries:
+
+CCCL Python Libraries
+=====================
+
+.. raw:: html
+
+   <meta http-equiv="refresh" content="0; url=https://nvidia.github.io/cccl/python/">
+   <script>
+   window.location.href = "https://nvidia.github.io/cccl/python/";
+   </script>
+
+If you are not redirected automatically, please click `here <https://nvidia.github.io/cccl/python/>`_.

--- a/docs/python/index.rst
+++ b/docs/python/index.rst
@@ -1,5 +1,3 @@
-.. _cccl-python-libraries:
-
 CCCL Python Libraries
 ======================
 


### PR DESCRIPTION
## Description

We have a bug in our top-level CCCL index page: https://nvidia.github.io/cccl/ introduced in https://github.com/NVIDIA/cccl/pull/5095.

This PR adds a new python.rst file at the top-level cccl, which redirects to https://nvidia.github.io/cccl/python/.

I'm doing it this way due to idiosyncrasies of our docs setup. The top-level "cccl" docs are a separate "project" from the Python docs, necessitating absolute URLs rather than relative ones.

This is also the reason we can't use any kind of relative URLs [here](https://github.com/NVIDIA/cccl/blob/eaba18d15e929baa33552fe678b43ae81c4e9478/docs/cpp.rst?plain=1#L10-L15). It's non-ideal but oh well.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
