### PR TITLE
[libcu++] Deprecate default stream_ref constructor and fix some few last usages

### DIFF
--- a/cub/cub/device/device_reduce.cuh
+++ b/cub/cub/device/device_reduce.cuh
@@ -480,7 +480,8 @@ public:
                                    default_determinism_t>;
 
       // Query relevant properties from the environment
-      auto stream = _CUDA_STD_EXEC::__query_or(env, ::cuda::get_stream, ::cuda::stream_ref{});
+      auto stream =
+        _CUDA_STD_EXEC::__query_or(env, ::cuda::get_stream, ::cuda::stream_ref{static_cast<cudaStream_t>(0)});
       auto mr = _CUDA_STD_EXEC::__query_or(env, ::cuda::mr::__get_memory_resource, detail::device_memory_resource{});
 
       void* d_temp_storage      = nullptr;
@@ -593,7 +594,7 @@ public:
                                           _CUDA_EXEC::determinism::run_to_run_t>;
 
     // Query relevant properties from the environment
-    auto stream = _CUDA_STD_EXEC::__query_or(env, ::cuda::get_stream, ::cuda::stream_ref{});
+    auto stream = _CUDA_STD_EXEC::__query_or(env, ::cuda::get_stream, ::cuda::stream_ref{static_cast<cudaStream_t>(0)});
     auto mr     = _CUDA_STD_EXEC::__query_or(env, ::cuda::mr::__get_memory_resource, detail::device_memory_resource{});
 
     void* d_temp_storage      = nullptr;

--- a/cub/cub/device/device_reduce.cuh
+++ b/cub/cub/device/device_reduce.cuh
@@ -481,7 +481,7 @@ public:
 
       // Query relevant properties from the environment
       auto stream =
-        _CUDA_STD_EXEC::__query_or(env, ::cuda::get_stream, ::cuda::stream_ref{static_cast<cudaStream_t>(0)});
+        _CUDA_STD_EXEC::__query_or(env, ::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}});
       auto mr = _CUDA_STD_EXEC::__query_or(env, ::cuda::mr::__get_memory_resource, detail::device_memory_resource{});
 
       void* d_temp_storage      = nullptr;
@@ -594,7 +594,7 @@ public:
                                           _CUDA_EXEC::determinism::run_to_run_t>;
 
     // Query relevant properties from the environment
-    auto stream = _CUDA_STD_EXEC::__query_or(env, ::cuda::get_stream, ::cuda::stream_ref{static_cast<cudaStream_t>(0)});
+    auto stream = _CUDA_STD_EXEC::__query_or(env, ::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}});
     auto mr     = _CUDA_STD_EXEC::__query_or(env, ::cuda::mr::__get_memory_resource, detail::device_memory_resource{});
 
     void* d_temp_storage      = nullptr;

--- a/cub/cub/device/device_reduce.cuh
+++ b/cub/cub/device/device_reduce.cuh
@@ -480,8 +480,7 @@ public:
                                    default_determinism_t>;
 
       // Query relevant properties from the environment
-      auto stream =
-        _CUDA_STD_EXEC::__query_or(env, ::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}});
+      auto stream = _CUDA_STD_EXEC::__query_or(env, ::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}});
       auto mr = _CUDA_STD_EXEC::__query_or(env, ::cuda::mr::__get_memory_resource, detail::device_memory_resource{});
 
       void* d_temp_storage      = nullptr;

--- a/cub/test/catch2_test_env_launch_helper.h
+++ b/cub/test/catch2_test_env_launch_helper.h
@@ -429,7 +429,7 @@ void launch(ActionT action, Args... args)
   c2h::device_vector<std::size_t> d_deallocated(1, 0);
 
   // Host-side stream is unusable in device code, force it to be 0
