### PR TITLE
Disable NVHPC optimization that leads to error

### DIFF
--- a/thrust/testing/unittest/special_types.h
+++ b/thrust/testing/unittest/special_types.h
@@ -25,7 +25,12 @@ struct FixedVector
     }
   }
 
-  _CCCL_HOST_DEVICE FixedVector operator+(const FixedVector& bs) const
+  _CCCL_HOST_DEVICE
+#if defined(__NVCOMPILER)
+  __attribute__((noinline))
+#endif
+  FixedVector
+  operator+(const FixedVector& bs) const
   {
     FixedVector output;
     for (unsigned int i = 0; i < N; i++)

--- a/thrust/testing/unittest/special_types.h
+++ b/thrust/testing/unittest/special_types.h
@@ -26,7 +26,7 @@ struct FixedVector
   }
 
   _CCCL_HOST_DEVICE
-#if defined(__NVCOMPILER)
+#if _CCCL_COMPILER(NVHPC)
   __attribute__((noinline))
 #endif
   FixedVector


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/cccl_private/issues/459

Seems like `nvhpc` somehow was optimizing this away for host for small input sizes and was leading to an error here

https://github.com/NVIDIA/cccl/blob/a96716140f78d4672c05dc0ab1002ef3cbe70f0d/thrust/testing/scan.cu#L457