### PR TITLE
Fix exit code capture under `set -e`

### DIFF
--- a/.github/actions/workflow-run-job-linux/action.yml
+++ b/.github/actions/workflow-run-job-linux/action.yml
@@ -70,8 +70,8 @@ runs:
         set -euo pipefail
         echo -e "\e[1;34mRunning as '$(whoami)' user in $(pwd):\e[0m"
         echo -e "\e[1;34m${COMMAND}\e[0m"
-        eval "${COMMAND}"
-        exit_code=$?
+        exit_code=0
+        eval "${COMMAND}" || exit_code=$?
         if [[ "$exit_code" -ne 0 ]]; then
           echo -e "::group::️❗ \e[1;31mInstructions to Reproduce CI Failure Locally\e[0m"
           echo "::error:: To replicate this failure locally, follow the steps below:"


### PR DESCRIPTION
This restores the "instructions to repro locally" message.

Test failure to verify: https://github.com/NVIDIA/cccl/actions/runs/16218083329/job/45792011551?pr=5213#step:4:401