### PR TITLE
Rework our `signbit` implementation to be potentially constexpr

### DIFF
--- a/libcudacxx/include/cuda/std/__bit/bit_cast.h
+++ b/libcudacxx/include/cuda/std/__bit/bit_cast.h
@@ -32,11 +32,11 @@
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 #if defined(_CCCL_BUILTIN_BIT_CAST)
-#  define _LIBCUDACXX_CONSTEXPR_BIT_CAST       constexpr
-#  define _LIBCUDACXX_HAS_CONSTEXPR_BIT_CAST() 1
+#  define _CCCL_CONSTEXPR_BIT_CAST       constexpr
+#  define _CCCL_HAS_CONSTEXPR_BIT_CAST() 1
 #else // ^^^ _CCCL_BUILTIN_BIT_CAST ^^^ / vvv !_CCCL_BUILTIN_BIT_CAST vvv
-#  define _LIBCUDACXX_CONSTEXPR_BIT_CAST
-#  define _LIBCUDACXX_HAS_CONSTEXPR_BIT_CAST() 0
+#  define _CCCL_CONSTEXPR_BIT_CAST
+#  define _CCCL_HAS_CONSTEXPR_BIT_CAST() 0
 #  if _CCCL_COMPILER(GCC, >=, 8)
 // GCC starting with GCC8 warns about our extended floating point types having protected data members
 _CCCL_DIAG_PUSH
@@ -50,7 +50,7 @@ template <
   enable_if_t<(sizeof(_To) == sizeof(_From)), int>                                                                = 0,
   enable_if_t<_CCCL_TRAIT(is_trivially_copyable, _To) || _CCCL_TRAIT(__is_extended_floating_point, _To), int>     = 0,
   enable_if_t<_CCCL_TRAIT(is_trivially_copyable, _From) || _CCCL_TRAIT(__is_extended_floating_point, _From), int> = 0>
-[[nodiscard]] _CCCL_API inline _LIBCUDACXX_CONSTEXPR_BIT_CAST _To bit_cast(const _From& __from) noexcept
+[[nodiscard]] _CCCL_API inline _CCCL_CONSTEXPR_BIT_CAST _To bit_cast(const _From& __from) noexcept
 {
 #if defined(_CCCL_BUILTIN_BIT_CAST)
   return _CCCL_BUILTIN_BIT_CAST(_To, __from);

--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -361,10 +361,6 @@
 #  define _CCCL_BUILTIN_PREFETCH(...)
 #endif // _CCCL_CHECK_BUILTIN(builtin_prefetch)
 
-#if _CCCL_CHECK_BUILTIN(builtin_signbit) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_SIGNBIT(...) __builtin_signbit(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(builtin_signbit)
-
 #if _CCCL_HAS_BUILTIN(__decay) && _CCCL_CUDA_COMPILER(CLANG)
 #  define _CCCL_BUILTIN_DECAY(...) __decay(__VA_ARGS__)
 #endif // _CCCL_HAS_BUILTIN(__decay) && clang-cuda

--- a/libcudacxx/include/cuda/std/__cmath/fpclassify.h
+++ b/libcudacxx/include/cuda/std/__cmath/fpclassify.h
@@ -136,13 +136,13 @@ template <class _Tp>
 {
 #  if defined(_CCCL_BUILTIN_FPCLASSIFY)
   return _CCCL_BUILTIN_FPCLASSIFY(FP_NAN, FP_INFINITE, FP_NORMAL, FP_SUBNORMAL, FP_ZERO, __x);
-#  else // ^^^ _CCCL_BUILTIN_SIGNBIT ^^^ / vvv !_CCCL_BUILTIN_SIGNBIT vvv
+#  else // ^^^ _CCCL_BUILTIN_FPCLASSIFY ^^^ / vvv !_CCCL_BUILTIN_FPCLASSIFY vvv
   if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
   {
     NV_IF_TARGET(NV_IS_HOST, (return ::fpclassify(__x);))
   }
   return _CUDA_VSTD::__fpclassify_impl(__x);
-#  endif // !_CCCL_BUILTIN_SIGNBIT
+#  endif // !_CCCL_BUILTIN_FPCLASSIFY
 }
 #endif // _CCCL_HAS_LONG_DOUBLE()
 

--- a/libcudacxx/include/cuda/std/__cmath/isfinite.h
+++ b/libcudacxx/include/cuda/std/__cmath/isfinite.h
@@ -61,11 +61,11 @@ template <class _Tp>
   {
     return ::isfinite(__x);
   }
-#  if _LIBCUDACXX_HAS_CONSTEXPR_BIT_CAST()
+#  if _CCCL_HAS_CONSTEXPR_BIT_CAST()
   return (_CUDA_VSTD::__fp_get_storage(__x) & __fp_exp_mask_of_v<float>) != __fp_exp_mask_of_v<float>;
-#  else // ^^^ _LIBCUDACXX_HAS_CONSTEXPR_BIT_CAST() ^^^ / vvv !_LIBCUDACXX_HAS_CONSTEXPR_BIT_CAST() vvv
+#  else // ^^^ _CCCL_HAS_CONSTEXPR_BIT_CAST() ^^^ / vvv !_CCCL_HAS_CONSTEXPR_BIT_CAST() vvv
   return _CUDA_VSTD::__isfinite_impl(__x);
-#  endif // ^^^ !_LIBCUDACXX_HAS_CONSTEXPR_BIT_CAST() ^^^
+#  endif // ^^^ !_CCCL_HAS_CONSTEXPR_BIT_CAST() ^^^
 #endif // ^^^ !_CCCL_BUILTIN_ISFINITE ^^^
 }
 
