### PR TITLE
Implement `format.arguments` and `format.context` from standard formatting library

### DIFF
--- a/libcudacxx/include/cuda/std/__format/buffer.h
+++ b/libcudacxx/include/cuda/std/__format/buffer.h
@@ -1,15 +1,14 @@
 //===----------------------------------------------------------------------===//
 //
-// Part of libcu++, the C++ Standard Library for your entire system,
-// under the Apache License v2.0 with LLVM Exceptions.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _LIBCUDACXX___FWD_ITERATOR_TRAITS_H
-#define _LIBCUDACXX___FWD_ITERATOR_TRAITS_H
+#ifndef _LIBCUDACXX___FORMAT_BUFFER_H
+#define _LIBCUDACXX___FORMAT_BUFFER_H
 
 #include <cuda/std/detail/__config>
 
@@ -21,20 +20,29 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/std/__fwd/format.h>
+
 #include <cuda/std/__cccl/prologue.h>
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-#if _CCCL_HAS_CONCEPTS()
-template <class>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT iterator_traits;
-#else // ^^^ _CCCL_HAS_CONCEPTS() ^^^ / vvv !_CCCL_HAS_CONCEPTS()
-template <class, class = void>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT iterator_traits;
-#endif // ^^^ !_CCCL_HAS_CONCEPTS() ^^^
+// todo: implement __fmt_output_buffer
+
+template <class _CharT>
+class __fmt_output_buffer
+{
+public:
+  using value_type = _CharT;
+
+  _CCCL_API void push_back(_CharT __c)
+  {
+    _CCCL_ASSERT(false, "unimplemented __fmt_output_buffer push_back method called");
+    (void) __c;
+  }
+};
 
 _LIBCUDACXX_END_NAMESPACE_STD
 
 #include <cuda/std/__cccl/epilogue.h>
 
-#endif // _LIBCUDACXX___FWD_ITERATOR_TRAITS_H
+#endif // _LIBCUDACXX___FORMAT_BUFFER_H

--- a/libcudacxx/include/cuda/std/__format/concepts.h
+++ b/libcudacxx/include/cuda/std/__format/concepts.h
@@ -1,0 +1,69 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___FORMAT_CONCEPTS_H
+#define _LIBCUDACXX___FORMAT_CONCEPTS_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__concepts/concept_macros.h>
+#include <cuda/std/__concepts/same_as.h>
+#include <cuda/std/__concepts/semiregular.h>
+#include <cuda/std/__fwd/format.h>
+#include <cuda/std/__fwd/tuple.h>
+#include <cuda/std/__type_traits/remove_const.h>
+#include <cuda/std/__type_traits/remove_reference.h>
+#include <cuda/std/__utility/pair.h>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_STD
+
+/// The character type specializations of \ref formatter.
+template <class _CharT>
+_CCCL_CONCEPT __fmt_char_type = same_as<_CharT, char>
+#if _CCCL_HAS_WCHAR_T()
+                             || same_as<_CharT, wchar_t>
+#endif // _CCCL_HAS_WCHAR_T()
+  ;
+
+// The output iterator isn't specified. A formatter should accept any
+// output_iterator. This iterator is a minimal iterator to test the concept.
+// (Note testing for (w)format_context would be a valid choice, but requires
+// selecting the proper one depending on the type of _CharT.)
+template <class _CharT>
+using __fmt_iter_for _CCCL_NODEBUG_ALIAS = _CharT*;
+
+template <class _Tp, class _Context, class _Formatter>
+_CCCL_CONCEPT __formattable_with_helper = _CCCL_REQUIRES_EXPR(
+  (_Tp, _Context, _Formatter),
+  _Formatter& __f,
+  const _Formatter& __cf,
+  _Tp&& __t,
+  _Context __fc,
+  basic_format_parse_context<typename _Context::char_type> __pc)(
+  _Same_as(typename decltype(__pc)::iterator) __f.parse(__pc),
+  _Same_as(typename _Context::iterator) __cf.format(__t, __fc));
+
+template <class _Tp, class _Context, class _Formatter = typename _Context::template formatter_type<remove_const_t<_Tp>>>
+_CCCL_CONCEPT __formattable_with = semiregular<_Formatter> && __formattable_with_helper<_Tp, _Context, _Formatter>;
+
+_LIBCUDACXX_END_NAMESPACE_STD
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _LIBCUDACXX___FORMAT_CONCEPTS_H

--- a/libcudacxx/include/cuda/std/__format/format_arg.h
+++ b/libcudacxx/include/cuda/std/__format/format_arg.h
@@ -1,0 +1,282 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___FORMAT_FORMAT_ARG_H
+#define _LIBCUDACXX___FORMAT_FORMAT_ARG_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__concepts/arithmetic.h>
+#include <cuda/std/__cstddef/types.h>
+#include <cuda/std/__format/concepts.h>
+#include <cuda/std/__format/format_parse_context.h>
+#include <cuda/std/__functional/invoke.h>
+#include <cuda/std/__fwd/format.h>
+#include <cuda/std/__memory/addressof.h>
+#include <cuda/std/__type_traits/conditional.h>
+#include <cuda/std/__type_traits/remove_const.h>
+#include <cuda/std/__utility/forward.h>
+#include <cuda/std/__utility/monostate.h>
+#include <cuda/std/__utility/move.h>
+#include <cuda/std/__utility/unreachable.h>
+#include <cuda/std/cstdint>
+#include <cuda/std/string_view>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_STD
+
+enum class __fmt_arg_t : uint8_t
+{
+  __none,
+  __boolean,
+  __char_type,
+  __int,
+  __long_long,
+  __unsigned,
+  __unsigned_long_long,
+  __float,
+  __double,
+  __long_double,
+  __const_char_type_ptr,
+  __string_view,
+  __ptr,
+  __handle,
+};
+
+inline constexpr unsigned __fmt_packed_arg_t_bits = 5;
+inline constexpr uint8_t __fmt_packed_arg_t_mask  = 0x1f;
+
+inline constexpr unsigned __fmt_packed_types_storage_bits = 64;
+inline constexpr unsigned __fmt_packed_types_max          = __fmt_packed_types_storage_bits / __fmt_packed_arg_t_bits;
+
+[[nodiscard]] _CCCL_API constexpr bool __fmt_use_packed_format_arg_store(size_t __size) noexcept
+{
+  return __size <= __fmt_packed_types_max;
+}
+
+[[nodiscard]] _CCCL_API constexpr __fmt_arg_t __fmt_get_packed_type(uint64_t __types, size_t __id) noexcept
+{
+  _CCCL_ASSERT(__id <= __fmt_packed_types_max, "");
+
+  if (__id > 0)
+  {
+    __types >>= __id * __fmt_packed_arg_t_bits;
+  }
+
+  return static_cast<__fmt_arg_t>(__types & __fmt_packed_arg_t_mask);
+}
+
+/// Contains the values used in basic_format_arg.
+///
+/// This is a separate type so it's possible to store the values and types in
+/// separate arrays.
+template <class _Context>
+class __basic_format_arg_value
+{
+  using _CharT _CCCL_NODEBUG_ALIAS = typename _Context::char_type;
+
+  template <class _Tp>
+  _CCCL_API static void
+  __formatter_invoker(basic_format_parse_context<_CharT>& __parse_ctx, _Context& __ctx, const void* __ptr)
+  {
+    using _Dp = remove_const_t<_Tp>;
+    using _Qp = conditional_t<__formattable_with<const _Dp, _Context>, const _Dp, _Dp>;
+    static_assert(__formattable_with<_Qp, _Context>, "Mandated by [format.arg]/10");
+
+    using _Formatter = typename _Context::template formatter_type<_Dp>;
+    _Formatter __f;
+    __parse_ctx.advance_to(__f.parse(__parse_ctx));
+    __ctx.advance_to(__f.format(*const_cast<_Qp*>(static_cast<const _Dp*>(__ptr)), __ctx));
+  }
+
+public:
+  /// Contains the implementation for basic_format_arg::handle.
+  struct __handle
+  {
+    template <class _Tp>
+    _CCCL_API explicit __handle(_Tp& __v) noexcept
+        : __ptr_(_CUDA_VSTD::addressof(__v))
+        , __format_(__formatter_invoker<_Tp>)
+    {}
+
+    const void* __ptr_;
+    void (*__format_)(basic_format_parse_context<_CharT>&, _Context&, const void*);
+  };
+
+  union
+  {
+    monostate __monostate_;
+    bool __boolean_;
+    _CharT __char_type_;
+    int __int_;
+    unsigned __unsigned_;
+    long long __long_long_;
+    unsigned long long __unsigned_long_long_;
+    float __float_;
+    double __double_;
+    long double __long_double_;
+    const _CharT* __const_char_type_ptr_;
+    basic_string_view<_CharT> __string_view_;
+    const void* __ptr_;
+    __handle __handle_;
+  };
+
+  _CCCL_API __basic_format_arg_value() noexcept
+      : __monostate_()
+  {}
+  _CCCL_API __basic_format_arg_value(bool __value) noexcept
+      : __boolean_(__value)
+  {}
+  _CCCL_API __basic_format_arg_value(_CharT __value) noexcept
+      : __char_type_(__value)
+  {}
+  _CCCL_API __basic_format_arg_value(int __value) noexcept
+      : __int_(__value)
+  {}
+  _CCCL_API __basic_format_arg_value(unsigned __value) noexcept
+      : __unsigned_(__value)
+  {}
+  _CCCL_API __basic_format_arg_value(long long __value) noexcept
+      : __long_long_(__value)
+  {}
+  _CCCL_API __basic_format_arg_value(unsigned long long __value) noexcept
+      : __unsigned_long_long_(__value)
+  {}
+  _CCCL_API __basic_format_arg_value(float __value) noexcept
+      : __float_(__value)
+  {}
+  _CCCL_API __basic_format_arg_value(double __value) noexcept
+      : __double_(__value)
+  {}
+  _CCCL_API __basic_format_arg_value(long double __value) noexcept
+      : __long_double_(__value)
+  {}
+  _CCCL_API __basic_format_arg_value(const _CharT* __value) noexcept
+      : __const_char_type_ptr_(__value)
+  {}
+  _CCCL_API __basic_format_arg_value(basic_string_view<_CharT> __value) noexcept
+      : __string_view_(__value)
+  {}
+  _CCCL_API __basic_format_arg_value(const void* __value) noexcept
+      : __ptr_(__value)
+  {}
+  _CCCL_API __basic_format_arg_value(__handle&& __value) noexcept
+      : __handle_(_CUDA_VSTD::move(__value))
+  {}
+};
+
+template <class _Context>
+class _CCCL_NO_SPECIALIZATIONS _CCCL_TYPE_VISIBILITY_DEFAULT basic_format_arg
+{
+public:
+  class handle;
+
+  _CCCL_API basic_format_arg() noexcept
+      : __type_{__fmt_arg_t::__none}
+  {}
+
+  _CCCL_API explicit operator bool() const noexcept
+  {
+    return __type_ != __fmt_arg_t::__none;
+  }
+
+private:
+  using char_type = typename _Context::char_type;
+
+  // TODO FMT Implement constrain [format.arg]/4
+  // Constraints: The template specialization
+  //   typename Context::template formatter_type<T>
+  // meets the Formatter requirements ([formatter.requirements]).  The extent
+  // to which an implementation determines that the specialization meets the
+  // Formatter requirements is unspecified, except that as a minimum the
+  // expression
+  //   typename Context::template formatter_type<T>()
+  //    .format(declval<const T&>(), declval<Context&>())
+  // shall be well-formed when treated as an unevaluated operand.
+
+public:
+  __basic_format_arg_value<_Context> __value_;
+  __fmt_arg_t __type_;
+
+  _CCCL_API explicit basic_format_arg(__fmt_arg_t __type, __basic_format_arg_value<_Context> __value) noexcept
+      : __value_(__value)
+      , __type_(__type)
+  {}
+};
+
+template <class _Context>
+class _CCCL_TYPE_VISIBILITY_DEFAULT basic_format_arg<_Context>::handle
+{
+public:
+  _CCCL_API void format(basic_format_parse_context<char_type>& __parse_ctx, _Context& __ctx) const
+  {
+    __handle_.__format_(__parse_ctx, __ctx, __handle_.__ptr_);
+  }
+
+  _CCCL_API explicit handle(typename __basic_format_arg_value<_Context>::__handle& __handle) noexcept
+      : __handle_(__handle)
+  {}
+
+private:
+  typename __basic_format_arg_value<_Context>::__handle& __handle_;
+};
+
+template <class _Visitor, class _Context>
+_CCCL_API decltype(auto) visit_format_arg(_Visitor&& __vis, basic_format_arg<_Context> __arg)
+{
+  switch (__arg.__type_)
+  {
+    case __fmt_arg_t::__none:
+      return _CUDA_VSTD::invoke(_CUDA_VSTD::forward<_Visitor>(__vis), __arg.__value_.__monostate_);
+    case __fmt_arg_t::__boolean:
+      return _CUDA_VSTD::invoke(_CUDA_VSTD::forward<_Visitor>(__vis), __arg.__value_.__boolean_);
+    case __fmt_arg_t::__char_type:
+      return _CUDA_VSTD::invoke(_CUDA_VSTD::forward<_Visitor>(__vis), __arg.__value_.__char_type_);
+    case __fmt_arg_t::__int:
+      return _CUDA_VSTD::invoke(_CUDA_VSTD::forward<_Visitor>(__vis), __arg.__value_.__int_);
+    case __fmt_arg_t::__long_long:
+      return _CUDA_VSTD::invoke(_CUDA_VSTD::forward<_Visitor>(__vis), __arg.__value_.__long_long_);
+    case __fmt_arg_t::__unsigned:
+      return _CUDA_VSTD::invoke(_CUDA_VSTD::forward<_Visitor>(__vis), __arg.__value_.__unsigned_);
+    case __fmt_arg_t::__unsigned_long_long:
+      return _CUDA_VSTD::invoke(_CUDA_VSTD::forward<_Visitor>(__vis), __arg.__value_.__unsigned_long_long_);
+    case __fmt_arg_t::__float:
+      return _CUDA_VSTD::invoke(_CUDA_VSTD::forward<_Visitor>(__vis), __arg.__value_.__float_);
+    case __fmt_arg_t::__double:
+      return _CUDA_VSTD::invoke(_CUDA_VSTD::forward<_Visitor>(__vis), __arg.__value_.__double_);
+    case __fmt_arg_t::__long_double:
+      return _CUDA_VSTD::invoke(_CUDA_VSTD::forward<_Visitor>(__vis), __arg.__value_.__long_double_);
+    case __fmt_arg_t::__const_char_type_ptr:
+      return _CUDA_VSTD::invoke(_CUDA_VSTD::forward<_Visitor>(__vis), __arg.__value_.__const_char_type_ptr_);
+    case __fmt_arg_t::__string_view:
+      return _CUDA_VSTD::invoke(_CUDA_VSTD::forward<_Visitor>(__vis), __arg.__value_.__string_view_);
+    case __fmt_arg_t::__ptr:
+      return _CUDA_VSTD::invoke(_CUDA_VSTD::forward<_Visitor>(__vis), __arg.__value_.__ptr_);
+    case __fmt_arg_t::__handle:
+      return _CUDA_VSTD::invoke(_CUDA_VSTD::forward<_Visitor>(__vis),
+                                typename basic_format_arg<_Context>::handle{__arg.__value_.__handle_});
+    default:
+      _CCCL_UNREACHABLE();
+  }
+}
+
+_LIBCUDACXX_END_NAMESPACE_STD
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _LIBCUDACXX___FORMAT_FORMAT_ARG_H

