### PR TITLE
Add scan tunings from leaderboard

### DIFF
--- a/cub/cub/device/dispatch/tuning/tuning_scan.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan.cuh
@@ -160,6 +160,29 @@ constexpr offset_size classify_offset_size()
   return sizeof(OffsetT) == 4 ? offset_size::_4 : sizeof(OffsetT) == 8 ? offset_size::_8 : offset_size::unknown;
 }
 
+template <class ValueT,
+          class AccumT,
+          class OffsetT,
+          op_type OpTypeT,
+          primitive_accum PrimitiveAccumulator = is_primitive_accum<AccumT>(),
+          offset_size OffsetSize               = classify_offset_size<OffsetT>(),
+          value_size ValueSize                 = classify_value_size<ValueT>()>
+struct sm75_tuning;
+
+template <class ValueT, class AccumT, class OffsetT>
+struct sm75_tuning<ValueT, AccumT, OffsetT, op_type::plus, primitive_accum::yes, offset_size::_8, value_size::_4>
+{
+  // ipt_7.tpb_128.ns_628.dcid_1.l2w_520.trp_1.ld_0
+  static constexpr int threads                         = 128;
+  static constexpr int items                           = 7;
+  using delay_constructor                              = fixed_delay_constructor_t<628, 520>;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
+  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
+  static constexpr CacheLoadModifier load_modifier     = LOAD_DEFAULT;
+};
+
+// Add sm89 tuning and verify it
+
 template <class AccumT,
           primitive_op PrimitiveOp,
           primitive_accum PrimitiveAccumulator = is_primitive_accum<AccumT>(),
@@ -501,7 +524,38 @@ struct policy_hub
   template <typename Tuning>
   static auto select_agent_policy(long) -> typename DefaultPolicy::ScanPolicyT;
 
-  struct Policy800 : ChainedPolicy<800, Policy800, Policy600>
+  struct Policy750 : ChainedPolicy<750, Policy750, Policy600>
+  {
+    // Use values from tuning if a specialization exists that matches a benchmark, otherwise pick Policy600
+    template <typename Tuning,
+              typename IVT,
+              // In the tuning benchmarks the Initial-, Input- and OutputType are the same. Let's check that the
+              // accumulator type's size matches what we used during the benchmark since that has an impact (The
+              // tunings also check later that it's a primitive type, so arithmetic impact is also comparable to the
+              // benchmark). Input- and OutputType only impact loading and storing data (all arithmetic is done in the
+              // accumulator type), so let's check that they are the same size and dispatch the size in the tunings.
+              ::cuda::std::enable_if_t<sizeof(AccumT) == sizeof(::cuda::std::__accumulator_t<ScanOpT, IVT, IVT>)
+                                         && sizeof(IVT) == sizeof(OutputValueT),
+                                       int> = 0>
+    static auto select_agent_policy750(int)
+      -> AgentScanPolicy<Tuning::threads,
+                         Tuning::items,
+                         AccumT,
+                         Tuning::load_algorithm,
+                         Tuning::load_modifier,
+                         Tuning::store_algorithm,
+                         BLOCK_SCAN_WARP_SCANS,
+                         MemBoundScaling<Tuning::threads, Tuning::items, AccumT>,
+                         typename Tuning::delay_constructor>;
+    template <typename Tuning, typename IVT>
+    static auto select_agent_policy750(long) -> typename Policy600::ScanPolicyT;
+
+    using ScanPolicyT =
+      decltype(select_agent_policy750<sm75_tuning<InputValueT, AccumT, OffsetT, classify_op<ScanOpT>()>, InputValueT>(
+        0));
+  };
+
+  struct Policy800 : ChainedPolicy<800, Policy800, Policy750>
   {
     using ScanPolicyT = decltype(select_agent_policy<sm80_tuning<AccumT, is_primitive_op<ScanOpT>()>>(0));
   };


### PR DESCRIPTION
Adding the tunings that were found as part of the GPU Mode leaderboard competition.

- [x] scan.exclusive.scan @ sm75
- [x] ~scan.exclusive.scan @ sm89~

I am a little bit troubled with the `I32, I64, 2^20` workload regression.

`scan.exclusive.scan` @ sm75

