### PR TITLE
Better specify `lane_mask::all_active()` behavior

### DIFF
--- a/docs/libcudacxx/extended_api/warp/lane_mask.rst
+++ b/docs/libcudacxx/extended_api/warp/lane_mask.rst
@@ -61,7 +61,7 @@ Defined in ``<cuda/warp>`` header.
 The class provides several ``static`` member functions to create common lane masks:
 
 - ``none()`` and ``all()`` are equivalent to ``lane_mask{0x0}`` and ``lane_mask{0xFFFFFFFF}``, respectively
-- ``all_active()`` returns a mask with all active lanes in the warp, equivalent to the result ``__activemask()``, and finally
+- ``all_active()`` returns a mask with all currently active lanes in the warp, equivalent to the result ``__activemask()``, and finally
 - ``this_lane()`` and other functions like ``all_greater()`` or ``all_less_equal()`` return masks depending on the current lane index. They are implemented using the PTX special registers.
 
 **Preconditions**
@@ -80,27 +80,8 @@ Example
     __global__ void lane_mask_kernel() {
         // import lane_mask symbol to current scope
         using cuda::device::lane_mask;
-
-        // all 32 lanes are active in the beginning
-        assert(lane_mask::all_active() == lane_mask::all());
-
         // this_lane() is equivalent to ~(all_less() | all_greater())
         assert(lane_mask::this_lane() == ~(lane_mask::all_less() | lane_mask::all_greater()));
-
-        constexpr auto active_lanes      = 20u;
-        constexpr auto active_lanes_mask = lane_mask{(1u << active_lanes) - 1};
-
-        // early exit lanes [20, 31]
-        if (threadIdx.x >= active_lanes)
-        {
-            return;
-        }
-
-        // not all lanes are active anymore
-        assert(lane_mask::all_active() != lane_mask::all());
-
-        // only lanes [0, 19] should be active now
-        assert(lane_mask::all_active() == lane_mask{active_lanes_mask});
     }
 
     int main() {
@@ -109,4 +90,4 @@ Example
         return 0;
     }
 
-`See it on Godbolt 🔗 <https://godbolt.org/z/Ed4s5oTr8>`_
+`See it on Godbolt 🔗 <https://godbolt.org/z/W7hExs16v>`_

--- a/docs/libcudacxx/extended_api/warp/warp_match_all.rst
+++ b/docs/libcudacxx/extended_api/warp/warp_match_all.rst
@@ -11,7 +11,7 @@ Defined in ``<cuda/warp>`` header.
 
     template <typename T>
     [[nodiscard]] __device__ bool
-    warp_match_all(const T& data, lane_mask = lane_mask::all_active());
+    warp_match_all(const T& data, lane_mask = lane_mask::all());
 
     } // namespace cuda::device
 
@@ -30,7 +30,11 @@ The function allows bitwise comparison of any data size, including raw arrays, p
 **Preconditions**
 
 - The functionality is only supported on ``SM >= 70``.
-- ``lane_mask`` must be a subset of the active mask and be non-zero.
+- ``lane_mask`` must be non-zero.
+
+**Undefined Behavior**
+
+- ``lane_mask`` must represent a subset of the active lanes, undefined behavior otherwise.
 
 **Performance considerations**
 

--- a/docs/libcudacxx/extended_api/warp/warp_shuffle.rst
+++ b/docs/libcudacxx/extended_api/warp/warp_shuffle.rst
@@ -129,9 +129,13 @@ The functions allow to exchange data of any data size, including raw arrays, poi
 
 **Preconditions**
 
-- ``lane_mask`` must be a subset of the active mask
-- The destination lane must be a member of the ``lane_mask``
-- ``delta`` and ``xor_mask`` must be less than ``Width``. Modulo behavior is allowed for ``src_lane``
+- The destination lane must be a member of the ``lane_mask``.
+- ``delta`` and ``xor_mask`` must be less than ``Width``. Modulo behavior is allowed for ``src_lane``.
+- ``lane_mask`` must be non-zero.
+
+**Undefined Behavior**
+
+- ``lane_mask`` must represent a subset of the active lanes, undefined behavior otherwise.
 - All lanes must have the same value for ``lane_mask``, ``delta`` and ``xor_mask``
 
 **Performance considerations**

--- a/libcudacxx/include/cuda/__warp/lane_mask.h
+++ b/libcudacxx/include/cuda/__warp/lane_mask.h
@@ -81,7 +81,7 @@ public:
     return lane_mask{0xffffffff};
   }
 
-  //! @brief Returns a lane mask object with all active lane bits set.
+  //! @brief Returns a lane mask object with all currently active lane bits set.
   //!
   //! This function returns a lane_mask object equivalent to calling `lane_mask{::__activemask()}`.
   //!

--- a/libcudacxx/include/cuda/__warp/warp_match_all.h
+++ b/libcudacxx/include/cuda/__warp/warp_match_all.h
@@ -38,9 +38,8 @@ extern "C" _CCCL_DEVICE void __cuda__match_all_sync_is_not_supported_before_SM_7
 
 template <typename _Tp, typename _Up = _CUDA_VSTD::remove_cv_t<_Tp>>
 [[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_DEVICE bool
-warp_match_all(const _Tp& __data, lane_mask __lane_mask = lane_mask::all_active())
+warp_match_all(const _Tp& __data, lane_mask __lane_mask = lane_mask::all())
 {
-  _CCCL_ASSERT((__lane_mask & lane_mask::all_active()) == __lane_mask, "lane mask must be a subset of the active mask");
   _CCCL_ASSERT(__lane_mask != lane_mask::none(), "lane_mask must be non-zero");
   constexpr int __ratio = ::cuda::ceil_div(sizeof(_Up), sizeof(uint32_t));
   uint32_t __array[__ratio];


### PR DESCRIPTION
## Description

`lane_mask::all_active()` and `__activemask()` cannot be used to evaluate the validity of warp lanes within a scope.
This PR documents this issue as undefined behavior. Secondly, replace `warp_match_all()` default input with `lane_mask::all()`