### PR TITLE
Remove `_LIBCUDACXX_EXTERN_TEMPLATE` and `_LIBCUDACXX_BUILDING_LIBRARY` macros

### DIFF
--- a/libcudacxx/include/cuda/std/__functional/bind.h
+++ b/libcudacxx/include/cuda/std/__functional/bind.h
@@ -73,29 +73,16 @@ template <int _Np>
 struct __ph
 {};
 
-#  if defined(_LIBCUDACXX_BUILDING_LIBRARY)
-_CCCL_API inline extern const __ph<1> _1;
-_CCCL_API inline extern const __ph<2> _2;
-_CCCL_API inline extern const __ph<3> _3;
-_CCCL_API inline extern const __ph<4> _4;
-_CCCL_API inline extern const __ph<5> _5;
-_CCCL_API inline extern const __ph<6> _6;
-_CCCL_API inline extern const __ph<7> _7;
-_CCCL_API inline extern const __ph<8> _8;
-_CCCL_API inline extern const __ph<9> _9;
-_CCCL_API inline extern const __ph<10> _10;
-#  else
-/* inline */ constexpr __ph<1> _1{};
-/* inline */ constexpr __ph<2> _2{};
-/* inline */ constexpr __ph<3> _3{};
-/* inline */ constexpr __ph<4> _4{};
-/* inline */ constexpr __ph<5> _5{};
-/* inline */ constexpr __ph<6> _6{};
-/* inline */ constexpr __ph<7> _7{};
-/* inline */ constexpr __ph<8> _8{};
-/* inline */ constexpr __ph<9> _9{};
-/* inline */ constexpr __ph<10> _10{};
-#  endif // defined(_LIBCUDACXX_BUILDING_LIBRARY)
+inline constexpr __ph<1> _1{};
+inline constexpr __ph<2> _2{};
+inline constexpr __ph<3> _3{};
+inline constexpr __ph<4> _4{};
+inline constexpr __ph<5> _5{};
+inline constexpr __ph<6> _6{};
+inline constexpr __ph<7> _7{};
+inline constexpr __ph<8> _8{};
+inline constexpr __ph<9> _9{};
+inline constexpr __ph<10> _10{};
 
 } // namespace placeholders
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__config
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__config
@@ -69,17 +69,6 @@ extern "C++" {
 #    else
 #      error Supported values for _LIBCUDACXX_DEBUG are 0 and 1
 #    endif
-#    if !defined(_LIBCUDACXX_BUILDING_LIBRARY)
-#      define _LIBCUDACXX_EXTERN_TEMPLATE(...)
-#    endif
-#  endif
-
-#  ifdef _LIBCUDACXX_DISABLE_EXTERN_TEMPLATE
-#    define _LIBCUDACXX_EXTERN_TEMPLATE(...)
-#  endif
-
-#  ifndef _LIBCUDACXX_EXTERN_TEMPLATE
-#    define _LIBCUDACXX_EXTERN_TEMPLATE(...) extern template __VA_ARGS__;
 #  endif
 
 // Deprecation macros.

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/algorithm
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/algorithm
@@ -1067,55 +1067,6 @@ _CCCL_API inline void sort(__wrap_iter<_Tp*> __first, __wrap_iter<_Tp*> __last, 
   _CUDA_VSTD::sort<_Tp*, _Comp_ref>(__first.base(), __last.base(), __comp);
 }
 
-_LIBCUDACXX_EXTERN_TEMPLATE(_CCCL_API inline void __sort<__less&, char*>(char*, char*, __less&))
-_LIBCUDACXX_EXTERN_TEMPLATE(_CCCL_API inline void __sort<__less&, wchar_t*>(wchar_t*, wchar_t*, __less&))
-_LIBCUDACXX_EXTERN_TEMPLATE(_CCCL_API inline void __sort<__less&, signed*>(signed*, signed*, __less&))
-_LIBCUDACXX_EXTERN_TEMPLATE(
-  _CCCL_API inline void __sort<__less&, unsigned char*>(unsigned char*, unsigned char*, __less&))
-_LIBCUDACXX_EXTERN_TEMPLATE(_CCCL_API inline void __sort<__less&, short*>(short*, short*, __less&))
-_LIBCUDACXX_EXTERN_TEMPLATE(
-  _CCCL_API inline void __sort<__less&, unsigned short*>(unsigned short*, unsigned short*, __less&))
-_LIBCUDACXX_EXTERN_TEMPLATE(_CCCL_API inline void __sort<__less&, int*>(int*, int*, __less&))
-_LIBCUDACXX_EXTERN_TEMPLATE(_CCCL_API inline void __sort<__less&, unsigned*>(unsigned*, unsigned*, __less&))
-_LIBCUDACXX_EXTERN_TEMPLATE(_CCCL_API inline void __sort<__less&, long*>(long*, long*, __less&))
-_LIBCUDACXX_EXTERN_TEMPLATE(
-  _CCCL_API inline void __sort<__less&, unsigned long*>(unsigned long*, unsigned long*, __less&))
-_LIBCUDACXX_EXTERN_TEMPLATE(_CCCL_API inline void __sort<__less&, long long*>(long long*, long long*, __less&))
-_LIBCUDACXX_EXTERN_TEMPLATE(
-  _CCCL_API inline void __sort<__less&, unsigned long long*>(unsigned long long*, unsigned long long*, __less&))
-_LIBCUDACXX_EXTERN_TEMPLATE(_CCCL_API inline void __sort<__less&, float*>(float*, float*, __less&))
-_LIBCUDACXX_EXTERN_TEMPLATE(_CCCL_API inline void __sort<__less&, double*>(double*, double*, __less&))
-_LIBCUDACXX_EXTERN_TEMPLATE(_CCCL_API inline void __sort<__less&, long double*>(long double*, long double*, __less&))
-
-_LIBCUDACXX_EXTERN_TEMPLATE(_CCCL_API inline bool __insertion_sort_incomplete<__less&, char*>(char*, char*, __less&))
-_LIBCUDACXX_EXTERN_TEMPLATE(
-  _CCCL_API inline bool __insertion_sort_incomplete<__less&, wchar_t*>(wchar_t*, wchar_t*, __less&))
-_LIBCUDACXX_EXTERN_TEMPLATE(
-  _CCCL_API inline bool __insertion_sort_incomplete<__less&, signed char*>(signed char*, signed char*, __less&))
-_LIBCUDACXX_EXTERN_TEMPLATE(
-  _CCCL_API inline bool __insertion_sort_incomplete<__less&, unsigned char*>(unsigned char*, unsigned char*, __less&))
-_LIBCUDACXX_EXTERN_TEMPLATE(_CCCL_API inline bool __insertion_sort_incomplete<__less&, short*>(short*, short*, __less&))
-_LIBCUDACXX_EXTERN_TEMPLATE(_CCCL_API inline bool __insertion_sort_incomplete<__less&, unsigned short*>(
-  unsigned short*, unsigned short*, __less&))
-_LIBCUDACXX_EXTERN_TEMPLATE(_CCCL_API inline bool __insertion_sort_incomplete<__less&, int*>(int*, int*, __less&))
-_LIBCUDACXX_EXTERN_TEMPLATE(
-  _CCCL_API inline bool __insertion_sort_incomplete<__less&, unsigned*>(unsigned*, unsigned*, __less&))
-_LIBCUDACXX_EXTERN_TEMPLATE(_CCCL_API inline bool __insertion_sort_incomplete<__less&, long*>(long*, long*, __less&))
-_LIBCUDACXX_EXTERN_TEMPLATE(
-  _CCCL_API inline bool __insertion_sort_incomplete<__less&, unsigned long*>(unsigned long*, unsigned long*, __less&))
-_LIBCUDACXX_EXTERN_TEMPLATE(
-  _CCCL_API inline bool __insertion_sort_incomplete<__less&, long long*>(long long*, long long*, __less&))
-_LIBCUDACXX_EXTERN_TEMPLATE(_CCCL_API inline bool __insertion_sort_incomplete<__less&, unsigned long long*>(
-  unsigned long long*, unsigned long long*, __less&))
-_LIBCUDACXX_EXTERN_TEMPLATE(_CCCL_API inline bool __insertion_sort_incomplete<__less&, float*>(float*, float*, __less&))
-_LIBCUDACXX_EXTERN_TEMPLATE(
-  _CCCL_API inline bool __insertion_sort_incomplete<__less&, double*>(double*, double*, __less&))
-_LIBCUDACXX_EXTERN_TEMPLATE(
-  _CCCL_API inline bool __insertion_sort_incomplete<__less&, long double*>(long double*, long double*, __less&))
-
-_LIBCUDACXX_EXTERN_TEMPLATE(_CCCL_API inline unsigned __sort5<__less&, long double*>(
-  long double*, long double*, long double*, long double*, long double*, __less&))
-
 // inplace_merge
 
 template <class _Compare, class _InputIterator1, class _InputIterator2, class _OutputIterator>


### PR DESCRIPTION
Remove `_LIBCUDACXX_EXTERN_TEMPLATE` and `_LIBCUDACXX_BUILDING_LIBRARY` macros together with some dead code