### PR TITLE
Fix unqualified call to `__unwrap_iter`

### DIFF
--- a/libcudacxx/include/cuda/std/__algorithm/copy.h
+++ b/libcudacxx/include/cuda/std/__algorithm/copy.h
@@ -130,7 +130,8 @@ _CCCL_API constexpr pair<_Tp*, _Up*> __copy(_Tp* __first, _Tp* __last, _Up* __re
 template <class _InputIterator, class _OutputIterator>
 _CCCL_API constexpr _OutputIterator copy(_InputIterator __first, _InputIterator __last, _OutputIterator __result)
 {
-  return _CUDA_VSTD::__copy<_ClassicAlgPolicy>(__unwrap_iter(__first), __unwrap_iter(__last), __unwrap_iter(__result))
+  return _CUDA_VSTD::__copy<_ClassicAlgPolicy>(
+           _CUDA_VSTD::__unwrap_iter(__first), _CUDA_VSTD::__unwrap_iter(__last), _CUDA_VSTD::__unwrap_iter(__result))
     .second;
 }
 

--- a/libcudacxx/include/cuda/std/__algorithm/copy_backward.h
+++ b/libcudacxx/include/cuda/std/__algorithm/copy_backward.h
@@ -69,7 +69,8 @@ template <class _BidirectionalIterator1, class _BidirectionalIterator2>
 _CCCL_API inline _CCCL_CONSTEXPR_CXX20 _BidirectionalIterator2
 copy_backward(_BidirectionalIterator1 __first, _BidirectionalIterator1 __last, _BidirectionalIterator2 __result)
 {
-  return _CUDA_VSTD::__copy_backward(__unwrap_iter(__first), __unwrap_iter(__last), __unwrap_iter(__result));
+  return _CUDA_VSTD::__copy_backward(
+    _CUDA_VSTD::__unwrap_iter(__first), _CUDA_VSTD::__unwrap_iter(__last), _CUDA_VSTD::__unwrap_iter(__result));
 }
 
 _LIBCUDACXX_END_NAMESPACE_STD


### PR DESCRIPTION
Fixes [BUG]: `cuda::std::copy()` uses unqualified `__unwrap_iter()`, which is ambiguous with LLVM libc++'s equivalent definition #5116
