### PR TITLE
Use `thrust::copy` in `thrust::uninitialized_copy[_n]` in CUDA system when possible

### DIFF
--- a/thrust/benchmarks/bench/uninitialized_copy/basic.cu
+++ b/thrust/benchmarks/bench/uninitialized_copy/basic.cu
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <thrust/device_vector.h>
+#include <thrust/uninitialized_copy.h>
+
+#include <nvbench_helper.cuh>
+
+template <typename T>
+static void basic(nvbench::state& state, nvbench::type_list<T>)
+{
+  const auto elements = static_cast<std::size_t>(state.get_int64("Elements"));
+
+  thrust::device_vector<T> input(elements, T{0xAA});
+  thrust::device_vector<T> output(elements, thrust::default_init);
+
+  state.add_element_count(elements);
+  state.add_global_memory_reads<T>(elements);
+  state.add_global_memory_writes<T>(elements);
+
+  caching_allocator_t alloc;
+  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync,
+             [&](nvbench::launch& launch) {
+               thrust::uninitialized_copy(policy(alloc, launch), input.cbegin(), input.cend(), output.begin());
+             });
+}
+
+// Not allowed to be copied using std::memcpy or cudaMemcpy. Cannot use TMA copies.
+struct no_copy
+{
+  nvbench::uint32_t a;
+
+  no_copy() = default;
+
+  _CCCL_HOST_DEVICE no_copy(nvbench::uint32_t i)
+      : a(i)
+  {}
+
+  // the user-defined copy constructor prevents the type from being trivially copyable
+  _CCCL_HOST_DEVICE no_copy(const no_copy& nt)
+      : a(nt.a)
+  {}
+};
+
+static_assert(::cuda::std::is_trivially_default_constructible_v<no_copy>);
+static_assert(!::cuda::std::is_trivially_copyable_v<no_copy>); // as required by the C++ standard
+static_assert(!thrust::is_trivially_relocatable_v<no_copy>); // thrust uses this check internally
+
+// Requires use of placement new
+struct no_construct
+{
+  nvbench::uint32_t a = 1337;
+};
+
+static_assert(!::cuda::std::is_trivially_default_constructible_v<no_construct>);
+static_assert(::cuda::std::is_trivially_copyable_v<no_construct>); // as required by the C++ standard
+static_assert(thrust::is_trivially_relocatable_v<no_construct>); // thrust uses this check internally
+
+using types =
+  nvbench::type_list<nvbench::uint8_t, nvbench::uint16_t, nvbench::uint32_t, nvbench::uint64_t, no_copy, no_construct>;
+
+NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(types))
+  .set_name("base")
+  .set_type_axes_names({"T{ct}"})
+  .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 4));

--- a/thrust/thrust/detail/raw_reference_cast.h
+++ b/thrust/thrust/detail/raw_reference_cast.h
@@ -87,6 +87,9 @@ template <typename T>
 struct raw_reference : raw_reference_detail::raw_reference_impl<T>
 {};
 
