### PR TITLE
Support types with any alignment in UBLKCP transform kernel

### DIFF
--- a/cub/cub/device/dispatch/dispatch_transform.cuh
+++ b/cub/cub/device/dispatch/dispatch_transform.cuh
@@ -275,7 +275,7 @@ struct dispatch_t<StableAddress,
     const int ipt =
       spread_out_items_per_thread(ActivePolicy{}, config->items_per_thread, config->sm_count, config->max_occupancy);
     const int tile_size = block_threads * ipt;
-    const int smem_size = smem_for_tile_size(tile_size, alignment);
+    const int smem_size = smem_for_tile_size(tile_size, block_threads, alignment);
     _CCCL_ASSERT((sizeof...(RandomAccessIteratorsIn) == 0) != (smem_size != 0), ""); // logical xor
 
     const auto grid_dim = static_cast<unsigned int>(::cuda::ceil_div(num_items, Offset{tile_size}));

--- a/cub/cub/device/dispatch/dispatch_transform.cuh
+++ b/cub/cub/device/dispatch/dispatch_transform.cuh
@@ -229,7 +229,7 @@ struct dispatch_t<StableAddress,
         static_assert(policy_t::min_items_per_thread <= policy_t::max_items_per_thread);
 
         const int tile_size = block_threads * items_per_thread;
-        const int smem_size = smem_for_tile_size(tile_size, alignment);
+        const int smem_size = smem_for_tile_size(tile_size, block_threads, alignment);
         if (smem_size > *max_smem)
         {
           // assert should be prevented by smem check in policy
@@ -279,6 +279,8 @@ struct dispatch_t<StableAddress,
     _CCCL_ASSERT((sizeof...(RandomAccessIteratorsIn) == 0) != (smem_size != 0), ""); // logical xor
 
     const auto grid_dim = static_cast<unsigned int>(::cuda::ceil_div(num_items, Offset{tile_size}));
+    // config->smem_size is 16 bytes larger than needed for UBLKCP because it's the total SMEM size, but 16 bytes are
+    // occupied by static shared memory and padding. But let's not complicate things.
     return ::cuda::std::make_tuple(
       launcher_factory(grid_dim, block_threads, smem_size, stream), kernel_source.TransformKernel(), ipt);
   }

--- a/cub/cub/device/dispatch/kernels/transform.cuh
+++ b/cub/cub/device/dispatch/kernels/transform.cuh
@@ -666,7 +666,7 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
   // Since alignment via the attribute may not work, we have to align explicitly if it's larger than the default dynamic
   // shared memory alignment (16). This is not needed when the tile size does not retain the alignment, since we align
   // each tile separately later
-  if constexpr (tile_sizes_retain_max_alignment && tile_padding > 16)
+  if constexpr (tile_sizes_retain_max_alignment && max_alignment > 16)
   {
     smem_base = round_up_smem_ptr<tile_padding>(smem_base);
     asm("" : "+l"(smem_base)); // keep the compiler from pulling the alignment deeper into the kernel

--- a/cub/cub/device/dispatch/kernels/transform.cuh
+++ b/cub/cub/device/dispatch/kernels/transform.cuh
@@ -605,19 +605,44 @@ _CCCL_DEVICE void bulk_copy_maybe_unaligned(
   }
 }
 
