### PR TITLE
Better motivates `cuda::device::is_address_from`

### DIFF
--- a/docs/libcudacxx/extended_api/memory/is_address_from.rst
+++ b/docs/libcudacxx/extended_api/memory/is_address_from.rst
@@ -21,6 +21,8 @@
 
 The function checks if a pointer ``ptr`` with a generic address is from a ``space`` address state space.
 
+Compared to the corresponding CUDA C functions ``__isGlobal()``, ``__isShared()``, ``__isConstant()``, ``__isLocal()``, ``__isGridConstant()``, or ``__isClusterShared()``, ``is_address_from()`` is portable across any compute capability and checks that the pointer is not a null in debug mode.
+
 **Parameters**
 
 - ``space``: The address space.
@@ -29,6 +31,10 @@ The function checks if a pointer ``ptr`` with a generic address is from a ``spac
 **Return value**
 
 - ``true`` if the pointer is from the specified address space, ``false`` otherwise.
+
+**Preconditions**
+
+- ``ptr`` is not a null pointer.
 
 **Performance considerations**
 
@@ -41,30 +47,26 @@ Example
 
     #include <cuda/memory>
 
-    struct MutableStruct
-    {
-        mutable int v;
-    };
-
-    __device__ int global_var;
+    __device__   int global_var;
     __constant__ int constant_var;
 
-    __global__ void kernel(const __grid_constant__ MutableStruct grid_constant_var)
+    __global__ void kernel(const __grid_constant__ int grid_constant_var)
     {
+        using cuda::device::address_space;
         __shared__ int shared_var;
         int local_var{};
 
-        assert(cuda::device::is_address_from(cuda::device::address_space::global, &global_var));
-        assert(cuda::device::is_address_from(cuda::device::address_space::shared, &shared_var));
-        assert(cuda::device::is_address_from(cuda::device::address_space::constant, &constant_var));
-        assert(cuda::device::is_address_from(cuda::device::address_space::local, &local_var));
-        assert(cuda::device::is_address_from(cuda::device::address_space::grid_constant, &grid_constant_var));
+        assert(cuda::device::is_address_from(address_space::global,        &global_var));
+        assert(cuda::device::is_address_from(address_space::shared,        &shared_var));
+        assert(cuda::device::is_address_from(address_space::constant,      &constant_var));
+        assert(cuda::device::is_address_from(address_space::local,         &local_var));
+        assert(cuda::device::is_address_from(address_space::grid_constant, &grid_constant_var));
     }
 
     int main(int, char**)
     {
-        kernel<<<1, 1>>>(MutableStruct{42});
+        kernel<<<1, 1>>>(42);
         cudaDeviceSynchronize();
     }
 
-`See it on Godbolt 🔗 <https://godbolt.org/z/r1qb31szz>`_
+`See it on Godbolt 🔗 <https://godbolt.org/z/jcqbdGKMn>`_

--- a/libcudacxx/include/cuda/__memory/address_space.h
+++ b/libcudacxx/include/cuda/__memory/address_space.h
@@ -42,14 +42,13 @@ enum class address_space
   __max,
 };
 
-[[nodiscard]] _CCCL_API constexpr bool __cccl_is_valid_address_space(address_space __space) noexcept
+[[nodiscard]] _CCCL_DEVICE_API constexpr bool __cccl_is_valid_address_space(address_space __space) noexcept
 {
   const auto __v = _CUDA_VSTD::to_underlying(__space);
   return __v >= 0 && __v < _CUDA_VSTD::to_underlying(address_space::__max);
 }
 
-[[nodiscard]] _CCCL_FORCEINLINE _CCCL_VISIBILITY_HIDDEN _CCCL_DEVICE bool
-is_address_from(address_space __space, const void* __ptr)
+[[nodiscard]] _CCCL_DEVICE_API bool is_address_from(address_space __space, const void* __ptr)
 {
   _CCCL_ASSERT(__ptr != nullptr, "invalid pointer");
   _CCCL_ASSERT(_CUDA_DEVICE::__cccl_is_valid_address_space(__space), "invalid address space");
@@ -57,21 +56,21 @@ is_address_from(address_space __space, const void* __ptr)
   switch (__space)
   {
     case address_space::global:
-      return ::__isGlobal(__ptr);
+      return static_cast<bool>(::__isGlobal(__ptr));
     case address_space::shared:
-      return ::__isShared(__ptr);
+      return static_cast<bool>(::__isShared(__ptr));
     case address_space::constant:
-      return ::__isConstant(__ptr);
+      return static_cast<bool>(::__isConstant(__ptr));
     case address_space::local:
-      return ::__isLocal(__ptr);
+      return static_cast<bool>(::__isLocal(__ptr));
     case address_space::grid_constant:
 #  if _CCCL_HAS_GRID_CONSTANT()
-      NV_IF_ELSE_TARGET(NV_PROVIDES_SM_70, (return ::__isGridConstant(__ptr);), (return false;))
+      NV_IF_ELSE_TARGET(NV_PROVIDES_SM_70, (return static_cast<bool>(::__isGridConstant(__ptr));), (return false;))
 #  else // ^^^ _CCCL_HAS_GRID_CONSTANT() ^^^ / vvv !_CCCL_HAS_GRID_CONSTANT() vvv
       return false;
 #  endif // ^^^ !_CCCL_HAS_GRID_CONSTANT() ^^^
     case address_space::cluster_shared:
-      NV_IF_ELSE_TARGET(NV_PROVIDES_SM_90, (return ::__isClusterShared(__ptr);), (return false;))
+      NV_IF_ELSE_TARGET(NV_PROVIDES_SM_90, (return static_cast<bool>(::__isClusterShared(__ptr));), (return false;))
     default:
       return false;
   }


### PR DESCRIPTION
## Description

The PR better motivates the benefits of `cuda::device::is_address_from` compared to CUDA C functions.
Minors: fixes UB in the example and potential warnings in the code
