### PR TITLE
fix race condition in `starts_on` execution test

### DIFF
--- a/cudax/test/execution/test_starts_on.cu
+++ b/cudax/test/execution/test_starts_on.cu
@@ -95,15 +95,13 @@ C2H_TEST("starts_on with thread context", "[adaptors][starts_on]")
   cudax_async::thread_context thread;
   bool executed = false;
 
-  {
-    auto snd = cudax_async::starts_on(thread.get_scheduler(), cudax_async::just() | cudax_async::then([&]() {
-                                                                executed = true;
-                                                                return 123;
-                                                              }));
+  auto snd = cudax_async::starts_on(thread.get_scheduler(), cudax_async::just() | cudax_async::then([&]() {
+                                                              executed = true;
+                                                              return 123;
+                                                            }));
 
-    auto op = cudax_async::connect(std::move(snd), checked_value_receiver{123});
-    cudax_async::start(op);
-  }
+  auto op = cudax_async::connect(std::move(snd), checked_value_receiver{123});
+  cudax_async::start(op);
 
   thread.join();
 


### PR DESCRIPTION
## Description

a test for `cudax::execution::starts_on` has a race condition in it:

```c++
  cudax_async::thread_context thread;

  {
    auto snd = cudax_async::starts_on(thread.get_scheduler(),
                                      cudax_async::just() | cudax_async::then([] {...}));

    auto op = cudax_async::connect(std::move(snd), checked_value_receiver{123});
    cudax_async::start(op);
  }              // <---- opstate destroyed here

  thread.join(); // <---- thread accessing the opstate stops here.
```

it starts work on a thread and then it stores the operation state on the program stack. the operation state then goes out of scope and is destroyed without synchronizing with the thread, which may still be accessing the operation state.


## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
