### PR TITLE
[Backport 3.1.x] `is_address_from` fixes (#5349)

### DIFF
--- a/docs/libcudacxx/extended_api/memory.rst
+++ b/docs/libcudacxx/extended_api/memory.rst
@@ -11,6 +11,7 @@ Memory
    memory/align_up
    memory/align_down
    memory/ptr_rebind
+   memory/is_address_from
 
 .. list-table::
    :widths: 25 45 30 30
@@ -38,5 +39,10 @@ Memory
 
    * - :ref:`ptr_rebind <libcudacxx-extended-api-memory-ptr_rebind>`
      - Rebind a pointer to a different type
+     - CCCL 3.1.0
+     - CUDA 13.1
+
+   * - :ref:`is_address_from <libcudacxx-extended-api-memory-is_address_from>`
+     - Check if a pointer is from a specific address space
      - CCCL 3.1.0
      - CUDA 13.1

--- a/docs/libcudacxx/extended_api/memory.rst
+++ b/docs/libcudacxx/extended_api/memory.rst
@@ -42,7 +42,7 @@ Memory
      - CCCL 3.1.0
      - CUDA 13.1
 
-   * - :ref:`is_address_from <libcudacxx-extended-api-memory-is_address_from>`
-     - Check if a pointer is from a specific address space
+   * - :ref:`is_address_from and is_object_from <libcudacxx-extended-api-memory-is_address_from>`
+     - Check if a pointer or an object is from a specific address space
      - CCCL 3.1.0
      - CUDA 13.1

--- a/docs/libcudacxx/extended_api/memory/is_address_from.rst
+++ b/docs/libcudacxx/extended_api/memory/is_address_from.rst
@@ -1,0 +1,71 @@
+.. _libcudacxx-extended-api-memory-is_address_from:
+
+``cuda::device::is_address_from``
+=================================
+
+.. code:: cuda
+
+   enum class address_space
+   {
+     global,
+     shared,
+     constant,
+     local,
+     grid_constant,
+     cluster_shared,
+   };
+
+   [[nodiscard]] __device__ inline
+   bool is_address_from(const void* ptr, address_space space)
+
+The function checks if a pointer ``ptr`` with a generic address is from a ``space`` address state space.
+
+Compared to the corresponding CUDA C functions ``__isGlobal()``, ``__isShared()``, ``__isConstant()``, ``__isLocal()``, ``__isGridConstant()``, or ``__isClusterShared()``, ``is_address_from()`` is portable across any compute capability and checks that the pointer is not a null in debug mode.
+
+**Parameters**
+
+- ``space``: The address space.
+- ``ptr``: The pointer.
+
+**Return value**
+
+- ``true`` if the pointer is from the specified address space, ``false`` otherwise.
+
+**Preconditions**
+
+- ``ptr`` is not a null pointer.
+
+**Performance considerations**
+
+- If possible, the ``__isGlobal``, ``__isShared``, ``__isConstant``, ``__isLocal``, ``__isGridConstant``, or ``__isClusterShared`` built-in functions are used to determine the address space.
+
+Example
+-------
+
+.. code:: cuda
+
+    #include <cuda/memory>
+
+    __device__   int global_var;
+    __constant__ int constant_var;
+
+    __global__ void kernel(const __grid_constant__ int grid_constant_var)
+    {
+        using cuda::device::address_space;
+        __shared__ int shared_var;
+        int local_var{};
+
+        assert(cuda::device::is_address_from(address_space::global,        &global_var));
+        assert(cuda::device::is_address_from(address_space::shared,        &shared_var));
+        assert(cuda::device::is_address_from(address_space::constant,      &constant_var));
+        assert(cuda::device::is_address_from(address_space::local,         &local_var));
+        assert(cuda::device::is_address_from(address_space::grid_constant, &grid_constant_var));
+    }
+
+    int main(int, char**)
+    {
+        kernel<<<1, 1>>>(42);
+        cudaDeviceSynchronize();
+    }
+
+`See it on Godbolt 🔗 <https://godbolt.org/z/jcqbdGKMn>`_

--- a/docs/libcudacxx/extended_api/memory/is_address_from.rst
+++ b/docs/libcudacxx/extended_api/memory/is_address_from.rst
@@ -1,9 +1,11 @@
 .. _libcudacxx-extended-api-memory-is_address_from:
 
-``cuda::device::is_address_from``
-=================================
+``cuda::device::is_address_from`` and ``cuda::device::is_object_from``
+======================================================================
 
-.. code:: cuda
+Defined in ``<cuda/memory>`` header.
+
+.. code:: cpp
 
    enum class address_space
    {
@@ -15,16 +17,28 @@
      cluster_shared,
    };
 
+.. code:: cpp
+
+   template <typename T>
    [[nodiscard]] __device__ inline
-   bool is_address_from(address_space space, const void* ptr)
+   bool is_address_from(const void* ptr, address_space space)
 
 The function checks if a pointer ``ptr`` with a generic address is from a ``space`` address state space.
+
+.. code:: cpp
+
+   template <typename T>
+   [[nodiscard]] __device__ inline
+   bool is_object_from(T& obj, address_space space)
+
+The function checks if an object ``obj`` with a generic address is from a ``space`` address state space.
 
 Compared to the corresponding CUDA C functions ``__isGlobal()``, ``__isShared()``, ``__isConstant()``, ``__isLocal()``, ``__isGridConstant()``, or ``__isClusterShared()``, ``is_address_from()`` is portable across any compute capability and checks that the pointer is not a null in debug mode.
 
 **Parameters**
 
 - ``ptr``: The pointer.
+- ``obj``: The object.
 - ``space``: The address space.
 
 **Return value**
@@ -60,6 +74,12 @@ Example
         assert(cuda::device::is_address_from(&constant_var, address_space::constant));
         assert(cuda::device::is_address_from(&local_var, address_space::local));
         assert(cuda::device::is_address_from(&grid_constant_var, address_space::grid_constant));
+
+        assert(cuda::device::is_object_from(global_var, address_space::global));
+        assert(cuda::device::is_object_from(shared_var, address_space::shared));
+        assert(cuda::device::is_object_from(constant_var, address_space::constant));
+        assert(cuda::device::is_object_from(local_var, address_space::local));
+        assert(cuda::device::is_object_from(grid_constant_var, address_space::grid_constant));
     }
 
     int main(int, char**)
