### PR TITLE
[CUDAX] Uglify driver API header and remove CUDAX prefix from the driver function getter

### DIFF
--- a/cudax/include/cuda/experimental/__algorithm/copy.cuh
+++ b/cudax/include/cuda/experimental/__algorithm/copy.cuh
@@ -45,7 +45,7 @@ void __copy_bytes_impl(stream_ref __stream, _CUDA_VSTD::span<_SrcTy> __src, _CUD
     _CUDA_VSTD::__throw_invalid_argument("Copy destination is too small to fit the source data");
   }
 
-  __detail::driver::memcpyAsync(__dst.data(), __src.data(), __src.size_bytes(), __stream.get());
+  __detail::driver::__memcpyAsync(__dst.data(), __src.data(), __src.size_bytes(), __stream.get());
 }
 
 template <typename _SrcExtents, typename _DstExtents>

--- a/cudax/include/cuda/experimental/__algorithm/copy.cuh
+++ b/cudax/include/cuda/experimental/__algorithm/copy.cuh
@@ -45,7 +45,7 @@ void __copy_bytes_impl(stream_ref __stream, _CUDA_VSTD::span<_SrcTy> __src, _CUD
     _CUDA_VSTD::__throw_invalid_argument("Copy destination is too small to fit the source data");
   }
 
-  __detail::driver::__memcpyAsync(__dst.data(), __src.data(), __src.size_bytes(), __stream.get());
+  ::cuda::experimental::__driver::__memcpyAsync(__dst.data(), __src.data(), __src.size_bytes(), __stream.get());
 }
 
 template <typename _SrcExtents, typename _DstExtents>

--- a/cudax/include/cuda/experimental/__algorithm/fill.cuh
+++ b/cudax/include/cuda/experimental/__algorithm/fill.cuh
@@ -39,7 +39,7 @@ void __fill_bytes_impl(stream_ref __stream, _CUDA_VSTD::span<_DstTy, _DstSize> _
   static_assert(_CUDA_VSTD::is_trivially_copyable_v<_DstTy>);
 
   // TODO do a host callback if not device accessible?
-  __detail::driver::__memsetAsync(__dst.data(), __value, __dst.size_bytes(), __stream.get());
+  ::cuda::experimental::__driver::__memsetAsync(__dst.data(), __value, __dst.size_bytes(), __stream.get());
 }
 
 template <typename _DstElem, typename _DstExtents, typename _DstLayout, typename _DstAccessor>

--- a/cudax/include/cuda/experimental/__algorithm/fill.cuh
+++ b/cudax/include/cuda/experimental/__algorithm/fill.cuh
@@ -39,7 +39,7 @@ void __fill_bytes_impl(stream_ref __stream, _CUDA_VSTD::span<_DstTy, _DstSize> _
   static_assert(_CUDA_VSTD::is_trivially_copyable_v<_DstTy>);
 
   // TODO do a host callback if not device accessible?
-  __detail::driver::memsetAsync(__dst.data(), __value, __dst.size_bytes(), __stream.get());
+  __detail::driver::__memsetAsync(__dst.data(), __value, __dst.size_bytes(), __stream.get());
 }
 
 template <typename _DstElem, typename _DstExtents, typename _DstLayout, typename _DstAccessor>

--- a/cudax/include/cuda/experimental/__container/async_buffer.cuh
+++ b/cudax/include/cuda/experimental/__container/async_buffer.cuh
@@ -175,7 +175,8 @@ private:
 
     static_assert(_CUDA_VSTD::contiguous_iterator<_Iter>, "Non contiguous iterators are not supported");
     // TODO use batched memcpy for non-contiguous iterators, it allows to specify stream ordered access
-    __detail::driver::memcpyAsync(__dest, _CUDA_VSTD::to_address(__first), sizeof(_Tp) * __count, __buf_.stream().get());
+    __detail::driver::__memcpyAsync(
+      __dest, _CUDA_VSTD::to_address(__first), sizeof(_Tp) * __count, __buf_.stream().get());
   }
 
   //! @brief Value-initializes elements in the range `[__first, __first + __count)`.
