### PR TITLE
Add `CONSTEXPR_STEPS:` option to lit config

### DIFF
--- a/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/left_shift.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/left_shift.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // The CI "Apple back-deployment with assertions enabled" needs a higher value
-// ADDITIONAL_COMPILE_FLAGS(has-fconstexpr-steps): -fconstexpr-steps=12712420
+// CONSTEXPR_STEPS: 12712420
 
 // bitset<N> operator<<(size_t pos) const; // constexpr since C++23
 

--- a/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/op_or_eq.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/op_or_eq.pass.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// ADDITIONAL_COMPILE_FLAGS(has-fconstexpr-steps): -fconstexpr-steps=15000000
+// CONSTEXPR_STEPS: 15000000
 
 // bitset<N>& operator|=(const bitset<N>& rhs); // constexpr since C++23
 

--- a/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/right_shift_eq.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/right_shift_eq.pass.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// ADDITIONAL_COMPILE_FLAGS(has-fconstexpr-steps): -fconstexpr-steps=15000000
+// CONSTEXPR_STEPS: 15000000
 
 // bitset<N>& operator<<=(size_t pos); // constexpr since C++23
 

--- a/libcudacxx/test/utils/libcudacxx/compiler.py
+++ b/libcudacxx/test/utils/libcudacxx/compiler.py
@@ -104,34 +104,34 @@ class CXXCompiler(object):
 
             if "__NVCC__" in macros.keys():
                 compiler_type = "nvcc"
-                major_ver = macros["__CUDACC_VER_MAJOR__"]
-                minor_ver = macros["__CUDACC_VER_MINOR__"]
-                patchlevel = macros["__CUDACC_VER_BUILD__"]
+                major_ver = int(macros["__CUDACC_VER_MAJOR__"])
+                minor_ver = int(macros["__CUDACC_VER_MINOR__"])
+                patchlevel = int(macros["__CUDACC_VER_BUILD__"])
             elif "__NVCOMPILER" in macros.keys():
                 compiler_type = "nvhpc"
                 # NVHPC, unfortunately, adds an extra space between the macro name
                 # and macro value in their macro dump mode.
-                major_ver = macros["__NVCOMPILER_MAJOR__"].strip()
-                minor_ver = macros["__NVCOMPILER_MINOR__"].strip()
-                patchlevel = macros["__NVCOMPILER_PATCHLEVEL__"].strip()
+                major_ver = int(macros["__NVCOMPILER_MAJOR__"].strip())
+                minor_ver = int(macros["__NVCOMPILER_MINOR__"].strip())
+                patchlevel = int(macros["__NVCOMPILER_PATCHLEVEL__"].strip())
             elif "__clang__" in macros.keys():
                 compiler_type = "clang"
                 # Treat Apple's LLVM fork differently.
                 if "__apple_build_version__" in macros.keys():
                     compiler_type = "apple-clang"
-                major_ver = macros["__clang_major__"]
-                minor_ver = macros["__clang_minor__"]
-                patchlevel = macros["__clang_patchlevel__"]
+                major_ver = int(macros["__clang_major__"])
+                minor_ver = int(macros["__clang_minor__"])
+                patchlevel = int(macros["__clang_patchlevel__"])
             elif "__GNUC__" in macros.keys():
                 compiler_type = "gcc"
-                major_ver = macros["__GNUC__"]
-                minor_ver = macros["__GNUC_MINOR__"]
-                patchlevel = macros["__GNUC_PATCHLEVEL__"]
+                major_ver = int(macros["__GNUC__"])
+                minor_ver = int(macros["__GNUC_MINOR__"])
+                patchlevel = int(macros["__GNUC_PATCHLEVEL__"])
             elif "_MSC_VER" in macros.keys():
                 compiler_type = "msvc"
