### PR TITLE
Re-enable UBLKCP transform kernel on sm120

### DIFF
--- a/cub/cub/device/dispatch/tuning/tuning_transform.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_transform.cuh
@@ -326,15 +326,7 @@ struct policy_hub<RequiresStableAddress, ::cuda::std::tuple<RandomAccessIterator
       , ChainedPolicy<1000, policy1000, policy900>
   {};
 
-  // UBLKCP is disabled on sm120 for now
-  struct policy1200 : ChainedPolicy<1200, policy1200, policy1000>
-  {
-    static constexpr int min_bif    = arch_to_min_bytes_in_flight(1200);
-    static constexpr auto algorithm = Algorithm::prefetch;
-    using algo_policy               = prefetch_policy_t<256>;
-  };
-
-  using max_policy = policy1200;
+  using max_policy = policy1000;
 };
 
 } // namespace detail::transform


### PR DESCRIPTION
The UBLKCP kernel was disabled in #4870, following several crashes we observed internally. Those crashes originated out of `cooperative_groups::memcpy_async`. However, the kernel has since been refactored to no longer use this API. Since  all `cub::DeviceTransform` tests pass under `compute-sanitiser` now on sm120, I don't have any reservations putting the kernel back into action.