@@ -637,7 +638,7 @@ template <typename _BufferTo, typename _BufferFrom>
 void __copy_cross_buffers(stream_ref __stream, _BufferTo& __to, const _BufferFrom& __from)
 {
   __stream.wait(__from.stream());
-  __detail::driver::memcpyAsync(
+  __detail::driver::__memcpyAsync(
     __to.__unwrapped_begin(),
     __from.__unwrapped_begin(),
     sizeof(typename _BufferTo::value_type) * __from.size(),

--- a/cudax/include/cuda/experimental/__container/async_buffer.cuh
+++ b/cudax/include/cuda/experimental/__container/async_buffer.cuh
@@ -175,7 +175,7 @@ private:
 
     static_assert(_CUDA_VSTD::contiguous_iterator<_Iter>, "Non contiguous iterators are not supported");
     // TODO use batched memcpy for non-contiguous iterators, it allows to specify stream ordered access
-    __detail::driver::__memcpyAsync(
+    ::cuda::experimental::__driver::__memcpyAsync(
       __dest, _CUDA_VSTD::to_address(__first), sizeof(_Tp) * __count, __buf_.stream().get());
   }
 
@@ -638,7 +638,7 @@ template <typename _BufferTo, typename _BufferFrom>
 void __copy_cross_buffers(stream_ref __stream, _BufferTo& __to, const _BufferFrom& __from)
 {
   __stream.wait(__from.stream());
-  __detail::driver::__memcpyAsync(
+  ::cuda::experimental::__driver::__memcpyAsync(
     __to.__unwrapped_begin(),
     __from.__unwrapped_begin(),
     sizeof(typename _BufferTo::value_type) * __from.size(),

--- a/cudax/include/cuda/experimental/__device/device.cuh
+++ b/cudax/include/cuda/experimental/__device/device.cuh
@@ -94,8 +94,8 @@ public:
   CUcontext primary_context() const
   {
     ::std::call_once(__init_once, [this]() {
-      __device      = __detail::driver::__deviceGet(__id_);
-      __primary_ctx = __detail::driver::__primaryCtxRetain(__device);
+      __device      = ::cuda::experimental::__driver::__deviceGet(__id_);
+      __primary_ctx = ::cuda::experimental::__driver::__primaryCtxRetain(__device);
     });
     _CCCL_ASSERT(__primary_ctx != nullptr, "cuda::experimental::primary_context failed to get context");
     return __primary_ctx;
@@ -105,7 +105,7 @@ public:
   {
     if (__primary_ctx)
     {
-      __detail::driver::__primaryCtxRelease(__device);
+      ::cuda::experimental::__driver::__primaryCtxRelease(__device);
     }
   }
 

--- a/cudax/include/cuda/experimental/__device/device.cuh
+++ b/cudax/include/cuda/experimental/__device/device.cuh
@@ -94,8 +94,8 @@ public:
   CUcontext primary_context() const
   {
     ::std::call_once(__init_once, [this]() {
-      __device      = __detail::driver::deviceGet(__id_);
-      __primary_ctx = __detail::driver::primaryCtxRetain(__device);
+      __device      = __detail::driver::__deviceGet(__id_);
+      __primary_ctx = __detail::driver::__primaryCtxRetain(__device);
     });
     _CCCL_ASSERT(__primary_ctx != nullptr, "cuda::experimental::primary_context failed to get context");
     return __primary_ctx;
@@ -105,7 +105,7 @@ public:
   {
     if (__primary_ctx)
     {
-      __detail::driver::primaryCtxRelease(__device);
+      __detail::driver::__primaryCtxRelease(__device);
     }
   }
 

--- a/cudax/include/cuda/experimental/__device/device_ref.cuh
+++ b/cudax/include/cuda/experimental/__device/device_ref.cuh
@@ -122,7 +122,7 @@ public:
     ::std::string __name(256, 0);
 
     // For some reason there is no separate name query in CUDA runtime
-    __detail::driver::getName(__name.data(), __max_name_length, get());
+    __detail::driver::__getName(__name.data(), __max_name_length, get());
     return __name;
   }
 

--- a/cudax/include/cuda/experimental/__device/device_ref.cuh
+++ b/cudax/include/cuda/experimental/__device/device_ref.cuh
@@ -122,7 +122,7 @@ public:
     ::std::string __name(256, 0);
 
     // For some reason there is no separate name query in CUDA runtime
-    __detail::driver::__getName(__name.data(), __max_name_length, get());
+    ::cuda::experimental::__driver::__getName(__name.data(), __max_name_length, get());
     return __name;
   }
 

--- a/cudax/include/cuda/experimental/__event/event.cuh
+++ b/cudax/include/cuda/experimental/__event/event.cuh
@@ -98,7 +98,7 @@ public:
     {
       // Needs to call driver API in case current device is not set, runtime version would set dev 0 current
       // Alternative would be to store the device and push/pop here
-      [[maybe_unused]] auto __status = __detail::driver::eventDestroy(__event_);
+      [[maybe_unused]] auto __status = __detail::driver::__eventDestroy(__event_);
     }
   }
 

--- a/cudax/include/cuda/experimental/__event/event.cuh
+++ b/cudax/include/cuda/experimental/__event/event.cuh
@@ -98,7 +98,7 @@ public:
     {
       // Needs to call driver API in case current device is not set, runtime version would set dev 0 current
       // Alternative would be to store the device and push/pop here
-      [[maybe_unused]] auto __status = __detail::driver::__eventDestroy(__event_);
+      [[maybe_unused]] auto __status = ::cuda::experimental::__driver::__eventDestroyNoThrow(__event_);
     }
   }
 

--- a/cudax/include/cuda/experimental/__event/event_ref.cuh
+++ b/cudax/include/cuda/experimental/__event/event_ref.cuh
@@ -79,7 +79,7 @@ public:
     _CCCL_ASSERT(__event_ != nullptr, "cuda::experimental::event_ref::record no event set");
     _CCCL_ASSERT(__stream.get() != nullptr, "cuda::experimental::event_ref::record invalid stream passed");
     // Need to use driver API, cudaEventRecord will push dev 0 if stack is empty
-    __detail::driver::eventRecord(__event_, __stream.get());
+    __detail::driver::__eventRecord(__event_, __stream.get());
   }
 
   //! @brief Synchronizes the event

--- a/cudax/include/cuda/experimental/__event/event_ref.cuh
+++ b/cudax/include/cuda/experimental/__event/event_ref.cuh
@@ -79,7 +79,7 @@ public:
     _CCCL_ASSERT(__event_ != nullptr, "cuda::experimental::event_ref::record no event set");
     _CCCL_ASSERT(__stream.get() != nullptr, "cuda::experimental::event_ref::record invalid stream passed");
     // Need to use driver API, cudaEventRecord will push dev 0 if stack is empty
-    __detail::driver::__eventRecord(__event_, __stream.get());
+    ::cuda::experimental::__driver::__eventRecord(__event_, __stream.get());
   }
 
   //! @brief Synchronizes the event

--- a/cudax/include/cuda/experimental/__event/timed_event.cuh
+++ b/cudax/include/cuda/experimental/__event/timed_event.cuh
@@ -100,7 +100,7 @@ public:
   [[nodiscard]] friend _CUDA_VSTD::chrono::nanoseconds operator-(const timed_event& __end, const timed_event& __start)
   {
     float __ms = 0.0f;
-    __detail::driver::__eventElapsedTime(__start.get(), __end.get(), &__ms);
+    ::cuda::experimental::__driver::__eventElapsedTime(__start.get(), __end.get(), &__ms);
     return _CUDA_VSTD::chrono::nanoseconds(static_cast<_CUDA_VSTD::chrono::nanoseconds::rep>(__ms * 1'000'000.0));
   }
 

--- a/cudax/include/cuda/experimental/__event/timed_event.cuh
+++ b/cudax/include/cuda/experimental/__event/timed_event.cuh
@@ -100,7 +100,7 @@ public:
   [[nodiscard]] friend _CUDA_VSTD::chrono::nanoseconds operator-(const timed_event& __end, const timed_event& __start)
   {
     float __ms = 0.0f;
-    __detail::driver::eventElapsedTime(__start.get(), __end.get(), &__ms);
+    __detail::driver::__eventElapsedTime(__start.get(), __end.get(), &__ms);
     return _CUDA_VSTD::chrono::nanoseconds(static_cast<_CUDA_VSTD::chrono::nanoseconds::rep>(__ms * 1'000'000.0));
   }
 

--- a/cudax/include/cuda/experimental/__green_context/green_ctx.cuh
+++ b/cudax/include/cuda/experimental/__green_context/green_ctx.cuh
@@ -44,9 +44,9 @@ struct green_context
       : __dev_id(__device.get())
   {
     // TODO get CUdevice from device
-    auto __dev_handle = __detail::driver::__deviceGet(__dev_id);
-    __green_ctx       = __detail::driver::__greenCtxCreate(__dev_handle);
-    __transformed     = __detail::driver::__ctxFromGreenCtx(__green_ctx);
+    auto __dev_handle = ::cuda::experimental::__driver::__deviceGet(__dev_id);
+    __green_ctx       = ::cuda::experimental::__driver::__greenCtxCreate(__dev_handle);
+    __transformed     = ::cuda::experimental::__driver::__ctxFromGreenCtx(__green_ctx);
   }
 
   green_context(const green_context&)            = delete;
@@ -56,10 +56,10 @@ struct green_context
   [[nodiscard]] static green_context from_native_handle(CUgreenCtx __gctx)
   {
     int __id;
-    CUcontext __transformed = __detail::driver::__ctxFromGreenCtx(__gctx);
-    __detail::driver::__ctxPush(__transformed);
+    CUcontext __transformed = ::cuda::experimental::__driver::__ctxFromGreenCtx(__gctx);
+    ::cuda::experimental::__driver::__ctxPush(__transformed);
     _CCCL_TRY_CUDA_API(cudaGetDevice, "Failed to get device ordinal from a green context", &__id);
-    __detail::driver::__ctxPop();
+    ::cuda::experimental::__driver::__ctxPop();
     return green_context(__id, __gctx, __transformed);
   }
 
@@ -74,7 +74,7 @@ struct green_context
   {
     if (__green_ctx)
     {
-      [[maybe_unused]] cudaError_t __status = __detail::driver::__greenCtxDestroy(__green_ctx);
+      [[maybe_unused]] cudaError_t __status = ::cuda::experimental::__driver::__greenCtxDestroyNoThrow(__green_ctx);
     }
   }
 

--- a/cudax/include/cuda/experimental/__green_context/green_ctx.cuh
+++ b/cudax/include/cuda/experimental/__green_context/green_ctx.cuh
@@ -44,9 +44,9 @@ struct green_context
       : __dev_id(__device.get())
   {
     // TODO get CUdevice from device
-    auto __dev_handle = __detail::driver::deviceGet(__dev_id);
-    __green_ctx       = __detail::driver::greenCtxCreate(__dev_handle);
-    __transformed     = __detail::driver::ctxFromGreenCtx(__green_ctx);
+    auto __dev_handle = __detail::driver::__deviceGet(__dev_id);
+    __green_ctx       = __detail::driver::__greenCtxCreate(__dev_handle);
+    __transformed     = __detail::driver::__ctxFromGreenCtx(__green_ctx);
   }
 
   green_context(const green_context&)            = delete;
@@ -56,10 +56,10 @@ struct green_context
   [[nodiscard]] static green_context from_native_handle(CUgreenCtx __gctx)
   {
     int __id;
-    CUcontext __transformed = __detail::driver::ctxFromGreenCtx(__gctx);
-    __detail::driver::ctxPush(__transformed);
+    CUcontext __transformed = __detail::driver::__ctxFromGreenCtx(__gctx);
+    __detail::driver::__ctxPush(__transformed);
     _CCCL_TRY_CUDA_API(cudaGetDevice, "Failed to get device ordinal from a green context", &__id);
-    __detail::driver::ctxPop();
+    __detail::driver::__ctxPop();
     return green_context(__id, __gctx, __transformed);
   }
 
@@ -74,7 +74,7 @@ struct green_context
   {
     if (__green_ctx)
     {
-      [[maybe_unused]] cudaError_t __status = __detail::driver::greenCtxDestroy(__green_ctx);
+      [[maybe_unused]] cudaError_t __status = __detail::driver::__greenCtxDestroy(__green_ctx);
     }
   }
 

--- a/cudax/include/cuda/experimental/__stream/stream.cuh
+++ b/cudax/include/cuda/experimental/__stream/stream.cuh
@@ -95,7 +95,7 @@ struct stream : stream_ref
     {
       // Needs to call driver API in case current device is not set, runtime version would set dev 0 current
       // Alternative would be to store the device and push/pop here
-      [[maybe_unused]] auto status = __detail::driver::__streamDestroy(__stream);
+      [[maybe_unused]] auto status = ::cuda::experimental::__driver::__streamDestroyNoThrow(__stream);
     }
   }
 

--- a/cudax/include/cuda/experimental/__stream/stream.cuh
+++ b/cudax/include/cuda/experimental/__stream/stream.cuh
@@ -95,7 +95,7 @@ struct stream : stream_ref
     {
       // Needs to call driver API in case current device is not set, runtime version would set dev 0 current
       // Alternative would be to store the device and push/pop here
-      [[maybe_unused]] auto status = __detail::driver::streamDestroy(__stream);
+      [[maybe_unused]] auto status = __detail::driver::__streamDestroy(__stream);
     }
   }
 