@@ -78,11 +78,11 @@ template <class _Tp>
   {
     return ::isfinite(__x);
   }
-#  if _LIBCUDACXX_HAS_CONSTEXPR_BIT_CAST()
+#  if _CCCL_HAS_CONSTEXPR_BIT_CAST()
   return (_CUDA_VSTD::__fp_get_storage(__x) & __fp_exp_mask_of_v<double>) != __fp_exp_mask_of_v<double>;
-#  else // ^^^ _LIBCUDACXX_HAS_CONSTEXPR_BIT_CAST() ^^^ / vvv !_LIBCUDACXX_HAS_CONSTEXPR_BIT_CAST() vvv
+#  else // ^^^ _CCCL_HAS_CONSTEXPR_BIT_CAST() ^^^ / vvv !_CCCL_HAS_CONSTEXPR_BIT_CAST() vvv
   return _CUDA_VSTD::__isfinite_impl(__x);
-#  endif // ^^^ !_LIBCUDACXX_HAS_CONSTEXPR_BIT_CAST() ^^^
+#  endif // ^^^ !_CCCL_HAS_CONSTEXPR_BIT_CAST() ^^^
 #endif // ^^^ !_CCCL_BUILTIN_ISFINITE ^^^
 }
 

--- a/libcudacxx/include/cuda/std/__cmath/isinf.h
+++ b/libcudacxx/include/cuda/std/__cmath/isinf.h
@@ -68,13 +68,13 @@ template <class _Tp>
     return _CCCL_BUILTIN_ISINF(__x);
   }
   return _CCCL_BUILTIN_ISINF(__x) && !_CCCL_BUILTIN_ISNAN(__x);
-#elif _LIBCUDACXX_HAS_CONSTEXPR_BIT_CAST()
+#elif _CCCL_HAS_CONSTEXPR_BIT_CAST()
   if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
   {
     return ::isinf(__x);
   }
   return (_CUDA_VSTD::__fp_get_storage(__x) & __fp_exp_mant_mask_of_v<float>) == __fp_exp_mask_of_v<float>;
-#else // ^^^ _LIBCUDACXX_HAS_CONSTEXPR_BIT_CAST() ^^^ / vvv !_LIBCUDACXX_HAS_CONSTEXPR_BIT_CAST() vvv
+#else // ^^^ _CCCL_HAS_CONSTEXPR_BIT_CAST() ^^^ / vvv !_CCCL_HAS_CONSTEXPR_BIT_CAST() vvv
   return _CUDA_VSTD::__isinf_impl(__x);
 #endif // ^^^ !_CCCL_BUILTIN_ISINF ^^^
 }
@@ -90,13 +90,13 @@ template <class _Tp>
     return _CCCL_BUILTIN_ISINF(__x);
   }
   return _CCCL_BUILTIN_ISINF(__x) && !_CCCL_BUILTIN_ISNAN(__x);
