### PR TITLE
Do not enable `__float128` support on device for clang-cuda or NVHPC

### DIFF
--- a/libcudacxx/include/cuda/std/__cccl/extended_data_types.h
+++ b/libcudacxx/include/cuda/std/__cccl/extended_data_types.h
@@ -93,11 +93,15 @@
 
 #if !defined(CCCL_DISABLE_FLOAT128_SUPPORT) && _CCCL_OS(LINUX) && !_CCCL_ARCH(ARM64)
 #  if (defined(__CUDACC_RTC_FLOAT128__) || defined(__SIZEOF_FLOAT128__) || defined(__FLOAT128__)) /*HOST COMPILERS*/
-#    if _CCCL_CUDA_COMPILER(NVHPC) \
-      || ((_CCCL_CUDA_COMPILER(NVCC) || _CCCL_CUDA_COMPILER(CLANG)) && _CCCL_PTX_ARCH() >= 1000) /*DEVICE CODE*/
+#    if _CCCL_CUDA_COMPILATION() // Only NVCC on architectures at least SM100 supports float128 on device
+#      if _CCCL_CUDA_COMPILER(NVCC) && _CCCL_PTX_ARCH() >= 1000 /*DEVICE CODE*/
+#        undef _CCCL_HAS_FLOAT128
+#        define _CCCL_HAS_FLOAT128() 1
+#      endif // _CCCL_CUDA_COMPILER(NVCC) && _CCCL_PTX_ARCH() >= 1000
+#    else // ^^^ _CCCL_CUDA_COMPILATION() ^^^ / vvv !_CCCL_CUDA_COMPILATION() vvv
 #      undef _CCCL_HAS_FLOAT128
 #      define _CCCL_HAS_FLOAT128() 1
-#    endif // CUDA compiler
+#    endif // !_CCCL_CUDA_COMPILATION()
 #  endif // Host compiler support
 #endif // !CCCL_DISABLE_FLOAT128_SUPPORT && _CCCL_OS(LINUX)
 


### PR DESCRIPTION
Neither does support it on device so we can only use it with NVCC and supported architectures.

Fixes #5228
