### PR TITLE
Introduce facilities to extract the exponent of a floating point value.

### DIFF
--- a/libcudacxx/include/cuda/std/__floating_point/decompose.h
+++ b/libcudacxx/include/cuda/std/__floating_point/decompose.h
@@ -1,0 +1,69 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD___FLOATING_POINT_DECOMPOSE_H
+#define _CUDA_STD___FLOATING_POINT_DECOMPOSE_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__bit/bit_cast.h>
+#include <cuda/std/__floating_point/cuda_fp_types.h>
+#include <cuda/std/__floating_point/format.h>
+#include <cuda/std/__floating_point/mask.h>
+#include <cuda/std/__floating_point/properties.h>
+#include <cuda/std/__floating_point/storage.h>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD
+
+//! @brief Returns the unbiased exponent of a floating point number
+//! @param __v The floating point number to extract the exponent from
+//! This is effectively the same as @c ilogb but no errors are raised and corner cases handled
+template <class _Tp>
+[[nodiscard]] _CCCL_API _CCCL_FORCEINLINE constexpr int __fp_get_exp(_Tp __v) noexcept
+{
+  constexpr auto __fmt = __fp_format_of_v<_Tp>;
+  using _Storage       = __fp_storage_t<__fmt>;
+  const auto __bits =
+    static_cast<_Storage>((::cuda::std::__fp_get_storage(__v) & __fp_exp_mask_v<__fmt>) >> __fp_mant_nbits_v<__fmt>);
+  static_assert(__fp_exp_nbits_v<__fmt> < sizeof(int) * CHAR_BIT,
+                "__fp_get_exp: floating point type with too many exponent bits");
+  return static_cast<int>(__bits) - __fp_exp_bias_v<__fmt>;
+}
+
+//! @brief Sets the exponent of a floating point number
+//! @param __v The floating point number to set the exponent of
+//! @param __exp The new exponent
+//! @return A floating point number with the same mantissa and sign as @c __v but the new - biased - exponent @c __exp
+template <class _Tp>
+[[nodiscard]] _CCCL_API _CCCL_FORCEINLINE constexpr _Tp __fp_set_exp(_Tp __v, int __exp) noexcept
+{
+  constexpr auto __fmt    = __fp_format_of_v<_Tp>;
+  using _Storage          = __fp_storage_t<__fmt>;
+  const auto __biased_exp = static_cast<_Storage>(__exp + __fp_exp_bias_v<__fmt>);
+  return ::cuda::std::__fp_from_storage<_Tp>(static_cast<_Storage>(
+    (::cuda::std::__fp_get_storage(__v) & __fp_inv_exp_mask_v<__fmt>)
+    | ((__biased_exp << __fp_mant_nbits_v<__fmt>) &__fp_exp_mask_v<__fmt>) ));
+}
+
+_CCCL_END_NAMESPACE_CUDA_STD
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA_STD___FLOATING_POINT_DECOMPOSE_H

--- a/libcudacxx/include/cuda/std/__floating_point/fp.h
+++ b/libcudacxx/include/cuda/std/__floating_point/fp.h
@@ -28,6 +28,7 @@
 #include <cuda/std/__floating_point/constants.h>
 #include <cuda/std/__floating_point/conversion_rank_order.h>
 #include <cuda/std/__floating_point/cuda_fp_types.h>
+#include <cuda/std/__floating_point/decompose.h>
 #include <cuda/std/__floating_point/format.h>
 #include <cuda/std/__floating_point/mask.h>
 #include <cuda/std/__floating_point/native_type.h>

--- a/libcudacxx/include/cuda/std/__floating_point/mask.h
+++ b/libcudacxx/include/cuda/std/__floating_point/mask.h
@@ -44,6 +44,12 @@ template <class _Tp>
 inline constexpr auto __fp_exp_mask_of_v = __fp_exp_mask_v<__fp_format_of_v<_Tp>>;
 
 template <__fp_format _Fmt>
