### PR TITLE
Add `sm86` tunings for deterministic DeviceReduce (RFA)

### DIFF
--- a/cub/cub/device/dispatch/tuning/tuning_reduce.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_reduce.cuh
@@ -387,7 +387,6 @@ struct policy_hub
 
     using ReducePolicy = decltype(select_agent_policy<sm86_tuning<AccumT>>(0));
 
-    // SingleTilePolicy
     using SingleTilePolicy = ReducePolicy;
   };
 

--- a/cub/cub/device/dispatch/tuning/tuning_reduce.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_reduce.cuh
@@ -395,12 +395,12 @@ struct policy_hub
   {
     static constexpr int items_per_vec_load = 4;
 
-    // Use values from tuning if a specialization exists, otherwise pick Policy600
+    // Use values from tuning if a specialization exists, otherwise pick Policy860
     template <typename Tuning>
     static auto select_agent_policy(int)
       -> AgentReducePolicy<Tuning::threads, Tuning::items, AccumT, items_per_vec_load, BLOCK_REDUCE_RAKING, LOAD_LDG>;
 
-    // use Policy600 as DefaultPolicy
+    // use Policy860 as DefaultPolicy
     template <typename Tuning>
     static auto select_agent_policy(long) -> typename Policy860::ReducePolicy;
 

--- a/cub/cub/device/dispatch/tuning/tuning_reduce.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_reduce.cuh
@@ -293,6 +293,25 @@ struct sm90_tuning<float>
   static constexpr int threads = 224;
 };
 
+template <class AccumT>
+struct sm86_tuning;
+
+template <>
+struct sm86_tuning<float>
+{
+  // ipt_6.tpb_224  1.034383  1.000000  1.032097  1.090909
+  static constexpr int items   = 6;
+  static constexpr int threads = 224;
+};
+
+template <>
+struct sm86_tuning<double>
+{
+  // ipt_11.tpb_128 ()  1.232089  1.002124  1.245336  1.582279
+  static constexpr int items   = 11;
+  static constexpr int threads = 128;
+};
+
 /**
  * @tparam AccumT
  *   Accumulator data type
@@ -352,8 +371,8 @@ struct policy_hub
     using SingleTilePolicy = ReducePolicy;
   };
 
-  /// SM90
-  struct Policy900 : ChainedPolicy<900, Policy900, Policy600>
+  /// SM86
+  struct Policy860 : ChainedPolicy<860, Policy860, Policy600>
   {
     static constexpr int items_per_vec_load = 4;
 
@@ -365,6 +384,26 @@ struct policy_hub
     // use Policy600 as DefaultPolicy
     template <typename Tuning>
     static auto select_agent_policy(long) -> typename Policy600::ReducePolicy;
+
+    using ReducePolicy = decltype(select_agent_policy<sm86_tuning<AccumT>>(0));
+
+    // SingleTilePolicy
+    using SingleTilePolicy = ReducePolicy;
+  };
+
+  /// SM90
+  struct Policy900 : ChainedPolicy<900, Policy900, Policy860>
+  {
+    static constexpr int items_per_vec_load = 4;
+
+    // Use values from tuning if a specialization exists, otherwise pick Policy600
+    template <typename Tuning>
+    static auto select_agent_policy(int)
+      -> AgentReducePolicy<Tuning::threads, Tuning::items, AccumT, items_per_vec_load, BLOCK_REDUCE_RAKING, LOAD_LDG>;
+
+    // use Policy600 as DefaultPolicy
+    template <typename Tuning>
+    static auto select_agent_policy(long) -> typename Policy860::ReducePolicy;
 
     using ReducePolicy = decltype(select_agent_policy<sm90_tuning<AccumT>>(0));
 


### PR DESCRIPTION
## Description

Tuned deterministic DeviceReduce (RFA) on A40
Performance improves 10% on average (Major improvments with F64)
```
['base.json', 'tuning.json']
# base

## [0] NVIDIA A40

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |        Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-------------|---------|----------|
|   F32   |      I32      |      2^16      |  13.796 us |       5.53% |  13.154 us |      10.14% |   -0.642 us |  -4.66% |   SAME   |
|   F32   |      I32      |      2^20      |  25.088 us |       4.09% |  22.712 us |       3.87% |   -2.376 us |  -9.47% |   FAST   |
|   F32   |      I32      |      2^24      | 140.859 us |       1.08% | 138.260 us |       0.49% |   -2.599 us |  -1.84% |   FAST   |
|   F32   |      I32      |      2^28      |   1.951 ms |       2.08% |   1.906 ms |       2.06% |  -44.603 us |  -2.29% |   FAST   |
|   F64   |      I32      |      2^16      |  27.476 us |       3.11% |  21.023 us |       4.64% |   -6.454 us | -23.49% |   FAST   |
|   F64   |      I32      |      2^20      | 128.476 us |       0.59% |  97.161 us |       1.00% |  -31.314 us | -24.37% |   FAST   |
|   F64   |      I32      |      2^24      | 921.904 us |       0.10% | 869.155 us |       0.13% |  -52.750 us |  -5.72% |   FAST   |
|   F64   |      I32      |      2^28      |  11.115 ms |       0.03% |  10.837 ms |       0.05% | -278.280 us |  -2.50% |   FAST   |

# Summary

- Total Matches: 8
  - Pass    (diff <= min_noise): 1
  - Unknown (infinite noise):    0
  - Failure (diff > min_noise):  7
```
