### PR TITLE
fix ODR voilation making cudax `launch` tests flaky

### DIFF
--- a/cudax/include/cuda/experimental/__launch/launch.cuh
+++ b/cudax/include/cuda/experimental/__launch/launch.cuh
@@ -39,6 +39,14 @@
 
 #include <cuda/std/__cccl/prologue.h>
 
+#ifdef _CCCL_LAUNCH_CONFIG_TEST
+using _cudaLaunchKernelExC_t                       = cudaError_t (*)(const cudaLaunchConfig_t*, const void*, void**);
+inline _cudaLaunchKernelExC_t _cudaLaunchKernelExC = &cudaLaunchKernelExC;
+#  define _CUDAX_LAUNCH_KERNEL_EX_C _cudaLaunchKernelExC
+#else // ^^^ defined(_CCCL_LAUNCH_CONFIG_TEST) / !defined(_CCCL_LAUNCH_CONFIG_TEST) vvv
+#  define _CUDAX_LAUNCH_KERNEL_EX_C cudaLaunchKernelExC
+#endif // !defined(_CCCL_LAUNCH_CONFIG_TEST)
+
 #if _CCCL_STD_VER >= 2017
 namespace cuda::experimental
 {
@@ -99,7 +107,7 @@ _CCCL_HOST_API void inline __do_launch(
   cuda::stream_ref __stream, cudaLaunchConfig_t& __config, const void* __kernel_fn, void** __args_ptrs)
 {
   __config.stream = __stream.get();
-  _CCCL_TRY_CUDA_API(cudaLaunchKernelExC, "Failed to launch a kernel", &__config, __kernel_fn, __args_ptrs);
+  _CCCL_TRY_CUDA_API(_CUDAX_LAUNCH_KERNEL_EX_C, "Failed to launch a kernel", &__config, __kernel_fn, __args_ptrs);
 }
 
 template <typename... _ExpTypes, typename _Dst, typename _Config>

--- a/cudax/test/CMakeLists.txt
+++ b/cudax/test/CMakeLists.txt
@@ -63,6 +63,7 @@ foreach(cn_target IN LISTS cudax_TARGETS)
     launch/launch_smoke.cu
     launch/configuration.cu
   )
+  target_compile_definitions(${test_target} PRIVATE _CCCL_LAUNCH_CONFIG_TEST)
 
   cudax_add_catch2_test(test_target device ${cn_target}
     device/device_smoke.cu

--- a/cudax/test/launch/configuration.cu
+++ b/cudax/test/launch/configuration.cu
@@ -8,13 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-cudaError_t cudaLaunchKernelExTestReplacement(const cudaLaunchConfig_t* config, const void* kernel, void** args);
-
 // Test translation of launch function arguments to cudaLaunchConfig_t sent to cudaLaunchKernelEx internally
 // We replace cudaLaunchKernelEx with a test function here through a macro to intercept the cudaLaunchConfig_t
-#define cudaLaunchKernelExC cudaLaunchKernelExTestReplacement
 #include <cuda/experimental/launch.cuh>
-#undef cudaLaunchKernelExC
 
 #include <host_device.cuh>
 
@@ -128,6 +124,7 @@ auto configuration_test(
     {
       add_cluster(cluster_dims, expectedConfig.attrs[1]);
     }
+    _cudaLaunchKernelExC = cudaLaunchKernelExTestReplacement; // Ensure the replacement is called
     cudax::launch(stream, config, empty_kernel, 0);
   }
 
@@ -147,6 +144,7 @@ auto configuration_test(
     {
       add_cluster(cluster_dims, expectedConfig.attrs[1]);
     }
+    _cudaLaunchKernelExC = cudaLaunchKernelExTestReplacement; // Ensure the replacement is called
     cudax::launch(stream, config, empty_kernel, 0);
   }
 
@@ -167,6 +165,7 @@ auto configuration_test(
     {
       add_cluster(cluster_dims, expectedConfig.attrs[0]);
     }
+    _cudaLaunchKernelExC = cudaLaunchKernelExTestReplacement; // Ensure the replacement is called
     cudax::launch(stream, config, empty_kernel, 0);
   }
   stream.sync();


### PR DESCRIPTION
## Description

`cudax::launch` is defined in terms of an inline called `__do_launch` which is defined as follows:

```c++
_CCCL_HOST_API void inline __do_launch(
  cuda::stream_ref __stream, cudaLaunchConfig_t& __config, const void* __kernel_fn, void** __args_ptrs)
{
  __config.stream = __stream.get();
  _CCCL_TRY_CUDA_API(cudaLaunchKernelExC, "Failed to launch a kernel", &__config, __kernel_fn, __args_ptrs);
}
```

the `launch` tests consist of two translation units: `launch_smoke.cu` and `configuration.cu`. In `configuration.cu`, the `cudaLaunchKernelExC` identifier is replaced with a mock, `cudaLaunchKernelExTestReplacement`, via macro replacement.

so, we are linking together to object files compiled with different definitions of the `__do_launch` inline function. which `__do_launch` implementation will the linker pick? nobody knows.

this PR uses a function pointer instead of macro replacement to hook `cudax::launch` in such a way that both translation units see the same definition of `__do_launch`.


## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
