### PR TITLE
Implement `format.formatter.spec`

### DIFF
--- a/libcudacxx/include/cuda/std/__format/format_integral.h
+++ b/libcudacxx/include/cuda/std/__format/format_integral.h
@@ -1,0 +1,237 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___FORMAT_FORMAT_INTEGRAL_H
+#define _LIBCUDACXX___FORMAT_FORMAT_INTEGRAL_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/__cmath/uabs.h>
+#include <cuda/std/__charconv/to_chars.h>
+#include <cuda/std/__format/format_spec_parser.h>
+#include <cuda/std/__format/output_utils.h>
+#include <cuda/std/__iterator/iterator_traits.h>
+#include <cuda/std/__type_traits/always_false.h>
+#include <cuda/std/__type_traits/is_same.h>
+#include <cuda/std/__type_traits/is_signed.h>
+#include <cuda/std/__type_traits/make_nbit_int.h>
+#include <cuda/std/__type_traits/make_unsigned.h>
+#include <cuda/std/__utility/cmp.h>
+#include <cuda/std/__utility/move.h>
+#include <cuda/std/__utility/to_underlying.h>
+#include <cuda/std/climits>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD
+
+template <class _Tp, class _CharT, class _OutIt>
+[[nodiscard]] _CCCL_API _OutIt __fmt_format_char(_Tp __value, _OutIt __out_it, __fmt_parsed_spec<_CharT> __specs)
+{
+  if constexpr (!is_same_v<_CharT, _Tp>)
+  {
+    using _CharInt = __make_nbit_int_t<sizeof(_CharT) * CHAR_BIT, is_signed_v<_CharT>>;
+    using _TpInt   = __make_nbit_int_t<sizeof(_Tp) * CHAR_BIT, is_signed_v<_Tp>>;
+
+    if (!::cuda::std::in_range<_CharInt>(static_cast<_TpInt>(__value)))
+    {
+      ::cuda::std::__throw_format_error("Integral value outside the range of the char type");
+    }
+  }
+  const auto __c = static_cast<_CharT>(__value);
+  return ::cuda::std::__fmt_write(
+    ::cuda::std::addressof(__c), ::cuda::std::addressof(__c) + 1, ::cuda::std::move(__out_it), __specs);
+}
+
+//! Helper to determine the buffer size to output an unsigned integer in Base @em x.
+//!
+//! There are several overloads for the supported bases. The function uses the
+//! base as template argument so it can be used in a constant expression.
+template <class _Tp, int _Base>
+inline constexpr int __fmt_int_buffer_size_v = 0;
+template <class _Tp>
+inline constexpr int __fmt_int_buffer_size_v<_Tp, 2> =
+  numeric_limits<_Tp>::digits // The number of binary digits.
+  + 2 // Reserve space for the '0[Bb]' prefix.
+  + 1; // Reserve space for the sign.
+template <class _Tp>
+inline constexpr int __fmt_int_buffer_size_v<_Tp, 8> =
+  numeric_limits<_Tp>::digits / 3 + 1 // The number of octal digits.
+  + 1 // Reserve space for the '0' prefix.
+  + 1; // Reserve space for the sign.
+template <class _Tp>
+inline constexpr int __fmt_int_buffer_size_v<_Tp, 10> =
+  numeric_limits<_Tp>::digits10 + 1 // The number of decimal digits.
+  + 1; // Reserve space for the sign.
+template <class _Tp>
+inline constexpr int __fmt_int_buffer_size_v<_Tp, 16> =
+  numeric_limits<_Tp>::digits / 4 // The number of hexadecimal digits.
+  + 2 // Reserve space for the '0x' prefix.
+  + 1; // Reserve space for the sign.
+
+[[nodiscard]] _CCCL_API constexpr char* __fmt_insert_sign(char* __buf, bool __negative, __fmt_spec_sign __sign)
+{
+  if (__negative)
+  {
+    *__buf++ = '-';
+  }
+  else
+  {
+    switch (__sign)
+    {
+      case __fmt_spec_sign::__default:
+      case __fmt_spec_sign::__minus:
+        // No sign added.
+        break;
+      case __fmt_spec_sign::__plus:
+        *__buf++ = '+';
+        break;
+      case __fmt_spec_sign::__space:
+        *__buf++ = ' ';
+        break;
+    }
+  }
+  return __buf;
+}
+
+template <class _Tp, class _CharT, class _FmtCtx>
+[[nodiscard]] _CCCL_API typename _FmtCtx::iterator __fmt_format_int_impl(
+  _Tp __value,
+  _FmtCtx& __ctx,
+  __fmt_parsed_spec<_CharT> __specs,
+  bool __negative,
+  char* __array,
+  int __size,
+  const char* __prefix,
+  int __base)
+{
+  char* __first = ::cuda::std::__fmt_insert_sign(__array, __negative, __fmt_spec_sign{__specs.__std_.__sign_});
+  if (__specs.__std_.__alternate_form_ && __prefix != nullptr)
+  {
+    while (*__prefix)
+    {
+      *__first++ = *__prefix++;
+    }
+  }
+
+  char* __last{};
+  {
+    const auto __r = ::cuda::std::to_chars(__first, __array + __size, __value, __base);
+    _CCCL_ASSERT(__r.ec == errc(0), "Internal buffer too small");
+    __last = __r.ptr;
+  }
+
+  auto __out_it = __ctx.out();
+  if (__fmt_spec_alignment{__specs.__alignment_} != __fmt_spec_alignment::__zero_padding)
+  {
+    __first = __array;
+  }
+  else
+  {
+    // __buf contains [sign][prefix]data
+    //                              ^ location of __first
+    // The zero padding is done like:
+    // - Write [sign][prefix]
+    // - Write data right aligned with '0' as fill character.
+    __out_it                  = ::cuda::std::__fmt_copy(__array, __first, ::cuda::std::move(__out_it));
+    __specs.__alignment_      = ::cuda::std::to_underlying(__fmt_spec_alignment::__right);
+    __specs.__fill_.__data[0] = _CharT{'0'};
+    __specs.__width_ -= ::cuda::std::min(static_cast<uint32_t>(__last - __first), __specs.__width_);
+  }
+
+  if (__specs.__std_.__type_ != __fmt_spec_type::__hexadecimal_upper_case)
+  {
+    return ::cuda::std::__fmt_write(__first, __last, __ctx.out(), __specs);
+  }
+  return ::cuda::std::__fmt_write_transformed(__first, __last, __ctx.out(), __specs, ::cuda::std::__fmt_hex_to_upper);
+}
+
+template <class _Tp, class _CharT, class _FmtCtx>
+[[nodiscard]] _CCCL_API typename _FmtCtx::iterator
+__fmt_format_int(_Tp __value, _FmtCtx& __ctx, __fmt_parsed_spec<_CharT> __specs)
+{
+  static_assert(__cccl_is_integer_v<_Tp>);
+
+  const auto __uvalue   = ::cuda::uabs(__value);
+  const auto __negative = is_signed_v<_Tp> && __value < 0;
+
+  switch (__specs.__std_.__type_)
+  {
+    case __fmt_spec_type::__binary_lower_case: {
+      char __array[__fmt_int_buffer_size_v<_Tp, 2>];
+      return ::cuda::std::__fmt_format_int_impl(
+        __uvalue, __ctx, __specs, __negative, __array, __fmt_int_buffer_size_v<_Tp, 2>, "0b", 2);
+    }
+    case __fmt_spec_type::__binary_upper_case: {
+      char __array[__fmt_int_buffer_size_v<_Tp, 2>];
+      return ::cuda::std::__fmt_format_int_impl(
+        __uvalue, __ctx, __specs, __negative, __array, __fmt_int_buffer_size_v<_Tp, 2>, "0B", 2);
+    }
+    case __fmt_spec_type::__octal: {
+      // Octal is special; if __uvalue == 0 there's no prefix.
+      char __array[__fmt_int_buffer_size_v<_Tp, 8>];
+      return ::cuda::std::__fmt_format_int_impl(
+        __uvalue, __ctx, __specs, __negative, __array, __fmt_int_buffer_size_v<_Tp, 8>, __uvalue != 0 ? "0" : nullptr, 8);
+    }
+    case __fmt_spec_type::__default:
+    case __fmt_spec_type::__decimal: {
+      char __array[__fmt_int_buffer_size_v<_Tp, 10>];
+      return ::cuda::std::__fmt_format_int_impl(
+        __uvalue, __ctx, __specs, __negative, __array, __fmt_int_buffer_size_v<_Tp, 10>, nullptr, 10);
+    }
+    case __fmt_spec_type::__hexadecimal_lower_case: {
+      char __array[__fmt_int_buffer_size_v<_Tp, 16>];
+      return ::cuda::std::__fmt_format_int_impl(
+        __uvalue, __ctx, __specs, __negative, __array, __fmt_int_buffer_size_v<_Tp, 16>, "0x", 16);
+    }
+    case __fmt_spec_type::__hexadecimal_upper_case: {
+      char __array[__fmt_int_buffer_size_v<_Tp, 16>];
+      return ::cuda::std::__fmt_format_int_impl(
+        __uvalue, __ctx, __specs, __negative, __array, __fmt_int_buffer_size_v<_Tp, 16>, "0X", 16);
+    }
+    default:
+      _CCCL_UNREACHABLE();
+  }
+}
+
+template <class _CharT, class _FmtContext>
+[[nodiscard]] _CCCL_API typename _FmtContext::iterator
+__fmt_format_bool(bool __value, _FmtContext& __ctx, __fmt_parsed_spec<_CharT> __specs)
+{
+  basic_string_view<_CharT> __str{};
+  if constexpr (is_same_v<_CharT, char>)
+  {
+    __str = (__value) ? "true" : "false";
+  }
+#if _CCCL_HAS_WCHAR_T()
+  else if constexpr (is_same_v<_CharT, wchar_t>)
+  {
+    __str = (__value) ? L"true" : L"false";
+  }
+#endif // _CCCL_HAS_WCHAR_T()
+  else
+  {
+    static_assert(__always_false_v<_CharT>, "Unsupported character type for boolean formatting");
+  }
+  return ::cuda::std::__fmt_write(__str, __ctx.out(), __specs, static_cast<ptrdiff_t>(__str.size()));
+}
+
+_CCCL_END_NAMESPACE_CUDA_STD
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _LIBCUDACXX___FORMAT_FORMAT_INTEGRAL_H