-#elif _LIBCUDACXX_HAS_CONSTEXPR_BIT_CAST()
+#elif _CCCL_HAS_CONSTEXPR_BIT_CAST()
   if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
   {
     return ::isinf(__x);
   }
   return (_CUDA_VSTD::__fp_get_storage(__x) & __fp_exp_mant_mask_of_v<double>) == __fp_exp_mask_of_v<double>;
-#else // ^^^ _LIBCUDACXX_HAS_CONSTEXPR_BIT_CAST() ^^^ / vvv !_LIBCUDACXX_HAS_CONSTEXPR_BIT_CAST() vvv
+#else // ^^^ _CCCL_HAS_CONSTEXPR_BIT_CAST() ^^^ / vvv !_CCCL_HAS_CONSTEXPR_BIT_CAST() vvv
   return _CUDA_VSTD::__isinf_impl(__x);
 #endif // ^^^ !_CCCL_BUILTIN_ISINF ^^^
 }

--- a/libcudacxx/include/cuda/std/__cmath/signbit.h
+++ b/libcudacxx/include/cuda/std/__cmath/signbit.h
@@ -23,128 +23,29 @@
 
 #include <cuda/std/__concepts/concept_macros.h>
 #include <cuda/std/__floating_point/fp.h>
+#include <cuda/std/__type_traits/is_extended_arithmetic.h>
 #include <cuda/std/__type_traits/is_integral.h>
-#include <cuda/std/__type_traits/is_signed.h>
 #include <cuda/std/limits>
