### PR TITLE
 make value_types_of_t and error_types_of_t work with non-variadic templates

### DIFF
--- a/cudax/include/cuda/experimental/__execution/completion_signatures.cuh
+++ b/cudax/include/cuda/experimental/__execution/completion_signatures.cuh
@@ -137,7 +137,9 @@ using __value_types _CCCL_NODEBUG_ALIAS =
 
 template <class _Sndr, class _Env, template <class...> class _Tuple, template <class...> class _Variant>
 using value_types_of_t _CCCL_NODEBUG_ALIAS =
-  __value_types<completion_signatures_of_t<_Sndr, _Env>, _Tuple, __type_try_quote<_Variant>::template __call>;
+  __value_types<completion_signatures_of_t<_Sndr, _Env>,
+                _CUDA_VSTD::__type_indirect_quote<_Tuple>::template __call,
+                _CUDA_VSTD::__type_indirect_quote<_Variant>::template __call>;
 
 template <class _Sigs,
           template <class...> class _Variant,
@@ -146,7 +148,8 @@ using __error_types _CCCL_NODEBUG_ALIAS =
   typename __partitioned_completions_of<_Sigs>::template __error_types<_Variant, _Transform>;
 
 template <class _Sndr, class _Env, template <class...> class _Variant>
-using error_types_of_t _CCCL_NODEBUG_ALIAS = __error_types<completion_signatures_of_t<_Sndr, _Env>, _Variant>;
+using error_types_of_t _CCCL_NODEBUG_ALIAS =
+  __error_types<completion_signatures_of_t<_Sndr, _Env>, _CUDA_VSTD::__type_indirect_quote<_Variant>::template __call>;
 
 template <class _Sigs, template <class...> class _Variant, class _Type = set_stopped_t()>
 using __stopped_types _CCCL_NODEBUG_ALIAS =


### PR DESCRIPTION
## Description

in the standard [here](https://eel.is/c++draft/exec#util.cmplsig-6), the alias templates `execution::value_types_of_t` and `execution::error_types_of_t` are defined in terms of an exposition-only pseudo-macro _`META-APPLY`_. the standard even tells you why:

![image](https://github.com/user-attachments/assets/806d0bad-7e2e-4b90-ae20-c5b9245b7d4d)

in the cudax implementation, those alias templates are not doing the proper _`META-APPLY`_ dance. this pr brings `[value|error]_types_of_t` into compliance.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
