### PR TITLE
[CUDAX] Rename async_buffer::change_stream to set_stream and add a test

### DIFF
--- a/cudax/include/cuda/experimental/__container/async_buffer.cuh
+++ b/cudax/include/cuda/experimental/__container/async_buffer.cuh
@@ -550,18 +550,18 @@ public:
   //! @brief Replaces the stored stream
   //! @param __new_stream the new stream
   //! @note Always synchronizes with the old stream
-  _CCCL_HIDE_FROM_ABI constexpr void change_stream(stream_ref __new_stream)
+  _CCCL_HIDE_FROM_ABI constexpr void set_stream(stream_ref __new_stream)
   {
-    __buf_.change_stream(__new_stream);
+    __buf_.set_stream(__new_stream);
   }
 
   //! @brief Replaces the stored stream
   //! @param __new_stream the new stream
   //! @warning This does not synchronize between \p __new_stream and the current stream. It is the user's responsibility
   //! to ensure proper stream order going forward
-  _CCCL_HIDE_FROM_ABI constexpr void change_stream_unsynchronized(stream_ref __new_stream) noexcept
+  _CCCL_HIDE_FROM_ABI constexpr void set_stream_unsynchronized(stream_ref __new_stream) noexcept
   {
-    __buf_.change_stream_unsynchronized(__new_stream);
+    __buf_.set_stream_unsynchronized(__new_stream);
   }
 
   //! @brief Move assignment operator

--- a/cudax/include/cuda/experimental/__container/uninitialized_async_buffer.cuh
+++ b/cudax/include/cuda/experimental/__container/uninitialized_async_buffer.cuh
@@ -340,7 +340,7 @@ public:
   //! @brief Replaces the stored stream
   //! @param __new_stream the new stream
   //! @note Always synchronizes with the old stream
-  _CCCL_HIDE_FROM_ABI constexpr void change_stream(::cuda::stream_ref __new_stream)
+  _CCCL_HIDE_FROM_ABI constexpr void set_stream(::cuda::stream_ref __new_stream)
   {
     if (__new_stream != __stream_)
     {
@@ -353,7 +353,7 @@ public:
   //! @param __new_stream the new stream
   //! @warning This does not synchronize between \p __new_stream and the current stream. It is the user's responsibility
   //! to ensure proper stream order going forward
-  _CCCL_HIDE_FROM_ABI constexpr void change_stream_unsynchronized(::cuda::stream_ref __new_stream) noexcept
+  _CCCL_HIDE_FROM_ABI constexpr void set_stream_unsynchronized(::cuda::stream_ref __new_stream) noexcept
   {
     __stream_ = __new_stream;
   }

--- a/cudax/test/containers/async_buffer/access.cu
+++ b/cudax/test/containers/async_buffer/access.cu
@@ -31,7 +31,7 @@ using test_types = c2h::type_list<cuda::std::tuple<cuda::mr::host_accessible>,
 using test_types = c2h::type_list<cuda::std::tuple<cuda::mr::device_accessible>>;
 #endif
 
-C2H_CCCLRT_TEST("cudax::async_buffer access", "[container][async_buffer]", test_types)
+C2H_CCCLRT_TEST("cudax::async_buffer access and stream", "[container][async_buffer]", test_types)
 {
   using TestT           = c2h::get<0, TestType>;
   using Env             = typename extract_properties<TestT>::env;
@@ -85,5 +85,20 @@ C2H_CCCLRT_TEST("cudax::async_buffer access", "[container][async_buffer]", test_
       CUDAX_CHECK(cuda::std::as_const(buf).data() != nullptr);
       CUDAX_CHECK(cuda::std::as_const(buf).data() == buf.data());
     }
+  }
+
+  SECTION("cudax::async_buffer::stream")
+  {
+    Buffer buf{env, {T(1), T(42), T(1337), T(0)}};
+    CUDAX_CHECK(buf.stream() == stream);
+
+    {
+      cudax::stream other_stream{cudax::device_ref{0}};
+      buf.set_stream_unsynchronized(other_stream);
+      CUDAX_CHECK(buf.stream() == other_stream);
+      buf.set_stream(stream);
+    }
+
+    CUDAX_CHECK(buf.stream() == stream);
   }
 }

--- a/cudax/test/containers/async_buffer/access.cu
+++ b/cudax/test/containers/async_buffer/access.cu
@@ -96,7 +96,8 @@ C2H_CCCLRT_TEST("cudax::async_buffer access and stream", "[container][async_buff
       cudax::stream other_stream{cudax::device_ref{0}};
       buf.set_stream_unsynchronized(other_stream);
       CUDAX_CHECK(buf.stream() == other_stream);
-      buf.set_stream(stream);
+      // TODO swap to synchronized setter one cudax::stream_ref is moved to cuda namespace
+      buf.set_stream_unsynchronized(stream);
     }
 
     CUDAX_CHECK(buf.stream() == stream);


### PR DESCRIPTION
`set_stream` and `set_stream_unsynchronized` was proposed as a shorter name aligned with the current RMM naming. I also noticed we don't have any tests calling `change_stream` so I added one.