### PR TITLE
[CUDAX] Rename device type to physical_device

### DIFF
--- a/cudax/include/cuda/experimental/__device/all_devices.cuh
+++ b/cudax/include/cuda/experimental/__device/all_devices.cuh
@@ -40,13 +40,13 @@ namespace __detail
 class all_devices
 {
 public:
-  using size_type      = ::std::vector<device>::size_type;
-  using iterator       = ::std::vector<device>::const_iterator;
-  using const_iterator = ::std::vector<device>::const_iterator;
+  using size_type      = ::std::vector<physical_device>::size_type;
+  using iterator       = ::std::vector<physical_device>::const_iterator;
+  using const_iterator = ::std::vector<physical_device>::const_iterator;
 
   all_devices() = default;
 
-  [[nodiscard]] const device& operator[](size_type __i) const;
+  [[nodiscard]] const physical_device& operator[](size_type __i) const;
 
   [[nodiscard]] size_type size() const;
 
@@ -59,7 +59,7 @@ public:
 private:
   struct __initializer_iterator;
 
-  static const ::std::vector<device>& __devices();
+  static const ::std::vector<physical_device>& __devices();
 };
 
 //! @brief An iterator used to in-place construct `device` objects in a
@@ -112,7 +112,7 @@ struct all_devices::__initializer_iterator
   }
 };
 