--- a/cudax/include/cuda/experimental/__stream/stream_ref.cuh
+++ b/cudax/include/cuda/experimental/__stream/stream_ref.cuh
@@ -85,7 +85,7 @@ struct stream_ref : ::cuda::stream_ref
   //! \return `true` if all operations have completed, or `false` if not.
   [[nodiscard]] bool is_done() const
   {
-    const auto __result = __detail::driver::__streamQuery(__stream);
+    const auto __result = ::cuda::experimental::__driver::__streamQueryNoThrow(__stream);
     switch (__result)
     {
       case ::cudaErrorNotReady:
@@ -110,7 +110,7 @@ struct stream_ref : ::cuda::stream_ref
   //! @throws cuda_error if the priority query fails
   [[nodiscard]] _CCCL_HOST_API int priority() const
   {
-    return __detail::driver::__streamGetPriority(__stream);
+    return ::cuda::experimental::__driver::__streamGetPriority(__stream);
   }
 
   //! @brief Get the unique ID of the stream
@@ -122,7 +122,7 @@ struct stream_ref : ::cuda::stream_ref
   //! @throws cuda_error if the ID query fails
   [[nodiscard]] _CCCL_HOST_API stream_id id() const
   {
-    return stream_id{__detail::driver::__streamGetId(__stream)};
+    return stream_id{::cuda::experimental::__driver::__streamGetId(__stream)};
   }
 
   //! @brief Create a new event and record it into this stream
@@ -150,7 +150,7 @@ struct stream_ref : ::cuda::stream_ref
   //! @throws cuda_error if synchronization fails
   _CCCL_HOST_API void sync() const
   {
-    __detail::driver::__streamSynchronize(__stream);
+    ::cuda::experimental::__driver::__streamSynchronize(__stream);
   }
 
   //! @brief Make all future work submitted into this stream depend on completion of the specified event
@@ -162,7 +162,7 @@ struct stream_ref : ::cuda::stream_ref
   {
     _CCCL_ASSERT(__ev.get() != nullptr, "cuda::experimental::stream_ref::wait invalid event passed");
     // Need to use driver API, cudaStreamWaitEvent would push dev 0 if stack was empty
-    __detail::driver::__streamWaitEvent(get(), __ev.get());
+    ::cuda::experimental::__driver::__streamWaitEvent(get(), __ev.get());
   }
 
   //! @brief Returns a \c execution::sender that completes on this stream.
@@ -197,12 +197,12 @@ struct stream_ref : ::cuda::stream_ref
     CUcontext __stream_ctx;
     ::cuda::experimental::logical_device::kinds __ctx_kind = ::cuda::experimental::logical_device::kinds::device;
 #if _CCCL_CTK_AT_LEAST(12, 5)
-    if (__detail::driver::__getVersion() >= 12050)
+    if (__driver::__getVersion() >= 12050)
     {
-      auto __ctx = __detail::driver::__streamGetCtx_v2(__stream);
-      if (__ctx.__ctx_kind == __detail::driver::__ctx_from_stream::__kind::__green)
+      auto __ctx = ::cuda::experimental::__driver::__streamGetCtx_v2(__stream);
+      if (__ctx.__ctx_kind == ::cuda::experimental::__driver::__ctx_from_stream::__kind::__green)
       {
-        __stream_ctx = __detail::driver::__ctxFromGreenCtx(__ctx.__ctx_ptr.__green);
+        __stream_ctx = ::cuda::experimental::__driver::__ctxFromGreenCtx(__ctx.__ctx_ptr.__green);
         __ctx_kind   = ::cuda::experimental::logical_device::kinds::green_context;
       }
       else
@@ -214,7 +214,7 @@ struct stream_ref : ::cuda::stream_ref
     else
 #endif // _CCCL_CTK_AT_LEAST(12, 5)
     {
-      __stream_ctx = __detail::driver::__streamGetCtx(__stream);
+      __stream_ctx = ::cuda::experimental::__driver::__streamGetCtx(__stream);
       __ctx_kind   = ::cuda::experimental::logical_device::kinds::device;
     }
     // Because the stream can come from_native_handle, we can't just loop over devices comparing contexts,

--- a/cudax/include/cuda/experimental/__stream/stream_ref.cuh
+++ b/cudax/include/cuda/experimental/__stream/stream_ref.cuh
@@ -85,7 +85,7 @@ struct stream_ref : ::cuda::stream_ref
   //! \return `true` if all operations have completed, or `false` if not.
   [[nodiscard]] bool is_done() const
   {
-    const auto __result = __detail::driver::streamQuery(__stream);
+    const auto __result = __detail::driver::__streamQuery(__stream);
     switch (__result)
     {
       case ::cudaErrorNotReady:
@@ -110,7 +110,7 @@ struct stream_ref : ::cuda::stream_ref
   //! @throws cuda_error if the priority query fails
   [[nodiscard]] _CCCL_HOST_API int priority() const
   {
-    return __detail::driver::streamGetPriority(__stream);
+    return __detail::driver::__streamGetPriority(__stream);
   }
 
   //! @brief Get the unique ID of the stream
@@ -122,7 +122,7 @@ struct stream_ref : ::cuda::stream_ref
   //! @throws cuda_error if the ID query fails
   [[nodiscard]] _CCCL_HOST_API stream_id id() const
   {
-    return stream_id{__detail::driver::streamGetId(__stream)};
+    return stream_id{__detail::driver::__streamGetId(__stream)};
   }
 
   //! @brief Create a new event and record it into this stream
@@ -150,7 +150,7 @@ struct stream_ref : ::cuda::stream_ref
   //! @throws cuda_error if synchronization fails
   _CCCL_HOST_API void sync() const
   {
-    __detail::driver::streamSynchronize(__stream);
+    __detail::driver::__streamSynchronize(__stream);
   }
 
   //! @brief Make all future work submitted into this stream depend on completion of the specified event
@@ -162,7 +162,7 @@ struct stream_ref : ::cuda::stream_ref
   {
     _CCCL_ASSERT(__ev.get() != nullptr, "cuda::experimental::stream_ref::wait invalid event passed");
     // Need to use driver API, cudaStreamWaitEvent would push dev 0 if stack was empty
-    __detail::driver::streamWaitEvent(get(), __ev.get());
+    __detail::driver::__streamWaitEvent(get(), __ev.get());
   }
 
   //! @brief Returns a \c execution::sender that completes on this stream.
@@ -196,14 +196,13 @@ struct stream_ref : ::cuda::stream_ref
   {
     CUcontext __stream_ctx;
     ::cuda::experimental::logical_device::kinds __ctx_kind = ::cuda::experimental::logical_device::kinds::device;
-
 #if _CCCL_CTK_AT_LEAST(12, 5)
-    if (__detail::driver::getVersion() >= 12050)
+    if (__detail::driver::__getVersion() >= 12050)
     {
-      auto __ctx = __detail::driver::streamGetCtx_v2(__stream);
+      auto __ctx = __detail::driver::__streamGetCtx_v2(__stream);
       if (__ctx.__ctx_kind == __detail::driver::__ctx_from_stream::__kind::__green)
       {
-        __stream_ctx = __detail::driver::ctxFromGreenCtx(__ctx.__ctx_ptr.__green);
+        __stream_ctx = __detail::driver::__ctxFromGreenCtx(__ctx.__ctx_ptr.__green);
         __ctx_kind   = ::cuda::experimental::logical_device::kinds::green_context;
       }
       else
@@ -215,7 +214,7 @@ struct stream_ref : ::cuda::stream_ref
     else
 #endif // _CCCL_CTK_AT_LEAST(12, 5)
     {
-      __stream_ctx = __detail::driver::streamGetCtx(__stream);
+      __stream_ctx = __detail::driver::__streamGetCtx(__stream);
       __ctx_kind   = ::cuda::experimental::logical_device::kinds::device;
     }
     // Because the stream can come from_native_handle, we can't just loop over devices comparing contexts,

--- a/cudax/include/cuda/experimental/__utility/driver_api.cuh
+++ b/cudax/include/cuda/experimental/__utility/driver_api.cuh
@@ -29,7 +29,8 @@ namespace cuda::experimental::__driver
 //! @brief Get a driver function pointer for a given API name and optionally specific CUDA version
 //!
 //! For minor version compatibility request the 12.0 version of everything for now, unless requested otherwise
-inline void* __get_driver_entry_point(const char* __name, [[maybe_unused]] int __major = 12, [[maybe_unused]] int __minor = 0)
+inline void*
+__get_driver_entry_point(const char* __name, [[maybe_unused]] int __major = 12, [[maybe_unused]] int __minor = 0)
 {
   void* __fn;
   ::cudaDriverEntryPointQueryResult __result;
@@ -171,8 +172,8 @@ struct __ctx_from_stream
 inline __ctx_from_stream __streamGetCtx_v2(::CUstream __stream)
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION_VERSIONED(cuStreamGetCtx, cuStreamGetCtx_v2, 12, 5);
-  ::CUcontext __ctx         = nullptr;
-  ::CUgreenCtx __gctx       = nullptr;
+  ::CUcontext __ctx       = nullptr;
+  ::CUgreenCtx __gctx     = nullptr;
   __ctx_from_stream __result;
   __call_driver_fn(__driver_fn, "Failed to get context from a stream", __stream, &__ctx, &__gctx);
   if (__gctx)
@@ -189,10 +190,10 @@ inline __ctx_from_stream __streamGetCtx_v2(::CUstream __stream)
 }
 #endif // _CCCL_CTK_AT_LEAST(12, 5)
 
-inline void __streamWaitEvent(::CUstream __stream, ::CUevent __event)
+inline void __streamWaitEvent(::CUstream __stream, ::CUevent __evnt)
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuStreamWaitEvent);
-  __call_driver_fn(__driver_fn, "Failed to make a stream wait for an event", __stream, __event, ::CU_EVENT_WAIT_DEFAULT);
+  __call_driver_fn(__driver_fn, "Failed to make a stream wait for an event", __stream, __evnt, ::CU_EVENT_WAIT_DEFAULT);
 }
 
 inline ::cudaError_t __streamQueryNoThrow(::CUstream __stream)
@@ -217,10 +218,10 @@ inline unsigned long long __streamGetId(::CUstream __stream)
   return __id;
 }
 
-inline void __eventRecord(::CUevent __event, ::CUstream __stream)
+inline void __eventRecord(::CUevent __evnt, ::CUstream __stream)
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuEventRecord);
-  __call_driver_fn(__driver_fn, "Failed to record CUDA event", __event, __stream);
+  __call_driver_fn(__driver_fn, "Failed to record CUDA event", __evnt, __stream);
 }
 
 // Destroy calls return error codes to let the calling code decide if the error should be ignored
@@ -230,10 +231,10 @@ inline ::cudaError_t __streamDestroyNoThrow(::CUstream __stream)
   return static_cast<::cudaError_t>(__driver_fn(__stream));
 }
 
-inline ::cudaError_t __eventDestroyNoThrow(::CUevent __event)
+inline ::cudaError_t __eventDestroyNoThrow(::CUevent __evnt)
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuEventDestroy);
-  return static_cast<::cudaError_t>(__driver_fn(__event));
+  return static_cast<::cudaError_t>(__driver_fn(__evnt));
 }
 
 inline void __eventElapsedTime(::CUevent __start, ::CUevent __end, float* __ms)

