### PR TITLE
Try, fail and ignore to guarantee dynamic SMEM alignment on Hopper

### DIFF
--- a/cub/cub/device/dispatch/kernels/transform.cuh
+++ b/cub/cub/device/dispatch/kernels/transform.cuh
@@ -617,15 +617,8 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
   constexpr int bulk_copy_alignment = BulkCopyPolicy::bulk_copy_alignment;
 
   __shared__ uint64_t bar;
-
-  // SMEM is 16-byte aligned by default
-  extern __shared__ char smem[];
-  // TODO(bgruber): we should align smem to bulk_copy_alignment, but the performance regression is huge (up to 22%)
-  // if constexpr (bulk_copy_alignment > 16)
-  // {
-  //   smem = ::cuda::align_up(smem, bulk_copy_alignment);
-  //   // also just `smem += 48;` (since smem is 16 bytes aligned after the 8-byte bar) incurs 7% regression
-  // }
+  extern __shared__ char smem[] __attribute__((aligned(bulk_copy_alignment)));
+  _CCCL_ASSERT(::cuda::is_aligned(smem, bulk_copy_alignment), "Compiler ignored alignment attribute");
 
   namespace ptx = ::cuda::ptx;
 

--- a/cub/cub/device/dispatch/kernels/transform.cuh
+++ b/cub/cub/device/dispatch/kernels/transform.cuh
@@ -617,7 +617,11 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
   constexpr int bulk_copy_alignment = BulkCopyPolicy::bulk_copy_alignment;
 
   __shared__ uint64_t bar;
+#if _CCCL_CUDA_COMPILER(CLANG)
   extern __shared__ char smem[] __attribute__((aligned(bulk_copy_alignment)));
+#else // _CCCL_COMPILER(MSVC)
+  extern __shared__ char smem[] alignas(bulk_copy_alignment);
+#endif // _CCCL_COMPILER(MSVC)
   _CCCL_ASSERT(::cuda::is_aligned(smem, bulk_copy_alignment), "Compiler ignored alignment attribute");
 
   namespace ptx = ::cuda::ptx;

--- a/cub/cub/device/dispatch/kernels/transform.cuh
+++ b/cub/cub/device/dispatch/kernels/transform.cuh
@@ -610,6 +610,20 @@ _CCCL_DEVICE void bulk_copy_maybe_unaligned(
   }
 }
 
+template <int Alignment>
+_CCCL_DEVICE auto align_shared_ptr_now(char* p) -> char*
+{
+  // shared memory addresses are 32-bit, so convert and align it
+  uint32_t smem32 = __cvta_generic_to_shared(p);
+  smem32          = ::cuda::round_up(smem32, Alignment);
+  // pretend to NVVM that the 32-bit pointer is modified. this is required to avoid constant propagation from pulling
+  // the smem32 definition into loops and branches in subsequent code. thus, the pointer alignment code remains at the
+  // start of the kernel.
+  asm("" : "+r"(smem32));
+  // convert back to a generic pointer for C++ code
+  return static_cast<char*>(__cvta_shared_to_generic(smem32));
+}
+
 template <typename BulkCopyPolicy, typename Offset, typename F, typename RandomAccessIteratorOut, typename... InTs>
 _CCCL_DEVICE void transform_kernel_ublkcp(
   Offset num_items, int num_elem_per_thread, F f, RandomAccessIteratorOut out, aligned_base_ptr<InTs>... aligned_ptrs)
@@ -617,12 +631,23 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
   constexpr int bulk_copy_alignment = BulkCopyPolicy::bulk_copy_alignment;
 
   __shared__ uint64_t bar;
-#if _CCCL_CUDA_COMPILER(CLANG)
-  extern __shared__ char smem[] __attribute__((aligned(bulk_copy_alignment)));
-#else // _CCCL_COMPILER(MSVC)
-  extern __shared__ char smem[] alignas(bulk_copy_alignment);
-#endif // _CCCL_COMPILER(MSVC)
-  _CCCL_ASSERT(::cuda::is_aligned(smem, bulk_copy_alignment), "Compiler ignored alignment attribute");
+
+  // We would ideally use an attribute to align the shared memory like (all versions are equivalent):
+  // * extern __shared__ char __align__(bulk_copy_alignment) smem[];
+  // * extern __shared__ char smem[] alignas(bulk_copy_alignment);
+  // * extern __shared__ char smem[] __attribute__((aligned(bulk_copy_alignment)))
+  // The compiler correctly takes the alignment into account and even emits an alignment specifier into ptx. However,
+  // this somewhat randomly fails at runtime because the shared memory start pointer is not correctly provided by the
+  // runtime. See also NVBug 5093902.
+  extern __shared__ char smem_base[];
+
+  // SMEM is 16-byte aligned by default
+  char* smem = smem_base;
+  if constexpr (bulk_copy_alignment > 16)
+  {
+    smem = align_shared_ptr_now<bulk_copy_alignment>(smem);
+  }
+  _CCCL_ASSERT(::cuda::is_aligned(smem, bulk_copy_alignment), "");
 
   namespace ptx = ::cuda::ptx;
 

--- a/cub/cub/device/dispatch/kernels/transform.cuh
+++ b/cub/cub/device/dispatch/kernels/transform.cuh
@@ -23,7 +23,6 @@
 
 #include <cuda/__barrier/aligned_size.h> // cannot include <cuda/barrier> directly on CUDA_ARCH < 700
 #include <cuda/cmath>
-#include <cuda/memory>
 #include <cuda/ptx>
 #include <cuda/std/bit>
 #include <cuda/std/cstdint>

--- a/cub/cub/device/dispatch/kernels/transform.cuh
+++ b/cub/cub/device/dispatch/kernels/transform.cuh
@@ -619,12 +619,13 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
   __shared__ uint64_t bar;
 
   // SMEM is 16-byte aligned by default
-  extern __shared__ char smem_base[];
-  char* smem = smem_base;
-  if constexpr (bulk_copy_alignment > 16)
-  {
-    smem = ::cuda::align_up(smem, bulk_copy_alignment);
-  }
+  extern __shared__ char smem[];
+  // TODO(bgruber): we should align smem to bulk_copy_alignment, but the performance regression is huge (up to 22%)
+  // if constexpr (bulk_copy_alignment > 16)
+  // {
+  //   smem = ::cuda::align_up(smem, bulk_copy_alignment);
+  //   // also just `smem += 48;` (since smem is 16 bytes aligned after the 8-byte bar) incurs 7% regression
+  // }
 
   namespace ptx = ::cuda::ptx;
 


### PR DESCRIPTION
This should also fix a performance bug on Hopper. However, any attempt to guarantee alignment of dynamic shared memory outweighted the benefit. So this PR documents all failures and changes nothing. 

