### PR TITLE
Replaces internal macros with `__host__` and `__device__` attributes

### DIFF
--- a/cub/test/catch2_large_array_sort_helper.cuh
+++ b/cub/test/catch2_large_array_sort_helper.cuh
@@ -78,7 +78,7 @@ public:
       , m_is_descending(is_descending)
   {}
 
-  _CCCL_HOST_DEVICE KeyType operator()(std::size_t idx) const
+  __host__ __device__ KeyType operator()(std::size_t idx) const
   {
     return m_is_descending ? static_cast<KeyType>((m_num_items - 1 - idx) * m_conversion)
                            : static_cast<KeyType>(idx * m_conversion);
@@ -103,7 +103,7 @@ struct index_to_summary
   bool is_descending;
 
   template <typename index_type>
-  _CCCL_HOST_DEVICE summary_t operator()(index_type idx) const
+  __host__ __device__ summary_t operator()(index_type idx) const
   {
     constexpr KeyType max_key = ::cuda::std::numeric_limits<KeyType>::max();
 
@@ -137,7 +137,7 @@ public:
       , m_is_descending(is_descending)
   {}
 
-  _CCCL_HOST_DEVICE KeyType operator()(std::size_t idx) const
+  __host__ __device__ KeyType operator()(std::size_t idx) const
   {
     // The final summary may be padded, so truncate the summary_idx at the last valid idx:
     const std::size_t summary_idx = cuda::std::min(m_num_summaries - 1, idx / m_unpadded_run_size);
@@ -152,7 +152,7 @@ template <typename ValueType>
 struct index_to_value
 {
   template <typename index_type>
-  _CCCL_HOST_DEVICE ValueType operator()(index_type index)
+  __host__ __device__ ValueType operator()(index_type index)
   {
     return static_cast<ValueType>(index);
   }

--- a/cub/test/catch2_large_problem_helper.cuh
+++ b/cub/test/catch2_large_problem_helper.cuh
@@ -28,7 +28,7 @@ struct concat_iterators_op
   SecondSegmentItT second_it;
   ::cuda::std::int64_t num_first_items;
 
-  _CCCL_HOST_DEVICE _CCCL_FORCEINLINE auto operator()(::cuda::std::int64_t i)
+  __host__ __device__ _CCCL_FORCEINLINE auto operator()(::cuda::std::int64_t i)
   {
     if (i < num_first_items)
     {
@@ -57,7 +57,7 @@ struct flag_correct_writes_op
 
   static constexpr auto bits_per_element = 8 * sizeof(std::uint32_t);
   template <typename OffsetT, typename T>
-  _CCCL_HOST_DEVICE void operator()(OffsetT index, T val)
+  __host__ __device__ void operator()(OffsetT index, T val)
   {
     // Set bit-flag if the correct result has been written at the given index
     if (expected_it[index] == val)

--- a/cub/test/catch2_segmented_sort_helper.cuh
+++ b/cub/test/catch2_segmented_sort_helper.cuh
@@ -81,7 +81,7 @@ struct segment_index_to_offset_op
   OffsetT segment_size;
   OffsetT num_items;
 
-  _CCCL_HOST_DEVICE _CCCL_FORCEINLINE OffsetT operator()(SegmentIndexT i)
+  __host__ __device__ _CCCL_FORCEINLINE OffsetT operator()(SegmentIndexT i)
   {
     if (i < num_empty_segments)
     {
@@ -104,7 +104,7 @@ struct mod_n
   std::size_t mod;
 
   template <typename IndexT>
-  _CCCL_HOST_DEVICE _CCCL_FORCEINLINE T operator()(IndexT x)
+  __host__ __device__ _CCCL_FORCEINLINE T operator()(IndexT x)
   {
     return static_cast<T>(x % mod);
   }
@@ -290,19 +290,19 @@ using unwrap_value_t = typename unwrap_value_t_impl<T>::type;
 // Derived element gen/validation
 
 template <typename T>
-_CCCL_HOST_DEVICE __forceinline__ double compute_conversion_factor(int segment_size, T)
+__host__ __device__ __forceinline__ double compute_conversion_factor(int segment_size, T)
 {
   const double max_value = static_cast<double>(::cuda::std::numeric_limits<T>::max());
   return (max_value + 1) / segment_size;
 }
 
-_CCCL_HOST_DEVICE __forceinline__ double compute_conversion_factor(int segment_size, double)
+__host__ __device__ __forceinline__ double compute_conversion_factor(int segment_size, double)
 {
   const double max_value = ::cuda::std::numeric_limits<double>::max();
   return max_value / segment_size;
 }
 
-_CCCL_HOST_DEVICE __forceinline__ double compute_conversion_factor(int, cub::NullType)
+__host__ __device__ __forceinline__ double compute_conversion_factor(int, cub::NullType)
 {
   return 1.0;
 }
@@ -320,7 +320,7 @@ struct segment_filler
       , descending(descending)
   {}
 
-  _CCCL_DEVICE void operator()(int segment_id) const
+  __device__ void operator()(int segment_id) const
   {
     const int segment_begin = d_offsets[segment_id];
     const int segment_end   = d_offsets[segment_id + 1];
@@ -366,7 +366,7 @@ struct segment_checker
       , sort_descending(sort_descending)
   {}
 
-  _CCCL_DEVICE bool operator()(int segment_id)
+  __device__ bool operator()(int segment_id)
   {
     const int segment_begin = d_offsets[segment_id];
     const int segment_end   = d_offsets[segment_id + 1];
@@ -386,7 +386,7 @@ struct segment_checker
 
 private:
   // Keys only:
-  _CCCL_DEVICE _CCCL_FORCEINLINE bool check_results(
+  __device__ _CCCL_FORCEINLINE bool check_results(
     int segment_begin, //
     int segment_size,
     cub::NullType)
@@ -407,7 +407,7 @@ private:
 
   // Pairs:
   template <typename DispatchValueT> // Same as ValueT if not cub::NullType
-  _CCCL_DEVICE _CCCL_FORCEINLINE bool
+  __device__ _CCCL_FORCEINLINE bool
   check_results(int segment_begin, //
                 int segment_size,
                 DispatchValueT)
@@ -503,7 +503,7 @@ private:
     return true;
   }
 
-  _CCCL_DEVICE _CCCL_FORCEINLINE KeyT compute_key(int seg_idx, int segment_size, double conversion)
+  __device__ _CCCL_FORCEINLINE KeyT compute_key(int seg_idx, int segment_size, double conversion)
   {
     int conv_idx = sort_descending ? (segment_size - 1 - seg_idx) : seg_idx;
     return static_cast<KeyT>(conv_idx * conversion);
@@ -674,7 +674,7 @@ struct unstable_segmented_value_checker
       , offsets_end(offsets_end)
   {}
 
-  _CCCL_DEVICE bool operator()(int segment_id) const
+  __device__ bool operator()(int segment_id) const
   {
     const int segment_begin = offsets_begin[segment_id];
     const int segment_end   = offsets_end[segment_id];
@@ -1522,7 +1522,7 @@ struct offset_scan_op_t
 {
   int max_items;
 
-  _CCCL_DEVICE _CCCL_FORCEINLINE int operator()(int a, int b) const
+  __device__ _CCCL_FORCEINLINE int operator()(int a, int b) const
   {
     const int sum = a + b;
     return _CUDA_VSTD::min(sum, max_items);

--- a/cub/test/catch2_test_device_histogram.cu
+++ b/cub/test/catch2_test_device_histogram.cu
@@ -263,7 +263,7 @@ auto generate_level_counts_to_test(int max_level_count) -> array<int, ActiveChan
 struct bit_and_anything
 {
   template <typename T>
-  _CCCL_HOST_DEVICE auto operator()(const T& a, const T& b) const -> T
+  __host__ __device__ auto operator()(const T& a, const T& b) const -> T
   {
     using U = typename cub::Traits<T>::UnsignedBits;
     return ::cuda::std::bit_cast<T>(static_cast<U>(::cuda::std::bit_cast<U>(a) & ::cuda::std::bit_cast<U>(b)));

--- a/cub/test/catch2_test_device_merge.cu
+++ b/cub/test/catch2_test_device_merge.cu
@@ -101,7 +101,7 @@ C2H_TEST("DeviceMerge::MergeKeys input sizes", "[merge][device]")
 using unordered_t = c2h::custom_type_t<c2h::equal_comparable_t>;
 struct order
 {
-  _CCCL_HOST_DEVICE auto operator()(const unordered_t& a, const unordered_t& b) const -> bool
+  __host__ __device__ auto operator()(const unordered_t& a, const unordered_t& b) const -> bool
   {
     return a.key < b.key;
   }
@@ -126,7 +126,7 @@ template <typename Value>
 struct key_to_value
 {
   template <typename Key>
-  _CCCL_HOST_DEVICE auto operator()(const Key& k) const -> Value
+  __host__ __device__ auto operator()(const Key& k) const -> Value
   {
     Value v{};
     convert(k, v, 0);
@@ -134,19 +134,19 @@ struct key_to_value
   }
 
   template <typename Key>
-  _CCCL_HOST_DEVICE static void convert(const Key& k, Value& v, ...)
+  __host__ __device__ static void convert(const Key& k, Value& v, ...)
   {
     v = static_cast<Value>(k);
   }
 
   template <template <typename> class... Policies>
-  _CCCL_HOST_DEVICE static void convert(const c2h::custom_type_t<Policies...>& k, Value& v, int)
+  __host__ __device__ static void convert(const c2h::custom_type_t<Policies...>& k, Value& v, int)
   {
     v = static_cast<Value>(k.val);
   }
 
   template <typename Key, template <typename> class... Policies>
-  _CCCL_HOST_DEVICE static void convert(const Key& k, c2h::custom_type_t<Policies...>& v, int)
+  __host__ __device__ static void convert(const Key& k, c2h::custom_type_t<Policies...>& v, int)
   {
     v     = {};
     v.val = static_cast<decltype(v.val)>(k);

--- a/cub/test/catch2_test_device_partition_flagged.cu
+++ b/cub/test/catch2_test_device_partition_flagged.cu
@@ -368,17 +368,17 @@ struct convertible_from_T
       : val_(val)
   {}
 
-  _CCCL_HOST_DEVICE friend bool operator==(const convertible_from_T& a, const T& b)
+  __host__ __device__ friend bool operator==(const convertible_from_T& a, const T& b)
   {
     return a.val_ == b;
   }
 
-  _CCCL_HOST_DEVICE friend bool operator==(const T& a, const convertible_from_T& b)
+  __host__ __device__ friend bool operator==(const T& a, const convertible_from_T& b)
   {
     return a == b.val_;
   }
 
-  _CCCL_HOST_DEVICE friend auto operator<<(std::ostream& os, const convertible_from_T& value) -> std::ostream&
+  __host__ __device__ friend auto operator<<(std::ostream& os, const convertible_from_T& value) -> std::ostream&
   {
     return os << value.val_;
   }

--- a/cub/test/catch2_test_device_reduce_deterministic.cu
+++ b/cub/test/catch2_test_device_reduce_deterministic.cu
@@ -250,7 +250,7 @@ C2H_TEST("Deterministic Device reduce works with float and double on gpu with di
 template <class T>
 struct square_t
 {
-  _CCCL_HOST_DEVICE T operator()(int x) const
+  __host__ __device__ T operator()(int x) const
   {
     return static_cast<T>(x * x);
   }

--- a/cub/test/catch2_test_device_reduce_large_offsets.cu
+++ b/cub/test/catch2_test_device_reduce_large_offsets.cu
@@ -29,7 +29,7 @@ DECLARE_LAUNCH_WRAPPER(cub::DeviceReduce::ArgMax, device_arg_max);
 // List of offset types to test
 using offset_types = c2h::type_list<std::int32_t, std::uint32_t, std::uint64_t>;
 
-_CCCL_HOST_DEVICE _CCCL_FORCEINLINE uint64_t
+__host__ __device__ _CCCL_FORCEINLINE uint64_t
 get_segmented_guassian_sum(const uint64_t num_items, const uint64_t segment_size)
 {
   const uint64_t sum_per_full_segment = (segment_size * (segment_size - 1)) / 2;
@@ -46,7 +46,7 @@ struct mod_op
 {
   uint64_t segment_size;
 
-  _CCCL_HOST_DEVICE _CCCL_FORCEINLINE uint64_t operator()(const uint64_t index) const
+  __host__ __device__ _CCCL_FORCEINLINE uint64_t operator()(const uint64_t index) const
   {
     return static_cast<ItemT>(index % segment_size);
   }
@@ -55,7 +55,7 @@ struct mod_op
 struct custom_sum_op
 {
   template <typename ItemT>
-  _CCCL_HOST_DEVICE _CCCL_FORCEINLINE ItemT operator()(const ItemT lhs, const ItemT rhs) const
+  __host__ __device__ _CCCL_FORCEINLINE ItemT operator()(const ItemT lhs, const ItemT rhs) const
   {
     return lhs + rhs;
   }

--- a/cub/test/catch2_test_device_reduce_nondeterministic.cu
+++ b/cub/test/catch2_test_device_reduce_nondeterministic.cu
@@ -194,7 +194,7 @@ C2H_TEST("Nondeterministic Device reduce works with float and double on gpu with
 template <class T>
 struct square_t
 {
-  _CCCL_HOST_DEVICE T operator()(int x) const
+  __host__ __device__ T operator()(int x) const
   {
     return thrust::square<T>{}(static_cast<T>(x));
   }

--- a/cub/test/catch2_test_device_segmented_reduce_large_offsets.cu
+++ b/cub/test/catch2_test_device_segmented_reduce_large_offsets.cu
@@ -29,7 +29,7 @@ DECLARE_LAUNCH_WRAPPER(cub::DeviceSegmentedReduce::ArgMax, device_segmented_argm
 
 struct get_gaussian_sum_from_offset_op
 {
-  _CCCL_HOST_DEVICE _CCCL_FORCEINLINE ::cuda::std::int64_t
+  __host__ __device__ _CCCL_FORCEINLINE ::cuda::std::int64_t
   operator()(::cuda::std::int64_t begin, ::cuda::std::int64_t end)
   {
     ::cuda::std::int64_t length                 = end - begin;
@@ -43,7 +43,7 @@ struct get_min_from_counting_it_range_op
 {
   IndexT init_val;
 
-  _CCCL_HOST_DEVICE _CCCL_FORCEINLINE IndexT operator()(IndexT begin, IndexT end)
+  __host__ __device__ _CCCL_FORCEINLINE IndexT operator()(IndexT begin, IndexT end)
   {
     return begin == end ? init_val : begin;
   }
@@ -54,7 +54,7 @@ struct get_max_from_counting_it_range_op
 {
   IndexT init_val;
 
-  _CCCL_HOST_DEVICE _CCCL_FORCEINLINE IndexT operator()(IndexT begin, IndexT end)
+  __host__ __device__ _CCCL_FORCEINLINE IndexT operator()(IndexT begin, IndexT end)
   {
     return begin == end ? init_val : end - 1;
   }
@@ -64,7 +64,7 @@ template <typename IndexT>
 struct get_argmax_from_counting_it_range_op
 {
   IndexT init_val;
-  _CCCL_HOST_DEVICE _CCCL_FORCEINLINE ::cuda::std::pair<int, IndexT> operator()(IndexT begin, IndexT end)
+  __host__ __device__ _CCCL_FORCEINLINE ::cuda::std::pair<int, IndexT> operator()(IndexT begin, IndexT end)
   {
     if (begin == end)
     {
@@ -77,7 +77,7 @@ struct get_argmax_from_counting_it_range_op
 struct custom_sum_op
 {
   template <typename ItemT>
-  _CCCL_HOST_DEVICE _CCCL_FORCEINLINE ItemT operator()(const ItemT lhs, const ItemT rhs) const
+  __host__ __device__ _CCCL_FORCEINLINE ItemT operator()(const ItemT lhs, const ItemT rhs) const
   {
     return lhs + rhs;
   }
@@ -97,13 +97,13 @@ struct iterator_without_plus_operator
   using iterator_category = std::random_access_iterator_tag;
 
   // Dereference always returns 0.
-  _CCCL_HOST_DEVICE int operator*() const
+  __host__ __device__ int operator*() const
   {
     return 0;
   }
 
   // Indexing also always returns 0.
-  _CCCL_HOST_DEVICE int operator[](difference_type /*idx*/) const
+  __host__ __device__ int operator[](difference_type /*idx*/) const
   {
     return 0;
   }
@@ -277,7 +277,7 @@ struct dispatch_helper
     return cudaSuccess;
   }
 
-  static _CCCL_HOST tuple_t get_thresholds()
+  static __host__ tuple_t get_thresholds()
   {
     // Get PTX version
     int ptx_version = 0;

--- a/cub/test/catch2_test_device_transform.cu
+++ b/cub/test/catch2_test_device_transform.cu
@@ -105,7 +105,7 @@ C2H_TEST("DeviceTransform::Transform with multiple inputs works for large number
 struct times_seven
 {
   template <typename T>
-  _CCCL_HOST_DEVICE auto operator()(T v) const -> T
+  __host__ __device__ auto operator()(T v) const -> T
   {
     return static_cast<T>(v * 7);
   }
@@ -146,20 +146,20 @@ struct overaligned_addable_and_equal_comparable_policy
   template <typename CustomType>
   struct alignas(Alignment) type
   {
-    _CCCL_HOST_DEVICE static void check(const CustomType& obj)
+    __host__ __device__ static void check(const CustomType& obj)
     {
       _CCCL_VERIFY(reinterpret_cast<uintptr_t>(&obj) % Alignment == 0,
                    "overaligned_addable_policy_t<Alignment> is not sufficiently aligned");
     }
 
-    _CCCL_HOST_DEVICE friend auto operator==(const CustomType& a, const CustomType& b) -> bool
+    __host__ __device__ friend auto operator==(const CustomType& a, const CustomType& b) -> bool
     {
       check(a);
       check(b);
       return a.key == b.key;
     }
 
-    _CCCL_HOST_DEVICE friend auto operator+(char u, const CustomType& b) -> CustomType
+    __host__ __device__ friend auto operator+(char u, const CustomType& b) -> CustomType
     {
       check(b);
       CustomType result{};
@@ -194,29 +194,29 @@ struct uncommon_plus
 {
   // vector types
   template <typename T>
-  _CCCL_HOST_DEVICE auto operator()(int8_t a, const T& b) const -> T
+  __host__ __device__ auto operator()(int8_t a, const T& b) const -> T
   {
     return T{a, 0, 0} + b;
   }
 
-  _CCCL_HOST_DEVICE auto operator()(int8_t a, const huge_t& b) const -> huge_t
+  __host__ __device__ auto operator()(int8_t a, const huge_t& b) const -> huge_t
   {
     huge_t r = b;
     r.key += static_cast<size_t>(a);
     return r;
   }
 
-  _CCCL_HOST_DEVICE auto operator()(int8_t a, const overaligned_t<32>& b) const -> overaligned_t<32>
+  __host__ __device__ auto operator()(int8_t a, const overaligned_t<32>& b) const -> overaligned_t<32>
   {
     return a + b;
   }
 
-  _CCCL_HOST_DEVICE auto operator()(int8_t a, const overaligned_t<256>& b) const -> overaligned_t<256>
+  __host__ __device__ auto operator()(int8_t a, const overaligned_t<256>& b) const -> overaligned_t<256>
   {
     return a + b;
   }
 
-  _CCCL_HOST_DEVICE auto operator()(int8_t a, const overaligned_t<512>& b) const -> overaligned_t<512>
+  __host__ __device__ auto operator()(int8_t a, const overaligned_t<512>& b) const -> overaligned_t<512>
   {
     return a + b;
   }
@@ -253,11 +253,11 @@ struct non_default_constructible
   non_default_constructible& operator=(const non_default_constructible&) = default;
   ~non_default_constructible()                                           = default;
 
-  _CCCL_HOST_DEVICE explicit non_default_constructible(int data)
+  __host__ __device__ explicit non_default_constructible(int data)
       : data(data)
   {}
 
-  friend _CCCL_HOST_DEVICE auto operator==(non_default_constructible a, non_default_constructible b) -> bool
+  friend __host__ __device__ auto operator==(non_default_constructible a, non_default_constructible b) -> bool
   {
     return a.data == b.data;
   }
@@ -286,7 +286,7 @@ struct nstream_kernel
 {
   static constexpr T scalar = 42;
 
-  _CCCL_HOST_DEVICE T operator()(const T& ai, const T& bi, const T& ci) const
+  __host__ __device__ T operator()(const T& ai, const T& bi, const T& ci) const
   {
     return ai + bi + scalar * ci;
   }
@@ -451,7 +451,7 @@ struct plus_needs_stable_address
   int* a;
   int* b;
 
-  _CCCL_HOST_DEVICE int operator()(const int& v) const
+  __host__ __device__ int operator()(const int& v) const
   {
     const auto i = &v - a;
     return v + b[i];
@@ -489,26 +489,26 @@ struct non_trivial
 
   non_trivial() = default;
 
-  _CCCL_HOST_DEVICE explicit non_trivial(int data)
+  __host__ __device__ explicit non_trivial(int data)
       : data(data)
   {}
 
-  _CCCL_HOST_DEVICE non_trivial(const non_trivial& nt)
+  __host__ __device__ non_trivial(const non_trivial& nt)
       : data(nt.data)
   {}
 
-  _CCCL_HOST_DEVICE auto operator=(const non_trivial& nt) -> non_trivial&
+  __host__ __device__ auto operator=(const non_trivial& nt) -> non_trivial&
   {
     data = nt.data;
     return *this;
   }
 
-  _CCCL_HOST_DEVICE auto operator-() const -> non_trivial
+  __host__ __device__ auto operator-() const -> non_trivial
   {
     return non_trivial{-data};
   }
 
-  friend _CCCL_HOST_DEVICE auto operator==(non_trivial a, non_trivial b) -> bool
+  friend __host__ __device__ auto operator==(non_trivial a, non_trivial b) -> bool
   {
     return a.data == b.data;
   }

--- a/cub/test/catch2_test_env_launch_helper.h
+++ b/cub/test/catch2_test_env_launch_helper.h
@@ -43,7 +43,7 @@
 struct get_expected_allocation_size_t
 {};
 
-_CCCL_HOST_DEVICE static cuda::std::execution::prop<get_expected_allocation_size_t, size_t>
+__host__ __device__ static cuda::std::execution::prop<get_expected_allocation_size_t, size_t>
 expected_allocation_size(size_t expected)
 {
   return cuda::std::execution::prop{get_expected_allocation_size_t{}, expected};
@@ -52,7 +52,7 @@ expected_allocation_size(size_t expected)
 struct get_allowed_kernels_t
 {};
 
-_CCCL_HOST_DEVICE static cuda::std::execution::prop<get_allowed_kernels_t, cuda::std::span<void*>>
+__host__ __device__ static cuda::std::execution::prop<get_allowed_kernels_t, cuda::std::span<void*>>
 allowed_kernels(cuda::std::span<void*> allowed_kernels)
 {
   return cuda::std::execution::prop{get_allowed_kernels_t{}, allowed_kernels};

--- a/cub/test/catch2_test_iterator.cu
+++ b/cub/test/catch2_test_iterator.cu
@@ -148,7 +148,7 @@ static_assert(
 template <typename T>
 struct transform_op_t
 {
-  _CCCL_HOST_DEVICE T operator()(T input) const
+  __host__ __device__ T operator()(T input) const
   {
     return input + input;
   }

--- a/cub/test/catch2_test_util_device.cu
+++ b/cub/test/catch2_test_util_device.cu
@@ -205,7 +205,7 @@ struct check_policy_closure
   ::cuda::std::array<int, NumPolicies> policies;
 
   // quick way to get a comparator for find_if below
-  _CCCL_HOST_DEVICE bool operator()(int policy_ver) const
+  __host__ __device__ bool operator()(int policy_ver) const
   {
     return policy_ver <= ptx_version;
   }


### PR DESCRIPTION
## Description

We want to write CUB tests and examples as an external user would. Hence, we want to get rid of usage of internal macros. 