### PR TITLE
Modify low-level cuda.cccl.parallel API to accept pointers directly instead of array objects

### DIFF
--- a/python/cuda_cccl/benchmarks/parallel/bench_reduce.py
+++ b/python/cuda_cccl/benchmarks/parallel/bench_reduce.py
@@ -13,10 +13,22 @@ def reduce_pointer(input_array, build_only):
         return a + b
 
     alg = parallel.make_reduce_into(input_array, res, my_add, h_init)
+
+    input_array_ptr = res.data.ptr
+    res_ptr = res.data.ptr
+    h_init_ptr = h_init.data.cast("B")
+
     if not build_only:
-        temp_storage_bytes = alg(None, input_array, res, size, h_init)
+        temp_storage_bytes = alg(0, 0, input_array_ptr, res_ptr, size, h_init_ptr)
         temp_storage = cp.empty(temp_storage_bytes, dtype=np.uint8)
-        alg(temp_storage, input_array, res, size, h_init)
+        alg(
+            temp_storage.data.ptr,
+            temp_storage.nbytes,
+            input_array_ptr,
+            res_ptr,
+            size,
+            h_init_ptr,
+        )
 
     cp.cuda.runtime.deviceSynchronize()
 
@@ -31,9 +43,9 @@ def reduce_struct(input_array, build_only):
 
     alg = parallel.make_reduce_into(input_array, res, my_add, h_init)
     if not build_only:
-        temp_storage_bytes = alg(None, input_array, res, size, h_init)
+        temp_storage_bytes = alg(0, 0, input_array, res, size, h_init)
         temp_storage = cp.empty(temp_storage_bytes, dtype=np.uint8)
-        alg(temp_storage, input_array, res, size, h_init)
+        alg(temp_storage.data.ptr, temp_storage.nbytes, input_array, res, size, h_init)
 
     cp.cuda.runtime.deviceSynchronize()
 
@@ -48,9 +60,9 @@ def reduce_iterator(inp, size, build_only):
 
     alg = parallel.make_reduce_into(inp, res, my_add, h_init)
     if not build_only:
-        temp_storage_bytes = alg(None, inp, res, size, h_init)
+        temp_storage_bytes = alg(0, 0, inp, res, size, h_init)
         temp_storage = cp.empty(temp_storage_bytes, dtype=np.uint8)
-        alg(temp_storage, inp, res, size, h_init)
+        alg(temp_storage.data.ptr, temp_storage.nbytes, inp, res, size, h_init)
 
     cp.cuda.runtime.deviceSynchronize()
 

--- a/python/cuda_cccl/benchmarks/parallel/bench_reduce.py
+++ b/python/cuda_cccl/benchmarks/parallel/bench_reduce.py
@@ -42,10 +42,21 @@ def reduce_struct(input_array, build_only):
         return MyStruct(a.x + b.x, a.y + b.y)
 
     alg = parallel.make_reduce_into(input_array, res, my_add, h_init)
+    input_array_ptr = res.data.ptr
+    res_ptr = res.data.ptr
+    h_init_ptr = h_init._data.data.cast("B")
+
     if not build_only:
-        temp_storage_bytes = alg(0, 0, input_array, res, size, h_init)
+        temp_storage_bytes = alg(0, 0, input_array_ptr, res_ptr, size, h_init_ptr)
         temp_storage = cp.empty(temp_storage_bytes, dtype=np.uint8)
-        alg(temp_storage.data.ptr, temp_storage.nbytes, input_array, res, size, h_init)
+        alg(
+            temp_storage.data.ptr,
+            temp_storage.nbytes,
+            input_array_ptr,
+            res_ptr,
+            size,
+            h_init_ptr,
+        )
 
     cp.cuda.runtime.deviceSynchronize()
 
@@ -59,10 +70,20 @@ def reduce_iterator(inp, size, build_only):
         return a + b
 
     alg = parallel.make_reduce_into(inp, res, my_add, h_init)
+    res_ptr = res.data.ptr
+    h_init_ptr = h_init.data.cast("B")
+
     if not build_only:
-        temp_storage_bytes = alg(0, 0, inp, res, size, h_init)
+        temp_storage_bytes = alg(0, 0, inp.state, res_ptr, size, h_init_ptr)
         temp_storage = cp.empty(temp_storage_bytes, dtype=np.uint8)
-        alg(temp_storage.data.ptr, temp_storage.nbytes, inp, res, size, h_init)
+        alg(
+            temp_storage.data.ptr,
+            temp_storage.nbytes,
+            inp.state,
+            res_ptr,
+            size,
+            h_init_ptr,
+        )
 
     cp.cuda.runtime.deviceSynchronize()
 

--- a/python/cuda_cccl/cuda/cccl/parallel/experimental/algorithms/_scan.py
+++ b/python/cuda_cccl/cuda/cccl/parallel/experimental/algorithms/_scan.py
@@ -13,7 +13,7 @@ import numpy as np
 from .. import _bindings
 from .. import _cccl_interop as cccl
 from .._caching import CachableFunction, cache_with_key
-from .._cccl_interop import call_build, set_cccl_iterator_state, to_cccl_value_state
+from .._cccl_interop import call_build, get_cccl_value_state, set_cccl_iterator_state
 from .._utils import protocols
 from .._utils.protocols import get_data_pointer, validate_and_get_stream
 from .._utils.temp_storage_buffer import TempStorageBuffer
@@ -75,7 +75,7 @@ class _Scan:
         set_cccl_iterator_state(self.d_in_cccl, d_in)
         set_cccl_iterator_state(self.d_out_cccl, d_out)
 