--- a/libcudacxx/include/cuda/std/__format/format_spec_parser.h
+++ b/libcudacxx/include/cuda/std/__format/format_spec_parser.h
@@ -1,0 +1,1230 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___FORMAT_FORMAT_SPEC_PARSER_H
+#define _LIBCUDACXX___FORMAT_FORMAT_SPEC_PARSER_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/copy_n.h>
+#include <cuda/std/__algorithm/min.h>
+#include <cuda/std/__concepts/arithmetic.h>
+#include <cuda/std/__format/format_arg.h>
+#include <cuda/std/__format/format_error.h>
+#include <cuda/std/__format/format_parse_context.h>
+#include <cuda/std/__format/parse_arg_id.h>
+#include <cuda/std/__iterator/concepts.h>
+#include <cuda/std/__iterator/iterator_traits.h>
+#include <cuda/std/__memory/addressof.h>
+#include <cuda/std/__type_traits/common_type.h>
+#include <cuda/std/__type_traits/is_constant_evaluated.h>
+#include <cuda/std/__type_traits/is_same.h>
+#include <cuda/std/__type_traits/is_signed.h>
+#include <cuda/std/__type_traits/is_trivially_copyable.h>
+#include <cuda/std/__type_traits/underlying_type.h>
+#include <cuda/std/__utility/monostate.h>
+#include <cuda/std/__utility/to_underlying.h>
+#include <cuda/std/cstdint>
+#include <cuda/std/string_view>
+
+#if !_CCCL_COMPILER(NVRTC)
+#  include <string>
+#endif // !_CCCL_COMPILER(NVRTC)
+
+// This file contains the std-format-spec parser.
+//
+// Most of the code can be reused in the chrono-format-spec.
+// This header has some support for the chrono-format-spec since it doesn't
+// affect the std-format-spec.
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD
+
+template <size_t _IdSize, size_t _OptSize>
+[[noreturn]] _CCCL_API inline void
+__throw_invalid_option_format_error(const char (&__id)[_IdSize], const char (&__option)[_OptSize])
+{
+  constexpr string_view __msg_pt1 = "The format specifier for ";
+  constexpr string_view __msg_pt2 = " does not allow the ";
+  constexpr string_view __msg_pt3 = " option";
+
+  char __msg[__msg_pt1.size() + _IdSize + __msg_pt2.size() + _OptSize + __msg_pt3.size() + 1]{};
+  char* __msg_it = __msg;
+
+  const string_view __id_view{__id};
+  const string_view __opt_view{__option};
+
+  // copy the message parts into the message buffer
+  char_traits<char>::copy(__msg_it, __msg_pt1.data(), __msg_pt1.size());
+  char_traits<char>::copy(__msg_it += __msg_pt1.size(), __id_view.data(), __id_view.size());
+  char_traits<char>::copy(__msg_it += __id_view.size(), __msg_pt2.data(), __msg_pt2.size());
+  char_traits<char>::copy(__msg_it += __msg_pt2.size(), __opt_view.data(), __opt_view.size());
+  char_traits<char>::copy(__msg_it += __opt_view.size(), __msg_pt3.data(), __msg_pt3.size());
+  __msg_it[__msg_pt3.size()] = '\0';
+
+  ::cuda::std::__throw_format_error(__msg);
+}
+
+template <size_t _IdSize>
+[[noreturn]] _CCCL_API inline void __throw_invalid_type_format_error(const char (&__id)[_IdSize])
+{
+  constexpr string_view __msg_pt1 = "The type option contains an invalid value for ";
+  constexpr string_view __msg_pt2 = " formatting argument";
+
+  char __msg[__msg_pt1.size() + _IdSize + __msg_pt2.size() + 1]{};
+  char* __msg_it = __msg;
+
+  const string_view __id_view{__id};
+
+  // copy the message parts into the message buffer
+  char_traits<char>::copy(__msg_it, __msg_pt1.data(), __msg_pt1.size());
+  char_traits<char>::copy(__msg_it += __msg_pt1.size(), __id_view.data(), __id_view.size());
+  char_traits<char>::copy(__msg_it += __id_view.size(), __msg_pt2.data(), __msg_pt2.size());
+  __msg_it[__msg_pt2.size()] = '\0';
+
+  ::cuda::std::__throw_format_error(__msg);
+}
+
+struct __fmt_substitute_arg_id_visitor
+{
+  template <class _Tp>
+  [[nodiscard]] _CCCL_API constexpr uint32_t operator()([[maybe_unused]] _Tp __arg)
+  {
+    if constexpr (is_same_v<_Tp, monostate>)
+    {
+      ::cuda::std::__throw_format_error("The argument index value is too large for the number of arguments supplied");
+    }
+
+    // [format.string.std]/8
+    // If { arg-idopt } is used in a width or precision, the value of the
+    // corresponding formatting argument is used in its place. If the
+    // corresponding formatting argument is not of standard signed or unsigned
+    // integer type, or its value is negative for precision or non-positive for
+    // width, an exception of type format_error is thrown.
+    //
+    // When an integral is used in a format function, it is stored as one of
+    // the types checked below. Other integral types are promoted. For example,
+    // a signed char is stored as an int.
+    else if constexpr (is_same_v<_Tp, int> || is_same_v<_Tp, unsigned int> || //
+                       is_same_v<_Tp, long long> || is_same_v<_Tp, unsigned long long>)
+    {
+      if constexpr (is_signed_v<_Tp>)
+      {
+        if (__arg < 0)
+        {
+          ::cuda::std::__throw_format_error("An argument index may not have a negative value");
+        }
+      }
+
+      using _CT = common_type_t<_Tp, decltype(__fmt_number_max)>;
+      if (static_cast<_CT>(__arg) > static_cast<_CT>(__fmt_number_max))
+      {
+        ::cuda::std::__throw_format_error("The value of the argument index exceeds its maximum value");
+      }
+
+      return static_cast<uint32_t>(__arg);
+    }
+    else
+    {
+      ::cuda::std::__throw_format_error("Replacement argument isn't a standard signed or unsigned integer type");
+    }
+  }
+};
+
+template <class _Context>
+[[nodiscard]] _CCCL_API constexpr uint32_t __fmt_substitute_arg_id(basic_format_arg<_Context> __format_arg)
+{
+  // [format.string.std]/8
+  //   If the corresponding formatting argument is not of integral type...
+  // This wording allows char and bool too. LWG-3720 changes the wording to
+  //    If the corresponding formatting argument is not of standard signed or
+  //    unsigned integer type,
+  return ::cuda::std::visit_format_arg(__fmt_substitute_arg_id_visitor{}, __format_arg);
+}
+
+//! These fields are a filter for which elements to parse.
+//!
+//! They default to false so when a new field is added it needs to be opted in
+//! explicitly.
+struct __fmt_spec_fields
+{
+  uint16_t __sign_                 : 1;
+  uint16_t __alternate_form_       : 1;
+  uint16_t __zero_padding_         : 1;
+  uint16_t __precision_            : 1;
+  uint16_t __locale_specific_form_ : 1;
+  uint16_t __type_                 : 1;
+  // Determines the valid values for fill.
+  //
+  // Originally the fill could be any character except { and }. Range-based
+  // formatters use the colon to mark the beginning of the
+  // underlying-format-spec. To avoid parsing ambiguities these formatter
+  // specializations prohibit the use of the colon as a fill character.
+  uint16_t __use_range_fill_ : 1;
+  uint16_t __clear_brackets_ : 1;
+  uint16_t __consume_all_    : 1;
+};
+
+// By not placing this constant in the formatter class it's not duplicated for
+// char and wchar_t.
+[[nodiscard]] _CCCL_API constexpr __fmt_spec_fields __fmt_spec_fields_bool() noexcept
+{
+  __fmt_spec_fields __ret{};
+  __ret.__locale_specific_form_ = true;
+  __ret.__type_                 = true;
+  __ret.__consume_all_          = true;
+  return __ret;
+}
+[[nodiscard]] _CCCL_API constexpr __fmt_spec_fields __fmt_spec_fields_int() noexcept
+{
+  __fmt_spec_fields __ret{};
+  __ret.__sign_                 = true;
+  __ret.__alternate_form_       = true;
+  __ret.__zero_padding_         = true;
+  __ret.__locale_specific_form_ = true;
+  __ret.__type_                 = true;
+  __ret.__consume_all_          = true;
+  return __ret;
+}
+[[nodiscard]] _CCCL_API constexpr __fmt_spec_fields __fmt_spec_fields_fp() noexcept
+{
+  __fmt_spec_fields __ret{};
+  __ret.__sign_                 = true;
+  __ret.__alternate_form_       = true;
+  __ret.__zero_padding_         = true;
+  __ret.__locale_specific_form_ = true;
+  __ret.__type_                 = true;
+  __ret.__consume_all_          = true;
+  return __ret;
+}
+[[nodiscard]] _CCCL_API constexpr __fmt_spec_fields __fmt_spec_fields_str() noexcept
+{
+  __fmt_spec_fields __ret{};
+  __ret.__precision_   = true;
+  __ret.__type_        = true;
+  __ret.__consume_all_ = true;
+  return __ret;
+}
+[[nodiscard]] _CCCL_API constexpr __fmt_spec_fields __fmt_spec_fields_ptr() noexcept
+{
+  __fmt_spec_fields __ret{};
+  __ret.__zero_padding_ = true;
+  __ret.__type_         = true;
+  __ret.__consume_all_  = true;
+  return __ret;
+}
+
+enum class __fmt_spec_alignment : uint8_t
+{
+  // No alignment is set in the format string.
+  __default,
+  __left,
+  __center,
+  __right,
+  __zero_padding,
+};
+
+enum class __fmt_spec_sign : uint8_t
+{
+  // No sign is set in the format string.
+  //
+  // The sign isn't allowed for certain format-types. By using this value
+  // it's possible to detect whether or not the user explicitly set the sign
+  // flag. For formatting purposes it behaves the same as \ref __minus.
+  __default,
+  __minus,
+  __plus,
+  __space,
+};
+
+enum class __fmt_spec_type : uint8_t
+{
+  __default = 0,
+  __string,
+  __binary_lower_case,
+  __binary_upper_case,
+  __octal,
+  __decimal,
+  __hexadecimal_lower_case,
+  __hexadecimal_upper_case,
+  __pointer_lower_case,
+  __pointer_upper_case,
+  __char,
+  __hexfloat_lower_case,
+  __hexfloat_upper_case,
+  __scientific_lower_case,
+  __scientific_upper_case,
+  __fixed_lower_case,
+  __fixed_upper_case,
+  __general_lower_case,
+  __general_upper_case,
+};
+
+[[nodiscard]] _CCCL_API constexpr uint32_t __fmt_spec_make_type_mask(__fmt_spec_type __t)
+{
+  const auto __shift = static_cast<uint32_t>(__t);
+  if (__shift > 31)
+  {
+    ::cuda::std::__throw_format_error("The type does not fit in the mask");
+  }
+  return 1 << __shift;
+}
+
+inline constexpr uint32_t __fmt_spec_type_mask_int =
+  ::cuda::std::__fmt_spec_make_type_mask(__fmt_spec_type::__binary_lower_case) | //
+  ::cuda::std::__fmt_spec_make_type_mask(__fmt_spec_type::__binary_upper_case) | //
+  ::cuda::std::__fmt_spec_make_type_mask(__fmt_spec_type::__decimal) | //
+  ::cuda::std::__fmt_spec_make_type_mask(__fmt_spec_type::__octal) | //
+  ::cuda::std::__fmt_spec_make_type_mask(__fmt_spec_type::__hexadecimal_lower_case) | //
+  ::cuda::std::__fmt_spec_make_type_mask(__fmt_spec_type::__hexadecimal_upper_case);
+
+// there is a bug in gcc < 10 that warns about `__fmt_spec_alignment : 3` being too small for all enum values,
+// so we use the underlying type instead
+struct __fmt_spec_std
+{
+  underlying_type_t<__fmt_spec_alignment> __alignment_ : 3;
+  underlying_type_t<__fmt_spec_sign> __sign_           : 2;
+  bool __alternate_form_                               : 1;
+  bool __locale_specific_form_                         : 1;
+  bool __padding_0_                                    : 1;
+  __fmt_spec_type __type_;
+};
+
+struct __fmt_spec_chrono
+{
+  underlying_type_t<__fmt_spec_alignment> __alignment_ : 3;
+  bool __locale_specific_form_                         : 1;
+  bool __hour_                                         : 1;
+  bool __weekday_name_                                 : 1;
+  bool __weekday_                                      : 1;
+  bool __day_of_year_                                  : 1;
+  bool __week_of_year_                                 : 1;
+  bool __month_name_                                   : 1;
+};
+
+//! The fill UCS scalar value.
+//!
+//! This is always an array, with 1, 2, or 4 elements.
+//! The size of the data structure is always 32-bits.
+template <class _CharT>
+struct __fmt_spec_code_point;
+
+template <>
+struct __fmt_spec_code_point<char>
+{
+  char __data[4] = {' '};
+};
+
+#if _CCCL_HAS_WCHAR_T()
+template <>
+struct __fmt_spec_code_point<wchar_t>
+{
+  wchar_t __data[4 / sizeof(wchar_t)] = {L' '};
+};
+#endif // _CCCL_HAS_WCHAR_T()
+
+//! Contains the parsed formatting specifications.
+//!
+//! This contains information for both the std-format-spec and the
+//! chrono-format-spec. This results in some unused members for both
+//! specifications. However these unused members don't increase the size
+//! of the structure.
+//!
+//! This struct doesn't cross ABI boundaries so its layout doesn't need to be
+//! kept stable.
+template <class _CharT>
+struct __fmt_parsed_spec
+{
+  union
+  {
+    // The field __alignment_ is the first element in __std_ and __chrono_.
+    // This allows the code to always inspect this value regardless of which member
+    // of the union is the active member [class.union.general]/2.
+    //
+    // This is needed since the generic output routines handle the alignment of
+    // the output.
+    underlying_type_t<__fmt_spec_alignment> __alignment_ : 3;
+    __fmt_spec_std __std_;
+    __fmt_spec_chrono __chrono_;
+  };
+
+  //! The requested width.
+  //!
+  //! When the format-spec used an arg-id for this field it has already been
+  //! replaced with the value of that arg-id.
+  uint32_t __width_;
+
+  //! The requested precision.
+  //!
+  //! When the format-spec used an arg-id for this field it has already been
+  //! replaced with the value of that arg-id.
+  int32_t __precision_;
+
+  __fmt_spec_code_point<_CharT> __fill_;
+
+  [[nodiscard]] _CCCL_API constexpr bool __has_width() const
+  {
+    return __width_ > 0;
+  }
+
+  [[nodiscard]] _CCCL_API constexpr bool __has_precision() const
+  {
+    return __precision_ >= 0;
+  }
+};
+
+// Validate the struct is small and cheap to copy since the struct is passed by
+// value in formatting functions.
+static_assert(sizeof(__fmt_parsed_spec<char>) == 16);
+static_assert(is_trivially_copyable_v<__fmt_parsed_spec<char>>);
+#if _CCCL_HAS_WCHAR_T()
+static_assert(sizeof(__fmt_parsed_spec<wchar_t>) == 16);
+static_assert(is_trivially_copyable_v<__fmt_parsed_spec<wchar_t>>);
+#endif // _CCCL_HAS_WCHAR_T()
+
+//! The parser for the std-format-spec.
+//!
+//! Note this class is a member of std::formatter specializations. It's
+//! expected developers will create their own formatter specializations that
+//! inherit from the std::formatter specializations. This means this class
+//! must be ABI stable. To aid the stability the unused bits in the class are
+//! set to zero. That way they can be repurposed if a future revision of the
+//! Standards adds new fields to std-format-spec.
+template <class _CharT>
+class __fmt_spec_parser
+{
+public:
+  //! Parses the format specification.
+  //!
+  //! Depending on whether the parsing is done compile-time or run-time
+  //! the method slightly differs.
+  //! - Only parses a field when it is in the __fields. Accepting all
+  //!   fields and then validating the valid ones has a performance impact.
+  //!   This is faster but gives slightly worse error messages.
+  //! - At compile-time when a field is not accepted the parser will still
+  //!   parse it and give an error when it's present. This gives a more
+  //!   accurate error.
+  //! The idea is that most times the format instead of the vformat
+  //! functions are used. In that case the error will be detected during
+  //! compilation and there is no need to pay for the run-time overhead.
+  template <class _ParseContext>
+  _CCCL_API constexpr typename _ParseContext::iterator __parse(_ParseContext& __ctx, __fmt_spec_fields __fields)
+  {
+    auto __begin = __ctx.begin();
+    auto __end   = __ctx.end();
+    if (__begin == __end || *__begin == _CharT{'}'} || (__fields.__use_range_fill_ && *__begin == _CharT{':'}))
+    {
+      return __begin;
+    }
+
+    if (__parse_fill_align(__begin, __end) && __begin == __end)
+    {
+      return __begin;
+    }
+
+    if (__fields.__sign_)
+    {
+      if (__parse_sign(__begin) && __begin == __end)
+      {
+        return __begin;
+      }
+    }
+    else if (::cuda::std::is_constant_evaluated() && __parse_sign(__begin))
+    {
+      ::cuda::std::__throw_format_error("The format specification does not allow the sign option");
+    }
+
+    if (__fields.__alternate_form_)
+    {
+      if (__parse_alternate_form(__begin) && __begin == __end)
+      {
+        return __begin;
+      }
+    }
+    else if (::cuda::std::is_constant_evaluated() && __parse_alternate_form(__begin))
+    {
+      ::cuda::std::__throw_format_error("The format specifier does not allow the alternate form option");
+    }
+
+    if (__fields.__zero_padding_)
+    {
+      if (__parse_zero_padding(__begin) && __begin == __end)
+      {
+        return __begin;
+      }
+    }
+    else if (::cuda::std::is_constant_evaluated() && __parse_zero_padding(__begin))
+    {
+      ::cuda::std::__throw_format_error("The format specifier does not allow the zero-padding option");
+    }
+
+    if (__parse_width(__begin, __end, __ctx) && __begin == __end)
+    {
+      return __begin;
+    }
+
+    if (__fields.__precision_)
+    {
+      if (__parse_precision(__begin, __end, __ctx) && __begin == __end)
+      {
+        return __begin;
+      }
+    }
+    else if (::cuda::std::is_constant_evaluated() && __parse_precision(__begin, __end, __ctx))
+    {
+      ::cuda::std::__throw_format_error("The format specifier does not allow the precision option");
+    }
+
+    if (__fields.__locale_specific_form_)
+    {
+      if (__parse_locale_specific_form(__begin) && __begin == __end)
+      {
+        return __begin;
+      }
+    }
+    else if (::cuda::std::is_constant_evaluated() && __parse_locale_specific_form(__begin))
+    {
+      ::cuda::std::__throw_format_error("The format specifier does not allow the locale-specific form option");
+    }
+
+    if (__fields.__clear_brackets_)
+    {
+      if (__parse_clear_brackets(__begin) && __begin == __end)
+      {
+        return __begin;
+      }
+    }
+    else if (::cuda::std::is_constant_evaluated() && __parse_clear_brackets(__begin))
+    {
+      ::cuda::std::__throw_format_error("The format specifier does not allow the n option");
+    }
+
+    if (__fields.__type_)
+    {
+      __parse_type(__begin);
+    }
+
+    if (!__fields.__consume_all_)
+    {
+      return __begin;
+    }
+
+    if (__begin != __end && *__begin != _CharT{'}'})
+    {
+      ::cuda::std::__throw_format_error("The format specifier should consume the input or end with a '}'");
+    }
+
+    return __begin;
+  }
+
+  //! Validates the selected the parsed data.
+  //!
+  //! The valid fields in the parser may depend on the display type
+  //! selected. But the type is the last optional field, so by the time
+  //! it's known an option can't be used, it already has been parsed.
+  //! This does the validation again.
+  //!
+  //! For example an integral may have a sign, zero-padding, or alternate
+  //! form when the type option is not 'c'. So the generic approach is:
+  //!
+  //! typename _ParseContext::iterator __result = __parser_.__parse(__ctx, __format_spec::__fields_integral);
+  //! if (__parser.__type_ == __format_spec::__type::__char) {
+  //!   __parser.__validate((__format_spec::__fields_bool, "an integer");
+  //!   ... // more char adjustments
+  //! } else {
+  //!   ... // validate an integral type.
+  //! }
+  //!
+  //! For some types all valid options need a second validation run, like
+  //! boolean types.
+  //!
+  //! Depending on whether the validation is done at compile-time or
+  //! run-time the error differs
+  //! - run-time the exception is thrown and contains the type of field
+  //!   being validated.
+  //! - at compile-time the line with `std::__throw_format_error` is shown
+  //!   in the output. In that case it's important for the error to be on one
+  //!   line.
+  //! Note future versions of C++ may allow better compile-time error
+  //! reporting.
+  template <size_t _IdSize>
+  _CCCL_API constexpr void
+  __validate(__fmt_spec_fields __fields, const char (&__id)[_IdSize], uint32_t __type_mask = ~uint32_t{0}) const
+  {
+    if (!__fields.__sign_ && __fmt_spec_sign{__sign_} != __fmt_spec_sign::__default)
+    {
+      if (::cuda::std::is_constant_evaluated())
+      {
+        ::cuda::std::__throw_format_error("The format specifier does not allow the sign option");
+      }
+      else
+      {
+        ::cuda::std::__throw_invalid_option_format_error(__id, "sign");
+      }
+    }
+
+    if (!__fields.__alternate_form_ && __alternate_form_)
+    {
+      if (::cuda::std::is_constant_evaluated())
+      {
+        ::cuda::std::__throw_format_error("The format specifier does not allow the alternate form option");
+      }
+      else
+      {
+        ::cuda::std::__throw_invalid_option_format_error(__id, "alternate form");
+      }
+    }
+
+    if (!__fields.__zero_padding_ && __fmt_spec_alignment{__alignment_} == __fmt_spec_alignment::__zero_padding)
+    {
+      if (::cuda::std::is_constant_evaluated())
+      {
+        ::cuda::std::__throw_format_error("The format specifier does not allow the zero-padding option");
+      }
+      else
+      {
+        ::cuda::std::__throw_invalid_option_format_error(__id, "zero-padding");
+      }
+    }
+
+    if (!__fields.__precision_ && __precision_ != -1)
+    { // Works both when the precision has a value or an arg-id.
+      if (::cuda::std::is_constant_evaluated())
+      {
+        ::cuda::std::__throw_format_error("The format specifier does not allow the precision option");
+      }
+      else
+      {
+        ::cuda::std::__throw_invalid_option_format_error(__id, "precision");
+      }
+    }
+
+    if (!__fields.__locale_specific_form_ && __locale_specific_form_)
+    {
+      if (::cuda::std::is_constant_evaluated())
+      {
+        ::cuda::std::__throw_format_error("The format specifier does not allow the locale-specific form option");
+      }
+      else
+      {
+        ::cuda::std::__throw_invalid_option_format_error(__id, "locale-specific form");
+      }
+    }
+
+    if ((::cuda::std::__fmt_spec_make_type_mask(__type_) & __type_mask) == 0)
+    {
+      if (::cuda::std::is_constant_evaluated())
+      {
+        ::cuda::std::__throw_format_error("The format specifier uses an invalid value for the type option");
+      }
+      else
+      {
+        ::cuda::std::__throw_invalid_type_format_error(__id);
+      }
+    }
+  }
+
+  //! Returns the `__fmt_parsed_spec` with the resolved dynamic sizes.
+  template <class _Ctx>
+  [[nodiscard]] _CCCL_API __fmt_parsed_spec<_CharT> __get_parsed_std_spec(_Ctx& __ctx) const
+  {
+    __fmt_parsed_spec<_CharT> __ret{};
+    __ret.__std_.__alignment_            = __alignment_;
+    __ret.__std_.__sign_                 = __sign_;
+    __ret.__std_.__alternate_form_       = __alternate_form_;
+    __ret.__std_.__locale_specific_form_ = __locale_specific_form_;
+    __ret.__std_.__type_                 = __type_;
+    __ret.__width_                       = __get_width(__ctx);
+    __ret.__precision_                   = __get_precision(__ctx);
+    __ret.__fill_                        = __fill_;
+    return __ret;
+  }
+
+  //! Returns the `__fmt_parsed_spec` with the resolved dynamic sizes.
+  template <class _Ctx>
+  [[nodiscard]] _CCCL_API __fmt_parsed_spec<_CharT> __get_parsed_chrono_spec(_Ctx& __ctx) const
+  {
+    __fmt_parsed_spec<_CharT> __ret{};
+    __ret.__chrono_.__alignment_            = __alignment_;
+    __ret.__chrono_.__locale_specific_form_ = __locale_specific_form_;
+    __ret.__chrono_.__hour_                 = __hour_;
+    __ret.__chrono_.__weekday_name_         = __weekday_name_;
+    __ret.__chrono_.__weekday_              = __weekday_;
+    __ret.__chrono_.__day_of_year_          = __day_of_year_;
+    __ret.__chrono_.__week_of_year_         = __week_of_year_;
+    __ret.__chrono_.__month_name_           = __month_name_;
+    __ret.__width_                          = __get_width(__ctx);
+    __ret.__precision_                      = __get_precision(__ctx);
+    __ret.__fill_                           = __fill_;
+    return __ret;
+  }
+
+  _CCCL_API constexpr __fmt_spec_parser() noexcept
+      : __alignment_{::cuda::std::to_underlying(__fmt_spec_alignment::__default)}
+      , __sign_{::cuda::std::to_underlying(__fmt_spec_sign::__default)}
+      , __alternate_form_{false}
+      , __locale_specific_form_{false}
+      , __clear_brackets_{false}
+      , __type_{__fmt_spec_type::__default}
+      , __hour_{false}
+      , __weekday_name_{false}
+      , __weekday_{false}
+      , __day_of_year_{false}
+      , __week_of_year_{false}
+      , __month_name_{false}
+      , __reserved_0_{}
+      , __reserved_1_{}
+      , __width_as_arg_{false}
+      , __precision_as_arg_{false}
+      , __width_{0}
+      , __precision_{-1}
+      , __fill_{}
+  {}
+
+  underlying_type_t<__fmt_spec_alignment> __alignment_ : 3;
+  underlying_type_t<__fmt_spec_sign> __sign_           : 2;
+  bool __alternate_form_                               : 1;
+  bool __locale_specific_form_                         : 1;
+  bool __clear_brackets_                               : 1;
+  __fmt_spec_type __type_;
+
+  // These flags are only used for formatting chrono. Since the struct has
+  // padding space left it's added to this structure.
+  bool __hour_ : 1;
+
+  bool __weekday_name_ : 1;
+  bool __weekday_      : 1;
+
+  bool __day_of_year_  : 1;
+  bool __week_of_year_ : 1;
+
+  bool __month_name_ : 1;
+
+  uint8_t __reserved_0_ : 2;
+  uint8_t __reserved_1_ : 6;
+  // These two flags are only used internally and not part of the
+  // __parsed_specifications. Therefore put them at the end.
+  bool __width_as_arg_     : 1;
+  bool __precision_as_arg_ : 1;
+
+  // The requested width, either the value or the arg-id.
+  uint32_t __width_;
+
+  // The requested precision, either the value or the arg-id.
+  int32_t __precision_;
+
+  __fmt_spec_code_point<_CharT> __fill_;
+
+private:
+  template <class _It, class _ParseCtx>
+  [[nodiscard]] _CCCL_API static constexpr __fmt_parse_number_result<_It>
+  __parse_arg_id(_It __begin, _It __end, _ParseCtx& __ctx)
+  {
+    // This function is a wrapper to call the real parser. But it does the
+    // validation for the pre-conditions and post-conditions.
+    if (__begin == __end)
+    {
+      ::cuda::std::__throw_format_error("End of input while parsing an argument index");
+    }
+
+    auto __r = ::cuda::std::__fmt_parse_arg_id(__begin, __end, __ctx);
+
+    if (__r.__last == __end || *__r.__last != _CharT{'}'})
+    {
+      ::cuda::std::__throw_format_error("The argument index is invalid");
+    }
+
+    ++__r.__last;
+    return __r;
+  }
+
+  [[nodiscard]] _CCCL_API constexpr bool __parse_alignment(_CharT __c)
+  {
+    switch (__c)
+    {
+      case _CharT{'<'}:
+        __alignment_ = ::cuda::std::to_underlying(__fmt_spec_alignment::__left);
+        return true;
+
+      case _CharT{'^'}:
+        __alignment_ = ::cuda::std::to_underlying(__fmt_spec_alignment::__center);
+        return true;
+
+      case _CharT{'>'}:
+        __alignment_ = ::cuda::std::to_underlying(__fmt_spec_alignment::__right);
+        return true;
+    }
+    return false;
+  }
+
+  _CCCL_API constexpr void __validate_fill_character(_CharT __fill)
+  {
+    // The forbidden fill characters all code points formed from a single code unit, thus the
+    // check can be omitted when more code units are used.
+    if (__fill == _CharT{'{'})
+    {
+      ::cuda::std::__throw_format_error("The fill option contains an invalid value");
+    }
+  }
+
+  // range-fill and tuple-fill are identical
+  template <class _It>
+  [[nodiscard]] _CCCL_API constexpr bool __parse_fill_align(_It& __begin, _It __end)
+  {
+    _CCCL_ASSERT(__begin != __end,
+                 "when called with an empty input the function will cause "
+                 "undefined behavior by evaluating data not in the input");
+    if (__begin + 1 != __end)
+    {
+      if (__parse_alignment(*(__begin + 1)))
+      {
+        __validate_fill_character(*__begin);
+
+        __fill_.__data[0] = *__begin;
+        __begin += 2;
+        return true;
+      }
+    }
+
+    if (!__parse_alignment(*__begin))
+    {
+      return false;
+    }
+
+    ++__begin;
+    return true;
+  }
+
+  template <class _It>
+  [[nodiscard]] _CCCL_API constexpr bool __parse_sign(_It& __begin)
+  {
+    switch (*__begin)
+    {
+      case _CharT{'-'}:
+        __sign_ = ::cuda::std::to_underlying(__fmt_spec_sign::__minus);
+        break;
+      case _CharT{'+'}:
+        __sign_ = ::cuda::std::to_underlying(__fmt_spec_sign::__plus);
+        break;
+      case _CharT{' '}:
+        __sign_ = ::cuda::std::to_underlying(__fmt_spec_sign::__space);
+        break;
+      default:
+        return false;
+    }
+    ++__begin;
+    return true;
+  }
+
+  template <class _It>
+  [[nodiscard]] _CCCL_API constexpr bool __parse_alternate_form(_It& __begin)
+  {
+    if (*__begin != _CharT{'#'})
+    {
+      return false;
+    }
+    __alternate_form_ = true;
+    ++__begin;
+    return true;
+  }
+
+  template <class _It>
+  [[nodiscard]] _CCCL_API constexpr bool __parse_zero_padding(_It& __begin)
+  {
+    if (*__begin != _CharT{'0'})
+    {
+      return false;
+    }
+    if (__fmt_spec_alignment{__alignment_} == __fmt_spec_alignment::__default)
+    {
+      __alignment_ = ::cuda::std::to_underlying(__fmt_spec_alignment::__zero_padding);
+    }
+    ++__begin;
+    return true;
+  }
+
+  template <class _It, class _Ctx>
+  [[nodiscard]] _CCCL_API constexpr bool __parse_width(_It& __begin, _It __end, _Ctx& __ctx)
+  {
+    if (*__begin == _CharT{'0'})
+    {
+      ::cuda::std::__throw_format_error("The width option should not have a leading zero");
+    }
+
+    if (*__begin == _CharT{'{'})
+    {
+      const auto __r  = __parse_arg_id(++__begin, __end, __ctx);
+      __width_as_arg_ = true;
+      __width_        = __r.__value;
+      __begin         = __r.__last;
+      return true;
+    }
+
+    if (*__begin < _CharT{'0'} || *__begin > _CharT{'9'})
+    {
+      return false;
+    }
+
+    const auto __r = ::cuda::std::__fmt_parse_number(__begin, __end);
+    __width_       = __r.__value;
+    _CCCL_ASSERT(__width_ != 0,
+                 "A zero value isn't allowed and should be impossible, due to validations in this function");
+    __begin = __r.__last;
+    return true;
+  }
+
+  template <class _It, class _Ctx>
+  [[nodiscard]] _CCCL_API constexpr bool __parse_precision(_It& __begin, _It __end, _Ctx& __ctx)
+  {
+    if (*__begin != _CharT{'.'})
+    {
+      return false;
+    }
+
+    ++__begin;
+    if (__begin == __end)
+    {
+      ::cuda::std::__throw_format_error("End of input while parsing format specifier precision");
+    }
+
+    if (*__begin == _CharT{'{'})
+    {
+      const auto __arg_id = __parse_arg_id(++__begin, __end, __ctx);
+      __precision_as_arg_ = true;
+      __precision_        = __arg_id.__value;
+      __begin             = __arg_id.__last;
+      return true;
+    }
+
+    if (*__begin < _CharT{'0'} || *__begin > _CharT{'9'})
+    {
+      ::cuda::std::__throw_format_error("The precision option does not contain a value or an argument index");
+    }
+
+    const auto __r      = ::cuda::std::__fmt_parse_number(__begin, __end);
+    __precision_        = __r.__value;
+    __precision_as_arg_ = false;
+    __begin             = __r.__last;
+    return true;
+  }
+
+  template <class _It>
+  [[nodiscard]] _CCCL_API constexpr bool __parse_locale_specific_form(_It& __begin)
+  {
+    if (*__begin != _CharT{'L'})
+    {
+      return false;
+    }
+    __locale_specific_form_ = true;
+    ++__begin;
+    return true;
+  }
+
+  template <class _It>
+  [[nodiscard]] _CCCL_API constexpr bool __parse_clear_brackets(_It& __begin)
+  {
+    if (*__begin != _CharT{'n'})
+    {
+      return false;
+    }
+    __clear_brackets_ = true;
+    ++__begin;
+    return true;
+  }
+
+  template <class _It>
+  _CCCL_API constexpr void __parse_type(_It& __begin)
+  {
+    // Determines the type. It does not validate whether the selected type is
+    // valid. Most formatters have optional fields that are only allowed for
+    // certain types. These parsers need to do validation after the type has
+    // been parsed. So its easier to implement the validation for all types in
+    // the specific parse function.
+    switch (*__begin)
+    {
+      case 'A':
+        __type_ = __fmt_spec_type::__hexfloat_upper_case;
+        break;
+      case 'B':
+        __type_ = __fmt_spec_type::__binary_upper_case;
+        break;
+      case 'E':
+        __type_ = __fmt_spec_type::__scientific_upper_case;
+        break;
+      case 'F':
+        __type_ = __fmt_spec_type::__fixed_upper_case;
+        break;
+      case 'G':
+        __type_ = __fmt_spec_type::__general_upper_case;
+        break;
+      case 'X':
+        __type_ = __fmt_spec_type::__hexadecimal_upper_case;
+        break;
+      case 'a':
+        __type_ = __fmt_spec_type::__hexfloat_lower_case;
+        break;
+      case 'b':
+        __type_ = __fmt_spec_type::__binary_lower_case;
+        break;
+      case 'c':
+        __type_ = __fmt_spec_type::__char;
+        break;
+      case 'd':
+        __type_ = __fmt_spec_type::__decimal;
+        break;
+      case 'e':
+        __type_ = __fmt_spec_type::__scientific_lower_case;
+        break;
+      case 'f':
+        __type_ = __fmt_spec_type::__fixed_lower_case;
+        break;
+      case 'g':
+        __type_ = __fmt_spec_type::__general_lower_case;
+        break;
+      case 'o':
+        __type_ = __fmt_spec_type::__octal;
+        break;
+      case 'p':
+        __type_ = __fmt_spec_type::__pointer_lower_case;
+        break;
+      case 'P':
+        __type_ = __fmt_spec_type::__pointer_upper_case;
+        break;
+      case 's':
+        __type_ = __fmt_spec_type::__string;
+        break;
+      case 'x':
+        __type_ = __fmt_spec_type::__hexadecimal_lower_case;
+        break;
+      default:
+        return;
+    }
+    ++__begin;
+  }
+
+  template <class _Ctx>
+  [[nodiscard]] _CCCL_API uint32_t __get_width(_Ctx& __ctx) const
+  {
+    if (!__width_as_arg_)
+    {
+      return __width_;
+    }
+    return ::cuda::std::__fmt_substitute_arg_id(__ctx.arg(__width_));
+  }
+
+  template <class _Ctx>
+  [[nodiscard]] _CCCL_API int32_t __get_precision(_Ctx& __ctx) const
+  {
+    if (!__precision_as_arg_)
+    {
+      return __precision_;
+    }
+    return ::cuda::std::__fmt_substitute_arg_id(__ctx.arg(__precision_));
+  }
+};
+
+// Validates whether the reserved bitfields don't change the size.
+static_assert(sizeof(__fmt_spec_parser<char>) == 16);
+#if _CCCL_HAS_WCHAR_T()
+static_assert(sizeof(__fmt_spec_parser<wchar_t>) == 16);
+#endif // _CCCL_HAS_WCHAR_T()
+
+_CCCL_API constexpr void __fmt_process_display_type_str(__fmt_spec_type __type)
+{
+  switch (__type)
+  {
+    case __fmt_spec_type::__default:
+    case __fmt_spec_type::__string:
+      break;
+    default:
+      ::cuda::std::__throw_format_error("The type option contains an invalid value for a string formatting argument");
+  }
+}
+
+template <class _CharT, size_t _IdSize>
+_CCCL_API constexpr void
+__fmt_process_display_type_bool_str(__fmt_spec_parser<_CharT>& __parser, const char (&__id)[_IdSize])
+{
+  __parser.__validate(::cuda::std::__fmt_spec_fields_bool(), __id);
+  if (__fmt_spec_alignment{__parser.__alignment_} == __fmt_spec_alignment::__default)
+  {
+    __parser.__alignment_ = ::cuda::std::to_underlying(__fmt_spec_alignment::__left);
+  }
+}
+
+template <class _CharT, size_t _IdSize>
+_CCCL_API constexpr void
+__fmt_process_display_type_char(__fmt_spec_parser<_CharT>& __parser, const char (&__id)[_IdSize])
+{
+  ::cuda::std::__fmt_process_display_type_bool_str(__parser, __id);
+}
+
+template <class _CharT>
+_CCCL_API constexpr void __fmt_process_parsed_bool(__fmt_spec_parser<_CharT>& __parser)
+{
+  constexpr auto& __id = "a bool";
+
+  switch (__parser.__type_)
+  {
+    case __fmt_spec_type::__default:
+    case __fmt_spec_type::__string:
+      ::cuda::std::__fmt_process_display_type_bool_str(__parser, __id);
+      break;
+    case __fmt_spec_type::__binary_lower_case:
+    case __fmt_spec_type::__binary_upper_case:
+    case __fmt_spec_type::__octal:
+    case __fmt_spec_type::__decimal:
+    case __fmt_spec_type::__hexadecimal_lower_case:
+    case __fmt_spec_type::__hexadecimal_upper_case:
+      break;
+    default:
+      ::cuda::std::__throw_invalid_type_format_error(__id);
+  }
+}
+
+template <class _CharT>
+_CCCL_API constexpr void __fmt_process_parsed_char(__fmt_spec_parser<_CharT>& __parser)
+{
+  constexpr auto& __id = "a character";
+
+  switch (__parser.__type_)
+  {
+    case __fmt_spec_type::__default:
+    case __fmt_spec_type::__char:
+      ::cuda::std::__fmt_process_display_type_char(__parser, __id);
+      break;
+    case __fmt_spec_type::__binary_lower_case:
+    case __fmt_spec_type::__binary_upper_case:
+    case __fmt_spec_type::__octal:
+    case __fmt_spec_type::__decimal:
+    case __fmt_spec_type::__hexadecimal_lower_case:
+    case __fmt_spec_type::__hexadecimal_upper_case:
+      break;
+    default:
+      ::cuda::std::__throw_invalid_type_format_error(__id);
+  }
+}
+
+template <class _CharT>
+_CCCL_API constexpr void __fmt_process_parsed_int(__fmt_spec_parser<_CharT>& __parser)
+{
+  constexpr auto& __id = "an integer";
+
+  switch (__parser.__type_)
+  {
+    case __fmt_spec_type::__default:
+    case __fmt_spec_type::__binary_lower_case:
+    case __fmt_spec_type::__binary_upper_case:
+    case __fmt_spec_type::__octal:
+    case __fmt_spec_type::__decimal:
+    case __fmt_spec_type::__hexadecimal_lower_case:
+    case __fmt_spec_type::__hexadecimal_upper_case:
+      break;
+    case __fmt_spec_type::__char:
+      ::cuda::std::__fmt_process_display_type_char(__parser, __id);
+      break;
+    default:
+      ::cuda::std::__throw_invalid_type_format_error(__id);
+  }
+}
+
+template <class _CharT>
+_CCCL_API constexpr void __fmt_process_parsed_fp(__fmt_spec_parser<_CharT>& __parser)
+{
+  switch (__parser.__type_)
+  {
+    case __fmt_spec_type::__default:
+    case __fmt_spec_type::__hexfloat_lower_case:
+    case __fmt_spec_type::__hexfloat_upper_case:
+      // Precision specific behavior will be handled later.
+      break;
+    case __fmt_spec_type::__scientific_lower_case:
+    case __fmt_spec_type::__scientific_upper_case:
+    case __fmt_spec_type::__fixed_lower_case:
+    case __fmt_spec_type::__fixed_upper_case:
+    case __fmt_spec_type::__general_lower_case:
+    case __fmt_spec_type::__general_upper_case:
+      if (!__parser.__precision_as_arg_ && __parser.__precision_ == -1)
+      {
+        // Set the default precision for the call to to_chars.
+        __parser.__precision_ = 6;
+      }
+      break;
+    default:
+      ::cuda::std::__throw_invalid_type_format_error("a floating-point");
+  }
+}
+
+_CCCL_API constexpr void __fmt_process_display_type_ptr(__fmt_spec_type __type)
+{
+  switch (__type)
+  {
+    case __fmt_spec_type::__default:
+    case __fmt_spec_type::__pointer_lower_case:
+    case __fmt_spec_type::__pointer_upper_case:
+      break;
+    default:
+      ::cuda::std::__throw_invalid_type_format_error("a pointer");
+  }
+}
+
+template <class _It>
+struct __fmt_column_width_result
+{
+  // The number of output columns.
+  size_t __width_;
+  // One beyond the last code unit used in the estimation.
+  //
+  // This limits the original output to fit in the wanted number of columns.
+  _It __last_;
+};
+
+template <class _It>
+_CCCL_HOST_DEVICE __fmt_column_width_result(size_t, _It) -> __fmt_column_width_result<_It>;
+
+//! Since a column width can be two it's possible that the requested column
+//! width can't be achieved. Depending on the intended usage the policy can be
+//! selected.
+//! - When used as precision the maximum width may not be exceeded and the
+//!   result should be "rounded down" to the previous boundary.
+//! - When used as a width we're done once the minimum is reached, but
+//!   exceeding is not an issue. Rounding down is an issue since that will
+//!   result in writing fill characters. Therefore the result needs to be
+//!   "rounded up".
+enum class __fmt_column_width_rounding
+{
+  __down,
+  __up,
+};
+
+template <class _CharT>
+[[nodiscard]] _CCCL_API constexpr __fmt_column_width_result<typename basic_string_view<_CharT>::const_iterator>
+__fmt_estimate_column_width(basic_string_view<_CharT> __str, size_t __maximum, __fmt_column_width_rounding) noexcept
+{
+  // When Unicode isn't supported assume ASCII and every code unit is one code
+  // point. In ASCII the estimated column width is always one. Thus there's no
+  // need for rounding.
+  size_t __width = ::cuda::std::min(__str.size(), __maximum);
+  return {__width, __str.begin() + __width};
+}
+
+_CCCL_END_NAMESPACE_CUDA_STD
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _LIBCUDACXX___FORMAT_FORMAT_SPEC_PARSER_H