@@ -68,4 +88,4 @@ Example
         cudaDeviceSynchronize();
     }
 
-`See it on Godbolt 🔗 <https://godbolt.org/z/fYWjbYqzo>`_
+`See it on Godbolt 🔗 <https://godbolt.org/z/5ajhe37df>`_

--- a/docs/libcudacxx/extended_api/memory/is_address_from.rst
+++ b/docs/libcudacxx/extended_api/memory/is_address_from.rst
@@ -16,7 +16,7 @@
    };
 
    [[nodiscard]] __device__ inline
-   bool is_address_from(const void* ptr, address_space space)
+   bool is_address_from(address_space space, const void* ptr)
 
 The function checks if a pointer ``ptr`` with a generic address is from a ``space`` address state space.
 
@@ -24,8 +24,8 @@ Compared to the corresponding CUDA C functions ``__isGlobal()``, ``__isShared()`
 
 **Parameters**
 
-- ``space``: The address space.
 - ``ptr``: The pointer.
+- ``space``: The address space.
 
 **Return value**
 
@@ -55,11 +55,11 @@ Example
         __shared__ int shared_var;
         int local_var{};
 
-        assert(cuda::device::is_address_from(address_space::global,        &global_var));
-        assert(cuda::device::is_address_from(address_space::shared,        &shared_var));
-        assert(cuda::device::is_address_from(address_space::constant,      &constant_var));
-        assert(cuda::device::is_address_from(address_space::local,         &local_var));
-        assert(cuda::device::is_address_from(address_space::grid_constant, &grid_constant_var));
+        assert(cuda::device::is_address_from(&global_var, address_space::global));
+        assert(cuda::device::is_address_from(&shared_var, address_space::shared));
+        assert(cuda::device::is_address_from(&constant_var, address_space::constant));
+        assert(cuda::device::is_address_from(&local_var, address_space::local));
+        assert(cuda::device::is_address_from(&grid_constant_var, address_space::grid_constant));
     }
 
     int main(int, char**)
@@ -68,4 +68,4 @@ Example
         cudaDeviceSynchronize();
     }
 
-`See it on Godbolt 🔗 <https://godbolt.org/z/jcqbdGKMn>`_
+`See it on Godbolt 🔗 <https://godbolt.org/z/fYWjbYqzo>`_