--- a/cudax/include/cuda/experimental/__utility/driver_api.cuh
+++ b/cudax/include/cuda/experimental/__utility/driver_api.cuh
@@ -18,32 +18,30 @@
 #include <cuda/std/__cccl/prologue.h>
 
 // Get the driver function by name using this macro
-#define CUDAX_GET_DRIVER_FUNCTION(function_name) \
-  reinterpret_cast<decltype(function_name)*>(get_driver_entry_point(#function_name))
+#define _CCCLRT_GET_DRIVER_FUNCTION(function_name) \
+  reinterpret_cast<decltype(function_name)*>(__get_driver_entry_point(#function_name))
 
-#define CUDAX_GET_DRIVER_FUNCTION_VERSIONED(function_name, versioned_fn_name, version) \
-  reinterpret_cast<decltype(versioned_fn_name)*>(get_driver_entry_point(#function_name, version))
+#define _CCCLRT_GET_DRIVER_FUNCTION_VERSIONED(function_name, versioned_fn_name, version) \
+  reinterpret_cast<decltype(versioned_fn_name)*>(__get_driver_entry_point(#function_name, version))
 
 namespace cuda::experimental::__detail::driver
 {
 //! @brief Get a driver function pointer for a given API name and optionally specific CUDA version
 //!
 //! For minor version compatibility request the 12.0 version of everything for now, unless requested otherwise
-inline void* get_driver_entry_point(const char* name, [[maybe_unused]] int version = 12000)
+inline void* __get_driver_entry_point(const char* __name, [[maybe_unused]] int __version = 12000)
 {
-  void* fn;
-  cudaDriverEntryPointQueryResult result;
-
+  void* __fn;
+  cudaDriverEntryPointQueryResult __result;
 #if _CCCL_CTK_AT_LEAST(12, 5)
-  cudaGetDriverEntryPointByVersion(name, &fn, version, cudaEnableDefault, &result);
-#else // ^^^ _CCCL_CTK_AT_LEAST(12, 5) ^^^ / vvv _CCCL_CTK_BELOW(12, 5) vvv
+  cudaGetDriverEntryPointByVersion(__name, &__fn, __version, cudaEnableDefault, &__result);
+#else
   // Versioned get entry point not available before 12.5, but we don't need anything versioned before that
-  cudaGetDriverEntryPoint(name, &fn, cudaEnableDefault, &result);
-#endif // ^^^ _CCCL_CTK_BELOW(12, 5) ^^^
-
-  if (result != cudaDriverEntryPointSuccess)
+  cudaGetDriverEntryPoint(__name, &__fn, cudaEnableDefault, &__result);
+#endif
+  if (__result != cudaDriverEntryPointSuccess)
   {
-    if (result == cudaDriverEntryPointVersionNotSufficent)
+    if (__result == cudaDriverEntryPointVersionNotSufficent)
     {
       ::cuda::__throw_cuda_error(cudaErrorNotSupported, "Driver does not support this API");
     }
@@ -52,105 +50,105 @@ inline void* get_driver_entry_point(const char* name, [[maybe_unused]] int versi
       ::cuda::__throw_cuda_error(cudaErrorUnknown, "Failed to access driver API");
     }
   }
-  return fn;
+  return __fn;
 }
 
 template <typename Fn, typename... Args>
-inline void call_driver_fn(Fn fn, const char* err_msg, Args... args)
+inline void __call_driver_fn(Fn __fn, const char* __err_msg, Args... __args)
 {
-  CUresult status = fn(args...);
-  if (status != CUDA_SUCCESS)
+  CUresult __status = __fn(__args...);
+  if (__status != CUDA_SUCCESS)
   {
-    ::cuda::__throw_cuda_error(static_cast<cudaError_t>(status), err_msg);
+    ::cuda::__throw_cuda_error(static_cast<cudaError_t>(__status), __err_msg);
   }
 }
 
-inline int getVersion()
+inline int __getVersion()
 {
-  static int version = []() {
-    int v;
-    auto driver_fn = CUDAX_GET_DRIVER_FUNCTION(cuDriverGetVersion);
-    call_driver_fn(driver_fn, "Failed to check CUDA driver version", &v);
-    return v;
+  static int __version = []() {
+    int __v;
+    auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuDriverGetVersion);
+    __call_driver_fn(__driver_fn, "Failed to check CUDA driver version", &__v);
+    return __v;
   }();
-  return version;
+  return __version;
 }
 
-inline void ctxPush(CUcontext ctx)
+inline void __ctxPush(CUcontext __ctx)
 {
-  static auto driver_fn = CUDAX_GET_DRIVER_FUNCTION(cuCtxPushCurrent);
-  call_driver_fn(driver_fn, "Failed to push context", ctx);
+  static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuCtxPushCurrent);
+  __call_driver_fn(__driver_fn, "Failed to push context", __ctx);
 }
 
-inline CUcontext ctxPop()
+inline CUcontext __ctxPop()
 {
-  static auto driver_fn = CUDAX_GET_DRIVER_FUNCTION(cuCtxPopCurrent);
-  CUcontext result;
-  call_driver_fn(driver_fn, "Failed to pop context", &result);
-  return result;
+  static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuCtxPopCurrent);
+  CUcontext __result;
+  __call_driver_fn(__driver_fn, "Failed to pop context", &__result);
+  return __result;
 }
 
-inline CUcontext ctxGetCurrent()
+inline CUcontext __ctxGetCurrent()
 {
-  static auto driver_fn = CUDAX_GET_DRIVER_FUNCTION(cuCtxGetCurrent);
-  CUcontext result;
-  call_driver_fn(driver_fn, "Failed to get current context", &result);
-  return result;
+  static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuCtxGetCurrent);
+  CUcontext __result;
+  __call_driver_fn(__driver_fn, "Failed to get current context", &__result);
+  return __result;
 }
 
-inline CUdevice deviceGet(int ordinal)
+inline CUdevice __deviceGet(int __ordinal)
 {
-  static auto driver_fn = CUDAX_GET_DRIVER_FUNCTION(cuDeviceGet);
-  CUdevice result;
-  call_driver_fn(driver_fn, "Failed to get device", &result, ordinal);
-  return result;
+  static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuDeviceGet);
+  CUdevice __result;
+  __call_driver_fn(__driver_fn, "Failed to get device", &__result, __ordinal);
+  return __result;
 }
 
-inline void getName(char* __name_out, int __len, int __ordinal)
+inline void __getName(char* __name_out, int __len, int __ordinal)
 {
-  static auto driver_fn = CUDAX_GET_DRIVER_FUNCTION(cuDeviceGetName);
+  static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuDeviceGetName);
 
   // TODO CUdevice is just an int, we probably could just cast, but for now do the safe thing
-  CUdevice __dev = deviceGet(__ordinal);
-  call_driver_fn(driver_fn, "Failed to query the name of a device", __name_out, __len, __dev);
+  CUdevice __dev = __deviceGet(__ordinal);
+  __call_driver_fn(__driver_fn, "Failed to query the name of a device", __name_out, __len, __dev);
 }
 
-inline CUcontext primaryCtxRetain(CUdevice dev)
+inline CUcontext __primaryCtxRetain(CUdevice __dev)
 {
-  static auto driver_fn = CUDAX_GET_DRIVER_FUNCTION(cuDevicePrimaryCtxRetain);
-  CUcontext result;
-  call_driver_fn(driver_fn, "Failed to retain context for a device", &result, dev);
-  return result;
+  static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuDevicePrimaryCtxRetain);
+  CUcontext __result;
+  __call_driver_fn(__driver_fn, "Failed to retain context for a device", &__result, __dev);
+  return __result;
 }
 
-inline void primaryCtxRelease(CUdevice dev)
+inline void __primaryCtxRelease(CUdevice __dev)
 {
-  static auto driver_fn = CUDAX_GET_DRIVER_FUNCTION(cuDevicePrimaryCtxRelease);
+  static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuDevicePrimaryCtxRelease);
   // TODO we might need to ignore failure here
-  call_driver_fn(driver_fn, "Failed to release context for a device", dev);
+  __call_driver_fn(__driver_fn, "Failed to release context for a device", __dev);
 }
 
-inline bool isPrimaryCtxActive(CUdevice dev)
+inline bool __isPrimaryCtxActive(CUdevice __dev)
 {
-  static auto driver_fn = CUDAX_GET_DRIVER_FUNCTION(cuDevicePrimaryCtxGetState);
-  int result;
-  unsigned int dummy;
-  call_driver_fn(driver_fn, "Failed to check the primary ctx state", dev, &dummy, &result);
-  return result == 1;
+  static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuDevicePrimaryCtxGetState);
+  int __result;
+  unsigned int __dummy;
+  __call_driver_fn(__driver_fn, "Failed to check the primary ctx state", __dev, &__dummy, &__result);
+  return __result == 1;
 }
 
-inline void streamSynchronize(CUstream stream)
+inline void __streamSynchronize(CUstream __stream)
 {
-  static auto driver_fn = CUDAX_GET_DRIVER_FUNCTION(cuStreamSynchronize);
-  call_driver_fn(driver_fn, "Failed to synchronize a stream", stream);
+  static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuStreamSynchronize);
+  __call_driver_fn(__driver_fn, "Failed to synchronize a stream", __stream);
 }
 