-  auto stream_env = cuda::std::execution::prop{cuda::get_stream_t{}, cuda::stream_ref{static_cast<cudaStream_t>(0)}};
+  auto stream_env = cuda::std::execution::prop{cuda::get_stream_t{}, cuda::stream_ref{cudaStream_t{}}};
 
   static_assert(!cuda::std::execution::__queryable_with<env_t, cuda::mr::__get_memory_resource_t>,
                 "Don't specify memory resource for launch tests.");

--- a/cub/test/catch2_test_env_launch_helper.h
+++ b/cub/test/catch2_test_env_launch_helper.h
@@ -429,7 +429,7 @@ void launch(ActionT action, Args... args)
   c2h::device_vector<std::size_t> d_deallocated(1, 0);
 
   // Host-side stream is unusable in device code, force it to be 0
-  auto stream_env = cuda::std::execution::prop{cuda::get_stream_t{}, cuda::stream_ref{}};
+  auto stream_env = cuda::std::execution::prop{cuda::get_stream_t{}, cuda::stream_ref{static_cast<cudaStream_t>(0)}};
 
   static_assert(!cuda::std::execution::__queryable_with<env_t, cuda::mr::__get_memory_resource_t>,
                 "Don't specify memory resource for launch tests.");

--- a/cudax/include/cuda/experimental/__container/uninitialized_async_buffer.cuh
+++ b/cudax/include/cuda/experimental/__container/uninitialized_async_buffer.cuh
@@ -82,7 +82,7 @@ private:
   using __async_resource = ::cuda::experimental::any_async_resource<_Properties...>;
 
   __async_resource __mr_;
-  ::cuda::stream_ref __stream_ = {static_cast<::cudaStream_t>(0)};
+  ::cuda::stream_ref __stream_ = {::cudaStream_t{}};
   size_t __count_              = 0;
   void* __buf_                 = nullptr;
 
@@ -211,7 +211,7 @@ public:
   //! Takes ownership of the allocation in \p __other and resets it
   _CCCL_HIDE_FROM_ABI uninitialized_async_buffer(uninitialized_async_buffer&& __other) noexcept
       : __mr_(_CUDA_VSTD::move(__other.__mr_))
-      , __stream_(_CUDA_VSTD::exchange(__other.__stream_, ::cuda::stream_ref{static_cast<::cudaStream_t>(0)}))
+      , __stream_(_CUDA_VSTD::exchange(__other.__stream_, ::cuda::stream_ref{::cudaStream_t{}}))
       , __count_(_CUDA_VSTD::exchange(__other.__count_, 0))
       , __buf_(_CUDA_VSTD::exchange(__other.__buf_, nullptr))
   {}
@@ -223,7 +223,7 @@ public:
   _CCCL_REQUIRES(__properties_match<_OtherProperties...>)
   _CCCL_HIDE_FROM_ABI uninitialized_async_buffer(uninitialized_async_buffer<_Tp, _OtherProperties...>&& __other) noexcept
       : __mr_(_CUDA_VSTD::move(__other.__mr_))
-      , __stream_(_CUDA_VSTD::exchange(__other.__stream_, ::cuda::stream_ref{static_cast<::cudaStream_t>(0)}))
+      , __stream_(_CUDA_VSTD::exchange(__other.__stream_, ::cuda::stream_ref{::cudaStream_t{}}))
       , __count_(_CUDA_VSTD::exchange(__other.__count_, 0))
       , __buf_(_CUDA_VSTD::exchange(__other.__buf_, nullptr))
   {}
@@ -243,7 +243,7 @@ public:
       __mr_.deallocate_async(__buf_, __get_allocation_size(__count_), __stream_);
     }
     __mr_     = _CUDA_VSTD::move(__other.__mr_);
-    __stream_ = _CUDA_VSTD::exchange(__other.__stream_, ::cuda::stream_ref{static_cast<::cudaStream_t>(0)});
+    __stream_ = _CUDA_VSTD::exchange(__other.__stream_, ::cuda::stream_ref{::cudaStream_t{}});
     __count_  = _CUDA_VSTD::exchange(__other.__count_, 0);
     __buf_    = _CUDA_VSTD::exchange(__other.__buf_, nullptr);
     return *this;