-[[nodiscard]] inline const device& all_devices::operator[](size_type __id_) const
+[[nodiscard]] inline const physical_device& all_devices::operator[](size_type __id_) const
 {
   if (__id_ >= size())
   {
@@ -150,12 +150,12 @@ inline all_devices::operator ::cuda::std::span<const device_ref>() const
   return ::cuda::std::span<const device_ref>(__refs);
 }
 
-inline const ::std::vector<device>& all_devices::__devices()
+inline const ::std::vector<physical_device>& all_devices::__devices()
 {
-  static const ::std::vector<device> __devices = [] {
+  static const ::std::vector<physical_device> __devices = [] {
     int __count = 0;
     _CCCL_TRY_CUDA_API(::cudaGetDeviceCount, "failed to get the count of CUDA devices", &__count);
-    return ::std::vector<device>{__initializer_iterator{0}, __initializer_iterator{__count}};
+    return ::std::vector<physical_device>{__initializer_iterator{0}, __initializer_iterator{__count}};
   }();
   return __devices;
 }
@@ -175,7 +175,7 @@ inline const ::std::vector<device>& all_devices::__devices()
 //!   struct iterator;
 //!   using const_iterator = iterator;
 //!
-//!   [[nodiscard]] constexpr const device& operator[](size_type i) const noexcept;
+//!   [[nodiscard]] constexpr const physical_device& operator[](size_type i) const noexcept;
 //!
 //!   [[nodiscard]] size_type size() const;
 //!
@@ -187,7 +187,7 @@ inline const ::std::vector<device>& all_devices::__devices()
 //!
 //! @par
 //! `__all_devices::iterator` is a random access iterator with a `reference`
-//! type of `const device&`.
+//! type of `const physical_device&`.
 //!
 //! @par Example
 //! @code
@@ -210,7 +210,7 @@ inline const arch_traits_t& device_ref::arch_traits() const
   ::std::vector<device_ref> __result;
   __result.reserve(devices.size());
 
-  for (const device& __other_dev : devices)
+  for (const physical_device& __other_dev : devices)
   {
     // Exclude the device this API is called on. The main use case for this API
     // is enable/disable peer access. While enable peer access can be called on

--- a/cudax/include/cuda/experimental/__device/arch_traits.cuh
+++ b/cudax/include/cuda/experimental/__device/arch_traits.cuh
@@ -488,16 +488,15 @@ namespace __detail
   {
     // If the architecture is unknown, we need to craft the arch_traits from attributes
     arch_traits_t __traits{};
-    __traits.compute_capability_major = __arch / 100;
-    __traits.compute_capability_minor = (__arch / 10) % 10;
-    __traits.compute_capability       = __arch;
-    __traits.max_shared_memory_per_multiprocessor =
-      __detail::__device_attrs::max_shared_memory_per_multiprocessor(__device);
-    __traits.max_blocks_per_multiprocessor  = __detail::__device_attrs::max_blocks_per_multiprocessor(__device);
-    __traits.max_threads_per_multiprocessor = __detail::__device_attrs::max_threads_per_multiprocessor(__device);
+    __traits.compute_capability_major             = __arch / 100;
+    __traits.compute_capability_minor             = (__arch / 10) % 10;
+    __traits.compute_capability                   = __arch;
+    __traits.max_shared_memory_per_multiprocessor = device_attributes::max_shared_memory_per_multiprocessor(__device);
+    __traits.max_blocks_per_multiprocessor        = device_attributes::max_blocks_per_multiprocessor(__device);
+    __traits.max_threads_per_multiprocessor       = device_attributes::max_threads_per_multiprocessor(__device);
     __traits.max_warps_per_multiprocessor =
       __traits.max_threads_per_multiprocessor / __detail::arch_common_traits::warp_size;
-    __traits.reserved_shared_memory_per_block = __detail::__device_attrs::reserved_shared_memory_per_block(__device);
+    __traits.reserved_shared_memory_per_block = device_attributes::reserved_shared_memory_per_block(__device);
     __traits.max_shared_memory_per_block_optin =
       __traits.max_shared_memory_per_multiprocessor - __traits.reserved_shared_memory_per_block;
 

--- a/cudax/include/cuda/experimental/__device/attributes.cuh
+++ b/cudax/include/cuda/experimental/__device/attributes.cuh
@@ -239,478 +239,477 @@ struct __dev_attr<::cudaDevAttrNumaConfig> //
 };
 #endif // _CCCL_CTK_AT_LEAST(12, 2)
 
-struct __device_attrs
+} // namespace __detail
+
+namespace device_attributes
 {
-  // Maximum number of threads per block
-  using max_threads_per_block_t = __detail::__dev_attr<::cudaDevAttrMaxThreadsPerBlock>;
-  static constexpr max_threads_per_block_t max_threads_per_block{};
-
-  // Maximum x-dimension of a block
-  using max_block_dim_x_t = __detail::__dev_attr<::cudaDevAttrMaxBlockDimX>;
-  static constexpr max_block_dim_x_t max_block_dim_x{};
-
-  // Maximum y-dimension of a block
-  using max_block_dim_y_t = __detail::__dev_attr<::cudaDevAttrMaxBlockDimY>;
-  static constexpr max_block_dim_y_t max_block_dim_y{};
-
-  // Maximum z-dimension of a block
-  using max_block_dim_z_t = __detail::__dev_attr<::cudaDevAttrMaxBlockDimZ>;
-  static constexpr max_block_dim_z_t max_block_dim_z{};
-
-  // Maximum x-dimension of a grid
-  using max_grid_dim_x_t = __detail::__dev_attr<::cudaDevAttrMaxGridDimX>;
-  static constexpr max_grid_dim_x_t max_grid_dim_x{};
-
-  // Maximum y-dimension of a grid
-  using max_grid_dim_y_t = __detail::__dev_attr<::cudaDevAttrMaxGridDimY>;
-  static constexpr max_grid_dim_y_t max_grid_dim_y{};
-
-  // Maximum z-dimension of a grid
-  using max_grid_dim_z_t = __detail::__dev_attr<::cudaDevAttrMaxGridDimZ>;
-  static constexpr max_grid_dim_z_t max_grid_dim_z{};
-
-  // Maximum amount of shared memory available to a thread block in bytes
-  using max_shared_memory_per_block_t = __detail::__dev_attr<::cudaDevAttrMaxSharedMemoryPerBlock>;
-  static constexpr max_shared_memory_per_block_t max_shared_memory_per_block{};
-
-  // Memory available on device for __constant__ variables in a CUDA C kernel in bytes
-  using total_constant_memory_t = __detail::__dev_attr<::cudaDevAttrTotalConstantMemory>;
-  static constexpr total_constant_memory_t total_constant_memory{};
-
-  // Warp size in threads
-  using warp_size_t = __detail::__dev_attr<::cudaDevAttrWarpSize>;
-  static constexpr warp_size_t warp_size{};
-
-  // Maximum pitch in bytes allowed by the memory copy functions that involve
-  // memory regions allocated through cudaMallocPitch()
-  using max_pitch_t = __detail::__dev_attr<::cudaDevAttrMaxPitch>;
-  static constexpr max_pitch_t max_pitch{};
-
-  // Maximum 1D texture width
-  using max_texture_1d_width_t = __detail::__dev_attr<::cudaDevAttrMaxTexture1DWidth>;
-  static constexpr max_texture_1d_width_t max_texture_1d_width{};
-
-  // Maximum width for a 1D texture bound to linear memory
-  using max_texture_1d_linear_width_t = __detail::__dev_attr<::cudaDevAttrMaxTexture1DLinearWidth>;
-  static constexpr max_texture_1d_linear_width_t max_texture_1d_linear_width{};
-
-  // Maximum mipmapped 1D texture width
-  using max_texture_1d_mipmapped_width_t = __detail::__dev_attr<::cudaDevAttrMaxTexture1DMipmappedWidth>;
-  static constexpr max_texture_1d_mipmapped_width_t max_texture_1d_mipmapped_width{};
-
-  // Maximum 2D texture width
-  using max_texture_2d_width_t = __detail::__dev_attr<::cudaDevAttrMaxTexture2DWidth>;
-  static constexpr max_texture_2d_width_t max_texture_2d_width{};
-
-  // Maximum 2D texture height
-  using max_texture_2d_height_t = __detail::__dev_attr<::cudaDevAttrMaxTexture2DHeight>;
-  static constexpr max_texture_2d_height_t max_texture_2d_height{};
-
-  // Maximum width for a 2D texture bound to linear memory
-  using max_texture_2d_linear_width_t = __detail::__dev_attr<::cudaDevAttrMaxTexture2DLinearWidth>;
-  static constexpr max_texture_2d_linear_width_t max_texture_2d_linear_width{};
-
-  // Maximum height for a 2D texture bound to linear memory
-  using max_texture_2d_linear_height_t = __detail::__dev_attr<::cudaDevAttrMaxTexture2DLinearHeight>;
-  static constexpr max_texture_2d_linear_height_t max_texture_2d_linear_height{};
-
-  // Maximum pitch in bytes for a 2D texture bound to linear memory
-  using max_texture_2d_linear_pitch_t = __detail::__dev_attr<::cudaDevAttrMaxTexture2DLinearPitch>;
-  static constexpr max_texture_2d_linear_pitch_t max_texture_2d_linear_pitch{};
-
-  // Maximum mipmapped 2D texture width
-  using max_texture_2d_mipmapped_width_t = __detail::__dev_attr<::cudaDevAttrMaxTexture2DMipmappedWidth>;
-  static constexpr max_texture_2d_mipmapped_width_t max_texture_2d_mipmapped_width{};
-
-  // Maximum mipmapped 2D texture height
-  using max_texture_2d_mipmapped_height_t = __detail::__dev_attr<::cudaDevAttrMaxTexture2DMipmappedHeight>;
-  static constexpr max_texture_2d_mipmapped_height_t max_texture_2d_mipmapped_height{};
-
-  // Maximum 3D texture width
-  using max_texture_3d_width_t = __detail::__dev_attr<::cudaDevAttrMaxTexture3DWidth>;
-  static constexpr max_texture_3d_width_t max_texture_3d_width{};
-
-  // Maximum 3D texture height
-  using max_texture_3d_height_t = __detail::__dev_attr<::cudaDevAttrMaxTexture3DHeight>;
-  static constexpr max_texture_3d_height_t max_texture_3d_height{};
-
-  // Maximum 3D texture depth
-  using max_texture_3d_depth_t = __detail::__dev_attr<::cudaDevAttrMaxTexture3DDepth>;
-  static constexpr max_texture_3d_depth_t max_texture_3d_depth{};
-
-  // Alternate maximum 3D texture width, 0 if no alternate maximum 3D texture size is supported
-  using max_texture_3d_width_alt_t = __detail::__dev_attr<::cudaDevAttrMaxTexture3DWidthAlt>;
-  static constexpr max_texture_3d_width_alt_t max_texture_3d_width_alt{};
-
-  // Alternate maximum 3D texture height, 0 if no alternate maximum 3D texture size is supported
-  using max_texture_3d_height_alt_t = __detail::__dev_attr<::cudaDevAttrMaxTexture3DHeightAlt>;
-  static constexpr max_texture_3d_height_alt_t max_texture_3d_height_alt{};
+// Maximum number of threads per block
+using max_threads_per_block_t = __detail::__dev_attr<::cudaDevAttrMaxThreadsPerBlock>;
+static constexpr max_threads_per_block_t max_threads_per_block{};
+
+// Maximum x-dimension of a block
+using max_block_dim_x_t = __detail::__dev_attr<::cudaDevAttrMaxBlockDimX>;
+static constexpr max_block_dim_x_t max_block_dim_x{};
+
+// Maximum y-dimension of a block
+using max_block_dim_y_t = __detail::__dev_attr<::cudaDevAttrMaxBlockDimY>;
+static constexpr max_block_dim_y_t max_block_dim_y{};
+
+// Maximum z-dimension of a block
+using max_block_dim_z_t = __detail::__dev_attr<::cudaDevAttrMaxBlockDimZ>;
+static constexpr max_block_dim_z_t max_block_dim_z{};
+
+// Maximum x-dimension of a grid
+using max_grid_dim_x_t = __detail::__dev_attr<::cudaDevAttrMaxGridDimX>;
+static constexpr max_grid_dim_x_t max_grid_dim_x{};
+
+// Maximum y-dimension of a grid
+using max_grid_dim_y_t = __detail::__dev_attr<::cudaDevAttrMaxGridDimY>;
+static constexpr max_grid_dim_y_t max_grid_dim_y{};
+
+// Maximum z-dimension of a grid
+using max_grid_dim_z_t = __detail::__dev_attr<::cudaDevAttrMaxGridDimZ>;
+static constexpr max_grid_dim_z_t max_grid_dim_z{};
+
+// Maximum amount of shared memory available to a thread block in bytes
+using max_shared_memory_per_block_t = __detail::__dev_attr<::cudaDevAttrMaxSharedMemoryPerBlock>;
+static constexpr max_shared_memory_per_block_t max_shared_memory_per_block{};
+
+// Memory available on device for __constant__ variables in a CUDA C kernel in bytes
+using total_constant_memory_t = __detail::__dev_attr<::cudaDevAttrTotalConstantMemory>;
+static constexpr total_constant_memory_t total_constant_memory{};
+
+// Warp size in threads
+using warp_size_t = __detail::__dev_attr<::cudaDevAttrWarpSize>;
+static constexpr warp_size_t warp_size{};
+
+// Maximum pitch in bytes allowed by the memory copy functions that involve
+// memory regions allocated through cudaMallocPitch()
+using max_pitch_t = __detail::__dev_attr<::cudaDevAttrMaxPitch>;
+static constexpr max_pitch_t max_pitch{};
+
+// Maximum 1D texture width
+using max_texture_1d_width_t = __detail::__dev_attr<::cudaDevAttrMaxTexture1DWidth>;
+static constexpr max_texture_1d_width_t max_texture_1d_width{};
+
+// Maximum width for a 1D texture bound to linear memory
+using max_texture_1d_linear_width_t = __detail::__dev_attr<::cudaDevAttrMaxTexture1DLinearWidth>;
+static constexpr max_texture_1d_linear_width_t max_texture_1d_linear_width{};
+
+// Maximum mipmapped 1D texture width
+using max_texture_1d_mipmapped_width_t = __detail::__dev_attr<::cudaDevAttrMaxTexture1DMipmappedWidth>;
+static constexpr max_texture_1d_mipmapped_width_t max_texture_1d_mipmapped_width{};
+
+// Maximum 2D texture width
+using max_texture_2d_width_t = __detail::__dev_attr<::cudaDevAttrMaxTexture2DWidth>;
+static constexpr max_texture_2d_width_t max_texture_2d_width{};
+
+// Maximum 2D texture height
+using max_texture_2d_height_t = __detail::__dev_attr<::cudaDevAttrMaxTexture2DHeight>;
+static constexpr max_texture_2d_height_t max_texture_2d_height{};
+
+// Maximum width for a 2D texture bound to linear memory
+using max_texture_2d_linear_width_t = __detail::__dev_attr<::cudaDevAttrMaxTexture2DLinearWidth>;
+static constexpr max_texture_2d_linear_width_t max_texture_2d_linear_width{};
+
+// Maximum height for a 2D texture bound to linear memory
+using max_texture_2d_linear_height_t = __detail::__dev_attr<::cudaDevAttrMaxTexture2DLinearHeight>;
+static constexpr max_texture_2d_linear_height_t max_texture_2d_linear_height{};
+
+// Maximum pitch in bytes for a 2D texture bound to linear memory
+using max_texture_2d_linear_pitch_t = __detail::__dev_attr<::cudaDevAttrMaxTexture2DLinearPitch>;
+static constexpr max_texture_2d_linear_pitch_t max_texture_2d_linear_pitch{};
+
+// Maximum mipmapped 2D texture width
+using max_texture_2d_mipmapped_width_t = __detail::__dev_attr<::cudaDevAttrMaxTexture2DMipmappedWidth>;
+static constexpr max_texture_2d_mipmapped_width_t max_texture_2d_mipmapped_width{};
+
+// Maximum mipmapped 2D texture height
+using max_texture_2d_mipmapped_height_t = __detail::__dev_attr<::cudaDevAttrMaxTexture2DMipmappedHeight>;
+static constexpr max_texture_2d_mipmapped_height_t max_texture_2d_mipmapped_height{};
+
+// Maximum 3D texture width
+using max_texture_3d_width_t = __detail::__dev_attr<::cudaDevAttrMaxTexture3DWidth>;
+static constexpr max_texture_3d_width_t max_texture_3d_width{};
+
+// Maximum 3D texture height
+using max_texture_3d_height_t = __detail::__dev_attr<::cudaDevAttrMaxTexture3DHeight>;
+static constexpr max_texture_3d_height_t max_texture_3d_height{};
+
+// Maximum 3D texture depth
+using max_texture_3d_depth_t = __detail::__dev_attr<::cudaDevAttrMaxTexture3DDepth>;
+static constexpr max_texture_3d_depth_t max_texture_3d_depth{};
+
+// Alternate maximum 3D texture width, 0 if no alternate maximum 3D texture size is supported
+using max_texture_3d_width_alt_t = __detail::__dev_attr<::cudaDevAttrMaxTexture3DWidthAlt>;
+static constexpr max_texture_3d_width_alt_t max_texture_3d_width_alt{};
+
+// Alternate maximum 3D texture height, 0 if no alternate maximum 3D texture size is supported
+using max_texture_3d_height_alt_t = __detail::__dev_attr<::cudaDevAttrMaxTexture3DHeightAlt>;
+static constexpr max_texture_3d_height_alt_t max_texture_3d_height_alt{};
 
-  // Alternate maximum 3D texture depth, 0 if no alternate maximum 3D texture size is supported
-  using max_texture_3d_depth_alt_t = __detail::__dev_attr<::cudaDevAttrMaxTexture3DDepthAlt>;
-  static constexpr max_texture_3d_depth_alt_t max_texture_3d_depth_alt{};
+// Alternate maximum 3D texture depth, 0 if no alternate maximum 3D texture size is supported
+using max_texture_3d_depth_alt_t = __detail::__dev_attr<::cudaDevAttrMaxTexture3DDepthAlt>;
+static constexpr max_texture_3d_depth_alt_t max_texture_3d_depth_alt{};
 
-  // Maximum cubemap texture width or height
-  using max_texture_cubemap_width_t = __detail::__dev_attr<::cudaDevAttrMaxTextureCubemapWidth>;
-  static constexpr max_texture_cubemap_width_t max_texture_cubemap_width{};
+// Maximum cubemap texture width or height
+using max_texture_cubemap_width_t = __detail::__dev_attr<::cudaDevAttrMaxTextureCubemapWidth>;
+static constexpr max_texture_cubemap_width_t max_texture_cubemap_width{};
 
-  // Maximum 1D layered texture width
-  using max_texture_1d_layered_width_t = __detail::__dev_attr<::cudaDevAttrMaxTexture1DLayeredWidth>;
-  static constexpr max_texture_1d_layered_width_t max_texture_1d_layered_width{};
+// Maximum 1D layered texture width
+using max_texture_1d_layered_width_t = __detail::__dev_attr<::cudaDevAttrMaxTexture1DLayeredWidth>;
+static constexpr max_texture_1d_layered_width_t max_texture_1d_layered_width{};
 
-  // Maximum layers in a 1D layered texture
-  using max_texture_1d_layered_layers_t = __detail::__dev_attr<::cudaDevAttrMaxTexture1DLayeredLayers>;
-  static constexpr max_texture_1d_layered_layers_t max_texture_1d_layered_layers{};
+// Maximum layers in a 1D layered texture
+using max_texture_1d_layered_layers_t = __detail::__dev_attr<::cudaDevAttrMaxTexture1DLayeredLayers>;
+static constexpr max_texture_1d_layered_layers_t max_texture_1d_layered_layers{};
 
-  // Maximum 2D layered texture width
-  using max_texture_2d_layered_width_t = __detail::__dev_attr<::cudaDevAttrMaxTexture2DLayeredWidth>;
-  static constexpr max_texture_2d_layered_width_t max_texture_2d_layered_width{};
+// Maximum 2D layered texture width
+using max_texture_2d_layered_width_t = __detail::__dev_attr<::cudaDevAttrMaxTexture2DLayeredWidth>;
+static constexpr max_texture_2d_layered_width_t max_texture_2d_layered_width{};
 
-  // Maximum 2D layered texture height
-  using max_texture_2d_layered_height_t = __detail::__dev_attr<::cudaDevAttrMaxTexture2DLayeredHeight>;
-  static constexpr max_texture_2d_layered_height_t max_texture_2d_layered_height{};
+// Maximum 2D layered texture height
+using max_texture_2d_layered_height_t = __detail::__dev_attr<::cudaDevAttrMaxTexture2DLayeredHeight>;
+static constexpr max_texture_2d_layered_height_t max_texture_2d_layered_height{};
 
-  // Maximum layers in a 2D layered texture
-  using max_texture_2d_layered_layers_t = __detail::__dev_attr<::cudaDevAttrMaxTexture2DLayeredLayers>;
-  static constexpr max_texture_2d_layered_layers_t max_texture_2d_layered_layers{};
+// Maximum layers in a 2D layered texture
+using max_texture_2d_layered_layers_t = __detail::__dev_attr<::cudaDevAttrMaxTexture2DLayeredLayers>;
+static constexpr max_texture_2d_layered_layers_t max_texture_2d_layered_layers{};
 
-  // Maximum cubemap layered texture width or height
-  using max_texture_cubemap_layered_width_t = __detail::__dev_attr<::cudaDevAttrMaxTextureCubemapLayeredWidth>;
-  static constexpr max_texture_cubemap_layered_width_t max_texture_cubemap_layered_width{};
+// Maximum cubemap layered texture width or height
+using max_texture_cubemap_layered_width_t = __detail::__dev_attr<::cudaDevAttrMaxTextureCubemapLayeredWidth>;
+static constexpr max_texture_cubemap_layered_width_t max_texture_cubemap_layered_width{};
 
-  // Maximum layers in a cubemap layered texture
-  using max_texture_cubemap_layered_layers_t = __detail::__dev_attr<::cudaDevAttrMaxTextureCubemapLayeredLayers>;
-  static constexpr max_texture_cubemap_layered_layers_t max_texture_cubemap_layered_layers{};
+// Maximum layers in a cubemap layered texture
+using max_texture_cubemap_layered_layers_t = __detail::__dev_attr<::cudaDevAttrMaxTextureCubemapLayeredLayers>;
+static constexpr max_texture_cubemap_layered_layers_t max_texture_cubemap_layered_layers{};
 
-  // Maximum 1D surface width
-  using max_surface_1d_width_t = __detail::__dev_attr<::cudaDevAttrMaxSurface1DWidth>;
-  static constexpr max_surface_1d_width_t max_surface_1d_width{};
-
-  // Maximum 2D surface width
-  using max_surface_2d_width_t = __detail::__dev_attr<::cudaDevAttrMaxSurface2DWidth>;
-  static constexpr max_surface_2d_width_t max_surface_2d_width{};
-
-  // Maximum 2D surface height
-  using max_surface_2d_height_t = __detail::__dev_attr<::cudaDevAttrMaxSurface2DHeight>;
-  static constexpr max_surface_2d_height_t max_surface_2d_height{};
-
-  // Maximum 3D surface width
-  using max_surface_3d_width_t = __detail::__dev_attr<::cudaDevAttrMaxSurface3DWidth>;
-  static constexpr max_surface_3d_width_t max_surface_3d_width{};
-
-  // Maximum 3D surface height
-  using max_surface_3d_height_t = __detail::__dev_attr<::cudaDevAttrMaxSurface3DHeight>;
-  static constexpr max_surface_3d_height_t max_surface_3d_height{};
-
-  // Maximum 3D surface depth
-  using max_surface_3d_depth_t = __detail::__dev_attr<::cudaDevAttrMaxSurface3DDepth>;
-  static constexpr max_surface_3d_depth_t max_surface_3d_depth{};
-
-  // Maximum 1D layered surface width
-  using max_surface_1d_layered_width_t = __detail::__dev_attr<::cudaDevAttrMaxSurface1DLayeredWidth>;
-  static constexpr max_surface_1d_layered_width_t max_surface_1d_layered_width{};
-
-  // Maximum layers in a 1D layered surface
-  using max_surface_1d_layered_layers_t = __detail::__dev_attr<::cudaDevAttrMaxSurface1DLayeredLayers>;
-  static constexpr max_surface_1d_layered_layers_t max_surface_1d_layered_layers{};
-
-  // Maximum 2D layered surface width
-  using max_surface_2d_layered_width_t = __detail::__dev_attr<::cudaDevAttrMaxSurface2DLayeredWidth>;
-  static constexpr max_surface_2d_layered_width_t max_surface_2d_layered_width{};
-
-  // Maximum 2D layered surface height
-  using max_surface_2d_layered_height_t = __detail::__dev_attr<::cudaDevAttrMaxSurface2DLayeredHeight>;
-  static constexpr max_surface_2d_layered_height_t max_surface_2d_layered_height{};
-
-  // Maximum layers in a 2D layered surface
-  using max_surface_2d_layered_layers_t = __detail::__dev_attr<::cudaDevAttrMaxSurface2DLayeredLayers>;
-  static constexpr max_surface_2d_layered_layers_t max_surface_2d_layered_layers{};
-
-  // Maximum cubemap surface width
-  using max_surface_cubemap_width_t = __detail::__dev_attr<::cudaDevAttrMaxSurfaceCubemapWidth>;
-  static constexpr max_surface_cubemap_width_t max_surface_cubemap_width{};
-
-  // Maximum cubemap layered surface width
-  using max_surface_cubemap_layered_width_t = __detail::__dev_attr<::cudaDevAttrMaxSurfaceCubemapLayeredWidth>;
-  static constexpr max_surface_cubemap_layered_width_t max_surface_cubemap_layered_width{};
-
-  // Maximum layers in a cubemap layered surface
-  using max_surface_cubemap_layered_layers_t = __detail::__dev_attr<::cudaDevAttrMaxSurfaceCubemapLayeredLayers>;
-  static constexpr max_surface_cubemap_layered_layers_t max_surface_cubemap_layered_layers{};
-
-  // Maximum number of 32-bit registers available to a thread block
-  using max_registers_per_block_t = __detail::__dev_attr<::cudaDevAttrMaxRegistersPerBlock>;
-  static constexpr max_registers_per_block_t max_registers_per_block{};
-
-  // Peak clock frequency in kilohertz
-  using clock_rate_t = __detail::__dev_attr<::cudaDevAttrClockRate>;
-  static constexpr clock_rate_t clock_rate{};
-
-  // Alignment requirement; texture base addresses aligned to textureAlign bytes
-  // do not need an offset applied to texture fetches
-  using texture_alignment_t = __detail::__dev_attr<::cudaDevAttrTextureAlignment>;
-  static constexpr texture_alignment_t texture_alignment{};
-
-  // Pitch alignment requirement for 2D texture references bound to pitched memory
-  using texture_pitch_alignment_t = __detail::__dev_attr<::cudaDevAttrTexturePitchAlignment>;
-  static constexpr texture_pitch_alignment_t texture_pitch_alignment{};
-
-  // true if the device can concurrently copy memory between host and device
-  // while executing a kernel, or false if not
-  using gpu_overlap_t = __detail::__dev_attr<::cudaDevAttrGpuOverlap>;
-  static constexpr gpu_overlap_t gpu_overlap{};
-
-  // Number of multiprocessors on the device
-  using multiprocessor_count_t = __detail::__dev_attr<::cudaDevAttrMultiProcessorCount>;
-  static constexpr multiprocessor_count_t multiprocessor_count{};
-
-  // true if there is a run time limit for kernels executed on the device, or
-  // false if not
-  using kernel_exec_timeout_t = __detail::__dev_attr<::cudaDevAttrKernelExecTimeout>;
-  static constexpr kernel_exec_timeout_t kernel_exec_timeout{};
-
-  // true if the device is integrated with the memory subsystem, or false if not
-  using integrated_t = __detail::__dev_attr<::cudaDevAttrIntegrated>;
-  static constexpr integrated_t integrated{};
-
-  // true if the device can map host memory into CUDA address space
-  using can_map_host_memory_t = __detail::__dev_attr<::cudaDevAttrCanMapHostMemory>;
-  static constexpr can_map_host_memory_t can_map_host_memory{};
-
-  // Compute mode is the compute mode that the device is currently in.
-  using compute_mode_t = __detail::__dev_attr<::cudaDevAttrComputeMode>;
-  static constexpr compute_mode_t compute_mode{};
-
-  // true if the device supports executing multiple kernels within the same
-  // context simultaneously, or false if not. It is not guaranteed that multiple
-  // kernels will be resident on the device concurrently so this feature should
-  // not be relied upon for correctness.
-  using concurrent_kernels_t = __detail::__dev_attr<::cudaDevAttrConcurrentKernels>;
-  static constexpr concurrent_kernels_t concurrent_kernels{};
-
-  // true if error correction is enabled on the device, 0 if error correction is
-  // disabled or not supported by the device
-  using ecc_enabled_t = __detail::__dev_attr<::cudaDevAttrEccEnabled>;
-  static constexpr ecc_enabled_t ecc_enabled{};
-
-  // PCI bus identifier of the device
-  using pci_bus_id_t = __detail::__dev_attr<::cudaDevAttrPciBusId>;
-  static constexpr pci_bus_id_t pci_bus_id{};
-
-  // PCI device (also known as slot) identifier of the device
-  using pci_device_id_t = __detail::__dev_attr<::cudaDevAttrPciDeviceId>;
-  static constexpr pci_device_id_t pci_device_id{};
-
-  // true if the device is using a TCC driver. TCC is only available on Tesla
-  // hardware running Windows Vista or later.
-  using tcc_driver_t = __detail::__dev_attr<::cudaDevAttrTccDriver>;
-  static constexpr tcc_driver_t tcc_driver{};
-
-  // Peak memory clock frequency in kilohertz
-  using memory_clock_rate_t = __detail::__dev_attr<::cudaDevAttrMemoryClockRate>;
-  static constexpr memory_clock_rate_t memory_clock_rate{};
-
-  // Global memory bus width in bits
-  using global_memory_bus_width_t = __detail::__dev_attr<::cudaDevAttrGlobalMemoryBusWidth>;
-  static constexpr global_memory_bus_width_t global_memory_bus_width{};
-
-  // Size of L2 cache in bytes. 0 if the device doesn't have L2 cache.
-  using l2_cache_size_t = __detail::__dev_attr<::cudaDevAttrL2CacheSize>;
-  static constexpr l2_cache_size_t l2_cache_size{};
-
-  // Maximum resident threads per multiprocessor
-  using max_threads_per_multiprocessor_t = __detail::__dev_attr<::cudaDevAttrMaxThreadsPerMultiProcessor>;
-  static constexpr max_threads_per_multiprocessor_t max_threads_per_multiprocessor{};
-
-  // true if the device shares a unified address space with the host, or false
-  // if not
-  using unified_addressing_t = __detail::__dev_attr<::cudaDevAttrUnifiedAddressing>;
-  static constexpr unified_addressing_t unified_addressing{};
-
-  // Major compute capability version number
-  using compute_capability_major_t = __detail::__dev_attr<::cudaDevAttrComputeCapabilityMajor>;
-  static constexpr compute_capability_major_t compute_capability_major{};
-
-  // Minor compute capability version number
-  using compute_capability_minor_t = __detail::__dev_attr<::cudaDevAttrComputeCapabilityMinor>;
-  static constexpr compute_capability_minor_t compute_capability_minor{};
-
-  // true if the device supports stream priorities, or false if not
-  using stream_priorities_supported_t = __detail::__dev_attr<::cudaDevAttrStreamPrioritiesSupported>;
-  static constexpr stream_priorities_supported_t stream_priorities_supported{};
-
-  // true if device supports caching globals in L1 cache, false if not
-  using global_l1_cache_supported_t = __detail::__dev_attr<::cudaDevAttrGlobalL1CacheSupported>;
-  static constexpr global_l1_cache_supported_t global_l1_cache_supported{};
-
-  // true if device supports caching locals in L1 cache, false if not
-  using local_l1_cache_supported_t = __detail::__dev_attr<::cudaDevAttrLocalL1CacheSupported>;
-  static constexpr local_l1_cache_supported_t local_l1_cache_supported{};
-
-  // Maximum amount of shared memory available to a multiprocessor in bytes;
-  // this amount is shared by all thread blocks simultaneously resident on a
-  // multiprocessor
-  using max_shared_memory_per_multiprocessor_t = __detail::__dev_attr<::cudaDevAttrMaxSharedMemoryPerMultiprocessor>;
-  static constexpr max_shared_memory_per_multiprocessor_t max_shared_memory_per_multiprocessor{};
-
-  // Maximum number of 32-bit registers available to a multiprocessor; this
-  // number is shared by all thread blocks simultaneously resident on a
-  // multiprocessor
-  using max_registers_per_multiprocessor_t = __detail::__dev_attr<::cudaDevAttrMaxRegistersPerMultiprocessor>;
-  static constexpr max_registers_per_multiprocessor_t max_registers_per_multiprocessor{};
-
-  // true if device supports allocating managed memory, false if not
-  using managed_memory_t = __detail::__dev_attr<::cudaDevAttrManagedMemory>;
-  static constexpr managed_memory_t managed_memory{};
-
-  // true if device is on a multi-GPU board, false if not
-  using is_multi_gpu_board_t = __detail::__dev_attr<::cudaDevAttrIsMultiGpuBoard>;
-  static constexpr is_multi_gpu_board_t is_multi_gpu_board{};
-
-  // Unique identifier for a group of devices on the same multi-GPU board
-  using multi_gpu_board_group_id_t = __detail::__dev_attr<::cudaDevAttrMultiGpuBoardGroupID>;
-  static constexpr multi_gpu_board_group_id_t multi_gpu_board_group_id{};
-
-  // true if the link between the device and the host supports native atomic
-  // operations
-  using host_native_atomic_supported_t = __detail::__dev_attr<::cudaDevAttrHostNativeAtomicSupported>;
-  static constexpr host_native_atomic_supported_t host_native_atomic_supported{};
-
-  // Ratio of single precision performance (in floating-point operations per
-  // second) to double precision performance
-  using single_to_double_precision_perf_ratio_t = __detail::__dev_attr<::cudaDevAttrSingleToDoublePrecisionPerfRatio>;
-  static constexpr single_to_double_precision_perf_ratio_t single_to_double_precision_perf_ratio{};
-
-  // true if the device supports coherently accessing pageable memory without
-  // calling cudaHostRegister on it, and false otherwise
-  using pageable_memory_access_t = __detail::__dev_attr<::cudaDevAttrPageableMemoryAccess>;
-  static constexpr pageable_memory_access_t pageable_memory_access{};
-
-  // true if the device can coherently access managed memory concurrently with
-  // the CPU, and false otherwise
-  using concurrent_managed_access_t = __detail::__dev_attr<::cudaDevAttrConcurrentManagedAccess>;
-  static constexpr concurrent_managed_access_t concurrent_managed_access{};
-
-  // true if the device supports Compute Preemption, false if not
-  using compute_preemption_supported_t = __detail::__dev_attr<::cudaDevAttrComputePreemptionSupported>;
-  static constexpr compute_preemption_supported_t compute_preemption_supported{};
-
-  // true if the device can access host registered memory at the same virtual
-  // address as the CPU, and false otherwise
-  using can_use_host_pointer_for_registered_mem_t =
-    __detail::__dev_attr<::cudaDevAttrCanUseHostPointerForRegisteredMem>;
-  static constexpr can_use_host_pointer_for_registered_mem_t can_use_host_pointer_for_registered_mem{};
-
-  // true if the device supports launching cooperative kernels via
-  // cudaLaunchCooperativeKernel, and false otherwise
-  using cooperative_launch_t = __detail::__dev_attr<::cudaDevAttrCooperativeLaunch>;
-  static constexpr cooperative_launch_t cooperative_launch{};
-
-  // true if the device supports flushing of outstanding remote writes, and
-  // false otherwise
-  using can_flush_remote_writes_t = __detail::__dev_attr<::cudaDevAttrCanFlushRemoteWrites>;
-  static constexpr can_flush_remote_writes_t can_flush_remote_writes{};
-
-  // true if the device supports host memory registration via cudaHostRegister,
-  // and false otherwise
-  using host_register_supported_t = __detail::__dev_attr<::cudaDevAttrHostRegisterSupported>;
-  static constexpr host_register_supported_t host_register_supported{};
-
-  // true if the device accesses pageable memory via the host's page tables, and
-  // false otherwise
-  using pageable_memory_access_uses_host_page_tables_t =
-    __detail::__dev_attr<::cudaDevAttrPageableMemoryAccessUsesHostPageTables>;
-  static constexpr pageable_memory_access_uses_host_page_tables_t pageable_memory_access_uses_host_page_tables{};
-
-  // true if the host can directly access managed memory on the device without
-  // migration, and false otherwise
-  using direct_managed_mem_access_from_host_t = __detail::__dev_attr<::cudaDevAttrDirectManagedMemAccessFromHost>;
-  static constexpr direct_managed_mem_access_from_host_t direct_managed_mem_access_from_host{};
-
-  // Maximum per block shared memory size on the device. This value can be opted
-  // into when using dynamic_shared_memory with NonPortableSize set to true
-  using max_shared_memory_per_block_optin_t = __detail::__dev_attr<::cudaDevAttrMaxSharedMemoryPerBlockOptin>;
-  static constexpr max_shared_memory_per_block_optin_t max_shared_memory_per_block_optin{};
-
-  // Maximum number of thread blocks that can reside on a multiprocessor
-  using max_blocks_per_multiprocessor_t = __detail::__dev_attr<::cudaDevAttrMaxBlocksPerMultiprocessor>;
-  static constexpr max_blocks_per_multiprocessor_t max_blocks_per_multiprocessor{};
-
-  // Maximum L2 persisting lines capacity setting in bytes
-  using max_persisting_l2_cache_size_t = __detail::__dev_attr<::cudaDevAttrMaxPersistingL2CacheSize>;
-  static constexpr max_persisting_l2_cache_size_t max_persisting_l2_cache_size{};
-
-  // Maximum value of cudaAccessPolicyWindow::num_bytes
-  using max_access_policy_window_size_t = __detail::__dev_attr<::cudaDevAttrMaxAccessPolicyWindowSize>;
-  static constexpr max_access_policy_window_size_t max_access_policy_window_size{};
-
-  // Shared memory reserved by CUDA driver per block in bytes
-  using reserved_shared_memory_per_block_t = __detail::__dev_attr<::cudaDevAttrReservedSharedMemoryPerBlock>;
-  static constexpr reserved_shared_memory_per_block_t reserved_shared_memory_per_block{};
-
-  // true if the device supports sparse CUDA arrays and sparse CUDA mipmapped arrays.
-  using sparse_cuda_array_supported_t = __detail::__dev_attr<::cudaDevAttrSparseCudaArraySupported>;
-  static constexpr sparse_cuda_array_supported_t sparse_cuda_array_supported{};
-
-  // Device supports using the cudaHostRegister flag cudaHostRegisterReadOnly to
-  // register memory that must be mapped as read-only to the GPU
-  using host_register_read_only_supported_t = __detail::__dev_attr<::cudaDevAttrHostRegisterReadOnlySupported>;
-  static constexpr host_register_read_only_supported_t host_register_read_only_supported{};
-
-  // true if the device supports using the cudaMallocAsync and cudaMemPool
-  // family of APIs, and false otherwise
-  using memory_pools_supported_t = __detail::__dev_attr<::cudaDevAttrMemoryPoolsSupported>;
-  static constexpr memory_pools_supported_t memory_pools_supported{};
-
-  // true if the device supports GPUDirect RDMA APIs, and false otherwise
-  using gpu_direct_rdma_supported_t = __detail::__dev_attr<::cudaDevAttrGPUDirectRDMASupported>;
-  static constexpr gpu_direct_rdma_supported_t gpu_direct_rdma_supported{};
-
-  // bitmask to be interpreted according to the
-  // cudaFlushGPUDirectRDMAWritesOptions enum
-  using gpu_direct_rdma_flush_writes_options_t = __detail::__dev_attr<::cudaDevAttrGPUDirectRDMAFlushWritesOptions>;
-  static constexpr gpu_direct_rdma_flush_writes_options_t gpu_direct_rdma_flush_writes_options{};
-
-  // see the cudaGPUDirectRDMAWritesOrdering enum for numerical values
-  using gpu_direct_rdma_writes_ordering_t = __detail::__dev_attr<::cudaDevAttrGPUDirectRDMAWritesOrdering>;
-  static constexpr gpu_direct_rdma_writes_ordering_t gpu_direct_rdma_writes_ordering{};
-
-  // Bitmask of handle types supported with mempool based IPC
-  using memory_pool_supported_handle_types_t = __detail::__dev_attr<::cudaDevAttrMemoryPoolSupportedHandleTypes>;
-  static constexpr memory_pool_supported_handle_types_t memory_pool_supported_handle_types{};
-
-  // true if the device supports deferred mapping CUDA arrays and CUDA mipmapped
-  // arrays.
-  using deferred_mapping_cuda_array_supported_t = __detail::__dev_attr<::cudaDevAttrDeferredMappingCudaArraySupported>;
-  static constexpr deferred_mapping_cuda_array_supported_t deferred_mapping_cuda_array_supported{};
-
-  // true if the device supports IPC Events, false otherwise.
-  using ipc_event_support_t = __detail::__dev_attr<::cudaDevAttrIpcEventSupport>;
-  static constexpr ipc_event_support_t ipc_event_support{};
+// Maximum 1D surface width
+using max_surface_1d_width_t = __detail::__dev_attr<::cudaDevAttrMaxSurface1DWidth>;
+static constexpr max_surface_1d_width_t max_surface_1d_width{};
+
+// Maximum 2D surface width
+using max_surface_2d_width_t = __detail::__dev_attr<::cudaDevAttrMaxSurface2DWidth>;
+static constexpr max_surface_2d_width_t max_surface_2d_width{};
+
+// Maximum 2D surface height
+using max_surface_2d_height_t = __detail::__dev_attr<::cudaDevAttrMaxSurface2DHeight>;
+static constexpr max_surface_2d_height_t max_surface_2d_height{};
+
+// Maximum 3D surface width
+using max_surface_3d_width_t = __detail::__dev_attr<::cudaDevAttrMaxSurface3DWidth>;
+static constexpr max_surface_3d_width_t max_surface_3d_width{};
+
+// Maximum 3D surface height
+using max_surface_3d_height_t = __detail::__dev_attr<::cudaDevAttrMaxSurface3DHeight>;
+static constexpr max_surface_3d_height_t max_surface_3d_height{};
+
+// Maximum 3D surface depth
+using max_surface_3d_depth_t = __detail::__dev_attr<::cudaDevAttrMaxSurface3DDepth>;
+static constexpr max_surface_3d_depth_t max_surface_3d_depth{};
+
+// Maximum 1D layered surface width
+using max_surface_1d_layered_width_t = __detail::__dev_attr<::cudaDevAttrMaxSurface1DLayeredWidth>;
+static constexpr max_surface_1d_layered_width_t max_surface_1d_layered_width{};
+
+// Maximum layers in a 1D layered surface
+using max_surface_1d_layered_layers_t = __detail::__dev_attr<::cudaDevAttrMaxSurface1DLayeredLayers>;
+static constexpr max_surface_1d_layered_layers_t max_surface_1d_layered_layers{};
+
+// Maximum 2D layered surface width
+using max_surface_2d_layered_width_t = __detail::__dev_attr<::cudaDevAttrMaxSurface2DLayeredWidth>;
+static constexpr max_surface_2d_layered_width_t max_surface_2d_layered_width{};
+
+// Maximum 2D layered surface height
+using max_surface_2d_layered_height_t = __detail::__dev_attr<::cudaDevAttrMaxSurface2DLayeredHeight>;
+static constexpr max_surface_2d_layered_height_t max_surface_2d_layered_height{};
+
+// Maximum layers in a 2D layered surface
+using max_surface_2d_layered_layers_t = __detail::__dev_attr<::cudaDevAttrMaxSurface2DLayeredLayers>;
+static constexpr max_surface_2d_layered_layers_t max_surface_2d_layered_layers{};
+
+// Maximum cubemap surface width
+using max_surface_cubemap_width_t = __detail::__dev_attr<::cudaDevAttrMaxSurfaceCubemapWidth>;
+static constexpr max_surface_cubemap_width_t max_surface_cubemap_width{};
+
+// Maximum cubemap layered surface width
+using max_surface_cubemap_layered_width_t = __detail::__dev_attr<::cudaDevAttrMaxSurfaceCubemapLayeredWidth>;
+static constexpr max_surface_cubemap_layered_width_t max_surface_cubemap_layered_width{};
+
+// Maximum layers in a cubemap layered surface
+using max_surface_cubemap_layered_layers_t = __detail::__dev_attr<::cudaDevAttrMaxSurfaceCubemapLayeredLayers>;
+static constexpr max_surface_cubemap_layered_layers_t max_surface_cubemap_layered_layers{};
+
+// Maximum number of 32-bit registers available to a thread block
+using max_registers_per_block_t = __detail::__dev_attr<::cudaDevAttrMaxRegistersPerBlock>;
+static constexpr max_registers_per_block_t max_registers_per_block{};
+
+// Peak clock frequency in kilohertz
+using clock_rate_t = __detail::__dev_attr<::cudaDevAttrClockRate>;
+static constexpr clock_rate_t clock_rate{};
+
+// Alignment requirement; texture base addresses aligned to textureAlign bytes
+// do not need an offset applied to texture fetches
+using texture_alignment_t = __detail::__dev_attr<::cudaDevAttrTextureAlignment>;
+static constexpr texture_alignment_t texture_alignment{};
+
+// Pitch alignment requirement for 2D texture references bound to pitched memory
+using texture_pitch_alignment_t = __detail::__dev_attr<::cudaDevAttrTexturePitchAlignment>;
+static constexpr texture_pitch_alignment_t texture_pitch_alignment{};
+
+// true if the device can concurrently copy memory between host and device
+// while executing a kernel, or false if not
+using gpu_overlap_t = __detail::__dev_attr<::cudaDevAttrGpuOverlap>;
+static constexpr gpu_overlap_t gpu_overlap{};
+
+// Number of multiprocessors on the device
+using multiprocessor_count_t = __detail::__dev_attr<::cudaDevAttrMultiProcessorCount>;
+static constexpr multiprocessor_count_t multiprocessor_count{};
+
+// true if there is a run time limit for kernels executed on the device, or
+// false if not
+using kernel_exec_timeout_t = __detail::__dev_attr<::cudaDevAttrKernelExecTimeout>;
+static constexpr kernel_exec_timeout_t kernel_exec_timeout{};
+
+// true if the device is integrated with the memory subsystem, or false if not
+using integrated_t = __detail::__dev_attr<::cudaDevAttrIntegrated>;
+static constexpr integrated_t integrated{};
+
+// true if the device can map host memory into CUDA address space
+using can_map_host_memory_t = __detail::__dev_attr<::cudaDevAttrCanMapHostMemory>;
+static constexpr can_map_host_memory_t can_map_host_memory{};
+
+// Compute mode is the compute mode that the device is currently in.
+using compute_mode_t = __detail::__dev_attr<::cudaDevAttrComputeMode>;
+static constexpr compute_mode_t compute_mode{};
+
+// true if the device supports executing multiple kernels within the same
+// context simultaneously, or false if not. It is not guaranteed that multiple
+// kernels will be resident on the device concurrently so this feature should
+// not be relied upon for correctness.
+using concurrent_kernels_t = __detail::__dev_attr<::cudaDevAttrConcurrentKernels>;
+static constexpr concurrent_kernels_t concurrent_kernels{};
+
+// true if error correction is enabled on the device, 0 if error correction is
+// disabled or not supported by the device
+using ecc_enabled_t = __detail::__dev_attr<::cudaDevAttrEccEnabled>;
+static constexpr ecc_enabled_t ecc_enabled{};
+
+// PCI bus identifier of the device
+using pci_bus_id_t = __detail::__dev_attr<::cudaDevAttrPciBusId>;
+static constexpr pci_bus_id_t pci_bus_id{};
+
+// PCI device (also known as slot) identifier of the device
+using pci_device_id_t = __detail::__dev_attr<::cudaDevAttrPciDeviceId>;
+static constexpr pci_device_id_t pci_device_id{};
+
+// true if the device is using a TCC driver. TCC is only available on Tesla
+// hardware running Windows Vista or later.
+using tcc_driver_t = __detail::__dev_attr<::cudaDevAttrTccDriver>;
+static constexpr tcc_driver_t tcc_driver{};
+
+// Peak memory clock frequency in kilohertz
+using memory_clock_rate_t = __detail::__dev_attr<::cudaDevAttrMemoryClockRate>;
+static constexpr memory_clock_rate_t memory_clock_rate{};
+
+// Global memory bus width in bits
+using global_memory_bus_width_t = __detail::__dev_attr<::cudaDevAttrGlobalMemoryBusWidth>;
+static constexpr global_memory_bus_width_t global_memory_bus_width{};
+
+// Size of L2 cache in bytes. 0 if the device doesn't have L2 cache.
+using l2_cache_size_t = __detail::__dev_attr<::cudaDevAttrL2CacheSize>;
+static constexpr l2_cache_size_t l2_cache_size{};
+
+// Maximum resident threads per multiprocessor
+using max_threads_per_multiprocessor_t = __detail::__dev_attr<::cudaDevAttrMaxThreadsPerMultiProcessor>;
+static constexpr max_threads_per_multiprocessor_t max_threads_per_multiprocessor{};
+
+// true if the device shares a unified address space with the host, or false
+// if not
+using unified_addressing_t = __detail::__dev_attr<::cudaDevAttrUnifiedAddressing>;
+static constexpr unified_addressing_t unified_addressing{};
+
+// Major compute capability version number
+using compute_capability_major_t = __detail::__dev_attr<::cudaDevAttrComputeCapabilityMajor>;
+static constexpr compute_capability_major_t compute_capability_major{};
+
+// Minor compute capability version number
+using compute_capability_minor_t = __detail::__dev_attr<::cudaDevAttrComputeCapabilityMinor>;
+static constexpr compute_capability_minor_t compute_capability_minor{};
+
+// true if the device supports stream priorities, or false if not
+using stream_priorities_supported_t = __detail::__dev_attr<::cudaDevAttrStreamPrioritiesSupported>;
+static constexpr stream_priorities_supported_t stream_priorities_supported{};
+
+// true if device supports caching globals in L1 cache, false if not
+using global_l1_cache_supported_t = __detail::__dev_attr<::cudaDevAttrGlobalL1CacheSupported>;
+static constexpr global_l1_cache_supported_t global_l1_cache_supported{};
+
+// true if device supports caching locals in L1 cache, false if not
+using local_l1_cache_supported_t = __detail::__dev_attr<::cudaDevAttrLocalL1CacheSupported>;
+static constexpr local_l1_cache_supported_t local_l1_cache_supported{};
+
+// Maximum amount of shared memory available to a multiprocessor in bytes;
+// this amount is shared by all thread blocks simultaneously resident on a
+// multiprocessor
+using max_shared_memory_per_multiprocessor_t = __detail::__dev_attr<::cudaDevAttrMaxSharedMemoryPerMultiprocessor>;
+static constexpr max_shared_memory_per_multiprocessor_t max_shared_memory_per_multiprocessor{};
+
+// Maximum number of 32-bit registers available to a multiprocessor; this
+// number is shared by all thread blocks simultaneously resident on a
+// multiprocessor
+using max_registers_per_multiprocessor_t = __detail::__dev_attr<::cudaDevAttrMaxRegistersPerMultiprocessor>;
+static constexpr max_registers_per_multiprocessor_t max_registers_per_multiprocessor{};
+
+// true if device supports allocating managed memory, false if not
+using managed_memory_t = __detail::__dev_attr<::cudaDevAttrManagedMemory>;
+static constexpr managed_memory_t managed_memory{};
+
+// true if device is on a multi-GPU board, false if not
+using is_multi_gpu_board_t = __detail::__dev_attr<::cudaDevAttrIsMultiGpuBoard>;
+static constexpr is_multi_gpu_board_t is_multi_gpu_board{};
+
+// Unique identifier for a group of devices on the same multi-GPU board
+using multi_gpu_board_group_id_t = __detail::__dev_attr<::cudaDevAttrMultiGpuBoardGroupID>;
+static constexpr multi_gpu_board_group_id_t multi_gpu_board_group_id{};
+
+// true if the link between the device and the host supports native atomic
+// operations
+using host_native_atomic_supported_t = __detail::__dev_attr<::cudaDevAttrHostNativeAtomicSupported>;
+static constexpr host_native_atomic_supported_t host_native_atomic_supported{};
+
+// Ratio of single precision performance (in floating-point operations per
+// second) to double precision performance
+using single_to_double_precision_perf_ratio_t = __detail::__dev_attr<::cudaDevAttrSingleToDoublePrecisionPerfRatio>;
+static constexpr single_to_double_precision_perf_ratio_t single_to_double_precision_perf_ratio{};
+
+// true if the device supports coherently accessing pageable memory without
+// calling cudaHostRegister on it, and false otherwise
+using pageable_memory_access_t = __detail::__dev_attr<::cudaDevAttrPageableMemoryAccess>;
+static constexpr pageable_memory_access_t pageable_memory_access{};
+
+// true if the device can coherently access managed memory concurrently with
+// the CPU, and false otherwise
+using concurrent_managed_access_t = __detail::__dev_attr<::cudaDevAttrConcurrentManagedAccess>;
+static constexpr concurrent_managed_access_t concurrent_managed_access{};
+
+// true if the device supports Compute Preemption, false if not
+using compute_preemption_supported_t = __detail::__dev_attr<::cudaDevAttrComputePreemptionSupported>;
+static constexpr compute_preemption_supported_t compute_preemption_supported{};
+
+// true if the device can access host registered memory at the same virtual
+// address as the CPU, and false otherwise
+using can_use_host_pointer_for_registered_mem_t = __detail::__dev_attr<::cudaDevAttrCanUseHostPointerForRegisteredMem>;
+static constexpr can_use_host_pointer_for_registered_mem_t can_use_host_pointer_for_registered_mem{};
+
+// true if the device supports launching cooperative kernels via
+// cudaLaunchCooperativeKernel, and false otherwise
+using cooperative_launch_t = __detail::__dev_attr<::cudaDevAttrCooperativeLaunch>;
+static constexpr cooperative_launch_t cooperative_launch{};
+
+// true if the device supports flushing of outstanding remote writes, and
+// false otherwise
+using can_flush_remote_writes_t = __detail::__dev_attr<::cudaDevAttrCanFlushRemoteWrites>;
+static constexpr can_flush_remote_writes_t can_flush_remote_writes{};
+
+// true if the device supports host memory registration via cudaHostRegister,
+// and false otherwise
+using host_register_supported_t = __detail::__dev_attr<::cudaDevAttrHostRegisterSupported>;
+static constexpr host_register_supported_t host_register_supported{};
+
+// true if the device accesses pageable memory via the host's page tables, and
+// false otherwise
+using pageable_memory_access_uses_host_page_tables_t =
+  __detail::__dev_attr<::cudaDevAttrPageableMemoryAccessUsesHostPageTables>;
+static constexpr pageable_memory_access_uses_host_page_tables_t pageable_memory_access_uses_host_page_tables{};
+
+// true if the host can directly access managed memory on the device without
+// migration, and false otherwise
+using direct_managed_mem_access_from_host_t = __detail::__dev_attr<::cudaDevAttrDirectManagedMemAccessFromHost>;
+static constexpr direct_managed_mem_access_from_host_t direct_managed_mem_access_from_host{};
+
+// Maximum per block shared memory size on the device. This value can be opted
+// into when using dynamic_shared_memory with NonPortableSize set to true
+using max_shared_memory_per_block_optin_t = __detail::__dev_attr<::cudaDevAttrMaxSharedMemoryPerBlockOptin>;
+static constexpr max_shared_memory_per_block_optin_t max_shared_memory_per_block_optin{};
+
+// Maximum number of thread blocks that can reside on a multiprocessor
+using max_blocks_per_multiprocessor_t = __detail::__dev_attr<::cudaDevAttrMaxBlocksPerMultiprocessor>;
+static constexpr max_blocks_per_multiprocessor_t max_blocks_per_multiprocessor{};
+
+// Maximum L2 persisting lines capacity setting in bytes
+using max_persisting_l2_cache_size_t = __detail::__dev_attr<::cudaDevAttrMaxPersistingL2CacheSize>;
+static constexpr max_persisting_l2_cache_size_t max_persisting_l2_cache_size{};
+
+// Maximum value of cudaAccessPolicyWindow::num_bytes
+using max_access_policy_window_size_t = __detail::__dev_attr<::cudaDevAttrMaxAccessPolicyWindowSize>;
+static constexpr max_access_policy_window_size_t max_access_policy_window_size{};
+
+// Shared memory reserved by CUDA driver per block in bytes
+using reserved_shared_memory_per_block_t = __detail::__dev_attr<::cudaDevAttrReservedSharedMemoryPerBlock>;
+static constexpr reserved_shared_memory_per_block_t reserved_shared_memory_per_block{};
+
+// true if the device supports sparse CUDA arrays and sparse CUDA mipmapped arrays.
+using sparse_cuda_array_supported_t = __detail::__dev_attr<::cudaDevAttrSparseCudaArraySupported>;
+static constexpr sparse_cuda_array_supported_t sparse_cuda_array_supported{};
+
+// Device supports using the cudaHostRegister flag cudaHostRegisterReadOnly to
+// register memory that must be mapped as read-only to the GPU
+using host_register_read_only_supported_t = __detail::__dev_attr<::cudaDevAttrHostRegisterReadOnlySupported>;
+static constexpr host_register_read_only_supported_t host_register_read_only_supported{};
+
+// true if the device supports using the cudaMallocAsync and cudaMemPool
+// family of APIs, and false otherwise
+using memory_pools_supported_t = __detail::__dev_attr<::cudaDevAttrMemoryPoolsSupported>;
+static constexpr memory_pools_supported_t memory_pools_supported{};
+
+// true if the device supports GPUDirect RDMA APIs, and false otherwise
+using gpu_direct_rdma_supported_t = __detail::__dev_attr<::cudaDevAttrGPUDirectRDMASupported>;
+static constexpr gpu_direct_rdma_supported_t gpu_direct_rdma_supported{};
+
+// bitmask to be interpreted according to the
+// cudaFlushGPUDirectRDMAWritesOptions enum
+using gpu_direct_rdma_flush_writes_options_t = __detail::__dev_attr<::cudaDevAttrGPUDirectRDMAFlushWritesOptions>;
+static constexpr gpu_direct_rdma_flush_writes_options_t gpu_direct_rdma_flush_writes_options{};
+
+// see the cudaGPUDirectRDMAWritesOrdering enum for numerical values
+using gpu_direct_rdma_writes_ordering_t = __detail::__dev_attr<::cudaDevAttrGPUDirectRDMAWritesOrdering>;
+static constexpr gpu_direct_rdma_writes_ordering_t gpu_direct_rdma_writes_ordering{};
+
+// Bitmask of handle types supported with mempool based IPC
+using memory_pool_supported_handle_types_t = __detail::__dev_attr<::cudaDevAttrMemoryPoolSupportedHandleTypes>;
+static constexpr memory_pool_supported_handle_types_t memory_pool_supported_handle_types{};
+
+// true if the device supports deferred mapping CUDA arrays and CUDA mipmapped
+// arrays.
+using deferred_mapping_cuda_array_supported_t = __detail::__dev_attr<::cudaDevAttrDeferredMappingCudaArraySupported>;
+static constexpr deferred_mapping_cuda_array_supported_t deferred_mapping_cuda_array_supported{};
+
+// true if the device supports IPC Events, false otherwise.
+using ipc_event_support_t = __detail::__dev_attr<::cudaDevAttrIpcEventSupport>;
+static constexpr ipc_event_support_t ipc_event_support{};
 
 #if _CCCL_CTK_AT_LEAST(12, 2)
-  // NUMA configuration of a device: value is of type cudaDeviceNumaConfig enum
-  using numa_config_t = __detail::__dev_attr<::cudaDevAttrNumaConfig>;
-  static constexpr numa_config_t numa_config{};
+// NUMA configuration of a device: value is of type cudaDeviceNumaConfig enum
+using numa_config_t = __detail::__dev_attr<::cudaDevAttrNumaConfig>;
+static constexpr numa_config_t numa_config{};
 
-  // NUMA node ID of the GPU memory
-  using numa_id_t = __detail::__dev_attr<::cudaDevAttrNumaId>;
-  static constexpr numa_id_t numa_id{};
+// NUMA node ID of the GPU memory
+using numa_id_t = __detail::__dev_attr<::cudaDevAttrNumaId>;
+static constexpr numa_id_t numa_id{};
 #endif // _CCCL_CTK_AT_LEAST(12, 2)
 
-  // Combines major and minor compute capability in a 100 * major + 10 * minor format, allows to query full compute
-  // capability in a single query
-  struct compute_capability_t
+// Combines major and minor compute capability in a 100 * major + 10 * minor format, allows to query full compute
+// capability in a single query
+struct compute_capability_t
+{
+  [[nodiscard]] int operator()(device_ref __dev_id) const
   {
-    [[nodiscard]] int operator()(device_ref __dev_id) const
-    {
-      return 100 * compute_capability_major(__dev_id) + 10 * compute_capability_minor(__dev_id);
-    }
-  };
-  static constexpr compute_capability_t compute_capability{};
+    return 100 * compute_capability_major(__dev_id) + 10 * compute_capability_minor(__dev_id);
+  }
 };
-
-} // namespace __detail
+static constexpr compute_capability_t compute_capability{};
+} // namespace device_attributes
 
 } // namespace cuda::experimental
 

