### PR TITLE
the stream implementation of `continues_on` is using a moved-from receiver

### DIFF
--- a/cudax/include/cuda/experimental/__execution/stream/continues_on.cuh
+++ b/cudax/include/cuda/experimental/__execution/stream/continues_on.cuh
@@ -84,7 +84,7 @@ struct __continues_on_t
 
     _CCCL_API constexpr explicit __opstate_t(_Sndr&& __sndr, _Rcvr __rcvr)
         : __rcvr_(static_cast<_Rcvr&&>(__rcvr))
-        , __stream_(__get_stream(__sndr, execution::get_env(__rcvr)))
+        , __stream_(__get_stream(__sndr, execution::get_env(__rcvr_)))
         , __opstate_(execution::connect(static_cast<_Sndr&&>(__sndr), __rcvr_t<_Rcvr>{__rcvr_}))
     {}
 


### PR DESCRIPTION
## Description

hopefully this fixes the V100 hangs we've been seeing in CI.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