--- a/cudax/include/cuda/experimental/__stream/device_transform.cuh
+++ b/cudax/include/cuda/experimental/__stream/device_transform.cuh
@@ -78,7 +78,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __device_transform_t
   // transform_device_argument that are find-able by ADL.
   template <typename _Arg>
   using __transform_result_t = __remove_rvalue_reference_t<decltype(transform_device_argument(
-    ::cuda::stream_ref{static_cast<::cudaStream_t>(0)}, _CUDA_VSTD::declval<_Arg>()))>;
+    ::cuda::stream_ref{::cudaStream_t{}}, _CUDA_VSTD::declval<_Arg>()))>;
 
   template <typename _Arg>
   using __transformed_argument_t =

--- a/cudax/test/containers/uninitialized_async_buffer.cu
+++ b/cudax/test/containers/uninitialized_async_buffer.cu
@@ -78,7 +78,7 @@ C2H_TEST_LIST(
       // Ensure that we properly reset the input buffer
       CUDAX_CHECK(input.data() == nullptr);
       CUDAX_CHECK(input.size() == 0);
-      CUDAX_CHECK(input.stream() == cuda::stream_ref{static_cast<::cudaStream_t>(0)});
+      CUDAX_CHECK(input.stream() == cuda::stream_ref{cudaStream_t{}});
     }
   }
 
@@ -96,7 +96,7 @@ C2H_TEST_LIST(
     // Ensure that we properly reset the input buffer
     CUDAX_CHECK(input.data() == nullptr);
     CUDAX_CHECK(input.size() == 0);
-    CUDAX_CHECK(input.stream() == cuda::stream_ref{static_cast<::cudaStream_t>(0)});
+    CUDAX_CHECK(input.stream() == cuda::stream_ref{cudaStream_t{}});
   }
 
   SECTION("assignment")