--- a/cudax/include/cuda/experimental/__device/attributes.cuh
+++ b/cudax/include/cuda/experimental/__device/attributes.cuh
@@ -705,7 +705,7 @@ struct compute_capability_t
 {
   [[nodiscard]] int operator()(device_ref __dev_id) const
   {
-    return 100 * compute_capability_major(__dev_id) + 10 * compute_capability_minor(__dev_id);
+    return 100 * ::cuda::experimental::device_attributes::compute_capability_major(__dev_id) + 10 * ::cuda::experimental::device_attributes::compute_capability_minor(__dev_id);
   }
 };
 static constexpr compute_capability_t compute_capability{};

--- a/cudax/include/cuda/experimental/__device/attributes.cuh
+++ b/cudax/include/cuda/experimental/__device/attributes.cuh
@@ -705,7 +705,8 @@ struct compute_capability_t
 {
   [[nodiscard]] int operator()(device_ref __dev_id) const
   {
-    return 100 * ::cuda::experimental::device_attributes::compute_capability_major(__dev_id) + 10 * ::cuda::experimental::device_attributes::compute_capability_minor(__dev_id);
+    return 100 * ::cuda::experimental::device_attributes::compute_capability_major(__dev_id)
+         + 10 * ::cuda::experimental::device_attributes::compute_capability_minor(__dev_id);
   }
 };
 static constexpr compute_capability_t compute_capability{};