-inline CUcontext streamGetCtx(CUstream stream)
+inline CUcontext __streamGetCtx(CUstream __stream)
 {
-  static auto driver_fn = CUDAX_GET_DRIVER_FUNCTION(cuStreamGetCtx);
-  CUcontext result;
-  call_driver_fn(driver_fn, "Failed to get context from a stream", stream, &result);
-  return result;
+  static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuStreamGetCtx);
+  CUcontext __result;
+  __call_driver_fn(__driver_fn, "Failed to get context from a stream", __stream, &__result);
+  return __result;
 }
 
 #if _CCCL_CTK_AT_LEAST(12, 5)
@@ -170,126 +168,128 @@ struct __ctx_from_stream
   } __ctx_ptr;
 };
 
-inline __ctx_from_stream streamGetCtx_v2(CUstream stream)
+inline __ctx_from_stream __streamGetCtx_v2(CUstream __stream)
 {
-  static auto driver_fn = CUDAX_GET_DRIVER_FUNCTION_VERSIONED(cuStreamGetCtx, cuStreamGetCtx_v2, 12050);
-  CUcontext ctx         = nullptr;
-  CUgreenCtx gctx       = nullptr;
+  static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION_VERSIONED(cuStreamGetCtx, cuStreamGetCtx_v2, 12050);
+  CUcontext __ctx         = nullptr;
+  CUgreenCtx __gctx       = nullptr;
   __ctx_from_stream __result;
-  call_driver_fn(driver_fn, "Failed to get context from a stream", stream, &ctx, &gctx);
-  if (gctx)
+  __call_driver_fn(__driver_fn, "Failed to get context from a stream", __stream, &__ctx, &__gctx);
+  if (__gctx)
   {
     __result.__ctx_kind        = __ctx_from_stream::__kind::__green;
-    __result.__ctx_ptr.__green = gctx;
+    __result.__ctx_ptr.__green = __gctx;
   }
   else
   {
     __result.__ctx_kind         = __ctx_from_stream::__kind::__device;
-    __result.__ctx_ptr.__device = ctx;
+    __result.__ctx_ptr.__device = __ctx;
   }
   return __result;
 }
 #endif // _CCCL_CTK_AT_LEAST(12, 5)
 