@@ -119,7 +119,7 @@ C2H_TEST_LIST(
       CUDAX_CHECK(input.data() == nullptr);
       CUDAX_CHECK(input.size() == 0);
       CUDAX_CHECK(input.size_bytes() == 0);
-      CUDAX_CHECK(input.stream() == cuda::stream_ref{static_cast<::cudaStream_t>(0)});
+      CUDAX_CHECK(input.stream() == cuda::stream_ref{cudaStream_t{}});
     }
 
     { // Ensure self move assignment does not do anything

--- a/cudax/test/stream/stream_smoke.cu
+++ b/cudax/test/stream/stream_smoke.cu
@@ -161,7 +161,7 @@ C2H_CCCLRT_TEST("Stream ID", "[stream]")
     // Test that stream_ref also supports id()
     // NULL stream needs a device to be set
     cudax::__ensure_current_device guard(cuda::device_ref{0});
-    cudax::stream_ref ref1(static_cast<cudaStream_t>(NULL));
+    cudax::stream_ref ref1(cudaStream_t{});
     cudax::stream_ref ref2(stream1);
 
     CUDAX_REQUIRE(ref1.id() != ref2.id());

--- a/libcudacxx/include/cuda/__stream/stream_ref.h
+++ b/libcudacxx/include/cuda/__stream/stream_ref.h
@@ -60,7 +60,7 @@ public:
   //!
   //! For behavior of the default stream,
   //! @see //! https://docs.nvidia.com/cuda/cuda-runtime-api/stream-sync-behavior.html
-  [[deprecated("Use the constructor from cudaStream_t instead")]]
+  [[deprecated("Using the default/null stream is generally discouraged. If you need to use it, please construct a  stream_ref from cudaStream_t{nullptr}")]]
   _CCCL_HIDE_FROM_ABI stream_ref() = default;
 
   //! @brief Constructs a `stream_ref` from a `cudaStream_t` handle.

--- a/libcudacxx/include/cuda/__stream/stream_ref.h
+++ b/libcudacxx/include/cuda/__stream/stream_ref.h
@@ -60,6 +60,7 @@ public:
   //!
   //! For behavior of the default stream,
   //! @see //! https://docs.nvidia.com/cuda/cuda-runtime-api/stream-sync-behavior.html
+  [[deprecated("Use the constructor from cudaStream_t instead")]]
   _CCCL_HIDE_FROM_ABI stream_ref() = default;
 
   //! @brief Constructs a `stream_ref` from a `cudaStream_t` handle.

--- a/libcudacxx/include/cuda/__stream/stream_ref.h
+++ b/libcudacxx/include/cuda/__stream/stream_ref.h
@@ -60,7 +60,8 @@ public:
   //!
   //! For behavior of the default stream,
   //! @see //! https://docs.nvidia.com/cuda/cuda-runtime-api/stream-sync-behavior.html
-  [[deprecated("Using the default/null stream is generally discouraged. If you need to use it, please construct a  stream_ref from cudaStream_t{nullptr}")]]
+  [[deprecated("Using the default/null stream is generally discouraged. If you need to use it, please construct a "
+               "stream_ref from cudaStream_t{nullptr}")]]
   _CCCL_HIDE_FROM_ABI stream_ref() = default;
 
   //! @brief Constructs a `stream_ref` from a `cudaStream_t` handle.

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/stream/stream_smoke.cu
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/stream/stream_smoke.cu
@@ -147,7 +147,7 @@ C2H_CCCLRT_TEST("Stream ID", "[stream]")
     // Test that stream_ref also supports id()
     // NULL stream needs a device to be set
     cuda::__ensure_current_context guard(cuda::device_ref{0});
-    cuda::stream_ref ref1(static_cast<cudaStream_t>(NULL));
+    cuda::stream_ref ref1(::cudaStream_t{});
     cuda::stream_ref ref2(stream1);
 
     CCCLRT_REQUIRE(ref1.id() != ref2.id());

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/allocate.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/allocate.pass.cpp
@@ -52,11 +52,11 @@ void test_allocate_async()
     cuda::mr::async_resource_ref<cuda::mr::host_accessible> ref{input};
 
     // Ensure that we properly pass on the allocate function
-    assert(input.allocate_async(0, 0, static_cast<cudaStream_t>(0))
-           == ref.allocate_async(0, static_cast<cudaStream_t>(0)));
+    assert(input.allocate_async(0, 0, ::cudaStream_t{})
+           == ref.allocate_async(0, ::cudaStream_t{}));
 
     int expected_after_deallocate = 1337;
-    ref.deallocate_async(static_cast<void*>(&expected_after_deallocate), 0, static_cast<cudaStream_t>(0));
+    ref.deallocate_async(static_cast<void*>(&expected_after_deallocate), 0, ::cudaStream_t{});
     assert(input._val == expected_after_deallocate);
   }
 
@@ -65,11 +65,11 @@ void test_allocate_async()
     cuda::mr::async_resource_ref<cuda::mr::host_accessible> ref{input};
 
     // Ensure that we properly pass on the allocate function
-    assert(input.allocate_async(0, 0, static_cast<cudaStream_t>(0))
-           == ref.allocate_async(0, 0, static_cast<cudaStream_t>(0)));
+    assert(input.allocate_async(0, 0, ::cudaStream_t{})
+           == ref.allocate_async(0, 0, ::cudaStream_t{}));
 
     int expected_after_deallocate = 1337;
-    ref.deallocate_async(static_cast<void*>(&expected_after_deallocate), 0, 0, static_cast<cudaStream_t>(0));
+    ref.deallocate_async(static_cast<void*>(&expected_after_deallocate), 0, 0, ::cudaStream_t{});
     assert(input._val == expected_after_deallocate);
   }
 }

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/allocate.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/allocate.pass.cpp
@@ -52,8 +52,7 @@ void test_allocate_async()
     cuda::mr::async_resource_ref<cuda::mr::host_accessible> ref{input};
 
     // Ensure that we properly pass on the allocate function