-        self.h_init_cccl.state = to_cccl_value_state(h_init)
+        self.h_init_cccl.state = get_cccl_value_state(h_init)
 
         stream_handle = validate_and_get_stream(stream)
 

--- a/python/cuda_cccl/cuda/cccl/parallel/experimental/algorithms/_segmented_reduce.py
+++ b/python/cuda_cccl/cuda/cccl/parallel/experimental/algorithms/_segmented_reduce.py
@@ -6,7 +6,7 @@ import numpy as np
 from .. import _bindings
 from .. import _cccl_interop as cccl
 from .._caching import CachableFunction, cache_with_key
-from .._cccl_interop import call_build, set_cccl_iterator_state, to_cccl_value_state
+from .._cccl_interop import call_build, get_cccl_value_state, set_cccl_iterator_state
 from .._utils import protocols
 from .._utils.protocols import (
     get_data_pointer,
@@ -95,7 +95,7 @@ class _SegmentedReduce:
         set_cccl_iterator_state(self.d_out_cccl, d_out)
         set_cccl_iterator_state(self.start_offsets_in_cccl, start_offsets_in)
         set_cccl_iterator_state(self.end_offsets_in_cccl, end_offsets_in)
-        self.h_init_cccl.state = to_cccl_value_state(h_init)
+        self.h_init_cccl.state = get_cccl_value_state(h_init)
 
         stream_handle = validate_and_get_stream(stream)
 

--- a/python/cuda_cccl/tests/parallel/examples/unique/unique_by_key_object.py
+++ b/python/cuda_cccl/tests/parallel/examples/unique/unique_by_key_object.py
@@ -34,23 +34,31 @@ def unique_by_key_object_example():
         compare_op,
     )
 
+    d_input_keys_ptr = d_input_keys.data.ptr
+    d_input_values_ptr = d_input_values.data.ptr
+    d_output_keys_ptr = d_output_keys.data.ptr
+    d_output_values_ptr = d_output_values.data.ptr
+    d_num_selected_ptr = d_num_selected.data.ptr
+
     temp_storage_size = uniquer(
-        None,
-        d_input_keys,
-        d_input_values,
-        d_output_keys,
-        d_output_values,
-        d_num_selected,
+        0,
+        0,
+        d_input_keys_ptr,
+        d_input_values_ptr,
+        d_output_keys_ptr,
+        d_output_values_ptr,
+        d_num_selected_ptr,
         len(h_input_keys),
     )
     d_temp_storage = cp.empty(temp_storage_size, dtype=np.uint8)
     uniquer(
-        d_temp_storage,
-        d_input_keys,
-        d_input_values,
-        d_output_keys,
-        d_output_values,
-        d_num_selected,
+        d_temp_storage.data.ptr,
+        d_temp_storage.nbytes,
+        d_input_keys_ptr,
+        d_input_values_ptr,
+        d_output_keys_ptr,
+        d_output_values_ptr,
+        d_num_selected_ptr,
         len(h_input_keys),
     )
 

--- a/python/cuda_cccl/tests/parallel/test_reduce.py
+++ b/python/cuda_cccl/tests/parallel/test_reduce.py
@@ -562,38 +562,16 @@ def test_reduce_invalid_stream():
     d_out = cp.empty(1)
     h_init = np.empty(1)
     d_in = cp.empty(1)
-    reduce_into = parallel.make_reduce_into(d_in, d_out, add_op, h_init)
 
     with pytest.raises(
         TypeError, match="does not implement the '__cuda_stream__' protocol"
     ):
-        _ = reduce_into(
-            None,
-            d_in=d_in,
-            d_out=d_out,
-            num_items=d_in.size,
-            h_init=h_init,
-            stream=Stream1(),
-        )
+        parallel.reduce_into(d_in, d_out, add_op, d_in.size, h_init, stream=Stream1())
 
     with pytest.raises(
         TypeError, match="could not obtain __cuda_stream__ protocol version and handle"
     ):
-        _ = reduce_into(
-            None,
-            d_in=d_in,
-            d_out=d_out,
-            num_items=d_in.size,
-            h_init=h_init,
-            stream=Stream2(),
-        )
+        parallel.reduce_into(d_in, d_out, add_op, d_in.size, h_init, stream=Stream2())
 
     with pytest.raises(TypeError, match="invalid stream handle"):
-        _ = reduce_into(
-            None,
-            d_in=d_in,
-            d_out=d_out,
-            num_items=d_in.size,
-            h_init=h_init,
-            stream=Stream3(),
-        )
+        parallel.reduce_into(d_in, d_out, add_op, d_in.size, h_init, stream=Stream3())


### PR DESCRIPTION
## Description

closes #3812 

This PR attempts to reduce the overheads we observe when processing input arrays in cuda.cccl.parallel. This overhead comes mainly from extracting the array pointers we pass to the bindings.

Now that we have the new higher-level single-phase API, we can adjust the existing low-level API to accept the pointers directly (this also applies to streams). While this makes the API "uglier", as users now have to extract the pointer from their Python array objects, this improves performance by around ~1us per input array.

Users who prefer passing in their arrays directly should stick to the single phase API. That API supports the CUDA Array Interface protocol so it supports a wide range of device array types.

For now, I have only ported `reduce` and `unique_by_key` as I expect there will be some discussion here first. Once we reach a consensus I will port the remaining algorithms.

Performance data on H200:

<img width="3572" height="2371" alt="api_comparison" src="https://github.com/user-attachments/assets/260305b9-6aa0-4799-b73f-6bb94a4f6dc1" />

Experimental setup:
Python 3.13.5
PyTorch 2.8.0

I call each 3 phase API using PyTorch tensors and streams as input. On the main branch, their pointers are extracted through the CUDA Array Interface.

## Checklist
- [X] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.


