### PR TITLE
Move TMA barrier in DeviceTransform into dynamic SMEM

### DIFF
--- a/cub/cub/device/dispatch/dispatch_transform.cuh
+++ b/cub/cub/device/dispatch/dispatch_transform.cuh
@@ -222,15 +222,8 @@ struct dispatch_t<StableAddress,
     CUB_DETAIL_STATIC_ISH_ASSERT(min_items_per_thread <= max_items_per_thread, "invalid policy");
 
     auto determine_element_counts = [&]() -> cuda_expected<async_config> {
-      int max_smem = 0;
-      auto error   = CubDebug(launcher_factory.MaxSharedMemory(max_smem));
-      if (error != cudaSuccess)
-      {
-        return ::cuda::std::unexpected<cudaError_t /* nvcc 12.0 fails CTAD here */>(error);
-      }
-
       int sm_count = 0;
-      error        = CubDebug(launcher_factory.MultiProcessorCount(sm_count));
+      auto error   = CubDebug(launcher_factory.MultiProcessorCount(sm_count));
       if (error != cudaSuccess)
       {
         return ::cuda::std::unexpected<cudaError_t /* nvcc 12.0 fails CTAD here */>(error);

--- a/cub/cub/device/dispatch/dispatch_transform.cuh
+++ b/cub/cub/device/dispatch/dispatch_transform.cuh
@@ -205,8 +205,9 @@ struct dispatch_t<StableAddress,
 
   template <typename ActivePolicy, typename SMemFunc>
   CUB_RUNTIME_FUNCTION _CCCL_VISIBILITY_HIDDEN _CCCL_FORCEINLINE auto
-  configure_async_kernel(int alignment, SMemFunc smem_for_tile_size, ActivePolicy policy = {}) -> cuda_expected<
-    ::cuda::std::tuple<decltype(launcher_factory(0, 0, 0, 0)), decltype(kernel_source.TransformKernel()), int>>
+  configure_async_kernel(int alignment, int static_smem, SMemFunc dyn_smem_for_tile_size, ActivePolicy policy = {})
+    -> cuda_expected<
+      ::cuda::std::tuple<decltype(launcher_factory(0, 0, 0, 0)), decltype(kernel_source.TransformKernel()), int>>
   {
     auto wrapped_policy = MakeTransformPolicyWrapper(policy);
     int block_threads   = wrapped_policy.AlgorithmPolicy().BlockThreads();
@@ -243,9 +244,9 @@ struct dispatch_t<StableAddress,
       async_config last_config{};
       for (int items_per_thread = +min_items_per_thread; items_per_thread <= +max_items_per_thread; ++items_per_thread)
       {
-        const int tile_size = block_threads * items_per_thread;
-        const int smem_size = smem_for_tile_size(tile_size, alignment);
-        if (smem_size > max_smem)
+        const int tile_size     = block_threads * items_per_thread;
+        const int dyn_smem_size = dyn_smem_for_tile_size(tile_size, alignment);
+        if (static_smem + dyn_smem_size > max_smem)
         {
           // assert should be prevented by smem check in policy
           _CCCL_ASSERT(last_config.items_per_thread > 0, "min_items_per_thread exceeds available shared memory");
@@ -253,8 +254,8 @@ struct dispatch_t<StableAddress,
         }
 
         int max_occupancy = 0;
-        error             = CubDebug(
-          launcher_factory.MaxSmOccupancy(max_occupancy, kernel_source.TransformKernel(), block_threads, smem_size));
+        error             = CubDebug(launcher_factory.MaxSmOccupancy(
+          max_occupancy, kernel_source.TransformKernel(), block_threads, dyn_smem_size));
         if (error != cudaSuccess)
         {
           return ::cuda::std::unexpected<cudaError_t /* nvcc 12.0 fails CTAD here */>(error);
@@ -297,15 +298,15 @@ struct dispatch_t<StableAddress,
 
     const int ipt =
       spread_out_items_per_thread(policy, config->items_per_thread, config->sm_count, config->max_occupancy);
-    const int tile_size = block_threads * ipt;
-    const int smem_size = smem_for_tile_size(tile_size, alignment);
-    _CCCL_ASSERT((sizeof...(RandomAccessIteratorsIn) == 0) != (smem_size != 0), ""); // logical xor
+    const int tile_size     = block_threads * ipt;
+    const int dyn_smem_size = dyn_smem_for_tile_size(tile_size, alignment);
+    _CCCL_ASSERT((sizeof...(RandomAccessIteratorsIn) == 0) != (dyn_smem_size != 0), ""); // logical xor
 
     const auto grid_dim = static_cast<unsigned int>(::cuda::ceil_div(num_items, Offset{tile_size}));
     // config->smem_size is 16 bytes larger than needed for UBLKCP because it's the total SMEM size, but 16 bytes are
     // occupied by static shared memory and padding. But let's not complicate things.
     return ::cuda::std::make_tuple(
-      launcher_factory(grid_dim, block_threads, smem_size, stream), kernel_source.TransformKernel(), ipt);
+      launcher_factory(grid_dim, block_threads, dyn_smem_size, stream), kernel_source.TransformKernel(), ipt);
   }
 
   // Avoid unnecessarily parsing these definitions when not needed.
@@ -327,9 +328,13 @@ struct dispatch_t<StableAddress,
 
   template <typename ActivePolicy, typename SMemFunc, std::size_t... Is>
   CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t invoke_async_algorithm(
-    int alignment, SMemFunc smem_for_tile_size, cuda::std::index_sequence<Is...>, ActivePolicy policy = {})
+    int alignment,
+    int static_smem,
+    SMemFunc dyn_smem_for_tile_size,
+    cuda::std::index_sequence<Is...>,
+    ActivePolicy policy = {})
   {
-    auto ret = configure_async_kernel(alignment, smem_for_tile_size, policy);
+    auto ret = configure_async_kernel(alignment, static_smem, dyn_smem_for_tile_size, policy);
     if (!ret)
     {
       return ret.error();
@@ -491,12 +496,9 @@ struct dispatch_t<StableAddress,
     {
       return invoke_async_algorithm(
         bulk_copy_align,
-        [this, wrapped_policy](int tile_size, int alignment) {
-          return bulk_copy_smem_for_tile_size(
-            kernel_source.ItValueSizesAlignments(),
-            tile_size,
-            wrapped_policy.AlgorithmPolicy().BlockThreads(),
-            alignment);
+        /* static SMEM used to align dynamic SMEM (and contains 8 byte barrier) */ max_bulk_copy_alignment,
+        [this](int tile_size, int alignment) {
+          return bulk_copy_dyn_smem_for_tile_size(kernel_source.ItValueSizesAlignments(), tile_size, alignment);
         },
         seq,
         active_policy);
@@ -505,12 +507,9 @@ struct dispatch_t<StableAddress,
     {
       return invoke_async_algorithm(
         ldgsts_size_and_align,
-        [this, wrapped_policy](int tile_size, int alignment) {
-          return memcpy_async_smem_for_tile_size(
-            kernel_source.ItValueSizesAlignments(),
-            tile_size,
-            wrapped_policy.AlgorithmPolicy().BlockThreads(),
-            alignment);
+        /* no static SMEM */ 0,
+        [this](int tile_size, int alignment) {
+          return memcpy_async_dyn_smem_for_tile_size(kernel_source.ItValueSizesAlignments(), tile_size, alignment);
         },
         seq,
         active_policy);

--- a/cub/cub/device/dispatch/kernels/transform.cuh
+++ b/cub/cub/device/dispatch/kernels/transform.cuh
@@ -649,7 +649,8 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
   // also what cutlass does.
 
   extern __shared__ char /*__align__(max_bulk_copy_alignment)*/ smem_with_barrier[];
-  _CCCL_ASSERT(::cuda::is_aligned(smem_with_barrier, max_bulk_copy_alignment), "");
+  _CCCL_ASSERT(::cuda::is_aligned(smem_with_barrier, max_bulk_copy_alignment),
+               "Dynamic shared memory is insufficiently aligned");
   uint64_t& bar         = *reinterpret_cast<uint64_t*>(smem_with_barrier);
   char* const smem_base = smem_with_barrier + max_bulk_copy_alignment;
 

--- a/cub/cub/device/dispatch/kernels/transform.cuh
+++ b/cub/cub/device/dispatch/kernels/transform.cuh
@@ -634,7 +634,7 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
   // Because extern (__shared__) variables are injected from inside a function (template) scope into the enclosing
   // namespace scope they must have the same type and (alignment) attributes for the same name. So we cannot specify a
   // different alignment based on the template parameters (i.e. the iterator value types). We settle on using 128 as
-  // alignment, since it's the maximum bulk copy alignment to handle Hopper and should cover must overaligned types as
+  // alignment, since it's the maximum bulk copy alignment to handle Hopper and should cover most overaligned types as
   // well (we don't expect many types with alignment > 128 bytes).
   //
   // We could use an attribute to align the shared memory. This is unfortunately not respected by nvcc in all cases and

--- a/cub/cub/device/dispatch/tuning/tuning_transform.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_transform.cuh
@@ -350,7 +350,6 @@ struct policy_hub<RequiresStableAddress, ::cuda::std::tuple<RandomAccessIterator
   struct bulk_copy_policy_base
   {
   private:
-    // TODO(bgruber): should we just use max_bulk_copy_alignment here? Would simplify the code
     static constexpr int alignment = bulk_copy_alignment(PtxVersion);
     using async_policy             = async_copy_policy_t<AsyncBlockSize, alignment>;
     // We cannot use the architecture-specific amount of SMEM here instead of max_smem_per_block, because this is not

--- a/cub/test/catch2_test_device_transform.cu
+++ b/cub/test/catch2_test_device_transform.cu
@@ -682,3 +682,18 @@ C2H_TEST("DeviceTransform::Transform function/output_iter return type not conver
   c2h::device_vector<C> reference(num_items, C{-43});
   CHECK(output == reference);
 }
+
+__global__ void unrelated_kernel()
+{
+  __shared__ int ssmem; // 4 bytes
+  extern __shared__ int dsmem[]; // aligned to 16 by default, so 12 bytes padding needed
+  asm("" : "+r"(ssmem));
+  asm("" : "+r"(dsmem[0]));
+}
+
+C2H_TEST("DeviceTransform::Transform does not effect unrelated kernel's static SMEM consumption", "[device][transform]")
+{
+  cudaFuncAttributes attrs;
+  REQUIRE(cudaFuncGetAttributes(&attrs, unrelated_kernel) == cudaSuccess);
+  REQUIRE(attrs.sharedSizeBytes == 4 + 12);
+}


### PR DESCRIPTION
First, this PR removes any `__align__` attribute from `extern __shared__` symbols (dynamic SMEM). This avoids a bunch of bugs caused by equally named `extern __shared__` symbols with different alignment (either via independent variables or a variable template). This fixes NvBug 5320137 and https://github.com/NVIDIA/cccl_private/issues/453.

This PR also moves the barrier into dynamic shared memory to avoid static SMEM and use a single SMEM symbol. This way we can rely on the naturally large alignment of the SMEM window. For conformance (in case the SMEM window alignment ever changes), manual alignment is only required for types with alignment > 16 to ensure correctness, which this PR implements. But no alignment is required for bulk copy, since SMEM is at least 16 bytes aligned (required by bulk copy), but aligned higher in practice (getting us at least 128 alignment on Hopper for free).

Furthermore, each `__shared__` symbol requires a `ULEA` for relocation, which this PR cuts down to one.

In addition, we fallback to prefetch if the tile size cannot retain the alignment required by bulk copy and value types. This simplifies the kernel and also the host side setup.

Fixes: #5344

Benchmark on H200 shows basically identical performance to before.
```
# mul

## [0] NVIDIA H200 NVL

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-----------|---------|----------|
|   I8    |      I32      |      2^16      |   4.266 us |       4.31% |   4.254 us |       4.46% | -0.012 us |  -0.29% |   SAME   |
|   I8    |      I32      |      2^20      |   5.362 us |       3.70% |   5.348 us |       3.39% | -0.013 us |  -0.25% |   SAME   |
|   I8    |      I32      |      2^24      |  15.651 us |       2.70% |  15.602 us |       2.67% | -0.049 us |  -0.31% |   SAME   |
|   I8    |      I32      |      2^28      | 154.276 us |       0.38% | 153.960 us |       0.17% | -0.316 us |  -0.21% |   FAST   |
|   I8    |      I64      |      2^16      |   4.419 us |       3.89% |   4.445 us |       3.67% |  0.026 us |   0.59% |   SAME   |
|   I8    |      I64      |      2^20      |   5.415 us |       4.05% |   5.423 us |       3.95% |  0.008 us |   0.14% |   SAME   |
|   I8    |      I64      |      2^24      |  15.502 us |       2.47% |  15.554 us |       2.55% |  0.051 us |   0.33% |   SAME   |
|   I8    |      I64      |      2^28      | 155.154 us |       0.45% | 155.943 us |       0.42% |  0.789 us |   0.51% |   SLOW   |
|   I16   |      I32      |      2^16      |   4.485 us |       4.06% |   4.493 us |       3.74% |  0.007 us |   0.16% |   SAME   |
|   I16   |      I32      |      2^20      |   6.136 us |       4.20% |   6.080 us |       3.64% | -0.056 us |  -0.91% |   SAME   |
|   I16   |      I32      |      2^24      |  22.441 us |       2.63% |  22.599 us |       2.70% |  0.159 us |   0.71% |   SAME   |
|   I16   |      I32      |      2^28      | 262.951 us |       0.43% | 263.167 us |       0.44% |  0.216 us |   0.08% |   SAME   |
|   I16   |      I64      |      2^16      |   4.561 us |       5.14% |   4.543 us |       4.28% | -0.018 us |  -0.40% |   SAME   |
|   I16   |      I64      |      2^20      |   6.150 us |       4.49% |   5.927 us |       4.48% | -0.223 us |  -3.63% |   SAME   |
|   I16   |      I64      |      2^24      |  22.513 us |       2.67% |  22.508 us |       2.63% | -0.005 us |  -0.02% |   SAME   |
|   I16   |      I64      |      2^28      | 266.174 us |       0.43% | 263.094 us |       0.42% | -3.080 us |  -1.16% |   FAST   |
|   F32   |      I32      |      2^16      |   4.488 us |       4.06% |   4.473 us |       4.55% | -0.015 us |  -0.34% |   SAME   |
|   F32   |      I32      |      2^20      |   6.808 us |       4.21% |   6.891 us |       4.74% |  0.083 us |   1.22% |   SAME   |
|   F32   |      I32      |      2^24      |  38.015 us |       2.34% |  38.103 us |       2.29% |  0.088 us |   0.23% |   SAME   |
|   F32   |      I32      |      2^28      | 527.275 us |       0.23% | 527.248 us |       0.23% | -0.028 us |  -0.01% |   SAME   |
|   F32   |      I64      |      2^16      |   4.518 us |       4.04% |   4.540 us |       5.10% |  0.022 us |   0.48% |   SAME   |
|   F32   |      I64      |      2^20      |   6.835 us |       3.95% |   6.774 us |       3.65% | -0.061 us |  -0.89% |   SAME   |
|   F32   |      I64      |      2^24      |  37.989 us |       2.32% |  37.930 us |       2.31% | -0.060 us |  -0.16% |   SAME   |
|   F32   |      I64      |      2^28      | 527.087 us |       0.22% | 527.088 us |       0.20% |  0.001 us |   0.00% |   SAME   |
|   F64   |      I32      |      2^16      |   4.715 us |       4.64% |   4.655 us |       4.85% | -0.061 us |  -1.29% |   SAME   |
|   F64   |      I32      |      2^20      |   9.209 us |       3.89% |   9.193 us |       4.49% | -0.016 us |  -0.17% |   SAME   |
|   F64   |      I32      |      2^24      |  70.420 us |       1.37% |  70.494 us |       1.37% |  0.074 us |   0.11% |   SAME   |
|   F64   |      I32      |      2^28      |   1.047 ms |       0.14% |   1.047 ms |       0.14% | -0.070 us |  -0.01% |   SAME   |
|   F64   |      I64      |      2^16      |   4.753 us |       4.02% |   4.728 us |       4.47% | -0.025 us |  -0.52% |   SAME   |
|   F64   |      I64      |      2^20      |   9.211 us |       4.16% |   9.128 us |       4.07% | -0.083 us |  -0.90% |   SAME   |
|   F64   |      I64      |      2^24      |  70.447 us |       1.33% |  70.417 us |       1.34% | -0.030 us |  -0.04% |   SAME   |
|   F64   |      I64      |      2^28      |   1.046 ms |       0.14% |   1.046 ms |       0.14% |  0.072 us |   0.01% |   SAME   |
|  I128   |      I32      |      2^16      |   5.017 us |       4.24% |   5.001 us |       4.93% | -0.016 us |  -0.33% |   SAME   |
|  I128   |      I32      |      2^20      |  13.603 us |       3.39% |  13.701 us |       3.46% |  0.097 us |   0.71% |   SAME   |
|  I128   |      I32      |      2^24      | 138.158 us |       0.72% | 138.109 us |       0.68% | -0.049 us |  -0.04% |   SAME   |
|  I128   |      I32      |      2^28      |   2.127 ms |       0.08% |   2.127 ms |       0.08% |  0.037 us |   0.00% |   SAME   |
|  I128   |      I64      |      2^16      |   5.076 us |       3.93% |   5.110 us |       4.81% |  0.034 us |   0.67% |   SAME   |
|  I128   |      I64      |      2^20      |  13.595 us |       3.56% |  13.716 us |       3.26% |  0.121 us |   0.89% |   SAME   |
|  I128   |      I64      |      2^24      | 137.882 us |       0.73% | 138.625 us |       0.67% |  0.743 us |   0.54% |   SAME   |
|  I128   |      I64      |      2^28      |   2.127 ms |       0.08% |   2.127 ms |       0.08% | -0.072 us |  -0.00% |   SAME   |

# add

## [0] NVIDIA H200 NVL

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-----------|---------|----------|
|   I8    |      I32      |      2^16      |   4.641 us |       4.42% |   4.540 us |       4.17% | -0.101 us |  -2.18% |   SAME   |
|   I8    |      I32      |      2^20      |   5.909 us |       4.50% |   5.786 us |       4.09% | -0.123 us |  -2.08% |   SAME   |
|   I8    |      I32      |      2^24      |  20.197 us |       2.75% |  20.060 us |       2.78% | -0.137 us |  -0.68% |   SAME   |
|   I8    |      I32      |      2^28      | 209.527 us |       0.31% | 209.054 us |       0.24% | -0.473 us |  -0.23% |   SAME   |
|   I8    |      I64      |      2^16      |   4.591 us |       4.41% |   4.502 us |       3.88% | -0.089 us |  -1.94% |   SAME   |
|   I8    |      I64      |      2^20      |   5.848 us |       3.80% |   5.825 us |       4.54% | -0.023 us |  -0.39% |   SAME   |
|   I8    |      I64      |      2^24      |  19.961 us |       2.80% |  20.091 us |       2.67% |  0.130 us |   0.65% |   SAME   |
|   I8    |      I64      |      2^28      | 210.348 us |       0.27% | 210.328 us |       0.28% | -0.020 us |  -0.01% |   SAME   |
|   I16   |      I32      |      2^16      |   4.623 us |       4.87% |   4.615 us |       3.61% | -0.008 us |  -0.16% |   SAME   |
|   I16   |      I32      |      2^20      |   6.814 us |       3.94% |   6.757 us |       4.25% | -0.057 us |  -0.84% |   SAME   |
|   I16   |      I32      |      2^24      |  31.494 us |       2.23% |  31.531 us |       2.22% |  0.037 us |   0.12% |   SAME   |
|   I16   |      I32      |      2^28      | 386.652 us |       0.20% | 386.190 us |       0.19% | -0.462 us |  -0.12% |   SAME   |
|   I16   |      I64      |      2^16      |   4.583 us |       4.18% |   4.615 us |       4.56% |  0.032 us |   0.69% |   SAME   |
|   I16   |      I64      |      2^20      |   6.772 us |       3.46% |   6.976 us |       4.16% |  0.204 us |   3.01% |   SAME   |
|   I16   |      I64      |      2^24      |  31.496 us |       2.19% |  31.515 us |       2.21% |  0.019 us |   0.06% |   SAME   |
|   I16   |      I64      |      2^28      | 387.484 us |       0.20% | 386.922 us |       0.20% | -0.562 us |  -0.15% |   SAME   |
|   F32   |      I32      |      2^16      |   4.725 us |       4.36% |   4.682 us |       4.16% | -0.043 us |  -0.91% |   SAME   |
|   F32   |      I32      |      2^20      |   8.411 us |       4.04% |   8.439 us |       4.55% |  0.029 us |   0.34% |   SAME   |
|   F32   |      I32      |      2^24      |  55.005 us |       1.54% |  55.013 us |       1.51% |  0.008 us |   0.01% |   SAME   |
|   F32   |      I32      |      2^28      | 755.900 us |       0.13% | 755.480 us |       0.13% | -0.420 us |  -0.06% |   SAME   |
|   F32   |      I64      |      2^16      |   4.849 us |       4.26% |   4.862 us |       4.82% |  0.013 us |   0.28% |   SAME   |
|   F32   |      I64      |      2^20      |   8.363 us |       3.91% |   8.458 us |       4.15% |  0.095 us |   1.14% |   SAME   |
|   F32   |      I64      |      2^24      |  55.018 us |       1.55% |  55.058 us |       1.53% |  0.040 us |   0.07% |   SAME   |
|   F32   |      I64      |      2^28      | 756.542 us |       0.13% | 756.028 us |       0.13% | -0.513 us |  -0.07% |   SAME   |
|   F64   |      I32      |      2^16      |   5.081 us |       5.07% |   5.026 us |       4.49% | -0.055 us |  -1.08% |   SAME   |
|   F64   |      I32      |      2^20      |  11.822 us |       3.09% |  11.859 us |       3.38% |  0.036 us |   0.31% |   SAME   |
|   F64   |      I32      |      2^24      | 101.230 us |       0.26% | 101.261 us |       0.38% |  0.032 us |   0.03% |   SAME   |
|   F64   |      I32      |      2^28      |   1.510 ms |       0.10% |   1.510 ms |       0.10% |  0.158 us |   0.01% |   SAME   |
|   F64   |      I64      |      2^16      |   5.192 us |       3.85% |   5.166 us |       4.96% | -0.026 us |  -0.50% |   SAME   |
|   F64   |      I64      |      2^20      |  11.876 us |       3.35% |  11.880 us |       3.25% |  0.004 us |   0.03% |   SAME   |
|   F64   |      I64      |      2^24      | 101.227 us |       0.36% | 101.304 us |       0.38% |  0.077 us |   0.08% |   SAME   |
|   F64   |      I64      |      2^28      |   1.510 ms |       0.09% |   1.510 ms |       0.09% |  0.122 us |   0.01% |   SAME   |
|  I128   |      I32      |      2^16      |   5.692 us |       4.83% |   5.781 us |       5.13% |  0.090 us |   1.57% |   SAME   |
|  I128   |      I32      |      2^20      |  18.607 us |       2.98% |  18.520 us |       2.96% | -0.087 us |  -0.47% |   SAME   |
|  I128   |      I32      |      2^24      | 194.871 us |       0.41% | 194.725 us |       0.41% | -0.146 us |  -0.08% |   SAME   |
|  I128   |      I32      |      2^28      |   3.015 ms |       0.06% |   3.016 ms |       0.06% |  0.182 us |   0.01% |   SAME   |
|  I128   |      I64      |      2^16      |   5.765 us |       4.74% |   5.818 us |       5.27% |  0.053 us |   0.92% |   SAME   |
|  I128   |      I64      |      2^20      |  19.311 us |       4.82% |  18.839 us |       4.43% | -0.472 us |  -2.44% |   SAME   |
|  I128   |      I64      |      2^24      | 195.127 us |       0.40% | 194.675 us |       0.42% | -0.451 us |  -0.23% |   SAME   |
|  I128   |      I64      |      2^28      |   3.015 ms |       0.06% |   3.015 ms |       0.06% |  0.205 us |   0.01% |   SAME   |

# triad

## [0] NVIDIA H200 NVL

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-----------|---------|----------|
|   I8    |      I32      |      2^16      |   4.589 us |       4.45% |   4.706 us |       4.58% |  0.117 us |   2.55% |   SAME   |
|   I8    |      I32      |      2^20      |   6.000 us |       4.10% |   6.143 us |       3.62% |  0.143 us |   2.39% |   SAME   |
|   I8    |      I32      |      2^24      |  20.587 us |       2.74% |  20.502 us |       2.70% | -0.085 us |  -0.41% |   SAME   |
|   I8    |      I32      |      2^28      | 218.171 us |       0.33% | 218.717 us |       0.34% |  0.546 us |   0.25% |   SAME   |
|   I8    |      I64      |      2^16      |   4.501 us |       3.84% |   4.619 us |       3.88% |  0.118 us |   2.61% |   SAME   |
|   I8    |      I64      |      2^20      |   5.985 us |       4.93% |   6.055 us |       3.48% |  0.070 us |   1.16% |   SAME   |
|   I8    |      I64      |      2^24      |  20.624 us |       2.65% |  20.628 us |       2.75% |  0.004 us |   0.02% |   SAME   |
|   I8    |      I64      |      2^28      | 219.916 us |       0.33% | 220.073 us |       0.33% |  0.157 us |   0.07% |   SAME   |
|   I16   |      I32      |      2^16      |   4.638 us |       4.28% |   4.635 us |       3.79% | -0.003 us |  -0.08% |   SAME   |
|   I16   |      I32      |      2^20      |   6.840 us |       4.33% |   6.976 us |       4.10% |  0.136 us |   1.99% |   SAME   |
|   I16   |      I32      |      2^24      |  31.861 us |       2.17% |  32.057 us |       2.19% |  0.196 us |   0.61% |   SAME   |
|   I16   |      I32      |      2^28      | 388.358 us |       0.20% | 388.130 us |       0.20% | -0.228 us |  -0.06% |   SAME   |
|   I16   |      I64      |      2^16      |   4.625 us |       3.26% |   4.677 us |       3.92% |  0.052 us |   1.13% |   SAME   |
|   I16   |      I64      |      2^20      |   6.833 us |       3.92% |   6.833 us |       4.30% | -0.001 us |  -0.01% |   SAME   |
|   I16   |      I64      |      2^24      |  31.860 us |       2.10% |  32.162 us |       2.17% |  0.301 us |   0.95% |   SAME   |
|   I16   |      I64      |      2^28      | 389.262 us |       0.20% | 388.889 us |       0.19% | -0.373 us |  -0.10% |   SAME   |
|   F32   |      I32      |      2^16      |   4.744 us |       4.82% |   4.801 us |       4.20% |  0.057 us |   1.20% |   SAME   |
|   F32   |      I32      |      2^20      |   8.337 us |       4.34% |   8.474 us |       3.97% |  0.137 us |   1.64% |   SAME   |
|   F32   |      I32      |      2^24      |  55.176 us |       1.52% |  55.145 us |       1.58% | -0.031 us |  -0.06% |   SAME   |
|   F32   |      I32      |      2^28      | 755.395 us |       0.14% | 755.308 us |       0.14% | -0.088 us |  -0.01% |   SAME   |
|   F32   |      I64      |      2^16      |   4.843 us |       4.36% |   4.739 us |       4.80% | -0.103 us |  -2.13% |   SAME   |
|   F32   |      I64      |      2^20      |   8.439 us |       3.90% |   8.595 us |       4.14% |  0.157 us |   1.86% |   SAME   |
|   F32   |      I64      |      2^24      |  55.308 us |       1.51% |  55.058 us |       1.54% | -0.251 us |  -0.45% |   SAME   |
|   F32   |      I64      |      2^28      | 755.807 us |       0.14% | 755.447 us |       0.14% | -0.360 us |  -0.05% |   SAME   |
|   F64   |      I32      |      2^16      |   5.077 us |       4.53% |   4.951 us |       4.72% | -0.126 us |  -2.48% |   SAME   |
|   F64   |      I32      |      2^20      |  11.932 us |       3.37% |  11.795 us |       3.37% | -0.137 us |  -1.14% |   SAME   |
|   F64   |      I32      |      2^24      | 101.553 us |       0.39% | 101.240 us |       0.48% | -0.313 us |  -0.31% |   SAME   |
|   F64   |      I32      |      2^28      |   1.510 ms |       0.09% |   1.510 ms |       0.09% | -0.045 us |  -0.00% |   SAME   |
|   F64   |      I64      |      2^16      |   5.151 us |       4.27% |   5.063 us |       4.38% | -0.089 us |  -1.72% |   SAME   |
|   F64   |      I64      |      2^20      |  12.036 us |       3.19% |  11.787 us |       3.42% | -0.249 us |  -2.07% |   SAME   |
|   F64   |      I64      |      2^24      | 101.604 us |       0.39% | 101.298 us |       0.37% | -0.306 us |  -0.30% |   SAME   |
|   F64   |      I64      |      2^28      |   1.510 ms |       0.10% |   1.510 ms |       0.09% |  0.022 us |   0.00% |   SAME   |
|  I128   |      I32      |      2^16      |   5.733 us |       4.72% |   5.594 us |       4.69% | -0.140 us |  -2.44% |   SAME   |
|  I128   |      I32      |      2^20      |  18.234 us |       3.05% |  18.508 us |       2.93% |  0.275 us |   1.51% |   SAME   |
|  I128   |      I32      |      2^24      | 194.544 us |       0.41% | 194.675 us |       0.43% |  0.131 us |   0.07% |   SAME   |
|  I128   |      I32      |      2^28      |   3.019 ms |       0.06% |   3.019 ms |       0.06% | -0.164 us |  -0.01% |   SAME   |
|  I128   |      I64      |      2^16      |   5.811 us |       4.83% |   5.656 us |       3.92% | -0.155 us |  -2.67% |   SAME   |
|  I128   |      I64      |      2^20      |  19.532 us |       4.66% |  18.956 us |       4.61% | -0.576 us |  -2.95% |   SAME   |
|  I128   |      I64      |      2^24      | 194.561 us |       0.41% | 194.750 us |       0.40% |  0.189 us |   0.10% |   SAME   |
|  I128   |      I64      |      2^28      |   3.019 ms |       0.05% |   3.019 ms |       0.06% | -0.062 us |  -0.00% |   SAME   |

# nstream

## [0] NVIDIA H200 NVL

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-----------|---------|----------|
|   I8    |      I32      |      2^16      |   4.767 us |       5.06% |   4.671 us |       4.40% | -0.095 us |  -2.00% |   SAME   |
|   I8    |      I32      |      2^20      |   6.618 us |       3.95% |   6.555 us |       4.45% | -0.063 us |  -0.95% |   SAME   |
|   I8    |      I32      |      2^24      |  24.490 us |       2.65% |  24.228 us |       2.65% | -0.262 us |  -1.07% |   SAME   |
|   I8    |      I32      |      2^28      | 275.995 us |       0.30% | 275.980 us |       0.31% | -0.015 us |  -0.01% |   SAME   |
|   I8    |      I64      |      2^16      |   4.691 us |       3.91% |   4.675 us |       3.16% | -0.017 us |  -0.35% |   SAME   |
|   I8    |      I64      |      2^20      |   6.447 us |       3.95% |   6.313 us |       3.62% | -0.134 us |  -2.08% |   SAME   |
|   I8    |      I64      |      2^24      |  24.070 us |       2.71% |  24.294 us |       2.67% |  0.224 us |   0.93% |   SAME   |
|   I8    |      I64      |      2^28      | 277.315 us |       0.28% | 276.972 us |       0.28% | -0.343 us |  -0.12% |   SAME   |
|   I16   |      I32      |      2^16      |   4.772 us |       3.95% |   4.732 us |       4.17% | -0.041 us |  -0.85% |   SAME   |
|   I16   |      I32      |      2^20      |   7.620 us |       3.73% |   7.700 us |       4.25% |  0.080 us |   1.05% |   SAME   |
|   I16   |      I32      |      2^24      |  39.798 us |       1.86% |  39.478 us |       1.92% | -0.319 us |  -0.80% |   SAME   |
|   I16   |      I32      |      2^28      | 515.448 us |       0.12% | 515.015 us |       0.12% | -0.433 us |  -0.08% |   SAME   |
|   I16   |      I64      |      2^16      |   4.799 us |       4.10% |   4.773 us |       3.98% | -0.026 us |  -0.55% |   SAME   |
|   I16   |      I64      |      2^20      |   7.695 us |       3.86% |   7.581 us |       3.69% | -0.115 us |  -1.49% |   SAME   |
|   I16   |      I64      |      2^24      |  39.934 us |       1.85% |  40.013 us |       1.85% |  0.080 us |   0.20% |   SAME   |
|   I16   |      I64      |      2^28      | 519.465 us |       0.14% | 517.658 us |       0.14% | -1.807 us |  -0.35% |   FAST   |
|   F32   |      I32      |      2^16      |   4.875 us |       4.40% |   4.902 us |       4.25% |  0.027 us |   0.56% |   SAME   |
|   F32   |      I32      |      2^20      |   9.814 us |       3.35% |   9.918 us |       2.33% |  0.105 us |   1.07% |   SAME   |
|   F32   |      I32      |      2^24      |  70.720 us |       1.07% |  70.881 us |       1.08% |  0.161 us |   0.23% |   SAME   |
|   F32   |      I32      |      2^28      |   1.001 ms |       0.05% |   1.001 ms |       0.05% | -0.108 us |  -0.01% |   SAME   |
|   F32   |      I64      |      2^16      |   4.950 us |       4.66% |   4.966 us |       5.32% |  0.016 us |   0.32% |   SAME   |
|   F32   |      I64      |      2^20      |  10.153 us |       5.97% |  10.330 us |       4.99% |  0.177 us |   1.74% |   SAME   |
|   F32   |      I64      |      2^24      |  70.845 us |       1.07% |  70.932 us |       1.09% |  0.087 us |   0.12% |   SAME   |
|   F32   |      I64      |      2^28      |   1.004 ms |       0.04% |   1.003 ms |       0.04% | -0.528 us |  -0.05% |   FAST   |
|   F64   |      I32      |      2^16      |   5.240 us |       4.60% |   5.248 us |       4.49% |  0.008 us |   0.15% |   SAME   |
|   F64   |      I32      |      2^20      |  14.458 us |       3.09% |  14.448 us |       3.23% | -0.010 us |  -0.07% |   SAME   |
|   F64   |      I32      |      2^24      | 132.169 us |       0.65% | 132.681 us |       0.64% |  0.512 us |   0.39% |   SAME   |
|   F64   |      I32      |      2^28      |   1.990 ms |       0.04% |   1.990 ms |       0.04% |  0.056 us |   0.00% |   SAME   |
|   F64   |      I64      |      2^16      |   5.306 us |       3.45% |   5.363 us |       3.89% |  0.057 us |   1.08% |   SAME   |
|   F64   |      I64      |      2^20      |  14.560 us |       3.13% |  14.543 us |       3.09% | -0.017 us |  -0.11% |   SAME   |
|   F64   |      I64      |      2^24      | 132.276 us |       0.66% | 132.737 us |       0.64% |  0.461 us |   0.35% |   SAME   |
|   F64   |      I64      |      2^28      |   1.992 ms |       0.04% |   1.991 ms |       0.04% | -0.301 us |  -0.02% |   SAME   |
|  I128   |      I32      |      2^16      |   6.043 us |       4.57% |   6.195 us |       4.53% |  0.152 us |   2.51% |   SAME   |
|  I128   |      I32      |      2^20      |  22.557 us |       2.69% |  22.581 us |       2.69% |  0.024 us |   0.10% |   SAME   |
|  I128   |      I32      |      2^24      | 256.830 us |       0.37% | 256.614 us |       0.38% | -0.215 us |  -0.08% |   SAME   |
|  I128   |      I32      |      2^28      |   3.987 ms |       0.04% |   3.987 ms |       0.04% |  0.253 us |   0.01% |   SAME   |
|  I128   |      I64      |      2^16      |   6.133 us |       4.43% |   6.181 us |       3.74% |  0.048 us |   0.78% |   SAME   |
|  I128   |      I64      |      2^20      |  23.124 us |       4.42% |  22.884 us |       3.56% | -0.241 us |  -1.04% |   SAME   |
|  I128   |      I64      |      2^24      | 256.782 us |       0.36% | 256.625 us |       0.38% | -0.158 us |  -0.06% |   SAME   |
|  I128   |      I64      |      2^28      |   3.987 ms |       0.04% |   3.987 ms |       0.04% |  0.252 us |   0.01% |   SAME   |
```