### PR TITLE
Extends benchmarks for `DeviceRunLengthEncode::NonTrivialRuns` to differentiate between offset and run-length type

### DIFF
--- a/cub/benchmarks/bench/run_length_encode/non_trivial_runs.cu
+++ b/cub/benchmarks/bench/run_length_encode/non_trivial_runs.cu
@@ -77,13 +77,11 @@ static void rle(nvbench::state& state, nvbench::type_list<T, OffsetT, RunLengthT
   using offset_t = cub::detail::choose_signed_offset_t<OffsetT>;
   // Offset type large enough to represent the longest run in the sequence
   using run_length_t = RunLengthT;
-  // Offset type large enough to represent the total number of runs in the sequence
-  using num_runs_t = offset_t;
 
   using keys_input_it_t            = const T*;
   using offset_output_it_t         = offset_t*;
   using length_output_it_t         = run_length_t*;
-  using num_runs_output_iterator_t = num_runs_t*;
+  using num_runs_output_iterator_t = offset_t*;
   using equality_op_t              = ::cuda::std::equal_to<>;
 
 #if !TUNE_BASE
@@ -109,7 +107,7 @@ static void rle(nvbench::state& state, nvbench::type_list<T, OffsetT, RunLengthT
   constexpr std::size_t min_segment_size = 1;
   const std::size_t max_segment_size     = static_cast<std::size_t>(state.get_int64("MaxSegSize"));
 
-  thrust::device_vector<num_runs_t> num_runs_out(1);
+  thrust::device_vector<offset_t> num_runs_out(1);
   thrust::device_vector<offset_t> out_offsets(elements);
   thrust::device_vector<run_length_t> out_lengths(elements);
   thrust::device_vector<T> in_keys = generate.uniform.key_segments(elements, min_segment_size, max_segment_size);
@@ -117,7 +115,7 @@ static void rle(nvbench::state& state, nvbench::type_list<T, OffsetT, RunLengthT
   T* d_in_keys                = thrust::raw_pointer_cast(in_keys.data());
   offset_t* d_out_offsets     = thrust::raw_pointer_cast(out_offsets.data());
   run_length_t* d_out_lengths = thrust::raw_pointer_cast(out_lengths.data());
-  num_runs_t* d_num_runs_out  = thrust::raw_pointer_cast(num_runs_out.data());
+  offset_t* d_num_runs_out    = thrust::raw_pointer_cast(num_runs_out.data());
 
   std::uint8_t* d_temp_storage{};
   std::size_t temp_storage_bytes{};

--- a/cub/cub/agent/agent_rle.cuh
+++ b/cub/cub/agent/agent_rle.cuh
@@ -963,7 +963,7 @@ struct AgentRle
   {
     // Blocks are launched in increasing order, so just assign one tile per block
     int tile_idx          = (blockIdx.x * gridDim.y) + blockIdx.y; // Current tile index
-    OffsetT tile_offset   = static_cast<OffsetT>(tile_idx) * TILE_ITEMS; // Global offset for the current tile
+    OffsetT tile_offset   = tile_idx * TILE_ITEMS; // Global offset for the current tile
     OffsetT num_remaining = num_items - tile_offset; // Remaining items (including this tile)
 
     if (tile_idx < num_tiles - 1)


### PR DESCRIPTION
## Description

This is the first PR of a chain of PRs to address https://github.com/NVIDIA/cccl/issues/2520 

This PR extends the benchmarks for `DeviceRunLengthEncode::NonTrivialRuns` to differentiate between the offset type (used to index into the input) and the run-length type (which must be large enough to cover the longest run length of any given run within the input).

It also fixes one overflow for larger-than-`int` offset type instantiation in the original implementation.