+template <typename T>
+using raw_reference_t = typename raw_reference<T>::type;
+
 namespace raw_reference_detail
 {
 

--- a/thrust/thrust/system/cuda/detail/internal/copy_device_to_device.h
+++ b/thrust/thrust/system/cuda/detail/internal/copy_device_to_device.h
@@ -61,6 +61,9 @@ template <class Derived, class InputIt, class OutputIt>
 OutputIt THRUST_RUNTIME_FUNCTION
 device_to_device(execution_policy<Derived>& policy, InputIt first, InputIt last, OutputIt result)
 {
+  // FIXME(bgruber): We must not check is_trivially_relocatable, since we do not semantically relocate, but copy (the
+  // source remains valid). This is relevant for types like `unique_ptr`, which are trivially relocatable, but not
+  // trivially copyable.
   if constexpr (is_indirectly_trivially_relocatable_to<InputIt, OutputIt>::value)
   {
     using InputTy = thrust::detail::it_value_t<InputIt>;

--- a/thrust/thrust/system/cuda/detail/uninitialized_copy.h
+++ b/thrust/thrust/system/cuda/detail/uninitialized_copy.h
@@ -88,8 +88,7 @@ uninitialized_copy_n(execution_policy<Derived>& policy, InputIt first, Size coun
   if constexpr (::cuda::std::is_trivially_constructible_v<output_t, ctor_arg_t>
                 && thrust::is_trivially_relocatable_v<output_t>)
   {
-    // TODO(bgruber): converting it+count to it+it may be wasteful, since transform internally converts back
-    cuda_cub::transform(policy, first, first + count, result, ::cuda::std::identity{});
+    cuda_cub::transform_n(policy, first, count, result, ::cuda::std::identity{});
   }
   else
   {

--- a/thrust/thrust/system/cuda/detail/uninitialized_copy.h
+++ b/thrust/thrust/system/cuda/detail/uninitialized_copy.h
@@ -49,6 +49,11 @@ THRUST_NAMESPACE_BEGIN
 
 namespace cuda_cub
 {
+// forward declare and not include thrust/system/cuda/detail/copy.h to avoid a circular dependency
+template <class System, class InputIterator, class Size, class OutputIterator>
+OutputIterator _CCCL_HOST_DEVICE
+copy_n(execution_policy<System>& system, InputIterator first, Size n, OutputIterator result);
+
 namespace __uninitialized_copy
 {
 template <class InputIt, class OutputIt>

--- a/thrust/thrust/system/cuda/detail/uninitialized_copy.h
+++ b/thrust/thrust/system/cuda/detail/uninitialized_copy.h
@@ -90,7 +90,7 @@ uninitialized_copy_n(execution_policy<Derived>& policy, InputIt first, Size coun
   if constexpr (::cuda::std::is_trivially_constructible_v<output_t, ctor_arg_t>
                 && ::cuda::std::is_trivially_copyable_v<output_t>)
   {
-    cuda_cub::transform_n(policy, first, count, result, ::cuda::std::identity{});
+    cuda_cub::transform_n(policy, first, count, result, ::cuda::proclaim_copyable_arguments(::cuda::std::identity{}));
   }
   else
   {

--- a/thrust/thrust/system/cuda/detail/uninitialized_copy.h
+++ b/thrust/thrust/system/cuda/detail/uninitialized_copy.h
@@ -81,16 +81,12 @@ OutputIt _CCCL_HOST_DEVICE
 uninitialized_copy_n(execution_policy<Derived>& policy, InputIt first, Size count, OutputIt result)
 {
   // if the output type is trivially constructible from the input, it has no side effect, and we can skip placement new
-  // and calling a constructor. If the type is also trivially copyable, we can construct the instances in a kernel
-  // and memcpy to the destination. In that case, transform offers several fast paths. We must not check
-  // is_trivially_relocatable, since we do not semantically relocate, but copy (the source remains valid). This is
-  // relevant for types like `unique_ptr`, which are trivially relocatable, but not trivially copyable.
+  // and calling a constructor. So we can delegate to copy_n.
   using ctor_arg_t = thrust::detail::raw_reference_t<::cuda::std::iter_reference_t<InputIt>>;
   using output_t   = thrust::detail::it_value_t<OutputIt>;
-  if constexpr (::cuda::std::is_trivially_constructible_v<output_t, ctor_arg_t>
-                && ::cuda::std::is_trivially_copyable_v<output_t>)
+  if constexpr (::cuda::std::is_trivially_constructible_v<output_t, ctor_arg_t>)
   {
-    cuda_cub::transform_n(policy, first, count, result, ::cuda::proclaim_copyable_arguments(::cuda::std::identity{}));
+    cuda_cub::copy_n(policy, first, count, result);
   }
   else
   {


### PR DESCRIPTION
Prerequisites:

- [x] #5238
- [x] #5182
- [x] Extend benchmark to cover both trivially default constructible and trivially copyable types

Fixes: #5245

Benchmark on RTX 5090:
```
|    T{ct}     |  Elements  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |        Diff |   %Diff |  Status  |
|--------------|------------|------------|-------------|------------|-------------|-------------|---------|----------|
|      U8      |    2^16    |   7.963 us |      16.38% |   7.582 us |      12.75% |   -0.381 us |  -4.78% |   SAME   |
|      U8      |    2^20    |  10.721 us |       9.09% |   8.969 us |       7.12% |   -1.752 us | -16.34% |   FAST   |
|      U8      |    2^24    |  44.837 us |       2.53% |  27.095 us |       4.72% |  -17.742 us | -39.57% |   FAST   |
|      U8      |    2^28    | 531.813 us |       0.22% | 359.187 us |       0.31% | -172.626 us | -32.46% |   FAST   |
|     U16      |    2^16    |   8.163 us |      13.42% |   7.922 us |      12.65% |   -0.241 us |  -2.96% |   SAME   |
|     U16      |    2^20    |  11.612 us |       9.91% |  10.113 us |      15.25% |   -1.499 us | -12.91% |   FAST   |
|     U16      |    2^24    |  56.904 us |       1.92% |  48.108 us |       1.98% |   -8.796 us | -15.46% |   FAST   |
|     U16      |    2^28    | 723.584 us |       0.18% | 714.181 us |       0.23% |   -9.403 us |  -1.30% |   FAST   |
|     U32      |    2^16    |   9.081 us |      10.91% |   8.631 us |      10.12% |   -0.450 us |  -4.95% |   SAME   |
|     U32      |    2^20    |  12.064 us |      11.89% |  11.673 us |      12.68% |   -0.390 us |  -3.23% |   SAME   |
|     U32      |    2^24    |  94.539 us |       2.22% |  93.535 us |       1.27% |   -1.004 us |  -1.06% |   SAME   |
|     U32      |    2^28    |   1.414 ms |       0.19% |   1.418 ms |       0.12% |    3.676 us |   0.26% |   SLOW   |
|     U64      |    2^16    |   8.980 us |       9.18% |   8.532 us |       5.62% |   -0.448 us |  -4.99% |   SAME   |
|     U64      |    2^20    |  15.852 us |       2.88% |  15.306 us |       2.94% |   -0.547 us |  -3.45% |   FAST   |
|     U64      |    2^24    | 183.653 us |       0.57% | 182.202 us |       0.52% |   -1.451 us |  -0.79% |   FAST   |
|     U64      |    2^28    |   2.826 ms |       0.16% |   2.825 ms |       0.12% |   -0.707 us |  -0.03% |   SAME   |
|   no_copy    |    2^16    |   8.968 us |       7.76% |   8.878 us |       6.75% |   -0.090 us |  -1.00% |   SAME   |
|   no_copy    |    2^20    |  11.737 us |       6.00% |  11.667 us |       6.99% |   -0.070 us |  -0.59% |   SAME   |
|   no_copy    |    2^24    |  94.842 us |       1.05% |  94.897 us |       1.36% |    0.055 us |   0.06% |   SAME   |
|   no_copy    |    2^28    |   1.414 ms |       0.15% |   1.414 ms |       0.12% |   -0.421 us |  -0.03% |   SAME   |
| no_construct |    2^16    |   9.088 us |      11.31% |   8.862 us |      17.49% |   -0.226 us |  -2.49% |   SAME   |
| no_construct |    2^20    |  13.550 us |      22.16% |  11.862 us |       6.59% |   -1.687 us | -12.45% |   FAST   |
| no_construct |    2^24    |  95.336 us |       2.88% |  93.464 us |       1.73% |   -1.873 us |  -1.96% |   FAST   |
| no_construct |    2^28    |   1.414 ms |       0.16% |   1.418 ms |       0.11% |    3.890 us |   0.28% |   SLOW   |
```