-                major_ver = int(int(macros["_MSC_FULL_VER"]) / 10000000)
-                minor_ver = int(int(macros["_MSC_FULL_VER"]) / 100000 % 100)
-                patchlevel = int(int(macros["_MSC_FULL_VER"]) % 100000)
+                major_ver = int(macros["_MSC_FULL_VER"]) // 10000000
+                minor_ver = int(macros["_MSC_FULL_VER"]) // 100000 % 100
+                patchlevel = int(macros["_MSC_FULL_VER"]) % 100000
 
             if "__cplusplus" in macros.keys():
                 if "_MSVC_LANG" in macros.keys():

--- a/libcudacxx/test/utils/libcudacxx/test/format.py
+++ b/libcudacxx/test/utils/libcudacxx/test/format.py
@@ -179,19 +179,22 @@ class LibcxxTestFormat(object):
                 if b"#define _CCCL_ASSERT" in contents:
                     test_cxx.useModules(False)
 
+        # Handle constexpr steps if specified
         constexpr_steps = self._get_parser("CONSTEXPR_STEPS:", parsers).getValue()
         if constexpr_steps is not None:
             constexpr_steps = constexpr_steps[0]
-            if test_cxx.host_cxx.type == "msvc":
+            cxx = test_cxx.host_cxx if test_cxx.type == "nvcc" else test_cxx
+            if cxx.type == "msvc":
                 constexpr_steps_opt = f"/constexpr:steps{constexpr_steps}"
-            elif test_cxx.host_cxx.type == "clang":
+            elif cxx.type == "clang":
                 constexpr_steps_opt = f"-fconstexpr-steps={constexpr_steps}"
-            elif test_cxx.host_cxx.type == "gcc" and test_cxx.host_cxx.version[0] >= 9:
+            elif cxx.type == "gcc" and cxx.version[0] >= 9:
                 constexpr_steps_opt = f"-fconstexpr-ops-limit={constexpr_steps}"
-            elif test_cxx.host_cxx.type == "nvhpc":
+            elif cxx.type == "nvhpc":
                 constexpr_steps_opt = f"-Wc,--max_cost_constexpr_call={constexpr_steps}"
             else:
                 constexpr_steps_opt = None
+
             if constexpr_steps_opt is not None:
                 if test_cxx.type == "nvcc":
                     test_cxx.compile_flags += ["-Xcompiler", constexpr_steps_opt]

--- a/libcudacxx/test/utils/libcudacxx/test/format.py
+++ b/libcudacxx/test/utils/libcudacxx/test/format.py
@@ -197,7 +197,7 @@ class LibcxxTestFormat(object):
 
             if constexpr_steps_opt is not None:
                 if test_cxx.type == "nvcc":
-                    test_cxx.compile_flags += ["-Xcompiler", constexpr_steps_opt]
+                    test_cxx.compile_flags += ["-Xcompiler", f'"{constexpr_steps_opt}"']
                 else:
                     test_cxx.compile_flags += [constexpr_steps_opt]
 

--- a/libcudacxx/test/utils/libcudacxx/test/format.py
+++ b/libcudacxx/test/utils/libcudacxx/test/format.py
@@ -186,7 +186,7 @@ class LibcxxTestFormat(object):
                 constexpr_steps_opt = f"/constexpr:steps{constexpr_steps}"
             elif test_cxx.host_cxx.type == "clang":
                 constexpr_steps_opt = f"-fconstexpr-steps={constexpr_steps}"
-            elif test_cxx.host_cxx.type == "gcc":
+            elif test_cxx.host_cxx.type == "gcc" and test_cxx.host_cxx.version[0] >= 9:
                 constexpr_steps_opt = f"-fconstexpr-ops-limit={constexpr_steps}"
             elif test_cxx.host_cxx.type == "nvhpc":
                 constexpr_steps_opt = f"-Wc,--max_cost_constexpr_call={constexpr_steps}"


### PR DESCRIPTION
This PR introduces `CONSTEXPR_STEPS:` option to lit config for specifying the number of constexpr steps a test can take.