### PR TITLE
fix `noexcept` clause on ctor of `let_value`'s opstate

### DIFF
--- a/cudax/include/cuda/experimental/__execution/let_value.cuh
+++ b/cudax/include/cuda/experimental/__execution/let_value.cuh
@@ -202,7 +202,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __let_t
     using __rcvr_t                = __let_t::__rcvr_t<_Rcvr, _Fn, __completions_t>;
 
     _CCCL_API constexpr explicit __opstate_t(_CvSndr&& __sndr, _Fn __fn, _Rcvr __rcvr) noexcept(
-      __nothrow_decay_copyable<_Fn, _Rcvr> && __nothrow_connectable<_CvSndr, __opstate_t*>)
+      __nothrow_decay_copyable<_Fn, _Rcvr> && __nothrow_connectable<_CvSndr, __rcvr_t>)
         : __state_{static_cast<_Rcvr&&>(__rcvr), static_cast<_Fn&&>(__fn)}
         , __opstate1_(execution::connect(static_cast<_CvSndr&&>(__sndr), __rcvr_t{&__state_}))
     {}


### PR DESCRIPTION
## Description

an incomplete edit to `let_value` made in #3841 left its operation state's ctor with an incorrect `noexcept` clause. this PR makes the `noexcept` clause agree with the current ctor implementation.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