--- a/libcudacxx/include/cuda/std/__format/format_arg_store.h
+++ b/libcudacxx/include/cuda/std/__format/format_arg_store.h
@@ -1,0 +1,279 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___FORMAT_FORMAT_ARG_STORE_H
+#define _LIBCUDACXX___FORMAT_FORMAT_ARG_STORE_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__concepts/concept_macros.h>
+#include <cuda/std/__concepts/same_as.h>
+#include <cuda/std/__cstddef/types.h>
+#include <cuda/std/__format/concepts.h>
+#include <cuda/std/__format/format_arg.h>
+#include <cuda/std/__string/char_traits.h>
+#include <cuda/std/__type_traits/conditional.h>
+#include <cuda/std/__type_traits/extent.h>
+#include <cuda/std/__type_traits/is_integer.h>
+#include <cuda/std/__type_traits/is_signed.h>
+#include <cuda/std/__type_traits/remove_const.h>
+#include <cuda/std/cstdint>
+#include <cuda/std/string_view>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_STD
+
+template <class _Arr, class _Elem>
+inline constexpr bool __is_bounded_array_of = false;
+
+template <class _Elem, size_t _Len>
+inline constexpr bool __is_bounded_array_of<_Elem[_Len], _Elem> = true;
+
+template <class _Context, class _Tp>
+[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL __fmt_arg_t __fmt_determine_arg_t()
+{
+  using _CtxCharT = typename _Context::char_type;
+
+  __fmt_arg_t __ret = __fmt_arg_t::__none;
+
+  if constexpr (is_same_v<_Tp, bool>)
+  {
+    __ret = __fmt_arg_t::__boolean;
+  }
+  else if constexpr (is_same_v<_Tp, _CtxCharT>)
+  {
+    __ret = __fmt_arg_t::__char_type;
+  }
+#if _CCCL_HAS_WCHAR_T()
+  else if (is_same_v<wchar_t, _CtxCharT> && is_same_v<_Tp, char>)
+  {
+    __ret = __fmt_arg_t::__char_type;
+  }
+#endif // _CCCL_HAS_WCHAR_T()
+  else if constexpr (__cccl_is_integer_v<_Tp>)
+  {
+    if constexpr (sizeof(_Tp) <= sizeof(int))
+    {
+      __ret = (is_signed_v<_Tp>) ? __fmt_arg_t::__int : __fmt_arg_t::__unsigned;
+    }
+    else if constexpr (sizeof(_Tp) <= sizeof(long long))
+    {
+      __ret = (is_signed_v<_Tp>) ? __fmt_arg_t::__long_long : __fmt_arg_t::__unsigned_long_long;
+    }
+    else
+    {
+      // Extended integer types are handled as handles
+      __ret = __fmt_arg_t::__handle;
+    }
+  }
+  else if constexpr (is_same_v<_Tp, float>)
+  {
+    __ret = __fmt_arg_t::__float;
+  }
+  else if constexpr (is_same_v<_Tp, double>)
+  {
+    __ret = __fmt_arg_t::__double;
+  }
+#if _CCCL_HAS_LONG_DOUBLE()
+  else if constexpr (is_same_v<_Tp, long double>)
+  {
+    __ret = __fmt_arg_t::__long_double;
+  }
+#endif // _CCCL_HAS_LONG_DOUBLE()
+  else if constexpr (is_same_v<_Tp, _CtxCharT*> || is_same_v<_Tp, const _CtxCharT*>)
+  {
+    __ret = __fmt_arg_t::__const_char_type_ptr;
+  }
+  // todo: add std::string and std::string_view support
+  // - add `|| __cccl_is_std_string_view_v<_Tp> || __cccl_is_std_string_v<_Tp>` to the condition
+  else if constexpr (__cccl_is_string_view_v<_Tp>)
+  {
+    __ret = (is_same_v<_CtxCharT, typename _Tp::value_type>) ? __fmt_arg_t::__string_view : __ret;
+  }
+  else if constexpr (__is_bounded_array_of<_Tp, _CtxCharT>)
+  {
+    __ret = __fmt_arg_t::__string_view;
+  }
+  else if constexpr (is_same_v<_Tp, void*> || is_same_v<_Tp, const void*> || is_same_v<_Tp, nullptr_t>)
+  {
+    __ret = __fmt_arg_t::__ptr;
+  }
+
+  if constexpr (__formattable_with<_Tp, _Context>)
+  {
+    __ret = (__ret == __fmt_arg_t::__none) ? __fmt_arg_t::__handle : __ret;
+  }
+
+  return __ret;
+}
+
+template <class _Context, class _Tp>
+[[nodiscard]] _CCCL_API basic_format_arg<_Context> __fmt_make_format_arg(_Tp& __value) noexcept
+{
+  using _Dp                   = remove_const_t<_Tp>;
+  constexpr __fmt_arg_t __arg = __fmt_determine_arg_t<_Context, _Dp>();
+
+  static_assert(__arg != __fmt_arg_t::__none, "the supplied type is not formattable");
+  static_assert(__formattable_with<_Tp, _Context>);
+
+  using _CtxCharT = typename _Context::char_type;
+  // Not all types can be used to directly initialize the
+  // __basic_format_arg_value.  First handle all types needing adjustment, the
+  // final else requires no adjustment.
+  if constexpr (__arg == __fmt_arg_t::__char_type)
+  {
+#if _CCCL_HAS_WCHAR_T()
+    if constexpr (is_same_v<wchar_t, _CtxCharT> && is_same_v<_Dp, char>)
+    {
+      return basic_format_arg<_Context>{__arg, static_cast<wchar_t>(static_cast<unsigned char>(__value))};
+    }
+    else
+#endif // _CCCL_HAS_WCHAR_T()
+    {
+      return basic_format_arg<_Context>{__arg, __value};
+    }
+  }
+  else if constexpr (__arg == __fmt_arg_t::__int)
+  {
+    return basic_format_arg<_Context>{__arg, static_cast<int>(__value)};
+  }
+  else if constexpr (__arg == __fmt_arg_t::__long_long)
+  {
+    return basic_format_arg<_Context>{__arg, static_cast<long long>(__value)};
+  }
+  else if constexpr (__arg == __fmt_arg_t::__unsigned)
+  {
+    return basic_format_arg<_Context>{__arg, static_cast<unsigned>(__value)};
+  }
+  else if constexpr (__arg == __fmt_arg_t::__unsigned_long_long)
+  {
+    return basic_format_arg<_Context>{__arg, static_cast<unsigned long long>(__value)};
+  }
+  else if constexpr (__arg == __fmt_arg_t::__string_view)
+  {
+    // Using std::size on a character array will add the NUL-terminator to the size.
+    if constexpr (__is_bounded_array_of<_Dp, _CtxCharT>)
+    {
+      const _CtxCharT* const __pbegin = begin(__value);
+      const _CtxCharT* const __pzero  = char_traits<_CtxCharT>::find(__pbegin, extent_v<_Dp>, _CtxCharT{});
+      _CCCL_ASSERT(__pzero != nullptr, "formatting a non-null-terminated array");
+      return basic_format_arg<_Context>{
+        __arg, basic_string_view<_CtxCharT>{__pbegin, static_cast<size_t>(__pzero - __pbegin)}};
+    }
+    else
+    {
+      // When the _Traits or _Allocator are different an implicit conversion will fail.
+      return basic_format_arg<_Context>{__arg, basic_string_view<_CtxCharT>{__value.data(), __value.size()}};
+    }
+  }
+  else if constexpr (__arg == __fmt_arg_t::__ptr)
+  {
+    return basic_format_arg<_Context>{__arg, static_cast<const void*>(__value)};
+  }
+  else if constexpr (__arg == __fmt_arg_t::__handle)
+  {
+    return basic_format_arg<_Context>{__arg, typename __basic_format_arg_value<_Context>::__handle{__value}};
+  }
+  else
+  {
+    return basic_format_arg<_Context>{__arg, __value};
+  }
+}
+
+template <class _Context, class _Tp>
+_CCCL_API void __fmt_make_packed_storage_impl(
+  uint64_t& __types, __basic_format_arg_value<_Context>*& __values, int& __shift, _Tp& __v) noexcept
+{
+  basic_format_arg<_Context> __arg = _CUDA_VSTD::__fmt_make_format_arg<_Context>(__v);
+  if (__shift != 0)
+  {
+    __types |= static_cast<uint64_t>(__arg.__type_) << __shift;
+  }
+  else
+  {
+    // Assigns the initial value.
+    __types = static_cast<uint64_t>(__arg.__type_);
+  }
+  __shift += __fmt_packed_arg_t_bits;
+  *__values++ = __arg.__value_;
+}
+
+template <class _Context, class... _Args>
+_CCCL_API void
+__fmt_make_packed_storage(uint64_t& __types, __basic_format_arg_value<_Context>* __values, _Args&... __args) noexcept
+{
+  int __shift = 0;
+  (_CUDA_VSTD::__fmt_make_packed_storage_impl(__types, __values, __shift, __args), ...);
+}
+
+template <class _Context, class... _Args>
+_CCCL_API void __fmt_store_basic_format_arg(basic_format_arg<_Context>* __data, _Args&... __args) noexcept
+{
+  ((*__data++ = _CUDA_VSTD::__fmt_make_format_arg<_Context>(__args)), ...);
+}
+
+template <class _Context, size_t _Np>
+struct __packed_format_arg_store
+{
+  __basic_format_arg_value<_Context> __values_[_Np];
+  uint64_t __types_ = 0;
+};
+
+template <class _Context>
+struct __packed_format_arg_store<_Context, 0>
+{
+  uint64_t __types_ = 0;
+};
+
+template <class _Context, size_t _Np>
+struct __unpacked_format_arg_store
+{
+  basic_format_arg<_Context> __args_[_Np];
+};
+
+template <class _Context, class... _Args>
+struct __format_arg_store
+{
+  _CCCL_API __format_arg_store(_Args&... __args) noexcept
+  {
+    if constexpr (sizeof...(_Args) != 0)
+    {
+      if constexpr (_CUDA_VSTD::__fmt_use_packed_format_arg_store(sizeof...(_Args)))
+      {
+        _CUDA_VSTD::__fmt_make_packed_storage(__storage.__types_, __storage.__values_, __args...);
+      }
+      else
+      {
+        _CUDA_VSTD::__fmt_store_basic_format_arg(__storage.__args_, __args...);
+      }
+    }
+  }
+
+  using _Storage _CCCL_NODEBUG_ALIAS =
+    conditional_t<_CUDA_VSTD::__fmt_use_packed_format_arg_store(sizeof...(_Args)),
+                  __packed_format_arg_store<_Context, sizeof...(_Args)>,
+                  __unpacked_format_arg_store<_Context, sizeof...(_Args)>>;
+
+  _Storage __storage;
+};
+
+_LIBCUDACXX_END_NAMESPACE_STD
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _LIBCUDACXX___FORMAT_FORMAT_ARG_STORE_H

--- a/libcudacxx/include/cuda/std/__format/format_args.h
+++ b/libcudacxx/include/cuda/std/__format/format_args.h
@@ -99,7 +99,7 @@ private:
 };
 
 template <class _Context, class... _Args>