-    assert(input.allocate_async(0, 0, ::cudaStream_t{})
-           == ref.allocate_async(0, ::cudaStream_t{}));
+    assert(input.allocate_async(0, 0, ::cudaStream_t{}) == ref.allocate_async(0, ::cudaStream_t{}));
 
     int expected_after_deallocate = 1337;
     ref.deallocate_async(static_cast<void*>(&expected_after_deallocate), 0, ::cudaStream_t{});
@@ -65,8 +64,7 @@ void test_allocate_async()
     cuda::mr::async_resource_ref<cuda::mr::host_accessible> ref{input};
 
     // Ensure that we properly pass on the allocate function
-    assert(input.allocate_async(0, 0, ::cudaStream_t{})
-           == ref.allocate_async(0, 0, ::cudaStream_t{}));
+    assert(input.allocate_async(0, 0, ::cudaStream_t{}) == ref.allocate_async(0, 0, ::cudaStream_t{}));
 
     int expected_after_deallocate = 1337;
     ref.deallocate_async(static_cast<void*>(&expected_after_deallocate), 0, 0, ::cudaStream_t{});

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/allocate.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/allocate.pass.cpp
@@ -52,10 +52,11 @@ void test_allocate_async()
     cuda::mr::async_resource_ref<cuda::mr::host_accessible> ref{input};
 
     // Ensure that we properly pass on the allocate function
-    assert(input.allocate_async(0, 0, {}) == ref.allocate_async(0, {}));
+    assert(input.allocate_async(0, 0, static_cast<cudaStream_t>(0))
+           == ref.allocate_async(0, static_cast<cudaStream_t>(0)));
 
     int expected_after_deallocate = 1337;
-    ref.deallocate_async(static_cast<void*>(&expected_after_deallocate), 0, {});
+    ref.deallocate_async(static_cast<void*>(&expected_after_deallocate), 0, static_cast<cudaStream_t>(0));
     assert(input._val == expected_after_deallocate);
   }
 
@@ -64,10 +65,11 @@ void test_allocate_async()
     cuda::mr::async_resource_ref<cuda::mr::host_accessible> ref{input};
 
     // Ensure that we properly pass on the allocate function
-    assert(input.allocate_async(0, 0, {}) == ref.allocate_async(0, 0, {}));
+    assert(input.allocate_async(0, 0, static_cast<cudaStream_t>(0))
+           == ref.allocate_async(0, 0, static_cast<cudaStream_t>(0)));
 
     int expected_after_deallocate = 1337;
-    ref.deallocate_async(static_cast<void*>(&expected_after_deallocate), 0, 0, {});
+    ref.deallocate_async(static_cast<void*>(&expected_after_deallocate), 0, 0, static_cast<cudaStream_t>(0));
     assert(input._val == expected_after_deallocate);
   }
 }

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/conversion.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/conversion.pass.cpp
@@ -40,11 +40,11 @@ void test_conversion_from_async_resource_ref()
     assert(fake_orig->static_vtable == fake_conv->static_vtable);
 
     // Ensure that we properly pass on the allocate function
-    assert(input.allocate_async(0, 0, {}) == ref.allocate_async(0, 0, {}));
+    assert(input.allocate_async(0, 0, ::cudaStream_t{}) == ref.allocate_async(0, 0, ::cudaStream_t{}));
 
     // Ensure we are deallocating properly
     int expected_after_deallocate = 1337;
-    ref.deallocate_async(static_cast<void*>(&expected_after_deallocate), 0, 0, {});
+    ref.deallocate_async(static_cast<void*>(&expected_after_deallocate), 0, 0, ::cudaStream_t{});
     assert(input._val == expected_after_deallocate);
   }
 
@@ -59,11 +59,11 @@ void test_conversion_from_async_resource_ref()
     assert(fake_orig->static_vtable == fake_conv->static_vtable);
 
     // Ensure that we properly pass on the allocate function
