### PR TITLE
Improve forward declarations. We often need only a forward declaration of vocabulary types and also want to know whether something is an instance of said type.

### DIFF
--- a/libcudacxx/include/cuda/std/__fwd/array.h
+++ b/libcudacxx/include/cuda/std/__fwd/array.h
@@ -29,6 +29,12 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 template <class _Tp, size_t _Size>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT array;
 
+template <class _Tp>
+inline constexpr bool __is_std_array_v = false;
+
+template <class _Tp, size_t _Sz>
+inline constexpr bool __is_std_array_v<array<_Tp, _Sz>> = true;
+
 _LIBCUDACXX_END_NAMESPACE_STD
 
 #include <cuda/std/__cccl/epilogue.h>

--- a/libcudacxx/include/cuda/std/__fwd/mdspan.h
+++ b/libcudacxx/include/cuda/std/__fwd/mdspan.h
@@ -34,6 +34,10 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+// [mdspan.accessor.default]
+template <class _ElementType>
+struct default_accessor;
+
 // Layout policy with a mapping which corresponds to Fortran-style array layouts
 struct layout_left
 {
@@ -65,6 +69,19 @@ template <class _Layout, class _Extents>
 inline constexpr bool
   __is_valid_layout_mapping<_Layout, _Extents, void_t<typename _Layout::template mapping<_Extents>>> = true;
 } // namespace __mdspan_detail
+
+// [mdspan.mdspan]
+template <class _ElementType,
+          class _Extents,
+          class _LayoutPolicy   = layout_right,
+          class _AccessorPolicy = default_accessor<_ElementType>>
+class mdspan;
+
+template <class _Tp>
+inline constexpr bool __is_std_mdspan_v = false;
+
+template <class _ElementType, class _Extents, class _LayoutPolicy, class _AccessorPolicy>
+inline constexpr bool __is_std_mdspan_v<mdspan<_ElementType, _Extents, _LayoutPolicy, _AccessorPolicy>> = true;
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__fwd/span.h
+++ b/libcudacxx/include/cuda/std/__fwd/span.h
@@ -28,8 +28,15 @@
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 inline constexpr size_t dynamic_extent = static_cast<size_t>(-1);
+
 template <typename _Tp, size_t _Extent = dynamic_extent>
 class span;
+
+template <class _Tp>
+inline constexpr bool __is_std_span_v = false;
+
+template <class _Tp, size_t _Extent>
+inline constexpr bool __is_std_span_v<span<_Tp, _Extent>> = true;
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__mdspan/default_accessor.h
+++ b/libcudacxx/include/cuda/std/__mdspan/default_accessor.h
@@ -29,6 +29,7 @@
 #endif // no system header
 
 #include <cuda/std/__concepts/concept_macros.h>
+#include <cuda/std/__fwd/mdspan.h>
 #include <cuda/std/__type_traits/is_abstract.h>
 #include <cuda/std/__type_traits/is_array.h>
 #include <cuda/std/__type_traits/is_convertible.h>

--- a/libcudacxx/include/cuda/std/__mdspan/extents.h
+++ b/libcudacxx/include/cuda/std/__mdspan/extents.h
@@ -239,14 +239,14 @@ public:
 
   // constructors from dynamic values only -- this covers the case for rank() == 0
   _CCCL_TEMPLATE(class... _DynVals)
-  _CCCL_REQUIRES((sizeof...(_DynVals) == __size_dynamic_) && (!__all<__is_std_span<_DynVals>...>::value))
+  _CCCL_REQUIRES((sizeof...(_DynVals) == __size_dynamic_) && (!__all<__is_std_span_v<_DynVals>...>::value))
   _CCCL_API constexpr __maybe_static_array(_DynVals... __vals) noexcept
       : _DynamicValues{static_cast<_TDynamic>(__vals)...}
   {}
 
   // constructors from all values -- here rank will be greater than 0
   _CCCL_TEMPLATE(class... _DynVals)
-  _CCCL_REQUIRES((sizeof...(_DynVals) != __size_dynamic_) && (!__all<__is_std_span<_DynVals>...>::value))
+  _CCCL_REQUIRES((sizeof...(_DynVals) != __size_dynamic_) && (!__all<__is_std_span_v<_DynVals>...>::value))
   _CCCL_API constexpr __maybe_static_array(_DynVals... __vals)
       : _DynamicValues{}
   {

--- a/libcudacxx/include/cuda/std/__mdspan/mdspan.h
+++ b/libcudacxx/include/cuda/std/__mdspan/mdspan.h
@@ -63,10 +63,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-template <class _ElementType,
-          class _Extents,
-          class _LayoutPolicy   = layout_right,
-          class _AccessorPolicy = default_accessor<_ElementType>>
+template <class _ElementType, class _Extents, class _LayoutPolicy, class _AccessorPolicy>
 class mdspan
     : private __mdspan_ebco<typename _AccessorPolicy::data_handle_type,
                             typename _LayoutPolicy::template mapping<_Extents>,

--- a/libcudacxx/include/cuda/std/span
+++ b/libcudacxx/include/cuda/std/span
@@ -61,18 +61,6 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-template <class _Tp>
-inline constexpr bool __is_std_array = false;
-
-template <class _Tp, size_t _Sz>
-inline constexpr bool __is_std_array<array<_Tp, _Sz>> = true;
-
-template <class _Tp>
-inline constexpr bool __is_std_span = false;
-
-template <class _Tp, size_t _Extent>
-inline constexpr bool __is_std_span<span<_Tp, _Extent>> = true;
-
 template <class _From, class _To>
 _CCCL_CONCEPT __span_array_convertible = _CCCL_TRAIT(is_convertible, _From (*)[], _To (*)[]);
 
@@ -84,7 +72,7 @@ _CCCL_CONCEPT_FRAGMENT(
     requires(_CUDA_VRANGES::sized_range<_Range>),
     requires((_CUDA_VRANGES::borrowed_range<_Range> || _CCCL_TRAIT(is_const, _ElementType))),
     requires((!_CCCL_TRAIT(is_array, remove_cvref_t<_Range>))),
-    requires((!__is_std_span<remove_cvref_t<_Range>> && !__is_std_array<remove_cvref_t<_Range>>) ),
+    requires((!__is_std_span_v<remove_cvref_t<_Range>> && !__is_std_array_v<remove_cvref_t<_Range>>) ),
     requires(_CCCL_TRAIT(
       is_convertible, remove_reference_t<_CUDA_VRANGES::range_reference_t<_Range>> (*)[], _ElementType (*)[]))));
 


### PR DESCRIPTION
A clean solution is to put both the forward declaration and the inline variable into the same header inside `__fwd`
