### PR TITLE
disable posix signal handling in Catch2 to avoid catchorg/Catch2#1833

### DIFF
--- a/cmake/CCCLGetDependencies.cmake
+++ b/cmake/CCCLGetDependencies.cmake
@@ -14,7 +14,13 @@ endmacro()
 
 macro(cccl_get_catch2)
   include("${_cccl_cpm_file}")
-  CPMAddPackage("gh:catchorg/Catch2@3.8.0")
+  CPMAddPackage(
+    NAME Catch2
+    GIT_REPOSITORY "https://github.com/catchorg/Catch2"
+    VERSION "3.8.0"
+    # To avoid https://github.com/catchorg/Catch2/issues/1833:
+    OPTIONS "CATCH_CONFIG_NO_POSIX_SIGNALS ON"
+  )
 endmacro()
 
 macro(cccl_get_fmt)


### PR DESCRIPTION
## Description

when compiling tests with clang and `-sanitize=thread`, if a program hits an assertion, the console is flooded with tsan messages about posix signal handling code calling APIs that are not signal-safe (`operator new` and `operator delete`). this is coming from the Catch2 test harness as described in catchorg/Catch2#1833.

this PR avoids the issue by disabling Catch2's support for POSIX signals.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
