### PR TITLE
Extend and refactor transform overloads in CUDA system

### DIFF
--- a/thrust/thrust/system/cuda/detail/transform.h
+++ b/thrust/thrust/system/cuda/detail/transform.h
@@ -311,13 +311,13 @@ transform(execution_policy<Derived>& policy, InputIt first, InputIt last, Output
               first, last, result, __transform::raw_reference_cast_args<TransformOp>{transform_op});));
 }
 
-template <typename Derived, typename InputIt, typename OutputIt, typename UnaryFunction>
+template <typename Derived, typename InputIt, typename OutputIt, typename TransformOp>
 THRUST_FUNCTION OutputIt transform_n(
   execution_policy<Derived>& policy,
   InputIt first,
   ::cuda::std::iter_difference_t<InputIt> num_items,
   OutputIt result,
-  UnaryFunction transform_op)
+  TransformOp transform_op)
 {
   THRUST_CDP_DISPATCH(
     (return __transform::cub_transform_many(policy, ::cuda::std::make_tuple(first), result, num_items, transform_op);),

--- a/thrust/thrust/system/cuda/detail/transform.h
+++ b/thrust/thrust/system/cuda/detail/transform.h
@@ -291,7 +291,7 @@ struct raw_reference_cast_args
   mutable F f; // mutable to support non-const F::operator()
 
   template <typename... Ts>
-  auto operator()(Ts&&... args) const
+  THRUST_FUNCTION decltype(auto) operator()(Ts&&... args) const
   {
     return f(raw_reference_cast(::cuda::std::forward<Ts>(args))...);
   }

--- a/thrust/thrust/system/cuda/detail/transform.h
+++ b/thrust/thrust/system/cuda/detail/transform.h
@@ -41,7 +41,6 @@
 
 #  include <cub/device/device_transform.cuh>
 
-#  include <thrust/distance.h>
 #  include <thrust/iterator/zip_iterator.h>
 #  include <thrust/system/cuda/detail/dispatch.h>
 #  include <thrust/system/cuda/detail/parallel_for.h>
@@ -50,6 +49,7 @@
 
 #  include <cuda/__functional/address_stability.h>
 #  include <cuda/std/__algorithm/transform.h>
+#  include <cuda/std/__iterator/distance.h>
 #  include <cuda/std/cstdint>
 
 THRUST_NAMESPACE_BEGIN

--- a/thrust/thrust/transform.h
+++ b/thrust/thrust/transform.h
@@ -157,7 +157,8 @@ _CCCL_HOST_DEVICE OutputIterator transform(
 //!
 //!  \see https://en.cppreference.com/w/cpp/algorithm/transform
 template <typename InputIterator, typename OutputIterator, typename UnaryFunction>
-OutputIterator transform(InputIterator first, InputIterator last, OutputIterator result, UnaryFunction op)
+_CCCL_HOST_DEVICE OutputIterator
+transform(InputIterator first, InputIterator last, OutputIterator result, UnaryFunction op)
 {
   _CCCL_NVTX_RANGE_SCOPE("thrust::transform");
   using thrust::system::detail::generic::select_system;
@@ -298,7 +299,7 @@ _CCCL_HOST_DEVICE OutputIterator transform(
 //!
 //! \see https://en.cppreference.com/w/cpp/algorithm/transform
 template <typename InputIterator1, typename InputIterator2, typename OutputIterator, typename BinaryFunction>
-OutputIterator
+_CCCL_HOST_DEVICE OutputIterator
 transform(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, OutputIterator result, BinaryFunction op)
 {
   _CCCL_NVTX_RANGE_SCOPE("thrust::transform");
@@ -461,7 +462,7 @@ _CCCL_HOST_DEVICE ForwardIterator transform_if(
  *  \see thrust::transform
  */
 template <typename InputIterator, typename ForwardIterator, typename UnaryFunction, typename Predicate>
-ForwardIterator
+_CCCL_HOST_DEVICE ForwardIterator
 transform_if(InputIterator first, InputIterator last, ForwardIterator result, UnaryFunction op, Predicate pred)
 {
   _CCCL_NVTX_RANGE_SCOPE("thrust::transform_if");
@@ -624,7 +625,7 @@ template <typename InputIterator1,
           typename ForwardIterator,
           typename UnaryFunction,
           typename Predicate>
-ForwardIterator transform_if(
+_CCCL_HOST_DEVICE ForwardIterator transform_if(
   InputIterator1 first,
   InputIterator1 last,
   InputIterator2 stencil,
@@ -815,7 +816,7 @@ template <typename InputIterator1,
           typename ForwardIterator,
           typename BinaryFunction,
           typename Predicate>
-ForwardIterator transform_if(
+_CCCL_HOST_DEVICE ForwardIterator transform_if(
   InputIterator1 first1,
   InputIterator1 last1,
   InputIterator2 first2,
@@ -857,7 +858,7 @@ _CCCL_HOST_DEVICE OutputIterator transform_n(
 
 //! Like \ref transform, but uses an element count instead of an iterator to the last element of the input sequence.
 template <typename InputIterator, typename OutputIterator, typename UnaryFunction>
-OutputIterator transform_n(
+_CCCL_HOST_DEVICE OutputIterator transform_n(
   InputIterator first, ::cuda::std::iter_difference_t<InputIterator> count, OutputIterator result, UnaryFunction op)
 {
   _CCCL_NVTX_RANGE_SCOPE("thrust::transform_n");
@@ -888,7 +889,7 @@ _CCCL_HOST_DEVICE OutputIterator transform_n(
 
 //! Like \ref transform, but uses an element count instead of an iterator to the last element of the input sequence.
 template <typename InputIterator1, typename InputIterator2, typename OutputIterator, typename BinaryFunction>
-OutputIterator transform_n(
+_CCCL_HOST_DEVICE OutputIterator transform_n(
   InputIterator1 first1,
   ::cuda::std::iter_difference_t<InputIterator1> count,
   InputIterator2 first2,
@@ -924,7 +925,7 @@ _CCCL_HOST_DEVICE ForwardIterator transform_if_n(
 
 //! Like \ref transform_if, but uses an element count instead of an iterator to the last element of the input sequence.
 template <typename InputIterator, typename ForwardIterator, typename UnaryFunction, typename Predicate>
-ForwardIterator transform_if_n(
+_CCCL_HOST_DEVICE ForwardIterator transform_if_n(
   InputIterator first,
   ::cuda::std::iter_difference_t<InputIterator> count,
   ForwardIterator result,
@@ -966,7 +967,7 @@ template <typename InputIterator1,
           typename ForwardIterator,
           typename UnaryFunction,
           typename Predicate>
-ForwardIterator transform_if_n(
+_CCCL_HOST_DEVICE ForwardIterator transform_if_n(
   InputIterator1 first,
   ::cuda::std::iter_difference_t<InputIterator1> count,
   InputIterator2 stencil,
@@ -1020,7 +1021,7 @@ template <typename InputIterator1,
           typename ForwardIterator,
           typename BinaryFunction,
           typename Predicate>
-ForwardIterator transform_if_n(
+_CCCL_HOST_DEVICE ForwardIterator transform_if_n(
   InputIterator1 first1,
   ::cuda::std::iter_difference_t<InputIterator1> count,
   InputIterator2 first2,

--- a/thrust/thrust/transform.h
+++ b/thrust/thrust/transform.h
@@ -157,8 +157,7 @@ _CCCL_HOST_DEVICE OutputIterator transform(
 //!
 //!  \see https://en.cppreference.com/w/cpp/algorithm/transform
 template <typename InputIterator, typename OutputIterator, typename UnaryFunction>
-_CCCL_HOST_DEVICE OutputIterator
-transform(InputIterator first, InputIterator last, OutputIterator result, UnaryFunction op)
+OutputIterator transform(InputIterator first, InputIterator last, OutputIterator result, UnaryFunction op)
 {
   _CCCL_NVTX_RANGE_SCOPE("thrust::transform");
   using thrust::system::detail::generic::select_system;
@@ -299,7 +298,7 @@ _CCCL_HOST_DEVICE OutputIterator transform(
 //!
 //! \see https://en.cppreference.com/w/cpp/algorithm/transform
 template <typename InputIterator1, typename InputIterator2, typename OutputIterator, typename BinaryFunction>
-_CCCL_HOST_DEVICE OutputIterator
+OutputIterator
 transform(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, OutputIterator result, BinaryFunction op)
 {
   _CCCL_NVTX_RANGE_SCOPE("thrust::transform");
@@ -462,7 +461,7 @@ _CCCL_HOST_DEVICE ForwardIterator transform_if(
  *  \see thrust::transform
  */
 template <typename InputIterator, typename ForwardIterator, typename UnaryFunction, typename Predicate>
-_CCCL_HOST_DEVICE ForwardIterator
+ForwardIterator
 transform_if(InputIterator first, InputIterator last, ForwardIterator result, UnaryFunction op, Predicate pred)
 {
   _CCCL_NVTX_RANGE_SCOPE("thrust::transform_if");
@@ -625,7 +624,7 @@ template <typename InputIterator1,
           typename ForwardIterator,
           typename UnaryFunction,
           typename Predicate>
-_CCCL_HOST_DEVICE ForwardIterator transform_if(
+ForwardIterator transform_if(
   InputIterator1 first,
   InputIterator1 last,
   InputIterator2 stencil,
@@ -816,7 +815,7 @@ template <typename InputIterator1,
           typename ForwardIterator,
           typename BinaryFunction,
           typename Predicate>
-_CCCL_HOST_DEVICE ForwardIterator transform_if(
+ForwardIterator transform_if(
   InputIterator1 first1,
   InputIterator1 last1,
   InputIterator2 first2,
@@ -858,7 +857,7 @@ _CCCL_HOST_DEVICE OutputIterator transform_n(
 
 //! Like \ref transform, but uses an element count instead of an iterator to the last element of the input sequence.
 template <typename InputIterator, typename OutputIterator, typename UnaryFunction>
-_CCCL_HOST_DEVICE OutputIterator transform_n(
+OutputIterator transform_n(
   InputIterator first, ::cuda::std::iter_difference_t<InputIterator> count, OutputIterator result, UnaryFunction op)
 {
   _CCCL_NVTX_RANGE_SCOPE("thrust::transform_n");
@@ -889,7 +888,7 @@ _CCCL_HOST_DEVICE OutputIterator transform_n(
 
 //! Like \ref transform, but uses an element count instead of an iterator to the last element of the input sequence.
 template <typename InputIterator1, typename InputIterator2, typename OutputIterator, typename BinaryFunction>
-_CCCL_HOST_DEVICE OutputIterator transform_n(
+OutputIterator transform_n(
   InputIterator1 first1,
   ::cuda::std::iter_difference_t<InputIterator1> count,
   InputIterator2 first2,
@@ -925,7 +924,7 @@ _CCCL_HOST_DEVICE ForwardIterator transform_if_n(
 
 //! Like \ref transform_if, but uses an element count instead of an iterator to the last element of the input sequence.
 template <typename InputIterator, typename ForwardIterator, typename UnaryFunction, typename Predicate>
-_CCCL_HOST_DEVICE ForwardIterator transform_if_n(
+ForwardIterator transform_if_n(
   InputIterator first,
   ::cuda::std::iter_difference_t<InputIterator> count,
   ForwardIterator result,
@@ -967,7 +966,7 @@ template <typename InputIterator1,
           typename ForwardIterator,
           typename UnaryFunction,
           typename Predicate>
-_CCCL_HOST_DEVICE ForwardIterator transform_if_n(
+ForwardIterator transform_if_n(
   InputIterator1 first,
   ::cuda::std::iter_difference_t<InputIterator1> count,
   InputIterator2 stencil,
@@ -1021,7 +1020,7 @@ template <typename InputIterator1,
           typename ForwardIterator,
           typename BinaryFunction,
           typename Predicate>
-_CCCL_HOST_DEVICE ForwardIterator transform_if_n(
+ForwardIterator transform_if_n(
   InputIterator1 first1,
   ::cuda::std::iter_difference_t<InputIterator1> count,
   InputIterator2 first2,


### PR DESCRIPTION
This PR mostly adds a few more `transform_if` and `transform[_if]_n` overloads in the Thrust CUDA system, so we can put more custimized algorithms there in the (near) future. I also reordered the overloads more logically and switched the CDP fallback path to use `cuda::std::transform`.