### PR TITLE
[STF] Keep dependency event names in DOT

### DIFF
--- a/cudax/include/cuda/experimental/__stf/internal/async_prereq.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/async_prereq.cuh
@@ -113,15 +113,23 @@ public:
    * @brief Sets a symbolic name for the event, useful for debugging or tracing.
    * @param s The symbolic name to associate with this event.
    */
-  template <typename context_t>
-  void set_symbol(context_t& ctx, ::std::string s)
+  void set_symbol_with_dot(reserved::per_ctx_dot& dot, ::std::string s)
   {
-    symbol    = mv(s);
-    auto& dot = *ctx.get_dot();
+    symbol = mv(s);
     if (dot.is_tracing())
     {
       dot.add_prereq_vertex(symbol, unique_prereq_id);
     }
+  }
+
+  /**
+   * @brief Sets a symbolic name for the event, useful for debugging or tracing.
+   * @param s The symbolic name to associate with this event.
+   */
+  template <typename context_t>
+  void set_symbol(context_t& ctx, ::std::string s)
+  {
+    set_symbol_with_dot(*ctx.get_dot(), mv(s));
   }
 
   /**

--- a/cudax/include/cuda/experimental/__stf/stream/internal/event_types.cuh
+++ b/cudax/include/cuda/experimental/__stf/stream/internal/event_types.cuh
@@ -451,6 +451,14 @@ inline event record_event_in_stream(const decorated_stream& dstream)
   return reserved::handle<stream_and_event>(dstream, true);
 }
 
+/* Overload to provide a symbol */
+inline event record_event_in_stream(const decorated_stream& dstream, reserved::per_ctx_dot& dot, ::std::string symbol)
+{
+  event res = record_event_in_stream(dstream);
+  res->set_symbol_with_dot(dot, mv(symbol));
+  return res;
+}
+
 } // end namespace reserved
 
 } // namespace cuda::experimental::stf

--- a/cudax/include/cuda/experimental/__stf/stream/stream_ctx.cuh
+++ b/cudax/include/cuda/experimental/__stf/stream/stream_ctx.cuh
@@ -653,10 +653,9 @@ private:
       reserved::backend_ctx_update_uncached_allocator(*this, mv(custom));
     }
 
-    event_list stream_to_event_list(cudaStream_t stream, ::std::string) const override
+    event_list stream_to_event_list(cudaStream_t stream, ::std::string symbol) const override
     {
-      auto e = reserved::record_event_in_stream(decorated_stream(stream));
-      /// e->set_symbol(mv(event_symbol));
+      auto e = reserved::record_event_in_stream(decorated_stream(stream), *get_dot(), mv(symbol));
       return event_list(mv(e));
     }
 


### PR DESCRIPTION
## Description
When we create an STF event that depends on the completion of work in a CUDA stream, we keep the name of the event in DOT

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes <!-- Link issue here -->

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