--- a/cudax/include/cuda/experimental/__device/device.cuh
+++ b/cudax/include/cuda/experimental/__device/device.cuh
@@ -49,22 +49,17 @@ struct __emplace_device
 };
 } // namespace __detail
 
-namespace device
-{
-using attributes = __detail::__device_attrs;
-
 //! @brief For a given attribute, type of the attribute value.
 //!
 //! @par Example
 //! @code
-//! using threads_per_block_t = device::attr_result_t<device::attributes::max_threads_per_block>;
+//! using threads_per_block_t = device::attr_result_t<device_attributes::max_threads_per_block>;
 //! static_assert(std::is_same_v<threads_per_block_t, int>);
 //! @endcode
 //!
-//! @sa device::attributes
+//! @sa device_attributes
 template <::cudaDeviceAttr _Attr>
-using attribute_result_t = typename __detail::__dev_attr<_Attr>::type;
-} // namespace device
+using device_attribute_result_t = typename __detail::__dev_attr<_Attr>::type;
 
 // This is the element type of the the global `devices` array. In the future, we
 // can cache device properties here.
@@ -130,7 +125,7 @@ private:
 
   explicit physical_device(int __id)
       : device_ref(__id)
-      , __traits(__detail::__arch_traits_might_be_unknown(__id, device::attributes::compute_capability(__id)))
+      , __traits(__detail::__arch_traits_might_be_unknown(__id, device_attributes::compute_capability(__id)))
   {}
 
   // `device` objects are not movable or copyable.

