### PR TITLE
Add some notes about performance of 1 and 2 byte atomic_ref.

### DIFF
--- a/docs/libcudacxx/extended_api/synchronization_primitives/atomic_ref.rst
+++ b/docs/libcudacxx/extended_api/synchronization_primitives/atomic_ref.rst
@@ -77,6 +77,10 @@ For each type ``T`` and :ref:`cuda::thread_scope <libcudacxx-extended-api-memory
      - Any thread scope
      - ``sizeof(T) <= 8``
 
+Types of ``T``, where ``sizeof(T) < 4``, are not natively supported by the underlying hardware. For these types atomic 
+operations are emulated and will be drastically slower. Contention with contiguous memory in the current 4 byte boundary
+will be exacerbated. In these situations it is advisable to perform a hierarchical reduction to non-adjacent memory first.
+
 Example
 -------
 

--- a/docs/libcudacxx/extended_api/synchronization_primitives/atomic_ref.rst
+++ b/docs/libcudacxx/extended_api/synchronization_primitives/atomic_ref.rst
@@ -77,7 +77,7 @@ For each type ``T`` and :ref:`cuda::thread_scope <libcudacxx-extended-api-memory
      - Any thread scope
      - ``sizeof(T) <= 8``
 
-Types of ``T``, where ``sizeof(T) < 4``, are not natively supported by the underlying hardware. For these types atomic 
+Types of ``T``, where ``sizeof(T) < 4``, are not natively supported by the underlying hardware. For these types atomic
 operations are emulated and will be drastically slower. Contention with contiguous memory in the current 4 byte boundary
 will be exacerbated. In these situations it is advisable to perform a hierarchical reduction to non-adjacent memory first.
 

--- a/docs/libcudacxx/extended_api/synchronization_primitives/atomic_ref.rst
+++ b/docs/libcudacxx/extended_api/synchronization_primitives/atomic_ref.rst
@@ -44,7 +44,7 @@ No object or subobject of an object referenced by an ``atomic_­ref`` shall be c
 ``atomic_­ref`` that has a different ``Scope``.
 
 For ``cuda::atomic_ref<T>`` and ``cuda::std::atomic_ref<T>`` the type ``T`` must satisfy the following:
-  - ``4 <= sizeof(T) <= 8``.
+  - ``sizeof(T) <= 8``.
   - ``T`` must not have “padding bits”, i.e., T's `object representation <https://en.cppreference.com/w/cpp/language/object#Object_representation_and_value_representation>`_
     must not have bits that do not participate in it's value representation.
 


### PR DESCRIPTION
## Description

Adds some clarity to `atomic_ref` where `sizeof(T) < 4`.


## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
