### PR TITLE
Remove mentions of CUDA experimental that sneaked into libcu++

### DIFF
--- a/libcudacxx/include/cuda/__device/all_devices.h
+++ b/libcudacxx/include/cuda/__device/all_devices.h
@@ -1,6 +1,6 @@
 //===----------------------------------------------------------------------===//
 //
-// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// Part of libcu++, the C++ Standard Library for your entire system,
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception

--- a/libcudacxx/include/cuda/__device/arch_traits.h
+++ b/libcudacxx/include/cuda/__device/arch_traits.h
@@ -1,6 +1,6 @@
 //===----------------------------------------------------------------------===//
 //
-// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// Part of libcu++, the C++ Standard Library for your entire system,
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception

--- a/libcudacxx/include/cuda/__device/attributes.h
+++ b/libcudacxx/include/cuda/__device/attributes.h
@@ -1,6 +1,6 @@
 //===----------------------------------------------------------------------===//
 //
-// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// Part of libcu++, the C++ Standard Library for your entire system,
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception

--- a/libcudacxx/include/cuda/__device/device_ref.h
+++ b/libcudacxx/include/cuda/__device/device_ref.h
@@ -1,6 +1,6 @@
 //===----------------------------------------------------------------------===//
 //
-// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// Part of libcu++, the C++ Standard Library for your entire system,
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception

--- a/libcudacxx/include/cuda/__device/physical_device.h
+++ b/libcudacxx/include/cuda/__device/physical_device.h
@@ -1,6 +1,6 @@
 //===----------------------------------------------------------------------===//
 //
-// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// Part of libcu++, the C++ Standard Library for your entire system,
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -97,7 +97,8 @@ public:
       __device      = _CUDA_DRIVER::__deviceGet(__id_);
       __primary_ctx = _CUDA_DRIVER::__primaryCtxRetain(__device);
     });
-    _CCCL_ASSERT(__primary_ctx != nullptr, "cuda::experimental::primary_context failed to get context");
+    _CCCL_ASSERT(__primary_ctx != nullptr, "cuda::primary_context failed to get context");
+
     return __primary_ctx;
   }
 

--- a/libcudacxx/include/cuda/__driver/driver_api.h
+++ b/libcudacxx/include/cuda/__driver/driver_api.h
@@ -1,6 +1,6 @@
 //===----------------------------------------------------------------------===//
 //
-// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// Part of libcu++, the C++ Standard Library for your entire system,
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception

--- a/libcudacxx/include/cuda/__event/event.h
+++ b/libcudacxx/include/cuda/__event/event.h
@@ -1,6 +1,6 @@
 //===----------------------------------------------------------------------===//
 //
-// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// Part of libcu++, the C++ Standard Library for your entire system,
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception

--- a/libcudacxx/include/cuda/__event/event_ref.h
+++ b/libcudacxx/include/cuda/__event/event_ref.h
@@ -1,6 +1,6 @@
 //===----------------------------------------------------------------------===//
 //
-// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// Part of libcu++, the C++ Standard Library for your entire system,
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -79,7 +79,7 @@ public:
   //! @throws cuda_error if waiting for the event fails
   _CCCL_HOST_API void sync() const
   {
-    _CCCL_ASSERT(__event_ != nullptr, "cuda::experimental::event_ref::sync no event set");
+    _CCCL_ASSERT(__event_ != nullptr, "cuda::event_ref::sync no event set");
     _CCCL_TRY_CUDA_API(::cudaEventSynchronize, "Failed to wait for CUDA event", __event_);
   }
 
