### PR TITLE
Suppress clang warnings on vector types in upcoming CTK

### DIFF
--- a/c2h/generators_vector.cu
+++ b/c2h/generators_vector.cu
@@ -167,3 +167,8 @@ VEC_GEN_MOD_SPECIALIZATION(ulonglong4, unsigned long long);
 VEC_GEN_MOD_SPECIALIZATION(ushort4, unsigned short);
 #endif // THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
 } // namespace c2h::detail
+
+// Suppress deprecation warnings for use of vector types in the `*cudafe1.stub.c` file
+#if _CCCL_CTK_AT_LEAST(13, 0) && _CCCL_COMPILER(CLANG)
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+#endif // _CCCL_CTK_AT_LEAST(13, 0) && _CCCL_COMPILER(CLANG)


### PR DESCRIPTION
I have not received a bug report for any of these warnings, but we may consider backporting this fix regardless.

Example warning:
```
n file included from tmpxft_0005455a_00000000-7_generators_vector.compute_120.cudafe1.stub.c:1:
/tmp/tmpxft_0005455a_00000000-7_generators_vector.compute_120.cudafe1.stub.c:36:118: warning: 'long4' is deprecated: use long4_16a or long4_32a [-Wdeprecated-declarations]
   36 | typedef cub::CUB_300200_SM_860_1200::detail::for_each::op_wrapper_t<long,  ::c2h::detail::random_to_vec_item_t<    ::long4, (int)4> ,  ::thrust::THRUST_300200_SM_860_1200_NS::counting_iterator<unsigned long,  ::thrust::THRUST_300200_SM_860_1200_NS::use_default,  ::thrust::THRUST_300200_SM_860_1200_NS::use_default,  ::thrust::THRUST_300200_SM_860_1200_NS::use_default,  ::thrust::THRUST_300200_SM_860_1200_NS::compile_time_value<(int)1> > >  _ZN3cub22CUB_300200_SM_860_12006detail8for_each12op_wrapper_tIlN3c2h6detail20random_to_vec_item_tI5long4Li4EEEN6thrust28THRUST_300200_SM_860_1200_NS17counting_iteratorImNSA_11use_defaultESC_SC_NSA_18compile_time_valueILi1EEEEEEE;
      |                                                                                                                      ^
/usr/local/cuda/targets/x86_64-linux/include/vector_types.h:530:41: note: 'long4' has been explicitly marked deprecated here
  530 | typedef __device_builtin__ struct long4 __VECTOR_TYPE_DEPRECATED__("use long4_16a or long4_32a") long4;
      |                                         ^
/usr/local/cuda/targets/x86_64-linux/include/vector_types.h:144:57: note: expanded from macro '__VECTOR_TYPE_DEPRECATED__'
  144 | # define __VECTOR_TYPE_DEPRECATED__(msg) __attribute__((deprecated(msg)))
      |                                                         ^
```