### PR TITLE
Rework our `copysign` implementation to be potentially constexpr

### DIFF
--- a/libcudacxx/include/cuda/std/__cmath/copysign.h
+++ b/libcudacxx/include/cuda/std/__cmath/copysign.h
@@ -21,170 +21,65 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/std/__cmath/isinf.h>
-#include <cuda/std/__cmath/isnan.h>
 #include <cuda/std/__concepts/concept_macros.h>
 #include <cuda/std/__floating_point/fp.h>
-#include <cuda/std/__type_traits/is_constant_evaluated.h>
+#include <cuda/std/__type_traits/is_extended_arithmetic.h>
 #include <cuda/std/__type_traits/is_integral.h>
-#include <cuda/std/__type_traits/is_signed.h>
-#include <cuda/std/cstdint>
 #include <cuda/std/limits>
-
-// MSVC and clang cuda need the host side functions included
-#if _CCCL_COMPILER(MSVC) || _CCCL_CUDA_COMPILER(CLANG)
-#  include <math.h>
-#endif // _CCCL_COMPILER(MSVC) || _CCCL_CUDA_COMPILER(CLANG)
 
 #include <cuda/std/__cccl/prologue.h>
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-#if _CCCL_CHECK_BUILTIN(builtin_copysign) || _CCCL_COMPILER(GCC)
-#  define _CCCL_BUILTIN_COPYSIGNF(...) __builtin_copysignf(__VA_ARGS__)
-#  define _CCCL_BUILTIN_COPYSIGN(...)  __builtin_copysign(__VA_ARGS__)
-#  define _CCCL_BUILTIN_COPYSIGNL(...) __builtin_copysignl(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(builtin_copysign)
-
-[[nodiscard]] _CCCL_API inline float copysign(float __x, float __y) noexcept
-{
-#if defined(_CCCL_BUILTIN_COPYSIGNF)
-  return _CCCL_BUILTIN_COPYSIGNF(__x, __y);
-#else // ^^^ _CCCL_BUILTIN_COPYSIGNF ^^^ / vvv !_CCCL_BUILTIN_COPYSIGNF vvv
-  return ::copysignf(__x, __y);
-#endif // !_CCCL_BUILTIN_COPYSIGNF
-}
-
-[[nodiscard]] _CCCL_API inline float copysignf(float __x, float __y) noexcept
-{
-#if defined(_CCCL_BUILTIN_COPYSIGNF)
-  return _CCCL_BUILTIN_COPYSIGNF(__x, __y);
-#else // ^^^ _CCCL_BUILTIN_COPYSIGNF ^^^ / vvv !_CCCL_BUILTIN_COPYSIGNF vvv
-  return ::copysignf(__x, __y);
-#endif // !_CCCL_BUILTIN_COPYSIGNF
-}
-
-[[nodiscard]] _CCCL_API inline double copysign(double __x, double __y) noexcept
-{
-#if defined(_CCCL_BUILTIN_COPYSIGN)
-  return _CCCL_BUILTIN_COPYSIGN(__x, __y);
-#else // ^^^ _CCCL_BUILTIN_COPYSIGN ^^^ / vvv !_CCCL_BUILTIN_COPYSIGN vvv
-  return ::copysign(__x, __y);
-#endif // !_CCCL_BUILTIN_COPYSIGN
-}
-
-#if _CCCL_HAS_LONG_DOUBLE()
-[[nodiscard]] _CCCL_API inline long double copysign(long double __x, long double __y) noexcept
-{
-#  if defined(_CCCL_BUILTIN_COPYSIGNL)
-  return _CCCL_BUILTIN_COPYSIGNL(__x, __y);
-#  else // ^^^ _CCCL_BUILTIN_COPYSIGNL ^^^ / vvv !_CCCL_BUILTIN_COPYSIGNL vvv
-  return ::copysignl(__x, __y);
-#  endif // !_CCCL_BUILTIN_COPYSIGNL
-}
-
-[[nodiscard]] _CCCL_API inline long double copysignl(long double __x, long double __y) noexcept
-{
-#  if defined(_CCCL_BUILTIN_COPYSIGNL)
-  return _CCCL_BUILTIN_COPYSIGNL(__x, __y);
-#  else // ^^^ _CCCL_BUILTIN_COPYSIGNL ^^^ / vvv !_CCCL_BUILTIN_COPYSIGNL vvv
-  return ::copysignl(__x, __y);
-#  endif // !_CCCL_BUILTIN_COPYSIGNL
-}
-#endif // _CCCL_HAS_LONG_DOUBLE()
-
-template <class _Tp>
-[[nodiscard]] _CCCL_API constexpr _Tp __copysign_impl(_Tp __x, [[maybe_unused]] _Tp __y) noexcept
-{
-  if constexpr (numeric_limits<_Tp>::is_signed)
-  {
-    const auto __val = (_CUDA_VSTD::__fp_get_storage(__x) & __fp_exp_mant_mask_of_v<_Tp>)
-                     | (_CUDA_VSTD::__fp_get_storage(__y) & __fp_sign_mask_of_v<_Tp>);
-    return _CUDA_VSTD::__fp_from_storage<_Tp>(static_cast<__fp_storage_of_t<_Tp>>(__val));
-  }
-  else
-  {
-    return __x;
-  }
-}
-
-#if _CCCL_HAS_NVFP16()
-[[nodiscard]] _CCCL_API constexpr __half copysign(__half __x, __half __y) noexcept
-{
-  return _CUDA_VSTD::__copysign_impl(__x, __y);
-}
-#endif // _CCCL_HAS_NVFP16()
-
-#if _CCCL_HAS_NVBF16()
-[[nodiscard]] _CCCL_API constexpr __nv_bfloat16 copysign(__nv_bfloat16 __x, __nv_bfloat16 __y) noexcept
-{
-  return _CUDA_VSTD::__copysign_impl(__x, __y);
-}
-#endif // _CCCL_HAS_NVBF16()
-
-#if _CCCL_HAS_NVFP8_E4M3()
-[[nodiscard]] _CCCL_API constexpr __nv_fp8_e4m3 copysign(__nv_fp8_e4m3 __x, __nv_fp8_e4m3 __y) noexcept
-{
-  return _CUDA_VSTD::__copysign_impl(__x, __y);
-}
-#endif // _CCCL_HAS_NVFP8_E4M3()
-
-#if _CCCL_HAS_NVFP8_E5M2()
-[[nodiscard]] _CCCL_API constexpr __nv_fp8_e5m2 copysign(__nv_fp8_e5m2 __x, __nv_fp8_e5m2 __y) noexcept
-{
-  return _CUDA_VSTD::__copysign_impl(__x, __y);
-}
-#endif // _CCCL_HAS_NVFP8_E5M2()
-
-#if _CCCL_HAS_NVFP8_E8M0()
-[[nodiscard]] _CCCL_API constexpr __nv_fp8_e8m0 copysign(__nv_fp8_e8m0 __x, __nv_fp8_e8m0 __y) noexcept
-{
-  return _CUDA_VSTD::__copysign_impl(__x, __y);
-}
-#endif // _CCCL_HAS_NVFP8_E8M0()
-
-#if _CCCL_HAS_NVFP6_E2M3()
-[[nodiscard]] _CCCL_API constexpr __nv_fp6_e2m3 copysign(__nv_fp6_e2m3 __x, __nv_fp6_e2m3 __y) noexcept
-{
-  return _CUDA_VSTD::__copysign_impl(__x, __y);
-}
-#endif // _CCCL_HAS_NVFP6_E2M3()
-
-#if _CCCL_HAS_NVFP6_E3M2()
-[[nodiscard]] _CCCL_API constexpr __nv_fp6_e3m2 copysign(__nv_fp6_e3m2 __x, __nv_fp6_e3m2 __y) noexcept
-{
-  return _CUDA_VSTD::__copysign_impl(__x, __y);
-}
-#endif // _CCCL_HAS_NVFP6_E3M2()
-
-#if _CCCL_HAS_NVFP4_E2M1()
-[[nodiscard]] _CCCL_API constexpr __nv_fp4_e2m1 copysign(__nv_fp4_e2m1 __x, __nv_fp4_e2m1 __y) noexcept
-{
-  return _CUDA_VSTD::__copysign_impl(__x, __y);
-}
-#endif // _CCCL_HAS_NVFP4_E2M1()
-
 _CCCL_TEMPLATE(class _Tp)