--- a/cudax/include/cuda/experimental/__device/device.cuh
+++ b/cudax/include/cuda/experimental/__device/device.cuh
@@ -43,22 +43,16 @@ struct __emplace_device
 {
   int __id_;
 
-  [[nodiscard]] operator device() const;
+  [[nodiscard]] operator physical_device() const;
 
   [[nodiscard]] constexpr const __emplace_device* operator->() const;
 };
 } // namespace __detail
 
-// This is the element type of the the global `devices` array. In the future, we
-// can cache device properties here.
-//
-//! @brief An immovable "owning" representation of a CUDA device.
-class device : public device_ref
-{
-public:
+namespace device {
   using attributes = __detail::__device_attrs;
 
-  //! @brief For a given attribute, returns the type of the attribute value.
+  //! @brief For a given attribute, type of the attribute value.
   //!
   //! @par Example
   //! @code
@@ -69,6 +63,15 @@ public:
   //! @sa device::attributes
   template <::cudaDeviceAttr _Attr>
   using attribute_result_t = typename __detail::__dev_attr<_Attr>::type;
+}
+
+// This is the element type of the the global `devices` array. In the future, we
+// can cache device properties here.
+//
+//! @brief An immovable "owning" representation of a CUDA device.
+class physical_device : public device_ref
+{
+public:
 
 #ifndef _CCCL_DOXYGEN_INVOKED // Do not document
 #  if _CCCL_COMPILER(MSVC)
@@ -101,7 +104,7 @@ public:
     return __primary_ctx;
   }
 
-  ~device()
+  ~physical_device()
   {
     if (__primary_ctx)
     {
@@ -125,31 +128,31 @@ private:
   //  We should have some of the attributes just return from the arch traits
   arch_traits_t __traits;
 
-  explicit device(int __id)
+  explicit physical_device(int __id)
       : device_ref(__id)
-      , __traits(__detail::__arch_traits_might_be_unknown(__id, attributes::compute_capability(__id)))
+      , __traits(__detail::__arch_traits_might_be_unknown(__id, device::attributes::compute_capability(__id)))
   {}
 
   // `device` objects are not movable or copyable.
-  device(device&&)                 = delete;
-  device(const device&)            = delete;
-  device& operator=(device&&)      = delete;
-  device& operator=(const device&) = delete;
+  physical_device(physical_device&&)                 = delete;
+  physical_device(const physical_device&)            = delete;
+  physical_device& operator=(physical_device&&)      = delete;
+  physical_device& operator=(const physical_device&) = delete;
 
-  friend bool operator==(const device& __lhs, int __rhs) = delete;
-  friend bool operator==(int __lhs, const device& __rhs) = delete;
+  friend bool operator==(const physical_device& __lhs, int __rhs) = delete;
+  friend bool operator==(int __lhs, const physical_device& __rhs) = delete;
 
 #if _CCCL_STD_VER <= 2017
-  friend bool operator!=(const device& __lhs, int __rhs) = delete;
-  friend bool operator!=(int __lhs, const device& __rhs) = delete;
+  friend bool operator!=(const physical_device& __lhs, int __rhs) = delete;
+  friend bool operator!=(int __lhs, const physical_device& __rhs) = delete;
 #endif // _CCCL_STD_VER <= 2017
 };
 
 namespace __detail
 {
-[[nodiscard]] inline __emplace_device::operator device() const
+[[nodiscard]] inline __emplace_device::operator physical_device() const
 {
-  return device(__id_);
+  return physical_device(__id_);
 }
 
 [[nodiscard]] inline constexpr const __emplace_device* __emplace_device::operator->() const

--- a/cudax/include/cuda/experimental/__device/device.cuh
+++ b/cudax/include/cuda/experimental/__device/device.cuh
@@ -89,7 +89,7 @@ public:
     return __traits;
   }
 
-  CUcontext primary_context() const
+  ::CUcontext primary_context() const
   {
     ::std::call_once(__init_once, [this]() {
       __device      = __detail::driver::deviceGet(__id_);
@@ -114,8 +114,8 @@ private:
   friend class device_ref;
   friend struct __detail::__emplace_device;
 
-  mutable CUcontext __primary_ctx = nullptr;
-  mutable CUdevice __device{};
+  mutable ::CUcontext __primary_ctx = nullptr;
+  mutable ::CUdevice __device{};
   mutable ::std::once_flag __init_once;
 
   // TODO should this be a reference/pointer to the constexpr traits instances?

--- a/cudax/include/cuda/experimental/__device/device.cuh
+++ b/cudax/include/cuda/experimental/__device/device.cuh
@@ -49,21 +49,22 @@ struct __emplace_device
 };
 } // namespace __detail
 
-namespace device {
-  using attributes = __detail::__device_attrs;
+namespace device
+{
+using attributes = __detail::__device_attrs;
 
-  //! @brief For a given attribute, type of the attribute value.
-  //!
-  //! @par Example
-  //! @code
-  //! using threads_per_block_t = device::attr_result_t<device::attributes::max_threads_per_block>;
-  //! static_assert(std::is_same_v<threads_per_block_t, int>);
-  //! @endcode
-  //!
-  //! @sa device::attributes
-  template <::cudaDeviceAttr _Attr>
-  using attribute_result_t = typename __detail::__dev_attr<_Attr>::type;
-}
+//! @brief For a given attribute, type of the attribute value.
+//!
+//! @par Example
+//! @code
+//! using threads_per_block_t = device::attr_result_t<device::attributes::max_threads_per_block>;
+//! static_assert(std::is_same_v<threads_per_block_t, int>);
+//! @endcode
+//!
+//! @sa device::attributes
+template <::cudaDeviceAttr _Attr>
+using attribute_result_t = typename __detail::__dev_attr<_Attr>::type;
+} // namespace device
 
 // This is the element type of the the global `devices` array. In the future, we
 // can cache device properties here.
@@ -72,13 +73,12 @@ namespace device {
 class physical_device : public device_ref
 {
 public:
-
 #ifndef _CCCL_DOXYGEN_INVOKED // Do not document
 #  if _CCCL_COMPILER(MSVC)
   // When __EDG__ is defined, std::construct_at will not permit constructing
   // a device object from an __emplace_device object. This is a workaround.
-  device(__detail::__emplace_device __ed)
-      : device(__ed.__id_)
+  physical_device(__detail::__emplace_device __ed)
+      : physical_device(__ed.__id_)
   {}
 #  endif
 #endif

--- a/cudax/include/cuda/experimental/__device/device_ref.cuh
+++ b/cudax/include/cuda/experimental/__device/device_ref.cuh
@@ -32,7 +32,7 @@
 
 namespace cuda::experimental
 {
-class device;
+class physical_device;
 struct arch_traits_t;
 
 namespace __detail
@@ -44,7 +44,7 @@ struct __dev_attr;
 //! @brief A non-owning representation of a CUDA device
 class device_ref
 {
-  friend class device;
+  friend class physical_device;
 
   int __id_ = 0;
 

--- a/cudax/include/cuda/experimental/__device/logical_device.cuh
+++ b/cudax/include/cuda/experimental/__device/logical_device.cuh
@@ -82,7 +82,7 @@ public:
   // More of a micro-optimization, we can also remove this (depending if we keep device_ref)
   //!
   //! Constructing a logical_device for a given device has a side effect of initializing that device
-  logical_device(const ::cuda::experimental::device& __dev)
+  logical_device(const ::cuda::experimental::physical_device& __dev)
       : __dev_id(__dev.get())
       , __kind(kinds::device)
       , __ctx(__dev.primary_context())

--- a/cudax/include/cuda/experimental/__green_context/green_ctx.cuh
+++ b/cudax/include/cuda/experimental/__green_context/green_ctx.cuh
@@ -40,7 +40,7 @@ struct green_context
   CUgreenCtx __green_ctx  = nullptr;
   CUcontext __transformed = nullptr;
 
-  explicit green_context(const device& __device)
+  explicit green_context(device_ref __device)
       : __dev_id(__device.get())
   {
     // TODO get CUdevice from device

--- a/cudax/test/device/arch_traits.cu
+++ b/cudax/test/device/arch_traits.cu
@@ -113,7 +113,7 @@ C2H_CCCLRT_TEST("Traits", "[device]")
   compare_static_and_dynamic<1200>();
 
   // Compare arch traits with attributes
-  for (const cudax::device& dev : cudax::devices)
+  for (const cudax::physical_device& dev : cudax::devices)
   {
     auto traits = dev.arch_traits();
 

--- a/cudax/test/device/arch_traits.cu
+++ b/cudax/test/device/arch_traits.cu
@@ -117,44 +117,41 @@ C2H_CCCLRT_TEST("Traits", "[device]")
   {
     auto traits = dev.arch_traits();
 
-    CUDAX_REQUIRE(traits.max_threads_per_block == dev.attribute(cudax::device::attributes::max_threads_per_block));
-    CUDAX_REQUIRE(traits.max_block_dim_x == dev.attribute(cudax::device::attributes::max_block_dim_x));
-    CUDAX_REQUIRE(traits.max_block_dim_y == dev.attribute(cudax::device::attributes::max_block_dim_y));
-    CUDAX_REQUIRE(traits.max_block_dim_z == dev.attribute(cudax::device::attributes::max_block_dim_z));
-    CUDAX_REQUIRE(traits.max_grid_dim_x == dev.attribute(cudax::device::attributes::max_grid_dim_x));
-    CUDAX_REQUIRE(traits.max_grid_dim_y == dev.attribute(cudax::device::attributes::max_grid_dim_y));
-    CUDAX_REQUIRE(traits.max_grid_dim_z == dev.attribute(cudax::device::attributes::max_grid_dim_z));
+    CUDAX_REQUIRE(traits.max_threads_per_block == dev.attribute(cudax::device_attributes::max_threads_per_block));
+    CUDAX_REQUIRE(traits.max_block_dim_x == dev.attribute(cudax::device_attributes::max_block_dim_x));
+    CUDAX_REQUIRE(traits.max_block_dim_y == dev.attribute(cudax::device_attributes::max_block_dim_y));
+    CUDAX_REQUIRE(traits.max_block_dim_z == dev.attribute(cudax::device_attributes::max_block_dim_z));
+    CUDAX_REQUIRE(traits.max_grid_dim_x == dev.attribute(cudax::device_attributes::max_grid_dim_x));
+    CUDAX_REQUIRE(traits.max_grid_dim_y == dev.attribute(cudax::device_attributes::max_grid_dim_y));
+    CUDAX_REQUIRE(traits.max_grid_dim_z == dev.attribute(cudax::device_attributes::max_grid_dim_z));
 
-    CUDAX_REQUIRE(traits.warp_size == dev.attribute(cudax::device::attributes::warp_size));
-    CUDAX_REQUIRE(traits.total_constant_memory == dev.attribute(cudax::device::attributes::total_constant_memory));
+    CUDAX_REQUIRE(traits.warp_size == dev.attribute(cudax::device_attributes::warp_size));
+    CUDAX_REQUIRE(traits.total_constant_memory == dev.attribute(cudax::device_attributes::total_constant_memory));
     CUDAX_REQUIRE(
-      traits.max_shared_memory_per_block == dev.attribute(cudax::device::attributes::max_shared_memory_per_block));
-    CUDAX_REQUIRE(traits.gpu_overlap == dev.attribute(cudax::device::attributes::gpu_overlap));
-    CUDAX_REQUIRE(traits.can_map_host_memory == dev.attribute(cudax::device::attributes::can_map_host_memory));
-    CUDAX_REQUIRE(traits.concurrent_kernels == dev.attribute(cudax::device::attributes::concurrent_kernels));
+      traits.max_shared_memory_per_block == dev.attribute(cudax::device_attributes::max_shared_memory_per_block));
+    CUDAX_REQUIRE(traits.gpu_overlap == dev.attribute(cudax::device_attributes::gpu_overlap));
+    CUDAX_REQUIRE(traits.can_map_host_memory == dev.attribute(cudax::device_attributes::can_map_host_memory));
+    CUDAX_REQUIRE(traits.concurrent_kernels == dev.attribute(cudax::device_attributes::concurrent_kernels));
     CUDAX_REQUIRE(
-      traits.stream_priorities_supported == dev.attribute(cudax::device::attributes::stream_priorities_supported));
+      traits.stream_priorities_supported == dev.attribute(cudax::device_attributes::stream_priorities_supported));
     CUDAX_REQUIRE(
-      traits.global_l1_cache_supported == dev.attribute(cudax::device::attributes::global_l1_cache_supported));
-    CUDAX_REQUIRE(
-      traits.local_l1_cache_supported == dev.attribute(cudax::device::attributes::local_l1_cache_supported));
-    CUDAX_REQUIRE(traits.max_registers_per_block == dev.attribute(cudax::device::attributes::max_registers_per_block));
+      traits.global_l1_cache_supported == dev.attribute(cudax::device_attributes::global_l1_cache_supported));
+    CUDAX_REQUIRE(traits.local_l1_cache_supported == dev.attribute(cudax::device_attributes::local_l1_cache_supported));
+    CUDAX_REQUIRE(traits.max_registers_per_block == dev.attribute(cudax::device_attributes::max_registers_per_block));
     CUDAX_REQUIRE(traits.max_registers_per_multiprocessor
-                  == dev.attribute(cudax::device::attributes::max_registers_per_multiprocessor));
-    CUDAX_REQUIRE(
-      traits.compute_capability_major == dev.attribute(cudax::device::attributes::compute_capability_major));
-    CUDAX_REQUIRE(
-      traits.compute_capability_minor == dev.attribute(cudax::device::attributes::compute_capability_minor));
-    CUDAX_REQUIRE(traits.compute_capability == dev.attribute(cudax::device::attributes::compute_capability));
+                  == dev.attribute(cudax::device_attributes::max_registers_per_multiprocessor));
+    CUDAX_REQUIRE(traits.compute_capability_major == dev.attribute(cudax::device_attributes::compute_capability_major));
+    CUDAX_REQUIRE(traits.compute_capability_minor == dev.attribute(cudax::device_attributes::compute_capability_minor));
+    CUDAX_REQUIRE(traits.compute_capability == dev.attribute(cudax::device_attributes::compute_capability));
     CUDAX_REQUIRE(traits.max_shared_memory_per_multiprocessor
-                  == dev.attribute(cudax::device::attributes::max_shared_memory_per_multiprocessor));
+                  == dev.attribute(cudax::device_attributes::max_shared_memory_per_multiprocessor));
     CUDAX_REQUIRE(
-      traits.max_blocks_per_multiprocessor == dev.attribute(cudax::device::attributes::max_blocks_per_multiprocessor));
-    CUDAX_REQUIRE(traits.max_threads_per_multiprocessor
-                  == dev.attribute(cudax::device::attributes::max_threads_per_multiprocessor));
+      traits.max_blocks_per_multiprocessor == dev.attribute(cudax::device_attributes::max_blocks_per_multiprocessor));
+    CUDAX_REQUIRE(
+      traits.max_threads_per_multiprocessor == dev.attribute(cudax::device_attributes::max_threads_per_multiprocessor));
     CUDAX_REQUIRE(traits.reserved_shared_memory_per_block
-                  == dev.attribute(cudax::device::attributes::reserved_shared_memory_per_block));
+                  == dev.attribute(cudax::device_attributes::reserved_shared_memory_per_block));
     CUDAX_REQUIRE(traits.max_shared_memory_per_block_optin
-                  == dev.attribute(cudax::device::attributes::max_shared_memory_per_block_optin));
+                  == dev.attribute(cudax::device_attributes::max_shared_memory_per_block_optin));
   }
 }

