### PR TITLE
Fix inplace_vector out of bounds access for at()

### DIFF
--- a/libcudacxx/include/cuda/std/inplace_vector
+++ b/libcudacxx/include/cuda/std/inplace_vector
@@ -1016,7 +1016,7 @@ public:
   // [containers.sequences.inplace.vector.access], element access
   [[nodiscard]] _CCCL_API constexpr reference at(const size_type __pos)
   {
-    if (__pos > this->size())
+    if (__pos >= this->size())
     {
       _CUDA_VSTD::__throw_out_of_range("inplace_vector::at");
     }
@@ -1025,7 +1025,7 @@ public:
 
   [[nodiscard]] _CCCL_API constexpr const_reference at(const size_type __pos) const
   {
-    if (__pos > this->size())
+    if (__pos >= this->size())
     {
       _CUDA_VSTD::__throw_out_of_range("inplace_vector::at");
     }

--- a/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/access.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/access.pass.cpp
@@ -114,6 +114,32 @@ void test_exceptions()
     {
       assert(false);
     }
+
+    try
+    {
+      vec too_small{};
+      auto res = too_small.at(vec.size());
+      unused(res);
+    }
+    catch (const std::out_of_range&)
+    {}
+    catch (...)
+    {
+      assert(false);
+    }
+
+    try
+    {
+      const vec too_small{};
+      auto res = too_small.at(vec.size());
+      unused(res);
+    }
+    catch (const std::out_of_range&)
+    {}
+    catch (...)
+    {
+      assert(false);
+    }
   }
 }
 #endif // TEST_HAS_EXCEPTIONS()

--- a/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/access.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/access.pass.cpp
@@ -118,7 +118,7 @@ void test_exceptions()
     try
     {
       vec too_small{};
-      auto res = too_small.at(vec.size());
+      auto res = too_small.at(too_small.size());
       unused(res);
     }
     catch (const std::out_of_range&)
@@ -131,7 +131,7 @@ void test_exceptions()
     try
     {
       const vec too_small{};
-      auto res = too_small.at(vec.size());
+      auto res = too_small.at(too_small.size());
       unused(res);
     }
     catch (const std::out_of_range&)


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes https://github.com/NVIDIA/cccl/issues/5294

<!-- Provide a standalone description of changes in this PR. -->

`cuda::std::inplace_vector::at()` allows out of bounds access if indexed when `pos == size()`.

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