@@ -90,7 +90,7 @@ public:
   //! @throws cuda_error if the event query fails
   [[nodiscard]] _CCCL_HOST_API bool is_done() const
   {
-    _CCCL_ASSERT(__event_ != nullptr, "cuda::experimental::event_ref::sync no event set");
+    _CCCL_ASSERT(__event_ != nullptr, "cuda::event_ref::sync no event set");
     cudaError_t __status = ::cudaEventQuery(__event_);
     if (__status == cudaSuccess)
     {

--- a/libcudacxx/include/cuda/__event/timed_event.h
+++ b/libcudacxx/include/cuda/__event/timed_event.h
@@ -1,6 +1,6 @@
 //===----------------------------------------------------------------------===//
 //
-// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// Part of libcu++, the C++ Standard Library for your entire system,
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception

--- a/libcudacxx/include/cuda/__stream/stream.h
+++ b/libcudacxx/include/cuda/__stream/stream.h
@@ -1,6 +1,6 @@
 //===----------------------------------------------------------------------===//
 //
-// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// Part of libcu++, the C++ Standard Library for your entire system,
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception

--- a/libcudacxx/include/cuda/__stream/stream_ref.h
+++ b/libcudacxx/include/cuda/__stream/stream_ref.h
@@ -134,7 +134,7 @@ public:
   //! @throws cuda_error if inserting the dependency fails
   _CCCL_HOST_API void wait(event_ref __ev) const
   {
-    _CCCL_ASSERT(__ev.get() != nullptr, "cuda::experimental::stream_ref::wait invalid event passed");
+    _CCCL_ASSERT(__ev.get() != nullptr, "cuda::stream_ref::wait invalid event passed");
     // Need to use driver API, cudaStreamWaitEvent would push dev 0 if stack was empty
     _CUDA_DRIVER::__streamWaitEvent(get(), __ev.get());
   }
@@ -149,7 +149,7 @@ public:
   {
     // TODO consider an optimization to not create an event every time and instead have one persistent event or one
     // per stream
-    _CCCL_ASSERT(__stream != __detail::__invalid_stream, "cuda::experimental::stream_ref::wait invalid stream passed");
+    _CCCL_ASSERT(__stream != __detail::__invalid_stream, "cuda::stream_ref::wait invalid stream passed");
     if (*this != __other)
     {
       event __tmp(__other);
@@ -253,8 +253,8 @@ public:
 
 inline void event_ref::record(stream_ref __stream) const
 {
-  _CCCL_ASSERT(__event_ != nullptr, "cuda::experimental::event_ref::record no event set");
-  _CCCL_ASSERT(__stream.get() != nullptr, "cuda::experimental::event_ref::record invalid stream passed");
+  _CCCL_ASSERT(__event_ != nullptr, "cuda::event_ref::record no event set");
+  _CCCL_ASSERT(__stream.get() != nullptr, "cuda::event_ref::record invalid stream passed");
   // Need to use driver API, cudaEventRecord will push dev 0 if stack is empty
   _CUDA_DRIVER::__eventRecord(__event_, __stream.get());
 }

--- a/libcudacxx/include/cuda/devices
+++ b/libcudacxx/include/cuda/devices
@@ -1,6 +1,6 @@
 //===----------------------------------------------------------------------===//
 //
-// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// Part of libcu++, the C++ Standard Library for your entire system,
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/common/testing.cuh
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/common/testing.cuh
@@ -1,6 +1,6 @@
 //===----------------------------------------------------------------------===//
 //
-// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// Part of libcu++, the C++ Standard Library for your entire system,
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/common/utility.cuh
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/common/utility.cuh
@@ -1,6 +1,6 @@
 //===----------------------------------------------------------------------===//
 //
-// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// Part of libcu++, the C++ Standard Library for your entire system,
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/device/arch_traits.c2h.cu
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/device/arch_traits.c2h.cu
@@ -1,6 +1,6 @@
 //===----------------------------------------------------------------------===//
 //
-// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// Part of libcu++, the C++ Standard Library for your entire system,
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/device/device_smoke.c2h.cu
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/device/device_smoke.c2h.cu
@@ -1,6 +1,6 @@
 //===----------------------------------------------------------------------===//
 //
-// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// Part of libcu++, the C++ Standard Library for your entire system,
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/event/event_smoke.cu
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/event/event_smoke.cu
@@ -1,6 +1,6 @@
 //===----------------------------------------------------------------------===//
 //
-// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// Part of libcu++, the C++ Standard Library for your entire system,
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/stream/stream_smoke.cu
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/stream/stream_smoke.cu
@@ -1,6 +1,6 @@
 //===----------------------------------------------------------------------===//
 //
-// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// Part of libcu++, the C++ Standard Library for your entire system,
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/utility/driver_api.c2h.cu
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/utility/driver_api.c2h.cu
@@ -1,6 +1,6 @@
 //===----------------------------------------------------------------------===//
 //
-// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// Part of libcu++, the C++ Standard Library for your entire system,
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/utility/ensure_current_context.c2h.cu
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/utility/ensure_current_context.c2h.cu
@@ -1,6 +1,6 @@
 //===----------------------------------------------------------------------===//
 //
-// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// Part of libcu++, the C++ Standard Library for your entire system,
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception


### PR DESCRIPTION
When moving things from cudax to libcu++ some license headers where not updated and some strings still mention `cuda::experimental`
This PR fixes that