--- a/libcudacxx/include/cuda/std/__format/formatter.h
+++ b/libcudacxx/include/cuda/std/__format/formatter.h
@@ -27,221 +27,30 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
-struct __disabled_formatter
+//! @brief A disabled formatter.
+//!
+//! This is used to disable formatting for types that are not supported.
+struct __fmt_disabled_formatter
 {
-  __disabled_formatter()                                       = delete;
-  __disabled_formatter(const __disabled_formatter&)            = delete;
-  __disabled_formatter(__disabled_formatter&&)                 = delete;
-  __disabled_formatter& operator=(const __disabled_formatter&) = delete;
-  __disabled_formatter& operator=(__disabled_formatter&&)      = delete;
+  __fmt_disabled_formatter()                                           = delete;
+  __fmt_disabled_formatter(const __fmt_disabled_formatter&)            = delete;
+  __fmt_disabled_formatter(__fmt_disabled_formatter&&)                 = delete;
+  __fmt_disabled_formatter& operator=(const __fmt_disabled_formatter&) = delete;
+  __fmt_disabled_formatter& operator=(__fmt_disabled_formatter&&)      = delete;
 };
 
-template <class _Tp>
-struct __dummy_formatter
-{
-  template <class _ParseContext>
-  _CCCL_API constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx)
-  {
-    _CCCL_ASSERT(false, "unimplemented formatter parse method called");
-    return __ctx.begin();
-  }
-
-  template <class _FormatContext>
-  _CCCL_API typename _FormatContext::iterator format(const _Tp& __value, _FormatContext& __ctx) const
-  {
-    _CCCL_ASSERT(false, "unimplemented formatter format method called");
-    (void) __value;
-    return __ctx.out();
-  }
-};
-
-/// The default formatter template.
-///
-/// [format.formatter.spec]/5
-/// If F is a disabled specialization of formatter, these values are false:
-/// - is_default_constructible_v<F>,
-/// - is_copy_constructible_v<F>,
-/// - is_move_constructible_v<F>,
-/// - is_copy_assignable_v<F>, and
-/// - is_move_assignable_v<F>.
+//! @brief The default formatter template.
+//!
+//! [format.formatter.spec]/5
+//! If F is a disabled specialization of formatter, these values are false:
+//! - is_default_constructible_v<F>,
+//! - is_copy_constructible_v<F>,
+//! - is_move_constructible_v<F>,
+//! - is_copy_assignable_v<F>, and
+//! - is_move_assignable_v<F>.
 template <class _Tp, class _CharT = char>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter : __disabled_formatter
+struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter : __fmt_disabled_formatter
 {};
-
-// todo: implement the formatters
-template <>
-struct formatter<bool, char> : __dummy_formatter<bool>
-{};
-template <>
-struct formatter<char, char> : __dummy_formatter<char>
-{};
-template <>
-struct formatter<float, char> : __dummy_formatter<float>
-{};
-template <>
-struct formatter<double, char> : __dummy_formatter<double>
-{};
-#if _CCCL_HAS_LONG_DOUBLE()
-template <>
-struct formatter<long double, char> : __dummy_formatter<long double>
-{};
-#endif // _CCCL_HAS_LONG_DOUBLE()
-template <>
-struct formatter<signed char, char> : __dummy_formatter<signed char>
-{};
-template <>
-struct formatter<short, char> : __dummy_formatter<short>
-{};
-template <>
-struct formatter<int, char> : __dummy_formatter<int>
-{};
-template <>
-struct formatter<long, char> : __dummy_formatter<long>
-{};
-template <>
-struct formatter<long long, char> : __dummy_formatter<long long>
-{};
-#if _CCCL_HAS_INT128()
-template <>
-struct formatter<__int128_t, char> : __dummy_formatter<__int128_t>
-{};
-#endif // _CCCL_HAS_INT128()
-template <>
-struct formatter<unsigned char, char> : __dummy_formatter<unsigned char>
-{};
-template <>
-struct formatter<unsigned short, char> : __dummy_formatter<unsigned short>
-{};
-template <>
-struct formatter<unsigned, char> : __dummy_formatter<unsigned>
-{};
-template <>
-struct formatter<unsigned long, char> : __dummy_formatter<unsigned long>
-{};
-template <>
-struct formatter<unsigned long long, char> : __dummy_formatter<unsigned long long>
-{};
-#if _CCCL_HAS_INT128()
-template <>
-struct formatter<__uint128_t, char> : __dummy_formatter<__uint128_t>
-{};
-#endif // _CCCL_HAS_INT128()
-template <>
-struct formatter<nullptr_t, char> : __dummy_formatter<nullptr_t>
-{};
-template <>
-struct formatter<void*, char> : __dummy_formatter<void*>
-{};
-template <>
-struct formatter<const void*, char> : __dummy_formatter<const void*>
-{};
-template <>
-struct formatter<const char*, char> : __dummy_formatter<const char*>
-{};
-template <>
-struct formatter<char*, char> : __dummy_formatter<char*>
-{};
-template <size_t _Size>
-struct formatter<char[_Size], char> : __dummy_formatter<char[_Size]>
-{};
-template <class _Traits>
-struct formatter<basic_string_view<char, _Traits>, char> : __dummy_formatter<basic_string_view<char, _Traits>>
-{};
-
-#if _CCCL_HAS_WCHAR_T()
-template <>
-struct formatter<bool, wchar_t> : __dummy_formatter<bool>
-{};
-template <>
-struct formatter<char, wchar_t> : __dummy_formatter<wchar_t>
-{};
-template <>
-struct formatter<wchar_t, wchar_t> : __dummy_formatter<wchar_t>
-{};
-struct formatter<float, wchar_t> : __dummy_formatter<float>
-{};
-template <>
-struct formatter<double, wchar_t> : __dummy_formatter<double>
-{};
-#  if _CCCL_HAS_LONG_DOUBLE()
-template <>
-struct formatter<long double, wchar_t> : __dummy_formatter<long double>
-{};
-#  endif // _CCCL_HAS_LONG_DOUBLE()
-template <>
-struct formatter<signed char, wchar_t> : __dummy_formatter<signed char>
-{};
-template <>
-struct formatter<short, wchar_t> : __dummy_formatter<short>
-{};
-template <>
-struct formatter<int, wchar_t> : __dummy_formatter<int>
-{};
-template <>
-struct formatter<long, wchar_t> : __dummy_formatter<long>
-{};
-template <>
-struct formatter<long long, wchar_t> : __dummy_formatter<long long>
-{};
-#  if _CCCL_HAS_INT128()
-template <>
-struct formatter<__int128_t, wchar_t> : __dummy_formatter<__int128_t>
-{};
-#  endif // _CCCL_HAS_INT128()
-template <>
-struct formatter<unsigned char, wchar_t> : __dummy_formatter<unsigned char>
-{};
-template <>
-struct formatter<unsigned short, wchar_t> : __dummy_formatter<unsigned short>
-{};
-template <>
-struct formatter<unsigned, wchar_t> : __dummy_formatter<unsigned>
-{};
-template <>
-struct formatter<unsigned long, wchar_t> : __dummy_formatter<unsigned long>
-{};
-template <>
-struct formatter<unsigned long long, wchar_t> : __dummy_formatter<unsigned long long>
-{};
-#  if _CCCL_HAS_INT128()
-template <>
-struct formatter<__uint128_t, wchar_t> : __dummy_formatter<__uint128_t>
-{};
-#  endif // _CCCL_HAS_INT128()
-template <>
-struct formatter<nullptr_t, wchar_t> : __dummy_formatter<nullptr_t>
-{};
-template <>
-struct formatter<void*, wchar_t> : __dummy_formatter<void*>
-{};
-template <>
-struct formatter<const void*, wchar_t> : __dummy_formatter<const void*>
-{};
-template <>
-struct formatter<const wchar_t*, wchar_t> : __dummy_formatter<const wchar_t*>
-{};
-template <>
-struct formatter<wchar_t*, wchar_t> : __dummy_formatter<wchar_t*>
-{};
-template <size_t _Size>
-struct formatter<wchar_t[_Size], wchar_t> : __dummy_formatter<wchar_t[_Size]>
-{};
-template <class _Traits>
-struct formatter<basic_string_view<wchar_t, _Traits>, wchar_t> : __dummy_formatter<basic_string_view<wchar_t, _Traits>>
-{};
-template <>
-struct formatter<char*, wchar_t> : __disabled_formatter
-{};
-template <>
-struct formatter<const char*, wchar_t> : __disabled_formatter
-{};
-template <size_t _Size>
-struct formatter<char[_Size], wchar_t> : __disabled_formatter
-{};
-template <class _Traits>
-struct formatter<basic_string_view<char, _Traits>, wchar_t> : __disabled_formatter
-{};
-#endif // _CCCL_HAS_WCHAR_T()
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/libcudacxx/include/cuda/std/__format/formatters/bool.h
+++ b/libcudacxx/include/cuda/std/__format/formatters/bool.h
@@ -1,0 +1,101 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___FORMAT_FORMATERS_BOOL_H
+#define _LIBCUDACXX___FORMAT_FORMATERS_BOOL_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__format/format_integral.h>
+#include <cuda/std/__format/format_spec_parser.h>
+#include <cuda/std/__format/formatter.h>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD
+
+//!
+//! @brief Formatter for boolean values.
+//!
+//! @tparam _CharT The character type used for formatting.
+//!
+template <class _CharT>
+struct __fmt_formatter_bool
+{
+  //!
+  //! @brief Parses the formatting specifications for boolean values.
+  //!
+  //! @param __ctx The parsing context containing the format specification.
+  //! @return An iterator pointing to the end of the parsed format specification.
+  //!
+  template <class _ParseCtx>
+  _CCCL_API constexpr typename _ParseCtx::iterator parse(_ParseCtx& __ctx)
+  {
+    typename _ParseCtx::iterator __result = __parser_.__parse(__ctx, ::cuda::std::__fmt_spec_fields_int());
+    ::cuda::std::__fmt_process_parsed_bool(__parser_);
+    return __result;
+  }
+
+  //!
+  //! @brief Formats a boolean value according to the parsed specifications.
+  //!
+  //! @param __value The boolean value to format.
+  //! @param __ctx The formatting context where the formatted output will be stored.
+  //! @return An iterator pointing to the end of the formatted output.
+  //!
+  template <class _FmtCtx>
+  _CCCL_API typename _FmtCtx::iterator format(bool __value, _FmtCtx& __ctx) const
+  {
+    switch (__parser_.__type_)
+    {
+      case __fmt_spec_type::__default:
+      case __fmt_spec_type::__string:
+        return ::cuda::std::__fmt_format_bool(__value, __ctx, __parser_.__get_parsed_std_spec(__ctx));
+      case __fmt_spec_type::__binary_lower_case:
+      case __fmt_spec_type::__binary_upper_case:
+      case __fmt_spec_type::__octal:
+      case __fmt_spec_type::__decimal:
+      case __fmt_spec_type::__hexadecimal_lower_case:
+      case __fmt_spec_type::__hexadecimal_upper_case:
+        // Promotes bool to an integral type. This reduces the number of
+        // instantiations of __format_integer reducing code size.
+        return ::cuda::std::__fmt_format_int(
+          static_cast<unsigned>(__value), __ctx, __parser_.__get_parsed_std_spec(__ctx));
+      default:
+        _CCCL_UNREACHABLE();
+    }
+  }
+
+private:
+  __fmt_spec_parser<_CharT> __parser_; //!< The parser for format specifications.
+};
+
+template <>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter<bool, char> : __fmt_formatter_bool<char>
+{};
+
+#if _CCCL_HAS_WCHAR_T()
+template <>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter<bool, wchar_t> : __fmt_formatter_bool<wchar_t>
+{};
+#endif // _CCCL_HAS_WCHAR_T()
+
+_CCCL_END_NAMESPACE_CUDA_STD
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _LIBCUDACXX___FORMAT_FORMATERS_BOOL_H

