### PR TITLE
fix the `_CCCL_PP_COMMA_IFF` macro

### DIFF
--- a/libcudacxx/include/cuda/std/__cccl/preprocessor.h
+++ b/libcudacxx/include/cuda/std/__cccl/preprocessor.h
@@ -86,7 +86,7 @@
 #define _CCCL_PP_COMMA()        ,
 #define _CCCL_PP_LBRACE()       {
 #define _CCCL_PP_RBRACE()       }
-#define _CCCL_PP_COMMA_IIF(_Xp) _CCCL_PP_IIF(_Xp)(_CCCL_PP_EMPTY, _CCCL_PP_COMMA)() /**/
+#define _CCCL_PP_COMMA_IIF(_Xp) _CCCL_PP_IIF(_Xp)(_CCCL_PP_COMMA, _CCCL_PP_EMPTY)()
 
 #define _CCCL_PP_FOR_EACH(_Mp, ...)                          _CCCL_PP_FOR_EACH_N(_CCCL_PP_COUNT(__VA_ARGS__), _Mp, __VA_ARGS__)
 #define _CCCL_PP_FOR_EACH_N(_Np, _Mp, ...)                   _CCCL_PP_CAT2(_CCCL_PP_FOR_EACH_, _Np)(_Mp, __VA_ARGS__)


### PR DESCRIPTION
## Description

`_CCCL_PP_COMMA_IFF(0)` should be empty, and `_CCCL_PP_COMMA_IFF(1)` should be `,`. the current definition gets it backwards.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
