### PR TITLE
Fix atomic reduce for arches < 600 with dtype double

### DIFF
--- a/cub/cub/device/device_reduce.cuh
+++ b/cub/cub/device/device_reduce.cuh
@@ -531,11 +531,14 @@ public:
       constexpr auto is_plus_fallback = !no_determinism || detail::is_cuda_std_plus_v<ReductionOpT>;
       constexpr auto is_4b_or_greater = !no_determinism || sizeof(accum_t) >= 4;
 
+      constexpr auto supports_atomic_add =
+        !no_determinism || (CUB_PTX_ARCH < 600 && !::cuda::std::is_same_v<accum_t, double>);
+
       // If the conditions for gpu-to-gpu determinism or non-deterministic
       // reduction are not met, we fall back to run-to-run determinism.
       using determinism_t = ::cuda::std::conditional_t<
         (gpu_gpu_determinism && (integral_fallback || fp_min_max_fallback))
-          || (no_determinism && !(is_contiguous_fallback && is_plus_fallback && is_4b_or_greater)),
+          || (no_determinism && !(is_contiguous_fallback && is_plus_fallback && is_4b_or_greater && supports_atomic_add)),
         ::cuda::execution::determinism::run_to_run_t,
         default_determinism_t>;
 
@@ -665,8 +668,11 @@ public:
     // determinism.
     constexpr auto is_4b_or_greater = !no_determinism || sizeof(OutputT) >= 4;
 
+    constexpr auto supports_atomic_add =
+      !no_determinism || (CUB_PTX_ARCH < 600 && !::cuda::std::is_same_v<OutputT, double>);
+
     using determinism_t =
-      ::cuda::std::conditional_t<no_determinism && !(is_contiguous_fallback && is_4b_or_greater),
+      ::cuda::std::conditional_t<no_determinism && !(is_contiguous_fallback && is_4b_or_greater && supports_atomic_add),
                                  ::cuda::execution::determinism::run_to_run_t,
                                  default_determinism_t>;
 

--- a/cub/test/catch2_test_device_reduce_nondeterministic.cu
+++ b/cub/test/catch2_test_device_reduce_nondeterministic.cu
@@ -202,7 +202,12 @@ struct square_t
 
 C2H_TEST("Nondeterministic Device reduce works with float and double on gpu with different transform operators",
          "[reduce][nondeterministic]",
-         float_type_list)
+         c2h::type_list<float
+#if CUB_PTX_ARCH >= 600
+                        ,
+                        double // atomicAdd is not supported for double on SM < 6.0
+#endif
+                        >)
 {
   using type = typename c2h::get<0, TestType>;
 


### PR DESCRIPTION
## Description

closes #5427

## Checklist
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
