### PR TITLE
Add a two-phase reduce API for cuda.parallel

### DIFF
--- a/python/cuda_cccl/benchmarks/parallel/bench_reduce.py
+++ b/python/cuda_cccl/benchmarks/parallel/bench_reduce.py
@@ -14,12 +14,12 @@ def reduce_pointer(input_array, build_only):
     def my_add(a, b):
         return a + b
 
-    alg = algorithms.reduce_into(input_array, res, my_add, h_init)
-
     if not build_only:
-        temp_bytes = alg(None, input_array, res, size, h_init)
+        temp_bytes = algorithms.reduce_into(
+            None, input_array, res, size, my_add, h_init
+        )
         scratch = cp.empty(temp_bytes, dtype=cp.uint8)
-        alg(scratch, input_array, res, size, h_init)
+        algorithms.reduce_into(scratch, input_array, res, size, my_add, h_init)
 
     cp.cuda.runtime.deviceSynchronize()
 
@@ -32,12 +32,12 @@ def reduce_struct(input_array, build_only):
     def my_add(a, b):
         return MyStruct(a.x + b.x, a.y + b.y)
 
-    alg = algorithms.reduce_into(input_array, res, my_add, h_init)
-
     if not build_only:
-        temp_bytes = alg(None, input_array, res, size, h_init)
+        temp_bytes = algorithms.reduce_into(
+            None, input_array, res, size, my_add, h_init
+        )
         scratch = cp.empty(temp_bytes, dtype=cp.uint8)
-        alg(scratch, input_array, res, size, h_init)
+        algorithms.reduce_into(scratch, input_array, res, size, my_add, h_init)
 
     cp.cuda.runtime.deviceSynchronize()
 
@@ -50,12 +50,10 @@ def reduce_iterator(inp, size, build_only):
     def my_add(a, b):
         return a + b
 
-    alg = algorithms.reduce_into(inp, res, my_add, h_init)
-
     if not build_only:
-        temp_bytes = alg(None, inp, res, size, h_init)
+        temp_bytes = algorithms.reduce_into(None, inp, res, size, my_add, h_init)
         scratch = cp.empty(temp_bytes, dtype=cp.uint8)
-        alg(scratch, inp, res, size, h_init)
+        algorithms.reduce_into(scratch, inp, res, size, my_add, h_init)
 
     cp.cuda.runtime.deviceSynchronize()
 

--- a/python/cuda_cccl/cuda/cccl/parallel/experimental/algorithms/__init__.py
+++ b/python/cuda_cccl/cuda/cccl/parallel/experimental/algorithms/__init__.py
@@ -6,7 +6,7 @@
 from ._merge_sort import merge_sort as merge_sort
 from ._radix_sort import DoubleBuffer, SortOrder
 from ._radix_sort import radix_sort as radix_sort
-from ._reduce import reduce_into as reduce_into
+from ._reduce import Reduce, reduce_into
 from ._scan import exclusive_scan as exclusive_scan
 from ._scan import inclusive_scan as inclusive_scan
 from ._segmented_reduce import segmented_reduce