-basic_format_args(__format_arg_store<_Context, _Args...>) -> basic_format_args<_Context>;
+_CCCL_HOST_DEVICE basic_format_args(__format_arg_store<_Context, _Args...>) -> basic_format_args<_Context>;
 
 template <class _Context = format_context, class... _Args>
 [[nodiscard]] _CCCL_API __format_arg_store<_Context, _Args...> make_format_args(_Args&... __args)

--- a/libcudacxx/include/cuda/std/__format/format_args.h
+++ b/libcudacxx/include/cuda/std/__format/format_args.h
@@ -1,0 +1,122 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___FORMAT_FORMAT_ARGS_H
+#define _LIBCUDACXX___FORMAT_FORMAT_ARGS_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__cstddef/types.h>
+#include <cuda/std/__format/format_arg.h>
+#include <cuda/std/__format/format_arg_store.h>
+#include <cuda/std/__fwd/format.h>
+#include <cuda/std/cstdint>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_STD
+
+template <class _Context>
+class _CCCL_TYPE_VISIBILITY_DEFAULT basic_format_args
+{
+public:
+  template <class... _Args>
+  _CCCL_API basic_format_args(const __format_arg_store<_Context, _Args...>& __store) noexcept
+      : __size_(sizeof...(_Args))
+  {
+    if constexpr (sizeof...(_Args) != 0)
+    {
+      if constexpr (_CUDA_VSTD::__fmt_use_packed_format_arg_store(sizeof...(_Args)))
+      {
+        __packed_.__values = __store.__storage.__values_;
+        __packed_.__types  = __store.__storage.__types_;
+      }
+      else
+      {
+        __unpacked_.__args = __store.__storage.__args_;
+      }
+    }
+  }
+
+  [[nodiscard]] _CCCL_API basic_format_arg<_Context> get(size_t __id) const noexcept
+  {
+    if (__id >= __size_)
+    {
+      return basic_format_arg<_Context>{};
+    }
+
+    if (_CUDA_VSTD::__fmt_use_packed_format_arg_store(__size_))
+    {
+      return basic_format_arg<_Context>{
+        _CUDA_VSTD::__fmt_get_packed_type(__packed_.__types, __id), __packed_.__values[__id]};
+    }
+
+    return __unpacked_.__args[__id];
+  }
+
+  [[nodiscard]] _CCCL_API size_t __size() const noexcept
+  {
+    return __size_;
+  }
+
+private:
+  size_t __size_{0};
+  // [format.args]/5
+  // [Note 1: Implementations are encouraged to optimize the representation of
+  // basic_format_args for small number of formatting arguments by storing
+  // indices of type alternatives separately from values and packing the
+  // former. - end note]
+
+  struct _Packed
+  {
+    const __basic_format_arg_value<_Context>* __values;
+    uint64_t __types;
+  };
+  struct _Unpacked
+  {
+    const basic_format_arg<_Context>* __args;
+  };
+
+  union
+  {
+    _Packed __packed_;
+    _Unpacked __unpacked_;
+  };
+};
+
+template <class _Context, class... _Args>
+basic_format_args(__format_arg_store<_Context, _Args...>) -> basic_format_args<_Context>;
+
+template <class _Context = format_context, class... _Args>
+[[nodiscard]] _CCCL_API __format_arg_store<_Context, _Args...> make_format_args(_Args&... __args)
+{
+  return __format_arg_store<_Context, _Args...>(__args...);
+}
+
+#if _CCCL_HAS_WCHAR_T()
+template <class... _Args>
+[[nodiscard]] _CCCL_API __format_arg_store<wformat_context, _Args...> make_wformat_args(_Args&... __args)
+{
+  return __format_arg_store<wformat_context, _Args...>(__args...);
+}
+#endif // _CCCL_HAS_WCHAR_T()
+
+_LIBCUDACXX_END_NAMESPACE_STD
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _LIBCUDACXX___FORMAT_FORMAT_ARGS_H

--- a/libcudacxx/include/cuda/std/__format/format_context.h
+++ b/libcudacxx/include/cuda/std/__format/format_context.h
@@ -1,0 +1,92 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___FORMAT_FORMAT_CONTEXT_H
+#define _LIBCUDACXX___FORMAT_FORMAT_CONTEXT_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__cstddef/types.h>
+#include <cuda/std/__format/buffer.h>
+#include <cuda/std/__format/formatter.h>
+#include <cuda/std/__fwd/format.h>
+#include <cuda/std/__iterator/back_insert_iterator.h>
+#include <cuda/std/__iterator/concepts.h>
+#include <cuda/std/__utility/move.h>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_STD
+
+// Since CCCL doesn't support localization, we don't implement the locale() method
+template <class _OutIt, class _CharT>
+class _CCCL_TYPE_VISIBILITY_DEFAULT basic_format_context
+{
+  static_assert(output_iterator<_OutIt, const _CharT&>, "_OutIt must be an output iterator for const _CharT&");
+
+public:
+  using iterator  = _OutIt;
+  using char_type = _CharT;
+  template <class _Tp>
+  using formatter_type = formatter<_Tp, _CharT>;
+
+  basic_format_context(const basic_format_context&)            = delete;
+  basic_format_context(basic_format_context&&)                 = delete;
+  basic_format_context& operator=(const basic_format_context&) = delete;
+  basic_format_context& operator=(basic_format_context&&)      = delete;
+
+  [[nodiscard]] _CCCL_API basic_format_arg<basic_format_context> arg(size_t __id) const noexcept
+  {
+    return __args_.get(__id);
+  }
+  [[nodiscard]] _CCCL_API iterator out()
+  {
+    return _CUDA_VSTD::move(__out_it_);
+  }
+  _CCCL_API void advance_to(iterator __it)
+  {
+    __out_it_ = _CUDA_VSTD::move(__it);
+  }
+
+  template <class _OtherOutIt, class _OtherCharT>
+  _CCCL_API friend basic_format_context<_OtherOutIt, _OtherCharT>
+    __fmt_make_format_context(_OtherOutIt, basic_format_args<basic_format_context<_OtherOutIt, _OtherCharT>>);
+
+private:
+  _CCCL_API explicit basic_format_context(_OutIt __out_it, basic_format_args<basic_format_context> __args)
+      : __out_it_(_CUDA_VSTD::move(__out_it))
+      , __args_(__args)
+  {}
+
+  iterator __out_it_;
+  basic_format_args<basic_format_context> __args_;
+};
+
+_LIBCUDACXX_CTAD_SUPPORTED_FOR_TYPE(basic_format_context);
+
+template <class _OutIt, class _CharT>
+[[nodiscard]] _CCCL_API basic_format_context<_OutIt, _CharT>
+__fmt_make_format_context(_OutIt __out_it, basic_format_args<basic_format_context<_OutIt, _CharT>> __args)
+{
+  return basic_format_context{_CUDA_VSTD::move(__out_it), __args};
+}
+
+_LIBCUDACXX_END_NAMESPACE_STD
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _LIBCUDACXX___FORMAT_FORMAT_CONTEXT_H

--- a/libcudacxx/include/cuda/std/__format/format_parse_context.h
+++ b/libcudacxx/include/cuda/std/__format/format_parse_context.h
@@ -22,6 +22,7 @@
 
 #include <cuda/std/__cstddef/types.h>
 #include <cuda/std/__format/format_error.h>
+#include <cuda/std/__fwd/format.h>
 #include <cuda/std/__type_traits/is_constant_evaluated.h>
 #include <cuda/std/string_view>
 
@@ -30,7 +31,7 @@
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 template <class _CharT>
-class basic_format_parse_context
+class _CCCL_TYPE_VISIBILITY_DEFAULT basic_format_parse_context
 {
 public:
   using char_type      = _CharT;
@@ -115,11 +116,6 @@ private:
 };
 
 _LIBCUDACXX_CTAD_SUPPORTED_FOR_TYPE(basic_format_parse_context);
-
-using format_parse_context = basic_format_parse_context<char>;
-#if _CCCL_HAS_WCHAR_T()
-using wformat_parse_context = basic_format_parse_context<wchar_t>;
-#endif // _CCCL_HAS_WCHAR_T()
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__format/formatter.h
+++ b/libcudacxx/include/cuda/std/__format/formatter.h
@@ -1,0 +1,250 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___FORMAT_FORMATTER_H
+#define _LIBCUDACXX___FORMAT_FORMATTER_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__cstddef/types.h>
+#include <cuda/std/string_view>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_STD
+
+struct __disabled_formatter
+{
+  __disabled_formatter()                                       = delete;
+  __disabled_formatter(const __disabled_formatter&)            = delete;
+  __disabled_formatter(__disabled_formatter&&)                 = delete;
+  __disabled_formatter& operator=(const __disabled_formatter&) = delete;
+  __disabled_formatter& operator=(__disabled_formatter&&)      = delete;
+};
+
+template <class _Tp>
+struct __dummy_formatter
+{
+  template <class _ParseContext>
+  _CCCL_API constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx)
+  {
+    _CCCL_ASSERT(false, "unimplemented formatter parse method called");
+    return __ctx.begin();
+  }
+
+  template <class _FormatContext>
+  _CCCL_API typename _FormatContext::iterator format(const _Tp& __value, _FormatContext& __ctx) const
+  {
+    _CCCL_ASSERT(false, "unimplemented formatter format method called");
+    (void) __value;
+    return __ctx.out();
+  }
+};
+
+/// The default formatter template.
+///
+/// [format.formatter.spec]/5
+/// If F is a disabled specialization of formatter, these values are false:
+/// - is_default_constructible_v<F>,
+/// - is_copy_constructible_v<F>,
+/// - is_move_constructible_v<F>,
+/// - is_copy_assignable_v<F>, and
+/// - is_move_assignable_v<F>.
+template <class _Tp, class _CharT = char>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter : __disabled_formatter
+{};
+
+// todo: implement the formatters
+template <>
+struct formatter<bool, char> : __dummy_formatter<bool>
+{};
+template <>
+struct formatter<char, char> : __dummy_formatter<char>
+{};
+template <>
+struct formatter<float, char> : __dummy_formatter<float>
+{};
+template <>
+struct formatter<double, char> : __dummy_formatter<double>
+{};
+#if _CCCL_HAS_LONG_DOUBLE()
+template <>
+struct formatter<long double, char> : __dummy_formatter<long double>
+{};
+#endif // _CCCL_HAS_LONG_DOUBLE()
+template <>
+struct formatter<signed char, char> : __dummy_formatter<signed char>
+{};
+template <>
+struct formatter<short, char> : __dummy_formatter<short>
+{};
+template <>
+struct formatter<int, char> : __dummy_formatter<int>
+{};
+template <>
+struct formatter<long, char> : __dummy_formatter<long>
+{};
+template <>
+struct formatter<long long, char> : __dummy_formatter<long long>
+{};
+#if _CCCL_HAS_INT128()
+template <>
+struct formatter<__int128_t, char> : __dummy_formatter<__int128_t>
+{};
+#endif // _CCCL_HAS_INT128()
+template <>
+struct formatter<unsigned char, char> : __dummy_formatter<unsigned char>
+{};
+template <>
+struct formatter<unsigned short, char> : __dummy_formatter<unsigned short>
+{};
+template <>
+struct formatter<unsigned, char> : __dummy_formatter<unsigned>
+{};
+template <>
+struct formatter<unsigned long, char> : __dummy_formatter<unsigned long>
+{};
+template <>
+struct formatter<unsigned long long, char> : __dummy_formatter<unsigned long long>
+{};
+#if _CCCL_HAS_INT128()
+template <>
+struct formatter<__uint128_t, char> : __dummy_formatter<__uint128_t>
+{};
+#endif // _CCCL_HAS_INT128()
+template <>
+struct formatter<nullptr_t, char> : __dummy_formatter<nullptr_t>
+{};
+template <>
+struct formatter<void*, char> : __dummy_formatter<void*>
+{};
+template <>
+struct formatter<const void*, char> : __dummy_formatter<const void*>
+{};
+template <>
+struct formatter<const char*, char> : __dummy_formatter<const char*>
+{};
+template <>
+struct formatter<char*, char> : __dummy_formatter<char*>
+{};
+template <size_t _Size>
+struct formatter<char[_Size], char> : __dummy_formatter<char[_Size]>
+{};
+template <class _Traits>
+struct formatter<basic_string_view<char, _Traits>, char> : __dummy_formatter<basic_string_view<char, _Traits>>
+{};
+
+#if _CCCL_HAS_WCHAR_T()
+template <>
+struct formatter<bool, wchar_t> : __dummy_formatter<bool>
+{};
+template <>
+struct formatter<char, wchar_t> : __dummy_formatter<wchar_t>
+{};
+template <>
+struct formatter<wchar_t, wchar_t> : __dummy_formatter<wchar_t>
+{};
+struct formatter<float, wchar_t> : __dummy_formatter<float>
+{};
+template <>
+struct formatter<double, wchar_t> : __dummy_formatter<double>
+{};
+#  if _CCCL_HAS_LONG_DOUBLE()
+template <>
+struct formatter<long double, wchar_t> : __dummy_formatter<long double>
+{};
+#  endif // _CCCL_HAS_LONG_DOUBLE()
+template <>
+struct formatter<signed char, wchar_t> : __dummy_formatter<signed char>
+{};
+template <>
+struct formatter<short, wchar_t> : __dummy_formatter<short>
+{};
+template <>
+struct formatter<int, wchar_t> : __dummy_formatter<int>
+{};
+template <>
+struct formatter<long, wchar_t> : __dummy_formatter<long>
+{};
+template <>
+struct formatter<long long, wchar_t> : __dummy_formatter<long long>
+{};
+#  if _CCCL_HAS_INT128()
+template <>
+struct formatter<__int128_t, wchar_t> : __dummy_formatter<__int128_t>
+{};
+#  endif // _CCCL_HAS_INT128()
+template <>
+struct formatter<unsigned char, wchar_t> : __dummy_formatter<unsigned char>
+{};
+template <>
+struct formatter<unsigned short, wchar_t> : __dummy_formatter<unsigned short>
+{};
+template <>
+struct formatter<unsigned, wchar_t> : __dummy_formatter<unsigned>
+{};
+template <>
+struct formatter<unsigned long, wchar_t> : __dummy_formatter<unsigned long>
+{};
+template <>
+struct formatter<unsigned long long, wchar_t> : __dummy_formatter<unsigned long long>
+{};
+#  if _CCCL_HAS_INT128()
+template <>
+struct formatter<__uint128_t, wchar_t> : __dummy_formatter<__uint128_t>
+{};
+#  endif // _CCCL_HAS_INT128()
+template <>
+struct formatter<nullptr_t, wchar_t> : __dummy_formatter<nullptr_t>
+{};
+template <>
+struct formatter<void*, wchar_t> : __dummy_formatter<void*>
+{};
+template <>
+struct formatter<const void*, wchar_t> : __dummy_formatter<const void*>
+{};
+template <>
+struct formatter<const wchar_t*, wchar_t> : __dummy_formatter<const wchar_t*>
+{};
+template <>
+struct formatter<wchar_t*, wchar_t> : __dummy_formatter<wchar_t*>
+{};
+template <size_t _Size>
+struct formatter<wchar_t[_Size], wchar_t> : __dummy_formatter<wchar_t[_Size]>
+{};
+template <class _Traits>
+struct formatter<basic_string_view<wchar_t, _Traits>, wchar_t> : __dummy_formatter<basic_string_view<wchar_t, _Traits>>
+{};
+template <>
+struct formatter<char*, wchar_t> : __disabled_formatter
+{};
+template <>
+struct formatter<const char*, wchar_t> : __disabled_formatter
+{};
+template <size_t _Size>
+struct formatter<char[_Size], wchar_t> : __disabled_formatter
+{};
+template <class _Traits>
+struct formatter<basic_string_view<char, _Traits>, wchar_t> : __disabled_formatter
+{};
+#endif // _CCCL_HAS_WCHAR_T()
+
+_LIBCUDACXX_END_NAMESPACE_STD
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _LIBCUDACXX___FORMAT_FORMATTER_H