--- a/cudax/test/device/device_smoke.cu
+++ b/cudax/test/device/device_smoke.cu
@@ -33,7 +33,7 @@ template <const auto& Attr, ::cudaDeviceAttr ExpectedAttr, class ExpectedResult>
 
 C2H_CCCLRT_TEST("Smoke", "[device]")
 {
-  using cudax::device;
+  using attributes = cudax::device::attributes;
   using cudax::device_ref;
 
   SECTION("Compare")
@@ -48,275 +48,226 @@ C2H_CCCLRT_TEST("Smoke", "[device]")
 
   SECTION("Attributes")
   {
-    ::test_device_attribute<device::attributes::max_threads_per_block, ::cudaDevAttrMaxThreadsPerBlock, int>();
-    ::test_device_attribute<device::attributes::max_block_dim_x, ::cudaDevAttrMaxBlockDimX, int>();
-    ::test_device_attribute<device::attributes::max_block_dim_y, ::cudaDevAttrMaxBlockDimY, int>();
-    ::test_device_attribute<device::attributes::max_block_dim_z, ::cudaDevAttrMaxBlockDimZ, int>();
-    ::test_device_attribute<device::attributes::max_grid_dim_x, ::cudaDevAttrMaxGridDimX, int>();
-    ::test_device_attribute<device::attributes::max_grid_dim_y, ::cudaDevAttrMaxGridDimY, int>();
-    ::test_device_attribute<device::attributes::max_grid_dim_z, ::cudaDevAttrMaxGridDimZ, int>();
-    ::test_device_attribute<device::attributes::max_shared_memory_per_block, ::cudaDevAttrMaxSharedMemoryPerBlock, int>();
-    ::test_device_attribute<device::attributes::total_constant_memory, ::cudaDevAttrTotalConstantMemory, int>();
-    ::test_device_attribute<device::attributes::warp_size, ::cudaDevAttrWarpSize, int>();
-    ::test_device_attribute<device::attributes::max_pitch, ::cudaDevAttrMaxPitch, int>();
-    ::test_device_attribute<device::attributes::max_texture_1d_width, ::cudaDevAttrMaxTexture1DWidth, int>();
-    ::test_device_attribute<device::attributes::max_texture_1d_linear_width, ::cudaDevAttrMaxTexture1DLinearWidth, int>();
-    ::test_device_attribute<device::attributes::max_texture_1d_mipmapped_width,
-                            ::cudaDevAttrMaxTexture1DMipmappedWidth,
-                            int>();
-    ::test_device_attribute<device::attributes::max_texture_2d_width, ::cudaDevAttrMaxTexture2DWidth, int>();
-    ::test_device_attribute<device::attributes::max_texture_2d_height, ::cudaDevAttrMaxTexture2DHeight, int>();
-    ::test_device_attribute<device::attributes::max_texture_2d_linear_width, ::cudaDevAttrMaxTexture2DLinearWidth, int>();
-    ::test_device_attribute<device::attributes::max_texture_2d_linear_height,
-                            ::cudaDevAttrMaxTexture2DLinearHeight,
-                            int>();
-    ::test_device_attribute<device::attributes::max_texture_2d_linear_pitch, ::cudaDevAttrMaxTexture2DLinearPitch, int>();
-    ::test_device_attribute<device::attributes::max_texture_2d_mipmapped_width,
-                            ::cudaDevAttrMaxTexture2DMipmappedWidth,
-                            int>();
-    ::test_device_attribute<device::attributes::max_texture_2d_mipmapped_height,
-                            ::cudaDevAttrMaxTexture2DMipmappedHeight,
-                            int>();
-    ::test_device_attribute<device::attributes::max_texture_3d_width, ::cudaDevAttrMaxTexture3DWidth, int>();
-    ::test_device_attribute<device::attributes::max_texture_3d_height, ::cudaDevAttrMaxTexture3DHeight, int>();
-    ::test_device_attribute<device::attributes::max_texture_3d_depth, ::cudaDevAttrMaxTexture3DDepth, int>();
-    ::test_device_attribute<device::attributes::max_texture_3d_width_alt, ::cudaDevAttrMaxTexture3DWidthAlt, int>();
-    ::test_device_attribute<device::attributes::max_texture_3d_height_alt, ::cudaDevAttrMaxTexture3DHeightAlt, int>();
-    ::test_device_attribute<device::attributes::max_texture_3d_depth_alt, ::cudaDevAttrMaxTexture3DDepthAlt, int>();
-    ::test_device_attribute<device::attributes::max_texture_cubemap_width, ::cudaDevAttrMaxTextureCubemapWidth, int>();
-    ::test_device_attribute<device::attributes::max_texture_1d_layered_width,
-                            ::cudaDevAttrMaxTexture1DLayeredWidth,
-                            int>();
-    ::test_device_attribute<device::attributes::max_texture_1d_layered_layers,
-                            ::cudaDevAttrMaxTexture1DLayeredLayers,
-                            int>();
-    ::test_device_attribute<device::attributes::max_texture_2d_layered_width,
-                            ::cudaDevAttrMaxTexture2DLayeredWidth,
-                            int>();
-    ::test_device_attribute<device::attributes::max_texture_2d_layered_height,
-                            ::cudaDevAttrMaxTexture2DLayeredHeight,
-                            int>();
-    ::test_device_attribute<device::attributes::max_texture_2d_layered_layers,
-                            ::cudaDevAttrMaxTexture2DLayeredLayers,
-                            int>();
-    ::test_device_attribute<device::attributes::max_texture_cubemap_layered_width,
+    ::test_device_attribute<attributes::max_threads_per_block, ::cudaDevAttrMaxThreadsPerBlock, int>();
+    ::test_device_attribute<attributes::max_block_dim_x, ::cudaDevAttrMaxBlockDimX, int>();
+    ::test_device_attribute<attributes::max_block_dim_y, ::cudaDevAttrMaxBlockDimY, int>();
+    ::test_device_attribute<attributes::max_block_dim_z, ::cudaDevAttrMaxBlockDimZ, int>();
+    ::test_device_attribute<attributes::max_grid_dim_x, ::cudaDevAttrMaxGridDimX, int>();
+    ::test_device_attribute<attributes::max_grid_dim_y, ::cudaDevAttrMaxGridDimY, int>();
+    ::test_device_attribute<attributes::max_grid_dim_z, ::cudaDevAttrMaxGridDimZ, int>();
+    ::test_device_attribute<attributes::max_shared_memory_per_block, ::cudaDevAttrMaxSharedMemoryPerBlock, int>();
+    ::test_device_attribute<attributes::total_constant_memory, ::cudaDevAttrTotalConstantMemory, int>();
+    ::test_device_attribute<attributes::warp_size, ::cudaDevAttrWarpSize, int>();
+    ::test_device_attribute<attributes::max_pitch, ::cudaDevAttrMaxPitch, int>();
+    ::test_device_attribute<attributes::max_texture_1d_width, ::cudaDevAttrMaxTexture1DWidth, int>();
+    ::test_device_attribute<attributes::max_texture_1d_linear_width, ::cudaDevAttrMaxTexture1DLinearWidth, int>();
+    ::test_device_attribute<attributes::max_texture_1d_mipmapped_width, ::cudaDevAttrMaxTexture1DMipmappedWidth, int>();
+    ::test_device_attribute<attributes::max_texture_2d_width, ::cudaDevAttrMaxTexture2DWidth, int>();
+    ::test_device_attribute<attributes::max_texture_2d_height, ::cudaDevAttrMaxTexture2DHeight, int>();
+    ::test_device_attribute<attributes::max_texture_2d_linear_width, ::cudaDevAttrMaxTexture2DLinearWidth, int>();
+    ::test_device_attribute<attributes::max_texture_2d_linear_height, ::cudaDevAttrMaxTexture2DLinearHeight, int>();
+    ::test_device_attribute<attributes::max_texture_2d_linear_pitch, ::cudaDevAttrMaxTexture2DLinearPitch, int>();
+    ::test_device_attribute<attributes::max_texture_2d_mipmapped_width, ::cudaDevAttrMaxTexture2DMipmappedWidth, int>();
+    ::test_device_attribute<attributes::max_texture_2d_mipmapped_height, ::cudaDevAttrMaxTexture2DMipmappedHeight, int>();
+    ::test_device_attribute<attributes::max_texture_3d_width, ::cudaDevAttrMaxTexture3DWidth, int>();
+    ::test_device_attribute<attributes::max_texture_3d_height, ::cudaDevAttrMaxTexture3DHeight, int>();
+    ::test_device_attribute<attributes::max_texture_3d_depth, ::cudaDevAttrMaxTexture3DDepth, int>();
+    ::test_device_attribute<attributes::max_texture_3d_width_alt, ::cudaDevAttrMaxTexture3DWidthAlt, int>();
+    ::test_device_attribute<attributes::max_texture_3d_height_alt, ::cudaDevAttrMaxTexture3DHeightAlt, int>();
+    ::test_device_attribute<attributes::max_texture_3d_depth_alt, ::cudaDevAttrMaxTexture3DDepthAlt, int>();
+    ::test_device_attribute<attributes::max_texture_cubemap_width, ::cudaDevAttrMaxTextureCubemapWidth, int>();
+    ::test_device_attribute<attributes::max_texture_1d_layered_width, ::cudaDevAttrMaxTexture1DLayeredWidth, int>();
+    ::test_device_attribute<attributes::max_texture_1d_layered_layers, ::cudaDevAttrMaxTexture1DLayeredLayers, int>();
+    ::test_device_attribute<attributes::max_texture_2d_layered_width, ::cudaDevAttrMaxTexture2DLayeredWidth, int>();
+    ::test_device_attribute<attributes::max_texture_2d_layered_height, ::cudaDevAttrMaxTexture2DLayeredHeight, int>();
+    ::test_device_attribute<attributes::max_texture_2d_layered_layers, ::cudaDevAttrMaxTexture2DLayeredLayers, int>();
+    ::test_device_attribute<attributes::max_texture_cubemap_layered_width,
                             ::cudaDevAttrMaxTextureCubemapLayeredWidth,
                             int>();
-    ::test_device_attribute<device::attributes::max_texture_cubemap_layered_layers,
+    ::test_device_attribute<attributes::max_texture_cubemap_layered_layers,
                             ::cudaDevAttrMaxTextureCubemapLayeredLayers,
                             int>();
-    ::test_device_attribute<device::attributes::max_surface_1d_width, ::cudaDevAttrMaxSurface1DWidth, int>();
-    ::test_device_attribute<device::attributes::max_surface_2d_width, ::cudaDevAttrMaxSurface2DWidth, int>();
-    ::test_device_attribute<device::attributes::max_surface_2d_height, ::cudaDevAttrMaxSurface2DHeight, int>();
-    ::test_device_attribute<device::attributes::max_surface_3d_width, ::cudaDevAttrMaxSurface3DWidth, int>();
-    ::test_device_attribute<device::attributes::max_surface_3d_height, ::cudaDevAttrMaxSurface3DHeight, int>();
-    ::test_device_attribute<device::attributes::max_surface_3d_depth, ::cudaDevAttrMaxSurface3DDepth, int>();
-    ::test_device_attribute<device::attributes::max_surface_1d_layered_width,
-                            ::cudaDevAttrMaxSurface1DLayeredWidth,
-                            int>();
-    ::test_device_attribute<device::attributes::max_surface_1d_layered_layers,
-                            ::cudaDevAttrMaxSurface1DLayeredLayers,
-                            int>();
-    ::test_device_attribute<device::attributes::max_surface_2d_layered_width,
-                            ::cudaDevAttrMaxSurface2DLayeredWidth,
-                            int>();
-    ::test_device_attribute<device::attributes::max_surface_2d_layered_height,
-                            ::cudaDevAttrMaxSurface2DLayeredHeight,
-                            int>();
-    ::test_device_attribute<device::attributes::max_surface_2d_layered_layers,
-                            ::cudaDevAttrMaxSurface2DLayeredLayers,
-                            int>();
-    ::test_device_attribute<device::attributes::max_surface_cubemap_width, ::cudaDevAttrMaxSurfaceCubemapWidth, int>();
-    ::test_device_attribute<device::attributes::max_surface_cubemap_layered_width,
+    ::test_device_attribute<attributes::max_surface_1d_width, ::cudaDevAttrMaxSurface1DWidth, int>();
+    ::test_device_attribute<attributes::max_surface_2d_width, ::cudaDevAttrMaxSurface2DWidth, int>();
+    ::test_device_attribute<attributes::max_surface_2d_height, ::cudaDevAttrMaxSurface2DHeight, int>();
+    ::test_device_attribute<attributes::max_surface_3d_width, ::cudaDevAttrMaxSurface3DWidth, int>();
+    ::test_device_attribute<attributes::max_surface_3d_height, ::cudaDevAttrMaxSurface3DHeight, int>();
+    ::test_device_attribute<attributes::max_surface_3d_depth, ::cudaDevAttrMaxSurface3DDepth, int>();
+    ::test_device_attribute<attributes::max_surface_1d_layered_width, ::cudaDevAttrMaxSurface1DLayeredWidth, int>();
+    ::test_device_attribute<attributes::max_surface_1d_layered_layers, ::cudaDevAttrMaxSurface1DLayeredLayers, int>();
+    ::test_device_attribute<attributes::max_surface_2d_layered_width, ::cudaDevAttrMaxSurface2DLayeredWidth, int>();
+    ::test_device_attribute<attributes::max_surface_2d_layered_height, ::cudaDevAttrMaxSurface2DLayeredHeight, int>();
+    ::test_device_attribute<attributes::max_surface_2d_layered_layers, ::cudaDevAttrMaxSurface2DLayeredLayers, int>();
+    ::test_device_attribute<attributes::max_surface_cubemap_width, ::cudaDevAttrMaxSurfaceCubemapWidth, int>();
+    ::test_device_attribute<attributes::max_surface_cubemap_layered_width,
                             ::cudaDevAttrMaxSurfaceCubemapLayeredWidth,
                             int>();
-    ::test_device_attribute<device::attributes::max_surface_cubemap_layered_layers,
+    ::test_device_attribute<attributes::max_surface_cubemap_layered_layers,
                             ::cudaDevAttrMaxSurfaceCubemapLayeredLayers,
                             int>();
-    ::test_device_attribute<device::attributes::max_registers_per_block, ::cudaDevAttrMaxRegistersPerBlock, int>();
-    ::test_device_attribute<device::attributes::clock_rate, ::cudaDevAttrClockRate, int>();
-    ::test_device_attribute<device::attributes::texture_alignment, ::cudaDevAttrTextureAlignment, int>();
-    ::test_device_attribute<device::attributes::texture_pitch_alignment, ::cudaDevAttrTexturePitchAlignment, int>();
-    ::test_device_attribute<device::attributes::gpu_overlap, ::cudaDevAttrGpuOverlap, bool>();
-    ::test_device_attribute<device::attributes::multiprocessor_count, ::cudaDevAttrMultiProcessorCount, int>();
-    ::test_device_attribute<device::attributes::kernel_exec_timeout, ::cudaDevAttrKernelExecTimeout, bool>();
-    ::test_device_attribute<device::attributes::integrated, ::cudaDevAttrIntegrated, bool>();
-    ::test_device_attribute<device::attributes::can_map_host_memory, ::cudaDevAttrCanMapHostMemory, bool>();
-    ::test_device_attribute<device::attributes::compute_mode, ::cudaDevAttrComputeMode, ::cudaComputeMode>();
-    ::test_device_attribute<device::attributes::concurrent_kernels, ::cudaDevAttrConcurrentKernels, bool>();
-    ::test_device_attribute<device::attributes::ecc_enabled, ::cudaDevAttrEccEnabled, bool>();
-    ::test_device_attribute<device::attributes::pci_bus_id, ::cudaDevAttrPciBusId, int>();
-    ::test_device_attribute<device::attributes::pci_device_id, ::cudaDevAttrPciDeviceId, int>();
-    ::test_device_attribute<device::attributes::tcc_driver, ::cudaDevAttrTccDriver, bool>();
-    ::test_device_attribute<device::attributes::memory_clock_rate, ::cudaDevAttrMemoryClockRate, int>();
-    ::test_device_attribute<device::attributes::global_memory_bus_width, ::cudaDevAttrGlobalMemoryBusWidth, int>();
-    ::test_device_attribute<device::attributes::l2_cache_size, ::cudaDevAttrL2CacheSize, int>();
-    ::test_device_attribute<device::attributes::max_threads_per_multiprocessor,
-                            ::cudaDevAttrMaxThreadsPerMultiProcessor,
-                            int>();
-    ::test_device_attribute<device::attributes::unified_addressing, ::cudaDevAttrUnifiedAddressing, bool>();
-    ::test_device_attribute<device::attributes::compute_capability_major, ::cudaDevAttrComputeCapabilityMajor, int>();
-    ::test_device_attribute<device::attributes::compute_capability_minor, ::cudaDevAttrComputeCapabilityMinor, int>();
-    ::test_device_attribute<device::attributes::stream_priorities_supported,
-                            ::cudaDevAttrStreamPrioritiesSupported,
-                            bool>();
-    ::test_device_attribute<device::attributes::global_l1_cache_supported, ::cudaDevAttrGlobalL1CacheSupported, bool>();
-    ::test_device_attribute<device::attributes::local_l1_cache_supported, ::cudaDevAttrLocalL1CacheSupported, bool>();
-    ::test_device_attribute<device::attributes::max_shared_memory_per_multiprocessor,
+    ::test_device_attribute<attributes::max_registers_per_block, ::cudaDevAttrMaxRegistersPerBlock, int>();
+    ::test_device_attribute<attributes::clock_rate, ::cudaDevAttrClockRate, int>();
+    ::test_device_attribute<attributes::texture_alignment, ::cudaDevAttrTextureAlignment, int>();
+    ::test_device_attribute<attributes::texture_pitch_alignment, ::cudaDevAttrTexturePitchAlignment, int>();
+    ::test_device_attribute<attributes::gpu_overlap, ::cudaDevAttrGpuOverlap, bool>();
+    ::test_device_attribute<attributes::multiprocessor_count, ::cudaDevAttrMultiProcessorCount, int>();
+    ::test_device_attribute<attributes::kernel_exec_timeout, ::cudaDevAttrKernelExecTimeout, bool>();
+    ::test_device_attribute<attributes::integrated, ::cudaDevAttrIntegrated, bool>();
+    ::test_device_attribute<attributes::can_map_host_memory, ::cudaDevAttrCanMapHostMemory, bool>();
+    ::test_device_attribute<attributes::compute_mode, ::cudaDevAttrComputeMode, ::cudaComputeMode>();
+    ::test_device_attribute<attributes::concurrent_kernels, ::cudaDevAttrConcurrentKernels, bool>();
+    ::test_device_attribute<attributes::ecc_enabled, ::cudaDevAttrEccEnabled, bool>();
+    ::test_device_attribute<attributes::pci_bus_id, ::cudaDevAttrPciBusId, int>();
+    ::test_device_attribute<attributes::pci_device_id, ::cudaDevAttrPciDeviceId, int>();
+    ::test_device_attribute<attributes::tcc_driver, ::cudaDevAttrTccDriver, bool>();
+    ::test_device_attribute<attributes::l2_cache_size, ::cudaDevAttrL2CacheSize, int>();
+    ::test_device_attribute<attributes::max_threads_per_multiprocessor, ::cudaDevAttrMaxThreadsPerMultiProcessor, int>();
+    ::test_device_attribute<attributes::unified_addressing, ::cudaDevAttrUnifiedAddressing, bool>();
+    ::test_device_attribute<attributes::compute_capability_major, ::cudaDevAttrComputeCapabilityMajor, int>();
+    ::test_device_attribute<attributes::compute_capability_minor, ::cudaDevAttrComputeCapabilityMinor, int>();
+    ::test_device_attribute<attributes::stream_priorities_supported, ::cudaDevAttrStreamPrioritiesSupported, bool>();
+    ::test_device_attribute<attributes::global_l1_cache_supported, ::cudaDevAttrGlobalL1CacheSupported, bool>();
+    ::test_device_attribute<attributes::local_l1_cache_supported, ::cudaDevAttrLocalL1CacheSupported, bool>();
+    ::test_device_attribute<attributes::max_shared_memory_per_multiprocessor,
                             ::cudaDevAttrMaxSharedMemoryPerMultiprocessor,
                             int>();
-    ::test_device_attribute<device::attributes::max_registers_per_multiprocessor,
+    ::test_device_attribute<attributes::max_registers_per_multiprocessor,
                             ::cudaDevAttrMaxRegistersPerMultiprocessor,
                             int>();
-    ::test_device_attribute<device::attributes::managed_memory, ::cudaDevAttrManagedMemory, bool>();
-    ::test_device_attribute<device::attributes::is_multi_gpu_board, ::cudaDevAttrIsMultiGpuBoard, bool>();
-    ::test_device_attribute<device::attributes::multi_gpu_board_group_id, ::cudaDevAttrMultiGpuBoardGroupID, int>();
-    ::test_device_attribute<device::attributes::host_native_atomic_supported,
-                            ::cudaDevAttrHostNativeAtomicSupported,
-                            bool>();
-    ::test_device_attribute<device::attributes::single_to_double_precision_perf_ratio,
+    ::test_device_attribute<attributes::is_multi_gpu_board, ::cudaDevAttrIsMultiGpuBoard, bool>();
+    ::test_device_attribute<attributes::multi_gpu_board_group_id, ::cudaDevAttrMultiGpuBoardGroupID, int>();
+    ::test_device_attribute<attributes::host_native_atomic_supported, ::cudaDevAttrHostNativeAtomicSupported, bool>();
+    ::test_device_attribute<attributes::single_to_double_precision_perf_ratio,
                             ::cudaDevAttrSingleToDoublePrecisionPerfRatio,
                             int>();
-    ::test_device_attribute<device::attributes::pageable_memory_access, ::cudaDevAttrPageableMemoryAccess, bool>();
-    ::test_device_attribute<device::attributes::concurrent_managed_access, ::cudaDevAttrConcurrentManagedAccess, bool>();
-    ::test_device_attribute<device::attributes::compute_preemption_supported,
-                            ::cudaDevAttrComputePreemptionSupported,
-                            bool>();
-    ::test_device_attribute<device::attributes::can_use_host_pointer_for_registered_mem,
+    ::test_device_attribute<attributes::pageable_memory_access, ::cudaDevAttrPageableMemoryAccess, bool>();
+    ::test_device_attribute<attributes::concurrent_managed_access, ::cudaDevAttrConcurrentManagedAccess, bool>();
+    ::test_device_attribute<attributes::compute_preemption_supported, ::cudaDevAttrComputePreemptionSupported, bool>();
+    ::test_device_attribute<attributes::can_use_host_pointer_for_registered_mem,
                             ::cudaDevAttrCanUseHostPointerForRegisteredMem,
                             bool>();
-    ::test_device_attribute<device::attributes::cooperative_launch, ::cudaDevAttrCooperativeLaunch, bool>();
-    ::test_device_attribute<device::attributes::can_flush_remote_writes, ::cudaDevAttrCanFlushRemoteWrites, bool>();
-    ::test_device_attribute<device::attributes::host_register_supported, ::cudaDevAttrHostRegisterSupported, bool>();
-    ::test_device_attribute<device::attributes::pageable_memory_access_uses_host_page_tables,
+    ::test_device_attribute<attributes::cooperative_launch, ::cudaDevAttrCooperativeLaunch, bool>();
+    ::test_device_attribute<attributes::can_flush_remote_writes, ::cudaDevAttrCanFlushRemoteWrites, bool>();
+    ::test_device_attribute<attributes::host_register_supported, ::cudaDevAttrHostRegisterSupported, bool>();
+    ::test_device_attribute<attributes::pageable_memory_access_uses_host_page_tables,
                             ::cudaDevAttrPageableMemoryAccessUsesHostPageTables,
                             bool>();
-    ::test_device_attribute<device::attributes::direct_managed_mem_access_from_host,
+    ::test_device_attribute<attributes::direct_managed_mem_access_from_host,
                             ::cudaDevAttrDirectManagedMemAccessFromHost,
                             bool>();
-    ::test_device_attribute<device::attributes::max_shared_memory_per_block_optin,
+    ::test_device_attribute<attributes::max_shared_memory_per_block_optin,
                             ::cudaDevAttrMaxSharedMemoryPerBlockOptin,
                             int>();
-    ::test_device_attribute<device::attributes::max_blocks_per_multiprocessor,
-                            ::cudaDevAttrMaxBlocksPerMultiprocessor,
-                            int>();
-    ::test_device_attribute<device::attributes::max_persisting_l2_cache_size,
-                            ::cudaDevAttrMaxPersistingL2CacheSize,
-                            int>();
-    ::test_device_attribute<device::attributes::max_access_policy_window_size,
-                            ::cudaDevAttrMaxAccessPolicyWindowSize,
-                            int>();
-    ::test_device_attribute<device::attributes::reserved_shared_memory_per_block,
+    ::test_device_attribute<attributes::max_blocks_per_multiprocessor, ::cudaDevAttrMaxBlocksPerMultiprocessor, int>();
+    ::test_device_attribute<attributes::max_persisting_l2_cache_size, ::cudaDevAttrMaxPersistingL2CacheSize, int>();
+    ::test_device_attribute<attributes::max_access_policy_window_size, ::cudaDevAttrMaxAccessPolicyWindowSize, int>();
+    ::test_device_attribute<attributes::reserved_shared_memory_per_block,
                             ::cudaDevAttrReservedSharedMemoryPerBlock,
                             int>();
-    ::test_device_attribute<device::attributes::sparse_cuda_array_supported,
-                            ::cudaDevAttrSparseCudaArraySupported,
-                            bool>();
-    ::test_device_attribute<device::attributes::host_register_read_only_supported,
+    ::test_device_attribute<attributes::sparse_cuda_array_supported, ::cudaDevAttrSparseCudaArraySupported, bool>();
+    ::test_device_attribute<attributes::host_register_read_only_supported,
                             ::cudaDevAttrHostRegisterReadOnlySupported,
                             bool>();
-    ::test_device_attribute<device::attributes::memory_pools_supported, ::cudaDevAttrMemoryPoolsSupported, bool>();
-    ::test_device_attribute<device::attributes::gpu_direct_rdma_supported, ::cudaDevAttrGPUDirectRDMASupported, bool>();
-    ::test_device_attribute<device::attributes::gpu_direct_rdma_flush_writes_options,
+    ::test_device_attribute<attributes::memory_pools_supported, ::cudaDevAttrMemoryPoolsSupported, bool>();
+    ::test_device_attribute<attributes::gpu_direct_rdma_supported, ::cudaDevAttrGPUDirectRDMASupported, bool>();
+    ::test_device_attribute<attributes::gpu_direct_rdma_flush_writes_options,
                             ::cudaDevAttrGPUDirectRDMAFlushWritesOptions,
                             ::cudaFlushGPUDirectRDMAWritesOptions>();
-    ::test_device_attribute<device::attributes::gpu_direct_rdma_writes_ordering,
+    ::test_device_attribute<attributes::gpu_direct_rdma_writes_ordering,
                             ::cudaDevAttrGPUDirectRDMAWritesOrdering,
                             ::cudaGPUDirectRDMAWritesOrdering>();
-    ::test_device_attribute<device::attributes::memory_pool_supported_handle_types,
+    ::test_device_attribute<attributes::memory_pool_supported_handle_types,
                             ::cudaDevAttrMemoryPoolSupportedHandleTypes,
                             ::cudaMemAllocationHandleType>();
-    ::test_device_attribute<device::attributes::deferred_mapping_cuda_array_supported,
+    ::test_device_attribute<attributes::deferred_mapping_cuda_array_supported,
                             ::cudaDevAttrDeferredMappingCudaArraySupported,
                             bool>();
-    ::test_device_attribute<device::attributes::ipc_event_support, ::cudaDevAttrIpcEventSupport, bool>();
+    ::test_device_attribute<attributes::ipc_event_support, ::cudaDevAttrIpcEventSupport, bool>();
 
 #if _CCCL_CTK_AT_LEAST(12, 2)
-    ::test_device_attribute<device::attributes::numa_config, ::cudaDevAttrNumaConfig, ::cudaDeviceNumaConfig>();
-    ::test_device_attribute<device::attributes::numa_id, ::cudaDevAttrNumaId, int>();
+    ::test_device_attribute<attributes::numa_config, ::cudaDevAttrNumaConfig, ::cudaDeviceNumaConfig>();
+    ::test_device_attribute<attributes::numa_id, ::cudaDevAttrNumaId, int>();
 #endif // _CCCL_CTK_AT_LEAST(12, 2)
 
     SECTION("compute_mode")
     {
-      STATIC_REQUIRE(::cudaComputeModeDefault == device::attributes::compute_mode.default_mode);
-      STATIC_REQUIRE(::cudaComputeModeProhibited == device::attributes::compute_mode.prohibited_mode);
-      STATIC_REQUIRE(::cudaComputeModeExclusiveProcess == device::attributes::compute_mode.exclusive_process_mode);
+      STATIC_REQUIRE(::cudaComputeModeDefault == attributes::compute_mode.default_mode);
+      STATIC_REQUIRE(::cudaComputeModeProhibited == attributes::compute_mode.prohibited_mode);
+      STATIC_REQUIRE(::cudaComputeModeExclusiveProcess == attributes::compute_mode.exclusive_process_mode);
 
-      auto mode = device_ref(0).attribute(device::attributes::compute_mode);
-      CUDAX_REQUIRE((mode == device::attributes::compute_mode.default_mode || //
-                     mode == device::attributes::compute_mode.prohibited_mode || //
-                     mode == device::attributes::compute_mode.exclusive_process_mode));
+      auto mode = device_ref(0).attribute(attributes::compute_mode);
+      CUDAX_REQUIRE((mode == attributes::compute_mode.default_mode || //
+                     mode == attributes::compute_mode.prohibited_mode || //
+                     mode == attributes::compute_mode.exclusive_process_mode));
     }
 
     SECTION("gpu_direct_rdma_flush_writes_options")
     {
+      STATIC_REQUIRE(::cudaFlushGPUDirectRDMAWritesOptionHost == attributes::gpu_direct_rdma_flush_writes_options.host);
       STATIC_REQUIRE(
-        ::cudaFlushGPUDirectRDMAWritesOptionHost == device::attributes::gpu_direct_rdma_flush_writes_options.host);
-      STATIC_REQUIRE(
-        ::cudaFlushGPUDirectRDMAWritesOptionMemOps == device::attributes::gpu_direct_rdma_flush_writes_options.mem_ops);
+        ::cudaFlushGPUDirectRDMAWritesOptionMemOps == attributes::gpu_direct_rdma_flush_writes_options.mem_ops);
 
-      [[maybe_unused]] auto options = device_ref(0).attribute(device::attributes::gpu_direct_rdma_flush_writes_options);
+      [[maybe_unused]] auto options = device_ref(0).attribute(attributes::gpu_direct_rdma_flush_writes_options);
 #if !_CCCL_COMPILER(MSVC)
-      CUDAX_REQUIRE((options == device::attributes::gpu_direct_rdma_flush_writes_options.host || //
-                     options == device::attributes::gpu_direct_rdma_flush_writes_options.mem_ops));
+      CUDAX_REQUIRE((options == attributes::gpu_direct_rdma_flush_writes_options.host || //
+                     options == attributes::gpu_direct_rdma_flush_writes_options.mem_ops));
 #endif
     }
 
     SECTION("gpu_direct_rdma_writes_ordering")
     {
-      STATIC_REQUIRE(::cudaGPUDirectRDMAWritesOrderingNone == device::attributes::gpu_direct_rdma_writes_ordering.none);
+      STATIC_REQUIRE(::cudaGPUDirectRDMAWritesOrderingNone == attributes::gpu_direct_rdma_writes_ordering.none);
+      STATIC_REQUIRE(::cudaGPUDirectRDMAWritesOrderingOwner == attributes::gpu_direct_rdma_writes_ordering.owner);
       STATIC_REQUIRE(
-        ::cudaGPUDirectRDMAWritesOrderingOwner == device::attributes::gpu_direct_rdma_writes_ordering.owner);
-      STATIC_REQUIRE(
-        ::cudaGPUDirectRDMAWritesOrderingAllDevices == device::attributes::gpu_direct_rdma_writes_ordering.all_devices);
+        ::cudaGPUDirectRDMAWritesOrderingAllDevices == attributes::gpu_direct_rdma_writes_ordering.all_devices);
 
-      auto ordering = device_ref(0).attribute(device::attributes::gpu_direct_rdma_writes_ordering);
-      CUDAX_REQUIRE((ordering == device::attributes::gpu_direct_rdma_writes_ordering.none || //
-                     ordering == device::attributes::gpu_direct_rdma_writes_ordering.owner || //
-                     ordering == device::attributes::gpu_direct_rdma_writes_ordering.all_devices));
+      auto ordering = device_ref(0).attribute(attributes::gpu_direct_rdma_writes_ordering);
+      CUDAX_REQUIRE((ordering == attributes::gpu_direct_rdma_writes_ordering.none || //
+                     ordering == attributes::gpu_direct_rdma_writes_ordering.owner || //
+                     ordering == attributes::gpu_direct_rdma_writes_ordering.all_devices));
     }
 
     SECTION("memory_pool_supported_handle_types")
     {
-      STATIC_REQUIRE(::cudaMemHandleTypeNone == device::attributes::memory_pool_supported_handle_types.none);
-      STATIC_REQUIRE(::cudaMemHandleTypePosixFileDescriptor
-                     == device::attributes::memory_pool_supported_handle_types.posix_file_descriptor);
-      STATIC_REQUIRE(::cudaMemHandleTypeWin32 == device::attributes::memory_pool_supported_handle_types.win32);
-      STATIC_REQUIRE(::cudaMemHandleTypeWin32Kmt == device::attributes::memory_pool_supported_handle_types.win32_kmt);
+      STATIC_REQUIRE(::cudaMemHandleTypeNone == attributes::memory_pool_supported_handle_types.none);
+      STATIC_REQUIRE(
+        ::cudaMemHandleTypePosixFileDescriptor == attributes::memory_pool_supported_handle_types.posix_file_descriptor);
+      STATIC_REQUIRE(::cudaMemHandleTypeWin32 == attributes::memory_pool_supported_handle_types.win32);
+      STATIC_REQUIRE(::cudaMemHandleTypeWin32Kmt == attributes::memory_pool_supported_handle_types.win32_kmt);
 #if _CCCL_CTK_AT_LEAST(12, 4)
       STATIC_REQUIRE(::cudaMemHandleTypeFabric == 0x8);
-      STATIC_REQUIRE(::cudaMemHandleTypeFabric == device::attributes::memory_pool_supported_handle_types.fabric);
+      STATIC_REQUIRE(::cudaMemHandleTypeFabric == attributes::memory_pool_supported_handle_types.fabric);
 #else // ^^^ _CCCL_CTK_AT_LEAST(12, 4) ^^^ / vvv _CCCL_CTK_BELOW(12, 4) vvv
-      STATIC_REQUIRE(0x8 == device::attributes::memory_pool_supported_handle_types.fabric);
+      STATIC_REQUIRE(0x8 == attributes::memory_pool_supported_handle_types.fabric);
 #endif // ^^^ _CCCL_CTK_BELOW(12, 4) ^^^
 
       constexpr int all_handle_types =
-        device::attributes::memory_pool_supported_handle_types.none
-        | device::attributes::memory_pool_supported_handle_types.posix_file_descriptor
-        | device::attributes::memory_pool_supported_handle_types.win32
-        | device::attributes::memory_pool_supported_handle_types.win32_kmt
-        | device::attributes::memory_pool_supported_handle_types.fabric;
-      auto handle_types = device_ref(0).attribute(device::attributes::memory_pool_supported_handle_types);
+        attributes::memory_pool_supported_handle_types.none
+        | attributes::memory_pool_supported_handle_types.posix_file_descriptor
+        | attributes::memory_pool_supported_handle_types.win32
+        | attributes::memory_pool_supported_handle_types.win32_kmt
+        | attributes::memory_pool_supported_handle_types.fabric;
+      auto handle_types = device_ref(0).attribute(attributes::memory_pool_supported_handle_types);
       CUDAX_REQUIRE(static_cast<int>(handle_types) <= static_cast<int>(all_handle_types));
     }
 
 #if _CCCL_CTK_AT_LEAST(12, 2)
     SECTION("numa_config")
     {
-      STATIC_REQUIRE(::cudaDeviceNumaConfigNone == device::attributes::numa_config.none);
-      STATIC_REQUIRE(::cudaDeviceNumaConfigNumaNode == device::attributes::numa_config.numa_node);
+      STATIC_REQUIRE(::cudaDeviceNumaConfigNone == attributes::numa_config.none);
+      STATIC_REQUIRE(::cudaDeviceNumaConfigNumaNode == attributes::numa_config.numa_node);
 
-      auto config = device_ref(0).attribute(device::attributes::numa_config);
-      CUDAX_REQUIRE((config == device::attributes::numa_config.none || //
-                     config == device::attributes::numa_config.numa_node));
+      auto config = device_ref(0).attribute(attributes::numa_config);
+      CUDAX_REQUIRE((config == attributes::numa_config.none || //
+                     config == attributes::numa_config.numa_node));
     }
 #endif // _CCCL_CTK_AT_LEAST(12, 2)
 
     SECTION("Compute capability")
     {
-      int compute_cap       = device_ref(0).attribute(device::attributes::compute_capability);
-      int compute_cap_major = device_ref(0).attribute(device::attributes::compute_capability_major);
-      int compute_cap_minor = device_ref(0).attribute(device::attributes::compute_capability_minor);
+      int compute_cap       = device_ref(0).attribute(attributes::compute_capability);
+      int compute_cap_major = device_ref(0).attribute(attributes::compute_capability_major);
+      int compute_cap_minor = device_ref(0).attribute(attributes::compute_capability_minor);
       CUDAX_REQUIRE(compute_cap == 100 * compute_cap_major + 10 * compute_cap_minor);
     }
   }