--- a/libcudacxx/include/cuda/__mdspan/host_device_accessor.h
+++ b/libcudacxx/include/cuda/__mdspan/host_device_accessor.h
@@ -240,12 +240,12 @@ class __device_accessor : public _Accessor
   [[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_DEVICE static constexpr bool
   __is_device_accessible_pointer_from_device(__data_handle_type __p) noexcept
   {
-    return _CUDA_DEVICE::is_address_from(_CUDA_DEVICE::address_space::global, __p)
-        || _CUDA_DEVICE::is_address_from(_CUDA_DEVICE::address_space::shared, __p)
-        || _CUDA_DEVICE::is_address_from(_CUDA_DEVICE::address_space::constant, __p)
-        || _CUDA_DEVICE::is_address_from(_CUDA_DEVICE::address_space::local, __p)
-        || _CUDA_DEVICE::is_address_from(_CUDA_DEVICE::address_space::grid_constant, __p)
-        || _CUDA_DEVICE::is_address_from(_CUDA_DEVICE::address_space::cluster_shared, __p);
+    return _CUDA_DEVICE::is_address_from(__p, _CUDA_DEVICE::address_space::global)
+        || _CUDA_DEVICE::is_address_from(__p, _CUDA_DEVICE::address_space::shared)
+        || _CUDA_DEVICE::is_address_from(__p, _CUDA_DEVICE::address_space::constant)
+        || _CUDA_DEVICE::is_address_from(__p, _CUDA_DEVICE::address_space::local)
+        || _CUDA_DEVICE::is_address_from(__p, _CUDA_DEVICE::address_space::grid_constant)
+        || _CUDA_DEVICE::is_address_from(__p, _CUDA_DEVICE::address_space::cluster_shared);
   }
 
 #endif // _CCCL_DEVICE_COMPILATION()

--- a/libcudacxx/include/cuda/__memory/address_space.h
+++ b/libcudacxx/include/cuda/__memory/address_space.h
@@ -23,6 +23,7 @@
 
 #if _CCCL_CUDA_COMPILATION()
 
+#  include <cuda/std/__memory/addressof.h>
 #  include <cuda/std/__utility/to_underlying.h>
 
 #  include <nv/target>
@@ -74,6 +75,12 @@ enum class address_space
     default:
       return false;
   }
+}
+
+template <typename T>
+[[nodiscard]] _CCCL_DEVICE_API inline bool is_object_from(T& __obj, address_space __space)
+{
+  return _CUDA_DEVICE::is_address_from(_CUDA_VSTD::addressof(__obj), __space);
 }
 
 _LIBCUDACXX_END_NAMESPACE_CUDA_DEVICE

--- a/libcudacxx/include/cuda/__memory/address_space.h
+++ b/libcudacxx/include/cuda/__memory/address_space.h
@@ -42,14 +42,13 @@ enum class address_space
   __max,
 };
 
-[[nodiscard]] _CCCL_API constexpr bool __cccl_is_valid_address_space(address_space __space) noexcept
+[[nodiscard]] _CCCL_DEVICE_API constexpr bool __cccl_is_valid_address_space(address_space __space) noexcept
 {
   const auto __v = _CUDA_VSTD::to_underlying(__space);
   return __v >= 0 && __v < _CUDA_VSTD::to_underlying(address_space::__max);
 }
 
-[[nodiscard]] _CCCL_FORCEINLINE _CCCL_VISIBILITY_HIDDEN _CCCL_DEVICE bool
-is_address_from(address_space __space, const void* __ptr)
+[[nodiscard]] _CCCL_DEVICE_API inline bool is_address_from(address_space __space, const void* __ptr)
 {
   _CCCL_ASSERT(__ptr != nullptr, "invalid pointer");
   _CCCL_ASSERT(_CUDA_DEVICE::__cccl_is_valid_address_space(__space), "invalid address space");
@@ -57,21 +56,21 @@ is_address_from(address_space __space, const void* __ptr)
   switch (__space)
   {
     case address_space::global:
-      return ::__isGlobal(__ptr);
+      return static_cast<bool>(::__isGlobal(__ptr));
     case address_space::shared:
-      return ::__isShared(__ptr);
+      return static_cast<bool>(::__isShared(__ptr));
     case address_space::constant:
-      return ::__isConstant(__ptr);
+      return static_cast<bool>(::__isConstant(__ptr));
     case address_space::local:
-      return ::__isLocal(__ptr);
+      return static_cast<bool>(::__isLocal(__ptr));
     case address_space::grid_constant:
 #  if _CCCL_HAS_GRID_CONSTANT()
-      NV_IF_ELSE_TARGET(NV_PROVIDES_SM_70, (return ::__isGridConstant(__ptr);), (return false;))
+      NV_IF_ELSE_TARGET(NV_PROVIDES_SM_70, (return static_cast<bool>(::__isGridConstant(__ptr));), (return false;))
 #  else // ^^^ _CCCL_HAS_GRID_CONSTANT() ^^^ / vvv !_CCCL_HAS_GRID_CONSTANT() vvv
       return false;
 #  endif // ^^^ !_CCCL_HAS_GRID_CONSTANT() ^^^
     case address_space::cluster_shared:
-      NV_IF_ELSE_TARGET(NV_PROVIDES_SM_90, (return ::__isClusterShared(__ptr);), (return false;))
+      NV_IF_ELSE_TARGET(NV_PROVIDES_SM_90, (return static_cast<bool>(::__isClusterShared(__ptr));), (return false;))
     default:
       return false;
   }

--- a/libcudacxx/include/cuda/__memory/address_space.h
+++ b/libcudacxx/include/cuda/__memory/address_space.h
@@ -48,7 +48,7 @@ enum class address_space
   return __v >= 0 && __v < _CUDA_VSTD::to_underlying(address_space::__max);
 }
 