-inline void streamWaitEvent(CUstream stream, CUevent event)
+inline void __streamWaitEvent(CUstream __stream, CUevent __event)
 {
-  static auto driver_fn = CUDAX_GET_DRIVER_FUNCTION(cuStreamWaitEvent);
-  call_driver_fn(driver_fn, "Failed to make a stream wait for an event", stream, event, CU_EVENT_WAIT_DEFAULT);
+  static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuStreamWaitEvent);
+  __call_driver_fn(__driver_fn, "Failed to make a stream wait for an event", __stream, __event, CU_EVENT_WAIT_DEFAULT);
 }
 
-inline cudaError_t streamQuery(CUstream stream)
+inline cudaError_t __streamQuery(CUstream __stream)
 {
-  static auto driver_fn = CUDAX_GET_DRIVER_FUNCTION(cuStreamQuery);
-  return static_cast<cudaError_t>(driver_fn(stream));
+  static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuStreamQuery);
+  return static_cast<cudaError_t>(__driver_fn(__stream));
 }
 
-inline int streamGetPriority(CUstream stream)
+inline int __streamGetPriority(CUstream __stream)
 {
   int __priority;
-  static auto driver_fn = CUDAX_GET_DRIVER_FUNCTION(cuStreamGetPriority);
-  call_driver_fn(driver_fn, "Failed to get the priority of a stream", stream, &__priority);
+  static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuStreamGetPriority);
+  __call_driver_fn(__driver_fn, "Failed to get the priority of a stream", __stream, &__priority);
   return __priority;
 }
 
-inline unsigned long long streamGetId(CUstream stream)
+inline unsigned long long __streamGetId(CUstream __stream)
 {
   unsigned long long __id;
-  static auto driver_fn = CUDAX_GET_DRIVER_FUNCTION(cuStreamGetId);
-  call_driver_fn(driver_fn, "Failed to get the ID of a stream", stream, &__id);
+  static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuStreamGetId);
+  __call_driver_fn(__driver_fn, "Failed to get the ID of a stream", __stream, &__id);
   return __id;
 }
 
-inline void eventRecord(CUevent event, CUstream stream)
+inline void __eventRecord(CUevent __event, CUstream __stream)
 {
-  static auto driver_fn = CUDAX_GET_DRIVER_FUNCTION(cuEventRecord);
-  call_driver_fn(driver_fn, "Failed to record CUDA event", event, stream);
+  static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuEventRecord);
+  __call_driver_fn(__driver_fn, "Failed to record CUDA event", __event, __stream);
 }
 
 // Destroy calls return error codes to let the calling code decide if the error should be ignored
-inline cudaError_t streamDestroy(CUstream stream)
+inline cudaError_t __streamDestroy(CUstream __stream)
 {
-  static auto driver_fn = CUDAX_GET_DRIVER_FUNCTION(cuStreamDestroy);
-  return static_cast<cudaError_t>(driver_fn(stream));
+  static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuStreamDestroy);
+  return static_cast<cudaError_t>(__driver_fn(__stream));
 }
 
-inline cudaError_t eventDestroy(CUevent event)
+inline cudaError_t __eventDestroy(CUevent __event)
 {
-  static auto driver_fn = CUDAX_GET_DRIVER_FUNCTION(cuEventDestroy);
-  return static_cast<cudaError_t>(driver_fn(event));
+  static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuEventDestroy);
+  return static_cast<cudaError_t>(__driver_fn(__event));
 }
 
-inline void eventElapsedTime(CUevent start, CUevent end, float* ms)
+inline void __eventElapsedTime(CUevent __start, CUevent __end, float* __ms)
 {
-  static auto driver_fn = CUDAX_GET_DRIVER_FUNCTION(cuEventElapsedTime);
-  call_driver_fn(driver_fn, "Failed to get CUDA event elapsed time", ms, start, end);
+  static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuEventElapsedTime);
+  __call_driver_fn(__driver_fn, "Failed to get CUDA event elapsed time", __ms, __start, __end);
 }
 
 #if _CCCL_CTK_AT_LEAST(12, 5)
 // Add actual resource description input once exposure is ready
-inline CUgreenCtx greenCtxCreate(CUdevice dev)
+inline CUgreenCtx __greenCtxCreate(CUdevice __dev)
 {
-  CUgreenCtx result;
-  static auto driver_fn = CUDAX_GET_DRIVER_FUNCTION_VERSIONED(cuGreenCtxCreate, cuGreenCtxCreate, 12050);
-  call_driver_fn(driver_fn, "Failed to create a green context", &result, nullptr, dev, CU_GREEN_CTX_DEFAULT_STREAM);
-  return result;
+  CUgreenCtx __result;
+  static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION_VERSIONED(cuGreenCtxCreate, cuGreenCtxCreate, 12050);
+  __call_driver_fn(
+    __driver_fn, "Failed to create a green context", &__result, nullptr, __dev, CU_GREEN_CTX_DEFAULT_STREAM);
+  return __result;
 }
 
-inline cudaError_t greenCtxDestroy(CUgreenCtx green_ctx)
+inline cudaError_t __greenCtxDestroy(CUgreenCtx __green_ctx)
 {
-  static auto driver_fn = CUDAX_GET_DRIVER_FUNCTION_VERSIONED(cuGreenCtxDestroy, cuGreenCtxDestroy, 12050);
-  return static_cast<cudaError_t>(driver_fn(green_ctx));
+  static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION_VERSIONED(cuGreenCtxDestroy, cuGreenCtxDestroy, 12050);
+  return static_cast<cudaError_t>(__driver_fn(__green_ctx));
 }
 