+inline constexpr auto __fp_inv_exp_mask_v = static_cast<__fp_storage_t<_Fmt>>(~__fp_exp_mask_v<_Fmt>);
+
+template <class _Tp>
+inline constexpr auto __fp_inv_exp_mask_of_v = __fp_inv_exp_mask_v<__fp_format_of_v<_Tp>>;
+
+template <__fp_format _Fmt>
 inline constexpr auto __fp_mant_mask_v =
   static_cast<__fp_storage_t<_Fmt>>((__fp_storage_t<_Fmt>(1) << __fp_mant_nbits_v<_Fmt>) -1);
 

--- a/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/decompose/get_exp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/decompose/get_exp.pass.cpp
@@ -1,0 +1,153 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/__floating_point/fp.h>
+#include <cuda/std/cassert>
+#include <cuda/std/cmath>
+#include <cuda/std/limits>
+#include <cuda/std/type_traits>
+
+#include "test_macros.h"
+
+template <class T>
+__host__ __device__ _CCCL_CONSTEXPR_BIT_CAST void test_fp_get_exp(T val, int expected)
+{
+  static_assert(cuda::std::is_same_v<decltype(cuda::std::__fp_get_exp(cuda::std::declval<T>())), int>);
+  static_assert(noexcept(cuda::std::__fp_get_exp(cuda::std::declval<T>())));
+  assert(cuda::std::__fp_get_exp(val) == expected);
+}
+
+template <class T>
+__host__ __device__ _CCCL_CONSTEXPR_BIT_CAST void test_fp_get_exp(T val)
+{
+  constexpr auto fmt = cuda::std::__fp_format_of_v<T>;
+
+  test_fp_get_exp(val, 0);
+  if constexpr (cuda::std::__fp_exp_nbits_v<fmt> > 3)
+  {
+    test_fp_get_exp(T{32}, 5);
+  }
+
+  // zero has ... all zeros
+  if constexpr (cuda::std::__fp_is_signed_v<fmt>)
+  {
+    test_fp_get_exp(T{}, cuda::std::__fp_exp_min_v<fmt> - 1);
+  }
+  else
+  { // Without sign 0 is equivalent to __fp_exp_min_v
+    test_fp_get_exp(T{}, cuda::std::__fp_exp_min_v<fmt>);
+  }
+
+  // min has all zeroes, max and lowest have max
+  test_fp_get_exp(cuda::std::numeric_limits<T>::min(), cuda::std::__fp_exp_min_v<fmt>);
+  test_fp_get_exp(cuda::std::numeric_limits<T>::max(), cuda::std::__fp_exp_max_v<fmt>);
+  if constexpr (cuda::std::__fp_is_signed_v<fmt>)
+  {
+    test_fp_get_exp(cuda::std::numeric_limits<T>::lowest(), cuda::std::__fp_exp_max_v<fmt>);
+  }
+  else
+  { // Without sign lowest is equivalent to min
+    test_fp_get_exp(cuda::std::numeric_limits<T>::lowest(), cuda::std::__fp_exp_min_v<fmt>);
+  }
+
+  // Denormals have all zeros, so its one less than __fp_exp_min_v
+  if constexpr (cuda::std::__fp_has_denorm_v<fmt>)
+  {
+    test_fp_get_exp(cuda::std::numeric_limits<T>::denorm_min(), cuda::std::__fp_exp_min_v<fmt> - 1);
+  }
+
+  // infinity and NaN have full zeros, so one more than __fp_exp_max_v
+  if constexpr (cuda::std::__fp_has_inf_v<fmt>)
+  {
+    test_fp_get_exp(cuda::std::numeric_limits<T>::infinity(), cuda::std::__fp_exp_max_v<fmt> + 1);
+  }
+  if constexpr (cuda::std::__fp_has_nan_v<fmt>)
+  {
+    if constexpr (cuda::std::is_same_v<T, __nv_fp8_e4m3>)
+    {
+      // __nv_fp8_e4m3 has only 2 NaNs so more of exponent are valid
+      test_fp_get_exp(cuda::std::numeric_limits<T>::quiet_NaN(), cuda::std::__fp_exp_max_v<fmt>);
+    }
+    else
+    {
+      test_fp_get_exp(cuda::std::numeric_limits<T>::quiet_NaN(), cuda::std::__fp_exp_max_v<fmt> + 1);
+    }
+  }
+  if constexpr (cuda::std::__fp_has_nans_v<fmt>)
+  {
+    test_fp_get_exp(cuda::std::numeric_limits<T>::signaling_NaN(), cuda::std::__fp_exp_max_v<fmt> + 1);
+  }
+}
+
+template <class T>
+__host__ __device__ _CCCL_CONSTEXPR_BIT_CAST void test(T val = T{1.0f})
+{
+  test_fp_get_exp<T>(val);
+}
+
+__host__ __device__ bool test(float val)
+{
+  test<float>(val);
+  test<double>(val);
+#if _CCCL_HAS_LONG_DOUBLE()
+  test<long double>();
+#endif // _CCCL_HAS_LONG_DOUBLE()
+
+#if _LIBCUDACXX_HAS_NVFP16()
+  test<__half>(val);
+#endif // _LIBCUDACXX_HAS_NVFP16()
+#if _LIBCUDACXX_HAS_NVBF16()
+  test<__nv_bfloat16>(val);
+#endif // _LIBCUDACXX_HAS_NVBF16()
+
+#if _CCCL_HAS_NVFP8_E4M3()
+  test<__nv_fp8_e4m3>();
+#endif // _CCCL_HAS_NVFP8_E4M3
+#if _CCCL_HAS_NVFP8_E5M2()
+  test<__nv_fp8_e5m2>();
+#endif // _CCCL_HAS_NVFP8_E5M2
+#if _CCCL_HAS_NVFP8_E8M0()
+  test<__nv_fp8_e8m0>();
+#endif // _CCCL_HAS_NVFP8_E8M0
+#if _CCCL_HAS_NVFP6_E2M3()
+  test<__nv_fp6_e2m3>();
+#endif // _CCCL_HAS_NVFP6_E2M3
+#if _CCCL_HAS_NVFP6_E3M2()
+  test<__nv_fp6_e3m2>();
+#endif // _CCCL_HAS_NVFP6_E3M2
+#if _CCCL_HAS_NVFP4_E2M1()
+  test<__nv_fp4_e2m1>();
+#endif // _CCCL_HAS_NVFP4_E2M1
+
+  return true;
+}
+
+__host__ __device__ _CCCL_CONSTEXPR_BIT_CAST bool test_constexpr(float val)
+{
+  test<float>(val);
+  test<double>(val);
+#if _CCCL_HAS_LONG_DOUBLE()
+  test<long double>(val);
+#endif // _CCCL_HAS_LONG_DOUBLE()
+
+  return true;
+}
+
+int main(int, char**)
+{
+  volatile float value = 1.0f;
+  test(value);
+
+#if _CCCL_HAS_CONSTEXPR_BIT_CAST()
+  static_assert(test_constexpr(1.0f));
+#endif // _CCCL_HAS_CONSTEXPR_BIT_CAST()
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/decompose/set_exp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/decompose/set_exp.pass.cpp
@@ -1,0 +1,191 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/__floating_point/fp.h>
+#include <cuda/std/cassert>
+#include <cuda/std/cmath>
+#include <cuda/std/limits>
+#include <cuda/std/type_traits>
+
+#include "test_macros.h"
+
+template <class T>
+__host__ __device__ _CCCL_CONSTEXPR_BIT_CAST void test_fp_set_exp(T val, int exponent)
+{
+  assert(cuda::std::__fp_get_exp(val) != exponent);
+  assert(cuda::std::__fp_get_exp(cuda::std::__fp_set_exp(val, exponent)) == exponent);
+}
+
+template <class T>
+__host__ __device__ _CCCL_CONSTEXPR_BIT_CAST void test_fp_set_exp(T val)
+{
+  constexpr auto fmt = cuda::std::__fp_format_of_v<T>;
+
+  static_assert(cuda::std::is_same_v<decltype(cuda::std::__fp_set_exp(cuda::std::declval<T>(), int{0})), T>);
+  static_assert(noexcept(cuda::std::__fp_set_exp(cuda::std::declval<T>(), 0)));
+
+  test_fp_set_exp(val, 2);
+  if constexpr (cuda::std::__fp_exp_nbits_v<fmt> > 3)
+  {
+    test_fp_set_exp(T{32}, 0);
+  }
+
+  { // set all exponent bits to zero
+    if constexpr (fmt != cuda::std::__fp_format::__fp8_nv_e8m0) // All zero counts as NaN for __fp8_nv_e8m0
+    { // 2 has no mantissa bit set, so it will be a zero
+      const T res = cuda::std::__fp_set_exp(T{2}, cuda::std::__fp_exp_min_v<fmt> - 1);
+      assert(!cuda::std::isnormal(res));
+      assert(!cuda::std::isnan(res));
+      assert(!cuda::std::isinf(res));
+      assert(cuda::std::isfinite(res));
+      assert(cuda::std::fpclassify(res) == FP_ZERO);
+    }
+
+    if constexpr (cuda::std::__fp_is_signed_v<fmt>)
+    { // -2 has no mantissa bit set, so it will be a zero
+      const T res = cuda::std::__fp_set_exp(T{-2}, cuda::std::__fp_exp_min_v<fmt> - 1);
+      assert(!cuda::std::isnormal(res));
+      assert(!cuda::std::isnan(res));
+      assert(!cuda::std::isinf(res));
+      assert(cuda::std::isfinite(res));
+      assert(cuda::std::fpclassify(res) == FP_ZERO);
+    }
+
+    if constexpr (cuda::std::__fp_has_denorm_v<fmt>)
+    { // 3 has a mantissa bit set, so it will be a denormal
+      const T res = cuda::std::__fp_set_exp(T{3}, cuda::std::__fp_exp_min_v<fmt> - 1);
+      assert(!cuda::std::isnormal(res));
+      assert(!cuda::std::isnan(res));
+      assert(!cuda::std::isinf(res));
+      assert(cuda::std::isfinite(res));
+      assert(cuda::std::fpclassify(res) == FP_SUBNORMAL);
+    }
+
+    if constexpr (cuda::std::__fp_has_denorm_v<fmt> && cuda::std::__fp_is_signed_v<fmt>)
+    { // -3 has a mantissa bit set, so it will be a denormal
+      const T res = cuda::std::__fp_set_exp(T{-3}, cuda::std::__fp_exp_min_v<fmt> - 1);
+      assert(!cuda::std::isnormal(res));
+      assert(!cuda::std::isnan(res));
+      assert(!cuda::std::isinf(res));
+      assert(cuda::std::isfinite(res));
+      assert(cuda::std::fpclassify(res) == FP_SUBNORMAL);
+    }
+  }
+
+  { // set all exponent bits to one
+    if constexpr (cuda::std::__fp_has_inf_v<fmt>)
+    { // 2 has no mantissa bit set, so it will be an infinity
+      const T res = cuda::std::__fp_set_exp(T{2}, cuda::std::__fp_exp_max_v<fmt> + 1);
+      assert(!cuda::std::isnormal(res));
+      assert(!cuda::std::isnan(res));
+      assert(cuda::std::isinf(res));
+      assert(!cuda::std::isfinite(res));
+      assert(cuda::std::fpclassify(res) == FP_INFINITE);
+    }
+
+    if constexpr (cuda::std::__fp_has_inf_v<fmt> && cuda::std::__fp_is_signed_v<fmt>)
+    { // -2 has no mantissa bit set, so it will be an infinity
+      const T res = cuda::std::__fp_set_exp(T{-2}, cuda::std::__fp_exp_max_v<fmt> + 1);
+      assert(!cuda::std::isnormal(res));
+      assert(!cuda::std::isnan(res));
+      assert(cuda::std::isinf(res));
+      assert(!cuda::std::isfinite(res));
+      assert(cuda::std::fpclassify(res) == FP_INFINITE);
+    }
+
+    if constexpr (fmt != cuda::std::__fp_format::__fp8_nv_e4m3)
+    { // __fp8_nv_e4m3 has special NaN values
+      if constexpr (cuda::std::__fp_has_nan_v<fmt>)
+      { // 3 has no mantissa bit set, so it will be a NaN
+        const T res = cuda::std::__fp_set_exp(T{3}, cuda::std::__fp_exp_max_v<fmt> + 1);
+        assert(!cuda::std::isnormal(res));
+        assert(cuda::std::isnan(res));
+        assert(!cuda::std::isinf(res));
+        assert(!cuda::std::isfinite(res));
+        assert(cuda::std::fpclassify(res) == FP_NAN);
+      }
+
+      if constexpr (cuda::std::__fp_has_nan_v<fmt> && cuda::std::__fp_is_signed_v<fmt>)
+      { // -3 has no mantissa bit set, so it will be a NaN
+        const T res = cuda::std::__fp_set_exp(T{-3}, cuda::std::__fp_exp_max_v<fmt> + 1);
+        assert(!cuda::std::isnormal(res));
+        assert(cuda::std::isnan(res));
+        assert(!cuda::std::isinf(res));
+        assert(!cuda::std::isfinite(res));
+        assert(cuda::std::fpclassify(res) == FP_NAN);
+      }
+    }
+  }
+}
+
+template <class T>
+__host__ __device__ _CCCL_CONSTEXPR_BIT_CAST void test(T val = T{1})
+{
+  test_fp_set_exp<T>(val);
+}
+
+__host__ __device__ bool test(float val)
+{
+  test<float>(val);
+  test<double>(val);
+#if _CCCL_HAS_LONG_DOUBLE()
+  test<long double>(val);
+#endif // _CCCL_HAS_LONG_DOUBLE()
+
+#if _LIBCUDACXX_HAS_NVFP16()
+  test<__half>(val);
+#endif // _LIBCUDACXX_HAS_NVFP16()
+#if _LIBCUDACXX_HAS_NVBF16()
+  test<__nv_bfloat16>(val);
+#endif // _LIBCUDACXX_HAS_NVBF16()
+
+#if _CCCL_HAS_NVFP8_E4M3()
+  test<__nv_fp8_e4m3>();
+#endif // _CCCL_HAS_NVFP8_E4M3
+#if _CCCL_HAS_NVFP8_E5M2()
+  test<__nv_fp8_e5m2>();
+#endif // _CCCL_HAS_NVFP8_E5M2
+#if _CCCL_HAS_NVFP8_E8M0()
+  test<__nv_fp8_e8m0>();
+#endif // _CCCL_HAS_NVFP8_E8M0
+#if _CCCL_HAS_NVFP6_E2M3()
+  test<__nv_fp6_e2m3>();
+#endif // _CCCL_HAS_NVFP6_E2M3
+#if _CCCL_HAS_NVFP6_E3M2()
+  test<__nv_fp6_e3m2>();
+#endif // _CCCL_HAS_NVFP6_E3M2
+#if _CCCL_HAS_NVFP4_E2M1()
+  test<__nv_fp4_e2m1>();
+#endif // _CCCL_HAS_NVFP4_E2M1
+
+  return true;
+}
+
+__host__ __device__ _CCCL_CONSTEXPR_BIT_CAST bool test_constexpr(float val)
+{
+  test<float>(val);
+  test<double>(val);
+#if _CCCL_HAS_LONG_DOUBLE()
+  test<long double>(val);
+#endif // _CCCL_HAS_LONG_DOUBLE()
+
+  return true;
+}
+
+int main(int, char**)
+{
+  volatile float value = 1.0f;
+  test(value);
+
+#if _CCCL_HAS_CONSTEXPR_BIT_CAST()
+  static_assert(test_constexpr(1.0f));
+#endif // _CCCL_HAS_CONSTEXPR_BIT_CAST()
+  return 0;
+}


### PR DESCRIPTION
For certain math functions we often want to get the exponent of a floating point number.

Extend our machinery with simple helper that extract those

This is a requirement to fix some of our current constexpr math functions