--- a/libcudacxx/include/cuda/std/__fwd/format.h
+++ b/libcudacxx/include/cuda/std/__fwd/format.h
@@ -1,0 +1,84 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___FWD_FORMAT_H
+#define _LIBCUDACXX___FWD_FORMAT_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__fwd/iterator.h>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_STD
+
+template <class _CharT>
+class _CCCL_TYPE_VISIBILITY_DEFAULT basic_format_parse_context;
+
+using format_parse_context = basic_format_parse_context<char>;
+#if _CCCL_HAS_WCHAR_T()
+using wformat_parse_context = basic_format_parse_context<wchar_t>;
+#endif // _CCCL_HAS_WCHAR_T()
+
+template <class _CharT>
+class _CCCL_TYPE_VISIBILITY_DEFAULT _CCCL_PREFERRED_NAME(format_parse_context)
+#if _CCCL_HAS_WCHAR_T()
+  _CCCL_PREFERRED_NAME(wformat_parse_context)
+#endif // _CCCL_HAS_WCHAR_T()
+    basic_format_parse_context;
+
+template <class _CharT>
+class __fmt_output_buffer;
+
+template <class _Context>
+class _CCCL_TYPE_VISIBILITY_DEFAULT basic_format_arg;
+
+template <class _OutIt, class _CharT>
+class _CCCL_TYPE_VISIBILITY_DEFAULT basic_format_context;
+
+using format_context = basic_format_context<__back_insert_iterator<__fmt_output_buffer<char>>, char>;
+#if _CCCL_HAS_WCHAR_T()
+using wformat_context = basic_format_context<__back_insert_iterator<__fmt_output_buffer<wchar_t>>, wchar_t>;
+#endif // _CCCL_HAS_WCHAR_T()
+
+template <class _OutIt, class _CharT>
+class _CCCL_TYPE_VISIBILITY_DEFAULT _CCCL_PREFERRED_NAME(format_context)
+#if _CCCL_HAS_WCHAR_T()
+  _CCCL_PREFERRED_NAME(wformat_context)
+#endif // _CCCL_HAS_WCHAR_T()
+    basic_format_context;
+
+template <class _Context>
+class _CCCL_TYPE_VISIBILITY_DEFAULT basic_format_args;
+
+using format_args = basic_format_args<format_context>;
+#if _CCCL_HAS_WCHAR_T()
+using wformat_args = basic_format_args<wformat_context>;
+#endif // _CCCL_HAS_WCHAR_T()
+
+template <class _Context>
+class _CCCL_TYPE_VISIBILITY_DEFAULT _CCCL_PREFERRED_NAME(format_args)
+#if _CCCL_HAS_WCHAR_T()
+  _CCCL_PREFERRED_NAME(wformat_args)
+#endif // _CCCL_HAS_WCHAR_T()
+    basic_format_args;
+
+_LIBCUDACXX_END_NAMESPACE_STD
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _LIBCUDACXX___FWD_FORMAT_H

--- a/libcudacxx/include/cuda/std/__fwd/iterator.h
+++ b/libcudacxx/include/cuda/std/__fwd/iterator.h
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _CUDA_STD_FORMAT
-#define _CUDA_STD_FORMAT
+#ifndef _LIBCUDACXX___FWD_ITERATOR_H
+#define _LIBCUDACXX___FWD_ITERATOR_H
 
 #include <cuda/std/detail/__config>
 
@@ -21,15 +21,23 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/std/__format/buffer.h>
-#include <cuda/std/__format/concepts.h>
-#include <cuda/std/__format/format_arg.h>
-#include <cuda/std/__format/format_arg_store.h>
-#include <cuda/std/__format/format_args.h>
-#include <cuda/std/__format/format_context.h>
-#include <cuda/std/__format/format_error.h>
-#include <cuda/std/__format/format_parse_context.h>
-#include <cuda/std/__format/formatter.h>
-#include <cuda/std/version>
+#include <cuda/std/__cccl/prologue.h>
 
-#endif // _CUDA_STD_FORMAT
+_LIBCUDACXX_BEGIN_NAMESPACE_STD
+
+template <class _Container>
+class _CCCL_TYPE_VISIBILITY_DEFAULT __back_insert_iterator;
+
+#if _CCCL_HAS_CONCEPTS()
+template <class>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT iterator_traits;
+#else // ^^^ _CCCL_HAS_CONCEPTS() ^^^ / vvv !_CCCL_HAS_CONCEPTS()
+template <class, class = void>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT iterator_traits;
+#endif // ^^^ !_CCCL_HAS_CONCEPTS() ^^^
+
+_LIBCUDACXX_END_NAMESPACE_STD
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _LIBCUDACXX___FWD_ITERATOR_H

--- a/libcudacxx/include/cuda/std/__iterator/back_insert_iterator.h
+++ b/libcudacxx/include/cuda/std/__iterator/back_insert_iterator.h
@@ -59,20 +59,24 @@ public:
     container->push_back(_CUDA_VSTD::move(__value));
     return *this;
   }
-  _CCCL_API inline constexpr __back_insert_iterator& operator*()
+  _CCCL_API inline constexpr __back_insert_iterator& operator*() noexcept
   {
     return *this;
   }
-  _CCCL_API inline constexpr __back_insert_iterator& operator++()
+  _CCCL_API inline constexpr const __back_insert_iterator& operator*() const noexcept
   {
     return *this;
   }
-  _CCCL_API inline constexpr __back_insert_iterator operator++(int)
+  _CCCL_API inline constexpr __back_insert_iterator& operator++() noexcept
+  {
+    return *this;
+  }
+  _CCCL_API inline constexpr __back_insert_iterator operator++(int) noexcept
   {
     return *this;
   }
 
-  _CCCL_API inline constexpr _Container* __get_container() const
+  _CCCL_API inline constexpr _Container* __get_container() const noexcept
   {
     return container;
   }

--- a/libcudacxx/include/cuda/std/__iterator/back_insert_iterator.h
+++ b/libcudacxx/include/cuda/std/__iterator/back_insert_iterator.h
@@ -21,6 +21,7 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/std/__fwd/iterator.h>
 #include <cuda/std/__iterator/iterator.h>
 #include <cuda/std/__iterator/iterator_traits.h>
 #include <cuda/std/__memory/addressof.h>
@@ -30,6 +31,52 @@
 #include <cuda/std/__cccl/prologue.h>
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
+
+template <class _Container>
+class _CCCL_TYPE_VISIBILITY_DEFAULT __back_insert_iterator
+{
+protected:
+  _Container* container;
+
+public:
+  using iterator_category = output_iterator_tag;
+  using value_type        = void;
+  using difference_type   = ptrdiff_t;
+  using pointer           = void;
+  using reference         = void;
+  using container_type    = _Container;
+
+  _CCCL_API inline constexpr explicit __back_insert_iterator(_Container& __x)
+      : container(_CUDA_VSTD::addressof(__x))
+  {}
+  _CCCL_API inline constexpr __back_insert_iterator& operator=(const typename _Container::value_type& __value)
+  {
+    container->push_back(__value);
+    return *this;
+  }
+  _CCCL_API inline constexpr __back_insert_iterator& operator=(typename _Container::value_type&& __value)
+  {
+    container->push_back(_CUDA_VSTD::move(__value));
+    return *this;
+  }
+  _CCCL_API inline constexpr __back_insert_iterator& operator*()
+  {
+    return *this;
+  }
+  _CCCL_API inline constexpr __back_insert_iterator& operator++()
+  {
+    return *this;
+  }
+  _CCCL_API inline constexpr __back_insert_iterator operator++(int)
+  {
+    return *this;
+  }
+
+  _CCCL_API inline constexpr _Container* __get_container() const
+  {
+    return container;
+  }
+};
 
 _CCCL_SUPPRESS_DEPRECATED_PUSH
 template <class _Container>

--- a/libcudacxx/include/cuda/std/__iterator/incrementable_traits.h
+++ b/libcudacxx/include/cuda/std/__iterator/incrementable_traits.h
@@ -23,7 +23,7 @@
 
 #include <cuda/std/__concepts/arithmetic.h>
 #include <cuda/std/__concepts/same_as.h>
-#include <cuda/std/__fwd/iterator_traits.h>
+#include <cuda/std/__fwd/iterator.h>
 #include <cuda/std/__type_traits/conditional.h>
 #include <cuda/std/__type_traits/enable_if.h>
 #include <cuda/std/__type_traits/is_const.h>

--- a/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
+++ b/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
@@ -28,7 +28,7 @@
 #include <cuda/std/__concepts/equality_comparable.h>
 #include <cuda/std/__concepts/same_as.h>
 #include <cuda/std/__concepts/totally_ordered.h>
-#include <cuda/std/__fwd/iterator_traits.h>
+#include <cuda/std/__fwd/iterator.h>
 #include <cuda/std/__fwd/pair.h>
 #include <cuda/std/__iterator/incrementable_traits.h>
 #include <cuda/std/__iterator/readable_traits.h>

--- a/libcudacxx/include/cuda/std/__iterator/readable_traits.h
+++ b/libcudacxx/include/cuda/std/__iterator/readable_traits.h
@@ -22,7 +22,7 @@
 #endif // no system header
 
 #include <cuda/std/__concepts/same_as.h>
-#include <cuda/std/__fwd/iterator_traits.h>
+#include <cuda/std/__fwd/iterator.h>
 #include <cuda/std/__iterator/incrementable_traits.h>
 #include <cuda/std/__type_traits/conditional.h>
 #include <cuda/std/__type_traits/enable_if.h>

--- a/libcudacxx/include/cuda/std/__type_traits/is_primary_template.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_primary_template.h
@@ -20,7 +20,7 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/std/__fwd/iterator_traits.h>
+#include <cuda/std/__fwd/iterator.h>
 #include <cuda/std/__type_traits/conditional.h>
 #include <cuda/std/__type_traits/enable_if.h>
 #include <cuda/std/__type_traits/is_base_of.h>

