### PR TITLE
[CUDAX] Use `stream_id` instead of `unsigned long long` as `stream_ref::id()` return type

### DIFF
--- a/cudax/include/cuda/experimental/__stream/stream_ref.cuh
+++ b/cudax/include/cuda/experimental/__stream/stream_ref.cuh
@@ -43,6 +43,11 @@ namespace __detail
 static const ::cudaStream_t __invalid_stream = reinterpret_cast<cudaStream_t>(~0ULL);
 } // namespace __detail
 
+//! @brief A type representing a stream ID.
+enum class stream_id : unsigned long long
+{
+};
+
 //! @brief A non-owning wrapper for cudaStream_t.
 //!
 //! @note It is undefined behavior to use a `stream_ref` object beyond the lifetime of the stream it was created from,
@@ -115,9 +120,9 @@ struct stream_ref : ::cuda::stream_ref
   //! @return The unique ID of the stream
   //!
   //! @throws cuda_error if the ID query fails
-  [[nodiscard]] _CCCL_HOST_API unsigned long long id() const
+  [[nodiscard]] _CCCL_HOST_API stream_id id() const
   {
-    return __detail::driver::streamGetId(__stream);
+    return stream_id{__detail::driver::streamGetId(__stream)};
   }
 
   //! @brief Create a new event and record it into this stream

--- a/cudax/test/stream/stream_smoke.cu
+++ b/cudax/test/stream/stream_smoke.cu
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <cuda/std/type_traits>
+#include <cuda/std/utility>
+
 #include <cuda/experimental/launch.cuh>
 #include <cuda/experimental/stream.cuh>
 
@@ -137,6 +140,9 @@ C2H_CCCLRT_TEST("Stream get device", "[stream]")
 
 C2H_CCCLRT_TEST("Stream ID", "[stream]")
 {
+  STATIC_REQUIRE(cuda::std::is_same_v<unsigned long long, cuda::std::underlying_type_t<cudax::stream_id>>);
+  STATIC_REQUIRE(cuda::std::is_same_v<cudax::stream_id, decltype(cuda::std::declval<cudax::stream_ref>().id())>);
+
   cudax::stream stream1{cudax::device_ref{0}};
   cudax::stream stream2{cudax::device_ref{0}};
 


### PR DESCRIPTION
This PR introduces a `stream_id` enum class type and uses it as the return type of the `stream_ref::id()` method. I think using a strong type is more suitable here, because I don't expect the ID to be arithmetically modified in any way