### PR TITLE
Remove CTK <12 version check for PDL

### DIFF
--- a/libcudacxx/include/cuda/std/__cccl/cuda_capabilities.h
+++ b/libcudacxx/include/cuda/std/__cccl/cuda_capabilities.h
@@ -33,7 +33,7 @@
 #ifdef CCCL_DISABLE_PDL
 #  define _CCCL_HAS_PDL() 0
 #else // CCCL_DISABLE_PDL
-#  define _CCCL_HAS_PDL() _CCCL_CTK_AT_LEAST(12, 0)
+#  define _CCCL_HAS_PDL() 1
 #endif // CCCL_DISABLE_PDL
 
 #if _CCCL_HAS_PDL()


### PR DESCRIPTION
We do not support CTK <12 anymore so we can always enable PDL.