-
-// MSVC and clang cuda need the host side functions included
-#if _CCCL_COMPILER(MSVC) || _CCCL_CUDA_COMPILER(CLANG)
-#  include <math.h>
-#endif // _CCCL_COMPILER(MSVC) || _CCCL_CUDA_COMPILER(CLANG)
 
 #include <cuda/std/__cccl/prologue.h>
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-[[nodiscard]] _CCCL_API inline bool signbit(float __x) noexcept
+_CCCL_TEMPLATE(class _Tp)
+_CCCL_REQUIRES(__is_extended_arithmetic_v<_Tp>)
+[[nodiscard]] _CCCL_API constexpr bool signbit([[maybe_unused]] _Tp __x) noexcept
 {
-#if defined(_CCCL_BUILTIN_SIGNBIT)
-  return _CCCL_BUILTIN_SIGNBIT(__x);
-#else // ^^^ _CCCL_BUILTIN_SIGNBIT ^^^ / vvv !_CCCL_BUILTIN_SIGNBIT vvv
-  return ::signbit(__x);
-#endif // !_CCCL_BUILTIN_SIGNBIT
-}
-
-[[nodiscard]] _CCCL_API inline bool signbit(double __x) noexcept
-{
-#if defined(_CCCL_BUILTIN_SIGNBIT)
-  return _CCCL_BUILTIN_SIGNBIT(__x);
-#else // ^^^ _CCCL_BUILTIN_SIGNBIT ^^^ / vvv !_CCCL_BUILTIN_SIGNBIT vvv
-  return ::signbit(__x);
-#endif // !_CCCL_BUILTIN_SIGNBIT
-}
-
-#if _CCCL_HAS_LONG_DOUBLE()
-[[nodiscard]] _CCCL_API inline bool signbit(long double __x) noexcept
-{
-#  if defined(_CCCL_BUILTIN_SIGNBIT)
-  return _CCCL_BUILTIN_SIGNBIT(__x);
-#  else // ^^^ _CCCL_BUILTIN_SIGNBIT ^^^ / vvv !_CCCL_BUILTIN_SIGNBIT vvv
-  return ::signbit(__x);
-#  endif // !_CCCL_BUILTIN_SIGNBIT
-}
-#endif // _CCCL_HAS_LONG_DOUBLE()
-
-template <class _Tp>
-[[nodiscard]] _CCCL_API constexpr bool __signbit_impl(_Tp __x) noexcept
-{
-  if constexpr (numeric_limits<_Tp>::is_signed)
-  {
-    return _CUDA_VSTD::__fp_get_storage(__x) & __fp_sign_mask_of_v<_Tp>;
-  }
-  else
+  if constexpr (!numeric_limits<_Tp>::is_signed)
   {
     return false;
   }
-}
-
-#if _CCCL_HAS_NVFP16()
-[[nodiscard]] _CCCL_API constexpr bool signbit(__half __x) noexcept
-{
-  return _CUDA_VSTD::__signbit_impl(__x);
-}
-#endif // _CCCL_HAS_NVFP16()
-
-#if _CCCL_HAS_NVBF16()
-[[nodiscard]] _CCCL_API constexpr bool signbit(__nv_bfloat16 __x) noexcept
-{
-  return _CUDA_VSTD::__signbit_impl(__x);
-}
-#endif // _CCCL_HAS_NVBF16()
-
-#if _CCCL_HAS_NVFP8_E4M3()
-[[nodiscard]] _CCCL_API constexpr bool signbit(__nv_fp8_e4m3 __x) noexcept
-{
-  return _CUDA_VSTD::__signbit_impl(__x);
-}
-#endif // _CCCL_HAS_NVFP8_E4M3()
-
-#if _CCCL_HAS_NVFP8_E5M2()
-[[nodiscard]] _CCCL_API constexpr bool signbit(__nv_fp8_e5m2 __x) noexcept
-{
-  return _CUDA_VSTD::__signbit_impl(__x);
-}
-#endif // _CCCL_HAS_NVFP8_E5M2()
-
-#if _CCCL_HAS_NVFP8_E8M0()
-[[nodiscard]] _CCCL_API constexpr bool signbit(__nv_fp8_e8m0) noexcept
-{
-  return false;
-}
-#endif // _CCCL_HAS_NVFP8_E8M0()
-
-#if _CCCL_HAS_NVFP6_E2M3()
-[[nodiscard]] _CCCL_API constexpr bool signbit(__nv_fp6_e2m3 __x) noexcept
-{
-  return _CUDA_VSTD::__signbit_impl(__x);
-}
-#endif // _CCCL_HAS_NVFP6_E2M3()
-
-#if _CCCL_HAS_NVFP6_E3M2()
-[[nodiscard]] _CCCL_API constexpr bool signbit(__nv_fp6_e3m2 __x) noexcept
-{
-  return _CUDA_VSTD::__signbit_impl(__x);
-}
-#endif // _CCCL_HAS_NVFP6_E3M2()
-
-#if _CCCL_HAS_NVFP4_E2M1()
-[[nodiscard]] _CCCL_API constexpr bool signbit(__nv_fp4_e2m1 __x) noexcept
-{
-  return _CUDA_VSTD::__signbit_impl(__x);
-}
-#endif // _CCCL_HAS_NVFP4_E2M1()
-
-_CCCL_TEMPLATE(class _Tp)
-_CCCL_REQUIRES(_CCCL_TRAIT(is_integral, _Tp))
-[[nodiscard]] _CCCL_API constexpr bool signbit([[maybe_unused]] _Tp __x) noexcept
-{
-  if constexpr (_CCCL_TRAIT(is_signed, _Tp))
+  else if constexpr (is_integral_v<_Tp>)
   {
     return __x < 0;
   }
   else
   {
-    return false;
+    return _CUDA_VSTD::__fp_get_storage(__x) & __fp_sign_mask_of_v<_Tp>;
   }
 }
 

--- a/libcudacxx/include/cuda/std/__floating_point/cast.h
+++ b/libcudacxx/include/cuda/std/__floating_point/cast.h
@@ -31,7 +31,7 @@
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 template <class _To, class _From>
-[[nodiscard]] _CCCL_API inline _To __fp_cast(_From __v) noexcept
+[[nodiscard]] _CCCL_API inline constexpr _To __fp_cast(_From __v) noexcept
 {
   if constexpr (_CCCL_TRAIT(is_same, _From, float))
   {

--- a/libcudacxx/include/cuda/std/__limits/numeric_limits.h
+++ b/libcudacxx/include/cuda/std/__limits/numeric_limits.h
@@ -370,7 +370,7 @@ public:
     return _CCCL_BUILTIN_HUGE_VALF();
   }
 #else // ^^^ _CCCL_BUILTIN_HUGE_VALF ^^^ // vvv !_CCCL_BUILTIN_HUGE_VALF vvv
-  _CCCL_API inline static _LIBCUDACXX_CONSTEXPR_BIT_CAST type infinity() noexcept
+  _CCCL_API inline static _CCCL_CONSTEXPR_BIT_CAST type infinity() noexcept
   {
     return _CUDA_VSTD::bit_cast<type>(0x7f800000);
   }
@@ -381,7 +381,7 @@ public:
     return _CCCL_BUILTIN_NANF("");
   }
 #else // ^^^ _CCCL_BUILTIN_NANF ^^^ // vvv !_CCCL_BUILTIN_NANF vvv
