### PR TITLE
Fix cudax compilation with upcoming CTK

### DIFF
--- a/cudax/include/cuda/experimental/__graph/path_builder.cuh
+++ b/cudax/include/cuda/experimental/__graph/path_builder.cuh
@@ -87,6 +87,8 @@ struct path_builder
     cudaStreamCaptureStatus __capture_status;
     const cudaGraphNode_t* __last_captured_node = nullptr;
     size_t __num_nodes                          = 0;
+
+#  if _CCCL_CTK_AT_LEAST(13, 0)
     _CCCL_TRY_CUDA_API(
       ::cudaStreamGetCaptureInfo,
       "Failed to get stream capture info",
@@ -95,10 +97,20 @@ struct path_builder
       nullptr,
       nullptr,
       &__last_captured_node,
-#if _CCCL_CTK_AT_LEAST(13, 0)
       nullptr,
-#endif // _CCCL_CTK_AT_LEAST(13, 0)
       &__num_nodes);
+#  else // _CCCL_CTK_AT_LEAST(13, 0)
+    _CCCL_TRY_CUDA_API(
+      ::cudaStreamGetCaptureInfo,
+      "Failed to get stream capture info",
+      __stream.get(),
+      &__capture_status,
+      nullptr,
+      nullptr,
+      &__last_captured_node,
+      &__num_nodes);
+#  endif // _CCCL_CTK_AT_LEAST(13, 0)
+
     if (__capture_status != cudaStreamCaptureStatusActive)
     {
       __throw_cuda_error(cudaErrorInvalidValue, "Stream capture no longer active", "cudaStreamGetCaptureInfo");


### PR DESCRIPTION
It seems [cudaStreamGetCaptureInfo_v3](https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__STREAM.html#group__CUDART__STREAM_1ga1f362b9563c124772a3e7bad3b848f7) became the default now and replaced `cudaStreamGetCaptureInfo`.