-_CCCL_REQUIRES(_CCCL_TRAIT(is_integral, _Tp))
-[[nodiscard]] _CCCL_API constexpr double copysign(_Tp __x, [[maybe_unused]] _Tp __y) noexcept
+_CCCL_REQUIRES(__is_extended_arithmetic_v<_Tp>)
+[[nodiscard]] _CCCL_API constexpr auto copysign(_Tp __x, [[maybe_unused]] _Tp __y) noexcept
 {
-  if constexpr (_CCCL_TRAIT(is_signed, _Tp))
+  if constexpr (is_integral_v<_Tp>)
   {
-    const auto __x_dbl = static_cast<double>(__x);
-    if (__y < 0)
+    if constexpr (!numeric_limits<_Tp>::is_signed)
     {
-      return (__x < 0) ? __x_dbl : -__x_dbl;
+      return static_cast<double>(__x);
     }
     else
     {
-      return (__x < 0) ? -__x_dbl : __x_dbl;
+      const auto __x_dbl = static_cast<double>(__x);
+      if (__y < 0)
+      {
+        return (__x < 0) ? __x_dbl : -__x_dbl;
+      }
+      else
+      {
+        return (__x < 0) ? -__x_dbl : __x_dbl;
+      }
     }
   }
-  else
+  else // ^^^ integral ^^^ / vvv floating_point vvv
   {
-    return static_cast<double>(__x);
+    if constexpr (!numeric_limits<_Tp>::is_signed)
+    {
+      return __x;
+    }
+    else
+    {
+      const auto __val = (_CUDA_VSTD::__fp_get_storage(__x) & __fp_exp_mant_mask_of_v<_Tp>)
+                       | (_CUDA_VSTD::__fp_get_storage(__y) & __fp_sign_mask_of_v<_Tp>);
+      return _CUDA_VSTD::__fp_from_storage<_Tp>(static_cast<__fp_storage_of_t<_Tp>>(__val));
+    }
   }
 }