-  _CCCL_API inline static _LIBCUDACXX_CONSTEXPR_BIT_CAST type quiet_NaN() noexcept
+  _CCCL_API inline static _CCCL_CONSTEXPR_BIT_CAST type quiet_NaN() noexcept
   {
     return _CUDA_VSTD::bit_cast<type>(0x7fc00000);
   }
@@ -392,7 +392,7 @@ public:
     return _CCCL_BUILTIN_NANSF("");
   }
 #else // ^^^ _CCCL_BUILTIN_NANSF ^^^ // vvv !_CCCL_BUILTIN_NANSF vvv
-  _CCCL_API inline static _LIBCUDACXX_CONSTEXPR_BIT_CAST type signaling_NaN() noexcept
+  _CCCL_API inline static _CCCL_CONSTEXPR_BIT_CAST type signaling_NaN() noexcept
   {
     return _CUDA_VSTD::bit_cast<type>(0x7fa00000);
   }
@@ -469,7 +469,7 @@ public:
     return _CCCL_BUILTIN_HUGE_VAL();
   }
 #else // ^^^ _CCCL_BUILTIN_HUGE_VAL ^^^ // vvv !_CCCL_BUILTIN_HUGE_VAL vvv
-  _CCCL_API inline static _LIBCUDACXX_CONSTEXPR_BIT_CAST type infinity() noexcept
+  _CCCL_API inline static _CCCL_CONSTEXPR_BIT_CAST type infinity() noexcept
   {
     return _CUDA_VSTD::bit_cast<type>(0x7ff0000000000000);
   }
@@ -480,7 +480,7 @@ public:
     return _CCCL_BUILTIN_NAN("");
   }
 #else // ^^^ _CCCL_BUILTIN_NAN ^^^ // vvv !_CCCL_BUILTIN_NAN vvv
-  _CCCL_API inline static _LIBCUDACXX_CONSTEXPR_BIT_CAST type quiet_NaN() noexcept
+  _CCCL_API inline static _CCCL_CONSTEXPR_BIT_CAST type quiet_NaN() noexcept
   {
     return _CUDA_VSTD::bit_cast<type>(0x7ff8000000000000);
   }
@@ -491,7 +491,7 @@ public:
     return _CCCL_BUILTIN_NANS("");
   }
 #else // ^^^ _CCCL_BUILTIN_NANS ^^^ // vvv !_CCCL_BUILTIN_NANS vvv
-  _CCCL_API inline static _LIBCUDACXX_CONSTEXPR_BIT_CAST type signaling_NaN() noexcept
+  _CCCL_API inline static _CCCL_CONSTEXPR_BIT_CAST type signaling_NaN() noexcept
   {
     return _CUDA_VSTD::bit_cast<type>(0x7ff4000000000000);
   }

--- a/libcudacxx/include/cuda/std/__limits/numeric_limits_ext.h
+++ b/libcudacxx/include/cuda/std/__limits/numeric_limits_ext.h
@@ -668,7 +668,7 @@ public:
     return _CCCL_FLOAT128_LITERAL(3.36210314311209350626267781732175260e-4932);
   }
 #  else // ^^^ _CCCL_HAS_FLOAT128_LITERAL() ^^^ // vvv !_CCCL_HAS_FLOAT128_LITERAL() vvv