Benchmark on H200 no attribute vs. manual alignment (what this PR tried, but it's commented out).
```
# mul

## [0] NVIDIA H200

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-----------|---------|----------|
|   I8    |      I32      |      2^16      |   4.781 us |       2.72% |   4.798 us |       3.29% |  0.017 us |   0.35% |   SAME   |
|   I8    |      I32      |      2^20      |   5.355 us |       2.95% |   5.394 us |       2.90% |  0.039 us |   0.73% |   SAME   |
|   I8    |      I32      |      2^24      |  14.414 us |       1.95% |  14.459 us |       2.01% |  0.045 us |   0.31% |   SAME   |
|   I8    |      I32      |      2^28      | 140.482 us |       0.57% | 141.232 us |       0.53% |  0.750 us |   0.53% |   SLOW   |
|   I8    |      I64      |      2^16      |   4.843 us |       2.89% |   4.862 us |       3.24% |  0.019 us |   0.38% |   SAME   |
|   I8    |      I64      |      2^20      |   5.355 us |       2.48% |   5.370 us |       2.69% |  0.016 us |   0.29% |   SAME   |
|   I8    |      I64      |      2^24      |  14.414 us |       1.89% |  14.491 us |       1.87% |  0.077 us |   0.54% |   SAME   |
|   I8    |      I64      |      2^28      | 141.249 us |       0.54% | 141.925 us |       0.54% |  0.676 us |   0.48% |   SAME   |
|   I16   |      I32      |      2^16      |   4.462 us |       2.86% |   4.490 us |       2.53% |  0.028 us |   0.64% |   SAME   |
|   I16   |      I32      |      2^20      |   5.591 us |       3.37% |   5.571 us |       2.72% | -0.020 us |  -0.36% |   SAME   |
|   I16   |      I32      |      2^24      |  21.329 us |       2.28% |  21.251 us |       2.51% | -0.078 us |  -0.37% |   SAME   |
|   I16   |      I32      |      2^28      | 253.291 us |       0.39% | 252.994 us |       0.42% | -0.297 us |  -0.12% |   SAME   |
|   I16   |      I64      |      2^16      |   4.500 us |       2.71% |   4.520 us |       2.71% |  0.020 us |   0.44% |   SAME   |
|   I16   |      I64      |      2^20      |   5.622 us |       2.97% |   5.664 us |       3.41% |  0.042 us |   0.75% |   SAME   |
|   I16   |      I64      |      2^24      |  21.321 us |       2.30% |  21.307 us |       2.53% | -0.013 us |  -0.06% |   SAME   |
|   I16   |      I64      |      2^28      | 253.542 us |       0.39% | 253.203 us |       0.42% | -0.340 us |  -0.13% |   SAME   |
|   F32   |      I32      |      2^16      |   4.508 us |       3.03% |   4.538 us |       2.99% |  0.029 us |   0.64% |   SAME   |
|   F32   |      I32      |      2^20      |   6.539 us |       3.31% |   6.514 us |       3.12% | -0.025 us |  -0.38% |   SAME   |
|   F32   |      I32      |      2^24      |  36.971 us |       1.93% |  36.977 us |       1.89% |  0.006 us |   0.02% |   SAME   |
|   F32   |      I32      |      2^28      | 508.947 us |       0.19% | 508.988 us |       0.20% |  0.040 us |   0.01% |   SAME   |
|   F32   |      I64      |      2^16      |   4.570 us |       3.57% |   4.610 us |       3.55% |  0.040 us |   0.89% |   SAME   |
|   F32   |      I64      |      2^20      |   6.553 us |       2.63% |   6.575 us |       2.57% |  0.022 us |   0.33% |   SAME   |
|   F32   |      I64      |      2^24      |  36.749 us |       1.91% |  36.782 us |       1.89% |  0.033 us |   0.09% |   SAME   |
|   F32   |      I64      |      2^28      | 508.815 us |       0.19% | 508.899 us |       0.19% |  0.084 us |   0.02% |   SAME   |
|   F64   |      I32      |      2^16      |   4.619 us |       3.01% |   4.761 us |       3.36% |  0.142 us |   3.08% |   SLOW   |
|   F64   |      I32      |      2^20      |   8.678 us |       2.85% |   8.679 us |       3.05% |  0.001 us |   0.01% |   SAME   |
|   F64   |      I32      |      2^24      |  67.655 us |       1.08% |  67.651 us |       1.07% | -0.003 us |  -0.00% |   SAME   |
|   F64   |      I32      |      2^28      |   1.011 ms |       0.11% |   1.011 ms |       0.12% |  0.017 us |   0.00% |   SAME   |
|   F64   |      I64      |      2^16      |   4.639 us |       3.65% |   4.660 us |       4.61% |  0.022 us |   0.47% |   SAME   |
|   F64   |      I64      |      2^20      |   8.678 us |       2.85% |   8.752 us |       3.03% |  0.074 us |   0.86% |   SAME   |
|   F64   |      I64      |      2^24      |  67.638 us |       1.05% |  67.715 us |       1.08% |  0.076 us |   0.11% |   SAME   |
|   F64   |      I64      |      2^28      |   1.011 ms |       0.12% |   1.011 ms |       0.12% | -0.028 us |  -0.00% |   SAME   |
|  I128   |      I32      |      2^16      |   4.941 us |       4.29% |   5.076 us |       4.12% |  0.134 us |   2.71% |   SAME   |
|  I128   |      I32      |      2^20      |  13.033 us |       2.56% |  13.006 us |       2.61% | -0.027 us |  -0.20% |   SAME   |
|  I128   |      I32      |      2^24      | 132.747 us |       0.64% | 132.715 us |       0.66% | -0.031 us |  -0.02% |   SAME   |
|  I128   |      I32      |      2^28      |   2.051 ms |       0.09% |   2.050 ms |       0.08% | -0.220 us |  -0.01% |   SAME   |
|  I128   |      I64      |      2^16      |   4.885 us |       3.14% |   4.865 us |       3.08% | -0.020 us |  -0.41% |   SAME   |
|  I128   |      I64      |      2^20      |  12.854 us |       2.55% |  12.877 us |       2.57% |  0.023 us |   0.18% |   SAME   |
|  I128   |      I64      |      2^24      | 134.160 us |       0.67% | 134.139 us |       0.63% | -0.021 us |  -0.02% |   SAME   |
|  I128   |      I64      |      2^28      |   2.053 ms |       0.37% |   2.053 ms |       0.37% | -0.279 us |  -0.01% |   SAME   |

# add

## [0] NVIDIA H200

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-----------|---------|----------|
|   I8    |      I32      |      2^16      |   4.751 us |       2.96% |   4.732 us |       3.14% | -0.020 us |  -0.41% |   SAME   |
|   I8    |      I32      |      2^20      |   5.701 us |       2.91% |   5.700 us |       3.01% | -0.001 us |  -0.01% |   SAME   |
|   I8    |      I32      |      2^24      |  19.107 us |       2.04% |  19.100 us |       1.87% | -0.008 us |  -0.04% |   SAME   |
|   I8    |      I32      |      2^28      | 197.820 us |       0.57% | 199.277 us |       0.20% |  1.457 us |   0.74% |   SLOW   |
|   I8    |      I64      |      2^16      |   4.700 us |       2.79% |   4.704 us |       2.95% |  0.003 us |   0.07% |   SAME   |
|   I8    |      I64      |      2^20      |   5.796 us |       2.55% |   5.776 us |       2.44% | -0.020 us |  -0.34% |   SAME   |
|   I8    |      I64      |      2^24      |  18.563 us |       2.03% |  18.676 us |       2.09% |  0.113 us |   0.61% |   SAME   |
|   I8    |      I64      |      2^28      | 197.636 us |       0.23% | 198.448 us |       0.22% |  0.812 us |   0.41% |   SLOW   |
|   I16   |      I32      |      2^16      |   4.619 us |       2.77% |   4.624 us |       2.86% |  0.006 us |   0.13% |   SAME   |
|   I16   |      I32      |      2^20      |   6.498 us |       3.18% |   6.486 us |       2.26% | -0.012 us |  -0.18% |   SAME   |
|   I16   |      I32      |      2^24      |  30.029 us |       1.83% |  30.013 us |       1.93% | -0.015 us |  -0.05% |   SAME   |
|   I16   |      I32      |      2^28      | 371.226 us |       0.21% | 371.276 us |       0.21% |  0.051 us |   0.01% |   SAME   |
|   I16   |      I64      |      2^16      |   4.796 us |       3.37% |   4.617 us |       3.14% | -0.180 us |  -3.74% |   FAST   |
|   I16   |      I64      |      2^20      |   6.523 us |       2.36% |   6.630 us |       3.54% |  0.107 us |   1.64% |   SAME   |
|   I16   |      I64      |      2^24      |  30.223 us |       1.93% |  30.357 us |       1.90% |  0.134 us |   0.44% |   SAME   |
|   I16   |      I64      |      2^28      | 371.637 us |       0.22% | 372.097 us |       0.21% |  0.460 us |   0.12% |   SAME   |
|   F32   |      I32      |      2^16      |   4.675 us |       3.01% |   4.648 us |       3.10% | -0.026 us |  -0.56% |   SAME   |
|   F32   |      I32      |      2^20      |   7.847 us |       2.48% |   7.834 us |       2.87% | -0.013 us |  -0.16% |   SAME   |
|   F32   |      I32      |      2^24      |  52.580 us |       1.39% |  52.611 us |       1.39% |  0.031 us |   0.06% |   SAME   |
|   F32   |      I32      |      2^28      | 730.819 us |       0.13% | 730.765 us |       0.12% | -0.055 us |  -0.01% |   SAME   |
|   F32   |      I64      |      2^16      |   4.607 us |       3.27% |   4.662 us |       3.88% |  0.055 us |   1.19% |   SAME   |
|   F32   |      I64      |      2^20      |   7.832 us |       2.68% |   7.912 us |       2.77% |  0.080 us |   1.02% |   SAME   |
|   F32   |      I64      |      2^24      |  52.554 us |       1.39% |  52.709 us |       1.38% |  0.155 us |   0.30% |   SAME   |
|   F32   |      I64      |      2^28      | 730.719 us |       0.12% | 730.851 us |       0.12% |  0.133 us |   0.02% |   SAME   |
|   F64   |      I32      |      2^16      |   4.811 us |       4.47% |   4.828 us |       3.71% |  0.017 us |   0.34% |   SAME   |
|   F64   |      I32      |      2^20      |  11.000 us |       2.56% |  10.970 us |       2.61% | -0.029 us |  -0.26% |   SAME   |
|   F64   |      I32      |      2^24      |  97.548 us |       0.48% |  97.490 us |       0.48% | -0.057 us |  -0.06% |   SAME   |
|   F64   |      I32      |      2^28      |   1.467 ms |       0.11% |   1.467 ms |       0.10% | -0.022 us |  -0.00% |   SAME   |
|   F64   |      I64      |      2^16      |   4.910 us |       4.91% |   4.910 us |       4.26% |  0.000 us |   0.00% |   SAME   |
|   F64   |      I64      |      2^20      |  11.043 us |       2.60% |  11.097 us |       2.78% |  0.054 us |   0.49% |   SAME   |
|   F64   |      I64      |      2^24      |  97.274 us |       0.52% |  97.456 us |       0.40% |  0.181 us |   0.19% |   SAME   |
|   F64   |      I64      |      2^28      |   1.466 ms |       0.11% |   1.466 ms |       0.10% | -0.006 us |  -0.00% |   SAME   |
|  I128   |      I32      |      2^16      |   5.403 us |       5.06% |   5.389 us |       4.43% | -0.014 us |  -0.26% |   SAME   |
|  I128   |      I32      |      2^20      |  17.280 us |       2.34% |  17.300 us |       2.23% |  0.019 us |   0.11% |   SAME   |
|  I128   |      I32      |      2^24      | 188.358 us |       0.31% | 188.376 us |       0.32% |  0.018 us |   0.01% |   SAME   |
|  I128   |      I32      |      2^28      |   2.930 ms |       0.07% |   2.930 ms |       0.06% |  0.138 us |   0.00% |   SAME   |
|  I128   |      I64      |      2^16      |   5.194 us |       3.91% |   5.205 us |       3.41% |  0.011 us |   0.22% |   SAME   |
|  I128   |      I64      |      2^20      |  17.487 us |       2.36% |  17.607 us |       2.48% |  0.120 us |   0.68% |   SAME   |
|  I128   |      I64      |      2^24      | 190.343 us |       0.35% | 190.395 us |       0.36% |  0.052 us |   0.03% |   SAME   |
|  I128   |      I64      |      2^28      |   2.935 ms |       0.37% |   2.935 ms |       0.40% |  0.269 us |   0.01% |   SAME   |

# triad

## [0] NVIDIA H200

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-----------|---------|----------|
|   I8    |      I32      |      2^16      |   4.710 us |       3.04% |   4.712 us |       2.61% |  0.002 us |   0.05% |   SAME   |
|   I8    |      I32      |      2^20      |   5.755 us |       3.32% |   5.755 us |       3.31% |  0.001 us |   0.01% |   SAME   |
|   I8    |      I32      |      2^24      |  19.312 us |       1.99% |  19.283 us |       1.96% | -0.029 us |  -0.15% |   SAME   |
|   I8    |      I32      |      2^28      | 205.127 us |       0.14% | 206.472 us |       0.19% |  1.344 us |   0.66% |   SLOW   |
|   I8    |      I64      |      2^16      |   4.755 us |       3.14% |   4.783 us |       3.21% |  0.028 us |   0.59% |   SAME   |
|   I8    |      I64      |      2^20      |   5.734 us |       3.56% |   5.767 us |       3.67% |  0.034 us |   0.58% |   SAME   |
|   I8    |      I64      |      2^24      |  19.322 us |       2.66% |  19.294 us |       2.03% | -0.028 us |  -0.15% |   SAME   |
|   I8    |      I64      |      2^28      | 205.500 us |       0.16% | 206.270 us |       0.15% |  0.770 us |   0.37% |   SLOW   |
|   I16   |      I32      |      2^16      |   4.516 us |       3.27% |   4.541 us |       3.03% |  0.025 us |   0.55% |   SAME   |
|   I16   |      I32      |      2^20      |   6.456 us |       3.14% |   6.512 us |       3.22% |  0.056 us |   0.87% |   SAME   |
|   I16   |      I32      |      2^24      |  30.524 us |       1.89% |  30.513 us |       1.85% | -0.012 us |  -0.04% |   SAME   |
|   I16   |      I32      |      2^28      | 373.102 us |       0.21% | 373.264 us |       0.21% |  0.162 us |   0.04% |   SAME   |
|   I16   |      I64      |      2^16      |   4.540 us |       3.47% |   4.558 us |       2.80% |  0.018 us |   0.40% |   SAME   |
|   I16   |      I64      |      2^20      |   6.549 us |       3.14% |   6.552 us |       3.27% |  0.004 us |   0.05% |   SAME   |
|   I16   |      I64      |      2^24      |  30.550 us |       1.86% |  30.689 us |       1.86% |  0.139 us |   0.45% |   SAME   |
|   I16   |      I64      |      2^28      | 373.663 us |       0.21% | 374.023 us |       0.21% |  0.361 us |   0.10% |   SAME   |
|   F32   |      I32      |      2^16      |   4.664 us |       3.32% |   4.557 us |       2.42% | -0.107 us |  -2.30% |   SAME   |
|   F32   |      I32      |      2^20      |   7.775 us |       2.56% |   7.780 us |       2.53% |  0.005 us |   0.07% |   SAME   |
|   F32   |      I32      |      2^24      |  53.066 us |       1.35% |  53.066 us |       1.38% |  0.000 us |   0.00% |   SAME   |
|   F32   |      I32      |      2^28      | 731.526 us |       0.14% | 731.440 us |       0.13% | -0.086 us |  -0.01% |   SAME   |
|   F32   |      I64      |      2^16      |   4.910 us |       3.82% |   4.687 us |       3.91% | -0.224 us |  -4.56% |   FAST   |
|   F32   |      I64      |      2^20      |   7.910 us |       2.77% |   8.001 us |       2.94% |  0.092 us |   1.16% |   SAME   |
|   F32   |      I64      |      2^24      |  53.175 us |       1.36% |  53.274 us |       1.37% |  0.099 us |   0.19% |   SAME   |
|   F32   |      I64      |      2^28      | 731.441 us |       0.13% | 731.379 us |       0.12% | -0.062 us |  -0.01% |   SAME   |
|   F64   |      I32      |      2^16      |   4.901 us |       3.88% |   4.932 us |       4.16% |  0.031 us |   0.62% |   SAME   |
|   F64   |      I32      |      2^20      |  11.232 us |       2.33% |  11.165 us |       2.58% | -0.066 us |  -0.59% |   SAME   |
|   F64   |      I32      |      2^24      |  97.655 us |       0.45% |  97.658 us |       0.43% |  0.003 us |   0.00% |   SAME   |
|   F64   |      I32      |      2^28      |   1.467 ms |       0.10% |   1.467 ms |       0.10% |  0.051 us |   0.00% |   SAME   |
|   F64   |      I64      |      2^16      |   4.976 us |       4.25% |   5.058 us |       3.88% |  0.082 us |   1.65% |   SAME   |
|   F64   |      I64      |      2^20      |  11.242 us |       2.59% |  11.300 us |       2.60% |  0.058 us |   0.52% |   SAME   |
|   F64   |      I64      |      2^24      |  97.709 us |       0.41% |  97.760 us |       0.44% |  0.051 us |   0.05% |   SAME   |
|   F64   |      I64      |      2^28      |   1.467 ms |       0.10% |   1.467 ms |       0.10% |  0.024 us |   0.00% |   SAME   |
|  I128   |      I32      |      2^16      |   5.438 us |       4.53% |   5.397 us |       4.16% | -0.041 us |  -0.74% |   SAME   |
|  I128   |      I32      |      2^20      |  17.606 us |       2.11% |  17.621 us |       2.20% |  0.016 us |   0.09% |   SAME   |
|  I128   |      I32      |      2^24      | 188.575 us |       0.35% | 188.725 us |       0.31% |  0.150 us |   0.08% |   SAME   |
|  I128   |      I32      |      2^28      |   2.934 ms |       0.06% |   2.934 ms |       0.06% | -0.108 us |  -0.00% |   SAME   |
|  I128   |      I64      |      2^16      |   5.250 us |       3.44% |   5.281 us |       3.64% |  0.032 us |   0.60% |   SAME   |
|  I128   |      I64      |      2^20      |  17.469 us |       2.32% |  17.550 us |       2.29% |  0.081 us |   0.46% |   SAME   |
|  I128   |      I64      |      2^24      | 190.554 us |       0.33% | 190.668 us |       0.35% |  0.114 us |   0.06% |   SAME   |
|  I128   |      I64      |      2^28      |   2.934 ms |       0.41% |   2.934 ms |       0.38% |  0.079 us |   0.00% |   SAME   |

# nstream

## [0] NVIDIA H200

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-----------|---------|----------|
|   I8    |      I32      |      2^16      |   4.704 us |       3.47% |   4.714 us |       3.95% |  0.009 us |   0.20% |   SAME   |
|   I8    |      I32      |      2^20      |   6.080 us |       3.15% |   6.110 us |       3.41% |  0.031 us |   0.50% |   SAME   |
|   I8    |      I32      |      2^24      |  23.017 us |       2.09% |  23.083 us |       2.02% |  0.066 us |   0.29% |   SAME   |
|   I8    |      I32      |      2^28      | 260.507 us |       0.35% | 264.847 us |       0.36% |  4.340 us |   1.67% |   SLOW   |
|   I8    |      I64      |      2^16      |   4.684 us |       3.69% |   4.697 us |       3.59% |  0.013 us |   0.29% |   SAME   |
|   I8    |      I64      |      2^20      |   6.171 us |       3.42% |   6.244 us |       2.83% |  0.073 us |   1.18% |   SAME   |
|   I8    |      I64      |      2^24      |  22.735 us |       1.91% |  22.955 us |       1.98% |  0.220 us |   0.97% |   SAME   |
|   I8    |      I64      |      2^28      | 259.290 us |       0.35% | 264.433 us |       0.34% |  5.143 us |   1.98% |   SLOW   |
|   I16   |      I32      |      2^16      |   4.621 us |       2.89% |   4.630 us |       2.78% |  0.009 us |   0.19% |   SAME   |
|   I16   |      I32      |      2^20      |   7.247 us |       3.19% |   7.211 us |       3.12% | -0.035 us |  -0.49% |   SAME   |
|   I16   |      I32      |      2^24      |  38.338 us |       1.75% |  38.344 us |       1.70% |  0.006 us |   0.02% |   SAME   |
|   I16   |      I32      |      2^28      | 492.389 us |       0.12% | 493.352 us |       0.12% |  0.963 us |   0.20% |   SLOW   |
|   I16   |      I64      |      2^16      |   4.665 us |       2.75% |   4.681 us |       3.20% |  0.015 us |   0.33% |   SAME   |
|   I16   |      I64      |      2^20      |   7.229 us |       3.81% |   7.261 us |       3.28% |  0.032 us |   0.44% |   SAME   |
|   I16   |      I64      |      2^24      |  38.425 us |       1.71% |  38.576 us |       1.71% |  0.151 us |   0.39% |   SAME   |
|   I16   |      I64      |      2^28      | 494.972 us |       0.11% | 495.783 us |       0.10% |  0.811 us |   0.16% |   SLOW   |
|   F32   |      I32      |      2^16      |   4.713 us |       3.54% |   4.714 us |       2.65% |  0.001 us |   0.03% |   SAME   |
|   F32   |      I32      |      2^20      |   9.325 us |       2.53% |   9.290 us |       2.53% | -0.035 us |  -0.38% |   SAME   |
|   F32   |      I32      |      2^24      |  68.613 us |       1.00% |  68.626 us |       1.01% |  0.013 us |   0.02% |   SAME   |
|   F32   |      I32      |      2^28      | 968.365 us |       0.09% | 968.793 us |       0.08% |  0.428 us |   0.04% |   SAME   |
|   F32   |      I64      |      2^16      |   4.778 us |       3.56% |   4.773 us |       3.84% | -0.006 us |  -0.12% |   SAME   |
|   F32   |      I64      |      2^20      |   9.331 us |       2.75% |   9.429 us |       2.51% |  0.098 us |   1.05% |   SAME   |
|   F32   |      I64      |      2^24      |  68.107 us |       1.00% |  68.328 us |       0.98% |  0.222 us |   0.33% |   SAME   |
|   F32   |      I64      |      2^28      | 968.948 us |       0.09% | 970.026 us |       0.08% |  1.078 us |   0.11% |   SLOW   |
|   F64   |      I32      |      2^16      |   4.978 us |       3.87% |   4.976 us |       3.33% | -0.002 us |  -0.04% |   SAME   |
|   F64   |      I32      |      2^20      |  13.659 us |       2.28% |  13.672 us |       2.42% |  0.013 us |   0.09% |   SAME   |
|   F64   |      I32      |      2^24      | 127.980 us |       0.60% | 127.855 us |       0.59% | -0.125 us |  -0.10% |   SAME   |
|   F64   |      I32      |      2^28      |   1.929 ms |       0.04% |   1.929 ms |       0.04% |  0.226 us |   0.01% |   SAME   |
|   F64   |      I64      |      2^16      |   5.108 us |       3.99% |   5.109 us |       3.98% |  0.002 us |   0.03% |   SAME   |
|   F64   |      I64      |      2^20      |  13.697 us |       2.20% |  13.796 us |       2.31% |  0.099 us |   0.72% |   SAME   |
|   F64   |      I64      |      2^24      | 127.852 us |       0.60% | 128.021 us |       0.59% |  0.169 us |   0.13% |   SAME   |
|   F64   |      I64      |      2^28      |   1.929 ms |       0.04% |   1.930 ms |       0.04% |  0.878 us |   0.05% |   SLOW   |
|  I128   |      I32      |      2^16      |   5.745 us |       3.82% |   5.762 us |       3.88% |  0.018 us |   0.30% |   SAME   |
|  I128   |      I32      |      2^20      |  21.592 us |       1.98% |  21.613 us |       2.05% |  0.021 us |   0.10% |   SAME   |
|  I128   |      I32      |      2^24      | 247.958 us |       0.36% | 247.917 us |       0.37% | -0.042 us |  -0.02% |   SAME   |
|  I128   |      I32      |      2^28      |   3.860 ms |       0.04% |   3.860 ms |       0.04% |  0.225 us |   0.01% |   SAME   |
|  I128   |      I64      |      2^16      |   5.614 us |       3.78% |   5.605 us |       3.08% | -0.009 us |  -0.16% |   SAME   |
|  I128   |      I64      |      2^20      |  21.775 us |       2.09% |  21.876 us |       2.08% |  0.101 us |   0.46% |   SAME   |
|  I128   |      I64      |      2^24      | 250.634 us |       0.36% | 250.747 us |       0.35% |  0.114 us |   0.05% |   SAME   |
|  I128   |      I64      |      2^28      |   3.861 ms |       0.35% |   3.860 ms |       0.30% | -0.202 us |  -0.01% |   SAME   |
```

Benchmark on H200 no attribute vs. using an attribute (does not work on all compilers/drivers, but best overall result, what this PR retains)

```
# mul

## [0] NVIDIA H200

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-----------|---------|----------|
|   I8    |      I32      |      2^16      |   4.756 us |       2.74% |   4.754 us |       2.86% | -0.002 us |  -0.04% |   SAME   |
|   I8    |      I32      |      2^20      |   5.345 us |       2.94% |   5.312 us |       2.94% | -0.033 us |  -0.62% |   SAME   |
|   I8    |      I32      |      2^24      |  14.391 us |       1.82% |  14.397 us |       2.30% |  0.006 us |   0.04% |   SAME   |
|   I8    |      I32      |      2^28      | 140.342 us |       0.53% | 140.529 us |       0.55% |  0.187 us |   0.13% |   SAME   |
|   I8    |      I64      |      2^16      |   4.841 us |       3.07% |   4.834 us |       2.74% | -0.006 us |  -0.13% |   SAME   |
|   I8    |      I64      |      2^20      |   5.337 us |       3.02% |   5.337 us |       2.57% |  0.000 us |   0.00% |   SAME   |
|   I8    |      I64      |      2^24      |  14.399 us |       1.90% |  14.412 us |       2.07% |  0.012 us |   0.08% |   SAME   |
|   I8    |      I64      |      2^28      | 141.306 us |       0.54% | 141.383 us |       0.53% |  0.077 us |   0.05% |   SAME   |
|   I16   |      I32      |      2^16      |   4.439 us |       2.66% |   4.439 us |       2.72% | -0.000 us |  -0.00% |   SAME   |
|   I16   |      I32      |      2^20      |   5.549 us |       2.73% |   5.538 us |       2.87% | -0.011 us |  -0.19% |   SAME   |
|   I16   |      I32      |      2^24      |  21.314 us |       2.30% |  21.305 us |       2.33% | -0.009 us |  -0.04% |   SAME   |
|   I16   |      I32      |      2^28      | 253.333 us |       0.40% | 253.280 us |       0.41% | -0.052 us |  -0.02% |   SAME   |
|   I16   |      I64      |      2^16      |   4.496 us |       3.11% |   4.489 us |       3.01% | -0.007 us |  -0.15% |   SAME   |
|   I16   |      I64      |      2^20      |   5.637 us |       3.38% |   5.597 us |       2.94% | -0.040 us |  -0.71% |   SAME   |
|   I16   |      I64      |      2^24      |  21.332 us |       2.35% |  21.310 us |       2.33% | -0.021 us |  -0.10% |   SAME   |
|   I16   |      I64      |      2^28      | 253.449 us |       0.39% | 253.422 us |       0.39% | -0.027 us |  -0.01% |   SAME   |
|   F32   |      I32      |      2^16      |   4.402 us |       2.96% |   4.403 us |       3.05% |  0.001 us |   0.02% |   SAME   |
|   F32   |      I32      |      2^20      |   6.413 us |       3.86% |   6.402 us |       3.31% | -0.011 us |  -0.18% |   SAME   |
|   F32   |      I32      |      2^24      |  36.914 us |       1.99% |  36.853 us |       1.86% | -0.061 us |  -0.16% |   SAME   |
|   F32   |      I32      |      2^28      | 508.779 us |       0.19% | 508.832 us |       0.18% |  0.054 us |   0.01% |   SAME   |
|   F32   |      I64      |      2^16      |   4.461 us |       3.01% |   4.480 us |       3.77% |  0.019 us |   0.42% |   SAME   |
|   F32   |      I64      |      2^20      |   6.488 us |       4.27% |   6.424 us |       3.13% | -0.064 us |  -0.99% |   SAME   |
|   F32   |      I64      |      2^24      |  36.644 us |       1.90% |  36.609 us |       1.83% | -0.035 us |  -0.09% |   SAME   |
|   F32   |      I64      |      2^28      | 508.838 us |       0.19% | 508.692 us |       0.18% | -0.146 us |  -0.03% |   SAME   |
|   F64   |      I32      |      2^16      |   4.503 us |       3.49% |   4.477 us |       2.96% | -0.026 us |  -0.57% |   SAME   |
|   F64   |      I32      |      2^20      |   8.604 us |       3.05% |   8.589 us |       2.86% | -0.014 us |  -0.17% |   SAME   |
|   F64   |      I32      |      2^24      |  67.597 us |       1.06% |  67.610 us |       1.09% |  0.013 us |   0.02% |   SAME   |
|   F64   |      I32      |      2^28      |   1.011 ms |       0.12% |   1.011 ms |       0.12% | -0.069 us |  -0.01% |   SAME   |
|   F64   |      I64      |      2^16      |   4.548 us |       3.92% |   4.540 us |       3.77% | -0.008 us |  -0.17% |   SAME   |
|   F64   |      I64      |      2^20      |   8.589 us |       2.92% |   8.546 us |       2.52% | -0.043 us |  -0.50% |   SAME   |
|   F64   |      I64      |      2^24      |  67.521 us |       1.08% |  67.537 us |       1.08% |  0.016 us |   0.02% |   SAME   |
|   F64   |      I64      |      2^28      |   1.011 ms |       0.12% |   1.011 ms |       0.13% | -0.037 us |  -0.00% |   SAME   |
|  I128   |      I32      |      2^16      |   4.839 us |       4.00% |   4.939 us |       4.49% |  0.101 us |   2.08% |   SAME   |
|  I128   |      I32      |      2^20      |  12.925 us |       2.60% |  12.903 us |       2.62% | -0.022 us |  -0.17% |   SAME   |
|  I128   |      I32      |      2^24      | 132.690 us |       0.65% | 132.658 us |       0.65% | -0.032 us |  -0.02% |   SAME   |
|  I128   |      I32      |      2^28      |   2.050 ms |       0.09% |   2.050 ms |       0.08% |  0.202 us |   0.01% |   SAME   |
|  I128   |      I64      |      2^16      |   4.875 us |       3.65% |   4.876 us |       3.57% |  0.001 us |   0.02% |   SAME   |
|  I128   |      I64      |      2^20      |  12.847 us |       2.42% |  12.816 us |       2.65% | -0.031 us |  -0.24% |   SAME   |
|  I128   |      I64      |      2^24      | 134.123 us |       0.63% | 134.116 us |       0.65% | -0.007 us |  -0.01% |   SAME   |
|  I128   |      I64      |      2^28      |   2.053 ms |       0.37% |   2.053 ms |       0.28% | -0.188 us |  -0.01% |   SAME   |

# add

## [0] NVIDIA H200

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-----------|---------|----------|
|   I8    |      I32      |      2^16      |   4.731 us |       3.21% |   4.722 us |       3.42% | -0.009 us |  -0.19% |   SAME   |
|   I8    |      I32      |      2^20      |   5.685 us |       2.99% |   5.697 us |       3.25% |  0.012 us |   0.21% |   SAME   |
|   I8    |      I32      |      2^24      |  19.085 us |       2.13% |  19.080 us |       2.06% | -0.005 us |  -0.02% |   SAME   |
|   I8    |      I32      |      2^28      | 197.708 us |       0.58% | 197.625 us |       0.61% | -0.083 us |  -0.04% |   SAME   |
|   I8    |      I64      |      2^16      |   4.680 us |       2.85% |   4.692 us |       2.93% |  0.012 us |   0.25% |   SAME   |
|   I8    |      I64      |      2^20      |   5.776 us |       2.39% |   5.767 us |       2.53% | -0.009 us |  -0.15% |   SAME   |
|   I8    |      I64      |      2^24      |  18.545 us |       1.98% |  18.530 us |       2.03% | -0.016 us |  -0.08% |   SAME   |
|   I8    |      I64      |      2^28      | 197.658 us |       0.22% | 197.439 us |       0.29% | -0.219 us |  -0.11% |   SAME   |
|   I16   |      I32      |      2^16      |   4.611 us |       3.26% |   4.603 us |       3.28% | -0.008 us |  -0.16% |   SAME   |
|   I16   |      I32      |      2^20      |   6.507 us |       2.66% |   6.496 us |       2.92% | -0.011 us |  -0.17% |   SAME   |
|   I16   |      I32      |      2^24      |  30.032 us |       1.88% |  30.005 us |       1.84% | -0.027 us |  -0.09% |   SAME   |
|   I16   |      I32      |      2^28      | 371.193 us |       0.22% | 371.152 us |       0.21% | -0.041 us |  -0.01% |   SAME   |
|   I16   |      I64      |      2^16      |   4.584 us |       3.37% |   4.580 us |       2.87% | -0.004 us |  -0.09% |   SAME   |
|   I16   |      I64      |      2^20      |   6.487 us |       2.88% |   6.519 us |       2.64% |  0.032 us |   0.49% |   SAME   |
|   I16   |      I64      |      2^24      |  30.187 us |       1.92% |  30.204 us |       1.84% |  0.017 us |   0.06% |   SAME   |
|   I16   |      I64      |      2^28      | 371.664 us |       0.21% | 371.650 us |       0.21% | -0.014 us |  -0.00% |   SAME   |
|   F32   |      I32      |      2^16      |   4.611 us |       2.83% |   4.617 us |       3.79% |  0.006 us |   0.13% |   SAME   |
|   F32   |      I32      |      2^20      |   7.959 us |       2.94% |   7.930 us |       2.81% | -0.029 us |  -0.37% |   SAME   |
|   F32   |      I32      |      2^24      |  52.672 us |       1.37% |  52.653 us |       1.37% | -0.019 us |  -0.04% |   SAME   |
|   F32   |      I32      |      2^28      | 730.851 us |       0.13% | 730.879 us |       0.13% |  0.029 us |   0.00% |   SAME   |
|   F32   |      I64      |      2^16      |   4.706 us |       4.50% |   4.685 us |       3.86% | -0.021 us |  -0.44% |   SAME   |
|   F32   |      I64      |      2^20      |   7.918 us |       2.65% |   7.917 us |       2.87% | -0.001 us |  -0.01% |   SAME   |
|   F32   |      I64      |      2^24      |  52.657 us |       1.40% |  52.667 us |       1.37% |  0.010 us |   0.02% |   SAME   |
|   F32   |      I64      |      2^28      | 730.779 us |       0.12% | 730.805 us |       0.12% |  0.027 us |   0.00% |   SAME   |
|   F64   |      I32      |      2^16      |   4.867 us |       4.22% |   4.851 us |       3.95% | -0.015 us |  -0.31% |   SAME   |
|   F64   |      I32      |      2^20      |  11.067 us |       2.67% |  11.023 us |       2.51% | -0.044 us |  -0.40% |   SAME   |
|   F64   |      I32      |      2^24      |  97.680 us |       0.37% |  97.602 us |       0.46% | -0.078 us |  -0.08% |   SAME   |
|   F64   |      I32      |      2^28      |   1.467 ms |       0.10% |   1.466 ms |       0.11% | -0.176 us |  -0.01% |   SAME   |
|   F64   |      I64      |      2^16      |   4.974 us |       4.53% |   4.963 us |       4.66% | -0.012 us |  -0.23% |   SAME   |
|   F64   |      I64      |      2^20      |  11.098 us |       2.68% |  11.082 us |       2.56% | -0.016 us |  -0.14% |   SAME   |
|   F64   |      I64      |      2^24      |  97.393 us |       0.47% |  97.421 us |       0.43% |  0.028 us |   0.03% |   SAME   |
|   F64   |      I64      |      2^28      |   1.466 ms |       0.11% |   1.466 ms |       0.11% |  0.072 us |   0.00% |   SAME   |
|  I128   |      I32      |      2^16      |   5.511 us |       5.98% |   5.483 us |       4.66% | -0.028 us |  -0.51% |   SAME   |
|  I128   |      I32      |      2^20      |  17.349 us |       2.20% |  17.323 us |       1.93% | -0.026 us |  -0.15% |   SAME   |
|  I128   |      I32      |      2^24      | 188.459 us |       0.30% | 188.432 us |       0.32% | -0.027 us |  -0.01% |   SAME   |
|  I128   |      I32      |      2^28      |   2.930 ms |       0.07% |   2.930 ms |       0.07% | -0.043 us |  -0.00% |   SAME   |
|  I128   |      I64      |      2^16      |   5.269 us |       3.75% |   5.293 us |       4.56% |  0.024 us |   0.46% |   SAME   |
|  I128   |      I64      |      2^20      |  17.585 us |       2.31% |  17.532 us |       2.11% | -0.053 us |  -0.30% |   SAME   |
|  I128   |      I64      |      2^24      | 190.321 us |       0.38% | 190.428 us |       0.32% |  0.107 us |   0.06% |   SAME   |
|  I128   |      I64      |      2^28      |   2.936 ms |       0.34% |   2.935 ms |       0.28% | -0.650 us |  -0.02% |   SAME   |

# triad

## [0] NVIDIA H200

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-----------|---------|----------|
|   I8    |      I32      |      2^16      |   4.690 us |       3.06% |   4.779 us |       3.46% |  0.088 us |   1.88% |   SAME   |
|   I8    |      I32      |      2^20      |   5.749 us |       3.26% |   5.815 us |       3.41% |  0.066 us |   1.15% |   SAME   |
|   I8    |      I32      |      2^24      |  19.308 us |       1.92% |  19.361 us |       2.05% |  0.053 us |   0.28% |   SAME   |
|   I8    |      I32      |      2^28      | 205.214 us |       0.19% | 205.246 us |       0.15% |  0.032 us |   0.02% |   SAME   |
|   I8    |      I64      |      2^16      |   4.744 us |       3.28% |   4.805 us |       3.34% |  0.062 us |   1.30% |   SAME   |
|   I8    |      I64      |      2^20      |   5.808 us |       2.35% |   5.802 us |       3.81% | -0.006 us |  -0.10% |   SAME   |
|   I8    |      I64      |      2^24      |  19.118 us |       1.89% |  19.293 us |       2.47% |  0.175 us |   0.91% |   SAME   |
|   I8    |      I64      |      2^28      | 205.538 us |       0.14% | 205.496 us |       0.14% | -0.042 us |  -0.02% |   SAME   |
|   I16   |      I32      |      2^16      |   4.497 us |       3.62% |   4.561 us |       3.07% |  0.063 us |   1.41% |   SAME   |
|   I16   |      I32      |      2^20      |   6.559 us |       3.04% |   6.526 us |       3.20% | -0.033 us |  -0.51% |   SAME   |
|   I16   |      I32      |      2^24      |  30.518 us |       1.89% |  30.516 us |       1.85% | -0.002 us |  -0.01% |   SAME   |
|   I16   |      I32      |      2^28      | 373.092 us |       0.21% | 373.126 us |       0.21% |  0.034 us |   0.01% |   SAME   |
|   I16   |      I64      |      2^16      |   4.541 us |       3.06% |   4.580 us |       3.23% |  0.038 us |   0.84% |   SAME   |
|   I16   |      I64      |      2^20      |   6.620 us |       3.75% |   6.617 us |       2.89% | -0.003 us |  -0.04% |   SAME   |
|   I16   |      I64      |      2^24      |  30.521 us |       1.82% |  30.617 us |       1.92% |  0.096 us |   0.31% |   SAME   |
|   I16   |      I64      |      2^28      | 373.651 us |       0.21% | 373.744 us |       0.21% |  0.093 us |   0.02% |   SAME   |
|   F32   |      I32      |      2^16      |   4.524 us |       2.87% |   4.615 us |       3.50% |  0.091 us |   2.01% |   SAME   |
|   F32   |      I32      |      2^20      |   7.900 us |       2.49% |   7.885 us |       3.03% | -0.015 us |  -0.19% |   SAME   |
|   F32   |      I32      |      2^24      |  53.049 us |       1.36% |  53.150 us |       1.34% |  0.101 us |   0.19% |   SAME   |
|   F32   |      I32      |      2^28      | 731.446 us |       0.14% | 731.631 us |       0.14% |  0.185 us |   0.03% |   SAME   |
|   F32   |      I64      |      2^16      |   4.578 us |       3.65% |   4.669 us |       4.01% |  0.091 us |   1.99% |   SAME   |
|   F32   |      I64      |      2^20      |   7.906 us |       2.46% |   7.892 us |       2.85% | -0.014 us |  -0.18% |   SAME   |
|   F32   |      I64      |      2^24      |  53.029 us |       1.37% |  53.143 us |       1.35% |  0.114 us |   0.21% |   SAME   |
|   F32   |      I64      |      2^28      | 731.358 us |       0.13% | 731.451 us |       0.13% |  0.093 us |   0.01% |   SAME   |
|   F64   |      I32      |      2^16      |   4.857 us |       3.96% |   4.891 us |       4.42% |  0.034 us |   0.69% |   SAME   |
|   F64   |      I32      |      2^20      |  11.142 us |       2.69% |  11.196 us |       2.59% |  0.053 us |   0.48% |   SAME   |
|   F64   |      I32      |      2^24      |  97.612 us |       0.42% |  97.661 us |       0.40% |  0.049 us |   0.05% |   SAME   |
|   F64   |      I32      |      2^28      |   1.467 ms |       0.10% |   1.467 ms |       0.10% | -0.056 us |  -0.00% |   SAME   |
|   F64   |      I64      |      2^16      |   4.873 us |       4.00% |   4.941 us |       4.41% |  0.068 us |   1.39% |   SAME   |
|   F64   |      I64      |      2^20      |  11.106 us |       2.54% |  11.198 us |       2.52% |  0.092 us |   0.83% |   SAME   |
|   F64   |      I64      |      2^24      |  97.575 us |       0.45% |  97.674 us |       0.41% |  0.099 us |   0.10% |   SAME   |
|   F64   |      I64      |      2^28      |   1.467 ms |       0.10% |   1.467 ms |       0.10% |  0.030 us |   0.00% |   SAME   |
|  I128   |      I32      |      2^16      |   5.356 us |       3.66% |   5.463 us |       4.85% |  0.107 us |   1.99% |   SAME   |
|  I128   |      I32      |      2^20      |  17.476 us |       2.18% |  17.575 us |       2.26% |  0.099 us |   0.57% |   SAME   |
|  I128   |      I32      |      2^24      | 188.645 us |       0.30% | 188.688 us |       0.32% |  0.043 us |   0.02% |   SAME   |
|  I128   |      I32      |      2^28      |   2.933 ms |       0.06% |   2.933 ms |       0.06% | -0.040 us |  -0.00% |   SAME   |
|  I128   |      I64      |      2^16      |   5.169 us |       3.09% |   5.322 us |       4.20% |  0.153 us |   2.95% |   SAME   |
|  I128   |      I64      |      2^20      |  17.408 us |       2.55% |  17.494 us |       2.25% |  0.085 us |   0.49% |   SAME   |
|  I128   |      I64      |      2^24      | 190.494 us |       0.34% | 190.515 us |       0.36% |  0.021 us |   0.01% |   SAME   |
|  I128   |      I64      |      2^28      |   2.932 ms |       0.33% |   2.934 ms |       0.42% |  1.807 us |   0.06% |   SAME   |

# nstream

## [0] NVIDIA H200

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-----------|---------|----------|
|   I8    |      I32      |      2^16      |   4.603 us |       3.33% |   4.679 us |       3.49% |  0.076 us |   1.66% |   SAME   |
|   I8    |      I32      |      2^20      |   6.076 us |       3.11% |   5.968 us |       3.36% | -0.108 us |  -1.78% |   SAME   |
|   I8    |      I32      |      2^24      |  22.907 us |       2.08% |  22.901 us |       1.92% | -0.005 us |  -0.02% |   SAME   |
|   I8    |      I32      |      2^28      | 260.519 us |       0.35% | 260.205 us |       0.35% | -0.315 us |  -0.12% |   SAME   |
|   I8    |      I64      |      2^16      |   4.689 us |       3.42% |   4.580 us |       3.72% | -0.109 us |  -2.33% |   SAME   |
|   I8    |      I64      |      2^20      |   6.089 us |       3.59% |   6.016 us |       2.73% | -0.073 us |  -1.20% |   SAME   |
|   I8    |      I64      |      2^24      |  22.674 us |       1.94% |  22.725 us |       1.90% |  0.051 us |   0.22% |   SAME   |
|   I8    |      I64      |      2^28      | 259.753 us |       0.35% | 258.670 us |       0.26% | -1.083 us |  -0.42% |   FAST   |
|   I16   |      I32      |      2^16      |   4.604 us |       2.91% |   4.515 us |       2.66% | -0.088 us |  -1.92% |   SAME   |
|   I16   |      I32      |      2^20      |   7.229 us |       2.11% |   7.071 us |       3.64% | -0.158 us |  -2.18% |   FAST   |
|   I16   |      I32      |      2^24      |  37.930 us |       1.73% |  38.198 us |       1.72% |  0.268 us |   0.71% |   SAME   |
|   I16   |      I32      |      2^28      | 492.315 us |       0.12% | 492.051 us |       0.14% | -0.264 us |  -0.05% |   SAME   |
|   I16   |      I64      |      2^16      |   4.627 us |       3.22% |   4.553 us |       2.88% | -0.073 us |  -1.59% |   SAME   |
|   I16   |      I64      |      2^20      |   7.308 us |       3.39% |   7.064 us |       3.32% | -0.244 us |  -3.34% |   FAST   |
|   I16   |      I64      |      2^24      |  38.187 us |       1.73% |  38.260 us |       1.78% |  0.072 us |   0.19% |   SAME   |
|   I16   |      I64      |      2^28      | 494.919 us |       0.10% | 494.847 us |       0.11% | -0.072 us |  -0.01% |   SAME   |
|   F32   |      I32      |      2^16      |   4.708 us |       3.00% |   4.593 us |       2.81% | -0.115 us |  -2.45% |   SAME   |
|   F32   |      I32      |      2^20      |   9.220 us |       2.83% |   9.171 us |       2.68% | -0.049 us |  -0.53% |   SAME   |
|   F32   |      I32      |      2^24      |  68.134 us |       1.00% |  68.523 us |       0.99% |  0.389 us |   0.57% |   SAME   |
|   F32   |      I32      |      2^28      | 968.294 us |       0.09% | 968.239 us |       0.08% | -0.055 us |  -0.01% |   SAME   |
|   F32   |      I64      |      2^16      |   4.759 us |       3.74% |   4.659 us |       4.13% | -0.100 us |  -2.10% |   SAME   |
|   F32   |      I64      |      2^20      |   9.264 us |       2.63% |   9.199 us |       2.70% | -0.065 us |  -0.70% |   SAME   |
|   F32   |      I64      |      2^24      |  68.286 us |       1.01% |  68.029 us |       1.01% | -0.257 us |  -0.38% |   SAME   |
|   F32   |      I64      |      2^28      | 968.962 us |       0.09% | 968.917 us |       0.09% | -0.045 us |  -0.00% |   SAME   |
|   F64   |      I32      |      2^16      |   5.036 us |       3.49% |   4.955 us |       3.84% | -0.081 us |  -1.60% |   SAME   |
|   F64   |      I32      |      2^20      |  13.894 us |       2.33% |  13.526 us |       2.27% | -0.368 us |  -2.65% |   FAST   |
|   F64   |      I32      |      2^24      | 128.225 us |       0.59% | 127.913 us |       0.57% | -0.313 us |  -0.24% |   SAME   |
|   F64   |      I32      |      2^28      |   1.929 ms |       0.04% |   1.929 ms |       0.04% | -0.126 us |  -0.01% |   SAME   |
|   F64   |      I64      |      2^16      |   5.115 us |       4.49% |   5.052 us |       4.61% | -0.063 us |  -1.23% |   SAME   |
|   F64   |      I64      |      2^20      |  13.907 us |       2.10% |  13.533 us |       2.17% | -0.374 us |  -2.69% |   FAST   |
|   F64   |      I64      |      2^24      | 128.154 us |       0.61% | 127.978 us |       0.59% | -0.176 us |  -0.14% |   SAME   |
|   F64   |      I64      |      2^28      |   1.929 ms |       0.04% |   1.929 ms |       0.04% | -0.132 us |  -0.01% |   SAME   |
|  I128   |      I32      |      2^16      |   5.890 us |       4.46% |   5.827 us |       4.83% | -0.063 us |  -1.06% |   SAME   |
|  I128   |      I32      |      2^20      |  21.454 us |       1.93% |  21.519 us |       2.01% |  0.065 us |   0.30% |   SAME   |
|  I128   |      I32      |      2^24      | 247.989 us |       0.36% | 247.917 us |       0.36% | -0.072 us |  -0.03% |   SAME   |
|  I128   |      I32      |      2^28      |   3.861 ms |       0.04% |   3.860 ms |       0.04% | -0.555 us |  -0.01% |   SAME   |
|  I128   |      I64      |      2^16      |   5.709 us |       3.47% |   5.645 us |       3.42% | -0.064 us |  -1.11% |   SAME   |
|  I128   |      I64      |      2^20      |  21.548 us |       2.07% |  21.829 us |       2.07% |  0.281 us |   1.30% |   SAME   |
|  I128   |      I64      |      2^24      | 250.607 us |       0.37% | 250.622 us |       0.36% |  0.015 us |   0.01% |   SAME   |
|  I128   |      I64      |      2^28      |   3.860 ms |       0.33% |   3.861 ms |       0.30% |  0.773 us |   0.02% |   SAME   |
```