--- a/libcudacxx/include/cuda/std/__format/formatters/char.h
+++ b/libcudacxx/include/cuda/std/__format/formatters/char.h
@@ -1,0 +1,124 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___FORMAT_FORMATERS_CHAR_H
+#define _LIBCUDACXX___FORMAT_FORMATERS_CHAR_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__concepts/concept_macros.h>
+#include <cuda/std/__format/format_integral.h>
+#include <cuda/std/__format/format_spec_parser.h>
+#include <cuda/std/__format/formatter.h>
+#include <cuda/std/__type_traits/is_same.h>
+#include <cuda/std/__type_traits/make_unsigned.h>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD
+
+//!
+//! @brief Formatter for character types.
+//!
+//! @tparam _CharT The character type used for formatting.
+//!
+template <class _CharT>
+struct __fmt_formatter_char
+{
+  //!
+  //! @brief Parses the formatting specifications for character types.
+  //!
+  //! @param __ctx The parsing context containing the format specification.
+  //! @return An iterator pointing to the end of the parsed format specification.
+  //!
+  template <class _ParseCtx>
+  _CCCL_API constexpr typename _ParseCtx::iterator parse(_ParseCtx& __ctx)
+  {
+    typename _ParseCtx::iterator __result = __parser_.__parse(__ctx, ::cuda::std::__fmt_spec_fields_int());
+    ::cuda::std::__fmt_process_parsed_char(__parser_);
+    return __result;
+  }
+
+  //!
+  //! @brief Formats a character value according to the parsed specifications.
+  //!
+  //! @param __value The character value to format.
+  //! @param __ctx The formatting context where the formatted output will be stored.
+  //! @return An iterator pointing to the end of the formatted output.
+  //!
+  template <class _FmtCtx>
+  _CCCL_API typename _FmtCtx::iterator format(_CharT __value, _FmtCtx& __ctx) const
+  {
+    using _Up = make_unsigned_t<_CharT>;
+
+    const auto __specs = __parser_.__get_parsed_std_spec(__ctx);
+
+    if (__parser_.__type_ == __fmt_spec_type::__default || __parser_.__type_ == __fmt_spec_type::__char)
+    {
+      return ::cuda::std::__fmt_format_char(__value, __ctx.out(), __specs);
+    }
+
+    if constexpr (sizeof(_CharT) <= sizeof(unsigned))
+    {
+      return ::cuda::std::__fmt_format_int(static_cast<unsigned>(static_cast<_Up>(__value)), __ctx, __specs);
+    }
+    else
+    {
+      return ::cuda::std::__fmt_format_int(static_cast<_Up>(__value), __ctx, __specs);
+    }
+  }
+
+#if _CCCL_HAS_WCHAR_T()
+  //!
+  //! @brief Formats a character value as a wide character.
+  //!
+  //! @param __value The character value to format.
+  //! @param __ctx The formatting context where the formatted output will be stored.
+  //! @return An iterator pointing to the end of the formatted output.
+  //!
+  //! @details This overload allows formatting of a `char` type as a `wchar_t`.
+  //!
+  _CCCL_TEMPLATE(class _FmtCtx, class _CharT2 = _CharT)
+  _CCCL_REQUIRES(is_same_v<_CharT2, wchar_t>)
+  _CCCL_API typename _FmtCtx::iterator format(char __value, _FmtCtx& __ctx) const
+  {
+    return format(static_cast<wchar_t>(static_cast<unsigned char>(__value)), __ctx);
+  }
+#endif // _CCCL_HAS_WCHAR_T()
+
+private:
+  __fmt_spec_parser<_CharT> __parser_; //!< The parser for format specifications.
+};
+
+template <>
+struct formatter<char, char> : __fmt_formatter_char<char>
+{};
+
+#if _CCCL_HAS_WCHAR_T()
+template <>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter<char, wchar_t> : __fmt_formatter_char<wchar_t>
+{};
+template <>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter<wchar_t, wchar_t> : __fmt_formatter_char<wchar_t>
+{};
+#endif // _CCCL_HAS_WCHAR_T()
+
+_CCCL_END_NAMESPACE_CUDA_STD
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _LIBCUDACXX___FORMAT_FORMATERS_CHAR_H

--- a/libcudacxx/include/cuda/std/__format/formatters/fp.h
+++ b/libcudacxx/include/cuda/std/__format/formatters/fp.h
@@ -1,0 +1,101 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___FORMAT_FORMATERS_FP_H
+#define _LIBCUDACXX___FORMAT_FORMATERS_FP_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__format/format_spec_parser.h>
+#include <cuda/std/__format/formatter.h>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD
+
+//!
+//! @brief Formatter for floating-point types.
+//!
+//! @tparam _CharT The character type used for formatting.
+//!
+template <class _CharT>
+struct __fmt_formatter_fp
+{
+  //!
+  //! @brief Parses the formatting specifications for floating-point types.
+  //!
+  //! @param __ctx The parsing context containing the format specification.
+  //! @return An iterator pointing to the end of the parsed format specification.
+  //!
+  template <class _ParseCtx>
+  _CCCL_API constexpr typename _ParseCtx::iterator parse(_ParseCtx& __ctx)
+  {
+    typename _ParseCtx::iterator __result = __parser_.__parse(__ctx, ::cuda::std::__fmt_spec_fields_fp());
+    ::cuda::std::__fmt_process_parsed_fp(__parser_);
+    return __result;
+  }
+
+  //!
+  //! @brief Formats a floating-point value according to the parsed specifications.
+  //!
+  //! @param __value The floating-point value to format.
+  //! @param __ctx The formatting context where the formatted output will be stored.
+  //! @return An iterator pointing to the end of the formatted output.
+  //!
+  template <class _Tp, class _FmtCtx>
+  _CCCL_API typename _FmtCtx::iterator format(_Tp __value, _FmtCtx& __ctx) const
+  {
+    _CCCL_ASSERT(false, "formatter</*floating-point-type*/>::format() is not implemented");
+    (void) __value;
+    return __ctx.out();
+  }
+
+private:
+  __fmt_spec_parser<_CharT> __parser_; //!< The parser for format specifications.
+};
+
+template <>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter<float, char> : __fmt_formatter_fp<char>
+{};
+template <>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter<double, char> : __fmt_formatter_fp<char>
+{};
+#if _CCCL_HAS_LONG_DOUBLE()
+template <>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter<long double, char> : __fmt_formatter_fp<char>
+{};
+#endif // _CCCL_HAS_LONG_DOUBLE()
+
+#if _CCCL_HAS_WCHAR_T()
+template <>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter<float, wchar_t> : __fmt_formatter_fp<wchar_t>
+{};
+template <>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter<double, wchar_t> : __fmt_formatter_fp<wchar_t>
+{};
+#  if _CCCL_HAS_LONG_DOUBLE()
+template <>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter<long double, wchar_t> : __fmt_formatter_fp<wchar_t>
+{};
+#  endif // _CCCL_HAS_LONG_DOUBLE()
+#endif // _CCCL_HAS_WCHAR_T()
+
+_CCCL_END_NAMESPACE_CUDA_STD
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _LIBCUDACXX___FORMAT_FORMATERS_FP_H

--- a/libcudacxx/include/cuda/std/__format/formatters/int.h
+++ b/libcudacxx/include/cuda/std/__format/formatters/int.h
@@ -1,0 +1,174 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___FORMAT_FORMATERS_INT_H
+#define _LIBCUDACXX___FORMAT_FORMATERS_INT_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/max.h>
+#include <cuda/std/__format/format_integral.h>
+#include <cuda/std/__format/format_spec_parser.h>
+#include <cuda/std/__format/formatter.h>
+#include <cuda/std/__type_traits/is_signed.h>
+#include <cuda/std/__type_traits/make_nbit_int.h>
+#include <cuda/std/climits>
+#include <cuda/std/cstdint>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD
+
+//!
+//! @brief Formatter for integer types.
+//!
+//! @tparam _CharT The character type used for formatting.
+//!
+template <class _CharT>
+struct __fmt_formatter_int
+{
+  //!
+  //! @brief Parses the formatting specifications for integer types.
+  //!
+  //! @param __ctx The parsing context containing the format specification.
+  //! @return An iterator pointing to the end of the parsed format specification.
+  //!
+  template <class _ParseCtx>
+  _CCCL_API constexpr typename _ParseCtx::iterator parse(_ParseCtx& __ctx)
+  {
+    typename _ParseCtx::iterator __result = __parser_.__parse(__ctx, ::cuda::std::__fmt_spec_fields_int());
+    ::cuda::std::__fmt_process_parsed_int(__parser_);
+    return __result;
+  }
+
+  //!
+  //! @brief Formats an integer value according to the parsed specifications.
+  //!
+  //! @param __value The integer value to format.
+  //! @param __ctx The formatting context where the formatted output will be stored.
+  //! @return An iterator pointing to the end of the formatted output.
+  //!
+  template <class _Tp, class _FmtCtx>
+  _CCCL_API typename _FmtCtx::iterator format(_Tp __value, _FmtCtx& __ctx) const
+  {
+    const auto __specs = __parser_.__get_parsed_std_spec(__ctx);
+
+    if (__specs.__std_.__type_ == __fmt_spec_type::__char)
+    {
+      return ::cuda::std::__fmt_format_char(__value, __ctx.out(), __specs);
+    }
+
+    using _Type =
+      __make_nbit_int_t<::cuda::std::max(sizeof(_Tp) * CHAR_BIT, sizeof(int32_t) * CHAR_BIT), is_signed_v<_Tp>>;
+
+    // Reduce the number of instantiation of the integer formatter
+    return ::cuda::std::__fmt_format_int(static_cast<_Type>(__value), __ctx, __specs);
+  }
+
+private:
+  __fmt_spec_parser<_CharT> __parser_; //!< The parser for format specifications.
+};
+
+template <>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter<signed char, char> : __fmt_formatter_int<char>
+{};
+template <>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter<short, char> : __fmt_formatter_int<char>
+{};
+template <>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter<int, char> : __fmt_formatter_int<char>
+{};
+template <>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter<long, char> : __fmt_formatter_int<char>
+{};
+template <>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter<long long, char> : __fmt_formatter_int<char>
+{};
+#if _CCCL_HAS_INT128()
+template <>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter<__int128_t, char> : __fmt_formatter_int<char>
+{};
+#endif // _CCCL_HAS_INT128()
+template <>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter<unsigned char, char> : __fmt_formatter_int<char>
+{};
+template <>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter<unsigned short, char> : __fmt_formatter_int<char>
+{};
+template <>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter<unsigned, char> : __fmt_formatter_int<char>
+{};
+template <>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter<unsigned long, char> : __fmt_formatter_int<char>
+{};
+template <>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter<unsigned long long, char> : __fmt_formatter_int<char>
+{};
+#if _CCCL_HAS_INT128()
+template <>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter<__uint128_t, char> : __fmt_formatter_int<char>
+{};
+#endif // _CCCL_HAS_INT128()
+
+#if _CCCL_HAS_WCHAR_T()
+template <>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter<signed char, wchar_t> : __fmt_formatter_int<wchar_t>
+{};
+template <>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter<short, wchar_t> : __fmt_formatter_int<wchar_t>
+{};
+template <>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter<int, wchar_t> : __fmt_formatter_int<wchar_t>
+{};
+template <>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter<long, wchar_t> : __fmt_formatter_int<wchar_t>
+{};
+template <>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter<long long, wchar_t> : __fmt_formatter_int<wchar_t>
+{};
+#  if _CCCL_HAS_INT128()
+template <>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter<__int128_t, wchar_t> : __fmt_formatter_int<wchar_t>
+{};
+#  endif // _CCCL_HAS_INT128()
+template <>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter<unsigned char, wchar_t> : __fmt_formatter_int<wchar_t>
+{};
+template <>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter<unsigned short, wchar_t> : __fmt_formatter_int<wchar_t>
+{};
+template <>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter<unsigned, wchar_t> : __fmt_formatter_int<wchar_t>
+{};
+template <>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter<unsigned long, wchar_t> : __fmt_formatter_int<wchar_t>
+{};
+template <>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter<unsigned long long, wchar_t> : __fmt_formatter_int<wchar_t>
+{};
+#  if _CCCL_HAS_INT128()
+template <>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter<__uint128_t, wchar_t> : __fmt_formatter_int<wchar_t>
+{};
+#  endif // _CCCL_HAS_INT128()
+#endif // _CCCL_HAS_WCHAR_T()
+
+_CCCL_END_NAMESPACE_CUDA_STD
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _LIBCUDACXX___FORMAT_FORMATERS_INT_H

--- a/libcudacxx/include/cuda/std/__format/formatters/ptr.h
+++ b/libcudacxx/include/cuda/std/__format/formatters/ptr.h
@@ -1,0 +1,104 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___FORMAT_FORMATERS_PTR_H
+#define _LIBCUDACXX___FORMAT_FORMATERS_PTR_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__format/format_integral.h>
+#include <cuda/std/__format/format_spec_parser.h>
+#include <cuda/std/__format/formatter.h>
+#include <cuda/std/cstdint>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD
+
+//!
+//! @brief Formatter for pointer types.
+//!
+//! @tparam _CharT The character type used for formatting.
+//!
+template <class _CharT>
+struct __fmt_formatter_ptr
+{
+  //!
+  //! @brief Parses the formatting specifications for pointer types.
+  //!
+  //! @param __ctx The parsing context containing the format specification.
+  //! @return An iterator pointing to the end of the parsed format specification.
+  //!
+  template <class _ParseCtx>
+  _CCCL_API constexpr typename _ParseCtx::iterator parse(_ParseCtx& __ctx)
+  {
+    typename _ParseCtx::iterator __result = __parser_.__parse(__ctx, ::cuda::std::__fmt_spec_fields_ptr());
+    ::cuda::std::__fmt_process_display_type_ptr(__parser_.__type_);
+    return __result;
+  }
+
+  //!
+  //! @brief Formats a pointer value according to the parsed specifications.
+  //!
+  //! @param __value The pointer value to format.
+  //! @param __ctx The formatting context where the formatted output will be stored.
+  //! @return An iterator pointing to the end of the formatted output.
+  //!
+  template <class _Tp, class _FmtCtx>
+  _CCCL_API typename _FmtCtx::iterator format([[maybe_unused]] _Tp __value, _FmtCtx& __ctx) const
+  {
+    auto __specs                     = __parser_.__get_parsed_std_spec(__ctx);
+    __specs.__std_.__alternate_form_ = true;
+    __specs.__std_.__type_ =
+      (__specs.__std_.__type_ == __fmt_spec_type::__pointer_upper_case)
+        ? __fmt_spec_type::__hexadecimal_upper_case
+        : __fmt_spec_type::__hexadecimal_lower_case;
+
+    return ::cuda::std::__fmt_format_int(reinterpret_cast<uintptr_t>(__value), __ctx, __specs);
+  }
+
+private:
+  __fmt_spec_parser<_CharT> __parser_; //!< The parser for format specifications.
+};
+
+template <>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter<nullptr_t, char> : __fmt_formatter_ptr<char>
+{};
+template <>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter<void*, char> : __fmt_formatter_ptr<char>
+{};
+template <>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter<const void*, char> : __fmt_formatter_ptr<char>
+{};
+
+#if _CCCL_HAS_WCHAR_T()
+template <>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter<nullptr_t, wchar_t> : __fmt_formatter_ptr<wchar_t>
+{};
+template <>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter<void*, wchar_t> : __fmt_formatter_ptr<wchar_t>
+{};
+template <>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter<const void*, wchar_t> : __fmt_formatter_ptr<wchar_t>
+{};
+#endif // _CCCL_HAS_WCHAR_T()
+
+_CCCL_END_NAMESPACE_CUDA_STD
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _LIBCUDACXX___FORMAT_FORMATERS_PTR_H

--- a/libcudacxx/include/cuda/std/__format/formatters/str.h
+++ b/libcudacxx/include/cuda/std/__format/formatters/str.h
@@ -1,0 +1,178 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___FORMAT_FORMATERS_STR_H
+#define _LIBCUDACXX___FORMAT_FORMATERS_STR_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__format/format_spec_parser.h>
+#include <cuda/std/__format/formatter.h>
+#include <cuda/std/__format/output_utils.h>
+#include <cuda/std/__string/char_traits.h>
+#include <cuda/std/__type_traits/is_null_pointer.h>
+#include <cuda/std/__type_traits/is_pointer.h>
+#include <cuda/std/__utility/to_underlying.h>
+#include <cuda/std/string_view>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD
+
+//!
+//! @brief Formatter for string types.
+//!
+//! @tparam _CharT The character type used for formatting.
+//!
+template <class _CharT>
+struct __fmt_formatter_str
+{
+  //!
+  //! @brief Parses the formatting specifications for string types.
+  //!
+  //! @param __ctx The parsing context containing the format specification.
+  //! @return An iterator pointing to the end of the parsed format specification.
+  //!
+  template <class _ParseCtx>
+  _CCCL_API constexpr typename _ParseCtx::iterator parse(_ParseCtx& __ctx)
+  {
+    typename _ParseCtx::iterator __result = __parser_.__parse(__ctx, ::cuda::std::__fmt_spec_fields_str());
+    ::cuda::std::__fmt_process_display_type_str(__parser_.__type_);
+    return __result;
+  }
+
+  //!
+  //! @brief Formats a string value according to the parsed specifications.
+  //!
+  //! @param __value The string value to format.
+  //! @param __ctx The formatting context where the formatted output will be stored.
+  //! @return An iterator pointing to the end of the formatted output.
+  //!
+  template <class _Tp, class _FmtCtx>
+  _CCCL_API typename _FmtCtx::iterator format(_Tp __value, _FmtCtx& __ctx) const
+  {
+    return __format(__value, __ctx);
+  }
+
+private:
+  //!
+  //! @brief Creates a parser for string formatting specifications.
+  //!
+  [[nodiscard]] _CCCL_API static constexpr __fmt_spec_parser<_CharT> __make_parser()
+  {
+    __fmt_spec_parser<_CharT> __parser{};
+    __parser.__alignment_ = ::cuda::std::to_underlying(__fmt_spec_alignment::__left);
+    return __parser;
+  }
+
+  //!
+  //! @brief Formats a C-string according to the parsed specifications.
+  //!
+  //! @param __str The C-string to format.
+  //! @param __ctx The formatting context where the formatted output will be stored.
+  //! @return An iterator pointing to the end of the formatted output.
+  //!
+  template <class _FmtCtx>
+  [[nodiscard]] _CCCL_API typename _FmtCtx::iterator __format(const _CharT* __str, _FmtCtx& __ctx) const
+  {
+    return __format(basic_string_view{__str}, __ctx);
+  }
+
+  //!
+  //! @brief Formats a fixed-size array of characters according to the parsed specifications.
+  //!
+  //! @param __str The fixed-size array of characters to format.
+  //! @param __ctx The formatting context where the formatted output will be stored.
+  //! @return An iterator pointing to the end of the formatted output.
+  //!
+  template <class _FmtCtx, size_t _Size>
+  [[nodiscard]] _CCCL_API typename _FmtCtx::iterator __format(const _CharT (&__str)[_Size], _FmtCtx& __ctx) const
+  {
+    const _CharT* const __pzero = char_traits<_CharT>::find(__str, _Size, _CharT{});
+    _CCCL_ASSERT(__pzero != nullptr, "formatting a non-null-terminated array");
+    return __format(basic_string_view{__str, static_cast<size_t>(__pzero - __str)}, __ctx);
+  }
+
+  //!
+  //! @brief Formats a `basic_string_view` according to the parsed specifications.
+  //!
+  //! @param __str The `basic_string_view` to format.
+  //! @param __ctx The formatting context where the formatted output will be stored.
+  //! @return An iterator pointing to the end of the formatted output.
+  //!
+  template <class _FmtCtx, class _Traits>
+  [[nodiscard]] _CCCL_API typename _FmtCtx::iterator
+  __format(basic_string_view<_CharT, _Traits> __str, _FmtCtx& __ctx) const
+  {
+    basic_string_view __str2{__str.data(), __str.size()};
+    return ::cuda::std::__fmt_write_string(__str2, __ctx.out(), __parser_.__get_parsed_std_spec(__ctx));
+  }
+
+  __fmt_spec_parser<_CharT> __parser_ = __make_parser(); //!< The parser for format specifications.
+};
+
+template <>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter<const char*, char> : __fmt_formatter_str<char>
+{};
+template <>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter<char*, char> : __fmt_formatter_str<char>
+{};
+template <size_t _Size>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter<char[_Size], char> : __fmt_formatter_str<char>
+{};
+template <class _Traits>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter<basic_string_view<char, _Traits>, char> : __fmt_formatter_str<char>
+{};
+
+#if _CCCL_HAS_WCHAR_T()
+template <>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter<const char*, wchar_t> : __fmt_formatter_str<wchar_t>
+{};
+template <>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter<char*, wchar_t> : __fmt_formatter_str<wchar_t>
+{};
+template <size_t _Size>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter<char[_Size], wchar_t> : __fmt_formatter_str<wchar_t>
+{};
+template <class _Traits>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter<basic_string_view<char, _Traits>, wchar_t> : __fmt_formatter_str<wchar_t>
+{};
+
+// Disable formatting string of type char to wchar_t output
+template <>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter<char*, wchar_t> : __fmt_disabled_formatter
+{};
+template <>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter<const char*, wchar_t> : __fmt_disabled_formatter
+{};
+template <size_t _Size>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter<char[_Size], wchar_t> : __fmt_disabled_formatter
+{};
+template <class _Traits, class _Allocator>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT
+formatter<basic_string<char, _Traits, _Allocator>, wchar_t> : __fmt_disabled_formatter
+{};
+template <class _Traits>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT formatter<basic_string_view<char, _Traits>, wchar_t> : __fmt_disabled_formatter
+{};
+#endif // _CCCL_HAS_WCHAR_T()
+
+_CCCL_END_NAMESPACE_CUDA_STD
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _LIBCUDACXX___FORMAT_FORMATERS_STR_H