+template <int Alignment>
+_CCCL_DEVICE auto round_up_smem_ptr(char* p) -> char*
+{
+  uint32_t smem32 = __cvta_generic_to_shared(p);
+  smem32          = ::cuda::round_up(smem32, Alignment);
+  asm("" : "+r"(smem32));
+  return static_cast<char*>(_CCCL_BUILTIN_ASSUME_ALIGNED(__cvta_shared_to_generic(smem32), Alignment));
+}
+
 template <typename BulkCopyPolicy, typename Offset, typename F, typename RandomAccessIteratorOut, typename... InTs>
 _CCCL_DEVICE void transform_kernel_ublkcp(
   Offset num_items, int num_elem_per_thread, F f, RandomAccessIteratorOut out, aligned_base_ptr<InTs>... aligned_ptrs)
 {
+  constexpr int block_threads       = BulkCopyPolicy::block_threads;
   constexpr int bulk_copy_alignment = BulkCopyPolicy::bulk_copy_alignment;
+
+  constexpr int min_retained_alignment           = ::cuda::std::min({sizeof(InTs)...}) * block_threads;
+  constexpr int max_alignment                    = ::cuda::std::max({alignof(InTs)...});
+  constexpr bool tile_sizes_retain_max_alignment = max_alignment <= min_retained_alignment;
+
+  // add padding after a tile in shared memory to make space for the next tile's head padding, and retain alignment
+  constexpr int tile_padding =
+    tile_sizes_retain_max_alignment ? ::cuda::std::max(bulk_copy_alignment, max_alignment) : bulk_copy_alignment;
 
   __shared__ uint64_t bar;
 
   // We use an attribute to align the shared memory. This is not respected on all drivers though. The compiler correctly
   // takes the alignment into account and even emits an alignment specifier into ptx. However, this sometimes randomly
   // fails at runtime because the shared memory start pointer is not correctly provided by the driver/runtime. See also
-  // NVBug 5093902 and discussion in PR #5122.
-  extern __shared__ char __align__(bulk_copy_alignment) smem_base[];
+  // NVBug 5093902, NVBug 5329745, and discussion in PR #5122.
+  extern __shared__ char __align__(tile_padding) smem_base_unaligned[];
+  char* smem_base = smem_base_unaligned;
+  // Since alignment via the attribute may not work, we have to align explicitly (no needed when tile size is not
+  // retained, since we align each tile separately later)
+  if constexpr (tile_sizes_retain_max_alignment)
+  {
+    smem_base = round_up_smem_ptr<tile_padding>(smem_base);
+  }
 
   // However, any manual alignment of the shared memory start address outweighs the performance benefits of a faster
   // bulk copy by introducing about 7 additional SASS instructions at the start of the kernel. This also has to be done
@@ -647,10 +672,9 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
 
   namespace ptx = ::cuda::ptx;
 
-  constexpr int block_threads = BulkCopyPolicy::block_threads;
-  const int tile_size         = block_threads * num_elem_per_thread;
-  const Offset offset         = static_cast<Offset>(blockIdx.x) * tile_size;
-  const int valid_items       = (::cuda::std::min) (num_items - offset, Offset{tile_size});
+  const int tile_size   = block_threads * num_elem_per_thread;
+  const Offset offset   = static_cast<Offset>(blockIdx.x) * tile_size;
+  const int valid_items = (::cuda::std::min) (num_items - offset, Offset{tile_size});
 
   const bool inner_blocks = 0 < blockIdx.x && blockIdx.x + 2 < gridDim.x;
   if (inner_blocks)
@@ -667,11 +691,13 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
 
       // turning this lambda into a function does not change SASS
       auto bulk_copy_tile = [&](auto aligned_ptr) {
-        using T = typename decltype(aligned_ptr)::value_type;
-        static_assert(alignof(T) <= bulk_copy_alignment, ""); // FIXME(bgruber): we need to support this eventually
-
+        using T         = typename decltype(aligned_ptr)::value_type;
         const char* src = aligned_ptr.ptr + offset * unsigned{sizeof(T)}; // compute expression in U32 if Offset==I32
-        char* dst       = smem;
+        if constexpr (!tile_sizes_retain_max_alignment)
+        {
+          smem = round_up_smem_ptr<alignof(T)>(smem);
+        }
+        char* dst = smem;
         _CCCL_ASSERT(reinterpret_cast<uintptr_t>(src) % bulk_copy_alignment == 0, "");
         _CCCL_ASSERT(reinterpret_cast<uintptr_t>(dst) % bulk_copy_alignment == 0, "");
 
@@ -691,8 +717,7 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
         ::cuda::ptx::cp_async_bulk(::cuda::ptx::space_cluster, ::cuda::ptx::space_global, dst, src, bytes_to_copy, &bar);
         total_copied += bytes_to_copy;
 
-        // add bulk_copy_alignment to make space for the next tile's head padding
-        smem += int{sizeof(T)} * tile_size + bulk_copy_alignment;
+        smem += tile_padding + int{sizeof(T)} * tile_size;
         _CCCL_ASSERT(bytes_to_copy <= int{sizeof(T)} * tile_size + bulk_copy_alignment, "");
       };
 
@@ -726,6 +751,10 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
 
       const char* src = aligned_ptr.ptr + offset * unsigned{sizeof(T)} + head_padding; // compute expression in U32 if
                                                                                        // Offset==I32
+      if constexpr (!tile_sizes_retain_max_alignment)
+      {
+        smem = round_up_smem_ptr<alignof(T)>(smem);
+      }
       char* dst = smem + head_padding;
       _CCCL_ASSERT(reinterpret_cast<uintptr_t>(src) % alignof(T) == 0, "");
       _CCCL_ASSERT(reinterpret_cast<uintptr_t>(dst) % alignof(T) == 0, "");
@@ -733,8 +762,8 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
       bulk_copy_maybe_unaligned<bulk_copy_alignment>(
         dst, src, bytes_to_copy, aligned_ptr.head_padding, bar, total_copied, elected);
 
-      // add bulk_copy_alignment to account for this tile's head padding
-      smem += bulk_copy_alignment + int{sizeof(T)} * tile_size;
+      // add padding to account for this tile's head padding
+      smem += tile_padding + int{sizeof(T)} * tile_size;
     };
 
     // Order of evaluation is left-to-right