-  _CCCL_API inline static _LIBCUDACXX_CONSTEXPR_BIT_CAST type min() noexcept
+  _CCCL_API inline static _CCCL_CONSTEXPR_BIT_CAST type min() noexcept
   {
     return _CUDA_VSTD::bit_cast<type>(__uint128_t{0x0001'0000'0000'0000} << 64);
   }
@@ -679,7 +679,7 @@ public:
     return _CCCL_FLOAT128_LITERAL(1.18973149535723176508575932662800702e+4932);
   }
 #  else // ^^^ _CCCL_HAS_FLOAT128_LITERAL() ^^^ // vvv !_CCCL_HAS_FLOAT128_LITERAL() vvv
-  _CCCL_API inline static _LIBCUDACXX_CONSTEXPR_BIT_CAST type max() noexcept
+  _CCCL_API inline static _CCCL_CONSTEXPR_BIT_CAST type max() noexcept
   {
     return _CUDA_VSTD::bit_cast<type>(__uint128_t{0x7ffe'ffff'ffff'ffff} << 64 | 0xffff'ffff'ffff'ffff);
   }
@@ -690,7 +690,7 @@ public:
     return -max();
   }
 #  else // ^^^ _CCCL_HAS_FLOAT128_LITERAL() ^^^ // vvv !_CCCL_HAS_FLOAT128_LITERAL() vvv
-  _CCCL_API inline static _LIBCUDACXX_CONSTEXPR_BIT_CAST type lowest() noexcept
+  _CCCL_API inline static _CCCL_CONSTEXPR_BIT_CAST type lowest() noexcept
   {
     return -max();
   }
@@ -725,7 +725,7 @@ public:
     return _CCCL_BUILTIN_HUGE_VALF128();
   }
 #  else // ^^^ _CCCL_BUILTIN_HUGE_VALF128 ^^^ // vvv !_CCCL_BUILTIN_HUGE_VALF128 vvv
