### PR TITLE
Implement `thrust::swap_ranges` via `transform` in CUDA system

### DIFF
--- a/thrust/benchmarks/bench/swap_ranges/basic.cu
+++ b/thrust/benchmarks/bench/swap_ranges/basic.cu
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <thrust/device_vector.h>
+#include <thrust/swap.h>
+
+#include <nvbench_helper.cuh>
+
+template <typename T>
+static void basic(nvbench::state& state, nvbench::type_list<T>)
+{
+  const auto elements        = static_cast<std::size_t>(state.get_int64("Elements"));
+  thrust::device_vector<T> a = generate(elements);
+  thrust::device_vector<T> b = generate(elements);
+
+  state.add_element_count(elements);
+  state.add_global_memory_reads<T>(2 * elements);
+  state.add_global_memory_writes<T>(2 * elements);
+
+  caching_allocator_t alloc; // swap_ranges shouldn't allocate, but let's be consistent
+  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync,
+             [&](nvbench::launch& launch) {
+               thrust::swap_ranges(policy(alloc, launch), a.begin(), a.end(), b.begin());
+             });
+}
+
+NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(integral_types))
+  .set_name("base")
+  .set_type_axes_names({"T{ct}"})
+  .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 4));


### PR DESCRIPTION
- [x] Prerequisite #5223

Fixes: #5244

Benchmark on RTX 5090 (UBLKCP)
```
|  T{ct}  |  Elements  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |        Diff |   %Diff |  Status  |
|---------|------------|------------|-------------|------------|-------------|-------------|---------|----------|
|   I8    |    2^16    |   8.062 us |       7.42% |   8.407 us |      14.80% |    0.345 us |   4.28% |   SAME   |
|   I8    |    2^20    |  13.707 us |       7.05% |  10.813 us |      33.11% |   -2.894 us | -21.11% |   FAST   |
|   I8    |    2^24    |  94.100 us |       4.87% |  50.968 us |       3.55% |  -43.132 us | -45.84% |   FAST   |
|   I8    |    2^28    |   1.418 ms |       3.15% | 715.401 us |       0.29% | -702.932 us | -49.56% |   FAST   |
|   I16   |    2^16    |   8.150 us |      20.03% |   8.402 us |      40.89% |    0.252 us |   3.09% |   SAME   |
|   I16   |    2^20    |  17.923 us |      10.09% |  11.785 us |       9.07% |   -6.138 us | -34.25% |   FAST   |
|   I16   |    2^24    | 178.861 us |       4.00% |  94.014 us |       0.99% |  -84.846 us | -47.44% |   FAST   |
|   I16   |    2^28    |   2.292 ms |       4.79% |   1.423 ms |       0.23% | -869.294 us | -37.92% |   FAST   |
|   I32   |    2^16    |   7.684 us |       6.44% |   8.052 us |       9.45% |    0.368 us |   4.79% |   SAME   |
|   I32   |    2^20    |  22.680 us |       6.71% |  15.292 us |       4.57% |   -7.388 us | -32.57% |   FAST   |
|   I32   |    2^24    | 213.162 us |       1.40% | 182.064 us |       0.50% |  -31.098 us | -14.59% |   FAST   |
|   I32   |    2^28    |   2.963 ms |       0.28% |   2.839 ms |       0.13% | -124.239 us |  -4.19% |   FAST   |
|   I64   |    2^16    |   9.710 us |      12.73% |   9.650 us |       7.93% |   -0.060 us |  -0.62% |   SAME   |
|   I64   |    2^20    |  26.074 us |       3.09% |  25.790 us |       3.33% |   -0.284 us |  -1.09% |   SAME   |
|   I64   |    2^24    | 362.611 us |       0.41% | 358.758 us |       0.44% |   -3.852 us |  -1.06% |   FAST   |
|   I64   |    2^28    |   5.677 ms |       0.12% |   5.669 ms |       0.07% |   -8.274 us |  -0.15% |   FAST   |

```