-    assert(input.allocate_async(0, 0, {}) == ref.allocate_async(0, 0, {}));
+    assert(input.allocate_async(0, 0, ::cudaStream_t{}) == ref.allocate_async(0, 0, ::cudaStream_t{}));
 
     // Ensure we are deallocating properly
     int expected_after_deallocate = 1337;
-    ref.deallocate_async(static_cast<void*>(&expected_after_deallocate), 0, 0, {});
+    ref.deallocate_async(static_cast<void*>(&expected_after_deallocate), 0, 0, ::cudaStream_t{});
     assert(input._val == expected_after_deallocate);
   }
 }

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/inheritance.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/inheritance.pass.cpp
@@ -139,12 +139,12 @@ void test_async_resource_ref()
   cuda::mr::async_resource_ref<cuda::mr::host_accessible, Properties...> ref_second{second};
 
   // Ensure that we properly pass on the allocate function
-  assert(ref_first.allocate_async(0, 0, {}) == first.allocate_async(0, 0, {}));
-  assert(ref_second.allocate_async(0, 0, {}) == second.allocate_async(0, 0, {}));
+  assert(ref_first.allocate_async(0, 0, ::cudaStream_t{}) == first.allocate_async(0, 0, ::cudaStream_t{}));
+  assert(ref_second.allocate_async(0, 0, ::cudaStream_t{}) == second.allocate_async(0, 0, ::cudaStream_t{}));
 
   // Ensure that assignment still works
   ref_second = ref_first;
-  assert(ref_second.allocate_async(0, 0, {}) == first.allocate_async(0, 0, {}));
+  assert(ref_second.allocate_async(0, 0, ::cudaStream_t{}) == first.allocate_async(0, 0, ::cudaStream_t{}));
 }
 
 template <class... Properties>
@@ -165,12 +165,12 @@ void test_async_resource_ref_from_pointer()
   cuda::mr::async_resource_ref<cuda::mr::host_accessible, Properties...> ref_second = indirection(&second);
 
   // Ensure that we properly pass on the allocate function
-  assert(ref_first.allocate_async(0, 0, {}) == first.allocate_async(0, 0, {}));
-  assert(ref_second.allocate_async(0, 0, {}) == second.allocate_async(0, 0, {}));
+  assert(ref_first.allocate_async(0, 0, ::cudaStream_t{}) == first.allocate_async(0, 0, ::cudaStream_t{}));
+  assert(ref_second.allocate_async(0, 0, ::cudaStream_t{}) == second.allocate_async(0, 0, ::cudaStream_t{}));
 
   // Ensure that assignment still works
   ref_second = ref_first;
-  assert(ref_second.allocate_async(0, 0, {}) == first.allocate_async(0, 0, {}));
+  assert(ref_second.allocate_async(0, 0, ::cudaStream_t{}) == first.allocate_async(0, 0, ::cudaStream_t{}));
 }
 
 // clang complains about pure virtual functions being called, so ensure that we properly crash if so

--- a/libcudacxx/test/libcudacxx/cuda/stream_ref/stream_ref.constructor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/stream_ref/stream_ref.constructor.pass.cpp
@@ -26,12 +26,6 @@ static_assert(has_value_type<cuda::stream_ref>, "");
 
 __host__ __device__ void test()
 {
-  { // default construction
-    cuda::stream_ref ref;
-    static_assert(noexcept(cuda::stream_ref{}), "");
-    assert(ref.get() == reinterpret_cast<cudaStream_t>(0));
-  }
-
   { // from stream
     cudaStream_t stream = reinterpret_cast<cudaStream_t>(42);
     cuda::stream_ref ref{stream};


### PR DESCRIPTION
We don't want users to use NULL stream unless they have to, it's either overly synchronizing or inferior to an explicit stream. Its meaning also depends on what device is set current and we want to push for a model without implicit state.
Currently `stream_ref` has an argument-less constructor that wraps NULL stream, we should deprecate it and remove it in the next major version.