-  _CCCL_API inline static _LIBCUDACXX_CONSTEXPR_BIT_CAST type infinity() noexcept
+  _CCCL_API inline static _CCCL_CONSTEXPR_BIT_CAST type infinity() noexcept
   {
     return _CUDA_VSTD::bit_cast<type>(__uint128_t{0x7fff'0000'0000'0000} << 64);
   }
@@ -736,7 +736,7 @@ public:
     return _CCCL_BUILTIN_NANF128("");
   }
 #  else // ^^^ _CCCL_BUILTIN_NANF128 ^^^ // vvv !_CCCL_BUILTIN_NANF128 vvv
-  _CCCL_API inline static _LIBCUDACXX_CONSTEXPR_BIT_CAST type quiet_NaN() noexcept
+  _CCCL_API inline static _CCCL_CONSTEXPR_BIT_CAST type quiet_NaN() noexcept
   {
     return _CUDA_VSTD::bit_cast<type>(__uint128_t{0x7fff'8000'0000'0000} << 64);
   }
@@ -747,7 +747,7 @@ public:
     return _CCCL_BUILTIN_NANSF128("");
   }
 #  else // ^^^ _CCCL_BUILTIN_NANSF128 ^^^ // vvv !_CCCL_BUILTIN_NANSF128 vvv
-  _CCCL_API inline static _LIBCUDACXX_CONSTEXPR_BIT_CAST type signaling_NaN() noexcept
+  _CCCL_API inline static _CCCL_CONSTEXPR_BIT_CAST type signaling_NaN() noexcept
   {
     return _CUDA_VSTD::bit_cast<type>(__uint128_t{0x7fff'4000'0000'0000} << 64);
   }
@@ -758,7 +758,7 @@ public:
     return _CCCL_FLOAT128_LITERAL(6.47517511943802511092443895822764655e-4966);
   }
 #  else // ^^^ _CCCL_HAS_FLOAT128_LITERAL() ^^^ // vvv !_CCCL_HAS_FLOAT128_LITERAL() vvv
-  _CCCL_API inline static _LIBCUDACXX_CONSTEXPR_BIT_CAST type denorm_min() noexcept
+  _CCCL_API inline static _CCCL_CONSTEXPR_BIT_CAST type denorm_min() noexcept
   {
     return _CUDA_VSTD::bit_cast<type>(__uint128_t{0x1});
   }

--- a/libcudacxx/test/libcudacxx/std/numerics/bit/bit.cast/bit_cast.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/bit/bit.cast/bit_cast.pass.cpp
@@ -89,7 +89,7 @@ __host__ __device__ void test_roundtrip_through(T from)
 }
 
 template <typename T>
-__host__ __device__ _LIBCUDACXX_CONSTEXPR_BIT_CAST cuda::std::array<T, 10> generate_signed_integral_values()
+__host__ __device__ _CCCL_CONSTEXPR_BIT_CAST cuda::std::array<T, 10> generate_signed_integral_values()
 {
   return {cuda::std::numeric_limits<T>::min(),
           cuda::std::numeric_limits<T>::min() + 1,
@@ -104,7 +104,7 @@ __host__ __device__ _LIBCUDACXX_CONSTEXPR_BIT_CAST cuda::std::array<T, 10> gener
 }
 
 template <typename T>
-__host__ __device__ _LIBCUDACXX_CONSTEXPR_BIT_CAST cuda::std::array<T, 6> generate_unsigned_integral_values()
+__host__ __device__ _CCCL_CONSTEXPR_BIT_CAST cuda::std::array<T, 6> generate_unsigned_integral_values()
 {
   return {static_cast<T>(0),
           static_cast<T>(1),

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/fp_traits/signbit.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/fp_traits/signbit.pass.cpp
@@ -48,9 +48,18 @@ __host__ __device__ constexpr void test_signbit(const T pos)
 }
 
 template <class T>
-__host__ __device__ constexpr void test_type()
+__host__ __device__ constexpr void test_type(float val)
 {
   static_assert(cuda::std::is_same_v<bool, decltype(cuda::std::signbit(T{}))>);
+  if constexpr (cuda::std::is_integral_v<T>)
+  {
+    // clang-cuda cannot directly cast float to the 128 bit integers. going through int is fine though
+    test_signbit(static_cast<T>(static_cast<int>(val)));
+  }
+  else
+  {
+    test_signbit(cuda::std::__fp_cast<T>(val));
+  }
 
   // __nv_fp8_e8m0 cannot represent 0
 #if _CCCL_HAS_NVFP8_E8M0()
@@ -86,104 +95,91 @@ __host__ __device__ constexpr void test_type()
   }
 }
 
-__host__ __device__ constexpr bool test()
+__host__ __device__ constexpr bool test(float val)
 {
-  test_type<float>();
-  test_type<double>();
+  test_type<float>(val);
+  test_type<double>(val);
 #if _CCCL_HAS_LONG_DOUBLE()
-  test_type<long double>();
+  test_type<long double>(val);
 #endif // _CCCL_HAS_LONG_DOUBLE()
 #if _CCCL_HAS_NVFP16()
-  test_type<__half>();
+  test_type<__half>(val);
 #endif // _CCCL_HAS_NVFP16()
 #if _CCCL_HAS_NVBF16()
-  test_type<__nv_bfloat16>();
+  test_type<__nv_bfloat16>(val);
 #endif // _CCCL_HAS_NVBF16()
 #if _CCCL_HAS_NVFP8_E4M3()
-  test_type<__nv_fp8_e4m3>();
+  test_type<__nv_fp8_e4m3>(val);
 #endif // _CCCL_HAS_NVFP8_E4M3
 #if _CCCL_HAS_NVFP8_E5M2()
-  test_type<__nv_fp8_e5m2>();
+  test_type<__nv_fp8_e5m2>(val);
 #endif // _CCCL_HAS_NVFP8_E5M2
 #if _CCCL_HAS_NVFP8_E8M0()
-  test_type<__nv_fp8_e8m0>();
+  test_type<__nv_fp8_e8m0>(val);
 #endif // _CCCL_HAS_NVFP8_E8M0
 #if _CCCL_HAS_NVFP6_E2M3()
-  test_type<__nv_fp6_e2m3>();
+  test_type<__nv_fp6_e2m3>(val);
 #endif // _CCCL_HAS_NVFP6_E2M3
 #if _CCCL_HAS_NVFP6_E3M2()
-  test_type<__nv_fp6_e3m2>();
+  test_type<__nv_fp6_e3m2>(val);
 #endif // _CCCL_HAS_NVFP6_E3M2
 #if _CCCL_HAS_NVFP4_E2M1()
-  test_type<__nv_fp4_e2m1>();
+  test_type<__nv_fp4_e2m1>(val);
 #endif // _CCCL_HAS_NVFP4_E2M1
 
-  test_type<signed char>();
-  test_type<unsigned char>();
-  test_type<signed short>();
-  test_type<unsigned short>();
-  test_type<signed int>();
-  test_type<unsigned int>();
-  test_type<signed long>();
-  test_type<unsigned long>();
-  test_type<signed long long>();
-  test_type<unsigned long long>();
+  test_type<signed char>(val);
+  test_type<unsigned char>(val);
+  test_type<signed short>(val);
+  test_type<unsigned short>(val);
+  test_type<signed int>(val);
+  test_type<unsigned int>(val);
+  test_type<signed long>(val);
+  test_type<unsigned long>(val);
+  test_type<signed long long>(val);
+  test_type<unsigned long long>(val);
 #if _CCCL_HAS_INT128()
-  test_type<__int128_t>();
-  test_type<__uint128_t>();
+  test_type<__int128_t>(val);
+  test_type<__uint128_t>(val);
 #endif // _CCCL_HAS_INT128()
 
   return true;
 }
 
-__host__ __device__ constexpr bool test_constexpr()
+#if _CCCL_HAS_CONSTEXPR_BIT_CAST()
+__host__ __device__ constexpr bool test_constexpr(float val)
 {
-#if _CCCL_HAS_NVFP16()
-  test_type<__half>();
-#endif // _CCCL_HAS_NVFP16()
-#if _CCCL_HAS_NVBF16()
-  test_type<__nv_bfloat16>();
-#endif // _CCCL_HAS_NVBF16()
-#if _CCCL_HAS_NVFP8_E4M3()
-  test_type<__nv_fp8_e4m3>();
-#endif // _CCCL_HAS_NVFP8_E4M3
-#if _CCCL_HAS_NVFP8_E5M2()
-  test_type<__nv_fp8_e5m2>();
-#endif // _CCCL_HAS_NVFP8_E5M2
-#if _CCCL_HAS_NVFP8_E8M0()
-  test_type<__nv_fp8_e8m0>();
-#endif // _CCCL_HAS_NVFP8_E8M0
-#if _CCCL_HAS_NVFP6_E2M3()
-  test_type<__nv_fp6_e2m3>();
-#endif // _CCCL_HAS_NVFP6_E2M3
-#if _CCCL_HAS_NVFP6_E3M2()
-  test_type<__nv_fp6_e3m2>();
-#endif // _CCCL_HAS_NVFP6_E3M2
-#if _CCCL_HAS_NVFP4_E2M1()
-  test_type<__nv_fp4_e2m1>();
-#endif // _CCCL_HAS_NVFP4_E2M1
+  test_type<float>(val);
+  test_type<double>(val);
+#  if _CCCL_HAS_LONG_DOUBLE()
+  test_type<long double>(val);
+#  endif // _CCCL_HAS_LONG_DOUBLE()
 
-  test_type<signed char>();
-  test_type<unsigned char>();
-  test_type<signed short>();
-  test_type<unsigned short>();
-  test_type<signed int>();
-  test_type<unsigned int>();
-  test_type<signed long>();
-  test_type<unsigned long>();
-  test_type<signed long long>();
-  test_type<unsigned long long>();
-#if _CCCL_HAS_INT128()
-  test_type<__int128_t>();
-  test_type<__uint128_t>();
-#endif // _CCCL_HAS_INT128()
+  test_type<signed char>(val);
+  test_type<unsigned char>(val);
+  test_type<signed short>(val);
+  test_type<unsigned short>(val);
+  test_type<signed int>(val);
+  test_type<unsigned int>(val);
+  test_type<signed long>(val);
+  test_type<unsigned long>(val);
+  test_type<signed long long>(val);
+  test_type<unsigned long long>(val);
+#  if _CCCL_HAS_INT128()
+  test_type<__int128_t>(val);
+  test_type<__uint128_t>(val);
+#  endif // _CCCL_HAS_INT128()
 
   return true;
 }
+#endif // _CCCL_HAS_CONSTEXPR_BIT_CAST()
 
 int main(int, char**)
 {
-  test();
-  static_assert(test_constexpr());
+  volatile float val = 1.0f;
+  test(val);
+#if _CCCL_HAS_CONSTEXPR_BIT_CAST()
+  static_assert(test_constexpr(1.0f));
+#endif // _CCCL_HAS_CONSTEXPR_BIT_CAST()
+
   return 0;
 }


### PR DESCRIPTION
Our `signbit` implementation relies on the compiler builtin.

However, that is not `constexpr` and the function itself is simple enough, so lets just implement it through proper masking.

That way we can enable it to be constexpr when we have the proper `bit_cast` builtin.