### PR TITLE
Introduce `i128` and `u128` literals to libcu++ testing

### DIFF
--- a/libcudacxx/test/libcudacxx/libcxx/literals/int128.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/literals/int128.pass.cpp
@@ -33,14 +33,14 @@ __host__ __device__ constexpr void test_octal()
   assert(07_i128 == 07);
   assert(017_i128 == 017);
   assert(0377_i128 == 0377);
-  assert(01'777'777'777'777'777'777'777'375_i128 == (__int128_t{(unsigned long long) -1} << 9) + 0'375);
+  assert(01'777'777'777'777'777'777'777'375_i128 == (__int128_t{~0ull} << 9) + 0'375);
 
   assert(-00_i128 == 00);
   assert(-01_i128 == -01);
   assert(-07_i128 == -07);
   assert(-017_i128 == -017);
   assert(-0377_i128 == -0377);
-  assert(-01'777'777'777'777'777'777'777'375_i128 == -(__int128_t{(unsigned long long) -1} << 9) - 0'375);
+  assert(-01'777'777'777'777'777'777'777'375_i128 == -(__int128_t{~0ull} << 9) - 0'375);
 }
 
 __host__ __device__ constexpr void test_decimal()
@@ -50,14 +50,14 @@ __host__ __device__ constexpr void test_decimal()
   assert(123_i128 == 123);
   assert(123'456'789_i128 == 123'456'789);
   assert(9'223'372'036'854'775'807_i128 == 9'223'372'036'854'775'807);
-  assert(12'345'678'901'234'567'890_i128 == __int128_t{12'345'678'901'234'567'890});
+  assert(12'345'678'901'234'567'890_i128 == __int128_t{12'345'678'901'234'567'890ull});
 
   assert(-0_i128 == 0);
   assert(-1_i128 == -1);
   assert(-123_i128 == -123);
   assert(-123'456'789_i128 == -123'456'789);
   assert(-9'223'372'036'854'775'807_i128 == -9'223'372'036'854'775'807);
-  assert(-12'345'678'901'234'567'890_i128 == -__int128_t{12'345'678'901'234'567'890});
+  assert(-12'345'678'901'234'567'890_i128 == -__int128_t{12'345'678'901'234'567'890ull});
 }
 
 __host__ __device__ constexpr void test_hexadecimal()
@@ -69,7 +69,7 @@ __host__ __device__ constexpr void test_hexadecimal()
   assert(0xFFFF_i128 == 0xFFFF);
   assert(0x7FFF'FFFF'FFFF'FFFF_i128 == 0x7FFF'FFFF'FFFF'FFFF);
   assert(0xFF'FFFF'FFFF'FFFF'FFFF_i128 == (__int128_t{0xFFFF'FFFF'FFFF'FFFF} << 8) + 0xff);
-  assert(0x7FFF'FFFF'FFFF'FFFF'FFFF'FFFF'FFFF'FFFF_i128 == __int128_t{__uint128_t{-1} >> 1});
+  assert(0x7FFF'FFFF'FFFF'FFFF'FFFF'FFFF'FFFF'FFFF_i128 == static_cast<__int128_t>(~__uint128_t{0} >> 1));
 
   assert(-0x0_i128 == 0x0);
   assert(-0x1_i128 == -0x1);
@@ -78,7 +78,7 @@ __host__ __device__ constexpr void test_hexadecimal()
   assert(-0xFFFF_i128 == -0xFFFF);
   assert(-0x7FFF'FFFF'FFFF'FFFF_i128 == -0x7FFF'FFFF'FFFF'FFFF);
   assert(-0xFF'FFFF'FFFF'FFFF'FFFF_i128 == -(__int128_t{0xFFFF'FFFF'FFFF'FFFF} << 8) - 0xff);
-  assert(-0x7FFF'FFFF'FFFF'FFFF'FFFF'FFFF'FFFF'FFFF_i128 == __int128_t{~(__uint128_t{-1} >> 1)} + 1);
+  assert(-0x7FFF'FFFF'FFFF'FFFF'FFFF'FFFF'FFFF'FFFF_i128 == static_cast<__int128_t>(~(~__uint128_t{0} >> 1)) + 1);
 
   assert(0Xabcdef_i128 == 0xABCDEF);
 }

--- a/libcudacxx/test/libcudacxx/libcxx/literals/int128.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/literals/int128.pass.cpp
@@ -1,0 +1,105 @@
+#include <cuda/std/cassert>
+
+#include "literal.h"
+
+// nvcc complains about the i128 literal constants being too large
+_CCCL_DIAG_SUPPRESS_NVCC(23)
+
+#if _CCCL_HAS_INT128()
+
+using namespace test_integer_literals;
+
+__host__ __device__ constexpr void test_binary()
+{
+  assert(0b0_i128 == 0b0);
+  assert(0b1_i128 == 0b1);
+  assert(0b1111'1111_i128 == 0b1111'1111);
+  assert(0b1111'1111'1111'1111_i128 == 0b1111'1111'1111'1111);
+  assert(0b0111'1111'1111'1111'1111'1111'1111'1111'1111'1111'1111'1111'1111'1111'1111_i128
+         == 0b0111'1111'1111'1111'1111'1111'1111'1111'1111'1111'1111'1111'1111'1111'1111);
+
+  assert(-0b0_i128 == 0b0);
+  assert(-0b1_i128 == -0b1);
+  assert(-0b1111'1111_i128 == -0b1111'1111);
+  assert(-0b1111'1111'1111'1111_i128 == -0b1111'1111'1111'1111);
+
+  assert(0B1 == 0b1);
+}
+
+__host__ __device__ constexpr void test_octal()
+{
+  assert(00_i128 == 00);
+  assert(01_i128 == 01);
+  assert(07_i128 == 07);
+  assert(017_i128 == 017);
+  assert(0377_i128 == 0377);
+  assert(01'777'777'777'777'777'777'777'375_i128 == (__int128_t{(unsigned long long) -1} << 9) + 0'375);
+
+  assert(-00_i128 == 00);
+  assert(-01_i128 == -01);
+  assert(-07_i128 == -07);
+  assert(-017_i128 == -017);
+  assert(-0377_i128 == -0377);
+  assert(-01'777'777'777'777'777'777'777'375_i128 == -(__int128_t{(unsigned long long) -1} << 9) - 0'375);
+}
+
+__host__ __device__ constexpr void test_decimal()
+{
+  assert(0_i128 == 0);
+  assert(1_i128 == 1);
+  assert(123_i128 == 123);
+  assert(123'456'789_i128 == 123'456'789);
+  assert(9'223'372'036'854'775'807_i128 == 9'223'372'036'854'775'807);
+  assert(12'345'678'901'234'567'890_i128 == __int128_t{12'345'678'901'234'567'890});
+
+  assert(-0_i128 == 0);
+  assert(-1_i128 == -1);
+  assert(-123_i128 == -123);
+  assert(-123'456'789_i128 == -123'456'789);
+  assert(-9'223'372'036'854'775'807_i128 == -9'223'372'036'854'775'807);
+  assert(-12'345'678'901'234'567'890_i128 == -__int128_t{12'345'678'901'234'567'890});
+}
+
+__host__ __device__ constexpr void test_hexadecimal()
+{
+  assert(0x0_i128 == 0x0);
+  assert(0x1_i128 == 0x1);
+  assert(0xF_i128 == 0xF);
+  assert(0xFF_i128 == 0xFF);
+  assert(0xFFFF_i128 == 0xFFFF);
+  assert(0x7FFF'FFFF'FFFF'FFFF_i128 == 0x7FFF'FFFF'FFFF'FFFF);
+  assert(0xFF'FFFF'FFFF'FFFF'FFFF_i128 == (__int128_t{0xFFFF'FFFF'FFFF'FFFF} << 8) + 0xff);
+  assert(0x7FFF'FFFF'FFFF'FFFF'FFFF'FFFF'FFFF'FFFF_i128 == __int128_t{__uint128_t{-1} >> 1});
+
+  assert(-0x0_i128 == 0x0);
+  assert(-0x1_i128 == -0x1);
+  assert(-0xF_i128 == -0xF);
+  assert(-0xFF_i128 == -0xFF);
+  assert(-0xFFFF_i128 == -0xFFFF);
+  assert(-0x7FFF'FFFF'FFFF'FFFF_i128 == -0x7FFF'FFFF'FFFF'FFFF);
+  assert(-0xFF'FFFF'FFFF'FFFF'FFFF_i128 == -(__int128_t{0xFFFF'FFFF'FFFF'FFFF} << 8) - 0xff);
+  assert(-0x7FFF'FFFF'FFFF'FFFF'FFFF'FFFF'FFFF'FFFF_i128 == __int128_t{~(__uint128_t{-1} >> 1)} + 1);
+
+  assert(0Xabcdef_i128 == 0xABCDEF);
+}
+
+__host__ __device__ constexpr bool test()
+{
+  test_binary();
+  test_octal();
+  test_decimal();
+  test_hexadecimal();
+
+  return true;
+}
+
+#endif // _CCCL_HAS_INT128()
+
+int main(int, char**)
+{
+#if _CCCL_HAS_INT128()
+  test();
+  static_assert(test());
+#endif // _CCCL_HAS_INT128()
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/literals/uint128.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/literals/uint128.pass.cpp
@@ -1,0 +1,79 @@
+#include <cuda/std/cassert>
+
+#include "literal.h"
+
+// nvcc complains about the u128 literal constants being too large
+_CCCL_DIAG_SUPPRESS_NVCC(23)
+
+#if _CCCL_HAS_INT128()
+
+using namespace test_integer_literals;
+
+__host__ __device__ constexpr void test_binary()
+{
+  assert(0b0_u128 == 0b0);
+  assert(0b1_u128 == 0b1);
+  assert(0b1111'1111_u128 == 0b1111'1111);
+  assert(0b1111'1111'1111'1111_u128 == 0b1111'1111'1111'1111);
+  assert(0b0111'1111'1111'1111'1111'1111'1111'1111'1111'1111'1111'1111'1111'1111'1111_u128
+         == 0b0111'1111'1111'1111'1111'1111'1111'1111'1111'1111'1111'1111'1111'1111'1111);
+
+  assert(0B1 == 0b1);
+}
+
+__host__ __device__ constexpr void test_octal()
+{
+  assert(00_u128 == 00);
+  assert(01_u128 == 01);
+  assert(07_u128 == 07);
+  assert(017_u128 == 017);
+  assert(0377_u128 == 0377);
+  assert(01'777'777'777'777'777'777'777'375_u128 == (__uint128_t{(unsigned long long) -1} << 9) + 0'375);
+}
+
+__host__ __device__ constexpr void test_decimal()
+{
+  assert(0_u128 == 0);
+  assert(1_u128 == 1);
+  assert(123_u128 == 123);
+  assert(123'456'789_u128 == 123'456'789);
+  assert(9'223'372'036'854'775'807_u128 == 9'223'372'036'854'775'807);
+  assert(12'345'678'901'234'567'890_u128 == 12'345'678'901'234'567'890);
+}
+
+__host__ __device__ constexpr void test_hexadecimal()
+{
+  assert(0x0_u128 == 0x0);
+  assert(0x1_u128 == 0x1);
+  assert(0xF_u128 == 0xF);
+  assert(0xFF_u128 == 0xFF);
+  assert(0xFFFF_u128 == 0xFFFF);
+  assert(0x7FFF'FFFF'FFFF'FFFF_u128 == 0x7FFF'FFFF'FFFF'FFFF);
+  assert(0xFF'FFFF'FFFF'FFFF'FFFF_u128 == (__uint128_t{0xFFFF'FFFF'FFFF'FFFF} << 8) + 0xff);
+  assert(0x7FFF'FFFF'FFFF'FFFF'FFFF'FFFF'FFFF'FFFF_u128 == __uint128_t{-1} >> 1);
+  assert(0xFFFF'FFFF'FFFF'FFFF'FFFF'FFFF'FFFF'FFFF_u128
+         == (__uint128_t{0xFFFF'FFFF'FFFF'FFFF} << 64) + 0xFFFF'FFFF'FFFF'FFFF);
+
+  assert(0Xabcdef_u128 == 0xABCDEF);
+}
+
+__host__ __device__ constexpr bool test()
+{
+  test_binary();
+  test_octal();
+  test_decimal();
+  test_hexadecimal();
+
+  return true;
+}
+
+#endif // _CCCL_HAS_INT128()
+
+int main(int, char**)
+{
+#if _CCCL_HAS_INT128()
+  test();
+  static_assert(test());
+#endif // _CCCL_HAS_INT128()
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/literals/uint128.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/literals/uint128.pass.cpp
@@ -28,7 +28,7 @@ __host__ __device__ constexpr void test_octal()
   assert(07_u128 == 07);
   assert(017_u128 == 017);
   assert(0377_u128 == 0377);
-  assert(01'777'777'777'777'777'777'777'375_u128 == (__uint128_t{(unsigned long long) -1} << 9) + 0'375);
+  assert(01'777'777'777'777'777'777'777'375_u128 == (__uint128_t{~0ull} << 9) + 0'375);
 }
 
 __host__ __device__ constexpr void test_decimal()
@@ -38,7 +38,7 @@ __host__ __device__ constexpr void test_decimal()
   assert(123_u128 == 123);
   assert(123'456'789_u128 == 123'456'789);
   assert(9'223'372'036'854'775'807_u128 == 9'223'372'036'854'775'807);
-  assert(12'345'678'901'234'567'890_u128 == 12'345'678'901'234'567'890);
+  assert(12'345'678'901'234'567'890_u128 == 12'345'678'901'234'567'890ull);
 }
 
 __host__ __device__ constexpr void test_hexadecimal()
@@ -50,7 +50,7 @@ __host__ __device__ constexpr void test_hexadecimal()
   assert(0xFFFF_u128 == 0xFFFF);
   assert(0x7FFF'FFFF'FFFF'FFFF_u128 == 0x7FFF'FFFF'FFFF'FFFF);
   assert(0xFF'FFFF'FFFF'FFFF'FFFF_u128 == (__uint128_t{0xFFFF'FFFF'FFFF'FFFF} << 8) + 0xff);
-  assert(0x7FFF'FFFF'FFFF'FFFF'FFFF'FFFF'FFFF'FFFF_u128 == __uint128_t{-1} >> 1);
+  assert(0x7FFF'FFFF'FFFF'FFFF'FFFF'FFFF'FFFF'FFFF_u128 == ~__uint128_t{0} >> 1);
   assert(0xFFFF'FFFF'FFFF'FFFF'FFFF'FFFF'FFFF'FFFF_u128
          == (__uint128_t{0xFFFF'FFFF'FFFF'FFFF} << 64) + 0xFFFF'FFFF'FFFF'FFFF);
 


### PR DESCRIPTION
This PR introduces `i128` and `u128` literals to libcu++ testing. This will allow us to make 128-bit ints direclty without the need for the common `(__int128_t{/*upper-64-bits*/} << 64) + /*lower-64-bits*/`.

Only problem is that nvcc warns about the literal constant value being too big (which is not), but it can be silenced by suppressing warning no.23