--- a/libcudacxx/include/cuda/std/__format/output_utils.h
+++ b/libcudacxx/include/cuda/std/__format/output_utils.h
@@ -1,0 +1,272 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___FORMAT_OUTPUT_UTILS_H
+#define _LIBCUDACXX___FORMAT_OUTPUT_UTILS_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/copy.h>
+#include <cuda/std/__algorithm/fill_n.h>
+#include <cuda/std/__algorithm/transform.h>
+#include <cuda/std/__cstddef/types.h>
+#include <cuda/std/__format/format_spec_parser.h>
+#include <cuda/std/__iterator/iterator_traits.h>
+#include <cuda/std/__utility/move.h>
+#include <cuda/std/string_view>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD
+
+[[nodiscard]] _CCCL_API constexpr char __fmt_hex_to_upper(char __c) noexcept
+{
+  switch (__c)
+  {
+    case 'a':
+      return 'A';
+    case 'b':
+      return 'B';
+    case 'c':
+      return 'C';
+    case 'd':
+      return 'D';
+    case 'e':
+      return 'E';
+    case 'f':
+      return 'F';
+    default:
+      return __c;
+  }
+}
+
+struct __fmt_padding_size_result
+{
+  size_t __before_;
+  size_t __after_;
+};
+
+// nvcc warns about missing return statement when compiling with msvc host compiler, adding more unreachables doesn't
+// help, so let's just suppress the warning
+#if _CCCL_COMPILER(MSVC)
+_CCCL_BEGIN_NV_DIAG_SUPPRESS(940) // missing return statement at end of non-void function
+#endif // _CCCL_COMPILER(MSVC)
+
+[[nodiscard]] _CCCL_API constexpr __fmt_padding_size_result
+__fmt_padding_size(size_t __size, size_t __width, __fmt_spec_alignment __align)
+{
+  _CCCL_ASSERT(__width > __size, "don't call this function when no padding is required");
+  _CCCL_ASSERT(__align != __fmt_spec_alignment::__zero_padding, "the caller should have handled the zero-padding");
+
+  const size_t __fill = __width - __size;
+  switch (__align)
+  {
+    case __fmt_spec_alignment::__left:
+      return {0, __fill};
+    case __fmt_spec_alignment::__center: {
+      // The extra padding is divided per [format.string.std]/3
+      // __before = floor(__fill, 2);
+      // __after = ceil(__fill, 2);
+      const size_t __before = __fill / 2;
+      const size_t __after  = __fill - __before;
+      return {__before, __after};
+    }
+    case __fmt_spec_alignment::__default:
+    case __fmt_spec_alignment::__right:
+      return {__fill, 0};
+    case __fmt_spec_alignment::__zero_padding:
+    default:
+      _CCCL_UNREACHABLE();
+  }
+}
+
+#if _CCCL_COMPILER(MSVC)
+_CCCL_END_NV_DIAG_SUPPRESS()
+#endif // _CCCL_COMPILER(MSVC)
+
+//! Copy wrapper.
+//!
+//! This uses a "mass output function" of __format::__output_buffer when possible.
+template <class _CharT, class _OutCharT = _CharT, class _OutIt>
+[[nodiscard]] _CCCL_API _OutIt __fmt_copy(basic_string_view<_CharT> __str, _OutIt __out_it)
+{
+  // todo: handle __fmt_output_buffer and __fmt_retarget_buffer when they are implemented
+  return ::cuda::std::copy(__str.begin(), __str.end(), ::cuda::std::move(__out_it));
+}
+
+template <class _It, class _CharT = iter_value_t<_It>, class _OutCharT = _CharT, class _OutIt>
+[[nodiscard]] _CCCL_API _OutIt __fmt_copy(_It __first, _It __last, _OutIt __out_it)
+{
+  return ::cuda::std::__fmt_copy(basic_string_view{__first, __last}, ::cuda::std::move(__out_it));
+}
+
+template <class _It, class _CharT = iter_value_t<_It>, class _OutCharT = _CharT, class _OutIt>
+[[nodiscard]] _CCCL_API _OutIt __fmt_copy(_It __first, size_t __n, _OutIt __out_it)
+{
+  return ::cuda::std::__fmt_copy(basic_string_view{::cuda::std::to_address(__first), __n}, ::cuda::std::move(__out_it));
+}
+
+//! Transform wrapper.
+//!
+//! This uses a "mass output function" of __format::__output_buffer when possible.
+template <class _It, class _CharT = iter_value_t<_It>, class _OutCharT = _CharT, class _OutIt, class _UnaryOp>
+[[nodiscard]] _CCCL_API _OutIt __fmt_transform(_It __first, _It __last, _OutIt __out_it, _UnaryOp __operation)
+{
+  // todo: handle __fmt_output_buffer and __fmt_retarget_buffer when they are implemented
+  return ::cuda::std::transform(__first, __last, ::cuda::std::move(__out_it), __operation);
+}
+
+//! Fill wrapper.
+//!
+//! This uses a "mass output function" of __format::__output_buffer when possible.
+template <class _CharT, class _OutIt>
+[[nodiscard]] _CCCL_API _OutIt __fmt_fill(_OutIt __out_it, size_t __n, _CharT __value)
+{
+  // todo: handle __fmt_output_buffer and __fmt_retarget_buffer when they are implemented
+  return ::cuda::std::fill_n(::cuda::std::move(__out_it), __n, __value);
+}
+
+template <class _CharT, class _OutIt>
+[[nodiscard]] _CCCL_API _OutIt __fmt_fill(_OutIt __out_it, size_t __n, __fmt_spec_code_point<_CharT> __value)
+{
+  return ::cuda::std::__fmt_fill(::cuda::std::move(__out_it), __n, __value.__data[0]);
+}
+
+//! Writes the input to the output with the required padding.
+//!
+//! Since the output column width is specified the function can be used for
+//! ASCII and Unicode output.
+//!
+//! @pre \a __size <= \a __width. Using this function when this pre-condition
+//!      doesn't hold incurs an unwanted overhead.
+//!
+//! @param __str       The string to write.
+//! @param __out_it    The output iterator to write to.
+//! @param __specs     The parsed formatting specifications.
+//! @param __size      The (estimated) output column width. When the elements
+//!                    to be written are ASCII the following condition holds
+//!                    \a __size == \a __last - \a __first.
+//!
+//! @returns           An iterator pointing beyond the last element written.
+//!
+//! @note The type of the elements in range [\a __first, \a __last) can differ
+//! from the type of \a __specs. Integer output uses \c std::to_chars for its
+//! conversion, which means the [\a __first, \a __last) always contains elements
+//! of the type \c char.
+template <class _CharT, class _ParserCharT, class _OutIt>
+[[nodiscard]] _CCCL_API _OutIt
+__fmt_write(basic_string_view<_CharT> __str, _OutIt __out_it, __fmt_parsed_spec<_ParserCharT> __specs, ptrdiff_t __size)
+{
+  if (__size >= static_cast<ptrdiff_t>(__specs.__width_))
+  {
+    return ::cuda::std::__fmt_copy(__str, ::cuda::std::move(__out_it));
+  }
+
+  const auto __padding =
+    ::cuda::std::__fmt_padding_size(__size, __specs.__width_, __fmt_spec_alignment{__specs.__std_.__alignment_});
+  __out_it = ::cuda::std::__fmt_fill(::cuda::std::move(__out_it), __padding.__before_, __specs.__fill_);
+  __out_it = ::cuda::std::__fmt_copy(__str, ::cuda::std::move(__out_it));
+  return ::cuda::std::__fmt_fill(::cuda::std::move(__out_it), __padding.__after_, __specs.__fill_);
+}
+
+template <class _It, class _ParserCharT, class _OutIt>
+[[nodiscard]] _CCCL_API _OutIt
+__fmt_write(_It __first, _It __last, _OutIt __out_it, __fmt_parsed_spec<_ParserCharT> __specs, ptrdiff_t __size)
+{
+  _CCCL_ASSERT(__first <= __last, "Not a valid range");
+  return ::cuda::std::__fmt_write(basic_string_view{__first, __last}, ::cuda::std::move(__out_it), __specs, __size);
+}
+
+// Calls the function above where \a __size = \a __last - \a __first.
+template <class _It, class _ParserCharT, class _OutIt>
+[[nodiscard]] _CCCL_API _OutIt
+__fmt_write(_It __first, _It __last, _OutIt __out_it, __fmt_parsed_spec<_ParserCharT> __specs)
+{
+  _CCCL_ASSERT(__first <= __last, "Not a valid range");
+  return ::cuda::std::__fmt_write(__first, __last, ::cuda::std::move(__out_it), __specs, __last - __first);
+}
+
+template <class _It, class _CharT = iter_value_t<_It>, class _ParserCharT, class _OutIt, class _UnaryOp>
+[[nodiscard]] _CCCL_API _OutIt __fmt_write_transformed(
+  _It __first, _It __last, _OutIt __out_it, __fmt_parsed_spec<_ParserCharT> __specs, _UnaryOp __op)
+{
+  _CCCL_ASSERT(__first <= __last, "Not a valid range");
+
+  ptrdiff_t __size = __last - __first;
+  if (__size >= __specs.__width_)
+  {
+    return ::cuda::std::__fmt_transform(__first, __last, ::cuda::std::move(__out_it), __op);
+  }
+  const auto __padding =
+    ::cuda::std::__fmt_padding_size(__size, __specs.__width_, __fmt_spec_alignment{__specs.__alignment_});
+  __out_it = ::cuda::std::__fmt_fill(::cuda::std::move(__out_it), __padding.__before_, __specs.__fill_);
+  __out_it = ::cuda::std::__fmt_transform(__first, __last, ::cuda::std::move(__out_it), __op);
+  return ::cuda::std::__fmt_fill(::cuda::std::move(__out_it), __padding.__after_, __specs.__fill_);
+}
+
+//! Writes a string using format's width estimation algorithm.
+//!
+//! @pre !__specs.__has_precision()
+//!
+//! @note When \c _LIBCPP_HAS_UNICODE is false the function assumes the input is ASCII.
+template <class _CharT, class _OutIt>
+[[nodiscard]] _CCCL_API _OutIt
+__fmt_write_string_no_precision(basic_string_view<_CharT> __str, _OutIt __out_it, __fmt_parsed_spec<_CharT> __specs)
+{
+  _CCCL_ASSERT(!__specs.__has_precision(), "use __write_string");
+
+  // No padding -> copy the string
+  if (!__specs.__has_width())
+  {
+    return ::cuda::std::__fmt_copy(__str, ::cuda::std::move(__out_it));
+  }
+
+  // Note when the estimated width is larger than size there's no padding. So
+  // there's no reason to get the real size when the estimate is larger than or
+  // equal to the minimum field width.
+  size_t __size =
+    ::cuda::std::__fmt_estimate_column_width(__str, __specs.__width_, __fmt_column_width_rounding::__up).__width_;
+  return ::cuda::std::__fmt_write(__str, ::cuda::std::move(__out_it), __specs, __size);
+}
+
+template <class _CharT>
+[[nodiscard]] _CCCL_API int __fmt_truncate(basic_string_view<_CharT>& __str, int __precision)
+{
+  const auto __result =
+    ::cuda::std::__fmt_estimate_column_width(__str, __precision, __fmt_column_width_rounding::__down);
+  __str = basic_string_view<_CharT>{__str.begin(), __result.__last_};
+  return static_cast<int>(__result.__width_);
+}
+
+//! Writes a string using format's width estimation algorithm.
+template <class _CharT, class _OutIt>
+[[nodiscard]] _CCCL_API _OutIt
+__fmt_write_string(basic_string_view<_CharT> __str, _OutIt __out_it, __fmt_parsed_spec<_CharT> __specs)
+{
+  if (!__specs.__has_precision())
+  {
+    return ::cuda::std::__fmt_write_string_no_precision(__str, ::cuda::std::move(__out_it), __specs);
+  }
+  int __size = ::cuda::std::__fmt_truncate(__str, __specs.__precision_);
+  return ::cuda::std::__fmt_write(__str.begin(), __str.end(), ::cuda::std::move(__out_it), __specs, __size);
+}
+
+_CCCL_END_NAMESPACE_CUDA_STD
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _LIBCUDACXX___FORMAT_OUTPUT_UTILS_H

--- a/libcudacxx/include/cuda/std/__format/parse_arg_id.h
+++ b/libcudacxx/include/cuda/std/__format/parse_arg_id.h
@@ -1,0 +1,138 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___FORMAT_PARSE_ARG_ID_H
+#define _LIBCUDACXX___FORMAT_PARSE_ARG_ID_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__format/format_error.h>
+#include <cuda/std/__iterator/iterator_traits.h>
+#include <cuda/std/__limits/numeric_limits.h>
+#include <cuda/std/cstdint>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD
+
+template <class _It>
+struct __fmt_parse_number_result
+{
+  _It __last;
+  uint32_t __value;
+};
+
+template <class _It>
+_CCCL_HOST_DEVICE __fmt_parse_number_result(_It, uint32_t) -> __fmt_parse_number_result<_It>;
+
+//! The maximum value of a numeric argument.
+//!
+//! This is used for:
+//! - arg-id
+//! - width as value or arg-id.
+//! - precision as value or arg-id.
+//!
+//! The value is compatible with the maximum formatting width and precision
+//! using the `%*` syntax on a 32-bit system.
+inline constexpr uint32_t __fmt_number_max = static_cast<uint32_t>(numeric_limits<int32_t>::max());
+
+//! Parses a number.
+//! The number is used for the 31-bit values @em width and @em precision. This allows a maximum value of 2147483647.
+template <class _It>
+[[nodiscard]] _CCCL_API constexpr __fmt_parse_number_result<_It> __fmt_parse_number(_It __begin, _It __end_input)
+{
+  static_assert(__fmt_number_max == static_cast<uint32_t>(numeric_limits<int32_t>::max()),
+                "The algorithm is implemented based on this value.");
+
+  using _CharT = iter_value_t<_It>;
+
+  // Limit the input to 9 digits, otherwise we need two checks during every
+  // iteration:
+  // - Are we at the end of the input?
+  // - Does the value exceed width of an uint32_t? (Switching to uint64_t would
+  //   have the same issue, but with a higher maximum.)
+  _It __end        = __end_input - __begin > 9 ? __begin + 9 : __end_input;
+  uint32_t __value = *__begin - _CharT{'0'};
+  while (++__begin != __end)
+  {
+    if (*__begin < _CharT{'0'} || *__begin > _CharT{'9'})
+    {
+      return {__begin, __value};
+    }
+    __value = __value * 10 + *__begin - _CharT{'0'};
+  }
+
+  if (__begin != __end_input && *__begin >= _CharT{'0'} && *__begin <= _CharT{'9'})
+  {
+    // There are more than 9 digits, do additional validations:
+    // - Does the 10th digit exceed the maximum allowed value?
+    // - Are there more than 10 digits?
+    // (More than 10 digits always overflows the maximum.)
+    uint64_t __v = uint64_t(__value) * 10 + *__begin++ - _CharT{'0'};
+    if (__v > __fmt_number_max || (__begin != __end_input && *__begin >= _CharT{'0'} && *__begin <= _CharT{'9'}))
+    {
+      ::cuda::std::__throw_format_error("The numeric value of the format specifier is too large");
+    }
+    __value = static_cast<uint32_t>(__v);
+  }
+
+  return {__begin, __value};
+}
+
+//! Multiplexer for all parse functions.
+//!
+//! The parser will return a pointer beyond the last consumed character. This
+//! should be the closing '}' of the arg-id.
+template <class _It, class _ParseCtx>
+[[nodiscard]] _CCCL_API constexpr __fmt_parse_number_result<_It>
+__fmt_parse_arg_id(_It __begin, _It __end, _ParseCtx& __parse_ctx)
+{
+  using _CharT = iter_value_t<_It>;
+
+  switch (*__begin)
+  {
+    case _CharT{'0'}:
+      __parse_ctx.check_arg_id(0);
+      return {++__begin, 0}; // can never be larger than the maximum.
+
+    case _CharT{':'}:
+      // This case is conditionally valid. It's allowed in an arg-id in the
+      // replacement-field, but not in the std-format-spec. The caller can
+      // provide a better diagnostic, so accept it here unconditionally.
+    case _CharT{'}'}: {
+      const auto __value = __parse_ctx.next_arg_id();
+      _CCCL_ASSERT(__value <= __fmt_number_max, "Compilers don't support this number of arguments");
+      return {__begin, static_cast<uint32_t>(__value)};
+    }
+    default:
+      break;
+  }
+  if (*__begin < _CharT{'0'} || *__begin > _CharT{'9'})
+  {
+    ::cuda::std::__throw_format_error("The argument index starts with an invalid character");
+  }
+
+  const auto __r = ::cuda::std::__fmt_parse_number(__begin, __end);
+  __parse_ctx.check_arg_id(__r.__value);
+  return __r;
+}
+
+_CCCL_END_NAMESPACE_CUDA_STD
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _LIBCUDACXX___FORMAT_PARSE_ARG_ID_H

--- a/libcudacxx/include/cuda/std/__format_
+++ b/libcudacxx/include/cuda/std/__format_
@@ -28,8 +28,18 @@
 #include <cuda/std/__format/format_args.h>
 #include <cuda/std/__format/format_context.h>
 #include <cuda/std/__format/format_error.h>
+#include <cuda/std/__format/format_integral.h>
 #include <cuda/std/__format/format_parse_context.h>
+#include <cuda/std/__format/format_spec_parser.h>
 #include <cuda/std/__format/formatter.h>
+#include <cuda/std/__format/formatters/bool.h>
+#include <cuda/std/__format/formatters/char.h>
+#include <cuda/std/__format/formatters/fp.h>
+#include <cuda/std/__format/formatters/int.h>
+#include <cuda/std/__format/formatters/ptr.h>
+#include <cuda/std/__format/formatters/str.h>
+#include <cuda/std/__format/output_utils.h>
+#include <cuda/std/__format/parse_arg_id.h>
 #include <cuda/std/version>
 
 #endif // _CUDA_STD_FORMAT