-inline CUcontext ctxFromGreenCtx(CUgreenCtx green_ctx)
+inline CUcontext __ctxFromGreenCtx(CUgreenCtx __green_ctx)
 {
-  CUcontext result;
-  static auto driver_fn = CUDAX_GET_DRIVER_FUNCTION_VERSIONED(cuCtxFromGreenCtx, cuCtxFromGreenCtx, 12050);
-  call_driver_fn(driver_fn, "Failed to convert a green context", &result, green_ctx);
-  return result;
+  CUcontext __result;
+  static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION_VERSIONED(cuCtxFromGreenCtx, cuCtxFromGreenCtx, 12050);
+  __call_driver_fn(__driver_fn, "Failed to convert a green context", &__result, __green_ctx);
+  return __result;
 }
 #endif // _CCCL_CTK_AT_LEAST(12, 5)
 
-inline void memcpyAsync(void* dst, const void* src, size_t count, CUstream stream)
+inline void __memcpyAsync(void* __dst, const void* __src, size_t __count, CUstream __stream)
 {
-  static auto driver_fn = CUDAX_GET_DRIVER_FUNCTION(cuMemcpyAsync);
-  call_driver_fn(
-    driver_fn,
+  static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuMemcpyAsync);
+  __call_driver_fn(
+    __driver_fn,
     "Failed to perform a memcpy",
-    reinterpret_cast<CUdeviceptr>(dst),
-    reinterpret_cast<CUdeviceptr>(src),
-    count,
-    stream);
+    reinterpret_cast<CUdeviceptr>(__dst),
+    reinterpret_cast<CUdeviceptr>(__src),
+    __count,
+    __stream);
 }
 
-inline void memsetAsync(void* dst, uint8_t value, size_t count, CUstream stream)
+inline void __memsetAsync(void* __dst, uint8_t __value, size_t __count, CUstream __stream)
 {
-  static auto driver_fn = CUDAX_GET_DRIVER_FUNCTION(cuMemsetD8Async);
-  call_driver_fn(driver_fn, "Failed to perform a memset", reinterpret_cast<CUdeviceptr>(dst), value, count, stream);
+  static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuMemsetD8Async);
+  __call_driver_fn(
+    __driver_fn, "Failed to perform a memset", reinterpret_cast<CUdeviceptr>(__dst), __value, __count, __stream);
 }
 
 } // namespace cuda::experimental::__detail::driver
 
-#undef CUDAX_GET_DRIVER_FUNCTION
+#undef _CCCLRT_GET_DRIVER_FUNCTION
 
 #include <cuda/std/__cccl/epilogue.h>
 

--- a/cudax/include/cuda/experimental/__utility/ensure_current_device.cuh
+++ b/cudax/include/cuda/experimental/__utility/ensure_current_device.cuh
@@ -51,7 +51,7 @@ struct [[maybe_unused]] __ensure_current_device
   explicit __ensure_current_device(device_ref __new_device)
   {
     auto __ctx = devices[__new_device.get()].primary_context();
-    __detail::driver::ctxPush(__ctx);
+    __detail::driver::__ctxPush(__ctx);
   }
 
   //! @brief Construct a new `__ensure_current_device` object and switch to the specified
@@ -65,14 +65,14 @@ struct [[maybe_unused]] __ensure_current_device
   //! @throws cuda_error if the device switch fails
   explicit __ensure_current_device(logical_device __new_device)
   {
-    __detail::driver::ctxPush(__new_device.context());
+    __detail::driver::__ctxPush(__new_device.context());
   }
 
   // Doesn't really fit into the type description, we might consider changing it once
   // green ctx design is more finalized
   explicit __ensure_current_device(CUcontext __ctx)
   {
-    __detail::driver::ctxPush(__ctx);
+    __detail::driver::__ctxPush(__ctx);
   }
 
   //! @brief Construct a new `__ensure_current_device` object and switch to the device
@@ -83,8 +83,8 @@ struct [[maybe_unused]] __ensure_current_device
   //! @throws cuda_error if the device switch fails
   explicit __ensure_current_device(stream_ref __stream)
   {
-    auto __ctx = __detail::driver::streamGetCtx(__stream.get());
-    __detail::driver::ctxPush(__ctx);
+    auto __ctx = __detail::driver::__streamGetCtx(__stream.get());
+    __detail::driver::__ctxPush(__ctx);
   }
 
   _CCCL_TEMPLATE(typename _GraphInserter)
@@ -106,7 +106,7 @@ struct [[maybe_unused]] __ensure_current_device
   ~__ensure_current_device() noexcept(false)
   {
     // TODO would it make sense to assert here that we pushed and popped the same thing?
-    __detail::driver::ctxPop();
+    __detail::driver::__ctxPop();
   }
 };
 } // namespace cuda::experimental

--- a/cudax/include/cuda/experimental/__utility/ensure_current_device.cuh
+++ b/cudax/include/cuda/experimental/__utility/ensure_current_device.cuh
@@ -51,7 +51,7 @@ struct [[maybe_unused]] __ensure_current_device
   explicit __ensure_current_device(device_ref __new_device)
   {
     auto __ctx = devices[__new_device.get()].primary_context();
-    __detail::driver::__ctxPush(__ctx);
+    ::cuda::experimental::__driver::__ctxPush(__ctx);
   }
 
   //! @brief Construct a new `__ensure_current_device` object and switch to the specified
@@ -65,14 +65,14 @@ struct [[maybe_unused]] __ensure_current_device
   //! @throws cuda_error if the device switch fails
   explicit __ensure_current_device(logical_device __new_device)
   {
-    __detail::driver::__ctxPush(__new_device.context());
+    ::cuda::experimental::__driver::__ctxPush(__new_device.context());
   }
 
   // Doesn't really fit into the type description, we might consider changing it once
   // green ctx design is more finalized
   explicit __ensure_current_device(CUcontext __ctx)
   {
-    __detail::driver::__ctxPush(__ctx);
+    ::cuda::experimental::__driver::__ctxPush(__ctx);
   }
 
   //! @brief Construct a new `__ensure_current_device` object and switch to the device
@@ -83,8 +83,8 @@ struct [[maybe_unused]] __ensure_current_device
   //! @throws cuda_error if the device switch fails
   explicit __ensure_current_device(stream_ref __stream)
   {
-    auto __ctx = __detail::driver::__streamGetCtx(__stream.get());
-    __detail::driver::__ctxPush(__ctx);
+    auto __ctx = __driver::__streamGetCtx(__stream.get());
+    ::cuda::experimental::__driver::__ctxPush(__ctx);
   }
 
   _CCCL_TEMPLATE(typename _GraphInserter)
@@ -106,7 +106,7 @@ struct [[maybe_unused]] __ensure_current_device
   ~__ensure_current_device() noexcept(false)
   {
     // TODO would it make sense to assert here that we pushed and popped the same thing?
-    __detail::driver::__ctxPop();
+    ::cuda::experimental::__driver::__ctxPop();
   }
 };
 } // namespace cuda::experimental