@@ -369,7 +320,7 @@ C2H_CCCLRT_TEST("global devices vector", "[device]")
 #if _CCCL_HAS_EXCEPTIONS()
   try
   {
-    [[maybe_unused]] const cudax::device& dev = cudax::devices[cudax::devices.size()];
+    [[maybe_unused]] const cudax::physical_device& dev = cudax::devices[cudax::devices.size()];
     CUDAX_REQUIRE(false); // should not get here
   }
   catch (const std::out_of_range&)

--- a/cudax/test/device/device_smoke.cu
+++ b/cudax/test/device/device_smoke.cu
@@ -21,7 +21,7 @@ template <const auto& Attr, ::cudaDeviceAttr ExpectedAttr, class ExpectedResult>
 {
   cudax::device_ref dev0(0);
   STATIC_REQUIRE(Attr == ExpectedAttr);
-  STATIC_REQUIRE(::cuda::std::is_same_v<cudax::device::attribute_result_t<Attr>, ExpectedResult>);
+  STATIC_REQUIRE(::cuda::std::is_same_v<cudax::device_attribute_result_t<Attr>, ExpectedResult>);
 
   auto result = dev0.attribute(Attr);
   STATIC_REQUIRE(::cuda::std::is_same_v<decltype(result), ExpectedResult>);
@@ -33,7 +33,7 @@ template <const auto& Attr, ::cudaDeviceAttr ExpectedAttr, class ExpectedResult>
 
 C2H_CCCLRT_TEST("Smoke", "[device]")
 {
-  using attributes = cudax::device::attributes;
+  namespace attributes = cudax::device_attributes;
   using cudax::device_ref;
 
   SECTION("Compare")


### PR DESCRIPTION
We already have multiple device-side APIs in `cuda::device::` namespace in CCCL and we can't have a type named the same way. Because of that we need to rename `cuda::experimental::device` to something else in order to make it possible to move it to `cuda::` namespace eventually. Because we already have `logical_device` I propose we name the current `device` type `physical_device`. Users should very rarely spell out the name of this type. They will usually use `device_ref` or access instances of this type in `devices` vector.

One change beyond the rename is moving `attributes` and `attribute_query_t` aliases to `cuda::device::` namespace. I think its better than to require access to the attributes as `cuda::experimental::physical_device::attributes`, `device` name works better in this case.