--- a/libcudacxx/test/libcudacxx/libcxx/text/format/format.formatter/format.formatter.spec/parsed_spec_abi.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/text/format/format.formatter/format.formatter.spec/parsed_spec_abi.pass.cpp
@@ -1,0 +1,126 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/format>
+
+// cuda::std::__fmt_parsed_spec
+
+#include <cuda/std/__format_>
+#include <cuda/std/cassert>
+#include <cuda/std/cstddef>
+#include <cuda/std/cstring>
+#include <cuda/std/utility>
+
+template <class CharT>
+struct TestParsedSpecValues
+{
+  cuda::std::__fmt_spec_std std;
+  cuda::std::uint32_t width;
+  cuda::std::int32_t precision;
+  cuda::std::__fmt_spec_code_point<CharT> fill;
+};
+
+template <class CharT>
+__host__ __device__ TestParsedSpecValues<CharT> make_test_parsed_spec_values() noexcept
+{
+  cuda::std::__fmt_spec_std value_std{};
+  value_std.__alignment_            = cuda::std::to_underlying(cuda::std::__fmt_spec_alignment::__center);
+  value_std.__sign_                 = cuda::std::to_underlying(cuda::std::__fmt_spec_sign::__space);
+  value_std.__alternate_form_       = false;
+  value_std.__locale_specific_form_ = true;
+  value_std.__padding_0_            = false;
+  value_std.__type_                 = cuda::std::__fmt_spec_type::__fixed_lower_case;
+
+  TestParsedSpecValues<CharT> value{};
+  value.std       = value_std;
+  value.width     = 0x1234'5678;
+  value.precision = 0x01ab'cdef;
+  // value.fill has it's own constructor
+  return value;
+}
+
+template <class CharT>
+__host__ __device__ void verify_parsed_spec(const cuda::std::__fmt_parsed_spec<CharT>& value) noexcept
+{
+  const auto ref = make_test_parsed_spec_values<CharT>();
+  assert(value.__std_.__alignment_ == ref.std.__alignment_);
+  assert(value.__std_.__sign_ == ref.std.__sign_);
+  assert(value.__std_.__alternate_form_ == ref.std.__alternate_form_);
+  assert(value.__std_.__locale_specific_form_ == ref.std.__locale_specific_form_);
+  assert(value.__std_.__type_ == ref.std.__type_);
+  assert(value.__width_ == ref.width);
+  assert(value.__precision_ == ref.precision);
+  assert(cuda::std::memcmp(&value.__fill_.__data, &ref.fill.__data, sizeof(ref.fill)) == 0);
+}
+
+template <class CharT>
+__host__ __device__ void test()
+{
+  static_assert(sizeof(cuda::std::__fmt_parsed_spec<CharT>) == 16);
+  assert(offsetof(cuda::std::__fmt_parsed_spec<CharT>, __std_) == 0);
+  assert(offsetof(cuda::std::__fmt_parsed_spec<CharT>, __width_) == 4);
+  assert(offsetof(cuda::std::__fmt_parsed_spec<CharT>, __precision_) == 8);
+  assert(offsetof(cuda::std::__fmt_parsed_spec<CharT>, __fill_) == 12);
+
+  const auto ref = make_test_parsed_spec_values<CharT>();
+
+  cuda::std::__fmt_parsed_spec<CharT> value{};
+  value.__std_       = ref.std;
+  value.__width_     = ref.width;
+  value.__precision_ = ref.precision;
+  value.__fill_      = ref.fill;
+
+  verify_parsed_spec(value);
+}
+
+__host__ __device__ void test()
+{
+  test<char>();
+#if _CCCL_HAS_WCHAR_T()
+  test<wchar_t>();
+#endif // _CCCL_HAS_WCHAR_T()
+}
+
+#if !_CCCL_COMPILER(NVRTC)
+template <class CharT>
+__global__ void test_host_device_abi_compatiblity_kernel(cuda::std::__fmt_parsed_spec<CharT> value)
+{
+  verify_parsed_spec(value);
+}
+
+template <class CharT>
+void test_host_device_abi_compatiblity()
+{
+  const auto ref = make_test_parsed_spec_values<CharT>();
+
+  cuda::std::__fmt_parsed_spec<CharT> value{};
+  value.__std_       = ref.std;
+  value.__width_     = ref.width;
+  value.__precision_ = ref.precision;
+  value.__fill_      = ref.fill;
+
+  test_host_device_abi_compatiblity_kernel<CharT><<<1, 1>>>(value);
+  assert(cudaDeviceSynchronize() == cudaSuccess);
+}
+
+void test_host_device_abi_compatiblity()
+{
+  test_host_device_abi_compatiblity<char>();
+#  if _CCCL_HAS_WCHAR_T()
+  test_host_device_abi_compatiblity<wchar_t>();
+#  endif // _CCCL_HAS_WCHAR_T()
+}
+#endif // !_CCCL_COMPILER(NVRTC)
+
+int main(int, char**)
+{
+  test();
+  NV_IF_TARGET(NV_IS_HOST, (test_host_device_abi_compatiblity();))
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/text/format/format.formatter/format.formatter.spec/spec_chrono_abi.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/text/format/format.formatter/format.formatter.spec/spec_chrono_abi.pass.cpp
@@ -1,0 +1,106 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/format>
+
+// cuda::std::__fmt_spec_chrono
+
+#include <cuda/std/__format_>
+#include <cuda/std/cassert>
+#include <cuda/std/utility>
+
+struct TestSpecChronoValues
+{
+  cuda::std::__fmt_spec_alignment alignment;
+  bool locale_specific_form;
+  bool hour;
+  bool weekday_name;
+  bool weekday;
+  bool day_of_year;
+  bool week_of_year;
+  bool month_name;
+};
+
+__host__ __device__ TestSpecChronoValues make_test_spec_chrono_values() noexcept
+{
+  TestSpecChronoValues value{};
+  value.alignment            = cuda::std::__fmt_spec_alignment::__center;
+  value.locale_specific_form = false;
+  value.hour                 = true;
+  value.weekday_name         = true;
+  value.weekday              = false;
+  value.day_of_year          = false;
+  value.week_of_year         = false;
+  value.month_name           = true;
+  return value;
+}
+
+__host__ __device__ void verify_spec_chrono(const cuda::std::__fmt_spec_chrono& value) noexcept
+{
+  const auto ref = make_test_spec_chrono_values();
+  assert(value.__alignment_ == cuda::std::to_underlying(ref.alignment));
+  assert(value.__locale_specific_form_ == ref.locale_specific_form);
+  assert(value.__hour_ == ref.hour);
+  assert(value.__weekday_name_ == ref.weekday_name);
+  assert(value.__weekday_ == ref.weekday);
+  assert(value.__day_of_year_ == ref.day_of_year);
+  assert(value.__week_of_year_ == ref.week_of_year);
+  assert(value.__month_name_ == ref.month_name);
+}
+
+__host__ __device__ void test()
+{
+  static_assert(sizeof(cuda::std::__fmt_spec_chrono) == 2);
+
+  const auto ref = make_test_spec_chrono_values();
+
+  cuda::std::__fmt_spec_chrono value{};
+  value.__alignment_            = cuda::std::to_underlying(ref.alignment);
+  value.__locale_specific_form_ = ref.locale_specific_form;
+  value.__hour_                 = ref.hour;
+  value.__weekday_name_         = ref.weekday_name;
+  value.__weekday_              = ref.weekday;
+  value.__day_of_year_          = ref.day_of_year;
+  value.__week_of_year_         = ref.week_of_year;
+  value.__month_name_           = ref.month_name;
+
+  verify_spec_chrono(value);
+}
+
+#if !_CCCL_COMPILER(NVRTC)
+__global__ void test_host_device_abi_compatiblity_kernel(const cuda::std::__fmt_spec_chrono value)
+{
+  verify_spec_chrono(value);
+}
+
+void test_host_device_abi_compatiblity()
+{
+  const auto ref = make_test_spec_chrono_values();
+
+  cuda::std::__fmt_spec_chrono value{};
+  value.__alignment_            = cuda::std::to_underlying(ref.alignment);
+  value.__locale_specific_form_ = ref.locale_specific_form;
+  value.__hour_                 = ref.hour;
+  value.__weekday_name_         = ref.weekday_name;
+  value.__weekday_              = ref.weekday;
+  value.__day_of_year_          = ref.day_of_year;
+  value.__week_of_year_         = ref.week_of_year;
+  value.__month_name_           = ref.month_name;
+
+  test_host_device_abi_compatiblity_kernel<<<1, 1>>>(value);
+  assert(cudaDeviceSynchronize() == cudaSuccess);
+}
+#endif // !_CCCL_COMPILER(NVRTC)
+
+int main(int, char**)
+{
+  test();
+  NV_IF_TARGET(NV_IS_HOST, (test_host_device_abi_compatiblity();))
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/text/format/format.formatter/format.formatter.spec/spec_fields_abi.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/text/format/format.formatter/format.formatter.spec/spec_fields_abi.pass.cpp
@@ -1,0 +1,110 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/format>
+
+// cuda::std::__fmt_spec_fields
+
+#include <cuda/std/__format_>
+#include <cuda/std/cassert>
+
+struct TestSpecFieldsValues
+{
+  bool sign;
+  bool alternate_form;
+  bool zero_padding;
+  bool precision;
+  bool locale_specific_form;
+  bool type;
+  bool use_range_fill;
+  bool clear_brackets;
+  bool consume_all;
+};
+
+__host__ __device__ TestSpecFieldsValues make_test_spec_fields_values() noexcept
+{
+  TestSpecFieldsValues value{};
+  value.sign                 = true;
+  value.alternate_form       = false;
+  value.zero_padding         = false;
+  value.precision            = true;
+  value.locale_specific_form = true;
+  value.type                 = false;
+  value.use_range_fill       = true;
+  value.clear_brackets       = false;
+  value.consume_all          = true;
+  return value;
+}
+
+__host__ __device__ void verify_spec_fields(const cuda::std::__fmt_spec_fields& value) noexcept
+{
+  const auto ref = make_test_spec_fields_values();
+  assert(value.__sign_ == ref.sign);
+  assert(value.__alternate_form_ == ref.alternate_form);
+  assert(value.__zero_padding_ == ref.zero_padding);
+  assert(value.__precision_ == ref.precision);
+  assert(value.__locale_specific_form_ == ref.locale_specific_form);
+  assert(value.__type_ == ref.type);
+  assert(value.__use_range_fill_ == ref.use_range_fill);
+  assert(value.__clear_brackets_ == ref.clear_brackets);
+  assert(value.__consume_all_ == ref.consume_all);
+}
+
+__host__ __device__ void test()
+{
+  static_assert(sizeof(cuda::std::__fmt_spec_fields) == 2);
+
+  const auto ref = make_test_spec_fields_values();
+
+  cuda::std::__fmt_spec_fields value{};
+  value.__sign_                 = ref.sign;
+  value.__alternate_form_       = ref.alternate_form;
+  value.__zero_padding_         = ref.zero_padding;
+  value.__precision_            = ref.precision;
+  value.__locale_specific_form_ = ref.locale_specific_form;
+  value.__type_                 = ref.type;
+  value.__use_range_fill_       = ref.use_range_fill;
+  value.__clear_brackets_       = ref.clear_brackets;
+  value.__consume_all_          = ref.consume_all;
+
+  verify_spec_fields(value);
+}
+
+#if !_CCCL_COMPILER(NVRTC)
+__global__ void test_host_device_abi_compatiblity_kernel(cuda::std::__fmt_spec_fields value)
+{
+  verify_spec_fields(value);
+}
+
+void test_host_device_abi_compatiblity()
+{
+  const auto ref = make_test_spec_fields_values();
+
+  cuda::std::__fmt_spec_fields value{};
+  value.__sign_                 = ref.sign;
+  value.__alternate_form_       = ref.alternate_form;
+  value.__zero_padding_         = ref.zero_padding;
+  value.__precision_            = ref.precision;
+  value.__locale_specific_form_ = ref.locale_specific_form;
+  value.__type_                 = ref.type;
+  value.__use_range_fill_       = ref.use_range_fill;
+  value.__clear_brackets_       = ref.clear_brackets;
+  value.__consume_all_          = ref.consume_all;
+
+  test_host_device_abi_compatiblity_kernel<<<1, 1>>>(value);
+  assert(cudaDeviceSynchronize() == cudaSuccess);
+}
+#endif // !_CCCL_COMPILER(NVRTC)
+
+int main(int, char**)
+{
+  test();
+  NV_IF_TARGET(NV_IS_HOST, (test_host_device_abi_compatiblity();))
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/text/format/format.formatter/format.formatter.spec/spec_parser_abi.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/text/format/format.formatter/format.formatter.spec/spec_parser_abi.pass.cpp
@@ -1,0 +1,186 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/format>
+
+// cuda::std::__fmt_spec_parser
+
+#include <cuda/std/__format_>
+#include <cuda/std/cassert>
+#include <cuda/std/cstddef>
+#include <cuda/std/cstdint>
+#include <cuda/std/cstring>
+#include <cuda/std/utility>
+
+template <class CharT>
+struct TestSpecParserValues
+{
+  cuda::std::__fmt_spec_alignment alignment;
+  cuda::std::__fmt_spec_sign sign;
+  bool alternate_form;
+  bool locale_specific_form;
+  bool padding_0;
+  cuda::std::__fmt_spec_type type;
+  bool hour;
+  bool weekday_name;
+  bool weekday;
+  bool day_of_year;
+  bool week_of_year;
+  bool month_name;
+  cuda::std::uint8_t reserved_0;
+  cuda::std::uint8_t reserved_1;
+  bool width_as_arg;
+  bool precision_as_arg;
+  cuda::std::uint32_t width;
+  cuda::std::int32_t precision;
+  cuda::std::__fmt_spec_code_point<CharT> fill;
+};
+
+template <class CharT>
+__host__ __device__ TestSpecParserValues<CharT> make_test_spec_parser_values() noexcept
+{
+  TestSpecParserValues<CharT> value{};
+  value.alignment            = cuda::std::__fmt_spec_alignment::__center;
+  value.sign                 = cuda::std::__fmt_spec_sign::__space;
+  value.alternate_form       = false;
+  value.locale_specific_form = true;
+  value.type                 = cuda::std::__fmt_spec_type::__fixed_lower_case;
+  value.hour                 = true;
+  value.weekday_name         = true;
+  value.weekday              = false;
+  value.day_of_year          = true;
+  value.week_of_year         = false;
+  value.month_name           = false;
+  value.reserved_0           = 0b10;
+  value.reserved_1           = 0b10'1001;
+  value.width_as_arg         = false;
+  value.precision_as_arg     = true;
+  value.width                = 0x1234'abcd;
+  value.precision            = 0x5678'ef01;
+  // value.fill has own constructor
+  return value;
+}
+
+template <class CharT>
+__host__ __device__ void verify_spec_parser(const cuda::std::__fmt_spec_parser<CharT>& value)
+{
+  const auto ref = make_test_spec_parser_values<CharT>();
+  assert(value.__alignment_ == cuda::std::to_underlying(ref.alignment));
+  assert(value.__sign_ == cuda::std::to_underlying(ref.sign));
+  assert(value.__alternate_form_ == ref.alternate_form);
+  assert(value.__locale_specific_form_ == ref.locale_specific_form);
+  assert(value.__type_ == ref.type);
+  assert(value.__hour_ == ref.hour);
+  assert(value.__weekday_name_ == ref.weekday_name);
+  assert(value.__weekday_ == ref.weekday);
+  assert(value.__day_of_year_ == ref.day_of_year);
+  assert(value.__week_of_year_ == ref.week_of_year);
+  assert(value.__month_name_ == ref.month_name);
+  assert(value.__reserved_0_ == ref.reserved_0);
+  assert(value.__reserved_1_ == ref.reserved_1);
+  assert(value.__width_as_arg_ == ref.width_as_arg);
+  assert(value.__precision_as_arg_ == ref.precision_as_arg);
+  assert(value.__width_ == ref.width);
+  assert(value.__precision_ == ref.precision);
+  assert(cuda::std::memcmp(&value.__fill_.__data, &ref.fill.__data, 4) == 0);
+}
+
+template <class CharT>
+__host__ __device__ void test_type()
+{
+  static_assert(sizeof(cuda::std::__fmt_spec_parser<CharT>) == 16);
+  assert(offsetof(cuda::std::__fmt_spec_parser<CharT>, __type_) == 1);
+  assert(offsetof(cuda::std::__fmt_spec_parser<CharT>, __width_) == 4);
+  assert(offsetof(cuda::std::__fmt_spec_parser<CharT>, __precision_) == 8);
+  assert(offsetof(cuda::std::__fmt_spec_parser<CharT>, __fill_) == 12);
+
+  const auto ref = make_test_spec_parser_values<CharT>();
+
+  cuda::std::__fmt_spec_parser<CharT> value{};
+  value.__alignment_            = cuda::std::to_underlying(ref.alignment);
+  value.__sign_                 = cuda::std::to_underlying(ref.sign);
+  value.__alternate_form_       = ref.alternate_form;
+  value.__locale_specific_form_ = ref.locale_specific_form;
+  value.__type_                 = ref.type;
+  value.__hour_                 = ref.hour;
+  value.__weekday_name_         = ref.weekday_name;
+  value.__weekday_              = ref.weekday;
+  value.__day_of_year_          = ref.day_of_year;
+  value.__week_of_year_         = ref.week_of_year;
+  value.__month_name_           = ref.month_name;
+  value.__reserved_0_           = ref.reserved_0;
+  value.__reserved_1_           = ref.reserved_1;
+  value.__width_as_arg_         = ref.width_as_arg;
+  value.__precision_as_arg_     = ref.precision_as_arg;
+  value.__width_                = ref.width;
+  value.__precision_            = ref.precision;
+  value.__fill_                 = ref.fill;
+
+  verify_spec_parser(value);
+}
+
+__host__ __device__ void test()
+{
+  test_type<char>();
+#if _CCCL_HAS_WCHAR_T()
+  test_type<wchar_t>();
+#endif // _CCCL_HAS_WCHAR_T()
+}
+
+#if !_CCCL_COMPILER(NVRTC)
+template <class T>
+__global__ void test_host_device_abi_compatiblity_kernel(cuda::std::__fmt_spec_parser<T> value)
+{
+  verify_spec_parser(value);
+}
+
+template <class CharT>
+void test_host_device_abi_compatiblity()
+{
+  const auto ref = make_test_spec_parser_values<CharT>();
+
+  cuda::std::__fmt_spec_parser<CharT> value{};
+  value.__alignment_            = cuda::std::to_underlying(ref.alignment);
+  value.__sign_                 = cuda::std::to_underlying(ref.sign);
+  value.__alternate_form_       = ref.alternate_form;
+  value.__locale_specific_form_ = ref.locale_specific_form;
+  value.__type_                 = ref.type;
+  value.__hour_                 = ref.hour;
+  value.__weekday_name_         = ref.weekday_name;
+  value.__weekday_              = ref.weekday;
+  value.__day_of_year_          = ref.day_of_year;
+  value.__week_of_year_         = ref.week_of_year;
+  value.__month_name_           = ref.month_name;
+  value.__reserved_0_           = ref.reserved_0;
+  value.__reserved_1_           = ref.reserved_1;
+  value.__width_as_arg_         = ref.width_as_arg;
+  value.__precision_as_arg_     = ref.precision_as_arg;
+  value.__width_                = ref.width;
+  value.__precision_            = ref.precision;
+  value.__fill_                 = ref.fill;
+
+  test_host_device_abi_compatiblity_kernel<CharT><<<1, 1>>>(value);
+  assert(cudaDeviceSynchronize() == cudaSuccess);
+}
+
+void test_host_device_abi_compatiblity()
+{
+  test_host_device_abi_compatiblity<char>();
+#  if _CCCL_HAS_WCHAR_T()
+  test_host_device_abi_compatiblity<wchar_t>();
+#  endif // _CCCL_HAS_WCHAR_T()
+}
+#endif // !_CCCL_COMPILER(NVRTC)
+
+int main(int, char**)
+{
+  test();
+  NV_IF_TARGET(NV_IS_HOST, (test_host_device_abi_compatiblity();))
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/text/format/format.formatter/format.formatter.spec/spec_std_abi.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/text/format/format.formatter/format.formatter.spec/spec_std_abi.pass.cpp
@@ -1,0 +1,98 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/format>
+
+// cuda::std::__fmt_spec_std
+
+#include <cuda/std/__format_>
+#include <cuda/std/cassert>
+#include <cuda/std/cstddef>
+#include <cuda/std/utility>
+
+struct TestSpecStdValues
+{
+  cuda::std::__fmt_spec_alignment alignment;
+  cuda::std::__fmt_spec_sign sign;
+  bool alternate_form;
+  bool locale_specific_form;
+  bool padding_0;
+  cuda::std::__fmt_spec_type type;
+};
+
+__host__ __device__ TestSpecStdValues make_test_spec_std_values() noexcept
+{
+  TestSpecStdValues value{};
+  value.alignment            = cuda::std::__fmt_spec_alignment::__center;
+  value.sign                 = cuda::std::__fmt_spec_sign::__space;
+  value.alternate_form       = false;
+  value.locale_specific_form = true;
+  value.padding_0            = false;
+  value.type                 = cuda::std::__fmt_spec_type::__fixed_lower_case;
+  return value;
+}
+
+__host__ __device__ void verify_spec_std(const cuda::std::__fmt_spec_std& value) noexcept
+{
+  const auto ref = make_test_spec_std_values();
+  assert(value.__alignment_ == cuda::std::to_underlying(ref.alignment));
+  assert(value.__sign_ == cuda::std::to_underlying(ref.sign));
+  assert(value.__alternate_form_ == ref.alternate_form);
+  assert(value.__locale_specific_form_ == ref.locale_specific_form);
+  assert(value.__padding_0_ == ref.padding_0);
+  assert(value.__type_ == ref.type);
+}
+
+__host__ __device__ void test()
+{
+  static_assert(sizeof(cuda::std::__fmt_spec_std) == 2);
+  assert(offsetof(cuda::std::__fmt_spec_std, __type_) == 1);
+
+  const auto ref = make_test_spec_std_values();
+
+  cuda::std::__fmt_spec_std value{};
+  value.__alignment_            = cuda::std::to_underlying(ref.alignment);
+  value.__sign_                 = cuda::std::to_underlying(ref.sign);
+  value.__alternate_form_       = ref.alternate_form;
+  value.__locale_specific_form_ = ref.locale_specific_form;
+  value.__padding_0_            = ref.padding_0;
+  value.__type_                 = ref.type;
+
+  verify_spec_std(value);
+}
+
+#if !_CCCL_COMPILER(NVRTC)
+__global__ void test_host_device_abi_compatiblity_kernel(cuda::std::__fmt_spec_std value)
+{
+  verify_spec_std(value);
+}
+
+void test_host_device_abi_compatiblity()
+{
+  const auto ref = make_test_spec_std_values();
+
+  cuda::std::__fmt_spec_std value{};
+  value.__alignment_            = cuda::std::to_underlying(ref.alignment);
+  value.__sign_                 = cuda::std::to_underlying(ref.sign);
+  value.__alternate_form_       = ref.alternate_form;
+  value.__locale_specific_form_ = ref.locale_specific_form;
+  value.__padding_0_            = ref.padding_0;
+  value.__type_                 = ref.type;
+
+  test_host_device_abi_compatiblity_kernel<<<1, 1>>>(value);
+  assert(cudaDeviceSynchronize() == cudaSuccess);
+}
+#endif // !_CCCL_COMPILER(NVRTC)
+
+int main(int, char**)
+{
+  test();
+  NV_IF_TARGET(NV_IS_HOST, (test_host_device_abi_compatiblity();))
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.bool.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.bool.pass.cpp
@@ -1,0 +1,115 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/format>
+
+// [format.formatter.spec]:
+// Each header that declares the template `formatter` provides the following
+// enabled specializations:
+// For each `charT`, for each cv-unqualified arithmetic type `ArithmeticT`
+// other than char, wchar_t, char8_t, char16_t, or char32_t, a specialization
+//    template<> struct formatter<ArithmeticT, charT>
+//
+// This file tests with `ArithmeticT = bool`, for each valid `charT`.
+
+#include <cuda/std/__format_>
+#include <cuda/std/cassert>
+#include <cuda/std/concepts>
+#include <cuda/std/inplace_vector>
+#include <cuda/std/iterator>
+#include <cuda/std/memory>
+#include <cuda/std/type_traits>
+
+#include "literal.h"
+
+template <class CharT>
+__host__ __device__ void test_bool_formatter(
+  cuda::std::basic_string_view<CharT> fmt,
+  bool value,
+  cuda::std::size_t offset,
+  cuda::std::basic_string_view<CharT> expected)
+{
+  using Container     = cuda::std::inplace_vector<CharT, 100>;
+  using OutIt         = cuda::std::__back_insert_iterator<Container>;
+  using ParseContext  = cuda::std::basic_format_parse_context<CharT>;
+  using FormatContext = cuda::std::basic_format_context<OutIt, CharT>;
+
+  Container container{};
+
+  auto store   = cuda::std::make_format_args<FormatContext>(value);
+  auto args    = cuda::std::basic_format_args{store};
+  auto context = cuda::std::__fmt_make_format_context(OutIt{container}, args);
+
+  cuda::std::formatter<bool, CharT> formatter{};
+  static_assert(cuda::std::semiregular<decltype(formatter)>);
+
+  ParseContext parse_ctx{fmt};
+  auto it = formatter.parse(parse_ctx);
+  static_assert(cuda::std::is_same_v<decltype(it), typename cuda::std::basic_string_view<CharT>::const_iterator>);
+
+  // std::to_address works around LWG3989 and MSVC STL's iterator debugging mechanism.
+  assert(cuda::std::to_address(it) == cuda::std::to_address(fmt.end()) - offset);
+
+  formatter.format(value, context);
+  assert((cuda::std::basic_string_view{container.data(), container.size()} == expected));
+}
+
+template <class CharT>
+__host__ __device__ void test_termination_condition(
+  cuda::std::basic_string_view<CharT> fmt, bool value, cuda::std::basic_string_view<CharT> expected)
+{
+  // The format-spec is valid if completely consumed or terminates at a '}'.
+  // The valid inputs all end with a '}'. The test is executed twice:
+  // - first with the terminating '}',
+  // - second consuming the entire input.
+  assert(fmt.back() == TEST_CHARLIT(CharT, '}'));
+
+  test_bool_formatter(fmt, value, 1, expected);
+  fmt.remove_suffix(1);
+  test_bool_formatter(fmt, value, 0, expected);
+}
+
+template <class CharT>
+__host__ __device__ void test_type()
+{
+  test_termination_condition<CharT>(TEST_STRLIT(CharT, "}"), true, TEST_STRLIT(CharT, "true"));
+  test_termination_condition<CharT>(TEST_STRLIT(CharT, ">6}"), true, TEST_STRLIT(CharT, "  true"));
+  test_termination_condition<CharT>(TEST_STRLIT(CharT, "*>5}"), true, TEST_STRLIT(CharT, "*true"));
+  test_termination_condition<CharT>(TEST_STRLIT(CharT, "_^7}"), true, TEST_STRLIT(CharT, "_true__"));
+  test_termination_condition<CharT>(TEST_STRLIT(CharT, "_<7}"), true, TEST_STRLIT(CharT, "true___"));
+  test_termination_condition<CharT>(TEST_STRLIT(CharT, "b}"), true, TEST_STRLIT(CharT, "1"));
+  test_termination_condition<CharT>(TEST_STRLIT(CharT, "_^3o}"), true, TEST_STRLIT(CharT, "_1_"));
+  test_termination_condition<CharT>(TEST_STRLIT(CharT, "_<5d}"), true, TEST_STRLIT(CharT, "1____"));
+  test_termination_condition<CharT>(TEST_STRLIT(CharT, ">7X}"), true, TEST_STRLIT(CharT, "      1"));
+
+  test_termination_condition<CharT>(TEST_STRLIT(CharT, "}"), false, TEST_STRLIT(CharT, "false"));
+  test_termination_condition<CharT>(TEST_STRLIT(CharT, ">7}"), false, TEST_STRLIT(CharT, "  false"));
+  test_termination_condition<CharT>(TEST_STRLIT(CharT, "*>8}"), false, TEST_STRLIT(CharT, "***false"));
+  test_termination_condition<CharT>(TEST_STRLIT(CharT, "_^7}"), false, TEST_STRLIT(CharT, "_false_"));
+  test_termination_condition<CharT>(TEST_STRLIT(CharT, "_<7}"), false, TEST_STRLIT(CharT, "false__"));
+  test_termination_condition<CharT>(TEST_STRLIT(CharT, "b}"), false, TEST_STRLIT(CharT, "0"));
+  test_termination_condition<CharT>(TEST_STRLIT(CharT, "_^3o}"), false, TEST_STRLIT(CharT, "_0_"));
+  test_termination_condition<CharT>(TEST_STRLIT(CharT, "_<5d}"), false, TEST_STRLIT(CharT, "0____"));
+  test_termination_condition<CharT>(TEST_STRLIT(CharT, ">7X}"), false, TEST_STRLIT(CharT, "      0"));
+}
+
+__host__ __device__ bool test()
+{
+  test_type<char>();
+#if _CCCL_HAS_WCHAR_T()
+  test_type<wchar_t>();
+#endif // _CCCL_HAS_WCHAR_T()
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.c_string.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.c_string.pass.cpp
@@ -1,0 +1,140 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/format>
+
+// C++23 the formatter is a debug-enabled specialization.
+// [format.formatter.spec]:
+// Each header that declares the template `formatter` provides the following
+// enabled specializations:
+// For each `charT`, the string type specializations
+//   template<> struct formatter<charT*, charT>;
+//   template<> struct formatter<const charT*, charT>;
+
+#include <cuda/std/__format_>
+#include <cuda/std/cassert>
+#include <cuda/std/concepts>
+#include <cuda/std/inplace_vector>
+#include <cuda/std/iterator>
+#include <cuda/std/memory>
+#include <cuda/std/type_traits>
+
+#include "literal.h"
+
+template <class CharT>
+__host__ __device__ void test_cstr_formatter(
+  cuda::std::basic_string_view<CharT> fmt,
+  const CharT* value,
+  cuda::std::size_t offset,
+  cuda::std::basic_string_view<CharT> expected)
+{
+  using Container     = cuda::std::inplace_vector<CharT, 100>;
+  using OutIt         = cuda::std::__back_insert_iterator<Container>;
+  using ParseContext  = cuda::std::basic_format_parse_context<CharT>;
+  using FormatContext = cuda::std::basic_format_context<OutIt, CharT>;
+
+  // 1. test const CharT*
+  {
+    Container container{};
+
+    auto store   = cuda::std::make_format_args<FormatContext>(value);
+    auto args    = cuda::std::basic_format_args{store};
+    auto context = cuda::std::__fmt_make_format_context(OutIt{container}, args);
+
+    cuda::std::formatter<const CharT*, CharT> formatter{};
+    static_assert(cuda::std::semiregular<decltype(formatter)>);
+
+    ParseContext parse_ctx{fmt};
+    auto it = formatter.parse(parse_ctx);
+    static_assert(cuda::std::is_same_v<decltype(it), typename cuda::std::basic_string_view<CharT>::const_iterator>);
+
+    // std::to_address works around LWG3989 and MSVC STL's iterator debugging mechanism.
+    assert(cuda::std::to_address(it) == cuda::std::to_address(fmt.end()) - offset);
+
+    formatter.format(value, context);
+    assert((cuda::std::basic_string_view{container.data(), container.size()} == expected));
+  }
+
+  // 2. test CharT*
+  {
+    Container container{};
+
+    auto store   = cuda::std::make_format_args<FormatContext>(value);
+    auto args    = cuda::std::basic_format_args{store};
+    auto context = cuda::std::__fmt_make_format_context(OutIt{container}, args);
+
+    cuda::std::formatter<CharT*, CharT> formatter{};
+    static_assert(cuda::std::semiregular<decltype(formatter)>);
+
+    ParseContext parse_ctx{fmt};
+    auto it = formatter.parse(parse_ctx);
+    static_assert(cuda::std::is_same_v<decltype(it), typename cuda::std::basic_string_view<CharT>::const_iterator>);
+
+    // std::to_address works around LWG3989 and MSVC STL's iterator debugging mechanism.
+    assert(cuda::std::to_address(it) == cuda::std::to_address(fmt.end()) - offset);
+
+    formatter.format(const_cast<CharT*>(value), context);
+    assert((cuda::std::basic_string_view{container.data(), container.size()} == expected));
+  }
+}
+
+template <class CharT>
+__host__ __device__ void test_termination_condition(
+  cuda::std::basic_string_view<CharT> fmt, const CharT* value, cuda::std::basic_string_view<CharT> expected)
+{
+  // The format-spec is valid if completely consumed or terminates at a '}'.
+  // The valid inputs all end with a '}'. The test is executed twice:
+  // - first with the terminating '}',
+  // - second consuming the entire input.
+  assert(fmt.back() == TEST_CHARLIT(CharT, '}'));
+
+  test_cstr_formatter<CharT>(fmt, value, 1, expected);
+  fmt.remove_suffix(1);
+  test_cstr_formatter<CharT>(fmt, value, 0, expected);
+}
+
+template <class CharT>
+__host__ __device__ void test_type()
+{
+  test_termination_condition<CharT>(
+    TEST_STRLIT(CharT, "}"), TEST_STRLIT(CharT, " azAZ09,./<>?"), TEST_STRLIT(CharT, " azAZ09,./<>?"));
+  test_termination_condition<CharT>(TEST_STRLIT(CharT, "}"), TEST_STRLIT(CharT, "abc\0abc"), TEST_STRLIT(CharT, "abc"));
+  test_termination_condition<CharT>(TEST_STRLIT(CharT, "}"), TEST_STRLIT(CharT, "world"), TEST_STRLIT(CharT, "world"));
+  test_termination_condition<CharT>(TEST_STRLIT(CharT, "_>}"), TEST_STRLIT(CharT, "world"), TEST_STRLIT(CharT, "world"));
+  test_termination_condition<CharT>(
+    TEST_STRLIT(CharT, ">8}"), TEST_STRLIT(CharT, "world"), TEST_STRLIT(CharT, "   world"));
+  test_termination_condition<CharT>(
+    TEST_STRLIT(CharT, "_>8}"), TEST_STRLIT(CharT, "world"), TEST_STRLIT(CharT, "___world"));
+  test_termination_condition<CharT>(
+    TEST_STRLIT(CharT, "_^8}"), TEST_STRLIT(CharT, "world"), TEST_STRLIT(CharT, "_world__"));
+  test_termination_condition<CharT>(
+    TEST_STRLIT(CharT, "_<8}"), TEST_STRLIT(CharT, "world"), TEST_STRLIT(CharT, "world___"));
+  test_termination_condition<CharT>(TEST_STRLIT(CharT, ".5}"), TEST_STRLIT(CharT, "world"), TEST_STRLIT(CharT, "world"));
+  test_termination_condition<CharT>(
+    TEST_STRLIT(CharT, ".5}"), TEST_STRLIT(CharT, "universe"), TEST_STRLIT(CharT, "unive"));
+  test_termination_condition<CharT>(
+    TEST_STRLIT(CharT, "%^7.7}"), TEST_STRLIT(CharT, "world"), TEST_STRLIT(CharT, "%world%"));
+  test_termination_condition<CharT>(
+    TEST_STRLIT(CharT, "%^7.7}"), TEST_STRLIT(CharT, "universe"), TEST_STRLIT(CharT, "univers"));
+}
+
+__host__ __device__ bool test()
+{
+  test_type<char>();
+#if _CCCL_HAS_WCHAR_T()
+  test_type<wchar_t>();
+#endif // _CCCL_HAS_WCHAR_T()
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.char.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.char.pass.cpp
@@ -1,0 +1,103 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/format>
+
+// C++23 the formatter is a debug-enabled specialization.
+// [format.formatter.spec]:
+// Each header that declares the template `formatter` provides the following
+// enabled specializations:
+// The specializations
+//   template<> struct formatter<char, char>;
+//   template<> struct formatter<char, wchar_t>;
+//   template<> struct formatter<wchar_t, wchar_t>;
+
+#include <cuda/std/__format_>
+#include <cuda/std/cassert>
+#include <cuda/std/concepts>
+#include <cuda/std/inplace_vector>
+#include <cuda/std/iterator>
+#include <cuda/std/memory>
+#include <cuda/std/type_traits>
+
+#include "literal.h"
+
+template <class CharT, class ArgT>
+__host__ __device__ void test_char_formatter(
+  cuda::std::basic_string_view<CharT> fmt,
+  ArgT value,
+  cuda::std::size_t offset,
+  cuda::std::basic_string_view<CharT> expected)
+{
+  using Container     = cuda::std::inplace_vector<CharT, 100>;
+  using OutIt         = cuda::std::__back_insert_iterator<Container>;
+  using ParseContext  = cuda::std::basic_format_parse_context<CharT>;
+  using FormatContext = cuda::std::basic_format_context<OutIt, CharT>;
+
+  Container container{};
+
+  auto store   = cuda::std::make_format_args<FormatContext>(value);
+  auto args    = cuda::std::basic_format_args{store};
+  auto context = cuda::std::__fmt_make_format_context(OutIt{container}, args);
+
+  cuda::std::formatter<ArgT, CharT> formatter{};
+  static_assert(cuda::std::semiregular<decltype(formatter)>);
+
+  ParseContext parse_ctx{fmt};
+  auto it = formatter.parse(parse_ctx);
+  static_assert(cuda::std::is_same_v<decltype(it), typename cuda::std::basic_string_view<CharT>::const_iterator>);
+
+  // std::to_address works around LWG3989 and MSVC STL's iterator debugging mechanism.
+  assert(cuda::std::to_address(it) == cuda::std::to_address(fmt.end()) - offset);
+
+  formatter.format(value, context);
+  assert((cuda::std::basic_string_view{container.data(), container.size()} == expected));
+}
+
+template <class CharT, class ArgT>
+__host__ __device__ void test_termination_condition(
+  cuda::std::basic_string_view<CharT> fmt, ArgT value, cuda::std::basic_string_view<CharT> expected)
+{
+  // The format-spec is valid if completely consumed or terminates at a '}'.
+  // The valid inputs all end with a '}'. The test is executed twice:
+  // - first with the terminating '}',
+  // - second consuming the entire input.
+  assert(fmt.back() == TEST_CHARLIT(CharT, '}'));
+
+  test_char_formatter(fmt, value, 1, expected);
+  fmt.remove_suffix(1);
+  test_char_formatter(fmt, value, 0, expected);
+}
+
+template <class CharT, class ArgT>
+__host__ __device__ void test_type()
+{
+  test_termination_condition<CharT>(TEST_STRLIT(CharT, "}"), TEST_CHARLIT(ArgT, 'a'), TEST_STRLIT(CharT, "a"));
+  test_termination_condition<CharT>(TEST_STRLIT(CharT, "}"), TEST_CHARLIT(ArgT, 'z'), TEST_STRLIT(CharT, "z"));
+  test_termination_condition<CharT>(TEST_STRLIT(CharT, "}"), TEST_CHARLIT(ArgT, 'A'), TEST_STRLIT(CharT, "A"));
+  test_termination_condition<CharT>(TEST_STRLIT(CharT, "}"), TEST_CHARLIT(ArgT, 'Z'), TEST_STRLIT(CharT, "Z"));
+  test_termination_condition<CharT>(TEST_STRLIT(CharT, "}"), TEST_CHARLIT(ArgT, '0'), TEST_STRLIT(CharT, "0"));
+  test_termination_condition<CharT>(TEST_STRLIT(CharT, "}"), TEST_CHARLIT(ArgT, '9'), TEST_STRLIT(CharT, "9"));
+}
+
+__host__ __device__ bool test()
+{
+  test_type<char, char>();
+#if _CCCL_HAS_WCHAR_T()
+  test_type<wchar_t, char>();
+  test_type<wchar_t, wchar_t>();
+#endif // _CCCL_HAS_WCHAR_T()
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.char_array.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.char_array.pass.cpp
@@ -1,0 +1,113 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/format>
+
+// C++23 the formatter is a debug-enabled specialization.
+// [format.functions]/25
+//   Preconditions: formatter<remove_cvref_t<Ti>, charT> meets the
+//   BasicFormatter requirements ([formatter.requirements]) for each Ti in
+//   Args.
+
+#include <cuda/std/__format_>
+#include <cuda/std/cassert>
+#include <cuda/std/concepts>
+#include <cuda/std/inplace_vector>
+#include <cuda/std/iterator>
+#include <cuda/std/memory>
+#include <cuda/std/type_traits>
+
+#include "literal.h"
+
+template <class CharT, cuda::std::size_t N>
+__host__ __device__ void test_array_formatter(
+  cuda::std::basic_string_view<CharT> fmt,
+  const CharT (&value)[N],
+  cuda::std::size_t offset,
+  cuda::std::basic_string_view<CharT> expected)
+{
+  using Container     = cuda::std::inplace_vector<CharT, 100>;
+  using OutIt         = cuda::std::__back_insert_iterator<Container>;
+  using ParseContext  = cuda::std::basic_format_parse_context<CharT>;
+  using FormatContext = cuda::std::basic_format_context<OutIt, CharT>;
+
+  Container container{};
+
+  auto store   = cuda::std::make_format_args<FormatContext>(value);
+  auto args    = cuda::std::basic_format_args{store};
+  auto context = cuda::std::__fmt_make_format_context(OutIt{container}, args);
+
+  cuda::std::formatter<CharT[N], CharT> formatter{};
+  static_assert(cuda::std::semiregular<decltype(formatter)>);
+
+  ParseContext parse_ctx{fmt};
+  auto it = formatter.parse(parse_ctx);
+  static_assert(cuda::std::is_same_v<decltype(it), typename cuda::std::basic_string_view<CharT>::const_iterator>);
+
+  // std::to_address works around LWG3989 and MSVC STL's iterator debugging mechanism.
+  assert(cuda::std::to_address(it) == cuda::std::to_address(fmt.end()) - offset);
+
+  formatter.format(value, context);
+  assert((cuda::std::basic_string_view{container.data(), container.size()} == expected));
+}
+
+template <class CharT, cuda::std::size_t N>
+__host__ __device__ void test_termination_condition(
+  cuda::std::basic_string_view<CharT> fmt, const CharT (&value)[N], cuda::std::basic_string_view<CharT> expected)
+{
+  // The format-spec is valid if completely consumed or terminates at a '}'.
+  // The valid inputs all end with a '}'. The test is executed twice:
+  // - first with the terminating '}',
+  // - second consuming the entire input.
+  assert(fmt.back() == TEST_CHARLIT(CharT, '}'));
+
+  test_array_formatter(fmt, value, 1, expected);
+  fmt.remove_suffix(1);
+  test_array_formatter(fmt, value, 0, expected);
+}
+
+template <class CharT>
+__host__ __device__ void test_type()
+{
+  test_termination_condition<CharT>(
+    TEST_STRLIT(CharT, "}"), TEST_STRLIT(CharT, " azAZ09,./<>?"), TEST_STRLIT(CharT, " azAZ09,./<>?"));
+  test_termination_condition<CharT>(TEST_STRLIT(CharT, "}"), TEST_STRLIT(CharT, "abc\0abc"), TEST_STRLIT(CharT, "abc"));
+  test_termination_condition<CharT>(TEST_STRLIT(CharT, "}"), TEST_STRLIT(CharT, "world"), TEST_STRLIT(CharT, "world"));
+  test_termination_condition<CharT>(TEST_STRLIT(CharT, "_>}"), TEST_STRLIT(CharT, "world"), TEST_STRLIT(CharT, "world"));
+  test_termination_condition<CharT>(
+    TEST_STRLIT(CharT, ">8}"), TEST_STRLIT(CharT, "world"), TEST_STRLIT(CharT, "   world"));
+  test_termination_condition<CharT>(
+    TEST_STRLIT(CharT, "_>8}"), TEST_STRLIT(CharT, "world"), TEST_STRLIT(CharT, "___world"));
+  test_termination_condition<CharT>(
+    TEST_STRLIT(CharT, "_^8}"), TEST_STRLIT(CharT, "world"), TEST_STRLIT(CharT, "_world__"));
+  test_termination_condition<CharT>(
+    TEST_STRLIT(CharT, "_<8}"), TEST_STRLIT(CharT, "world"), TEST_STRLIT(CharT, "world___"));
+  test_termination_condition<CharT>(TEST_STRLIT(CharT, ".5}"), TEST_STRLIT(CharT, "world"), TEST_STRLIT(CharT, "world"));
+  test_termination_condition<CharT>(
+    TEST_STRLIT(CharT, ".5}"), TEST_STRLIT(CharT, "universe"), TEST_STRLIT(CharT, "unive"));
+  test_termination_condition<CharT>(
+    TEST_STRLIT(CharT, "%^7.7}"), TEST_STRLIT(CharT, "world"), TEST_STRLIT(CharT, "%world%"));
+  test_termination_condition<CharT>(
+    TEST_STRLIT(CharT, "%^7.7}"), TEST_STRLIT(CharT, "universe"), TEST_STRLIT(CharT, "univers"));
+}
+
+__host__ __device__ bool test()
+{
+  test_type<char>();
+#if _CCCL_HAS_WCHAR_T()
+  test_type<wchar_t>();
+#endif // _CCCL_HAS_WCHAR_T()
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.handle.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.handle.pass.cpp
@@ -1,0 +1,112 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/format>
+
+// A user defined formatter using
+// template<class Context>
+// class basic_format_arg<Context>::handle
+
+#include <cuda/std/__format_>
+#include <cuda/std/cassert>
+#include <cuda/std/concepts>
+#include <cuda/std/inplace_vector>
+#include <cuda/std/iterator>
+#include <cuda/std/memory>
+#include <cuda/std/type_traits>
+
+#include "literal.h"
+
+enum class color
+{
+  black,
+  red,
+  gold
+};
+
+template <class CharT>
+struct cuda::std::formatter<color, CharT> : cuda::std::formatter<const char*, CharT>
+{
+  template <class Context>
+  __host__ __device__ auto format(color c, Context& ctx) const
+  {
+    const CharT* color_names[]{TEST_STRLIT(CharT, "black"), TEST_STRLIT(CharT, "red"), TEST_STRLIT(CharT, "gold")};
+    return cuda::std::formatter<const CharT*>::format(color_names[static_cast<int>(c)], ctx);
+  }
+};
+
+template <class CharT>
+__host__ __device__ void test_handle(
+  cuda::std::basic_string_view<CharT> fmt,
+  color value,
+  cuda::std::size_t offset,
+  cuda::std::basic_string_view<CharT> expected)
+{
+  using Container     = cuda::std::inplace_vector<CharT, 100>;
+  using OutIt         = cuda::std::__back_insert_iterator<Container>;
+  using ParseContext  = cuda::std::basic_format_parse_context<CharT>;
+  using FormatContext = cuda::std::basic_format_context<OutIt, CharT>;
+
+  Container container{};
+
+  auto store   = cuda::std::make_format_args<FormatContext>(value);
+  auto args    = cuda::std::basic_format_args{store};
+  auto context = cuda::std::__fmt_make_format_context(OutIt{container}, args);
+
+  cuda::std::formatter<color, CharT> formatter{};
+  static_assert(cuda::std::semiregular<decltype(formatter)>);
+
+  ParseContext parse_ctx{fmt};
+  auto it = formatter.parse(parse_ctx);
+  static_assert(cuda::std::is_same_v<decltype(it), typename cuda::std::basic_string_view<CharT>::const_iterator>);
+
+  // std::to_address works around LWG3989 and MSVC STL's iterator debugging mechanism.
+  assert(cuda::std::to_address(it) == cuda::std::to_address(fmt.end()) - offset);
+
+  formatter.format(value, context);
+  assert((cuda::std::basic_string_view{container.data(), container.size()} == expected));
+}
+
+template <class CharT>
+__host__ __device__ void test_termination_condition(
+  cuda::std::basic_string_view<CharT> fmt, color value, cuda::std::basic_string_view<CharT> expected)
+{
+  // The format-spec is valid if completely consumed or terminates at a '}'.
+  // The valid inputs all end with a '}'. The test is executed twice:
+  // - first with the terminating '}',
+  // - second consuming the entire input.
+  assert(fmt.back() == TEST_CHARLIT(CharT, '}'));
+
+  test_handle(fmt, value, 1, expected);
+  fmt.remove_suffix(1);
+  test_handle(fmt, value, 0, expected);
+}
+
+template <class CharT>
+__host__ __device__ void test_type()
+{
+  test_termination_condition<CharT>(TEST_STRLIT(CharT, "}"), color::black, TEST_STRLIT(CharT, "black"));
+  test_termination_condition<CharT>(TEST_STRLIT(CharT, "}"), color::red, TEST_STRLIT(CharT, "red"));
+  test_termination_condition<CharT>(TEST_STRLIT(CharT, "}"), color::gold, TEST_STRLIT(CharT, "gold"));
+}
+
+__host__ __device__ bool test()
+{
+  test_type<char>();
+#if _CCCL_HAS_WCHAR_T()
+  test_type<wchar_t>();
+#endif // _CCCL_HAS_WCHAR_T()
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.pointer.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.pointer.pass.cpp
@@ -1,0 +1,114 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/format>
+
+// [format.formatter.spec]:
+// Each header that declares the template `formatter` provides the following
+// enabled specializations:
+// ...
+// For each charT, the pointer type specializations
+// - template<> struct formatter<nullptr_t, charT>;
+// - template<> struct formatter<void*, charT>;
+// - template<> struct formatter<const void*, charT>;
+
+#include <cuda/std/__format_>
+#include <cuda/std/cassert>
+#include <cuda/std/concepts>
+#include <cuda/std/cstdint>
+#include <cuda/std/inplace_vector>
+#include <cuda/std/iterator>
+#include <cuda/std/memory>
+#include <cuda/std/type_traits>
+
+#include "literal.h"
+
+template <class CharT, class PointerT>
+__host__ __device__ void test_ptr_formatter(
+  cuda::std::basic_string_view<CharT> fmt,
+  PointerT arg,
+  cuda::std::size_t offset,
+  cuda::std::basic_string_view<CharT> expected)
+{
+  using Container     = cuda::std::inplace_vector<CharT, 100>;
+  using OutIt         = cuda::std::__back_insert_iterator<Container>;
+  using ParseContext  = cuda::std::basic_format_parse_context<CharT>;
+  using FormatContext = cuda::std::basic_format_context<OutIt, CharT>;
+
+  Container container{};
+
+  auto store   = cuda::std::make_format_args<FormatContext>(arg);
+  auto args    = cuda::std::basic_format_args{store};
+  auto context = cuda::std::__fmt_make_format_context(OutIt{container}, args);
+
+  cuda::std::formatter<PointerT, CharT> formatter;
+  static_assert(cuda::std::semiregular<decltype(formatter)>);
+
+  ParseContext parse_ctx{fmt};
+  auto it = formatter.parse(parse_ctx);
+  static_assert(cuda::std::is_same_v<decltype(it), typename cuda::std::basic_string_view<CharT>::const_iterator>);
+
+  // std::to_address works around LWG3989 and MSVC STL's iterator debugging mechanism.
+  assert(cuda::std::to_address(it) == cuda::std::to_address(fmt.end()) - offset);
+
+  formatter.format(arg, context);
+  assert((cuda::std::basic_string_view{container.data(), container.size()} == expected));
+}
+
+template <class CharT, class PointerT>
+__host__ __device__ void test_termination_condition(
+  cuda::std::basic_string_view<CharT> fmt, PointerT arg, cuda::std::basic_string_view<CharT> expected)
+{
+  // The format-spec is valid if completely consumed or terminates at a '}'.
+  // The valid inputs all end with a '}'. The test is executed twice:
+  // - first with the terminating '}',
+  // - second consuming the entire input.
+  assert(fmt.back() == TEST_CHARLIT(CharT, '}'));
+
+  test_ptr_formatter(fmt, arg, 1, expected);
+  fmt.remove_suffix(1);
+  test_ptr_formatter(fmt, arg, 0, expected);
+}
+
+template <class CharT>
+__host__ __device__ void test_type()
+{
+  // 1. Test for nullptr_t
+  test_termination_condition<CharT>(TEST_STRLIT(CharT, "}"), nullptr, TEST_STRLIT(CharT, "0x0"));
+  test_termination_condition<CharT>(TEST_STRLIT(CharT, "p}"), nullptr, TEST_STRLIT(CharT, "0x0"));
+  test_termination_condition<CharT>(TEST_STRLIT(CharT, "P}"), nullptr, TEST_STRLIT(CharT, "0X0"));
+
+  // 2. Test for void*
+  test_termination_condition<CharT>(TEST_STRLIT(CharT, "}"), (void*) (0), TEST_STRLIT(CharT, "0x0"));
+  test_termination_condition<CharT>(TEST_STRLIT(CharT, "p}"), (void*) (0x42), TEST_STRLIT(CharT, "0x42"));
+  test_termination_condition<CharT>(TEST_STRLIT(CharT, "P}"), (void*) (0xffff), TEST_STRLIT(CharT, "0XFFFF"));
+  test_termination_condition<CharT>(TEST_STRLIT(CharT, "}"), (void*) (-1), TEST_STRLIT(CharT, "0xffffffffffffffff"));
+
+  // 3. Test for const void*
+  test_termination_condition<CharT>(TEST_STRLIT(CharT, "}"), (const void*) (0), TEST_STRLIT(CharT, "0x0"));
+  test_termination_condition<CharT>(TEST_STRLIT(CharT, "p}"), (const void*) (0x42), TEST_STRLIT(CharT, "0x42"));
+  test_termination_condition<CharT>(TEST_STRLIT(CharT, "P}"), (const void*) (0xffff), TEST_STRLIT(CharT, "0XFFFF"));
+  test_termination_condition<CharT>(
+    TEST_STRLIT(CharT, "}"), (const void*) (-1), TEST_STRLIT(CharT, "0xffffffffffffffff"));
+}
+
+__host__ __device__ bool test()
+{
+  test_type<char>();
+#if _CCCL_HAS_WCHAR_T()
+  test_type<wchar_t>();
+#endif // _CCCL_HAS_WIDE_CHARACTERS
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.signed_integral.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.signed_integral.pass.cpp
@@ -1,0 +1,148 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/format>
+
+// [format.formatter.spec]:
+// Each header that declares the template `formatter` provides the following
+// enabled specializations:
+// For each `charT`, for each cv-unqualified arithmetic type `ArithmeticT`
+// other than char, wchar_t, char8_t, char16_t, or char32_t, a specialization
+//    template<> struct formatter<ArithmeticT, charT>
+//
+// This file tests with `ArithmeticT = signed integer`, for each valid `charT`.
+// Where `signed integer` is one of:
+// - signed char
+// - short
+// - int
+// - long
+// - long long
+// - __int128_t
+
+#include <cuda/std/__format_>
+#include <cuda/std/cassert>
+#include <cuda/std/concepts>
+#include <cuda/std/inplace_vector>
+#include <cuda/std/iterator>
+#include <cuda/std/memory>
+#include <cuda/std/type_traits>
+#include <cuda/std/utility>
+
+#include "literal.h"
+
+template <class CharT, class T>
+__host__ __device__ void test_signed_int_formatter(
+  cuda::std::basic_string_view<CharT> fmt,
+  T value,
+  cuda::std::size_t offset,
+  cuda::std::basic_string_view<CharT> expected)
+{
+  using Container     = cuda::std::inplace_vector<CharT, 100>;
+  using OutIt         = cuda::std::__back_insert_iterator<Container>;
+  using ParseContext  = cuda::std::basic_format_parse_context<CharT>;
+  using FormatContext = cuda::std::basic_format_context<OutIt, CharT>;
+
+  Container container{};
+
+  auto store   = cuda::std::make_format_args<FormatContext>(value);
+  auto args    = cuda::std::basic_format_args{store};
+  auto context = cuda::std::__fmt_make_format_context(OutIt{container}, args);
+
+  cuda::std::formatter<T, CharT> formatter{};
+  static_assert(cuda::std::semiregular<decltype(formatter)>);
+
+  ParseContext parse_ctx{fmt};
+  auto it = formatter.parse(parse_ctx);
+  static_assert(cuda::std::is_same_v<decltype(it), typename cuda::std::basic_string_view<CharT>::const_iterator>);
+
+  // std::to_address works around LWG3989 and MSVC STL's iterator debugging mechanism.
+  assert(cuda::std::to_address(it) == cuda::std::to_address(fmt.end()) - offset);
+
+  formatter.format(value, context);
+  assert((cuda::std::basic_string_view{container.data(), container.size()} == expected));
+}
+
+template <class CharT, class T, class ValueT>
+__host__ __device__ void test_termination_condition(
+  cuda::std::basic_string_view<CharT> fmt, ValueT value, cuda::std::basic_string_view<CharT> expected)
+{
+  // Skip the test if the value is out of range for the type.
+  if (!cuda::std::in_range<T>(value))
+  {
+    return;
+  }
+
+  // The format-spec is valid if completely consumed or terminates at a '}'.
+  // The valid inputs all end with a '}'. The test is executed twice:
+  // - first with the terminating '}',
+  // - second consuming the entire input.
+  assert(fmt.back() == TEST_CHARLIT(CharT, '}'));
+
+  test_signed_int_formatter(fmt, static_cast<T>(value), 1, expected);
+  fmt.remove_suffix(1);
+  test_signed_int_formatter(fmt, static_cast<T>(value), 0, expected);
+}
+
+template <class CharT, class T>
+__host__ __device__ void test_type()
+{
+  test_termination_condition<CharT, T>(TEST_STRLIT(CharT, "}"), -128, TEST_STRLIT(CharT, "-128"));
+  test_termination_condition<CharT, T>(TEST_STRLIT(CharT, "}"), 0, TEST_STRLIT(CharT, "0"));
+  test_termination_condition<CharT, T>(TEST_STRLIT(CharT, "}"), 127, TEST_STRLIT(CharT, "127"));
+  test_termination_condition<CharT, T>(TEST_STRLIT(CharT, "}"), -32768, TEST_STRLIT(CharT, "-32768"));
+  test_termination_condition<CharT, T>(TEST_STRLIT(CharT, "}"), 32767, TEST_STRLIT(CharT, "32767"));
+  test_termination_condition<CharT, T>(TEST_STRLIT(CharT, "}"), -2147483647, TEST_STRLIT(CharT, "-2147483647"));
+  test_termination_condition<CharT, T>(TEST_STRLIT(CharT, "}"), 2147483647, TEST_STRLIT(CharT, "2147483647"));
+  test_termination_condition<CharT, T>(
+    TEST_STRLIT(CharT, "}"),
+    cuda::std::numeric_limits<cuda::std::int64_t>::min(),
+    TEST_STRLIT(CharT, "-9223372036854775808"));
+  test_termination_condition<CharT, T>(
+    TEST_STRLIT(CharT, "}"),
+    cuda::std::numeric_limits<cuda::std::int64_t>::max(),
+    TEST_STRLIT(CharT, "9223372036854775807"));
+#if _CCCL_HAS_INT128()
+  test_termination_condition<CharT, T>(
+    TEST_STRLIT(CharT, "}"),
+    cuda::std::numeric_limits<__int128_t>::min(),
+    TEST_STRLIT(CharT, "-170141183460469231731687303715884105728"));
+  test_termination_condition<CharT, T>(
+    TEST_STRLIT(CharT, "}"),
+    cuda::std::numeric_limits<__int128_t>::max(),
+    TEST_STRLIT(CharT, "170141183460469231731687303715884105727"));
+#endif // _CCCL_HAS_INT128()
+}
+
+template <class CharT>
+__host__ __device__ void test_type()
+{
+  test_type<CharT, signed char>();
+  test_type<CharT, signed short>();
+  test_type<CharT, signed int>();
+  test_type<CharT, signed long>();
+  test_type<CharT, signed long long>();
+#if _CCCL_HAS_INT128()
+  test_type<CharT, __int128_t>();
+#endif // _CCCL_HAS_INT128()
+}
+
+__host__ __device__ bool test()
+{
+  test_type<char>();
+#if _CCCL_HAS_WCHAR_T()
+  test_type<wchar_t>();
+#endif // _CCCL_HAS_WCHAR_T()
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.string.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.string.pass.cpp
@@ -1,0 +1,157 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/format>
+
+// C++23 the formatter is a debug-enabled specialization.
+// [format.formatter.spec]:
+// Each header that declares the template `formatter` provides the following
+// enabled specializations:
+// For each `charT`, the string type specializations
+//   template<class traits, class Allocator>
+//     struct formatter<basic_string<charT, traits, Allocator>, charT>;
+//   template<class traits>
+//     struct formatter<basic_string_view<charT, traits>, charT>;
+
+#include <cuda/std/__format_>
+#include <cuda/std/cassert>
+#include <cuda/std/concepts>
+#include <cuda/std/inplace_vector>
+#include <cuda/std/iterator>
+#include <cuda/std/memory>
+#include <cuda/std/type_traits>
+
+#include "literal.h"
+
+template <class CharT>
+struct custom_char_traits : cuda::std::char_traits<CharT>
+{};
+
+template <class CharT>
+__host__ __device__ void test_str_formatter(
+  cuda::std::basic_string_view<CharT> fmt,
+  cuda::std::basic_string_view<CharT> value,
+  cuda::std::size_t offset,
+  cuda::std::basic_string_view<CharT> expected)
+{
+  using Container     = cuda::std::inplace_vector<CharT, 100>;
+  using OutIt         = cuda::std::__back_insert_iterator<Container>;
+  using ParseContext  = cuda::std::basic_format_parse_context<CharT>;
+  using FormatContext = cuda::std::basic_format_context<OutIt, CharT>;
+
+  // 1. test basic_string_view with default char traits
+  {
+    Container container{};
+
+    auto store   = cuda::std::make_format_args<FormatContext>(value);
+    auto args    = cuda::std::basic_format_args{store};
+    auto context = cuda::std::__fmt_make_format_context(OutIt{container}, args);
+
+    cuda::std::formatter<cuda::std::basic_string_view<CharT>, CharT> formatter{};
+    static_assert(cuda::std::semiregular<decltype(formatter)>);
+
+    ParseContext parse_ctx{fmt};
+    auto it = formatter.parse(parse_ctx);
+    static_assert(cuda::std::is_same_v<decltype(it), typename cuda::std::basic_string_view<CharT>::const_iterator>);
+
+    // std::to_address works around LWG3989 and MSVC STL's iterator debugging mechanism.
+    assert(cuda::std::to_address(it) == cuda::std::to_address(fmt.end()) - offset);
+
+    formatter.format(value, context);
+    assert((cuda::std::basic_string_view{container.data(), container.size()} == expected));
+  }
+
+  // 2. test basic_string_view with custom char traits
+  {
+    cuda::std::basic_string_view<CharT, custom_char_traits<CharT>> custom_value{value.data(), value.size()};
+
+    Container container{};
+
+    auto store   = cuda::std::make_format_args<FormatContext>(custom_value);
+    auto args    = cuda::std::basic_format_args{store};
+    auto context = cuda::std::__fmt_make_format_context(OutIt{container}, args);
+
+    cuda::std::formatter<cuda::std::basic_string_view<CharT, custom_char_traits<CharT>>, CharT> formatter{};
+    static_assert(cuda::std::semiregular<decltype(formatter)>);
+
+    ParseContext parse_ctx{fmt};
+    auto it = formatter.parse(parse_ctx);
+    static_assert(cuda::std::is_same_v<decltype(it), typename cuda::std::basic_string_view<CharT>::const_iterator>);
+
+    // std::to_address works around LWG3989 and MSVC STL's iterator debugging mechanism.
+    assert(cuda::std::to_address(it) == cuda::std::to_address(fmt.end()) - offset);
+
+    formatter.format(value, context);
+    assert((cuda::std::basic_string_view{container.data(), container.size()} == expected));
+  }
+
+  // 3. test basic_string
+  {
+    // todo: implement when basic_string is available
+  }
+}
+
+template <class CharT>
+__host__ __device__ void test_termination_condition(
+  cuda::std::basic_string_view<CharT> fmt,
+  cuda::std::basic_string_view<CharT> value,
+  cuda::std::basic_string_view<CharT> expected)
+{
+  // The format-spec is valid if completely consumed or terminates at a '}'.
+  // The valid inputs all end with a '}'. The test is executed twice:
+  // - first with the terminating '}',
+  // - second consuming the entire input.
+  assert(fmt.back() == TEST_CHARLIT(CharT, '}'));
+
+  test_str_formatter<CharT>(fmt, value, 1, expected);
+  fmt.remove_suffix(1);
+  test_str_formatter<CharT>(fmt, value, 0, expected);
+}
+
+template <class CharT>
+__host__ __device__ void test_type()
+{
+  test_termination_condition<CharT>(
+    TEST_STRLIT(CharT, "}"), TEST_STRLIT(CharT, " azAZ09,./<>?"), TEST_STRLIT(CharT, " azAZ09,./<>?"));
+  test_termination_condition<CharT>(TEST_STRLIT(CharT, "}"), TEST_STRLIT(CharT, "world"), TEST_STRLIT(CharT, "world"));
+  test_termination_condition<CharT>(TEST_STRLIT(CharT, "_>}"), TEST_STRLIT(CharT, "world"), TEST_STRLIT(CharT, "world"));
+  test_termination_condition<CharT>(
+    TEST_STRLIT(CharT, ">8}"), TEST_STRLIT(CharT, "world"), TEST_STRLIT(CharT, "   world"));
+  test_termination_condition<CharT>(
+    TEST_STRLIT(CharT, "_>8}"), TEST_STRLIT(CharT, "world"), TEST_STRLIT(CharT, "___world"));
+  test_termination_condition<CharT>(
+    TEST_STRLIT(CharT, "_^8}"), TEST_STRLIT(CharT, "world"), TEST_STRLIT(CharT, "_world__"));
+  test_termination_condition<CharT>(
+    TEST_STRLIT(CharT, "_<8}"), TEST_STRLIT(CharT, "world"), TEST_STRLIT(CharT, "world___"));
+  test_termination_condition<CharT>(TEST_STRLIT(CharT, ".5}"), TEST_STRLIT(CharT, "world"), TEST_STRLIT(CharT, "world"));
+  test_termination_condition<CharT>(
+    TEST_STRLIT(CharT, ".5}"), TEST_STRLIT(CharT, "universe"), TEST_STRLIT(CharT, "unive"));
+  test_termination_condition<CharT>(
+    TEST_STRLIT(CharT, "%^7.7}"), TEST_STRLIT(CharT, "world"), TEST_STRLIT(CharT, "%world%"));
+  test_termination_condition<CharT>(
+    TEST_STRLIT(CharT, "%^7.7}"), TEST_STRLIT(CharT, "universe"), TEST_STRLIT(CharT, "univers"));
+
+  cuda::std::basic_string_view with_zero{TEST_STRLIT(CharT, "abc\0abc"), 7};
+  test_termination_condition<CharT>(TEST_STRLIT(CharT, "}"), with_zero, with_zero);
+}
+
+__host__ __device__ bool test()
+{
+  test_type<char>();
+#if _CCCL_HAS_WCHAR_T()
+  test_type<wchar_t>();
+#endif // _CCCL_HAS_WCHAR_T()
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.unsigned_integral.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.formatter/format.formatter.spec/formatter.unsigned_integral.pass.cpp
@@ -1,0 +1,136 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/format>
+
+// [format.formatter.spec]:
+// Each header that declares the template `formatter` provides the following
+// enabled specializations:
+// For each `charT`, for each cv-unqualified arithmetic type `ArithmeticT`
+// other than char, wchar_t, char8_t, char16_t, or char32_t, a specialization
+//    template<> struct formatter<ArithmeticT, charT>
+//
+// This file tests with `ArithmeticT = unsigned integer`, for each valid `charT`.
+// Where `unsigned integer` is one of:
+// - unsigned char
+// - unsigned short
+// - unsigned
+// - unsigned long
+// - unsigned long long
+// - __uint128_t
+
+#include <cuda/std/__format_>
+#include <cuda/std/cassert>
+#include <cuda/std/concepts>
+#include <cuda/std/inplace_vector>
+#include <cuda/std/iterator>
+#include <cuda/std/memory>
+#include <cuda/std/type_traits>
+#include <cuda/std/utility>
+
+#include "literal.h"
+
+template <class CharT, class T>
+__host__ __device__ void test_unsigned_int_formatter(
+  cuda::std::basic_string_view<CharT> fmt,
+  T value,
+  cuda::std::size_t offset,
+  cuda::std::basic_string_view<CharT> expected)
+{
+  using Container     = cuda::std::inplace_vector<CharT, 100>;
+  using OutIt         = cuda::std::__back_insert_iterator<Container>;
+  using ParseContext  = cuda::std::basic_format_parse_context<CharT>;
+  using FormatContext = cuda::std::basic_format_context<OutIt, CharT>;
+
+  Container container{};
+
+  auto store   = cuda::std::make_format_args<FormatContext>(value);
+  auto args    = cuda::std::basic_format_args{store};
+  auto context = cuda::std::__fmt_make_format_context(OutIt{container}, args);
+
+  cuda::std::formatter<T, CharT> formatter{};
+  static_assert(cuda::std::semiregular<decltype(formatter)>);
+
+  ParseContext parse_ctx{fmt};
+  auto it = formatter.parse(parse_ctx);
+  static_assert(cuda::std::is_same_v<decltype(it), typename cuda::std::basic_string_view<CharT>::const_iterator>);
+
+  // std::to_address works around LWG3989 and MSVC STL's iterator debugging mechanism.
+  assert(cuda::std::to_address(it) == cuda::std::to_address(fmt.end()) - offset);
+
+  formatter.format(value, context);
+  assert((cuda::std::basic_string_view{container.data(), container.size()} == expected));
+}
+
+template <class CharT, class T, class ValueT>
+__host__ __device__ void test_termination_condition(
+  cuda::std::basic_string_view<CharT> fmt, ValueT value, cuda::std::basic_string_view<CharT> expected)
+{
+  // Skip the test if the value is out of range for the type.
+  if (!cuda::std::in_range<T>(value))
+  {
+    return;
+  }
+
+  // The format-spec is valid if completely consumed or terminates at a '}'.
+  // The valid inputs all end with a '}'. The test is executed twice:
+  // - first with the terminating '}',
+  // - second consuming the entire input.
+  assert(fmt.back() == TEST_CHARLIT(CharT, '}'));
+
+  test_unsigned_int_formatter(fmt, static_cast<T>(value), 1, expected);
+  fmt.remove_suffix(1);
+  test_unsigned_int_formatter(fmt, static_cast<T>(value), 0, expected);
+}
+
+template <class CharT, class T>
+__host__ __device__ void test_type()
+{
+  test_termination_condition<CharT, T>(TEST_STRLIT(CharT, "}"), 0, TEST_STRLIT(CharT, "0"));
+  test_termination_condition<CharT, T>(TEST_STRLIT(CharT, "}"), 255, TEST_STRLIT(CharT, "255"));
+  test_termination_condition<CharT, T>(TEST_STRLIT(CharT, "}"), 65535, TEST_STRLIT(CharT, "65535"));
+  test_termination_condition<CharT, T>(TEST_STRLIT(CharT, "}"), 4294967295, TEST_STRLIT(CharT, "4294967295"));
+  test_termination_condition<CharT, T>(
+    TEST_STRLIT(CharT, "}"), 8446744073709551615, TEST_STRLIT(CharT, "8446744073709551615"));
+#if _CCCL_HAS_INT128()
+  test_termination_condition<CharT, T>(
+    TEST_STRLIT(CharT, "}"),
+    cuda::std::numeric_limits<__uint128_t>::max(),
+    TEST_STRLIT(CharT, "340282366920938463463374607431768211455"));
+#endif // _CCCL_HAS_INT128()
+  test_termination_condition<CharT, T>(TEST_STRLIT(CharT, "X}"), 255, TEST_STRLIT(CharT, "FF"));
+}
+
+template <class CharT>
+__host__ __device__ void test_type()
+{
+  test_type<CharT, unsigned char>();
+  test_type<CharT, unsigned short>();
+  test_type<CharT, unsigned int>();
+  test_type<CharT, unsigned long>();
+  test_type<CharT, unsigned long long>();
+#if _CCCL_HAS_INT128()
+  test_type<CharT, __uint128_t>();
+#endif // _CCCL_HAS_INT128()
+}
+
+__host__ __device__ bool test()
+{
+  test_type<char>();
+#if _CCCL_HAS_WCHAR_T()
+  test_type<wchar_t>();
+#endif // _CCCL_HAS_WCHAR_T()
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  return 0;
+}

--- a/libcudacxx/test/support/literal.h
+++ b/libcudacxx/test/support/literal.h
@@ -11,6 +11,7 @@
 #ifndef TEST_SUPPORT_LITERAL_H
 #define TEST_SUPPORT_LITERAL_H
 
+#include <cuda/std/cstddef>
 #include <cuda/std/type_traits>
 
 template <class CharT>
@@ -59,37 +60,37 @@ template <class CharT>
 #  define TEST_CHARLIT(CharT, val) _test_charlit_impl<CharT>(val, L##val, u##val, U##val)
 #endif // _CCCL_HAS_CHAR8_T()
 
-template <class CharT>
-[[nodiscard]] __host__ __device__ constexpr const CharT* _test_strlit_impl(
-  [[maybe_unused]] const char* char_ptr,
-  [[maybe_unused]] const wchar_t* wchar_ptr,
+template <class CharT, cuda::std::size_t N>
+[[nodiscard]] __host__ __device__ constexpr auto _test_strlit_impl(
+  [[maybe_unused]] const char (&char_str)[N],
+  [[maybe_unused]] const wchar_t (&wchar_str)[N],
 #if _CCCL_HAS_CHAR8_T()
-  [[maybe_unused]] const char8_t* char8_ptr,
+  [[maybe_unused]] const char8_t (&char8_str)[N],
 #endif // _CCCL_HAS_CHAR8_T()
-  [[maybe_unused]] const char16_t* char16_ptr,
-  [[maybe_unused]] const char32_t* char32_ptr) noexcept
+  [[maybe_unused]] const char16_t (&char16_str)[N],
+  [[maybe_unused]] const char32_t (&char32_str)[N]) noexcept -> const CharT (&)[N]
 {
   if constexpr (cuda::std::is_same_v<CharT, char>)
   {
-    return char_ptr;
+    return char_str;
   }
   else if constexpr (cuda::std::is_same_v<CharT, wchar_t>)
   {
-    return wchar_ptr;
+    return wchar_str;
   }
 #if _CCCL_HAS_CHAR8_T()
   else if constexpr (cuda::std::is_same_v<CharT, char8_t>)
   {
-    return char8_ptr;
+    return char8_str;
   }
 #endif // _CCCL_HAS_CHAR8_T()
   else if constexpr (cuda::std::is_same_v<CharT, char16_t>)
   {
-    return char16_ptr;
+    return char16_str;
   }
   else if constexpr (cuda::std::is_same_v<CharT, char32_t>)
   {
-    return char32_ptr;
+    return char32_str;
   }
   else
   {


### PR DESCRIPTION
This PR ports  std::format` formatters for standard library types.

I've omitted support (for now) for:
- locales
- unicode characters
- formatting floating point types due to missing `to_chars` implementation for floats