--- a/libcudacxx/include/cuda/std/string_view
+++ b/libcudacxx/include/cuda/std/string_view
@@ -64,6 +64,17 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+template <class _Tp>
+inline constexpr bool __cccl_is_string_view_v = false;
+template <class _Tp>
+inline constexpr bool __cccl_is_string_view_v<const _Tp> = __cccl_is_string_view_v<_Tp>;
+template <class _Tp>
+inline constexpr bool __cccl_is_string_view_v<volatile _Tp> = __cccl_is_string_view_v<_Tp>;
+template <class _Tp>
+inline constexpr bool __cccl_is_string_view_v<const volatile _Tp> = __cccl_is_string_view_v<_Tp>;
+template <class _CharT, class _Traits>
+inline constexpr bool __cccl_is_string_view_v<basic_string_view<_CharT, _Traits>> = true;
+
 template <class _Range, class _CharT, class _Traits>
 _CCCL_CONCEPT __cccl_has_basic_sv_conv_operator =
   _CCCL_REQUIRES_EXPR((_Range, _CharT, _Traits), remove_cvref_t<_Range>& __d)(

--- a/libcudacxx/test/libcudacxx/libcxx/text/format/format.arguments/format.arg/arg_t.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/text/format/format.arguments/format.arg/arg_t.compile.pass.cpp
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/format>
+
+// cuda::std::__fmt_arg_t
+
+#include <cuda/std/__format_>
+#include <cuda/std/cstdint>
+#include <cuda/std/type_traits>
+
+static_assert(cuda::std::is_same_v<cuda::std::underlying_type_t<cuda::std::__fmt_arg_t>, cuda::std::uint8_t>);
+
+static_assert(cuda::std::uint8_t(cuda::std::__fmt_arg_t::__none) == 0);
+static_assert(cuda::std::uint8_t(cuda::std::__fmt_arg_t::__boolean) == 1);
+static_assert(cuda::std::uint8_t(cuda::std::__fmt_arg_t::__char_type) == 2);
+static_assert(cuda::std::uint8_t(cuda::std::__fmt_arg_t::__int) == 3);
+static_assert(cuda::std::uint8_t(cuda::std::__fmt_arg_t::__long_long) == 4);
+static_assert(cuda::std::uint8_t(cuda::std::__fmt_arg_t::__unsigned) == 5);
+static_assert(cuda::std::uint8_t(cuda::std::__fmt_arg_t::__unsigned_long_long) == 6);
+static_assert(cuda::std::uint8_t(cuda::std::__fmt_arg_t::__float) == 7);
+static_assert(cuda::std::uint8_t(cuda::std::__fmt_arg_t::__double) == 8);
+static_assert(cuda::std::uint8_t(cuda::std::__fmt_arg_t::__long_double) == 9);
+static_assert(cuda::std::uint8_t(cuda::std::__fmt_arg_t::__const_char_type_ptr) == 10);
+static_assert(cuda::std::uint8_t(cuda::std::__fmt_arg_t::__string_view) == 11);
+static_assert(cuda::std::uint8_t(cuda::std::__fmt_arg_t::__ptr) == 12);
+static_assert(cuda::std::uint8_t(cuda::std::__fmt_arg_t::__handle) == 13);
+
+int main(int, char**)
+{
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/text/format/format.arguments/format.arg/determine_arg_t.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/text/format/format.arguments/format.arg/determine_arg_t.compile.pass.cpp
@@ -1,0 +1,122 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/format>
+
+// cuda::std::__fmt_determine_arg_t
+
+#include <cuda/std/__format_>
+#include <cuda/std/__string_>
+#include <cuda/std/cstddef>
+#include <cuda/std/type_traits>
+
+struct FormattableType
+{};
+struct UnformattableType
+{};
+
+template <class CharT>
+struct cuda::std::formatter<FormattableType, CharT>
+{
+  template <class ParseContext>
+  constexpr typename ParseContext::iterator parse(ParseContext& pc);
+
+  template <class FmtContext>
+  typename FmtContext::iterator format(FormattableType v, FmtContext& ctx) const;
+};
+
+template <class CharT>
+__host__ __device__ void test_arg_of_v()
+{
+  using cuda::std::__fmt_arg_t;
+  using cuda::std::__fmt_determine_arg_t;
+
+  using Context = cuda::std::basic_format_context<CharT*, CharT>;
+
+  // Boolean
+  static_assert(__fmt_determine_arg_t<Context, bool>() == __fmt_arg_t::__boolean);
+
+  // Char types
+  static_assert(__fmt_determine_arg_t<Context, CharT>() == __fmt_arg_t::__char_type);
+#if _CCCL_HAS_WCHAR_T()
+  if constexpr (cuda::std::is_same_v<CharT, wchar_t>)
+  {
+    static_assert(__fmt_determine_arg_t<Context, char>() == __fmt_arg_t::__char_type);
+  }
+#endif // _CCCL_HAS_WCHAR_T()
+
+  // Signed integer types
+  static_assert(__fmt_determine_arg_t<Context, signed char>() == __fmt_arg_t::__int);
+  static_assert(__fmt_determine_arg_t<Context, signed short>() == __fmt_arg_t::__int);
+  static_assert(__fmt_determine_arg_t<Context, signed int>() == __fmt_arg_t::__int);
+  static_assert(__fmt_determine_arg_t<Context, signed long>()
+                == ((sizeof(signed long) == sizeof(signed int)) ? __fmt_arg_t::__int : __fmt_arg_t::__long_long));
+  static_assert(__fmt_determine_arg_t<Context, signed long long>() == __fmt_arg_t::__long_long);
+
+  // Unsigned integer types
+  static_assert(__fmt_determine_arg_t<Context, unsigned char>() == __fmt_arg_t::__unsigned);
+  static_assert(__fmt_determine_arg_t<Context, unsigned short>() == __fmt_arg_t::__unsigned);
+  static_assert(__fmt_determine_arg_t<Context, unsigned int>() == __fmt_arg_t::__unsigned);
+  static_assert(
+    __fmt_determine_arg_t<Context, unsigned long>()
+    == ((sizeof(unsigned long) == sizeof(unsigned int)) ? __fmt_arg_t::__unsigned : __fmt_arg_t::__unsigned_long_long));
+  static_assert(__fmt_determine_arg_t<Context, unsigned long long>() == __fmt_arg_t::__unsigned_long_long);
+
+  // Floating-point types
+  static_assert(__fmt_determine_arg_t<Context, float>() == __fmt_arg_t::__float);
+  static_assert(__fmt_determine_arg_t<Context, double>() == __fmt_arg_t::__double);
+#if _CCCL_HAS_LONG_DOUBLE()
+  static_assert(__fmt_determine_arg_t<Context, long double>() == __fmt_arg_t::__long_double);
+#endif // _CCCL_HAS_LONG_DOUBLE()
+
+  // Const char pointer types
+  static_assert(__fmt_determine_arg_t<Context, CharT*>() == __fmt_arg_t::__const_char_type_ptr);
+  static_assert(__fmt_determine_arg_t<Context, const CharT*>() == __fmt_arg_t::__const_char_type_ptr);
+
+  // String view types
+  static_assert(__fmt_determine_arg_t<Context, CharT[10]>() == __fmt_arg_t::__string_view);
+  static_assert(__fmt_determine_arg_t<Context, cuda::std::basic_string_view<CharT>>() == __fmt_arg_t::__string_view);
+  {
+    struct TestCharTraits : cuda::std::char_traits<CharT>
+    {};
+    static_assert(__fmt_determine_arg_t<Context, cuda::std::basic_string_view<CharT, TestCharTraits>>()
+                  == __fmt_arg_t::__string_view);
+  }
+
+  // Pointer types
+  static_assert(__fmt_determine_arg_t<Context, void*>() == __fmt_arg_t::__ptr);
+  static_assert(__fmt_determine_arg_t<Context, const void*>() == __fmt_arg_t::__ptr);
+  static_assert(__fmt_determine_arg_t<Context, cuda::std::nullptr_t>() == __fmt_arg_t::__ptr);
+
+  // Handle types
+  static_assert(__fmt_determine_arg_t<Context, FormattableType>() == __fmt_arg_t::__handle);
+#if _CCCL_HAS_INT128()
+  static_assert(__fmt_determine_arg_t<Context, __int128_t>() == __fmt_arg_t::__handle);
+  static_assert(__fmt_determine_arg_t<Context, __uint128_t>() == __fmt_arg_t::__handle);
+#endif // _CCCL_HAS_INT128()
+
+  // Unknown types
+  static_assert(__fmt_determine_arg_t<Context, void>() == __fmt_arg_t::__none);
+  static_assert(__fmt_determine_arg_t<Context, CharT[]>() == __fmt_arg_t::__none);
+  static_assert(__fmt_determine_arg_t<Context, int[10]>() == __fmt_arg_t::__none);
+  static_assert(__fmt_determine_arg_t<Context, UnformattableType>() == __fmt_arg_t::__none);
+}
+
+__host__ __device__ void test()
+{
+  test_arg_of_v<char>();
+#if _CCCL_HAS_WCHAR_T()
+  test_arg_of_v<wchar_t>();
+#endif // _CCCL_HAS_WCHAR_T()
+}
+
+int main(int, char**)
+{
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/text/format/format.arguments/format.arg/determine_arg_t.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/text/format/format.arguments/format.arg/determine_arg_t.compile.pass.cpp
@@ -25,10 +25,10 @@ template <class CharT>
 struct cuda::std::formatter<FormattableType, CharT>
 {
   template <class ParseContext>
-  constexpr typename ParseContext::iterator parse(ParseContext& pc);
+  __host__ __device__ constexpr typename ParseContext::iterator parse(ParseContext& pc);
 
   template <class FmtContext>
-  typename FmtContext::iterator format(FormattableType v, FmtContext& ctx) const;
+  __host__ __device__ typename FmtContext::iterator format(FormattableType v, FmtContext& ctx) const;
 };
 
 template <class CharT>

--- a/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.arg.store/make_format_args.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.arg.store/make_format_args.pass.cpp
@@ -15,13 +15,14 @@
 #include <cuda/std/__format_>
 #include <cuda/std/cstddef>
 #include <cuda/std/iterator>
+#include <cuda/std/type_traits>
 #include <cuda/std/utility>
 
 template <class Arg, class = void>
 inline constexpr bool can_make_format_args = false;
 template <class Arg>
 inline constexpr bool
-  can_make_format_args<Arg, std::void_t<decltype(cuda::std::make_format_args(cuda::std::declval<Arg>()))>> = true;
+  can_make_format_args<Arg, cuda::std::void_t<decltype(cuda::std::make_format_args(cuda::std::declval<Arg>()))>> = true;
 
 static_assert(can_make_format_args<int&>);
 static_assert(!can_make_format_args<int>);

--- a/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.arg.store/make_format_args.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.arg.store/make_format_args.pass.cpp
@@ -1,0 +1,47 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/format>
+
+// template<class Context = format_context, class... Args>
+// format-arg-store<Context, Args...> make_format_args(Args&... args);
+
+#include <cuda/std/__format_>
+#include <cuda/std/cstddef>
+#include <cuda/std/iterator>
+#include <cuda/std/utility>
+
+template <class Arg, class = void>
+inline constexpr bool can_make_format_args = false;
+template <class Arg>
+inline constexpr bool
+  can_make_format_args<Arg, std::void_t<decltype(cuda::std::make_format_args(cuda::std::declval<Arg>()))>> = true;
+
+static_assert(can_make_format_args<int&>);
+static_assert(!can_make_format_args<int>);
+static_assert(!can_make_format_args<int&&>);
+
+__host__ __device__ void test()
+{
+  auto i = 1;
+  auto c = 'c';
+  auto p = nullptr;
+  auto b = false;
+
+  [[maybe_unused]] auto store = cuda::std::make_format_args(i, p, b, c);
+  static_assert(cuda::std::is_same_v<
+                decltype(store),
+                cuda::std::__format_arg_store<cuda::std::format_context, int, cuda::std::nullptr_t, bool, char>>);
+}
+
+int main(int, char**)
+{
+  test();
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.arg.store/make_wformat_args.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.arg.store/make_wformat_args.pass.cpp
@@ -16,6 +16,7 @@
 #include <cuda/std/__format_>
 #include <cuda/std/cstddef>
 #include <cuda/std/iterator>
+#include <cuda/std/type_traits>
 #include <cuda/std/utility>
 
 #if _CCCL_HAS_WCHAR_T()
@@ -23,7 +24,8 @@ template <class Arg, class = void>
 inline constexpr bool can_make_wformat_args = false;
 template <class Arg>
 inline constexpr bool
-  can_make_wformat_args<Arg, std::void_t<decltype(cuda::std::make_wformat_args(cuda::std::declval<Arg>()))>> = true;
+  can_make_wformat_args<Arg, cuda::std::void_t<decltype(cuda::std::make_wformat_args(cuda::std::declval<Arg>()))>> =
+    true;
 
 static_assert(can_make_wformat_args<int&>);
 static_assert(!can_make_wformat_args<int>);

--- a/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.arg.store/make_wformat_args.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.arg.store/make_wformat_args.pass.cpp
@@ -1,0 +1,52 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/format>
+
+// template<class... Args>
+//   format-arg-store<wformat_context, Args...>
+//   make_wformat_args(Args&... args);
+
+#include <cuda/std/__format_>
+#include <cuda/std/cstddef>
+#include <cuda/std/iterator>
+#include <cuda/std/utility>
+
+#if _CCCL_HAS_WCHAR_T()
+template <class Arg, class = void>
+inline constexpr bool can_make_wformat_args = false;
+template <class Arg>
+inline constexpr bool
+  can_make_wformat_args<Arg, std::void_t<decltype(cuda::std::make_wformat_args(cuda::std::declval<Arg>()))>> = true;
+
+static_assert(can_make_wformat_args<int&>);
+static_assert(!can_make_wformat_args<int>);
+static_assert(!can_make_wformat_args<int&&>);
+
+__host__ __device__ void test()
+{
+  auto i = 1;
+  auto c = 'c';
+  auto p = nullptr;
+  auto b = false;
+
+  [[maybe_unused]] auto store = cuda::std::make_wformat_args(i, p, b, c);
+  static_assert(cuda::std::is_same_v<
+                decltype(store),
+                cuda::std::__format_arg_store<cuda::std::wformat_context, int, cuda::std::nullptr_t, bool, char>>);
+}
+#endif // _CCCL_HAS_WCHAR_T()
+
+int main(int, char**)
+{
+#if _CCCL_HAS_WCHAR_T()
+  test();
+#endif // _CCCL_HAS_WCHAR_T()
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.arg/ctor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.arg/ctor.pass.cpp
@@ -1,0 +1,49 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/format>
+
+// basic_format_arg() noexcept;
+
+// The class has several exposition only private constructors. These are tested
+// in visit_format_arg.pass.cpp
+
+#include <cuda/std/__format_>
+#include <cuda/std/cassert>
+#include <cuda/std/type_traits>
+
+template <class CharT>
+__host__ __device__ void test_constructor()
+{
+  using Context = cuda::std::basic_format_context<CharT*, CharT>;
+
+  static_assert(cuda::std::is_nothrow_default_constructible_v<cuda::std::basic_format_arg<Context>>);
+
+  cuda::std::basic_format_arg<Context> format_arg{};
+  assert(!format_arg);
+}
+
+__host__ __device__ void test()
+{
+  test_constructor<char>();
+#if _CCCL_HAS_CHAR8_T()
+  test_constructor<char8_t>();
+#endif // _CCCL_HAS_CHAR8_T()
+  test_constructor<char16_t>();
+  test_constructor<char32_t>();
+#if _CCCL_HAS_WCHAR_T()
+  test_constructor<wchar_t>();
+#endif // _CCCL_HAS_WCHAR_T()
+}
+
+int main(int, char**)
+{
+  test();
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.arg/operator_bool.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.arg/operator_bool.pass.cpp
@@ -1,0 +1,48 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/format>
+
+// explicit operator bool() const noexcept
+//
+// Note more testing is done in the unit test for:
+// template<class Visitor, class Context>
+//   see below visit_format_arg(Visitor&& vis, basic_format_arg<Context> arg);
+
+#include <cuda/std/__format_>
+#include <cuda/std/cassert>
+#include <cuda/std/type_traits>
+
+template <class CharT>
+__host__ __device__ void test_operator_bool()
+{
+  using Context = cuda::std::basic_format_context<CharT*, CharT>;
+
+  cuda::std::basic_format_arg<Context> format_arg{};
+
+  static_assert(!cuda::std::is_convertible_v<cuda::std::basic_format_arg<Context>, bool>);
+  static_assert(cuda::std::is_nothrow_constructible_v<bool, cuda::std::basic_format_arg<Context>>);
+
+  assert(!format_arg);
+  assert(!static_cast<bool>(format_arg));
+}
+
+__host__ __device__ void test()
+{
+  test_operator_bool<char>();
+#if _CCCL_HAS_WCHAR_T()
+  test_operator_bool<wchar_t>();
+#endif // _CCCL_HAS_WCHAR_T()
+}
+
+int main(int, char**)
+{
+  test();
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.arg/visit_format_arg.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.arg/visit_format_arg.pass.cpp
@@ -1,0 +1,299 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/format>
+
+// template<class Visitor, class Context>
+//   see below visit_format_arg(Visitor&& vis, basic_format_arg<Context> arg); // Deprecated in C++26
+
+#include <cuda/std/__algorithm_>
+#include <cuda/std/__format_>
+#include <cuda/std/__string_>
+#include <cuda/std/cassert>
+#include <cuda/std/limits>
+#include <cuda/std/type_traits>
+
+#include "literal.h"
+
+struct HandleTag
+{};
+
+template <class Context, class To>
+struct Visitor
+{
+  template <class T>
+  __host__ __device__ To operator()(T v) const
+  {
+    constexpr auto fmt_arg =
+      (cuda::std::is_same_v<To, HandleTag>)
+        ? cuda::std::__fmt_arg_t::__handle
+        : cuda::std::__fmt_determine_arg_t<Context, To>();
+
+    if constexpr (fmt_arg != cuda::std::__fmt_arg_t::__handle)
+    {
+      if constexpr (cuda::std::is_same_v<T, To>)
+      {
+        return v;
+      }
+      else
+      {
+        assert(false);
+        return To{};
+      }
+    }
+    else
+    {
+      assert((cuda::std::is_same_v<T, typename cuda::std::basic_format_arg<Context>::handle>) );
+      return HandleTag{};
+    }
+  }
+};
+
+template <class CharT, class To, class From>
+__host__ __device__ void test_visit_format_arg(From value)
+{
+  using Context = cuda::std::basic_format_context<CharT*, CharT>;
+
+  constexpr auto fmt_arg = cuda::std::__fmt_determine_arg_t<Context, From>();
+
+  auto store = cuda::std::make_format_args<Context>(value);
+  auto args  = cuda::std::basic_format_args<Context>{store};
+
+  assert(args.__size() == 1);
+  assert(args.get(0));
+
+  auto result = cuda::std::visit_format_arg(Visitor<Context, To>{}, args.get(0));
+
+  if constexpr (fmt_arg == cuda::std::__fmt_arg_t::__string_view)
+  {
+    assert(cuda::std::equal(value.begin(), value.end(), result.begin(), result.end()));
+  }
+  else if constexpr (fmt_arg != cuda::std::__fmt_arg_t::__handle)
+  {
+    using Common = cuda::std::common_type_t<From, To>;
+    assert(static_cast<Common>(result) == static_cast<Common>(value));
+  }
+}
+
+template <class CharT>
+__host__ __device__ void test_boolean()
+{
+  test_visit_format_arg<CharT, bool>(true);
+  test_visit_format_arg<CharT, bool>(false);
+}
+
+template <class CharT>
+__host__ __device__ void test_char()
+{
+  test_visit_format_arg<CharT, CharT, CharT>('a');
+  test_visit_format_arg<CharT, CharT, CharT>('z');
+  test_visit_format_arg<CharT, CharT, CharT>('0');
+  test_visit_format_arg<CharT, CharT, CharT>('9');
+
+  if (cuda::std::is_same_v<CharT, char>)
+  {
+    // char to char -> char
+    test_visit_format_arg<CharT, CharT, char>('a');
+    test_visit_format_arg<CharT, CharT, char>('z');
+    test_visit_format_arg<CharT, CharT, char>('0');
+    test_visit_format_arg<CharT, CharT, char>('9');
+  }
+#if _CCCL_HAS_WCHAR_T()
+  else if (cuda::std::is_same_v<CharT, wchar_t>)
+  {
+    // char to wchar_t -> wchar_t
+    test_visit_format_arg<CharT, wchar_t, char>('a');
+    test_visit_format_arg<CharT, wchar_t, char>('z');
+    test_visit_format_arg<CharT, wchar_t, char>('0');
+    test_visit_format_arg<CharT, wchar_t, char>('9');
+  }
+#endif // _CCCL_HAS_WCHAR_T()
+}
+
+template <class CharT>
+__host__ __device__ void test_signed_integers()
+{
+  test_visit_format_arg<CharT, int, signed char>(cuda::std::numeric_limits<signed char>::min());
+  test_visit_format_arg<CharT, int, signed char>(0);
+  test_visit_format_arg<CharT, int, signed char>(cuda::std::numeric_limits<signed char>::max());
+
+  test_visit_format_arg<CharT, int, short>(cuda::std::numeric_limits<short>::min());
+  test_visit_format_arg<CharT, int, short>(cuda::std::numeric_limits<signed char>::min());
+  test_visit_format_arg<CharT, int, short>(0);
+  test_visit_format_arg<CharT, int, short>(cuda::std::numeric_limits<signed char>::max());
+  test_visit_format_arg<CharT, int, short>(cuda::std::numeric_limits<short>::max());
+
+  test_visit_format_arg<CharT, int, int>(cuda::std::numeric_limits<int>::min());
+  test_visit_format_arg<CharT, int, int>(cuda::std::numeric_limits<short>::min());
+  test_visit_format_arg<CharT, int, int>(cuda::std::numeric_limits<signed char>::min());
+  test_visit_format_arg<CharT, int, int>(0);
+  test_visit_format_arg<CharT, int, int>(cuda::std::numeric_limits<signed char>::max());
+  test_visit_format_arg<CharT, int, int>(cuda::std::numeric_limits<short>::max());
+  test_visit_format_arg<CharT, int, int>(cuda::std::numeric_limits<int>::max());
+
+  using LongToType = cuda::std::conditional_t<sizeof(long) == sizeof(int), int, long long>;
+
+  test_visit_format_arg<CharT, LongToType, long>(cuda::std::numeric_limits<long>::min());
+  test_visit_format_arg<CharT, LongToType, long>(cuda::std::numeric_limits<int>::min());
+  test_visit_format_arg<CharT, LongToType, long>(cuda::std::numeric_limits<short>::min());
+  test_visit_format_arg<CharT, LongToType, long>(cuda::std::numeric_limits<signed char>::min());
+  test_visit_format_arg<CharT, LongToType, long>(0);
+  test_visit_format_arg<CharT, LongToType, long>(cuda::std::numeric_limits<signed char>::max());
+  test_visit_format_arg<CharT, LongToType, long>(cuda::std::numeric_limits<short>::max());
+  test_visit_format_arg<CharT, LongToType, long>(cuda::std::numeric_limits<int>::max());
+  test_visit_format_arg<CharT, LongToType, long>(cuda::std::numeric_limits<long>::max());
+
+  test_visit_format_arg<CharT, long long, long long>(cuda::std::numeric_limits<long long>::min());
+  test_visit_format_arg<CharT, long long, long long>(cuda::std::numeric_limits<long>::min());
+  test_visit_format_arg<CharT, long long, long long>(cuda::std::numeric_limits<int>::min());
+  test_visit_format_arg<CharT, long long, long long>(cuda::std::numeric_limits<short>::min());
+  test_visit_format_arg<CharT, long long, long long>(cuda::std::numeric_limits<signed char>::min());
+  test_visit_format_arg<CharT, long long, long long>(0);
+  test_visit_format_arg<CharT, long long, long long>(cuda::std::numeric_limits<signed char>::max());
+  test_visit_format_arg<CharT, long long, long long>(cuda::std::numeric_limits<short>::max());
+  test_visit_format_arg<CharT, long long, long long>(cuda::std::numeric_limits<int>::max());
+  test_visit_format_arg<CharT, long long, long long>(cuda::std::numeric_limits<long>::max());
+  test_visit_format_arg<CharT, long long, long long>(cuda::std::numeric_limits<long long>::max());
+
+#if _CCCL_HAS_INT128()
+  test_visit_format_arg<CharT, HandleTag>(__int128_t{});
+#endif // _CCCL_HAS_INT128()
+}
+
+template <class CharT>
+__host__ __device__ void test_unsigned_integers()
+{
+  test_visit_format_arg<CharT, unsigned, unsigned char>(0);
+  test_visit_format_arg<CharT, unsigned, unsigned char>(cuda::std::numeric_limits<unsigned char>::max());
+
+  test_visit_format_arg<CharT, unsigned, unsigned short>(0);
+  test_visit_format_arg<CharT, unsigned, unsigned short>(cuda::std::numeric_limits<unsigned char>::max());
+  test_visit_format_arg<CharT, unsigned, unsigned short>(cuda::std::numeric_limits<unsigned short>::max());
+
+  test_visit_format_arg<CharT, unsigned, unsigned>(0);
+  test_visit_format_arg<CharT, unsigned, unsigned>(cuda::std::numeric_limits<unsigned char>::max());
+  test_visit_format_arg<CharT, unsigned, unsigned>(cuda::std::numeric_limits<unsigned short>::max());
+  test_visit_format_arg<CharT, unsigned, unsigned>(cuda::std::numeric_limits<unsigned>::max());
+
+  using UnsignedLongToType =
+    cuda::std::conditional_t<sizeof(unsigned long) == sizeof(unsigned), unsigned, unsigned long long>;
+
+  test_visit_format_arg<CharT, UnsignedLongToType, unsigned long>(0);
+  test_visit_format_arg<CharT, UnsignedLongToType, unsigned long>(cuda::std::numeric_limits<unsigned char>::max());
+  test_visit_format_arg<CharT, UnsignedLongToType, unsigned long>(cuda::std::numeric_limits<unsigned short>::max());
+  test_visit_format_arg<CharT, UnsignedLongToType, unsigned long>(cuda::std::numeric_limits<unsigned>::max());
+  test_visit_format_arg<CharT, UnsignedLongToType, unsigned long>(cuda::std::numeric_limits<unsigned long>::max());
+
+  test_visit_format_arg<CharT, unsigned long long, unsigned long long>(0);
+  test_visit_format_arg<CharT, unsigned long long, unsigned long long>(cuda::std::numeric_limits<unsigned char>::max());
+  test_visit_format_arg<CharT, unsigned long long, unsigned long long>(
+    cuda::std::numeric_limits<unsigned short>::max());
+  test_visit_format_arg<CharT, unsigned long long, unsigned long long>(cuda::std::numeric_limits<unsigned>::max());
+  test_visit_format_arg<CharT, unsigned long long, unsigned long long>(cuda::std::numeric_limits<unsigned long>::max());
+  test_visit_format_arg<CharT, unsigned long long, unsigned long long>(
+    cuda::std::numeric_limits<unsigned long long>::max());
+
+#if _CCCL_HAS_INT128()
+  test_visit_format_arg<CharT, HandleTag>(__uint128_t{});
+#endif // _CCCL_HAS_INT128()
+}
+
+template <class CharT>
+__host__ __device__ void test_floating_point_types()
+{
+  test_visit_format_arg<CharT, float>(-cuda::std::numeric_limits<float>::max());
+  test_visit_format_arg<CharT, float>(-cuda::std::numeric_limits<float>::min());
+  test_visit_format_arg<CharT, float>(-0.0f);
+  test_visit_format_arg<CharT, float>(0.0f);
+  test_visit_format_arg<CharT, float>(cuda::std::numeric_limits<float>::min());
+  test_visit_format_arg<CharT, float>(cuda::std::numeric_limits<float>::max());
+
+  test_visit_format_arg<CharT, double>(-cuda::std::numeric_limits<double>::max());
+  test_visit_format_arg<CharT, double>(-cuda::std::numeric_limits<double>::min());
+  test_visit_format_arg<CharT, double>(-0.0);
+  test_visit_format_arg<CharT, double>(0.0);
+  test_visit_format_arg<CharT, double>(cuda::std::numeric_limits<double>::min());
+  test_visit_format_arg<CharT, double>(cuda::std::numeric_limits<double>::max());
+
+#if _CCCL_HAS_LONG_DOUBLE()
+  test_visit_format_arg<CharT, long double>(-cuda::std::numeric_limits<long double>::max());
+  test_visit_format_arg<CharT, long double>(-cuda::std::numeric_limits<long double>::min());
+  test_visit_format_arg<CharT, long double>(-0.0l);
+  test_visit_format_arg<CharT, long double>(0.0l);
+  test_visit_format_arg<CharT, long double>(cuda::std::numeric_limits<long double>::min());
+  test_visit_format_arg<CharT, long double>(cuda::std::numeric_limits<long double>::max());
+#endif // _CCCL_HAS_LONG_DOUBLE()
+}
+
+template <class CharT>
+__host__ __device__ void test_const_char_pointers()
+{
+  test_visit_format_arg<CharT, const CharT*>(TEST_STRLIT(CharT, ""));
+  test_visit_format_arg<CharT, const CharT*>(TEST_STRLIT(CharT, "abc"));
+}
+
+template <class CharT>
+__host__ __device__ void test_string_view()
+{
+  constexpr auto empty = TEST_STRLIT(CharT, "");
+  constexpr auto str   = TEST_STRLIT(CharT, "abc");
+
+  {
+    using SV = cuda::std::basic_string_view<CharT>;
+
+    test_visit_format_arg<CharT, SV>(SV{});
+    test_visit_format_arg<CharT, SV>(SV{empty});
+    test_visit_format_arg<CharT, SV>(SV{str});
+  }
+  {
+    struct test_char_traits : cuda::std::char_traits<CharT>
+    {};
+    using SV = cuda::std::basic_string_view<CharT, test_char_traits>;
+
+    test_visit_format_arg<CharT, SV>(SV{});
+    test_visit_format_arg<CharT, SV>(SV{empty});
+    test_visit_format_arg<CharT, SV>(SV{str});
+  }
+}
+
+template <class CharT>
+__host__ __device__ void test_pointers()
+{
+  test_visit_format_arg<CharT, const void*>(nullptr);
+  int i = 0;
+  test_visit_format_arg<CharT, const void*>(static_cast<void*>(&i));
+  const int ci = 0;
+  test_visit_format_arg<CharT, const void*>(static_cast<const void*>(&ci));
+}
+
+template <class CharT>
+__host__ __device__ void test()
+{
+  test_boolean<CharT>();
+  test_char<CharT>();
+  test_signed_integers<CharT>();
+  test_unsigned_integers<CharT>();
+  test_floating_point_types<CharT>();
+  test_const_char_pointers<CharT>();
+  test_string_view<CharT>();
+  test_pointers<CharT>();
+}
+
+__host__ __device__ void test()
+{
+  test<char>();
+#if _CCCL_HAS_WCHAR_T()
+  test<wchar_t>();
+#endif // _CCCL_HAS_WCHAR_T()
+}
+
+int main(int, char**)
+{
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.arg/visit_format_arg.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.arg/visit_format_arg.pass.cpp
@@ -28,7 +28,7 @@ template <class Context, class To>
 struct Visitor
 {
   template <class T>
-  __host__ __device__ To operator()(T v) const
+  __host__ __device__ To operator()([[maybe_unused]] T v) const
   {
     constexpr auto fmt_arg =
       (cuda::std::is_same_v<To, HandleTag>)
@@ -68,7 +68,7 @@ __host__ __device__ void test_visit_format_arg(From value)
   assert(args.__size() == 1);
   assert(args.get(0));
 
-  auto result = cuda::std::visit_format_arg(Visitor<Context, To>{}, args.get(0));
+  [[maybe_unused]] auto result = cuda::std::visit_format_arg(Visitor<Context, To>{}, args.get(0));
 
   if constexpr (fmt_arg == cuda::std::__fmt_arg_t::__string_view)
   {

--- a/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.args/ctad.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.args/ctad.compile.pass.cpp
@@ -1,0 +1,29 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/format>
+
+// template<class Context, class... Args>
+//   basic_format_args(format-arg-store<Context, Args...>) -> basic_format_args<Context>;
+
+#include <cuda/std/__format_>
+#include <cuda/std/type_traits>
+#include <cuda/std/utility>
+
+using namespace cuda::std;
+
+static_assert(is_same_v<format_args, decltype(basic_format_args{make_format_args(declval<int&>())})>);
+#if _CCCL_HAS_WCHAR_T()
+static_assert(is_same_v<wformat_args, decltype(basic_format_args{make_wformat_args(declval<int&>())})>);
+#endif // _CCCL_HAS_WCHAR_T()
+
+int main(int, char**)
+{
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.args/ctor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.args/ctor.pass.cpp
@@ -1,0 +1,68 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/format>
+
+// template<class... Args>
+//   basic_format_args(const format-arg-store<Context, Args...>& store) noexcept;
+
+#include <cuda/std/__format_>
+#include <cuda/std/cassert>
+#include <cuda/std/type_traits>
+
+template <class CharT>
+__host__ __device__ void test_constructor()
+{
+  using Context = cuda::std::basic_format_context<CharT*, CharT>;
+
+  auto i = 1;
+  auto c = 'c';
+  auto p = nullptr;
+
+  static_assert(!cuda::std::is_default_constructible_v<cuda::std::basic_format_args<Context>>);
+
+  {
+    auto store = cuda::std::make_format_args<Context>(i);
+    static_assert(cuda::std::is_nothrow_constructible_v<cuda::std::basic_format_args<Context>, decltype(store)>);
+    cuda::std::basic_format_args<Context> format_args{store};
+    assert(format_args.get(0));
+    assert(!format_args.get(1));
+  }
+  {
+    auto store = cuda::std::make_format_args<Context>(i, c);
+    static_assert(cuda::std::is_nothrow_constructible_v<cuda::std::basic_format_args<Context>, decltype(store)>);
+    cuda::std::basic_format_args<Context> format_args{store};
+    assert(format_args.get(0));
+    assert(format_args.get(1));
+    assert(!format_args.get(2));
+  }
+  {
+    auto store = cuda::std::make_format_args<Context>(i, c, p);
+    static_assert(cuda::std::is_nothrow_constructible_v<cuda::std::basic_format_args<Context>, decltype(store)>);
+    cuda::std::basic_format_args<Context> format_args{store};
+    assert(format_args.get(0));
+    assert(format_args.get(1));
+    assert(format_args.get(2));
+    assert(!format_args.get(3));
+  }
+}
+
+__host__ __device__ void test()
+{
+  test_constructor<char>();
+#if _CCCL_HAS_WCHAR_T()
+  test_constructor<wchar_t>();
+#endif // _CCCL_HAS_WCHAR_T()
+}
+
+int main(int, char**)
+{
+  test();
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.args/get.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.args/get.pass.cpp
@@ -1,0 +1,141 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/format>
+
+// basic_format_arg<Context> get(size_t i) const noexcept;
+
+#include <cuda/std/__format_>
+#include <cuda/std/cassert>
+#include <cuda/std/limits>
+#include <cuda/std/type_traits>
+
+#include "literal.h"
+
+template <class Context>
+__host__ __device__ bool
+test_format_arg_eq(const cuda::std::basic_format_arg<Context>& lhs, const cuda::std::basic_format_arg<Context>& rhs)
+{
+  if (lhs.__type_ != rhs.__type_)
+  {
+    return false;
+  }
+  switch (lhs.__type_)
+  {
+    case cuda::std::__fmt_arg_t::__none:
+      return true;
+    case cuda::std::__fmt_arg_t::__boolean:
+      return lhs.__value_.__boolean_ == rhs.__value_.__boolean_;
+    case cuda::std::__fmt_arg_t::__char_type:
+      return lhs.__value_.__char_type_ == rhs.__value_.__char_type_;
+    case cuda::std::__fmt_arg_t::__int:
+      return lhs.__value_.__int_ == rhs.__value_.__int_;
+    case cuda::std::__fmt_arg_t::__long_long:
+      return lhs.__value_.__long_long_ == rhs.__value_.__long_long_;
+    case cuda::std::__fmt_arg_t::__unsigned:
+      return lhs.__value_.__unsigned_ == rhs.__value_.__unsigned_;
+    case cuda::std::__fmt_arg_t::__unsigned_long_long:
+      return lhs.__value_.__unsigned_long_long_ == rhs.__value_.__unsigned_long_long_;
+    case cuda::std::__fmt_arg_t::__float:
+      return lhs.__value_.__float_ == rhs.__value_.__float_;
+    case cuda::std::__fmt_arg_t::__double:
+      return lhs.__value_.__double_ == rhs.__value_.__double_;
+    case cuda::std::__fmt_arg_t::__long_double:
+      return lhs.__value_.__long_double_ == rhs.__value_.__long_double_;
+    case cuda::std::__fmt_arg_t::__const_char_type_ptr:
+      return lhs.__value_.__const_char_type_ptr_ == rhs.__value_.__const_char_type_ptr_;
+    case cuda::std::__fmt_arg_t::__string_view:
+      return lhs.__value_.__string_view_.data() == rhs.__value_.__string_view_.data()
+          && lhs.__value_.__string_view_.size() == rhs.__value_.__string_view_.size();
+    case cuda::std::__fmt_arg_t::__ptr:
+      return lhs.__value_.__ptr_ == rhs.__value_.__ptr_;
+    case cuda::std::__fmt_arg_t::__handle:
+      return lhs.__value_.__handle_.__ptr_ == rhs.__value_.__handle_.__ptr_
+          && lhs.__value_.__handle_.__format_ == rhs.__value_.__handle_.__format_;
+    default:
+      assert(false);
+      return false;
+  }
+}
+
+template <class CharT>
+__host__ __device__ void test_get()
+{
+  using Context = cuda::std::basic_format_context<CharT*, CharT>;
+
+  // 1. test packed format args
+  {
+    constexpr auto nargs = 3;
+    static_assert(nargs <= cuda::std::__fmt_packed_types_max);
+
+    auto n = 1;
+    auto c = 'c';
+    auto p = nullptr;
+
+    auto store = cuda::std::make_format_args<Context>(n, c, p);
+    auto args  = cuda::std::basic_format_args<Context>{store};
+
+    assert(args.__size() == nargs);
+    assert(test_format_arg_eq(
+      args.get(0), cuda::std::basic_format_arg<Context>{cuda::std::__fmt_arg_t::__int, store.__storage.__values_[0]}));
+    assert(test_format_arg_eq(
+      args.get(1),
+      cuda::std::basic_format_arg<Context>{cuda::std::__fmt_arg_t::__char_type, store.__storage.__values_[1]}));
+    assert(test_format_arg_eq(
+      args.get(2), cuda::std::basic_format_arg<Context>{cuda::std::__fmt_arg_t::__ptr, store.__storage.__values_[2]}));
+    assert(!args.get(3));
+  }
+
+  // 2. test unpacked format args
+  {
+    constexpr auto nargs = 16;
+    static_assert(nargs > cuda::std::__fmt_packed_types_max);
+
+    auto n1 = 1;
+    auto n2 = 2u;
+    auto n3 = 3ll;
+    auto n4 = 4ull;
+    auto c1 = 'c';
+    auto c2 = '1';
+    auto c3 = '?';
+    auto c4 = '*';
+    auto p1 = nullptr;
+    auto p2 = TEST_STRLIT(CharT, "test");
+    auto p3 = static_cast<void*>(&n1);
+    auto p4 = static_cast<const void*>(&n2);
+    auto f1 = 3.14f;
+    auto f2 = 10.0;
+    auto f3 = 2.718281828459045;
+    auto f4 = 1.4142135623730951f;
+
+    auto store = cuda::std::make_format_args<Context>(n1, n2, n3, n4, c1, c2, c3, c4, p1, p2, p3, p4, f1, f2, f3, f4);
+    auto args  = cuda::std::basic_format_args<Context>{store};
+
+    assert(args.__size() == nargs);
+
+    for (cuda::std::size_t i = 0; i < nargs; ++i)
+    {
+      assert(test_format_arg_eq(args.get(i), store.__storage.__args_[i]));
+    }
+    assert(!args.get(nargs));
+  }
+}
+
+__host__ __device__ void test()
+{
+  test_get<char>();
+#if _CCCL_HAS_WCHAR_T()
+  test_get<wchar_t>();
+#endif // _CCCL_HAS_WCHAR_T()
+}
+
+int main(int, char**)
+{
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.args/types.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.arguments/format.args/types.compile.pass.cpp
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/format>
+
+// Namespace std typedefs:
+// using format_args = basic_format_args<format_context>;
+// using wformat_args = basic_format_args<wformat_context>;
+
+#include <cuda/std/__format_>
+#include <cuda/std/type_traits>
+
+static_assert(cuda::std::is_same_v<cuda::std::format_args, cuda::std::basic_format_args<cuda::std::format_context>>);
+#if _CCCL_HAS_WCHAR_T()
+static_assert(cuda::std::is_same_v<cuda::std::wformat_args, cuda::std::basic_format_args<cuda::std::wformat_context>>);
+#endif // _CCCL_HAS_WCHAR_T()
+
+int main(int, char**)
+{
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.context/advance_to.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.context/advance_to.pass.cpp
@@ -1,0 +1,79 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/format>
+
+// void advance_to(iterator it);
+
+#include <cuda/std/__format_>
+#include <cuda/std/cassert>
+#include <cuda/std/inplace_vector>
+#include <cuda/std/iterator>
+#include <cuda/std/type_traits>
+#include <cuda/std/utility>
+
+template <class CharT>
+__host__ __device__ void test_advance_to()
+{
+  using Container = cuda::std::inplace_vector<CharT, 3>;
+  using OutIt     = cuda::std::__back_insert_iterator<Container>;
+  using Context   = cuda::std::basic_format_context<OutIt, CharT>;
+
+  Container container{};
+
+  auto store   = cuda::std::make_format_args<Context>();
+  auto args    = cuda::std::basic_format_args{store};
+  auto context = cuda::std::__fmt_make_format_context(OutIt{container}, args);
+
+  static_assert(cuda::std::is_same_v<void, decltype(context.advance_to(cuda::std::declval<OutIt>()))>);
+
+  {
+    auto it = context.out();
+    *it     = CharT('a');
+    context.advance_to(cuda::std::move(it));
+
+    assert(container.size() == 1);
+    assert(container[0] == CharT('a'));
+  }
+  {
+    auto it = context.out();
+    *it     = CharT('b');
+    context.advance_to(cuda::std::move(it));
+
+    assert(container.size() == 2);
+    assert(container[1] == CharT('b'));
+  }
+  {
+    auto it = context.out();
+    *it     = CharT('c');
+    context.advance_to(cuda::std::move(it));
+
+    assert(container.size() == 3);
+    assert(container[2] == CharT('c'));
+  }
+}
+
+__host__ __device__ void test()
+{
+  test_advance_to<char>();
+#if _CCCL_HAS_CHAR8_T()
+  test_advance_to<char8_t>();
+#endif // _CCCL_HAS_CHAR8_T()
+  test_advance_to<char16_t>();
+  test_advance_to<char32_t>();
+#if _CCCL_HAS_WCHAR_T()
+  test_advance_to<wchar_t>();
+#endif // _CCCL_HAS_WCHAR_T()
+}
+
+int main(int, char**)
+{
+  test();
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.context/arg.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.context/arg.pass.cpp
@@ -1,0 +1,95 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/format>
+
+// basic_format_arg<basic_format_context> arg(size_t id) const;
+
+#include <cuda/std/__format_>
+#include <cuda/std/cassert>
+#include <cuda/std/cstddef>
+#include <cuda/std/inplace_vector>
+#include <cuda/std/iterator>
+#include <cuda/std/type_traits>
+
+#include "literal.h"
+
+template <class Expected>
+struct Visitor
+{
+  template <class T>
+  [[nodiscard]] __host__ __device__ bool operator()(T v) const
+  {
+    if constexpr (cuda::std::is_same_v<T, Expected>)
+    {
+      return v == expected;
+    }
+    else
+    {
+      return false;
+    }
+  }
+  Expected expected;
+};
+
+template <class Context, class T>
+__host__ __device__ bool test_basic_format_arg(cuda::std::basic_format_arg<Context> arg, T expected)
+{
+  return cuda::std::visit_format_arg(Visitor<T>{expected}, arg);
+}
+
+template <class CharT>
+__host__ __device__ void test_arg()
+{
+  using Container = cuda::std::inplace_vector<CharT, 3>;
+  using OutIt     = cuda::std::__back_insert_iterator<Container>;
+  using Context   = cuda::std::basic_format_context<OutIt, CharT>;
+
+  auto b = true;
+  auto c = TEST_CHARLIT(CharT, 'a');
+  auto n = 42;
+  auto s = cuda::std::basic_string_view{TEST_STRLIT(CharT, "string")};
+
+  Container container{};
+
+  auto store   = cuda::std::make_format_args<Context>(b, c, n, s);
+  auto args    = cuda::std::basic_format_args{store};
+  auto context = cuda::std::__fmt_make_format_context(OutIt{container}, args);
+
+  static_assert(cuda::std::is_same_v<cuda::std::basic_format_arg<Context>, decltype(context.arg(cuda::std::size_t{}))>);
+  static_assert(noexcept(context.arg(cuda::std::size_t{})));
+
+  assert(args.__size() == 4);
+
+  for (cuda::std::size_t i = 0; i != args.__size(); ++i)
+  {
+    assert(context.arg(i));
+  }
+
+  assert(!context.arg(args.__size()));
+
+  assert(test_basic_format_arg(context.arg(0), b));
+  assert(test_basic_format_arg(context.arg(1), c));
+  assert(test_basic_format_arg(context.arg(2), n));
+  assert(test_basic_format_arg(context.arg(3), s));
+}
+
+__host__ __device__ void test()
+{
+  test_arg<char>();
+#if _CCCL_HAS_WCHAR_T()
+  test_arg<wchar_t>();
+#endif // _CCCL_HAS_WCHAR_T()
+}
+
+int main(int, char**)
+{
+  test();
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.context/arg.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.context/arg.pass.cpp
@@ -24,7 +24,7 @@ template <class Expected>
 struct Visitor
 {
   template <class T>
-  [[nodiscard]] __host__ __device__ bool operator()(T v) const
+  [[nodiscard]] __host__ __device__ bool operator()([[maybe_unused]] T v) const
   {
     if constexpr (cuda::std::is_same_v<T, Expected>)
     {

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.context/ctor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.context/ctor.pass.cpp
@@ -25,7 +25,7 @@ template <class Expected>
 struct Visitor
 {
   template <class T>
-  [[nodiscard]] __host__ __device__ bool operator()(T v) const
+  [[nodiscard]] __host__ __device__ bool operator()([[maybe_unused]] T v) const
   {
     if constexpr (cuda::std::is_same_v<T, Expected>)
     {

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.context/ctor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.context/ctor.pass.cpp
@@ -1,0 +1,98 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/format>
+
+// The Standard does not specify a constructor
+// basic_format_context(Out out, basic_format_args<basic_format_context> args);
+
+#include <cuda/std/__format_>
+#include <cuda/std/cassert>
+#include <cuda/std/cstddef>
+#include <cuda/std/inplace_vector>
+#include <cuda/std/iterator>
+#include <cuda/std/type_traits>
+
+#include "literal.h"
+
+template <class Expected>
+struct Visitor
+{
+  template <class T>
+  [[nodiscard]] __host__ __device__ bool operator()(T v) const
+  {
+    if constexpr (cuda::std::is_same_v<T, Expected>)
+    {
+      return v == expected;
+    }
+    else
+    {
+      return false;
+    }
+  }
+  Expected expected;
+};
+
+template <class Context, class T>
+__host__ __device__ bool test_basic_format_arg(cuda::std::basic_format_arg<Context> arg, T expected)
+{
+  return cuda::std::visit_format_arg(Visitor<T>{expected}, arg);
+}
+
+template <class CharT>
+__host__ __device__ void test_constructor()
+{
+  using Container = cuda::std::inplace_vector<CharT, 3>;
+  using OutIt     = cuda::std::__back_insert_iterator<Container>;
+  using Context   = cuda::std::basic_format_context<OutIt, CharT>;
+
+  auto b = true;
+  auto c = TEST_CHARLIT(CharT, 'a');
+  auto n = 42;
+  auto s = cuda::std::basic_string_view{TEST_STRLIT(CharT, "string")};
+
+  Container container{};
+
+  auto store   = cuda::std::make_format_args<Context>(b, c, n, s);
+  auto args    = cuda::std::basic_format_args{store};
+  auto context = cuda::std::__fmt_make_format_context(OutIt{container}, args);
+
+  assert(args.__size() == 4);
+
+  assert(test_basic_format_arg(context.arg(0), b));
+  assert(test_basic_format_arg(context.arg(1), c));
+  assert(test_basic_format_arg(context.arg(2), n));
+  assert(test_basic_format_arg(context.arg(3), s));
+
+  context.out() = CharT('a');
+  assert(container.size() == 1);
+  assert(container.front() == CharT('a'));
+
+  // Format context cannot be constructed by user, is not default constructible, copyable, movable, assignable and
+  // move-assignable
+  static_assert(!cuda::std::is_default_constructible_v<Context>);
+  static_assert(!cuda::std::is_copy_constructible_v<Context>);
+  static_assert(!cuda::std::is_move_constructible_v<Context>);
+  static_assert(!cuda::std::is_copy_assignable_v<Context>);
+  static_assert(!cuda::std::is_move_assignable_v<Context>);
+}
+
+__host__ __device__ void test()
+{
+  test_constructor<char>();
+#if _CCCL_HAS_WCHAR_T()
+  test_constructor<wchar_t>();
+#endif // _CCCL_HAS_WCHAR_T()
+}
+
+int main(int, char**)
+{
+  test();
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.context/out.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.context/out.pass.cpp
@@ -1,0 +1,65 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/format>
+
+// iterator out();
+
+#include <cuda/std/__format_>
+#include <cuda/std/cassert>
+#include <cuda/std/inplace_vector>
+#include <cuda/std/iterator>
+#include <cuda/std/type_traits>
+
+template <class CharT>
+__host__ __device__ void test_out()
+{
+  using Container = cuda::std::inplace_vector<CharT, 3>;
+  using OutIt     = cuda::std::__back_insert_iterator<Container>;
+  using Context   = cuda::std::basic_format_context<OutIt, CharT>;
+
+  Container container{};
+
+  auto store   = cuda::std::make_format_args<Context>();
+  auto args    = cuda::std::basic_format_args{store};
+  auto context = cuda::std::__fmt_make_format_context(OutIt{container}, args);
+
+  static_assert(cuda::std::is_same_v<OutIt, decltype(context.out())>);
+
+  {
+    OutIt out_it = context.out();
+    *out_it++    = CharT('a');
+    *out_it++    = CharT('b');
+    *out_it++    = CharT('c');
+
+    assert(container.size() == 3);
+    assert(container[0] == CharT('a'));
+    assert(container[1] == CharT('b'));
+    assert(container[2] == CharT('c'));
+  }
+}
+
+__host__ __device__ void test()
+{
+  test_out<char>();
+#if _CCCL_HAS_CHAR8_T()
+  test_out<char8_t>();
+#endif // _CCCL_HAS_CHAR8_T()
+  test_out<char16_t>();
+  test_out<char32_t>();
+#if _CCCL_HAS_WCHAR_T()
+  test_out<wchar_t>();
+#endif // _CCCL_HAS_WCHAR_T()
+}
+
+int main(int, char**)
+{
+  test();
+  return 0;
+}


### PR DESCRIPTION
This PR addopts the libc++'s implementation `format.arguments` and `format.context` from the standard formatting library.

Implemented types:
- [`basic_format_arg`](https://en.cppreference.com/w/cpp/utility/format/basic_format_arg.html)
- [`basic_format_arg::handle`](https://en.cppreference.com/w/cpp/utility/format/basic_format_arg/handle.html)
- [`basic_format_args`](https://en.cppreference.com/w/cpp/utility/format/basic_format_args.html)
- [`basic_format_context`](https://en.cppreference.com/w/cpp/utility/format/basic_format_context.html)

Implemented functions:
- [`visit_format_arg`](https://en.cppreference.com/w/cpp/utility/format/visit_format_arg.html)
- [`make_(w)format_args`](https://en.cppreference.com/w/cpp/utility/format/make_format_args.html)

Introduced, but not implemented types (future work):
- [`formatter`](https://en.cppreference.com/w/cpp/utility/format/formatter.html)
- `__fmt_output_buffer` (internal)

The implementation is missing C++23 and C++26 features as well as support for host's standard library types for now.

PS: I am sorry about how big the PR is, but the types and functions are tied up together so closely it was not possible.