-[[nodiscard]] _CCCL_DEVICE_API inline bool is_address_from(address_space __space, const void* __ptr)
+[[nodiscard]] _CCCL_DEVICE_API inline bool is_address_from(const void* __ptr, address_space __space)
 {
   _CCCL_ASSERT(__ptr != nullptr, "invalid pointer");
   _CCCL_ASSERT(_CUDA_DEVICE::__cccl_is_valid_address_space(__space), "invalid address space");

--- a/libcudacxx/test/libcudacxx/cuda/memory/is_address_from.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory/is_address_from.pass.cpp
@@ -10,9 +10,6 @@
 
 #include <cuda/memory>
 
-using cuda::device::address_space;
-using cuda::device::is_address_from;
-
 struct MyStruct
 {
   int v;
@@ -23,6 +20,9 @@ __constant__ int constant_var;
 
 __global__ void test_kernel(const _CCCL_GRID_CONSTANT MyStruct grid_constant_var)
 {
+  using cuda::device::address_space;
+  using cuda::device::is_address_from;
+  using cuda::device::is_object_from;
   __shared__ int shared_var;
   int local_var;
 
@@ -31,8 +31,13 @@ __global__ void test_kernel(const _CCCL_GRID_CONSTANT MyStruct grid_constant_var
   assert(is_address_from(&constant_var, address_space::constant));
   assert(is_address_from(&local_var, address_space::local));
   assert(is_address_from(&grid_constant_var, address_space::grid_constant) == _CCCL_HAS_GRID_CONSTANT());
-
   // todo: test address_space::cluster_shared
+
+  assert(is_object_from(global_var, address_space::global));
+  assert(is_object_from(shared_var, address_space::shared));
+  assert(is_object_from(constant_var, address_space::constant));
+  assert(is_object_from(local_var, address_space::local));
+  assert(is_object_from(grid_constant_var, address_space::grid_constant) == _CCCL_HAS_GRID_CONSTANT());
 }
 
 int main(int, char**)

--- a/libcudacxx/test/libcudacxx/cuda/memory/is_address_from.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory/is_address_from.pass.cpp
@@ -13,30 +13,30 @@
 using cuda::device::address_space;
 using cuda::device::is_address_from;
 
-struct MutableStruct
+struct MyStruct
 {
-  mutable int v;
+  int v;
 };
 
 __device__ int global_var;
 __constant__ int constant_var;
 
-__global__ void test_kernel(const _CCCL_GRID_CONSTANT MutableStruct grid_constant_var)
+__global__ void test_kernel(const _CCCL_GRID_CONSTANT MyStruct grid_constant_var)
 {
   __shared__ int shared_var;
   int local_var;
 
-  assert(is_address_from(address_space::global, &global_var));
-  assert(is_address_from(address_space::shared, &shared_var));
-  assert(is_address_from(address_space::constant, &constant_var));
-  assert(is_address_from(address_space::local, &local_var));
-  assert(is_address_from(address_space::grid_constant, &grid_constant_var) == _CCCL_HAS_GRID_CONSTANT());
+  assert(is_address_from(&global_var, address_space::global));
+  assert(is_address_from(&shared_var, address_space::shared));
+  assert(is_address_from(&constant_var, address_space::constant));
+  assert(is_address_from(&local_var, address_space::local));
+  assert(is_address_from(&grid_constant_var, address_space::grid_constant) == _CCCL_HAS_GRID_CONSTANT());
 
   // todo: test address_space::cluster_shared
 }
 
 int main(int, char**)
 {
-  NV_IF_TARGET(NV_IS_HOST, (test_kernel<<<1, 1>>>(MutableStruct{}); assert(cudaDeviceSynchronize() == cudaSuccess);))
+  NV_IF_TARGET(NV_IS_HOST, (test_kernel<<<1, 1>>>(MyStruct{}); assert(cudaDeviceSynchronize() == cudaSuccess);))
   return 0;
 }


### PR DESCRIPTION
Backporting changes of #5349 and https://github.com/NVIDIA/cccl/pull/5364