+
+[[nodiscard]] _CCCL_API constexpr float copysignf(float __x, float __y) noexcept
+{
+  return _CUDA_VSTD::copysign(__x, __y);
+}
+
+#if _CCCL_HAS_LONG_DOUBLE()
+[[nodiscard]] _CCCL_API constexpr long double copysignl(long double __x, long double __y) noexcept
+{
+  return _CUDA_VSTD::copysign(__x, __y);
+}
+#endif // _CCCL_HAS_LONG_DOUBLE()
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__cmath/nvbf16.h
+++ b/libcudacxx/include/cuda/std/__cmath/nvbf16.h
@@ -34,11 +34,6 @@
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 // floating point helper
-_CCCL_API constexpr __nv_bfloat16 __constexpr_copysign(__nv_bfloat16 __x, __nv_bfloat16 __y) noexcept
-{
-  return _CUDA_VSTD::copysign(__x, __y);
-}
-
 _CCCL_API inline __nv_bfloat16 __constexpr_fabs(__nv_bfloat16 __x) noexcept
 {
   return ::__habs(__x);

--- a/libcudacxx/include/cuda/std/__cmath/nvfp16.h
+++ b/libcudacxx/include/cuda/std/__cmath/nvfp16.h
@@ -34,11 +34,6 @@
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 // floating point helper
-_CCCL_API constexpr __half __constexpr_copysign(__half __x, __half __y) noexcept
-{
-  return _CUDA_VSTD::copysign(__x, __y);
-}
-
 _CCCL_API inline __half __constexpr_fabs(__half __x) noexcept
 {
   return ::__habs(__x);

--- a/libcudacxx/include/cuda/std/__complex/complex.h
+++ b/libcudacxx/include/cuda/std/__complex/complex.h
@@ -327,29 +327,29 @@ operator*(const complex<_Tp>& __z, const complex<_Tp>& __w)
     bool __recalc = false;
     if (_CUDA_VSTD::isinf(__a) || _CUDA_VSTD::isinf(__b))
     {
-      __a = _CUDA_VSTD::__constexpr_copysign(_CUDA_VSTD::isinf(__a) ? _Tp(1) : _Tp(0), __a);
-      __b = _CUDA_VSTD::__constexpr_copysign(_CUDA_VSTD::isinf(__b) ? _Tp(1) : _Tp(0), __b);
+      __a = _CUDA_VSTD::copysign(_CUDA_VSTD::isinf(__a) ? _Tp(1) : _Tp(0), __a);
+      __b = _CUDA_VSTD::copysign(_CUDA_VSTD::isinf(__b) ? _Tp(1) : _Tp(0), __b);
       if (_CUDA_VSTD::isnan(__c))
       {
-        __c = _CUDA_VSTD::__constexpr_copysign(_Tp(0), __c);
+        __c = _CUDA_VSTD::copysign(_Tp(0), __c);
       }
       if (_CUDA_VSTD::isnan(__d))
       {
-        __d = _CUDA_VSTD::__constexpr_copysign(_Tp(0), __d);
+        __d = _CUDA_VSTD::copysign(_Tp(0), __d);
       }
       __recalc = true;
     }
     if (_CUDA_VSTD::isinf(__c) || _CUDA_VSTD::isinf(__d))
     {
-      __c = _CUDA_VSTD::__constexpr_copysign(_CUDA_VSTD::isinf(__c) ? _Tp(1) : _Tp(0), __c);
-      __d = _CUDA_VSTD::__constexpr_copysign(_CUDA_VSTD::isinf(__d) ? _Tp(1) : _Tp(0), __d);
+      __c = _CUDA_VSTD::copysign(_CUDA_VSTD::isinf(__c) ? _Tp(1) : _Tp(0), __c);
+      __d = _CUDA_VSTD::copysign(_CUDA_VSTD::isinf(__d) ? _Tp(1) : _Tp(0), __d);
       if (_CUDA_VSTD::isnan(__a))
       {
-        __a = _CUDA_VSTD::__constexpr_copysign(_Tp(0), __a);
+        __a = _CUDA_VSTD::copysign(_Tp(0), __a);
       }
       if (_CUDA_VSTD::isnan(__b))
       {
-        __b = _CUDA_VSTD::__constexpr_copysign(_Tp(0), __b);
+        __b = _CUDA_VSTD::copysign(_Tp(0), __b);
       }
       __recalc = true;
     }
@@ -359,19 +359,19 @@ operator*(const complex<_Tp>& __z, const complex<_Tp>& __w)
     {
       if (_CUDA_VSTD::isnan(__a))
       {
-        __a = _CUDA_VSTD::__constexpr_copysign(_Tp(0), __a);
+        __a = _CUDA_VSTD::copysign(_Tp(0), __a);
       }
       if (_CUDA_VSTD::isnan(__b))
       {
-        __b = _CUDA_VSTD::__constexpr_copysign(_Tp(0), __b);
+        __b = _CUDA_VSTD::copysign(_Tp(0), __b);
       }
       if (_CUDA_VSTD::isnan(__c))
       {
-        __c = _CUDA_VSTD::__constexpr_copysign(_Tp(0), __c);
+        __c = _CUDA_VSTD::copysign(_Tp(0), __c);
       }
       if (_CUDA_VSTD::isnan(__d))
       {
-        __d = _CUDA_VSTD::__constexpr_copysign(_Tp(0), __d);
+        __d = _CUDA_VSTD::copysign(_Tp(0), __d);
       }
       __recalc = true;
     }
@@ -479,21 +479,21 @@ operator/(const complex<_Tp>& __z, const complex<_Tp>& __w)
   {
     if ((__denom == _Tp(0)) && (!_CUDA_VSTD::isnan(__a) || !_CUDA_VSTD::isnan(__b)))
     {
-      __x = _CUDA_VSTD::__constexpr_copysign(numeric_limits<_Tp>::infinity(), __c) * __a;
-      __y = _CUDA_VSTD::__constexpr_copysign(numeric_limits<_Tp>::infinity(), __c) * __b;
+      __x = _CUDA_VSTD::copysign(numeric_limits<_Tp>::infinity(), __c) * __a;
+      __y = _CUDA_VSTD::copysign(numeric_limits<_Tp>::infinity(), __c) * __b;
     }
     else if ((_CUDA_VSTD::isinf(__a) || _CUDA_VSTD::isinf(__b)) && _CUDA_VSTD::isfinite(__c)
              && _CUDA_VSTD::isfinite(__d))
     {
-      __a = _CUDA_VSTD::__constexpr_copysign(_CUDA_VSTD::isinf(__a) ? _Tp(1) : _Tp(0), __a);
-      __b = _CUDA_VSTD::__constexpr_copysign(_CUDA_VSTD::isinf(__b) ? _Tp(1) : _Tp(0), __b);
+      __a = _CUDA_VSTD::copysign(_CUDA_VSTD::isinf(__a) ? _Tp(1) : _Tp(0), __a);
+      __b = _CUDA_VSTD::copysign(_CUDA_VSTD::isinf(__b) ? _Tp(1) : _Tp(0), __b);
       __x = numeric_limits<_Tp>::infinity() * (__a * __c + __b * __d);
       __y = numeric_limits<_Tp>::infinity() * (__b * __c - __a * __d);
     }
     else if (_CUDA_VSTD::isinf(__logbw) && __logbw > _Tp(0) && _CUDA_VSTD::isfinite(__a) && _CUDA_VSTD::isfinite(__b))
     {
-      __c = _CUDA_VSTD::__constexpr_copysign(_CUDA_VSTD::isinf(__c) ? _Tp(1) : _Tp(0), __c);
-      __d = _CUDA_VSTD::__constexpr_copysign(_CUDA_VSTD::isinf(__d) ? _Tp(1) : _Tp(0), __d);
+      __c = _CUDA_VSTD::copysign(_CUDA_VSTD::isinf(__c) ? _Tp(1) : _Tp(0), __c);
+      __d = _CUDA_VSTD::copysign(_CUDA_VSTD::isinf(__d) ? _Tp(1) : _Tp(0), __d);
       __x = _Tp(0) * (__a * __c + __b * __d);
       __y = _Tp(0) * (__b * __c - __a * __d);
     }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/cmath
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/cmath
@@ -394,40 +394,6 @@ using ::nanl;
 
 #if _CCCL_COMPILER(MSVC) || _CCCL_COMPILER(NVRTC)
 template <class _A1>
-_CCCL_API inline _A1 __constexpr_copysign(_A1 __x, _A1 __y) noexcept
-{
-  return ::copysign(__x, __y);
-}
-#else
-_CCCL_API constexpr float __constexpr_copysign(float __x, float __y) noexcept
-{
-  return __builtin_copysignf(__x, __y);
-}
-
-_CCCL_API constexpr double __constexpr_copysign(double __x, double __y) noexcept
-{
-  return __builtin_copysign(__x, __y);
-}
-
-#  if _CCCL_HAS_LONG_DOUBLE()
-_CCCL_API constexpr long double __constexpr_copysign(long double __x, long double __y) noexcept
-{
-  return __builtin_copysignl(__x, __y);
-}
-#  endif // _CCCL_HAS_LONG_DOUBLE()
-
-template <class _A1, class _A2>
-_CCCL_API constexpr enable_if_t<is_arithmetic<_A1>::value && is_arithmetic<_A2>::value, __promote_t<_A1, _A2>>
-__constexpr_copysign(_A1 __x, _A2 __y) noexcept
-{
-  using __result_type = __promote_t<_A1, _A2>;
-  static_assert((!(_IsSame<_A1, __result_type>::value && _IsSame<_A2, __result_type>::value)), "");
-  return __builtin_copysign((__result_type) __x, (__result_type) __y);
-}
-#endif // !_CCCL_COMPILER(MSVC)
-
-#if _CCCL_COMPILER(MSVC) || _CCCL_COMPILER(NVRTC)
-template <class _A1>
 _CCCL_API inline _A1 __constexpr_fabs(_A1 __x) noexcept
 {
   return ::fabs(__x);

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/fp_manip/copysign.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/fp_manip/copysign.pass.cpp
@@ -78,8 +78,22 @@ __host__ __device__ constexpr void test_copysign(const T pos)
 }
 
 template <class T>
-__host__ __device__ constexpr void test_type()
+__host__ __device__ constexpr void test_type(float val)
 {
+  if constexpr (cuda::std::is_integral_v<T>)
+  {
+#if TEST_CUDA_COMPILER(CLANG)
+    if constexpr (sizeof(T) < 16) // clang fails the conversion from float to 128 bit integers
+#endif // TEST_CUDA_COMPILER(CLANG)
+    {
+      test_copysign(static_cast<T>(val));
+    }
+  }
+  else
+  {
+    test_copysign(cuda::std::__fp_cast<T>(val));
+  }
+
   // __nv_fp8_e8m0 cannot represent 0
 #if _CCCL_HAS_NVFP8_E8M0()
   if constexpr (!cuda::std::is_same_v<T, __nv_fp8_e8m0>)
@@ -114,91 +128,91 @@ __host__ __device__ constexpr void test_type()
   }
 }
 
-__host__ __device__ constexpr bool test()
+__host__ __device__ constexpr bool test(float val)
 {
-  test_type<float>();
-  test_type<double>();
+  test_type<float>(val);
+  test_type<double>(val);
 #if _CCCL_HAS_LONG_DOUBLE()
-  test_type<long double>();
+  test_type<long double>(val);
 #endif // _CCCL_HAS_LONG_DOUBLE()
 #if _CCCL_HAS_NVFP16()
-  test_type<__half>();
+  test_type<__half>(val);
 #endif // _CCCL_HAS_NVFP16()
 #if _CCCL_HAS_NVBF16()
-  test_type<__nv_bfloat16>();
+  test_type<__nv_bfloat16>(val);
 #endif // _CCCL_HAS_NVBF16()
 #if _CCCL_HAS_NVFP8_E4M3()
-  test_type<__nv_fp8_e4m3>();
+  test_type<__nv_fp8_e4m3>(val);
 #endif // _CCCL_HAS_NVFP8_E4M3
 #if _CCCL_HAS_NVFP8_E5M2()
-  test_type<__nv_fp8_e5m2>();
+  test_type<__nv_fp8_e5m2>(val);
 #endif // _CCCL_HAS_NVFP8_E5M2
 #if _CCCL_HAS_NVFP8_E8M0()
-  test_type<__nv_fp8_e8m0>();
+  test_type<__nv_fp8_e8m0>(val);
 #endif // _CCCL_HAS_NVFP8_E8M0
 #if _CCCL_HAS_NVFP6_E2M3()
-  test_type<__nv_fp6_e2m3>();
+  test_type<__nv_fp6_e2m3>(val);
 #endif // _CCCL_HAS_NVFP6_E2M3
 #if _CCCL_HAS_NVFP6_E3M2()
-  test_type<__nv_fp6_e3m2>();
+  test_type<__nv_fp6_e3m2>(val);
 #endif // _CCCL_HAS_NVFP6_E3M2
 #if _CCCL_HAS_NVFP4_E2M1()
-  test_type<__nv_fp4_e2m1>();
+  test_type<__nv_fp4_e2m1>(val);
 #endif // _CCCL_HAS_NVFP4_E2M1
 
-  test_type<signed char>();
-  test_type<unsigned char>();
-  test_type<signed short>();
-  test_type<unsigned short>();
-  test_type<signed int>();
-  test_type<unsigned int>();
-  test_type<signed long>();
-  test_type<unsigned long>();
-  test_type<signed long long>();
-  test_type<unsigned long long>();
+  test_type<signed char>(val);
+  test_type<unsigned char>(val);
+  test_type<signed short>(val);
+  test_type<unsigned short>(val);
+  test_type<signed int>(val);
+  test_type<unsigned int>(val);
+  test_type<signed long>(val);
+  test_type<unsigned long>(val);
+  test_type<signed long long>(val);
+  test_type<unsigned long long>(val);
 #if _CCCL_HAS_INT128()
-  test_type<__int128_t>();
-  test_type<__uint128_t>();
+  test_type<__int128_t>(val);
+  test_type<__uint128_t>(val);
 #endif // _CCCL_HAS_INT128()
 
   return true;
 }
 
-__host__ __device__ constexpr bool test_constexpr()
+#if _CCCL_HAS_CONSTEXPR_BIT_CAST()
+__host__ __device__ constexpr bool test_constexpr(float val)
 {
-#if _LIBCUDACXX_HAS_NVFP16()
-  test_type<__half>();
-#endif // _LIBCUDACXX_HAS_NVFP16()
-#if _LIBCUDACXX_HAS_NVBF16()
-  test_type<__nv_bfloat16>();
-#endif // _LIBCUDACXX_HAS_NVBF16()
-#if _CCCL_HAS_NVFP8_E4M3()
-  test_type<__nv_fp8_e4m3>();
-#endif // _CCCL_HAS_NVFP8_E4M3
-#if _CCCL_HAS_NVFP8_E5M2()
-  test_type<__nv_fp8_e5m2>();
-#endif // _CCCL_HAS_NVFP8_E5M2
-#if _CCCL_HAS_NVFP8_E8M0()
-  test_type<__nv_fp8_e8m0>();
-#endif // _CCCL_HAS_NVFP8_E8M0
-#if _CCCL_HAS_NVFP6_E2M3()
-  test_type<__nv_fp6_e2m3>();
-#endif // _CCCL_HAS_NVFP6_E2M3
-#if _CCCL_HAS_NVFP6_E3M2()
-  test_type<__nv_fp6_e3m2>();
-#endif // _CCCL_HAS_NVFP6_E3M2
-#if _CCCL_HAS_NVFP4_E2M1()
-  test_type<__nv_fp4_e2m1>();
-#endif // _CCCL_HAS_NVFP4_E2M1
+  test_type<float>(val);
+  test_type<double>(val);
+#  if _CCCL_HAS_LONG_DOUBLE()
+  test_type<long double>(val);
+#  endif // _CCCL_HAS_LONG_DOUBLE()
 
-  // we cannot test integral types, because signbit(double) is not constexpr
+  test_type<signed char>(val);
+  test_type<unsigned char>(val);
+  test_type<signed short>(val);
+  test_type<unsigned short>(val);
+  test_type<signed int>(val);
+  test_type<unsigned int>(val);
+  test_type<signed long>(val);
+  test_type<unsigned long>(val);
+  test_type<signed long long>(val);
+  test_type<unsigned long long>(val);
+#  if _CCCL_HAS_INT128()
+  test_type<__int128_t>(val);
+  test_type<__uint128_t>(val);
+#  endif // _CCCL_HAS_INT128()
 
   return true;
 }
+#endif // _CCCL_HAS_CONSTEXPR_BIT_CAST()
 
 int main(int, char**)
 {
-  test();
-  static_assert(test_constexpr());
+  volatile float val = 1.0f;
+  test(val);
+#if _CCCL_HAS_CONSTEXPR_BIT_CAST()
+  static_assert(test_constexpr(1.0f));
+#endif // _CCCL_HAS_CONSTEXPR_BIT_CAST()
+
   return 0;
 }


### PR DESCRIPTION
We were previously relying on the compiler builtins, however those are not constexpr and their availability is limited especially given the new extended floating point types.

So just implement it through bit masking.