### PR TITLE
Allow 128-bit int/float in nvrtc tests

### DIFF
--- a/libcudacxx/test/utils/libcudacxx/test/config.py
+++ b/libcudacxx/test/utils/libcudacxx/test/config.py
@@ -723,6 +723,8 @@ class Configuration(object):
         compute_archs = self.get_lit_conf("compute_archs")
         if self.cxx.type == "nvrtcc":
             self.config.available_features.add("nvrtc")
+            self.cxx.compile_flags += ["-device-int128"]
+            self.cxx.compile_flags += ["-device-float128"]
         if self.cxx.type == "nvcc":
             self.cxx.compile_flags += ["--extended-lambda"]
         real_arch_format = "-gencode=arch=compute_{0},code=sm_{0}"

--- a/libcudacxx/test/utils/nvidia/nvrtc/nvrtcc.cpp
+++ b/libcudacxx/test/utils/nvidia/nvrtc/nvrtcc.cpp
@@ -163,6 +163,20 @@ ArgPair argHandlers[] = {
      nvrtcArguments.emplace_back("-G");
      return NORMAL;
    }},
+  {// Matches --device-int128/-device-int128
+   std::regex("^(?:--device-int128|-device-int128)$"),
+   [](const std::smatch&) {
+     nvrtcArguments.emplace_back("-device-int128");
+     return NORMAL;
+   }},
+#if CUDA_VERSION >= 12080
+  {// Matches --device-float128/-device-float128
+   std::regex("^(?:--device-float128|-device-float128)$"),
+   [](const std::smatch&) {
+     nvrtcArguments.emplace_back("-device-float128");
+     return NORMAL;
+   }},
+#endif // CUDA_VERSION >= 12080
   {// Matches -D
    std::regex("^-D.+$"),
    [](const std::smatch& match) {


### PR DESCRIPTION
Currently, we don't test 128-bit int/float types with NVRTC. This PR fixes that.