### PR TITLE
Don't mention C++ 11 and 14 in more places

### DIFF
--- a/ci/windows/build_common.psm1
+++ b/ci/windows/build_common.psm1
@@ -2,7 +2,7 @@ Param(
     [Parameter(Mandatory = $false)]
     [Alias("std")]
     [ValidateNotNullOrEmpty()]
-    [ValidateSet(11, 14, 17, 20)]
+    [ValidateSet(17, 20)]
     [int]$CXX_STANDARD = 17,
     [Parameter(Mandatory = $false)]
     [Alias("arch")]

--- a/ci/windows/build_cub.ps1
+++ b/ci/windows/build_cub.ps1
@@ -2,7 +2,7 @@ Param(
     [Parameter(Mandatory = $false)]
     [Alias("std")]
     [ValidateNotNullOrEmpty()]
-    [ValidateSet(11, 14, 17, 20)]
+    [ValidateSet(17, 20)]
     [int]$CXX_STANDARD = 17,
     [Parameter(Mandatory = $false)]
     [Alias("arch")]

--- a/ci/windows/build_libcudacxx.ps1
+++ b/ci/windows/build_libcudacxx.ps1
@@ -2,7 +2,7 @@ Param(
     [Parameter(Mandatory = $false)]
     [Alias("std")]
     [ValidateNotNullOrEmpty()]
-    [ValidateSet(11, 14, 17, 20)]
+    [ValidateSet(17, 20)]
     [int]$CXX_STANDARD = 17,
     [Parameter(Mandatory = $false)]
     [Alias("arch")]

--- a/ci/windows/build_thrust.ps1
+++ b/ci/windows/build_thrust.ps1
@@ -2,7 +2,7 @@ Param(
     [Parameter(Mandatory = $false)]
     [Alias("std")]
     [ValidateNotNullOrEmpty()]
-    [ValidateSet(11, 14, 17, 20)]
+    [ValidateSet(17, 20)]
     [int]$CXX_STANDARD = 17,
     [Parameter(Mandatory = $false)]
     [Alias("arch")]

--- a/ci/windows/test_thrust.ps1
+++ b/ci/windows/test_thrust.ps1
@@ -2,7 +2,7 @@ Param(
     [Parameter(Mandatory = $false)]
     [Alias("std")]
     [ValidateNotNullOrEmpty()]
-    [ValidateSet(11, 14, 17, 20)]
+    [ValidateSet(17, 20)]
     [int]$CXX_STANDARD = 17,
     [Parameter(Mandatory = $false)]
     [Alias("arch")]

--- a/cub/cmake/CubBuildTargetList.cmake
+++ b/cub/cmake/CubBuildTargetList.cmake
@@ -18,7 +18,7 @@
 #   - <prop_var> is any valid cmake identifier.
 #   - <target_name> is the name of a CUB target.
 #   - <prop> is one of the following:
-#     - DIALECT: The C++ dialect. Valid values: 11, 14, 17, 20.
+#     - DIALECT: The C++ dialect. Valid values: 17, 20.
 #     - PREFIX: A unique prefix that should be used to name all
 #       targets/tests/examples that use this configuration.
 #
@@ -35,13 +35,13 @@
 
 # Dialects:
 set(CUB_CPP_DIALECT_OPTIONS
-  11 14 17 20
+  17 20
   CACHE INTERNAL "C++ dialects supported by CUB." FORCE
 )
 
 define_property(TARGET PROPERTY _CUB_DIALECT
-  BRIEF_DOCS "A target's C++ dialect: 11, 14, 17 or 20."
-  FULL_DOCS "A target's C++ dialect: 11, 14, 17 or 20."
+  BRIEF_DOCS "A target's C++ dialect: 17 or 20."
+  FULL_DOCS "A target's C++ dialect: 17 or 20."
 )
 define_property(TARGET PROPERTY _CUB_PREFIX
   BRIEF_DOCS "A prefix describing the config, eg. 'cub.cpp17'."

--- a/docs/thrust/cmake_options.rst
+++ b/docs/thrust/cmake_options.rst
@@ -106,7 +106,7 @@ Single Config CMake Options
 
    -  Selects the device system. Default: ``CUDA``
 
--  ``THRUST_CPP_DIALECT={11, 14, 17}``
+-  ``THRUST_CPP_DIALECT={17, 20}``
 
    -  Selects the C++ standard dialect to use. Default is ``14``
       (C++14).
@@ -119,7 +119,7 @@ Multi Config CMake Options
 -  ``THRUST_MULTICONFIG_ENABLE_DIALECT_CPPXX={ON, OFF}``
 
    -  Toggle whether a specific C++ dialect will be targeted.
-   -  Possible values of ``XX`` are ``{11, 14, 17}``.
+   -  Possible values of ``XX`` are ``{17, 20}``.
    -  By default, only C++14 is enabled.
 
 -  ``THRUST_MULTICONFIG_ENABLE_SYSTEM_XXXX={ON, OFF}``

--- a/thrust/cmake/ThrustBuildTargetList.cmake
+++ b/thrust/cmake/ThrustBuildTargetList.cmake
@@ -19,7 +19,7 @@
 #   - <prop> is one of the following:
 #     - HOST: The host system. Valid values: CPP, OMP, TBB.
 #     - DEVICE: The device system. Valid values: CUDA, CPP, OMP, TBB.
-#     - DIALECT: The C++ dialect. Valid values: 11, 14, 17, 20.
+#     - DIALECT: The C++ dialect. Valid values: 17, 20.
 #     - PREFIX: A unique prefix that should be used to name all
 #       targets/tests/examples that use this configuration.
 #
@@ -43,8 +43,8 @@ define_property(TARGET PROPERTY _THRUST_DEVICE
   FULL_DOCS "A target's device system: CUDA, CPP, TBB, or OMP."
 )
 define_property(TARGET PROPERTY _THRUST_DIALECT
-  BRIEF_DOCS "A target's C++ dialect: 11, 14, or 17."
-  FULL_DOCS "A target's C++ dialect: 11, 14, or 17."
+  BRIEF_DOCS "A target's C++ dialect: 17 or 20."
+  FULL_DOCS "A target's C++ dialect: 17 or 20."
 )
 define_property(TARGET PROPERTY _THRUST_PREFIX
   BRIEF_DOCS "A prefix describing the config, eg. 'thrust.cpp.cuda.cpp14'."

--- a/thrust/cmake/ThrustMultiConfig.cmake
+++ b/thrust/cmake/ThrustMultiConfig.cmake
@@ -7,7 +7,7 @@ function(thrust_configure_multiconfig)
 
   # Dialects:
   set(THRUST_CPP_DIALECT_OPTIONS
-    11 14 17 20
+    17 20
     CACHE INTERNAL "C++ dialects supported by Thrust." FORCE
   )
 


### PR DESCRIPTION
I looked at the CMake cache and found variables from bygone times.