--- a/cudax/test/common/testing.cuh
+++ b/cudax/test/common/testing.cuh
@@ -98,11 +98,11 @@ namespace test
 {
 inline int count_driver_stack()
 {
-  if (cudax::__detail::driver::__ctxGetCurrent() != nullptr)
+  if (cudax::__driver::__ctxGetCurrent() != nullptr)
   {
-    auto ctx    = cudax::__detail::driver::__ctxPop();
+    auto ctx    = cudax::__driver::__ctxPop();
     auto result = 1 + count_driver_stack();
-    cudax::__detail::driver::__ctxPush(ctx);
+    cudax::__driver::__ctxPush(ctx);
     return result;
   }
   else
@@ -113,15 +113,15 @@ inline int count_driver_stack()
 
 inline void empty_driver_stack()
 {
-  while (cudax::__detail::driver::__ctxGetCurrent() != nullptr)
+  while (cudax::__driver::__ctxGetCurrent() != nullptr)
   {
-    cudax::__detail::driver::__ctxPop();
+    cudax::__driver::__ctxPop();
   }
 }
 
 inline int cuda_driver_version()
 {
-  return cudax::__detail::driver::__getVersion();
+  return cudax::__driver::__getVersion();
 }
 
 // Needs to be a template because we use template catch2 macro

--- a/cudax/test/common/testing.cuh
+++ b/cudax/test/common/testing.cuh
@@ -98,11 +98,11 @@ namespace test
 {
 inline int count_driver_stack()
 {
-  if (cudax::__detail::driver::ctxGetCurrent() != nullptr)
+  if (cudax::__detail::driver::__ctxGetCurrent() != nullptr)
   {
-    auto ctx    = cudax::__detail::driver::ctxPop();
+    auto ctx    = cudax::__detail::driver::__ctxPop();
     auto result = 1 + count_driver_stack();
-    cudax::__detail::driver::ctxPush(ctx);
+    cudax::__detail::driver::__ctxPush(ctx);
     return result;
   }
   else
@@ -113,15 +113,15 @@ inline int count_driver_stack()
 
 inline void empty_driver_stack()
 {
-  while (cudax::__detail::driver::ctxGetCurrent() != nullptr)
+  while (cudax::__detail::driver::__ctxGetCurrent() != nullptr)
   {
-    cudax::__detail::driver::ctxPop();
+    cudax::__detail::driver::__ctxPop();
   }
 }
 
 inline int cuda_driver_version()
 {
-  return cudax::__detail::driver::getVersion();
+  return cudax::__detail::driver::__getVersion();
 }
 
 // Needs to be a template because we use template catch2 macro

--- a/cudax/test/utility/driver_api.cu
+++ b/cudax/test/utility/driver_api.cu
@@ -22,48 +22,48 @@ C2H_TEST("Call each driver api", "[utility]")
   // Pushes the primary context if the stack is empty
   CUDART(cudaStreamCreate(&stream));
 
-  auto ctx = driver::ctxGetCurrent();
+  auto ctx = driver::__ctxGetCurrent();
   CUDAX_REQUIRE(ctx != nullptr);
 
   // Confirm pop will leave the stack empty
-  driver::ctxPop();
-  CUDAX_REQUIRE(driver::ctxGetCurrent() == nullptr);
+  driver::__ctxPop();
+  CUDAX_REQUIRE(driver::__ctxGetCurrent() == nullptr);
 
   // Confirm we can push multiple times
-  driver::ctxPush(ctx);
-  CUDAX_REQUIRE(driver::ctxGetCurrent() == ctx);
+  driver::__ctxPush(ctx);
+  CUDAX_REQUIRE(driver::__ctxGetCurrent() == ctx);
 
-  driver::ctxPush(ctx);
-  CUDAX_REQUIRE(driver::ctxGetCurrent() == ctx);
+  driver::__ctxPush(ctx);
+  CUDAX_REQUIRE(driver::__ctxGetCurrent() == ctx);
 
-  driver::ctxPop();
-  CUDAX_REQUIRE(driver::ctxGetCurrent() == ctx);
+  driver::__ctxPop();
+  CUDAX_REQUIRE(driver::__ctxGetCurrent() == ctx);
 
   // Confirm stream ctx match
-  auto stream_ctx = driver::streamGetCtx(stream);
+  auto stream_ctx = driver::__streamGetCtx(stream);
   CUDAX_REQUIRE(ctx == stream_ctx);
 
   CUDART(cudaStreamDestroy(stream));
 
-  CUDAX_REQUIRE(driver::deviceGet(0) == 0);
+  CUDAX_REQUIRE(driver::__deviceGet(0) == 0);
 
   // Confirm we can retain the primary ctx that cudart retained first
-  auto primary_ctx = driver::primaryCtxRetain(0);
+  auto primary_ctx = driver::__primaryCtxRetain(0);
   CUDAX_REQUIRE(ctx == primary_ctx);
 
-  driver::ctxPop();
-  CUDAX_REQUIRE(driver::ctxGetCurrent() == nullptr);
+  driver::__ctxPop();
+  CUDAX_REQUIRE(driver::__ctxGetCurrent() == nullptr);
 
-  CUDAX_REQUIRE(driver::isPrimaryCtxActive(0));
+  CUDAX_REQUIRE(driver::__isPrimaryCtxActive(0));
   // Confirm we can reset the primary context with double release
-  driver::primaryCtxRelease(0);
-  driver::primaryCtxRelease(0);
+  driver::__primaryCtxRelease(0);
+  driver::__primaryCtxRelease(0);
 
-  CUDAX_REQUIRE(!driver::isPrimaryCtxActive(0));
+  CUDAX_REQUIRE(!driver::__isPrimaryCtxActive(0));
 
   // Confirm cudart can recover
   CUDART(cudaStreamCreate(&stream));
-  CUDAX_REQUIRE(driver::ctxGetCurrent() == ctx);
+  CUDAX_REQUIRE(driver::__ctxGetCurrent() == ctx);
 
-  CUDART(driver::streamDestroy(stream));
+  CUDART(driver::__streamDestroy(stream));
 }

--- a/cudax/test/utility/driver_api.cu
+++ b/cudax/test/utility/driver_api.cu
@@ -14,7 +14,7 @@
 
 C2H_TEST("Call each driver api", "[utility]")
 {
-  namespace driver = cuda::experimental::__detail::driver;
+  namespace driver = cuda::experimental::__driver;
   cudaStream_t stream;
   // Assumes the ctx stack was empty or had one ctx, should be the case unless some other
   // test leaves 2+ ctxs on the stack
@@ -65,5 +65,5 @@ C2H_TEST("Call each driver api", "[utility]")
   CUDART(cudaStreamCreate(&stream));
   CUDAX_REQUIRE(driver::__ctxGetCurrent() == ctx);
 
-  CUDART(driver::__streamDestroy(stream));
+  CUDART(driver::__streamDestroyNoThrow(stream));
 }

--- a/cudax/test/utility/ensure_current_device.cu
+++ b/cudax/test/utility/ensure_current_device.cu
@@ -15,7 +15,7 @@
 
 #include <utility.cuh>
 
-namespace driver = cuda::experimental::__detail::driver;
+namespace driver = cuda::experimental::__driver;
 
 void recursive_check_device_setter(int id)
 {

--- a/cudax/test/utility/ensure_current_device.cu
+++ b/cudax/test/utility/ensure_current_device.cu
@@ -22,7 +22,7 @@ void recursive_check_device_setter(int id)
   int cudart_id;
   cudax::__ensure_current_device setter(cudax::device_ref{id});
   CUDAX_REQUIRE(test::count_driver_stack() == cudax::devices.size() - id);
-  auto ctx = driver::ctxGetCurrent();
+  auto ctx = driver::__ctxGetCurrent();
   CUDART(cudaGetDevice(&cudart_id));
   CUDAX_REQUIRE(cudart_id == id);
 
@@ -31,7 +31,7 @@ void recursive_check_device_setter(int id)
     recursive_check_device_setter(id - 1);
 
     CUDAX_REQUIRE(test::count_driver_stack() == cudax::devices.size() - id);
-    CUDAX_REQUIRE(ctx == driver::ctxGetCurrent());
+    CUDAX_REQUIRE(ctx == driver::__ctxGetCurrent());
     CUDART(cudaGetDevice(&cudart_id));
     CUDAX_REQUIRE(cudart_id == id);
   }


### PR DESCRIPTION
We should use ugly names in the Driver API header.

This change also renames `CUDAX_GET_DRIVER_FUNCTION` to `_CCCLRT_GET_DRIVER_FUNCTION` to prepare for release from experimental