### PR TITLE
Move ownership of cudax test cmake to cudax owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,6 +19,8 @@ c2h/ @nvidia/cccl-infra-codeowners
 # cmake
 **/CMakeLists.txt @nvidia/cccl-cmake-codeowners
 **/cmake/ @nvidia/cccl-cmake-codeowners
+# make an exception for the cudax test cmake file
+cudax/test/CMakeLists.txt @nvidia/cccl-cudax-codeowners
 
 # benchmarks
 benchmarks/ @nvidia/cccl-benchmark-codeowners


### PR DESCRIPTION
You need to list all sources for cudax tests in the cmake file. But all cmake files are owned by the cmake owners group, which means they get added to every cudax review adding/removing tests and their review is required on all those changes.
This PR adds an exception to the general rule in CODEOWNERS and makes cudax owners own the test cmake file.