@@ -766,17 +795,14 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
       {
         char* smem         = smem_base;
         auto fetch_operand = [&](auto aligned_ptr) {
-          using T         = typename decltype(aligned_ptr)::value_type;
-          const char* src = smem;
-          if constexpr (alignof(T) < bulk_copy_alignment)
+          using T                = typename decltype(aligned_ptr)::value_type;
+          const int head_padding = alignof(T) < bulk_copy_alignment ? aligned_ptr.head_padding : 0;
+          if constexpr (!tile_sizes_retain_max_alignment)
           {
-            src += aligned_ptr.head_padding;
+            smem = round_up_smem_ptr<alignof(T)>(smem);
           }
-          else
-          {
-            _CCCL_ASSERT(aligned_ptr.head_padding == 0, "");
-          }
-          smem += int{sizeof(T)} * tile_size + bulk_copy_alignment;
+          const char* src = smem + head_padding;
+          smem += tile_padding + int{sizeof(T)} * tile_size;
           return reinterpret_cast<const T*>(src)[idx];
         };
 

--- a/cub/cub/device/dispatch/tuning/tuning_transform.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_transform.cuh
@@ -100,7 +100,7 @@ constexpr int ldgsts_size_and_align = 16;
 
 template <typename... RandomAccessIteratorsIn>
 _CCCL_HOST_DEVICE constexpr auto
-memcpy_async_smem_for_tile_size(int tile_size, int copy_alignment = ldgsts_size_and_align) -> int
+memcpy_async_smem_for_tile_size(int tile_size, int /*block_threads*/, int copy_alignment = ldgsts_size_and_align) -> int
 {
   int smem_size                    = 0;
   [[maybe_unused]] auto count_smem = [&](int vt_size, int vt_alignment) {
@@ -122,16 +122,37 @@ _CCCL_HOST_DEVICE constexpr auto bulk_copy_alignment(int sm_arch) -> int
 }
 
 template <typename... RandomAccessIteratorsIn>
-_CCCL_HOST_DEVICE constexpr auto bulk_copy_smem_for_tile_size(int tile_size, int bulk_copy_align) -> int
+_CCCL_HOST_DEVICE constexpr auto bulk_copy_smem_for_tile_size(int tile_size, int block_threads, int bulk_copy_align)
+  -> int
 {
   // we rely on the tile_size being a multiple of alignments, so shifting offsets/pointers by it retains alignments
   _CCCL_ASSERT(tile_size % bulk_copy_align == 0, "");
   _CCCL_ASSERT(tile_size % bulk_copy_size_multiple == 0, "");
 
-  return ::cuda::round_up(int{sizeof(int64_t)}, bulk_copy_align) /* bar */
-       + tile_size * loaded_bytes_per_iteration<RandomAccessIteratorsIn...>()
-       // padding for each input tile (handles before + after as long as tile_size is a multiple of bulk_copy_align)
-       + sizeof...(RandomAccessIteratorsIn) * bulk_copy_align;
+  const int min_retained_alignment = ::cuda::std::min(
+    {(int{sizeof(it_value_t<RandomAccessIteratorsIn>)} * block_threads)...,
+     2 << 30 /* largest alignment that can fit into int */});
+  const int max_alignment = ::cuda::std::max({int{alignof(it_value_t<RandomAccessIteratorsIn>)}..., 1});
+  const bool tile_sizes_retain_max_alignment = max_alignment <= min_retained_alignment;
+
+  const int tile_padding =
+    tile_sizes_retain_max_alignment ? ::cuda::std::max(bulk_copy_align, max_alignment) : bulk_copy_align;
+
+  // dynamic SMEM comes after static shared memory (which contains the 8-byte barrier) and is at least 16 bytes aligned.
+  // So let's start at offset 16. This also hits the worst case scenario for types with alignment larger than 16,
+  // needing the most padding before the first tile. From observation, dynamic shared memory starts at address 0x408
+  // within the shared memory window of the current CTA.
+  int smem_size                    = ::cuda::round_up(int{sizeof(uint64_t)}, 16);
+  [[maybe_unused]] auto count_smem = [&](int vt_size, int vt_alignment) {
+    if (!tile_sizes_retain_max_alignment)
+    {
+      smem_size = ::cuda::round_up(smem_size, vt_alignment);
+    }
+    smem_size += tile_padding + vt_size * tile_size;
+  };
+  // left to right evaluation!
+  (..., count_smem(sizeof(it_value_t<RandomAccessIteratorsIn>), alignof(it_value_t<RandomAccessIteratorsIn>)));
+  return smem_size;
 }
 
 _CCCL_HOST_DEVICE constexpr int arch_to_min_bytes_in_flight(int sm_arch)
@@ -281,7 +302,7 @@ struct policy_hub<RequiresStableAddress, ::cuda::std::tuple<RandomAccessIterator
     // then runs on the next architecture after that, which may have a smaller available SMEM, we get a crash.
     static constexpr bool exhaust_smem =
       memcpy_async_smem_for_tile_size<RandomAccessIteratorsIn...>(
-        block_threads * async_policy::min_items_per_thread, ldgsts_size_and_align)
+        block_threads * async_policy::min_items_per_thread, block_threads, ldgsts_size_and_align)
       > int{max_smem_per_block};
     static constexpr bool use_fallback =
       RequiresStableAddress || !can_memcpy_inputs || no_input_streams || exhaust_smem;
@@ -303,12 +324,10 @@ struct policy_hub<RequiresStableAddress, ::cuda::std::tuple<RandomAccessIterator
     // then runs on the next architecture after that, which may have a smaller available SMEM, we get a crash.
     static constexpr bool exhaust_smem =
       bulk_copy_smem_for_tile_size<RandomAccessIteratorsIn...>(
-        AsyncBlockSize * async_policy::min_items_per_thread, alignment)
+        AsyncBlockSize * async_policy::min_items_per_thread, AsyncBlockSize, alignment)
       > int{max_smem_per_block};
-    // FIXME(bgruber): we need to support overaligned types eventually !!!
-    static constexpr bool any_type_is_overalinged = ((alignof(it_value_t<RandomAccessIteratorsIn>) > alignment) || ...);
     static constexpr bool use_fallback =
-      RequiresStableAddress || !can_memcpy_inputs || no_input_streams || exhaust_smem || any_type_is_overalinged;
+      RequiresStableAddress || !can_memcpy_inputs || no_input_streams || exhaust_smem;
 
   public:
     static constexpr int min_bif    = arch_to_min_bytes_in_flight(PtxVersion);


### PR DESCRIPTION
- [x] Merge before: #5173 
- [x] No SASS change for `thrust.bench.transform.basic.base` for sm90
- [x] No SASS change for `thrust.bench.transform.basic.base` for sm100

Fixes: #5118