### PR TITLE
fix a data race and use-after-free in `execution::run_loop`

### DIFF
--- a/cudax/include/cuda/experimental/__execution/atomic_intrusive_queue.cuh
+++ b/cudax/include/cuda/experimental/__execution/atomic_intrusive_queue.cuh
@@ -29,6 +29,7 @@
 
 namespace cuda::experimental::execution
 {
+// An atomic queue that supports multiple producers and a single consumer.
 template <auto _NextPtr>
 class _CCCL_TYPE_VISIBILITY_DEFAULT __atomic_intrusive_queue;
 
@@ -36,29 +37,25 @@ template <class _Tp, _Tp* _Tp::* _NextPtr>
 class alignas(64) __atomic_intrusive_queue<_NextPtr>
 {
 public:
-  using __node_pointer _CCCL_NODEBUG_ALIAS        = _Tp*;
-  using __atomic_node_pointer _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::atomic<_Tp*>;
-
-  [[nodiscard]]
-  _CCCL_API auto empty() const noexcept -> bool
-  {
-    return __head_.load(_CUDA_VSTD::memory_order_relaxed) == nullptr;
-  }
-
-  _CCCL_API auto push(__node_pointer __node) noexcept -> bool
+  _CCCL_API auto push(_Tp* __node) noexcept -> bool
   {
     _CCCL_ASSERT(__node != nullptr, "Cannot push a null pointer to the queue");
-    __node_pointer __old_head = __head_.load(_CUDA_VSTD::memory_order_relaxed);
+    _Tp* __old_head = __head_.load(_CUDA_VSTD::memory_order_relaxed);
     do
     {
       __node->*_NextPtr = __old_head;
     } while (!__head_.compare_exchange_weak(__old_head, __node, _CUDA_VSTD::memory_order_acq_rel));
 
+    // If the queue was empty before, we notify the consumer thread that there is now an
+    // item available. If the queue was not empty, we do not notify, because the consumer
+    // thread has already been notified.
     if (__old_head != nullptr)
     {
       return false;
     }
 
+    // There can be only one consumer thread, so we can use notify_one here instead of
+    // notify_all:
     __head_.notify_one();
     return true;
   }
@@ -72,11 +69,12 @@ public:
   [[nodiscard]]
   _CCCL_API auto pop_all() noexcept -> __intrusive_queue<_NextPtr>
   {
-    return __intrusive_queue<_NextPtr>::make_reversed(__head_.exchange(nullptr, _CUDA_VSTD::memory_order_acq_rel));
+    auto* const __list = __head_.exchange(nullptr, _CUDA_VSTD::memory_order_acquire);
+    return __intrusive_queue<_NextPtr>::make_reversed(__list);
   }
 
 private:
-  __atomic_node_pointer __head_{nullptr};
+  _CUDA_VSTD::atomic<_Tp*> __head_{nullptr};
 };
 } // namespace cuda::experimental::execution
 

--- a/cudax/include/cuda/experimental/__execution/run_loop.cuh
+++ b/cudax/include/cuda/experimental/__execution/run_loop.cuh
@@ -57,8 +57,9 @@ public:
   {
     if (!__finishing_.exchange(true, _CUDA_VSTD::memory_order_acq_rel))
     {
-      // push an empty work item to the queue to wake up any waiting threads
-      __queue_.push(&__finish_task);
+      // push an empty work item to the queue to wake up the consuming thread
+      // and let it finish:
+      __queue_.push(&__noop_task);
     }
   }
 
@@ -222,17 +223,24 @@ private:
   // Returns true if any tasks were executed.
   _CCCL_API bool __execute_all() noexcept
   {
-    // Wait until the queue has tasks to execute and then dequeue all of them.
+    // Dequeue all tasks at once. This returns an __intrusive_queue.
     auto __queue = __queue_.pop_all();
-    if (__queue.empty())
-    {
-      return false;
-    }
+
     // Execute all the tasks in the queue.
-    for (auto __task : __queue)
+    auto __it = __queue.begin();
+    if (__it == __queue.end())
     {
-      __task->__execute();
+      return false; // No tasks to execute.
     }
+
+    do
+    {
+      // Take care to increment the iterator before executing the task,
+      // because __execute() may invalidate the current node.
+      auto __prev = __it++;
+      (*__prev)->__execute();
+    } while (__it != __queue.end());
+
     __queue.clear();
     return true;
   }
@@ -241,7 +249,7 @@ private:
 
   _CUDA_VSTD::atomic<bool> __finishing_{false};
   __atomic_intrusive_queue<&__task::__next_> __queue_{};
-  __task __finish_task{&__noop_};
+  __task __noop_task{&__noop_};
 };
 
 } // namespace cuda::experimental::execution


### PR DESCRIPTION
## Description

in `run_loop::execute_all`, we iterate over an `__intrusive_queue` with a range-based `for` loop, calling `__execute()` on each item in the queue. as its name suggests, `__intrusive_queue` is implemented in terms of an intrusive singly-linked list. the increment operation of `__intrusive_queue`'s iterator must do something like this:

```c++
struct iterator {
  ...
  iterator& operator++() {
    item_ = item_->next; // PROBLEM HERE
    return *this;
  }
  ...
  Item* item_;
};
```

given code such as:

```c++
for( auto& item : queue )
{
  item.__execute();
}
```

if `__execute()` causes the invalidation of `item`, the program hits UB when it tries to increment the iterator because the access of `item_->next` in `operator++` will be reading from freed memory.

this PR fixes the problem in `run_loop` by incrementing the queue iterator _before_ calling `__execute()`.

this PR also tidies up the `__atomic_intrusive_queue` implementation and weakens one atomic memory ordering that was over-strong.

EDIT: with these changes, the execution tests are TSAN-clean.


## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
