### PR TITLE
Use a unique symbol name for each extern SMEM with different alignment

### DIFF
--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -8,7 +8,7 @@ workflows:
   #   - {jobs: ['test'], project: 'thrust', std: 17, ctk: 'curr', cxx: ['gcc12', 'clang16']}
   #
   override:
-
+  - {jobs: ['test_lid0'], project: 'cub',                   std: 'max', gpu: 'h100', sm: 'gpu' }
   pull_request:
     # Old CTK/compiler
     - {jobs: ['build'], std: 'minmax', ctk: '12.0', cxx: ['gcc7', 'gcc9', 'clang14', 'msvc2019']}

--- a/cub/cub/device/dispatch/dispatch_transform.cuh
+++ b/cub/cub/device/dispatch/dispatch_transform.cuh
@@ -259,6 +259,16 @@ struct dispatch_t<StableAddress,
         {
           return ::cuda::std::unexpected<cudaError_t /* nvcc 12.0 fails CTAD here */>(error);
         }
+        if (max_occupancy == 0)
+        {
+          printf("items_per_thread: %d, block_threads: %d, smem_size: %d (max: %d) -> max_occupancy %d\n",
+                 items_per_thread,
+                 block_threads,
+                 smem_size,
+                 max_smem,
+                 max_occupancy);
+          _CCCL_ASSERT(max_occupancy > 0, "");
+        }
 
         const auto config = async_config{items_per_thread, max_occupancy, sm_count};
 

--- a/cub/cub/device/dispatch/kernels/transform.cuh
+++ b/cub/cub/device/dispatch/kernels/transform.cuh
@@ -623,8 +623,6 @@ _CCCL_DEVICE auto round_up_smem_ptr(char* p) -> char*
 
 // We use an attribute to align the shared memory. This is unfortunately not respected by nvcc in all cases and fails
 // for example when compiling with -G or -rdc=true. See also NVBug 5093902, NVBug 5329745, and discussion in PR #5122.
-// The choice of attribute does not matter ('alignas(N)`, `__align__(N)` or `__attribute__((aligned(N)))`.
-// extern __shared__ char __align__(tile_padding) smem[];
 
 // However, any manual alignment of the shared memory start address outweighs the performance benefits of a faster
 // bulk copy by introducing about 7 additional SASS instructions at the start of the kernel. This also has to be done
@@ -651,7 +649,7 @@ _CCCL_DEVICE auto round_up_smem_ptr(char* p) -> char*
 // attribute, we also need to make sure the extern declaration produces a different symbol name. Therefore, we declare
 // the external shared memory as a variable template.
 template <int Alignment>
-extern __shared__ char hopefully_aligned_smem[] alignas(Alignment);
+extern __shared__ char __align__(Alignment) hopefully_aligned_smem[];
 
 template <typename BulkCopyPolicy, typename Offset, typename F, typename RandomAccessIteratorOut, typename... InTs>
 _CCCL_DEVICE void transform_kernel_ublkcp(

--- a/cub/cub/device/dispatch/kernels/transform.cuh
+++ b/cub/cub/device/dispatch/kernels/transform.cuh
@@ -642,8 +642,11 @@ extern __shared__ char __align__(512) smem512[];
 extern __shared__ char __align__(1024) smem1024[];
 extern __shared__ char __align__(2048) smem2048[];
 extern __shared__ char __align__(4096) smem4096[];
+// MSVC does not allow alignment larger than 4KiB
+#if !_CCCL_COMPILER(MSVC)
 extern __shared__ char __align__(16384) smem16384[];
 extern __shared__ char __align__(32768) smem32768[];
+#endif // !_CCCL_COMPILER(MSVC)
 // cannot have larger alignment since it would exhause the 48KiB shared memory even for a single item
 
 template <int Alignment, bool EnsureAlignment = true>
@@ -687,6 +690,7 @@ _CCCL_DEVICE auto aligned_smem() -> char*
   {
     smem = smem4096;
   }
+#if !_CCCL_COMPILER(MSVC)
   else if constexpr (Alignment == 16384)
   {
     smem = smem16384;
@@ -695,6 +699,7 @@ _CCCL_DEVICE auto aligned_smem() -> char*
   {
     smem = smem32768;
   }
+#endif // !_CCCL_COMPILER(MSVC)
   else
   {
     static_assert(Alignment <= 32768, "Unsupported shared memory alignment");

--- a/cub/cub/device/dispatch/kernels/transform.cuh
+++ b/cub/cub/device/dispatch/kernels/transform.cuh
@@ -642,6 +642,7 @@ extern __shared__ char __align__(512) smem512[];
 extern __shared__ char __align__(1024) smem1024[];
 extern __shared__ char __align__(2048) smem2048[];
 extern __shared__ char __align__(4096) smem4096[];
+extern __shared__ char __align__(8192) smem8192[];
 // MSVC does not allow alignment larger than 4KiB
 #if !_CCCL_COMPILER(MSVC)
 extern __shared__ char __align__(16384) smem16384[];
@@ -689,6 +690,10 @@ _CCCL_DEVICE auto aligned_smem() -> char*
   else if constexpr (Alignment == 4096)
   {
     smem = smem4096;
+  }
+  else if constexpr (Alignment == 8192)
+  {
+    smem = smem8192;
   }
 #if !_CCCL_COMPILER(MSVC)
   else if constexpr (Alignment == 16384)

--- a/cub/test/catch2_test_device_transform.cu
+++ b/cub/test/catch2_test_device_transform.cu
@@ -723,6 +723,10 @@ C2H_TEST("DeviceTransform::Transform maybe_aligned_smem", "[device][transform]")
   check_maybe_aligned_smem<1024>();
   check_maybe_aligned_smem<2048>();
   check_maybe_aligned_smem<4096>();
+  check_maybe_aligned_smem<8192>();
+  // MSVC does not allow alignment larger than 4KiB
+#if !_CCCL_COMPILER(MSVC)
   check_maybe_aligned_smem<16384>();
   check_maybe_aligned_smem<32768>();
+#endif // #if !_CCCL_COMPILER(MSVC)
 }


### PR DESCRIPTION
Fixes NVBug 5320137

There are small SASS changes for `cub.cpp17.test.device_transform.lid_0` configured with `CMAKE_CUDA_ARCHITECTURES="90;100;120"`