### PR TITLE
use constexpr `std::exception` if it is available

### DIFF
--- a/cudax/include/cuda/experimental/__execution/completion_signatures.cuh
+++ b/cudax/include/cuda/experimental/__execution/completion_signatures.cuh
@@ -620,7 +620,7 @@ template <bool _PotentiallyThrowing>
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // invalid_completion_signature
-#if _CCCL_HAS_EXCEPTIONS() && defined(__cpp_constexpr_exceptions) // C++26, https://wg21.link/p3068
+#if _CCCL_HAS_EXCEPTIONS() && __cpp_constexpr_exceptions >= 202411L // C++26, https://wg21.link/p3068
 
 template <class... _What, class... _Values>
 [[noreturn, nodiscard]] _CCCL_API consteval auto invalid_completion_signature(_Values... __values)

--- a/cudax/include/cuda/experimental/__execution/get_completion_signatures.cuh
+++ b/cudax/include/cuda/experimental/__execution/get_completion_signatures.cuh
@@ -35,12 +35,43 @@
 namespace cuda::experimental::execution
 {
 
+#if __cpp_lib_constexpr_exceptions >= 202502L // constexpr exception types, https://wg21.link/p3378
+
+using __exception = ::std::exception;
+
+#elif __cpp_constexpr >= 202411L // constexpr virtual functions
+
+struct _CCCL_TYPE_VISIBILITY_DEFAULT __exception
+{
+  _CCCL_HIDE_FROM_ABI constexpr __exception() noexcept = default;
+  _CCCL_HIDE_FROM_ABI virtual constexpr ~__exception() = default;
+
+  [[nodiscard]] _CCCL_API virtual constexpr auto what() const noexcept -> const char*
+  {
+    return "<exception>";
+  }
+};
+
+#else // no constexpr virtual functions:
+
+struct _CCCL_TYPE_VISIBILITY_DEFAULT __exception
+{
+  _CCCL_HIDE_FROM_ABI constexpr __exception() noexcept = default;
+
+  [[nodiscard]] _CCCL_API constexpr auto what() const noexcept -> const char*
+  {
+    return "<exception>";
+  }
+};
+
+#endif // __cpp_lib_constexpr_exceptions >= 202502L
+
 template <class _Derived>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT __compile_time_error // : ::std::exception
+struct _CCCL_TYPE_VISIBILITY_DEFAULT __compile_time_error : __exception
 {
   _CCCL_HIDE_FROM_ABI __compile_time_error() = default;
 
-  [[nodiscard]] auto what() const noexcept -> const char* // override
+  [[nodiscard]] _CCCL_API constexpr auto what() const noexcept -> const char*
   {
     return static_cast<_Derived const*>(this)->__what();
   }
@@ -50,28 +81,41 @@ template <class _Data, class... _What>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __sender_type_check_failure //
     : __compile_time_error<__sender_type_check_failure<_Data, _What...>>
 {
-  _CCCL_HIDE_FROM_ABI __sender_type_check_failure() = default;
+  static_assert(__nothrow_movable<_Data>,
+                "The data member of __sender_type_check_failure must be nothrow move constructible.");
 
-  _CCCL_API explicit constexpr __sender_type_check_failure(_Data data)
-      : data_(data)
+  _CCCL_HIDE_FROM_ABI constexpr __sender_type_check_failure() noexcept = default;
+
+  _CCCL_API constexpr explicit __sender_type_check_failure(_Data __data)
+      : __data_(static_cast<_Data&&>(__data))
   {}
 
-  _CCCL_TRIVIAL_API auto __what() const noexcept -> const char*
+private:
+  friend __sender_type_check_failure::__compile_time_error;
+
+  _CCCL_TRIVIAL_API constexpr auto __what() const noexcept -> const char*
   {
     return "This sender is not well-formed. It does not meet the requirements of a sender type.";
   }
 
-  _Data data_{};
+  _Data __data_{};
 };
 
-struct _CCCL_TYPE_VISIBILITY_DEFAULT dependent_sender_error // : ::std::exception
+struct _CCCL_TYPE_VISIBILITY_DEFAULT dependent_sender_error : __compile_time_error<dependent_sender_error>
 {
-  [[nodiscard]] _CCCL_TRIVIAL_API auto what() const noexcept -> char const* // override
+  _CCCL_API constexpr explicit dependent_sender_error(char const* __what) noexcept
+      : __what_(__what)
+  {}
+
+private:
+  friend dependent_sender_error::__compile_time_error;
+
+  [[nodiscard]] _CCCL_TRIVIAL_API constexpr auto __what() const noexcept -> char const*
   {
-    return what_;
+    return __what_;
   }
 
-  char const* what_;
+  char const* __what_;
 };
 
 template <class _Sndr>
@@ -117,7 +161,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __dependent_sender_error : dependent_sender
 //   }
 //   else
 
-#if _CCCL_HAS_EXCEPTIONS() && defined(__cpp_constexpr_exceptions) // C++26, https://wg21.link/p3068
+#if _CCCL_HAS_EXCEPTIONS() && __cpp_constexpr_exceptions >= 202411L // C++26, https://wg21.link/p3068
 
 #  define _CUDAX_LET_COMPLETIONS(...)                  \
     if constexpr ([[maybe_unused]] __VA_ARGS__; false) \
@@ -270,7 +314,7 @@ template <class _Parent, class _Child, class... _Env>
 #undef _CUDAX_CHECKED_COMPLSIGS
 _CCCL_DIAG_POP
 
-#if _CCCL_HAS_EXCEPTIONS() && defined(__cpp_constexpr_exceptions) // C++26, https://wg21.link/p3068
+#if _CCCL_HAS_EXCEPTIONS() && __cpp_constexpr_exceptions >= 202411L // C++26, https://wg21.link/p3068
 // When asked for its completions without an envitonment, a dependent sender
 // will throw an exception of a type derived from `dependent_sender_error`.
 template <class _Sndr>

--- a/cudax/include/cuda/experimental/__execution/get_completion_signatures.cuh
+++ b/cudax/include/cuda/experimental/__execution/get_completion_signatures.cuh
@@ -91,7 +91,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __sender_type_check_failure //
   {}
 
 private:
-  friend __sender_type_check_failure::__compile_time_error;
+  friend struct __compile_time_error<__sender_type_check_failure>;
 
   _CCCL_TRIVIAL_API constexpr auto __what() const noexcept -> const char*
   {
@@ -108,7 +108,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT dependent_sender_error : __compile_time_err
   {}
 
 private:
-  friend dependent_sender_error::__compile_time_error;
+  friend struct __compile_time_error<dependent_sender_error>;
 
   [[nodiscard]] _CCCL_TRIVIAL_API constexpr auto __what() const noexcept -> char const*
   {


### PR DESCRIPTION
## Description

gcc-trunk now supports `throw`/`catch` in `constexpr` functions in c++26 mode. a restriction is that any exception thrown must derived from `std::exception`. that means that to use `constexpr` exceptions when computing completion signatures, our exception types must derive from `std::exception`, but only if the stdlib has a `constexpr`-aware `std::exception` implementation. otherwise, we must avoid inheriting from `std::exception` lest our `throw` statements be non-`constexpr`.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