@@ -15,6 +15,7 @@ from ._unique_by_key import unique_by_key as unique_by_key
 
 __all__ = [
     "merge_sort",
+    "Reduce",
     "reduce_into",
     "exclusive_scan",
     "inclusive_scan",

--- a/python/cuda_cccl/tests/parallel/examples/reduction/custom_types.py
+++ b/python/cuda_cccl/tests/parallel/examples/reduction/custom_types.py
@@ -30,11 +30,14 @@ def pixel_reduction_example():
 
     h_init = Pixel(0, 0, 0)
 
-    reduce_into = parallel.reduce_into(d_rgb, d_out, max_g_value, h_init)
-    temp_storage_bytes = reduce_into(None, d_rgb, d_out, d_rgb.size, h_init)
+    temp_storage_bytes = parallel.reduce_into(
+        None, d_rgb, d_out, d_rgb.size, max_g_value, h_init
+    )
 
     d_temp_storage = cp.empty(temp_storage_bytes, dtype=np.uint8)
-    _ = reduce_into(d_temp_storage, d_rgb, d_out, d_rgb.size, h_init)
+    _ = parallel.reduce_into(
+        d_temp_storage, d_rgb, d_out, d_rgb.size, max_g_value, h_init
+    )
 
     # Verify result
     h_rgb = d_rgb.get()
@@ -77,15 +80,12 @@ def minmax_reduction_example():
     # minimum and maximum operators
     h_init = MinMax(np.inf, -np.inf)
 
-    # get algorithm object
-    cccl_sum = parallel.reduce_into(tr_it, d_out, minmax_op, h_init)
-
     # allocated needed temporary
-    tmp_sz = cccl_sum(None, tr_it, d_out, nelems, h_init)
+    tmp_sz = parallel.reduce_into(None, tr_it, d_out, nelems, minmax_op, h_init)
     tmp_storage = cp.empty(tmp_sz, dtype=cp.uint8)
 
     # invoke the reduction algorithm
-    cccl_sum(tmp_storage, tr_it, d_out, nelems, h_init)
+    parallel.reduce_into(tmp_storage, tr_it, d_out, nelems, minmax_op, h_init)
 
     # display values computed on the device
     actual = d_out.get()

--- a/python/cuda_cccl/tests/parallel/examples/reduction/iterator/counting_iterator.py
+++ b/python/cuda_cccl/tests/parallel/examples/reduction/iterator/counting_iterator.py
@@ -29,12 +29,15 @@ def counting_iterator_example():
     d_output = cp.empty(1, dtype=np.int32)  # Storage for output
 
     # Instantiate reduction, determine storage requirements, and allocate storage
-    reduce_into = algorithms.reduce_into(first_it, d_output, add_op, h_init)
-    temp_storage_size = reduce_into(None, first_it, d_output, num_items, h_init)
+    temp_storage_size = algorithms.reduce_into(
+        None, first_it, d_output, num_items, add_op, h_init
+    )
     d_temp_storage = cp.empty(temp_storage_size, dtype=np.uint8)
 
     # Run reduction
-    reduce_into(d_temp_storage, first_it, d_output, num_items, h_init)
+    algorithms.reduce_into(
+        d_temp_storage, first_it, d_output, num_items, add_op, h_init
+    )
 
     expected_output = functools.reduce(
         lambda a, b: a + b, range(first_item, first_item + num_items)

--- a/python/cuda_cccl/tests/parallel/examples/reduction/iterator/transform_iterator.py
+++ b/python/cuda_cccl/tests/parallel/examples/reduction/iterator/transform_iterator.py
@@ -34,12 +34,15 @@ def transform_iterator_example():
     d_output = cp.empty(1, dtype=np.int32)  # Storage for output
 
     # Instantiate reduction, determine storage requirements, and allocate storage
-    reduce_into = algorithms.reduce_into(transform_it, d_output, add_op, h_init)
-    temp_storage_size = reduce_into(None, transform_it, d_output, num_items, h_init)
+    temp_storage_size = algorithms.reduce_into(
+        None, transform_it, d_output, num_items, add_op, h_init
+    )
     d_temp_storage = cp.empty(temp_storage_size, dtype=np.uint8)
 
     # Run reduction
-    reduce_into(d_temp_storage, transform_it, d_output, num_items, h_init)
+    algorithms.reduce_into(
+        d_temp_storage, transform_it, d_output, num_items, add_op, h_init
+    )
 
     expected_output = functools.reduce(
         lambda a, b: a + b, [a**2 for a in range(first_item, first_item + num_items)]

--- a/python/cuda_cccl/tests/parallel/test_reduce.py
+++ b/python/cuda_cccl/tests/parallel/test_reduce.py
@@ -610,3 +610,19 @@ def test_reduce_invalid_stream():
         _ = algorithms.reduce_into(
             None, d_in, d_out, d_in.size, add_op, h_init, stream=Stream3()
         )
+
+
+def test_reduce_class_interface():
+    # test that construct a Reduce object by hand works
+    def add_op(x, y):
+        return x + y
+
+    h_init = np.asarray([0], dtype=np.int32)
+    d_in = cp.asarray([1, 2, 3, 4, 5], dtype=np.int32)
+    d_out = cp.empty(1, dtype=np.int32)
+
+    reduce = algorithms.Reduce(d_in, d_out, add_op, h_init)
+    temp_storage_size = reduce(None, d_in, d_out, d_in.size, h_init)
+    temp_storage = cp.empty(temp_storage_size, dtype=np.uint8)
+    reduce(temp_storage, d_in, d_out, d_in.size, h_init)
+    cp.testing.assert_allclose(d_in.sum().get(), d_out.get())


### PR DESCRIPTION
A potential solution for #5163.

This PR proposes a two-phase API for Python that is closer to the C++ API. In particular, it gets rid of the object construction step:

```python
# Determine temporary device storage requirements
temp_storage_size = reduce_into(
    None, d_input, d_output, len(d_input), add_op, h_init
)

# Allocate temporary storage
d_temp_storage = cp.empty(temp_storage_size, dtype=np.uint8)

# Run reduction
reduce_into(
    d_temp_storage, d_input, d_output, len(d_input), add_op, h_init
)
``` 

This works by having each call to `reduce_into` either construct a reducer object, or retrieve one from the cache (TL; DR reducer objects are cached on the input types).

## Tradeoff ❗⚠  

Unfortunately, this introduces the additional cost of cache key computation and lookup on every call to `reduce_into`. In practice, this can translate into a 5-10% increase in runtime, as shown in the results of prototype benchmarking:

```bash
---------------------------------------------------------------------------------------------------------------------- benchmark: 22 tests -----------------------------------------------------------------------------------------------------------------------
Name (time in us)                                         Min                       Max                      Mean                 StdDev                    Median                     IQR            Outliers          OPS (uops/s)            Rounds  Iterations
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
bench_compile_reduce_iterator (0001_main)      1,924,858.6350 (>1000.0)  2,060,009.1760 (>1000.0)  1,994,558.7313 (>1000.0)  67,675.4153 (>1000.0)  1,998,808.3830 (>1000.0)  101,362.9057 (>1000.0)       1;0          501,364.0282 (0.00)          3           1
bench_compile_reduce_iterator (NOW)                    3.3450 (1.0)             13.4210 (1.0)              7.2543 (1.0)           5.4040 (6.56)             4.9970 (1.0)            7.5570 (44.45)         1;0  137,848,455,283.1612 (1.0)           3           1
bench_compile_reduce_pointer (0001_main)       2,047,941.5530 (>1000.0)  2,231,425.6340 (>1000.0)  2,121,085.8130 (>1000.0)  97,232.8870 (>1000.0)  2,083,890.2520 (>1000.0)  137,613.0607 (>1000.0)       1;0          471,456.6445 (0.00)          3           1
bench_compile_reduce_pointer (NOW)                     3.8560 (1.15)            17.3160 (1.29)             9.0873 (1.25)          7.2132 (8.76)             6.0900 (1.22)          10.0950 (59.37)         1;0  110,043,188,227.8086 (0.80)          3           1
bench_reduce_iterator[1000000] (0001_main)            16.5150 (4.94)            61.1230 (4.55)            17.2526 (2.38)          0.9777 (1.19)            17.0760 (3.42)           0.1900 (1.12)     774;1738   57,962,289,526.6106 (0.42)      21945           1
bench_reduce_iterator[1000000] (NOW)                  18.4390 (5.51)            45.1490 (3.36)            19.3861 (2.67)          1.0349 (1.26)            19.1290 (3.83)           0.2600 (1.53)     895;3262   51,583,297,407.7754 (0.37)      20295           1
bench_reduce_iterator[100000] (0001_main)             16.3050 (4.87)           122.6080 (9.14)            17.0295 (2.35)          1.1145 (1.35)            16.8560 (3.37)           0.1700 (1.0)      774;2006   58,721,551,678.7424 (0.43)      24503           1
bench_reduce_iterator[100000] (NOW)                   18.1880 (5.44)            58.2600 (4.34)            19.1799 (2.64)          1.1146 (1.35)            18.8990 (3.78)           0.2400 (1.41)    1018;2937   52,137,793,355.8612 (0.38)      20833           1
bench_reduce_iterator[10000] (0001_main)              16.4650 (4.92)            38.6590 (2.88)            17.5079 (2.41)          1.8019 (2.19)            17.0360 (3.41)           0.7960 (4.68)        19;19   57,117,174,125.4093 (0.41)        384           1
bench_reduce_iterator[10000] (NOW)                    19.1700 (5.73)            43.7680 (3.26)            25.1810 (3.47)         10.5224 (12.78)           20.3310 (4.07)           9.1315 (53.71)         1;1   39,712,480,340.6700 (0.29)          5           1
bench_reduce_pointer[1000000] (0001_main)             17.2260 (5.15)           203.4820 (15.16)           17.8793 (2.46)          1.4359 (1.74)            17.7380 (3.55)           0.1800 (1.06)     538;1616   55,930,539,883.8798 (0.41)      24276           1
bench_reduce_pointer[1000000] (NOW)                   18.3380 (5.48)            52.0200 (3.88)            19.2939 (2.66)          1.0495 (1.27)            19.0590 (3.81)           0.2710 (1.59)     792;3927   51,829,793,664.9561 (0.38)      22524           1
bench_reduce_pointer[100000] (0001_main)              15.9040 (4.75)            50.0670 (3.73)            16.5719 (2.28)          0.8236 (1.0)             16.4150 (3.28)           0.1710 (1.01)    1136;2864   60,343,285,909.4099 (0.44)      28850           1
bench_reduce_pointer[100000] (NOW)                    17.0760 (5.10)            60.0420 (4.47)            18.1862 (2.51)          1.2486 (1.52)            17.7970 (3.56)           0.8520 (5.01)    1110;1009   54,986,876,409.0649 (0.40)      26009           1
bench_reduce_pointer[10000] (0001_main)               18.2780 (5.46)            51.8400 (3.86)            26.6408 (3.67)         14.2104 (17.25)           20.5820 (4.12)          11.3950 (67.02)         1;1   37,536,406,951.9353 (0.27)          5           1
bench_reduce_pointer[10000] (NOW)                     19.7400 (5.90)            41.6840 (3.11)            25.4410 (3.51)          9.2627 (11.25)           20.8220 (4.17)           8.4823 (49.89)         1;1   39,306,635,697.0117 (0.29)          5           1
bench_reduce_struct[1000000] (0001_main)              20.9420 (6.26)           192.1540 (14.32)           21.7255 (2.99)          1.5795 (1.92)            21.5330 (4.31)           0.2000 (1.18)     638;1744   46,028,765,471.9953 (0.33)      22565           1
bench_reduce_struct[1000000] (NOW)                    22.3350 (6.68)            56.8670 (4.24)            23.4514 (3.23)          1.1942 (1.45)            23.1560 (4.63)           0.2610 (1.54)     886;3135   42,641,396,904.3751 (0.31)      19874           1
bench_reduce_struct[100000] (0001_main)               17.9880 (5.38)           260.4080 (19.40)           19.1844 (2.64)          3.6653 (4.45)            18.8190 (3.77)           0.3500 (2.06)     461;1912   52,125,772,238.3448 (0.38)      21669           1
bench_reduce_struct[100000] (NOW)                     19.6200 (5.87)           228.6610 (17.04)           20.8227 (2.87)          2.1687 (2.63)            20.4510 (4.09)           0.3710 (2.18)     714;3669   48,024,509,717.1422 (0.35)      19037           1
bench_reduce_struct[10000] (0001_main)                20.4020 (6.10)            71.8000 (5.35)            33.8000 (4.66)         21.8057 (26.48)           22.8550 (4.57)          21.4272 (126.02)        1;0   29,585,787,526.9641 (0.21)          5           1
bench_reduce_struct[10000] (NOW)                      23.8360 (7.13)            62.1250 (4.63)            32.9424 (4.54)         16.3946 (19.91)           25.5800 (5.12)          12.0735 (71.01)         1;1   30,356,011,196.8240 (0.22)          5           1
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

## Best of both worlds?

To address the performance concerns above, we can continues to expose the object-based interface while introducing a two-phase API that is truly 1:1 with the C++ API.

## Questions

1. Should we do this?
2. If so, is there another API we can/should consider? I chose to go with what's closest to the C++ API.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
