### PR TITLE
add `_CCCL_DECLSPEC_EMPTY_BASES` as an AttributeMacro to .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -27,6 +27,7 @@ AttributeMacros: [
                   '_CCCL_ALIGNAS',
                   '_CCCL_CONSTEXPR_CXX20',
                   '_CCCL_CONSTEXPR_CXX23',
+                  '_CCCL_DECLSPEC_EMPTY_BASES',
                   '_CCCL_DEVICE',
                   '_CCCL_FORCEINLINE',
                   '_CCCL_HIDE_FROM_ABI',


### PR DESCRIPTION
## Description

`_CCCL_DECLSPEC_EMPTY_BASES` should be treated as an attribute for the purposes of formatting.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
