### PR TITLE
[CUDAX] Add id() getter to stream_ref

### DIFF
--- a/cudax/include/cuda/experimental/__stream/stream_ref.cuh
+++ b/cudax/include/cuda/experimental/__stream/stream_ref.cuh
@@ -44,6 +44,9 @@ static const ::cudaStream_t __invalid_stream = reinterpret_cast<cudaStream_t>(~0
 } // namespace __detail
 
 //! @brief A non-owning wrapper for cudaStream_t.
+//!
+//! @note It is undefined behavior to use a `stream_ref` object beyond the lifetime of the stream it was created from,
+//! except for the `get()` member function.
 struct stream_ref : ::cuda::stream_ref
 {
   using scheduler_concept = execution::scheduler_t;
@@ -103,6 +106,18 @@ struct stream_ref : ::cuda::stream_ref
   [[nodiscard]] _CCCL_HOST_API int priority() const
   {
     return __detail::driver::streamGetPriority(__stream);
+  }
+
+  //! @brief Get the unique ID of the stream
+  //!
+  //! Stream handles are sometimes reused, but ID is guaranteed to be unique.
+  //!
+  //! @return The unique ID of the stream
+  //!
+  //! @throws cuda_error if the ID query fails
+  [[nodiscard]] _CCCL_HOST_API unsigned long long id() const
+  {
+    return __detail::driver::streamGetId(__stream);
   }
 
   //! @brief Create a new event and record it into this stream

--- a/cudax/include/cuda/experimental/__utility/driver_api.cuh
+++ b/cudax/include/cuda/experimental/__utility/driver_api.cuh
@@ -209,6 +209,14 @@ inline int streamGetPriority(CUstream stream)
   return __priority;
 }
 
+inline unsigned long long streamGetId(CUstream stream)
+{
+  unsigned long long __id;
+  static auto driver_fn = CUDAX_GET_DRIVER_FUNCTION(cuStreamGetId);
+  call_driver_fn(driver_fn, "Failed to get the ID of a stream", stream, &__id);
+  return __id;
+}
+
 inline void eventRecord(CUevent event, CUstream stream)
 {
   static auto driver_fn = CUDAX_GET_DRIVER_FUNCTION(cuEventRecord);

--- a/cudax/test/stream/stream_smoke.cu
+++ b/cudax/test/stream/stream_smoke.cu
@@ -134,3 +134,31 @@ C2H_CCCLRT_TEST("Stream get device", "[stream]")
     }
   }
 }
+
+C2H_CCCLRT_TEST("Stream ID", "[stream]")
+{
+  cudax::stream stream1{cudax::device_ref{0}};
+  cudax::stream stream2{cudax::device_ref{0}};
+
+  // Test that id() returns a valid ID
+  auto id1 = stream1.id();
+  auto id2 = stream2.id();
+
+  // Test that different streams have different IDs
+  CUDAX_REQUIRE(id1 != id2);
+
+  // Test that the same stream returns the same ID when called multiple times
+  CUDAX_REQUIRE(stream1.id() == id1);
+  CUDAX_REQUIRE(stream2.id() == id2);
+
+  {
+    // Test that stream_ref also supports id()
+    // NULL stream needs a device to be set
+    cudax::__ensure_current_device guard(cudax::device_ref{0});
+    cudax::stream_ref ref1(static_cast<cudaStream_t>(NULL));
+    cudax::stream_ref ref2(stream1);
+
+    CUDAX_REQUIRE(ref1.id() != ref2.id());
+    CUDAX_REQUIRE(ref2.id() == id1);
+  }
+}


### PR DESCRIPTION
Stream handles are sometimes reused for a new stream from a previous destroyed stream, but every stream is assigned an ID that is unique across all other streams. This PR adds `id()` member function to `stream_ref` that allows to query the unique ID of a stream.

It also adds a note on the `stream_ref` type that its UB to use it past the underlying stream lifetime except for `get()` member function.