```
['build_main/base.json', 'build_sm75/sm75.json']
# base

## [0] Quadro RTX 8000

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |        Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-------------|---------|----------|
|   I8    |      I32      |      2^16      |   8.034 us |       3.93% |   7.952 us |       4.67% |   -0.082 us |  -1.02% |   SAME   |
|   I8    |      I32      |      2^20      |  15.695 us |       3.87% |  15.807 us |       4.27% |    0.112 us |   0.71% |   SAME   |
|   I8    |      I32      |      2^24      | 111.250 us |       0.73% | 111.342 us |       0.87% |    0.092 us |   0.08% |   SAME   |
|   I8    |      I32      |      2^28      |   1.390 ms |       4.05% |   1.380 ms |       1.74% |   -9.863 us |  -0.71% |   SAME   |
|   I8    |      I64      |      2^16      |   6.333 us |       5.08% |   6.412 us |       5.62% |    0.079 us |   1.25% |   SAME   |
|   I8    |      I64      |      2^20      |  12.834 us |       6.27% |  12.878 us |       4.93% |    0.044 us |   0.34% |   SAME   |
|   I8    |      I64      |      2^24      |  90.085 us |       1.16% |  90.204 us |       1.16% |    0.119 us |   0.13% |   SAME   |
|   I8    |      I64      |      2^28      |   1.380 ms |       0.96% |   1.379 ms |       0.97% |   -1.225 us |  -0.09% |   SAME   |
|   I16   |      I32      |      2^16      |   6.391 us |       5.34% |   6.453 us |       5.85% |    0.062 us |   0.97% |   SAME   |
|   I16   |      I32      |      2^20      |  16.037 us |       4.47% |  15.649 us |       6.22% |   -0.388 us |  -2.42% |   SAME   |
|   I16   |      I32      |      2^24      | 153.112 us |       1.37% | 152.964 us |       1.21% |   -0.148 us |  -0.10% |   SAME   |
|   I16   |      I32      |      2^28      |   2.354 ms |       2.06% |   2.354 ms |       2.01% |   -0.367 us |  -0.02% |   SAME   |
|   I16   |      I64      |      2^16      |   6.233 us |      10.21% |   6.231 us |      10.48% |   -0.002 us |  -0.03% |   SAME   |
|   I16   |      I64      |      2^20      |  15.553 us |       4.72% |  15.423 us |       4.03% |   -0.130 us |  -0.84% |   SAME   |
|   I16   |      I64      |      2^24      | 153.039 us |       1.33% | 152.939 us |       1.26% |   -0.101 us |  -0.07% |   SAME   |
|   I16   |      I64      |      2^28      |   2.355 ms |       2.25% |   2.354 ms |       2.01% |   -1.179 us |  -0.05% |   SAME   |
|   I32   |      I32      |      2^16      |   6.485 us |       6.04% |   6.530 us |       6.59% |    0.045 us |   0.70% |   SAME   |
|   I32   |      I32      |      2^20      |  22.110 us |       2.31% |  22.111 us |       2.95% |    0.000 us |   0.00% |   SAME   |
|   I32   |      I32      |      2^24      | 303.096 us |       1.04% | 303.211 us |       0.94% |    0.114 us |   0.04% |   SAME   |
|   I32   |      I32      |      2^28      |   4.806 ms |       1.35% |   4.805 ms |       1.19% |   -0.688 us |  -0.01% |   SAME   |
|   I32   |      I64      |      2^16      |   6.457 us |       6.07% |   6.823 us |       9.10% |    0.366 us |   5.67% |   SAME   |
|   I32   |      I64      |      2^20      |  21.252 us |       2.85% |  22.845 us |       4.29% |    1.593 us |   7.50% |   SLOW   |
|   I32   |      I64      |      2^24      | 302.795 us |       1.00% | 290.359 us |       1.16% |  -12.436 us |  -4.11% |   FAST   |
|   I32   |      I64      |      2^28      |   4.805 ms |       1.28% |   4.558 ms |       1.58% | -246.779 us |  -5.14% |   FAST   |
|   I64   |      I32      |      2^16      |   7.542 us |       6.88% |   7.431 us |       7.08% |   -0.111 us |  -1.47% |   SAME   |
|   I64   |      I32      |      2^20      |  40.861 us |       2.85% |  40.870 us |       2.81% |    0.009 us |   0.02% |   SAME   |
|   I64   |      I32      |      2^24      | 596.080 us |       0.59% | 596.006 us |       0.64% |   -0.074 us |  -0.01% |   SAME   |
|   I64   |      I32      |      2^28      |   9.503 ms |       0.64% |   9.502 ms |       0.61% |   -1.515 us |  -0.02% |   SAME   |
|   I64   |      I64      |      2^16      |   7.550 us |       6.56% |   7.403 us |       7.32% |   -0.148 us |  -1.96% |   SAME   |
|   I64   |      I64      |      2^20      |  42.339 us |       1.68% |  42.304 us |       2.25% |   -0.035 us |  -0.08% |   SAME   |
|   I64   |      I64      |      2^24      | 596.740 us |       1.16% | 597.799 us |       1.98% |    1.059 us |   0.18% |   SAME   |
|   I64   |      I64      |      2^28      |   9.499 ms |       0.66% |   9.499 ms |       0.65% |   -0.499 us |  -0.01% |   SAME   |
|  I128   |      I32      |      2^16      |  13.188 us |       4.49% |  13.109 us |       4.85% |   -0.079 us |  -0.60% |   SAME   |
|  I128   |      I32      |      2^20      |  95.223 us |       3.47% |  95.295 us |       3.49% |    0.072 us |   0.08% |   SAME   |
|  I128   |      I32      |      2^24      |   1.348 ms |       0.21% |   1.348 ms |       0.21% |   -0.229 us |  -0.02% |   SAME   |
|  I128   |      I32      |      2^28      |  21.445 ms |       0.10% |  21.450 ms |       0.11% |    5.042 us |   0.02% |   SAME   |
|  I128   |      I64      |      2^16      |  13.588 us |       6.40% |  13.554 us |       5.15% |   -0.034 us |  -0.25% |   SAME   |
|  I128   |      I64      |      2^20      |  98.806 us |       1.06% |  93.419 us |       2.54% |   -5.387 us |  -5.45% |   FAST   |
|  I128   |      I64      |      2^24      |   1.356 ms |       2.71% |   1.349 ms |       0.21% |   -7.118 us |  -0.52% |   FAST   |
|  I128   |      I64      |      2^28      |  21.451 ms |       0.10% |  21.449 ms |       0.11% |   -1.617 us |  -0.01% |   SAME   |
|   F32   |      I32      |      2^16      |   6.676 us |       7.45% |   6.734 us |       8.75% |    0.058 us |   0.87% |   SAME   |
|   F32   |      I32      |      2^20      |  21.494 us |       4.03% |  21.350 us |       3.08% |   -0.145 us |  -0.67% |   SAME   |
|   F32   |      I32      |      2^24      | 318.604 us |       6.09% | 318.738 us |       6.10% |    0.134 us |   0.04% |   SAME   |
|   F32   |      I32      |      2^28      |   4.794 ms |       1.13% |   4.798 ms |       1.19% |    3.792 us |   0.08% |   SAME   |
|   F32   |      I64      |      2^16      |   6.595 us |       9.97% |   6.797 us |       7.48% |    0.202 us |   3.07% |   SAME   |
|   F32   |      I64      |      2^20      |  21.465 us |       3.04% |  23.087 us |       3.84% |    1.622 us |   7.56% |   SLOW   |
|   F32   |      I64      |      2^24      | 302.527 us |       0.99% | 290.137 us |       1.13% |  -12.390 us |  -4.10% |   FAST   |
|   F32   |      I64      |      2^28      |   4.794 ms |       1.19% |   4.554 ms |       1.48% | -240.133 us |  -5.01% |   FAST   |
|   F64   |      I32      |      2^16      |   9.207 us |       6.77% |   9.178 us |      10.24% |   -0.029 us |  -0.31% |   SAME   |
|   F64   |      I32      |      2^20      |  43.074 us |       1.70% |  43.105 us |       1.66% |    0.031 us |   0.07% |   SAME   |
|   F64   |      I32      |      2^24      | 585.544 us |       0.68% | 586.050 us |       0.69% |    0.506 us |   0.09% |   SAME   |
|   F64   |      I32      |      2^28      |   9.281 ms |       0.69% |   9.288 ms |       0.70% |    6.815 us |   0.07% |   SAME   |
|   F64   |      I64      |      2^16      |   9.153 us |       6.48% |   9.307 us |       5.93% |    0.154 us |   1.68% |   SAME   |
|   F64   |      I64      |      2^20      |  43.218 us |       1.53% |  43.280 us |       1.53% |    0.062 us |   0.14% |   SAME   |
|   F64   |      I64      |      2^24      | 585.519 us |       0.66% | 585.863 us |       0.59% |    0.344 us |   0.06% |   SAME   |
|   F64   |      I64      |      2^28      |   9.273 ms |       0.68% |   9.283 ms |       0.70% |   10.262 us |   0.11% |   SAME   |
|   C64   |      I32      |      2^16      |   9.114 us |       6.37% |   8.981 us |       6.06% |   -0.133 us |  -1.46% |   SAME   |
|   C64   |      I32      |      2^20      |  43.188 us |       1.51% |  41.297 us |       1.62% |   -1.891 us |  -4.38% |   FAST   |
|   C64   |      I32      |      2^24      | 583.546 us |       1.25% | 582.790 us |       0.55% |   -0.757 us |  -0.13% |   SAME   |
|   C64   |      I32      |      2^28      |   9.243 ms |       0.59% |   9.242 ms |       0.57% |   -1.050 us |  -0.01% |   SAME   |
|   C64   |      I64      |      2^16      |   8.949 us |       5.90% |   8.888 us |       6.16% |   -0.060 us |  -0.68% |   SAME   |
|   C64   |      I64      |      2^20      |  43.156 us |       1.83% |  42.969 us |       1.98% |   -0.186 us |  -0.43% |   SAME   |
|   C64   |      I64      |      2^24      | 583.355 us |       0.97% | 582.961 us |       0.58% |   -0.394 us |  -0.07% |   SAME   |
|   C64   |      I64      |      2^28      |   9.243 ms |       0.56% |   9.243 ms |       0.57% |   -0.294 us |  -0.00% |   SAME   |
```