### PR TITLE
Port `thrust::zip_iterator` to namespace `cuda`

### DIFF
--- a/libcudacxx/include/cuda/__fwd/zip_iterator.h
+++ b/libcudacxx/include/cuda/__fwd/zip_iterator.h
@@ -7,9 +7,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
-
-#ifndef _CUDA_ITERATOR
-#define _CUDA_ITERATOR
+#ifndef _CUDA___FORWARD_ZIP_ITERATOR_H
+#define _CUDA___FORWARD_ZIP_ITERATOR_H
 
 #include <cuda/std/detail/__config>
 
@@ -21,16 +20,21 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/__iterator/constant_iterator.h>
-#include <cuda/__iterator/counting_iterator.h>
-#include <cuda/__iterator/discard_iterator.h>
-#include <cuda/__iterator/permutation_iterator.h>
-#include <cuda/__iterator/strided_iterator.h>
-#include <cuda/__iterator/tabulate_output_iterator.h>
-#include <cuda/__iterator/transform_input_output_iterator.h>
-#include <cuda/__iterator/transform_iterator.h>
-#include <cuda/__iterator/transform_output_iterator.h>
-#include <cuda/__iterator/zip_iterator.h>
-#include <cuda/std/iterator>
+#include <cuda/std/__cccl/prologue.h>
 
-#endif // _CUDA_ITERATOR
+_LIBCUDACXX_BEGIN_NAMESPACE_CUDA
+
+template <class... _Iterators>
+class zip_iterator;
+
+template <class>
+inline constexpr bool __is_zip_iterator = false;
+
+template <class... _Iterators>
+inline constexpr bool __is_zip_iterator<zip_iterator<_Iterators...>> = true;
+
+_LIBCUDACXX_END_NAMESPACE_CUDA
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA___FORWARD_ZIP_ITERATOR_H

--- a/libcudacxx/include/cuda/__fwd/zip_iterator.h
+++ b/libcudacxx/include/cuda/__fwd/zip_iterator.h
@@ -33,6 +33,15 @@ inline constexpr bool __is_zip_iterator = false;
 template <class... _Iterators>
 inline constexpr bool __is_zip_iterator<zip_iterator<_Iterators...>> = true;
 
+template <class _Fn>
+class zip_function;
+
+template <class>
+inline constexpr bool __is_zip_function = false;
+
+template <class _Fn>
+inline constexpr bool __is_zip_function<zip_function<_Fn>> = true;
+
 _LIBCUDACXX_END_NAMESPACE_CUDA
 
 #include <cuda/std/__cccl/epilogue.h>

--- a/libcudacxx/include/cuda/__iterator/zip_function.h
+++ b/libcudacxx/include/cuda/__iterator/zip_function.h
@@ -1,0 +1,94 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES
+//
+//===----------------------------------------------------------------------===//
+#ifndef _CUDA___ITERATOR_ZIP_FUNCTION_H
+#define _CUDA___ITERATOR_ZIP_FUNCTION_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/__fwd/zip_iterator.h>
+#include <cuda/std/__concepts/constructible.h>
+#include <cuda/std/__functional/invoke.h>
+#include <cuda/std/__type_traits/is_nothrow_copy_constructible.h>
+#include <cuda/std/__type_traits/is_nothrow_default_constructible.h>
+#include <cuda/std/__type_traits/is_nothrow_move_constructible.h>
+#include <cuda/std/__utility/declval.h>
+#include <cuda/std/__utility/forward.h>
+#include <cuda/std/__utility/move.h>
+#include <cuda/std/__utility/pair.h>
+#include <cuda/std/tuple>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_CUDA
+
+//! @brief Adaptor that transforms a N-ary function \c _Fn into one accepting a \c tuple of size N
+template <class _Fn>
+class zip_function
+{
+private:
+  _Fn __fun_;
+
+public:
+  //! @brief default construct a zip_function if \c _Fn is default_initializable
+  _CCCL_EXEC_CHECK_DISABLE
+  _CCCL_TEMPLATE(class _Fn2 = _Fn)
+  _CCCL_REQUIRES(_CUDA_VSTD::default_initializable<_Fn>)
+  _CCCL_API constexpr zip_function() noexcept(_CUDA_VSTD::is_nothrow_default_constructible_v<_Fn>)
+      : __fun_()
+  {}
+
+  //! @brief construct a zip_function from a functor \p __fun
+  _CCCL_EXEC_CHECK_DISABLE
+  _CCCL_API constexpr zip_function(const _Fn& __fun) noexcept(_CUDA_VSTD::is_nothrow_copy_constructible_v<_Fn>)
+      : __fun_(__fun)
+  {}
+
+  //! @brief construct a zip_function from a functor \p __fun
+  _CCCL_EXEC_CHECK_DISABLE
+  _CCCL_API constexpr zip_function(_Fn&& __fun) noexcept(_CUDA_VSTD::is_nothrow_move_constructible_v<_Fn>)
+      : __fun_(_CUDA_VSTD::move(__fun))
+  {}
+
+  template <class _Fn2, class _Tuple>
+  static constexpr bool __is_nothrow_invocable =
+    noexcept(_CUDA_VSTD::apply(_CUDA_VSTD::declval<_Fn2>(), _CUDA_VSTD::declval<_Tuple>()));
+
+  //! @brief Applies a tuple \p __tuple to the stored functor
+  _CCCL_EXEC_CHECK_DISABLE
+  template <class _Tuple>
+  [[nodiscard]] _CCCL_API constexpr decltype(auto) operator()(_Tuple&& __tuple) const
+    noexcept(__is_nothrow_invocable<const _Fn&, _Tuple>)
+  {
+    return _CUDA_VSTD::apply(__fun_, _CUDA_VSTD::forward<_Tuple>(__tuple));
+  }
+
+  //! @brief Applies a tuple \p __tuple to the stored functor
+  _CCCL_EXEC_CHECK_DISABLE
+  template <class _Tuple>
+  [[nodiscard]] _CCCL_API constexpr decltype(auto)
+  operator()(_Tuple&& __tuple) noexcept(__is_nothrow_invocable<_Fn&, _Tuple>)
+  {
+    return _CUDA_VSTD::apply(__fun_, _CUDA_VSTD::forward<_Tuple>(__tuple));
+  }
+};
+
+_LIBCUDACXX_END_NAMESPACE_CUDA
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA___ITERATOR_ZIP_FUNCTION_H

--- a/libcudacxx/include/cuda/__iterator/zip_function.h
+++ b/libcudacxx/include/cuda/__iterator/zip_function.h
@@ -47,8 +47,8 @@ public:
   //! @brief default construct a zip_function if \c _Fn is default_initializable
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Fn2 = _Fn)
-  _CCCL_REQUIRES(_CUDA_VSTD::default_initializable<_Fn>)
-  _CCCL_API constexpr zip_function() noexcept(_CUDA_VSTD::is_nothrow_default_constructible_v<_Fn>)
+  _CCCL_REQUIRES(_CUDA_VSTD::default_initializable<_Fn2>)
+  _CCCL_API constexpr zip_function() noexcept(_CUDA_VSTD::is_nothrow_default_constructible_v<_Fn2>)
       : __fun_()
   {}
 

--- a/libcudacxx/include/cuda/__iterator/zip_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/zip_iterator.h
@@ -89,89 +89,6 @@ struct __zip_iter_functors
       _CUDA_VSTD::make_index_sequence<_CUDA_VSTD::tuple_size_v<_CUDA_VSTD::remove_cvref_t<_Tuple1>>>());
   }
 
-  struct __zip_op_star
-  {
-    template <class... _Types>
-    using __ret = __tuple_or_pair<decltype(*_CUDA_VSTD::declval<_Types>())...>;
-
-    _CCCL_EXEC_CHECK_DISABLE
-    template <class... _Types>
-    [[nodiscard]] _CCCL_API constexpr __ret<_Types...> operator()(_Types&&... __tuple_elements) const
-      noexcept(noexcept(__ret<_Types...>{*_CUDA_VSTD::forward<_Types>(__tuple_elements)...}))
-    {
-      return __ret<_Types...>{*_CUDA_VSTD::forward<_Types>(__tuple_elements)...};
-    }
-  };
-
-  struct __zip_op_increment
-  {
-    _CCCL_EXEC_CHECK_DISABLE
-    template <class... _Types>
-    _CCCL_API constexpr void operator()(_Types&&... __tuple_elements) const
-      noexcept(noexcept(((void) ++_CUDA_VSTD::forward<_Types>(__tuple_elements), ...)))
-    {
-      ((void) ++_CUDA_VSTD::forward<_Types>(__tuple_elements), ...);
-    }
-  };
-
-  struct __zip_op_decrement
-  {
-    _CCCL_EXEC_CHECK_DISABLE
-    template <class... _Types>
-    _CCCL_API constexpr void operator()(_Types&&... __tuple_elements) const
-      noexcept(noexcept(((void) --_CUDA_VSTD::forward<_Types>(__tuple_elements), ...)))
-    {
-      ((void) --_CUDA_VSTD::forward<_Types>(__tuple_elements), ...);
-    }
-  };
-
-  template <class _Diff>
-  struct __zip_op_pe
-  {
-    _Diff __n;
-
-    _CCCL_EXEC_CHECK_DISABLE
-    template <class... _Types>
-    _CCCL_API constexpr void operator()(_Types&&... __tuple_elements) const noexcept(noexcept(
-      ((void) (_CUDA_VSTD::forward<_Types>(__tuple_elements) += _CUDA_VSTD::iter_difference_t<_Types>(__n)), ...)))
-    {
-      ((void) (_CUDA_VSTD::forward<_Types>(__tuple_elements) += _CUDA_VSTD::iter_difference_t<_Types>(__n)), ...);
-    }
-  };
-
-  template <class _Diff>
-  struct __zip_op_me
-  {
-    _Diff __n;
-
-    _CCCL_EXEC_CHECK_DISABLE
-    template <class... _Types>
-    _CCCL_API constexpr void operator()(_Types&&... __tuple_elements) const noexcept(noexcept(
-      ((void) (_CUDA_VSTD::forward<_Types>(__tuple_elements) -= _CUDA_VSTD::iter_difference_t<_Types>(__n)), ...)))
-    {
-      ((void) (_CUDA_VSTD::forward<_Types>(__tuple_elements) -= _CUDA_VSTD::iter_difference_t<_Types>(__n)), ...);
-    }
-  };
-
-  template <class _Diff>
-  struct __zip_op_index
-  {
-    _Diff __n;
-
-    template <class... _Types>
-    using __ret = __tuple_or_pair<decltype(_CUDA_VSTD::declval<_Types>()[_CUDA_VSTD::iter_difference_t<_Types>(0)])...>;
-
-    _CCCL_EXEC_CHECK_DISABLE
-    template <class... _Types>
-    [[nodiscard]] _CCCL_API constexpr __ret<_Types...> operator()(_Types&&... __tuple_elements) const
-      noexcept(noexcept(__ret<_Types...>{
-        _CUDA_VSTD::forward<_Types>(__tuple_elements)[_CUDA_VSTD::iter_difference_t<_Types>(__n)]...}))
-    {
-      return __ret<_Types...>{
-        _CUDA_VSTD::forward<_Types>(__tuple_elements)[_CUDA_VSTD::iter_difference_t<_Types>(__n)]...};
-    }
-  };
-
   struct __op_comp_abs
   {
     // abs in cstdlib is not constexpr
@@ -204,7 +121,7 @@ struct __zip_iter_functors
     }
 
     const _Diff __temp[] = {__first, _CUDA_VSTD::get<_Indices>(__tuple1) - _CUDA_VSTD::get<_Indices>(__tuple2)...};
-    return *(_CUDA_VRANGES::min_element)(__temp, __op_comp_abs{});
+    return *_CUDA_VRANGES::min_element(__temp, __op_comp_abs{});
   }
 
   template <class _Diff, class _Tuple1, class _Tuple2>
@@ -220,20 +137,6 @@ struct __zip_iter_functors
       __tuple2,
       _CUDA_VSTD::make_index_sequence<_CUDA_VSTD::tuple_size_v<_CUDA_VSTD::remove_cvref_t<_Tuple1>>>());
   }
-
-  struct __zip_iter_move
-  {
-    template <class... _Types>
-    using __ret = __tuple_or_pair<_CUDA_VSTD::invoke_result_t<decltype(_CUDA_VRANGES::iter_move)&, _Types>...>;
-
-    _CCCL_EXEC_CHECK_DISABLE
-    template <class... _Types>
-    [[nodiscard]] _CCCL_API constexpr __ret<_Types...> operator()(_Types&&... __tuple_elements) const
-      noexcept(noexcept(__ret<_Types...>{_CUDA_VRANGES::iter_move(_CUDA_VSTD::forward<_Types>(__tuple_elements))...}))
-    {
-      return __ret<_Types...>{_CUDA_VRANGES::iter_move(_CUDA_VSTD::forward<_Types>(__tuple_elements))...};
-    }
-  };
 
   template <class _Tuple1, class _Tuple2, size_t... _Indices>
   _CCCL_API static constexpr void
@@ -347,6 +250,7 @@ public:
 
   using iterator_concept = decltype(__get_zip_view_iterator_tag<_Iterators...>());
   using value_type       = __tuple_or_pair<_CUDA_VSTD::iter_value_t<_Iterators>...>;
+  using reference        = __tuple_or_pair<_CUDA_VSTD::iter_reference_t<_Iterators>...>;
   using difference_type  = _CUDA_VSTD::common_type_t<_CUDA_VSTD::iter_difference_t<_Iterators>...>;
 
   _CCCL_HIDE_FROM_ABI zip_iterator() = default;
@@ -362,14 +266,28 @@ public:
       : __current_(_CUDA_VSTD::move(__i.__current_))
   {}
 
-  _CCCL_API constexpr auto operator*() const
+  _CCCL_EXEC_CHECK_DISABLE
+  [[nodiscard]] _CCCL_API static constexpr reference
+  __zip_op_star(const _Iterators&... __iters) noexcept(noexcept(reference{*__iters...}))
   {
-    return _CUDA_VSTD::apply(__zip_iter_functors::__zip_op_star{}, __current_);
+    return reference{*__iters...};
   }
 
-  _CCCL_API constexpr zip_iterator& operator++()
+  [[nodiscard]] _CCCL_API constexpr auto operator*() const
+    noexcept(noexcept(_CUDA_VSTD::apply(__zip_op_star, __current_)))
   {
-    _CUDA_VSTD::apply(__zip_iter_functors::__zip_op_increment{}, __current_);
+    return _CUDA_VSTD::apply(__zip_op_star, __current_);
+  }
+
+  _CCCL_EXEC_CHECK_DISABLE
+  _CCCL_API static constexpr void __zip_op_increment(_Iterators&... __iters) noexcept(noexcept(((void) ++__iters, ...)))
+  {
+    ((void) ++__iters, ...);
+  }
+
+  _CCCL_API constexpr zip_iterator& operator++() noexcept(noexcept(_CUDA_VSTD::apply(__zip_op_increment, __current_)))
+  {
+    _CUDA_VSTD::apply(__zip_op_increment, __current_);
     return *this;
   }
 
@@ -387,11 +305,17 @@ public:
     }
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
+  _CCCL_API static constexpr void __zip_op_decrement(_Iterators&... __iters) noexcept(noexcept(((void) --__iters, ...)))
+  {
+    ((void) --__iters, ...);
+  }
+
   _CCCL_TEMPLATE(class _Constraints = __zip_iter_constraints<_Iterators...>)
   _CCCL_REQUIRES(_Constraints::__all_bidirectional)
-  _CCCL_API constexpr zip_iterator& operator--()
+  _CCCL_API constexpr zip_iterator& operator--() noexcept(noexcept(_CUDA_VSTD::apply(__zip_op_decrement, __current_)))
   {
-    _CUDA_VSTD::apply(__zip_iter_functors::__zip_op_decrement{}, __current_);
+    _CUDA_VSTD::apply(__zip_op_decrement, __current_);
     return *this;
   }
 
@@ -404,31 +328,67 @@ public:
     return __tmp;
   }
 
+  struct __zip_op_pe
+  {
+    difference_type __n;
+
+    _CCCL_EXEC_CHECK_DISABLE
+    _CCCL_API constexpr void operator()(_Iterators&... __iters) const
+      noexcept(noexcept(((void) (__iters += _CUDA_VSTD::iter_difference_t<_Iterators>(__n)), ...)))
+    {
+      ((void) (__iters += _CUDA_VSTD::iter_difference_t<_Iterators>(__n)), ...);
+    }
+  };
+
   _CCCL_TEMPLATE(class _Constraints = __zip_iter_constraints<_Iterators...>)
   _CCCL_REQUIRES(_Constraints::__all_random_access)
   _CCCL_API constexpr zip_iterator& operator+=(difference_type __n)
   {
-    _CUDA_VSTD::apply(__zip_iter_functors::__zip_op_pe<difference_type>{__n}, __current_);
+    _CUDA_VSTD::apply(__zip_op_pe{__n}, __current_);
     return *this;
   }
+
+  struct __zip_op_me
+  {
+    difference_type __n;
+
+    _CCCL_EXEC_CHECK_DISABLE
+    _CCCL_API constexpr void operator()(_Iterators&... __iters) const
+      noexcept(noexcept(((void) (__iters -= _CUDA_VSTD::iter_difference_t<_Iterators>(__n)), ...)))
+    {
+      ((void) (__iters -= _CUDA_VSTD::iter_difference_t<_Iterators>(__n)), ...);
+    }
+  };
 
   _CCCL_TEMPLATE(class _Constraints = __zip_iter_constraints<_Iterators...>)
   _CCCL_REQUIRES(_Constraints::__all_random_access)
   _CCCL_API constexpr zip_iterator& operator-=(difference_type __n)
   {
-    _CUDA_VSTD::apply(__zip_iter_functors::__zip_op_me<difference_type>{__n}, __current_);
+    _CUDA_VSTD::apply(__zip_op_me{__n}, __current_);
     return *this;
   }
+
+  struct __zip_op_index
+  {
+    difference_type __n;
+
+    _CCCL_EXEC_CHECK_DISABLE
+    [[nodiscard]] _CCCL_API constexpr reference operator()(const _Iterators&... __iters) const
+      noexcept(noexcept(reference{__iters[_CUDA_VSTD::iter_difference_t<_Iterators>(__n)]...}))
+    {
+      return reference{__iters[_CUDA_VSTD::iter_difference_t<_Iterators>(__n)]...};
+    }
+  };
 
   _CCCL_TEMPLATE(class _Constraints = __zip_iter_constraints<_Iterators...>)
   _CCCL_REQUIRES(_Constraints::__all_random_access)
   _CCCL_API constexpr auto operator[](difference_type __n) const
   {
-    return _CUDA_VSTD::apply(__zip_iter_functors::__zip_op_index<difference_type>{__n}, __current_);
+    return _CUDA_VSTD::apply(__zip_op_index{__n}, __current_);
   }
 
   template <class _Constraints = __zip_iter_constraints<_Iterators...>>
-  friend _CCCL_API constexpr auto operator==(const zip_iterator& __n, const zip_iterator& __y)
+  _CCCL_API friend constexpr auto operator==(const zip_iterator& __n, const zip_iterator& __y)
     _CCCL_TRAILING_REQUIRES(bool)(_Constraints::__all_equality_comparable)
   {
     if constexpr (_Constraints::__all_bidirectional)
@@ -444,7 +404,7 @@ public:
 
 #if _CCCL_STD_VER <= 2017
   template <class _Constraints = __zip_iter_constraints<_Iterators...>>
-  friend _CCCL_API constexpr auto operator!=(const zip_iterator& __n, const zip_iterator& __y)
+  _CCCL_API friend constexpr auto operator!=(const zip_iterator& __n, const zip_iterator& __y)
     _CCCL_TRAILING_REQUIRES(bool)(_Constraints::__all_equality_comparable)
   {
     if constexpr (_Constraints::__all_bidirectional)
@@ -461,7 +421,7 @@ public:
 
 #if _LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
   template <class _Constraints = __zip_iter_constraints<_Iterators...>>
-  friend _CCCL_API constexpr auto operator<=>(const zip_iterator& __n, const zip_iterator& __y)
+  _CCCL_API friend constexpr auto operator<=>(const zip_iterator& __n, const zip_iterator& __y)
     _CCCL_TRAILING_REQUIRES(bool)(_Constraints::__all_random_access&& _Constraints::__all_three_way_comparable)
   {
     return __n.__current_ <=> __y.__current_;
@@ -470,28 +430,28 @@ public:
 #else // ^^^ _LIBCUDACXX_HAS_SPACESHIP_OPERATOR() ^^^ / vvv !_LIBCUDACXX_HAS_SPACESHIP_OPERATOR() vvv
 
   template <class _Constraints = __zip_iter_constraints<_Iterators...>>
-  friend _CCCL_API constexpr auto operator<(const zip_iterator& __n, const zip_iterator& __y)
+  _CCCL_API friend constexpr auto operator<(const zip_iterator& __n, const zip_iterator& __y)
     _CCCL_TRAILING_REQUIRES(bool)(_Constraints::__all_random_access)
   {
     return __n.__current_ < __y.__current_;
   }
 
   template <class _Constraints = __zip_iter_constraints<_Iterators...>>
-  friend _CCCL_API constexpr auto operator>(const zip_iterator& __n, const zip_iterator& __y)
+  _CCCL_API friend constexpr auto operator>(const zip_iterator& __n, const zip_iterator& __y)
     _CCCL_TRAILING_REQUIRES(bool)(_Constraints::__all_random_access)
   {
     return __y < __n;
   }
 
   template <class _Constraints = __zip_iter_constraints<_Iterators...>>
-  friend _CCCL_API constexpr auto operator<=(const zip_iterator& __n, const zip_iterator& __y)
+  _CCCL_API friend constexpr auto operator<=(const zip_iterator& __n, const zip_iterator& __y)
     _CCCL_TRAILING_REQUIRES(bool)(_Constraints::__all_random_access)
   {
     return !(__y < __n);
   }
 
   template <class _Constraints = __zip_iter_constraints<_Iterators...>>
-  friend _CCCL_API constexpr auto operator>=(const zip_iterator& __n, const zip_iterator& __y)
+  _CCCL_API friend constexpr auto operator>=(const zip_iterator& __n, const zip_iterator& __y)
     _CCCL_TRAILING_REQUIRES(bool)(_Constraints::__all_random_access)
   {
     return !(__n < __y);
@@ -499,7 +459,7 @@ public:
 #endif // !_LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
 
   template <class _Constraints = __zip_iter_constraints<_Iterators...>>
-  friend _CCCL_API constexpr auto operator+(const zip_iterator& __i, difference_type __n)
+  _CCCL_API friend constexpr auto operator+(const zip_iterator& __i, difference_type __n)
     _CCCL_TRAILING_REQUIRES(zip_iterator)(_Constraints::__all_random_access)
   {
     auto __r = __i;
@@ -508,14 +468,14 @@ public:
   }
 
   template <class _Constraints = __zip_iter_constraints<_Iterators...>>
-  friend _CCCL_API constexpr auto operator+(difference_type __n, const zip_iterator& __i)
+  _CCCL_API friend constexpr auto operator+(difference_type __n, const zip_iterator& __i)
     _CCCL_TRAILING_REQUIRES(zip_iterator)(_Constraints::__all_random_access)
   {
     return __i + __n;
   }
 
   template <class _Constraints = __zip_iter_constraints<_Iterators...>>
-  friend _CCCL_API constexpr auto operator-(const zip_iterator& __i, difference_type __n)
+  _CCCL_API friend constexpr auto operator-(const zip_iterator& __i, difference_type __n)
     _CCCL_TRAILING_REQUIRES(zip_iterator)(_Constraints::__all_random_access)
   {
     auto __r = __i;
@@ -524,21 +484,30 @@ public:
   }
 
   template <class _Constraints = __zip_iter_constraints<_Iterators...>>
-  friend _CCCL_API constexpr auto operator-(const zip_iterator& __n, const zip_iterator& __y)
+  _CCCL_API friend constexpr auto operator-(const zip_iterator& __n, const zip_iterator& __y)
     _CCCL_TRAILING_REQUIRES(difference_type)(_Constraints::__all_sized_sentinel)
   {
     return __zip_iter_functors::__iter_op_minus<difference_type>(__n.__current_, __y.__current_);
   }
 
+  using __iter_move_ret = __tuple_or_pair<_CUDA_VSTD::iter_rvalue_reference_t<_Iterators>...>;
+
+  _CCCL_EXEC_CHECK_DISABLE
+  [[nodiscard]] _CCCL_API static constexpr __iter_move_ret __zip_iter_move(const _Iterators&... __iters) noexcept(
+    noexcept(__iter_move_ret{_CUDA_VRANGES::iter_move(__iters)...}))
+  {
+    return __iter_move_ret{_CUDA_VRANGES::iter_move(__iters)...};
+  }
+
   // MSVC falls over its feet if this is not a template
   template <class _Constraints = __zip_iter_constraints<_Iterators...>>
-  friend _CCCL_API constexpr auto iter_move(const zip_iterator& __i) noexcept(_Constraints::__all_nothrow_iter_movable)
+  _CCCL_API friend constexpr auto iter_move(const zip_iterator& __i) noexcept(_Constraints::__all_nothrow_iter_movable)
   {
-    return _CUDA_VSTD::apply(__zip_iter_functors::__zip_iter_move{}, __i.__current_);
+    return _CUDA_VSTD::apply(__zip_iter_move, __i.__current_);
   }
 
   template <class _Constraints = __zip_iter_constraints<_Iterators...>>
-  friend _CCCL_API constexpr auto
+  _CCCL_API friend constexpr auto
   iter_swap(const zip_iterator& __l, const zip_iterator& __r) noexcept(_Constraints::__all_noexcept_swappable)
     _CCCL_TRAILING_REQUIRES(void)(_Constraints::__all_indirectly_swappable)
   {

--- a/libcudacxx/include/cuda/__iterator/zip_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/zip_iterator.h
@@ -91,6 +91,7 @@ struct __zip_iter_functors
   {
     struct __op_star
     {
+      _CCCL_EXEC_CHECK_DISABLE
       template <class _Iter>
       _CCCL_API constexpr decltype(auto) operator()(_Iter& __i) const noexcept(noexcept(*__i))
       {
@@ -101,10 +102,10 @@ struct __zip_iter_functors
     template <class... _Types>
     _CCCL_API constexpr auto operator()(_Types&&... __tuple_elements) const
       noexcept(noexcept(__tuple_or_pair<_CUDA_VSTD::invoke_result_t<__op_star&, _Types>...>{
-        _CUDA_VSTD::invoke(__op_star{}, _CUDA_VSTD::forward<_Types>(__tuple_elements))...}))
+        __op_star{}(_CUDA_VSTD::forward<_Types>(__tuple_elements))...}))
     {
       return __tuple_or_pair<_CUDA_VSTD::invoke_result_t<__op_star&, _Types>...>{
-        _CUDA_VSTD::invoke(__op_star{}, _CUDA_VSTD::forward<_Types>(__tuple_elements))...};
+        __op_star{}(_CUDA_VSTD::forward<_Types>(__tuple_elements))...};
     }
   };
 
@@ -119,6 +120,7 @@ struct __zip_iter_functors
   {
     struct __op_increment
     {
+      _CCCL_EXEC_CHECK_DISABLE
       template <class _Iter>
       _CCCL_API constexpr void operator()(_Iter& __i) const noexcept(noexcept(++__i))
       {
@@ -128,9 +130,9 @@ struct __zip_iter_functors
 
     template <class... _Types>
     _CCCL_API constexpr void operator()(_Types&&... __tuple_elements) const
-      noexcept(noexcept((_CUDA_VSTD::invoke(__op_increment{}, _CUDA_VSTD::forward<_Types>(__tuple_elements)), ...)))
+      noexcept(noexcept((__op_increment{}(_CUDA_VSTD::forward<_Types>(__tuple_elements)), ...)))
     {
-      (_CUDA_VSTD::invoke(__op_increment{}, _CUDA_VSTD::forward<_Types>(__tuple_elements)), ...);
+      (__op_increment{}(_CUDA_VSTD::forward<_Types>(__tuple_elements)), ...);
     }
   };
 
@@ -145,6 +147,7 @@ struct __zip_iter_functors
   {
     struct __op_decrement
     {
+      _CCCL_EXEC_CHECK_DISABLE
       template <class _Iter>
       _CCCL_API constexpr void operator()(_Iter& __i) const noexcept(noexcept(--__i))
       {
@@ -154,9 +157,9 @@ struct __zip_iter_functors
 
     template <class... _Types>
     _CCCL_API constexpr void operator()(_Types&&... __tuple_elements) const
-      noexcept(noexcept((_CUDA_VSTD::invoke(__op_decrement{}, _CUDA_VSTD::forward<_Types>(__tuple_elements)), ...)))
+      noexcept(noexcept((__op_decrement{}(_CUDA_VSTD::forward<_Types>(__tuple_elements)), ...)))
     {
-      (_CUDA_VSTD::invoke(__op_decrement{}, _CUDA_VSTD::forward<_Types>(__tuple_elements)), ...);
+      (__op_decrement{}(_CUDA_VSTD::forward<_Types>(__tuple_elements)), ...);
     }
   };
 
@@ -176,6 +179,7 @@ struct __zip_iter_functors
     {
       _Diff __x;
 
+      _CCCL_EXEC_CHECK_DISABLE
       template <class _Iter>
       _CCCL_API constexpr void operator()(_Iter& __i) const
         noexcept(noexcept(__i += _CUDA_VSTD::iter_difference_t<_Iter>(__x)))
@@ -186,9 +190,9 @@ struct __zip_iter_functors
 
     template <class... _Types>
     _CCCL_API constexpr void operator()(_Types&&... __tuple_elements) const
-      noexcept(noexcept((_CUDA_VSTD::invoke(__op_pe{__x}, _CUDA_VSTD::forward<_Types>(__tuple_elements)), ...)))
+      noexcept(noexcept((__op_pe{__x}(_CUDA_VSTD::forward<_Types>(__tuple_elements)), ...)))
     {
-      (_CUDA_VSTD::invoke(__op_pe{__x}, _CUDA_VSTD::forward<_Types>(__tuple_elements)), ...);
+      (__op_pe{__x}(_CUDA_VSTD::forward<_Types>(__tuple_elements)), ...);
     }
   };
 
@@ -208,6 +212,7 @@ struct __zip_iter_functors
     {
       _Diff __x;
 
+      _CCCL_EXEC_CHECK_DISABLE
       template <class _Iter>
       _CCCL_API constexpr void operator()(_Iter& __i) const
         noexcept(noexcept(__i -= _CUDA_VSTD::iter_difference_t<_Iter>(__x)))
@@ -218,9 +223,9 @@ struct __zip_iter_functors
 
     template <class... _Types>
     _CCCL_API constexpr void operator()(_Types&&... __tuple_elements) const
-      noexcept(noexcept((_CUDA_VSTD::invoke(__op_me{__x}, _CUDA_VSTD::forward<_Types>(__tuple_elements)), ...)))
+      noexcept(noexcept((__op_me{__x}(_CUDA_VSTD::forward<_Types>(__tuple_elements)), ...)))
     {
-      (_CUDA_VSTD::invoke(__op_me{__x}, _CUDA_VSTD::forward<_Types>(__tuple_elements)), ...);
+      (__op_me{__x}(_CUDA_VSTD::forward<_Types>(__tuple_elements)), ...);
     }
   };
 
@@ -240,6 +245,7 @@ struct __zip_iter_functors
     {
       _Diff __n;
 
+      _CCCL_EXEC_CHECK_DISABLE
       template <class _Iter>
       _CCCL_API constexpr decltype(auto) operator()(_Iter& __i) const
         noexcept(noexcept(__i[_CUDA_VSTD::iter_difference_t<_Iter>(__n)]))
@@ -251,10 +257,11 @@ struct __zip_iter_functors
     template <class... _Types>
     _CCCL_API constexpr auto operator()(_Types&&... __tuple_elements) const
       noexcept(noexcept(__tuple_or_pair<_CUDA_VSTD::invoke_result_t<__zip_op_index::__op_index&, _Types>...>{
-        _CUDA_VSTD::invoke(__zip_op_index::__op_index{__n}, _CUDA_VSTD::forward<_Types>(__tuple_elements))...}))
+        __zip_op_index::__op_index{__n}(_CUDA_VSTD::forward<_Types>(__tuple_elements))...}))
     {
+      const auto __op = __zip_op_index::__op_index{__n};
       return __tuple_or_pair<_CUDA_VSTD::invoke_result_t<__zip_op_index::__op_index&, _Types>...>{
-        _CUDA_VSTD::invoke(__zip_op_index::__op_index{__n}, _CUDA_VSTD::forward<_Types>(__tuple_elements))...};
+        __op(_CUDA_VSTD::forward<_Types>(__tuple_elements))...};
     }
   };
 
@@ -268,6 +275,7 @@ struct __zip_iter_functors
   struct __op_comp_abs
   {
     // abs in cstdlib is not constexpr
+    _CCCL_EXEC_CHECK_DISABLE
     template <class _Diff>
     _CCCL_API static constexpr _Diff __abs(_Diff __t) noexcept(noexcept(__t < 0 ? -__t : __t))
     {
@@ -282,6 +290,7 @@ struct __zip_iter_functors
     }
   };
 
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _Diff, class _Tuple1, class _Tuple2, size_t _Zero, size_t... _Indices>
   _CCCL_API static constexpr _Diff
   __iter_op_minus(const _Tuple1& __tuple1, const _Tuple2& __tuple2, _CUDA_VSTD::index_sequence<_Zero, _Indices...>) //
@@ -294,7 +303,7 @@ struct __zip_iter_functors
     }
 
     const _Diff __temp[] = {__first, _CUDA_VSTD::get<_Indices>(__tuple1) - _CUDA_VSTD::get<_Indices>(__tuple2)...};
-    return *(_CUDA_VRANGES::min_element) (__temp, __op_comp_abs{});
+    return *(_CUDA_VRANGES::min_element)(__temp, __op_comp_abs{});
   }
 
   template <class _Diff, class _Tuple1, class _Tuple2>
@@ -316,9 +325,9 @@ struct __zip_iter_functors
     _CCCL_API constexpr __tuple_or_pair<_CUDA_VSTD::invoke_result_t<decltype(_CUDA_VRANGES::iter_move)&, _Types>...>
     operator()(_Types&&... __tuple_elements) const
       noexcept(noexcept(__tuple_or_pair<_CUDA_VSTD::invoke_result_t<decltype(_CUDA_VRANGES::iter_move)&, _Types>...>{
-        _CUDA_VSTD::invoke(_CUDA_VRANGES::iter_move, _CUDA_VSTD::forward<_Types>(__tuple_elements))...}))
+        _CUDA_VRANGES::iter_move(_CUDA_VSTD::forward<_Types>(__tuple_elements))...}))
     {
-      return {_CUDA_VSTD::invoke(_CUDA_VRANGES::iter_move, _CUDA_VSTD::forward<_Types>(__tuple_elements))...};
+      return {_CUDA_VRANGES::iter_move(_CUDA_VSTD::forward<_Types>(__tuple_elements))...};
     }
   };
 

--- a/libcudacxx/include/cuda/__iterator/zip_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/zip_iterator.h
@@ -66,6 +66,7 @@ using __tuple_or_pair = typename __tuple_or_pair_impl<_Iterators...>::type;
 struct __zip_iter_functors
 {
   // iterator functions
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _Tuple1, class _Tuple2, size_t... _Indices>
   _CCCL_API static constexpr bool
   __iter_op_eq(const _Tuple1& __tuple1, const _Tuple2& __tuple2, _CUDA_VSTD::index_sequence<_Indices...>) noexcept(
@@ -74,6 +75,7 @@ struct __zip_iter_functors
     return ((_CUDA_VSTD::get<_Indices>(__tuple1) == _CUDA_VSTD::get<_Indices>(__tuple2)) || ...);
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _Tuple1, class _Tuple2>
   _CCCL_API static constexpr bool
   __iter_op_eq(const _Tuple1& __tuple1, const _Tuple2& __tuple2) noexcept(noexcept(__zip_iter_functors::__iter_op_eq(
@@ -89,210 +91,109 @@ struct __zip_iter_functors
 
   struct __zip_op_star
   {
-    struct __op_star
-    {
-      _CCCL_EXEC_CHECK_DISABLE
-      template <class _Iter>
-      _CCCL_API constexpr decltype(auto) operator()(_Iter& __i) const noexcept(noexcept(*__i))
-      {
-        return *__i;
-      }
-    };
-
     template <class... _Types>
-    _CCCL_API constexpr auto operator()(_Types&&... __tuple_elements) const
-      noexcept(noexcept(__tuple_or_pair<_CUDA_VSTD::invoke_result_t<__op_star&, _Types>...>{
-        __op_star{}(_CUDA_VSTD::forward<_Types>(__tuple_elements))...}))
+    using __ret = __tuple_or_pair<decltype(*_CUDA_VSTD::declval<_Types>())...>;
+
+    _CCCL_EXEC_CHECK_DISABLE
+    template <class... _Types>
+    [[nodiscard]] _CCCL_API constexpr __ret<_Types...> operator()(_Types&&... __tuple_elements) const
+      noexcept(noexcept(__ret<_Types...>{*_CUDA_VSTD::forward<_Types>(__tuple_elements)...}))
     {
-      return __tuple_or_pair<_CUDA_VSTD::invoke_result_t<__op_star&, _Types>...>{
-        __op_star{}(_CUDA_VSTD::forward<_Types>(__tuple_elements))...};
+      return __ret<_Types...>{*_CUDA_VSTD::forward<_Types>(__tuple_elements)...};
     }
   };
-
-  template <class _Tuple>
-  _CCCL_API static constexpr auto __iter_op_star(_Tuple&& __tuple) noexcept(
-    noexcept(_CUDA_VSTD::apply(__zip_iter_functors::__zip_op_star{}, _CUDA_VSTD::forward<_Tuple>(__tuple))))
-  {
-    return _CUDA_VSTD::apply(__zip_iter_functors::__zip_op_star{}, _CUDA_VSTD::forward<_Tuple>(__tuple));
-  }
 
   struct __zip_op_increment
   {
-    struct __op_increment
-    {
-      _CCCL_EXEC_CHECK_DISABLE
-      template <class _Iter>
-      _CCCL_API constexpr void operator()(_Iter& __i) const noexcept(noexcept(++__i))
-      {
-        ++__i;
-      }
-    };
-
+    _CCCL_EXEC_CHECK_DISABLE
     template <class... _Types>
     _CCCL_API constexpr void operator()(_Types&&... __tuple_elements) const
-      noexcept(noexcept((__op_increment{}(_CUDA_VSTD::forward<_Types>(__tuple_elements)), ...)))
+      noexcept(noexcept(((void) ++_CUDA_VSTD::forward<_Types>(__tuple_elements), ...)))
     {
-      (__op_increment{}(_CUDA_VSTD::forward<_Types>(__tuple_elements)), ...);
+      ((void) ++_CUDA_VSTD::forward<_Types>(__tuple_elements), ...);
     }
   };
-
-  template <class _Tuple>
-  _CCCL_API static constexpr void __iter_op_increment(_Tuple&& __tuple) noexcept(
-    noexcept(_CUDA_VSTD::apply(__zip_iter_functors::__zip_op_increment{}, _CUDA_VSTD::forward<_Tuple>(__tuple))))
-  {
-    _CUDA_VSTD::apply(__zip_iter_functors::__zip_op_increment{}, _CUDA_VSTD::forward<_Tuple>(__tuple));
-  }
 
   struct __zip_op_decrement
   {
-    struct __op_decrement
-    {
-      _CCCL_EXEC_CHECK_DISABLE
-      template <class _Iter>
-      _CCCL_API constexpr void operator()(_Iter& __i) const noexcept(noexcept(--__i))
-      {
-        --__i;
-      }
-    };
-
+    _CCCL_EXEC_CHECK_DISABLE
     template <class... _Types>
     _CCCL_API constexpr void operator()(_Types&&... __tuple_elements) const
-      noexcept(noexcept((__op_decrement{}(_CUDA_VSTD::forward<_Types>(__tuple_elements)), ...)))
+      noexcept(noexcept(((void) --_CUDA_VSTD::forward<_Types>(__tuple_elements), ...)))
     {
-      (__op_decrement{}(_CUDA_VSTD::forward<_Types>(__tuple_elements)), ...);
+      ((void) --_CUDA_VSTD::forward<_Types>(__tuple_elements), ...);
     }
   };
-
-  template <class _Tuple>
-  _CCCL_API static constexpr void __iter_op_decrement(_Tuple&& __tuple) noexcept(
-    noexcept(_CUDA_VSTD::apply(__zip_iter_functors::__zip_op_decrement{}, _CUDA_VSTD::forward<_Tuple>(__tuple))))
-  {
-    _CUDA_VSTD::apply(__zip_iter_functors::__zip_op_decrement{}, _CUDA_VSTD::forward<_Tuple>(__tuple));
-  }
 
   template <class _Diff>
   struct __zip_op_pe
   {
-    _Diff __x;
+    _Diff __n;
 
-    struct __op_pe
-    {
-      _Diff __x;
-
-      _CCCL_EXEC_CHECK_DISABLE
-      template <class _Iter>
-      _CCCL_API constexpr void operator()(_Iter& __i) const
-        noexcept(noexcept(__i += _CUDA_VSTD::iter_difference_t<_Iter>(__x)))
-      {
-        __i += _CUDA_VSTD::iter_difference_t<_Iter>(__x);
-      }
-    };
-
+    _CCCL_EXEC_CHECK_DISABLE
     template <class... _Types>
-    _CCCL_API constexpr void operator()(_Types&&... __tuple_elements) const
-      noexcept(noexcept((__op_pe{__x}(_CUDA_VSTD::forward<_Types>(__tuple_elements)), ...)))
+    _CCCL_API constexpr void operator()(_Types&&... __tuple_elements) const noexcept(noexcept(
+      ((void) (_CUDA_VSTD::forward<_Types>(__tuple_elements) += _CUDA_VSTD::iter_difference_t<_Types>(__n)), ...)))
     {
-      (__op_pe{__x}(_CUDA_VSTD::forward<_Types>(__tuple_elements)), ...);
+      ((void) (_CUDA_VSTD::forward<_Types>(__tuple_elements) += _CUDA_VSTD::iter_difference_t<_Types>(__n)), ...);
     }
   };
-
-  template <class _Diff, class _Tuple>
-  _CCCL_API static constexpr void __iter_op_pe(_Diff __x, _Tuple&& __tuple) noexcept(
-    noexcept(_CUDA_VSTD::apply(__zip_iter_functors::__zip_op_pe<_Diff>{__x}, _CUDA_VSTD::forward<_Tuple>(__tuple))))
-  {
-    _CUDA_VSTD::apply(__zip_iter_functors::__zip_op_pe<_Diff>{__x}, _CUDA_VSTD::forward<_Tuple>(__tuple));
-  }
 
   template <class _Diff>
   struct __zip_op_me
   {
-    _Diff __x;
+    _Diff __n;
 
-    struct __op_me
-    {
-      _Diff __x;
-
-      _CCCL_EXEC_CHECK_DISABLE
-      template <class _Iter>
-      _CCCL_API constexpr void operator()(_Iter& __i) const
-        noexcept(noexcept(__i -= _CUDA_VSTD::iter_difference_t<_Iter>(__x)))
-      {
-        __i -= _CUDA_VSTD::iter_difference_t<_Iter>(__x);
-      }
-    };
-
+    _CCCL_EXEC_CHECK_DISABLE
     template <class... _Types>
-    _CCCL_API constexpr void operator()(_Types&&... __tuple_elements) const
-      noexcept(noexcept((__op_me{__x}(_CUDA_VSTD::forward<_Types>(__tuple_elements)), ...)))
+    _CCCL_API constexpr void operator()(_Types&&... __tuple_elements) const noexcept(noexcept(
+      ((void) (_CUDA_VSTD::forward<_Types>(__tuple_elements) -= _CUDA_VSTD::iter_difference_t<_Types>(__n)), ...)))
     {
-      (__op_me{__x}(_CUDA_VSTD::forward<_Types>(__tuple_elements)), ...);
+      ((void) (_CUDA_VSTD::forward<_Types>(__tuple_elements) -= _CUDA_VSTD::iter_difference_t<_Types>(__n)), ...);
     }
   };
-
-  template <class _Diff, class _Tuple>
-  _CCCL_API static constexpr void __iter_op_me(_Diff __x, _Tuple&& __tuple) noexcept(
-    noexcept(_CUDA_VSTD::apply(__zip_iter_functors::__zip_op_me<_Diff>{__x}, _CUDA_VSTD::forward<_Tuple>(__tuple))))
-  {
-    _CUDA_VSTD::apply(__zip_iter_functors::__zip_op_me<_Diff>{__x}, _CUDA_VSTD::forward<_Tuple>(__tuple));
-  }
 
   template <class _Diff>
   struct __zip_op_index
   {
     _Diff __n;
 
-    struct __op_index
-    {
-      _Diff __n;
-
-      _CCCL_EXEC_CHECK_DISABLE
-      template <class _Iter>
-      _CCCL_API constexpr decltype(auto) operator()(_Iter& __i) const
-        noexcept(noexcept(__i[_CUDA_VSTD::iter_difference_t<_Iter>(__n)]))
-      {
-        return __i[_CUDA_VSTD::iter_difference_t<_Iter>(__n)];
-      }
-    };
-
     template <class... _Types>
-    _CCCL_API constexpr auto operator()(_Types&&... __tuple_elements) const
-      noexcept(noexcept(__tuple_or_pair<_CUDA_VSTD::invoke_result_t<__zip_op_index::__op_index&, _Types>...>{
-        __zip_op_index::__op_index{__n}(_CUDA_VSTD::forward<_Types>(__tuple_elements))...}))
+    using __ret = __tuple_or_pair<decltype(_CUDA_VSTD::declval<_Types>()[_CUDA_VSTD::iter_difference_t<_Types>(0)])...>;
+
+    _CCCL_EXEC_CHECK_DISABLE
+    template <class... _Types>
+    [[nodiscard]] _CCCL_API constexpr __ret<_Types...> operator()(_Types&&... __tuple_elements) const
+      noexcept(noexcept(__ret<_Types...>{
+        _CUDA_VSTD::forward<_Types>(__tuple_elements)[_CUDA_VSTD::iter_difference_t<_Types>(__n)]...}))
     {
-      const auto __op = __zip_op_index::__op_index{__n};
-      return __tuple_or_pair<_CUDA_VSTD::invoke_result_t<__zip_op_index::__op_index&, _Types>...>{
-        __op(_CUDA_VSTD::forward<_Types>(__tuple_elements))...};
+      return __ret<_Types...>{
+        _CUDA_VSTD::forward<_Types>(__tuple_elements)[_CUDA_VSTD::iter_difference_t<_Types>(__n)]...};
     }
   };
-
-  template <class _Diff, class _Tuple>
-  _CCCL_API static constexpr auto __iter_op_index(_Diff __n, _Tuple&& __tuple) noexcept(
-    noexcept(_CUDA_VSTD::apply(__zip_iter_functors::__zip_op_index<_Diff>{__n}, _CUDA_VSTD::forward<_Tuple>(__tuple))))
-  {
-    return _CUDA_VSTD::apply(__zip_iter_functors::__zip_op_index<_Diff>{__n}, _CUDA_VSTD::forward<_Tuple>(__tuple));
-  }
 
   struct __op_comp_abs
   {
     // abs in cstdlib is not constexpr
     _CCCL_EXEC_CHECK_DISABLE
     template <class _Diff>
-    _CCCL_API static constexpr _Diff __abs(_Diff __t) noexcept(noexcept(__t < 0 ? -__t : __t))
+    [[nodiscard]] _CCCL_API static constexpr _Diff __abs(_Diff __t) noexcept(noexcept(__t < 0 ? -__t : __t))
     {
       return __t < 0 ? -__t : __t;
     }
 
+    _CCCL_EXEC_CHECK_DISABLE
     template <class _Diff>
-    _CCCL_API constexpr bool operator()(const _Diff& __x, const _Diff& __y) const
-      noexcept(noexcept(__op_comp_abs::__abs(__x) < __op_comp_abs::__abs(__y)))
+    [[nodiscard]] _CCCL_API constexpr bool operator()(const _Diff& __n, const _Diff& __y) const
+      noexcept(noexcept(__op_comp_abs::__abs(__n) < __op_comp_abs::__abs(__y)))
     {
-      return __op_comp_abs::__abs(__x) < __op_comp_abs::__abs(__y);
+      return __op_comp_abs::__abs(__n) < __op_comp_abs::__abs(__y);
     }
   };
 
   _CCCL_EXEC_CHECK_DISABLE
   template <class _Diff, class _Tuple1, class _Tuple2, size_t _Zero, size_t... _Indices>
-  _CCCL_API static constexpr _Diff
+  [[nodiscard]] _CCCL_API static constexpr _Diff
   __iter_op_minus(const _Tuple1& __tuple1, const _Tuple2& __tuple2, _CUDA_VSTD::index_sequence<_Zero, _Indices...>) //
     noexcept(noexcept(((_CUDA_VSTD::get<_Indices>(__tuple1) - _CUDA_VSTD::get<_Indices>(__tuple2)) && ...)))
   {
@@ -307,7 +208,8 @@ struct __zip_iter_functors
   }
 
   template <class _Diff, class _Tuple1, class _Tuple2>
-  _CCCL_API static constexpr _Diff __iter_op_minus(const _Tuple1& __tuple1, const _Tuple2& __tuple2) noexcept(
+  [[nodiscard]] _CCCL_API static constexpr _Diff
+  __iter_op_minus(const _Tuple1& __tuple1, const _Tuple2& __tuple2) noexcept(
     noexcept(__zip_iter_functors::__iter_op_minus<_Diff>(
       __tuple1,
       __tuple2,
@@ -322,21 +224,16 @@ struct __zip_iter_functors
   struct __zip_iter_move
   {
     template <class... _Types>
-    _CCCL_API constexpr __tuple_or_pair<_CUDA_VSTD::invoke_result_t<decltype(_CUDA_VRANGES::iter_move)&, _Types>...>
-    operator()(_Types&&... __tuple_elements) const
-      noexcept(noexcept(__tuple_or_pair<_CUDA_VSTD::invoke_result_t<decltype(_CUDA_VRANGES::iter_move)&, _Types>...>{
-        _CUDA_VRANGES::iter_move(_CUDA_VSTD::forward<_Types>(__tuple_elements))...}))
+    using __ret = __tuple_or_pair<_CUDA_VSTD::invoke_result_t<decltype(_CUDA_VRANGES::iter_move)&, _Types>...>;
+
+    _CCCL_EXEC_CHECK_DISABLE
+    template <class... _Types>
+    [[nodiscard]] _CCCL_API constexpr __ret<_Types...> operator()(_Types&&... __tuple_elements) const
+      noexcept(noexcept(__ret<_Types...>{_CUDA_VRANGES::iter_move(_CUDA_VSTD::forward<_Types>(__tuple_elements))...}))
     {
-      return {_CUDA_VRANGES::iter_move(_CUDA_VSTD::forward<_Types>(__tuple_elements))...};
+      return __ret<_Types...>{_CUDA_VRANGES::iter_move(_CUDA_VSTD::forward<_Types>(__tuple_elements))...};
     }
   };
-
-  template <class _Tuple>
-  _CCCL_API static constexpr auto __iter_move(_Tuple&& __tuple) noexcept(
-    noexcept(_CUDA_VSTD::apply(__zip_iter_move{}, _CUDA_VSTD::forward<_Tuple>(__tuple))))
-  {
-    return _CUDA_VSTD::apply(__zip_iter_move{}, _CUDA_VSTD::forward<_Tuple>(__tuple));
-  }
 
   template <class _Tuple1, class _Tuple2, size_t... _Indices>
   _CCCL_API static constexpr void
@@ -437,7 +334,7 @@ public:
       : __current_(_CUDA_VSTD::move(__iters))
   {}
 
-  // We want to use the simpler `pair` if possible, but still want to be able to construct from a 3 element tuple
+  // We want to use the simpler `pair` if possible, but still want to be able to construct from a 2 element tuple
   _CCCL_TEMPLATE(size_t _NumIterators = sizeof...(_Iterators))
   _CCCL_REQUIRES((_NumIterators == 2))
   _CCCL_API constexpr explicit zip_iterator(_CUDA_VSTD::tuple<_Iterators...> __iters)
@@ -467,12 +364,12 @@ public:
 
   _CCCL_API constexpr auto operator*() const
   {
-    return __zip_iter_functors::__iter_op_star(__current_);
+    return _CUDA_VSTD::apply(__zip_iter_functors::__zip_op_star{}, __current_);
   }
 
   _CCCL_API constexpr zip_iterator& operator++()
   {
-    __zip_iter_functors::__iter_op_increment(__current_);
+    _CUDA_VSTD::apply(__zip_iter_functors::__zip_op_increment{}, __current_);
     return *this;
   }
 
@@ -494,7 +391,7 @@ public:
   _CCCL_REQUIRES(_Constraints::__all_bidirectional)
   _CCCL_API constexpr zip_iterator& operator--()
   {
-    __zip_iter_functors::__iter_op_decrement(__current_);
+    _CUDA_VSTD::apply(__zip_iter_functors::__zip_op_decrement{}, __current_);
     return *this;
   }
 
@@ -509,17 +406,17 @@ public:
 
   _CCCL_TEMPLATE(class _Constraints = __zip_iter_constraints<_Iterators...>)
   _CCCL_REQUIRES(_Constraints::__all_random_access)
-  _CCCL_API constexpr zip_iterator& operator+=(difference_type __x)
+  _CCCL_API constexpr zip_iterator& operator+=(difference_type __n)
   {
-    __zip_iter_functors::__iter_op_pe(__x, __current_);
+    _CUDA_VSTD::apply(__zip_iter_functors::__zip_op_pe<difference_type>{__n}, __current_);
     return *this;
   }
 
   _CCCL_TEMPLATE(class _Constraints = __zip_iter_constraints<_Iterators...>)
   _CCCL_REQUIRES(_Constraints::__all_random_access)
-  _CCCL_API constexpr zip_iterator& operator-=(difference_type __x)
+  _CCCL_API constexpr zip_iterator& operator-=(difference_type __n)
   {
-    __zip_iter_functors::__iter_op_me(__x, __current_);
+    _CUDA_VSTD::apply(__zip_iter_functors::__zip_op_me<difference_type>{__n}, __current_);
     return *this;
   }
 
@@ -527,36 +424,36 @@ public:
   _CCCL_REQUIRES(_Constraints::__all_random_access)
   _CCCL_API constexpr auto operator[](difference_type __n) const
   {
-    return __zip_iter_functors::__iter_op_index(__n, __current_);
+    return _CUDA_VSTD::apply(__zip_iter_functors::__zip_op_index<difference_type>{__n}, __current_);
   }
 
   template <class _Constraints = __zip_iter_constraints<_Iterators...>>
-  friend _CCCL_API constexpr auto operator==(const zip_iterator& __x, const zip_iterator& __y)
+  friend _CCCL_API constexpr auto operator==(const zip_iterator& __n, const zip_iterator& __y)
     _CCCL_TRAILING_REQUIRES(bool)(_Constraints::__all_equality_comparable)
   {
     if constexpr (_Constraints::__all_bidirectional)
     {
-      return __x.__current_ == __y.__current_;
+      return __n.__current_ == __y.__current_;
     }
     else
     {
-      return __zip_iter_functors::__iter_op_eq(__x.__current_, __y.__current_);
+      return __zip_iter_functors::__iter_op_eq(__n.__current_, __y.__current_);
     }
     _CCCL_UNREACHABLE();
   }
 
 #if _CCCL_STD_VER <= 2017
   template <class _Constraints = __zip_iter_constraints<_Iterators...>>
-  friend _CCCL_API constexpr auto operator!=(const zip_iterator& __x, const zip_iterator& __y)
+  friend _CCCL_API constexpr auto operator!=(const zip_iterator& __n, const zip_iterator& __y)
     _CCCL_TRAILING_REQUIRES(bool)(_Constraints::__all_equality_comparable)
   {
     if constexpr (_Constraints::__all_bidirectional)
     {
-      return __x.__current_ != __y.__current_;
+      return __n.__current_ != __y.__current_;
     }
     else
     {
-      return !__zip_iter_functors::__iter_op_eq(__x.__current_, __y.__current_);
+      return !__zip_iter_functors::__iter_op_eq(__n.__current_, __y.__current_);
     }
     _CCCL_UNREACHABLE();
   }
@@ -564,40 +461,40 @@ public:
 
 #if _LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
   template <class _Constraints = __zip_iter_constraints<_Iterators...>>
-  friend _CCCL_API constexpr auto operator<=>(const zip_iterator& __x, const zip_iterator& __y)
+  friend _CCCL_API constexpr auto operator<=>(const zip_iterator& __n, const zip_iterator& __y)
     _CCCL_TRAILING_REQUIRES(bool)(_Constraints::__all_random_access&& _Constraints::__all_three_way_comparable)
   {
-    return __x.__current_ <=> __y.__current_;
+    return __n.__current_ <=> __y.__current_;
   }
 
 #else // ^^^ _LIBCUDACXX_HAS_SPACESHIP_OPERATOR() ^^^ / vvv !_LIBCUDACXX_HAS_SPACESHIP_OPERATOR() vvv
 
   template <class _Constraints = __zip_iter_constraints<_Iterators...>>
-  friend _CCCL_API constexpr auto operator<(const zip_iterator& __x, const zip_iterator& __y)
+  friend _CCCL_API constexpr auto operator<(const zip_iterator& __n, const zip_iterator& __y)
     _CCCL_TRAILING_REQUIRES(bool)(_Constraints::__all_random_access)
   {
-    return __x.__current_ < __y.__current_;
+    return __n.__current_ < __y.__current_;
   }
 
   template <class _Constraints = __zip_iter_constraints<_Iterators...>>
-  friend _CCCL_API constexpr auto operator>(const zip_iterator& __x, const zip_iterator& __y)
+  friend _CCCL_API constexpr auto operator>(const zip_iterator& __n, const zip_iterator& __y)
     _CCCL_TRAILING_REQUIRES(bool)(_Constraints::__all_random_access)
   {
-    return __y < __x;
+    return __y < __n;
   }
 
   template <class _Constraints = __zip_iter_constraints<_Iterators...>>
-  friend _CCCL_API constexpr auto operator<=(const zip_iterator& __x, const zip_iterator& __y)
+  friend _CCCL_API constexpr auto operator<=(const zip_iterator& __n, const zip_iterator& __y)
     _CCCL_TRAILING_REQUIRES(bool)(_Constraints::__all_random_access)
   {
-    return !(__y < __x);
+    return !(__y < __n);
   }
 
   template <class _Constraints = __zip_iter_constraints<_Iterators...>>
-  friend _CCCL_API constexpr auto operator>=(const zip_iterator& __x, const zip_iterator& __y)
+  friend _CCCL_API constexpr auto operator>=(const zip_iterator& __n, const zip_iterator& __y)
     _CCCL_TRAILING_REQUIRES(bool)(_Constraints::__all_random_access)
   {
-    return !(__x < __y);
+    return !(__n < __y);
   }
 #endif // !_LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
 
@@ -627,17 +524,17 @@ public:
   }
 
   template <class _Constraints = __zip_iter_constraints<_Iterators...>>
-  friend _CCCL_API constexpr auto operator-(const zip_iterator& __x, const zip_iterator& __y)
+  friend _CCCL_API constexpr auto operator-(const zip_iterator& __n, const zip_iterator& __y)
     _CCCL_TRAILING_REQUIRES(difference_type)(_Constraints::__all_sized_sentinel)
   {
-    return __zip_iter_functors::__iter_op_minus<difference_type>(__x.__current_, __y.__current_);
+    return __zip_iter_functors::__iter_op_minus<difference_type>(__n.__current_, __y.__current_);
   }
 
   // MSVC falls over its feet if this is not a template
   template <class _Constraints = __zip_iter_constraints<_Iterators...>>
   friend _CCCL_API constexpr auto iter_move(const zip_iterator& __i) noexcept(_Constraints::__all_nothrow_iter_movable)
   {
-    return __zip_iter_functors::__iter_move(__i.__current_);
+    return _CUDA_VSTD::apply(__zip_iter_functors::__zip_iter_move{}, __i.__current_);
   }
 
   template <class _Constraints = __zip_iter_constraints<_Iterators...>>

--- a/libcudacxx/include/cuda/__iterator/zip_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/zip_iterator.h
@@ -63,107 +63,6 @@ struct __tuple_or_pair_impl<_Iterator1, _Iterator2>
 template <class... _Iterators>
 using __tuple_or_pair = typename __tuple_or_pair_impl<_Iterators...>::type;
 
-struct __zip_iter_functors
-{
-  // iterator functions
-  _CCCL_EXEC_CHECK_DISABLE
-  template <class _Tuple1, class _Tuple2, size_t... _Indices>
-  _CCCL_API static constexpr bool
-  __iter_op_eq(const _Tuple1& __tuple1, const _Tuple2& __tuple2, _CUDA_VSTD::index_sequence<_Indices...>) noexcept(
-    noexcept(((_CUDA_VSTD::get<_Indices>(__tuple1) == _CUDA_VSTD::get<_Indices>(__tuple2)) || ...)))
-  {
-    return ((_CUDA_VSTD::get<_Indices>(__tuple1) == _CUDA_VSTD::get<_Indices>(__tuple2)) || ...);
-  }
-
-  _CCCL_EXEC_CHECK_DISABLE
-  template <class _Tuple1, class _Tuple2>
-  _CCCL_API static constexpr bool
-  __iter_op_eq(const _Tuple1& __tuple1, const _Tuple2& __tuple2) noexcept(noexcept(__zip_iter_functors::__iter_op_eq(
-    __tuple1,
-    __tuple2,
-    _CUDA_VSTD::make_index_sequence<_CUDA_VSTD::tuple_size_v<_CUDA_VSTD::remove_cvref_t<_Tuple1>>>())))
-  {
-    return __zip_iter_functors::__iter_op_eq(
-      __tuple1,
-      __tuple2,
-      _CUDA_VSTD::make_index_sequence<_CUDA_VSTD::tuple_size_v<_CUDA_VSTD::remove_cvref_t<_Tuple1>>>());
-  }
-
-  struct __op_comp_abs
-  {
-    // abs in cstdlib is not constexpr
-    _CCCL_EXEC_CHECK_DISABLE
-    template <class _Diff>
-    [[nodiscard]] _CCCL_API static constexpr _Diff __abs(_Diff __t) noexcept(noexcept(__t < 0 ? -__t : __t))
-    {
-      return __t < 0 ? -__t : __t;
-    }
-
-    _CCCL_EXEC_CHECK_DISABLE
-    template <class _Diff>
-    [[nodiscard]] _CCCL_API constexpr bool operator()(const _Diff& __n, const _Diff& __y) const
-      noexcept(noexcept(__op_comp_abs::__abs(__n) < __op_comp_abs::__abs(__y)))
-    {
-      return __op_comp_abs::__abs(__n) < __op_comp_abs::__abs(__y);
-    }
-  };
-
-  _CCCL_EXEC_CHECK_DISABLE
-  template <class _Diff, class _Tuple1, class _Tuple2, size_t _Zero, size_t... _Indices>
-  [[nodiscard]] _CCCL_API static constexpr _Diff
-  __iter_op_minus(const _Tuple1& __tuple1, const _Tuple2& __tuple2, _CUDA_VSTD::index_sequence<_Zero, _Indices...>) //
-    noexcept(noexcept(((_CUDA_VSTD::get<_Indices>(__tuple1) - _CUDA_VSTD::get<_Indices>(__tuple2)) && ...)))
-  {
-    const _Diff __first = _CUDA_VSTD::get<0>(__tuple1) - _CUDA_VSTD::get<0>(__tuple2);
-    if (__first == 0)
-    {
-      return __first;
-    }
-
-    const _Diff __temp[] = {__first, _CUDA_VSTD::get<_Indices>(__tuple1) - _CUDA_VSTD::get<_Indices>(__tuple2)...};
-    return *_CUDA_VRANGES::min_element(__temp, __op_comp_abs{});
-  }
-
-  template <class _Diff, class _Tuple1, class _Tuple2>
-  [[nodiscard]] _CCCL_API static constexpr _Diff
-  __iter_op_minus(const _Tuple1& __tuple1, const _Tuple2& __tuple2) noexcept(
-    noexcept(__zip_iter_functors::__iter_op_minus<_Diff>(
-      __tuple1,
-      __tuple2,
-      _CUDA_VSTD::make_index_sequence<_CUDA_VSTD::tuple_size_v<_CUDA_VSTD::remove_cvref_t<_Tuple1>>>())))
-  {
-    return __zip_iter_functors::__iter_op_minus<_Diff>(
-      __tuple1,
-      __tuple2,
-      _CUDA_VSTD::make_index_sequence<_CUDA_VSTD::tuple_size_v<_CUDA_VSTD::remove_cvref_t<_Tuple1>>>());
-  }
-
-  template <class _Tuple1, class _Tuple2, size_t... _Indices>
-  _CCCL_API static constexpr void
-  __iter_swap(_Tuple1&& __tuple1, _Tuple2&& __tuple2, _CUDA_VSTD::index_sequence<_Indices...>) noexcept(
-    _CUDA_VSTD::__all<noexcept(_CUDA_VRANGES::iter_swap(
-      _CUDA_VSTD::get<_Indices>(_CUDA_VSTD::declval<_Tuple1>()),
-      _CUDA_VSTD::get<_Indices>(_CUDA_VSTD::declval<_Tuple2>())))...>::value)
-  {
-    (_CUDA_VRANGES::iter_swap(_CUDA_VSTD::get<_Indices>(_CUDA_VSTD::forward<_Tuple1>(__tuple1)),
-                              _CUDA_VSTD::get<_Indices>(_CUDA_VSTD::forward<_Tuple2>(__tuple2))),
-     ...);
-  }
-
-  template <class _Tuple1, class _Tuple2>
-  _CCCL_API static constexpr void
-  __iter_swap(_Tuple1&& __tuple1, _Tuple2&& __tuple2) noexcept(noexcept(__zip_iter_functors::__iter_swap(
-    _CUDA_VSTD::forward<_Tuple1>(__tuple1),
-    _CUDA_VSTD::forward<_Tuple2>(__tuple2),
-    _CUDA_VSTD::make_index_sequence<_CUDA_VSTD::tuple_size<_CUDA_VSTD::remove_cvref_t<_Tuple1>>::value>())))
-  {
-    return __zip_iter_functors::__iter_swap(
-      _CUDA_VSTD::forward<_Tuple1>(__tuple1),
-      _CUDA_VSTD::forward<_Tuple2>(__tuple2),
-      _CUDA_VSTD::make_index_sequence<_CUDA_VSTD::tuple_size<_CUDA_VSTD::remove_cvref_t<_Tuple1>>::value>());
-  }
-};
-
 template <class... _Iterators>
 struct __zip_iter_constraints
 {
@@ -231,6 +130,16 @@ class zip_iterator : public __zv_iter_category_base<_Iterators...>
 
   template <class...>
   friend class zip_iterator;
+
+  template <class _Fn>
+  _CCCL_API static constexpr auto
+  __zip_apply(const _Fn& __fun,
+              const __tuple_or_pair<_Iterators...>& __tuple1,
+              const __tuple_or_pair<_Iterators...>& __tuple2) //
+    noexcept(noexcept(__fun(__tuple1, __tuple2, _CUDA_VSTD::make_index_sequence<sizeof...(_Iterators)>())))
+  {
+    return __fun(__tuple1, __tuple2, _CUDA_VSTD::make_index_sequence<sizeof...(_Iterators)>());
+  }
 
 public:
   _CCCL_API constexpr explicit zip_iterator(__tuple_or_pair<_Iterators...> __iters)
@@ -387,6 +296,19 @@ public:
     return _CUDA_VSTD::apply(__zip_op_index{__n}, __current_);
   }
 
+  struct __zip_op_eq
+  {
+    _CCCL_EXEC_CHECK_DISABLE
+    template <size_t... _Indices>
+    _CCCL_API constexpr bool operator()(const __tuple_or_pair<_Iterators...>& __iters1,
+                                        const __tuple_or_pair<_Iterators...>& __iters2,
+                                        _CUDA_VSTD::index_sequence<_Indices...>) const
+      noexcept(noexcept(((_CUDA_VSTD::get<_Indices>(__iters1) == _CUDA_VSTD::get<_Indices>(__iters2)) || ...)))
+    {
+      return ((_CUDA_VSTD::get<_Indices>(__iters1) == _CUDA_VSTD::get<_Indices>(__iters2)) || ...);
+    }
+  };
+
   template <class _Constraints = __zip_iter_constraints<_Iterators...>>
   _CCCL_API friend constexpr auto operator==(const zip_iterator& __n, const zip_iterator& __y)
     _CCCL_TRAILING_REQUIRES(bool)(_Constraints::__all_equality_comparable)
@@ -397,7 +319,7 @@ public:
     }
     else
     {
-      return __zip_iter_functors::__iter_op_eq(__n.__current_, __y.__current_);
+      return __zip_apply(__zip_op_eq{}, __n.__current_, __y.__current_);
     }
     _CCCL_UNREACHABLE();
   }
@@ -413,7 +335,7 @@ public:
     }
     else
     {
-      return !__zip_iter_functors::__iter_op_eq(__n.__current_, __y.__current_);
+      return !__zip_apply(__zip_op_eq{}, __n.__current_, __y.__current_);
     }
     _CCCL_UNREACHABLE();
   }
@@ -483,11 +405,52 @@ public:
     return __r;
   }
 
+  struct __zip_op_minus
+  {
+    struct __less_abs
+    {
+      // abs in cstdlib is not constexpr
+      _CCCL_EXEC_CHECK_DISABLE
+      [[nodiscard]] _CCCL_API static constexpr difference_type
+      __abs(difference_type __t) noexcept(noexcept(__t < 0 ? -__t : __t))
+      {
+        return __t < 0 ? -__t : __t;
+      }
+
+      _CCCL_EXEC_CHECK_DISABLE
+      [[nodiscard]] _CCCL_API constexpr bool operator()(difference_type __n, difference_type __y) const
+        noexcept(noexcept(__abs(__n) < __abs(__y)))
+      {
+        return __abs(__n) < __abs(__y);
+      }
+    };
+
+    _CCCL_EXEC_CHECK_DISABLE
+    template <size_t _Zero, size_t... _Indices>
+    [[nodiscard]] _CCCL_API constexpr difference_type
+    operator()(const __tuple_or_pair<_Iterators...>& __iters1,
+               const __tuple_or_pair<_Iterators...>& __iters2,
+               _CUDA_VSTD::index_sequence<_Zero, _Indices...>) const //
+      noexcept(noexcept(((_CUDA_VSTD::get<_Indices>(__iters1) - _CUDA_VSTD::get<_Indices>(__iters2)) && ...)))
+    {
+      const auto __first = static_cast<difference_type>(_CUDA_VSTD::get<0>(__iters1) - _CUDA_VSTD::get<0>(__iters2));
+      if (__first == 0)
+      {
+        return __first;
+      }
+
+      const difference_type __temp[] = {
+        __first,
+        static_cast<difference_type>(_CUDA_VSTD::get<_Indices>(__iters1) - _CUDA_VSTD::get<_Indices>(__iters2))...};
+      return *_CUDA_VRANGES::min_element(__temp, __zip_op_minus::__less_abs{});
+    }
+  };
+
   template <class _Constraints = __zip_iter_constraints<_Iterators...>>
   _CCCL_API friend constexpr auto operator-(const zip_iterator& __n, const zip_iterator& __y)
     _CCCL_TRAILING_REQUIRES(difference_type)(_Constraints::__all_sized_sentinel)
   {
-    return __zip_iter_functors::__iter_op_minus<difference_type>(__n.__current_, __y.__current_);
+    return __zip_apply(__zip_op_minus{}, __n.__current_, __y.__current_);
   }
 
   using __iter_move_ret = __tuple_or_pair<_CUDA_VSTD::iter_rvalue_reference_t<_Iterators>...>;
@@ -506,12 +469,28 @@ public:
     return _CUDA_VSTD::apply(__zip_iter_move, __i.__current_);
   }
 
+  template <class... _OtherIterators>
+  static constexpr bool __all_nothrow_swappable =
+    (_CUDA_VSTD::__noexcept_swappable<_OtherIterators, _OtherIterators> && ...);
+
+  struct __zip_op_iter_swap
+  {
+    template <size_t... _Indices>
+    _CCCL_API constexpr void
+    operator()(const __tuple_or_pair<_Iterators...>& __iters1,
+               const __tuple_or_pair<_Iterators...>& __iters2,
+               _CUDA_VSTD::index_sequence<_Indices...>) const noexcept(__all_nothrow_swappable<_Iterators...>)
+    {
+      (_CUDA_VRANGES::iter_swap(_CUDA_VSTD::get<_Indices>(__iters1), _CUDA_VSTD::get<_Indices>(__iters2)), ...);
+    }
+  };
+
   template <class _Constraints = __zip_iter_constraints<_Iterators...>>
   _CCCL_API friend constexpr auto
   iter_swap(const zip_iterator& __l, const zip_iterator& __r) noexcept(_Constraints::__all_noexcept_swappable)
     _CCCL_TRAILING_REQUIRES(void)(_Constraints::__all_indirectly_swappable)
   {
-    return __zip_iter_functors::__iter_swap(__l.__current_, __r.__current_);
+    return __zip_apply(__zip_op_iter_swap{}, __l.__current_, __r.__current_);
   }
 };
 

--- a/libcudacxx/include/cuda/__iterator/zip_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/zip_iterator.h
@@ -1,0 +1,685 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES
+//
+//===----------------------------------------------------------------------===//
+#ifndef _CUDA___ITERATOR_ZIP_ITERATOR_H
+#define _CUDA___ITERATOR_ZIP_ITERATOR_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/__fwd/zip_iterator.h>
+#include <cuda/std/__algorithm/ranges_min_element.h>
+#if _LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
+#  include <cuda/std/__compare/three_way_comparable.h>
+#endif // _LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
+#include <cuda/std/__concepts/convertible_to.h>
+#include <cuda/std/__concepts/equality_comparable.h>
+#include <cuda/std/__functional/invoke.h>
+#include <cuda/std/__functional/operations.h>
+#include <cuda/std/__iterator/concepts.h>
+#include <cuda/std/__iterator/incrementable_traits.h>
+#include <cuda/std/__iterator/iter_move.h>
+#include <cuda/std/__iterator/iter_swap.h>
+#include <cuda/std/__iterator/iterator_traits.h>
+#include <cuda/std/__ranges/concepts.h>
+#include <cuda/std/__type_traits/common_type.h>
+#include <cuda/std/__type_traits/make_unsigned.h>
+#include <cuda/std/__type_traits/remove_cvref.h>
+#include <cuda/std/__utility/forward.h>
+#include <cuda/std/__utility/integer_sequence.h>
+#include <cuda/std/__utility/move.h>
+#include <cuda/std/__utility/pair.h>
+#include <cuda/std/tuple>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_CUDA
+
+template <class... _Iterators>
+struct __tuple_or_pair_impl
+{
+  using type = _CUDA_VSTD::tuple<_Iterators...>;
+};
+
+template <class _Iterator1, class _Iterator2>
+struct __tuple_or_pair_impl<_Iterator1, _Iterator2>
+{
+  using type = _CUDA_VSTD::pair<_Iterator1, _Iterator2>;
+};
+
+template <class... _Iterators>
+using __tuple_or_pair = typename __tuple_or_pair_impl<_Iterators...>::type;
+
+struct __zip_iter_functors
+{
+  // iterator functions
+  template <class _Tuple1, class _Tuple2, size_t... _Indices>
+  _CCCL_API static constexpr bool
+  __iter_op_eq(const _Tuple1& __tuple1, const _Tuple2& __tuple2, _CUDA_VSTD::index_sequence<_Indices...>) noexcept(
+    noexcept(((_CUDA_VSTD::get<_Indices>(__tuple1) == _CUDA_VSTD::get<_Indices>(__tuple2)) || ...)))
+  {
+    return ((_CUDA_VSTD::get<_Indices>(__tuple1) == _CUDA_VSTD::get<_Indices>(__tuple2)) || ...);
+  }
+
+  template <class _Tuple1, class _Tuple2>
+  _CCCL_API static constexpr bool
+  __iter_op_eq(const _Tuple1& __tuple1, const _Tuple2& __tuple2) noexcept(noexcept(__zip_iter_functors::__iter_op_eq(
+    __tuple1,
+    __tuple2,
+    _CUDA_VSTD::make_index_sequence<_CUDA_VSTD::tuple_size_v<_CUDA_VSTD::remove_cvref_t<_Tuple1>>>())))
+  {
+    return __zip_iter_functors::__iter_op_eq(
+      __tuple1,
+      __tuple2,
+      _CUDA_VSTD::make_index_sequence<_CUDA_VSTD::tuple_size_v<_CUDA_VSTD::remove_cvref_t<_Tuple1>>>());
+  }
+
+  struct __zip_op_star
+  {
+    struct __op_star
+    {
+      template <class _Iter>
+      _CCCL_API constexpr decltype(auto) operator()(_Iter& __i) const noexcept(noexcept(*__i))
+      {
+        return *__i;
+      }
+    };
+
+    template <class... _Types>
+    _CCCL_API constexpr auto operator()(_Types&&... __tuple_elements) const
+      noexcept(noexcept(__tuple_or_pair<_CUDA_VSTD::invoke_result_t<__op_star&, _Types>...>{
+        _CUDA_VSTD::invoke(__op_star{}, _CUDA_VSTD::forward<_Types>(__tuple_elements))...}))
+    {
+      return __tuple_or_pair<_CUDA_VSTD::invoke_result_t<__op_star&, _Types>...>{
+        _CUDA_VSTD::invoke(__op_star{}, _CUDA_VSTD::forward<_Types>(__tuple_elements))...};
+    }
+  };
+
+  template <class _Tuple>
+  _CCCL_API static constexpr auto __iter_op_star(_Tuple&& __tuple) noexcept(
+    noexcept(_CUDA_VSTD::apply(__zip_iter_functors::__zip_op_star{}, _CUDA_VSTD::forward<_Tuple>(__tuple))))
+  {
+    return _CUDA_VSTD::apply(__zip_iter_functors::__zip_op_star{}, _CUDA_VSTD::forward<_Tuple>(__tuple));
+  }
+
+  struct __zip_op_increment
+  {
+    struct __op_increment
+    {
+      template <class _Iter>
+      _CCCL_API constexpr void operator()(_Iter& __i) const noexcept(noexcept(++__i))
+      {
+        ++__i;
+      }
+    };
+
+    template <class... _Types>
+    _CCCL_API constexpr void operator()(_Types&&... __tuple_elements) const
+      noexcept(noexcept((_CUDA_VSTD::invoke(__op_increment{}, _CUDA_VSTD::forward<_Types>(__tuple_elements)), ...)))
+    {
+      (_CUDA_VSTD::invoke(__op_increment{}, _CUDA_VSTD::forward<_Types>(__tuple_elements)), ...);
+    }
+  };
+
+  template <class _Tuple>
+  _CCCL_API static constexpr void __iter_op_increment(_Tuple&& __tuple) noexcept(
+    noexcept(_CUDA_VSTD::apply(__zip_iter_functors::__zip_op_increment{}, _CUDA_VSTD::forward<_Tuple>(__tuple))))
+  {
+    _CUDA_VSTD::apply(__zip_iter_functors::__zip_op_increment{}, _CUDA_VSTD::forward<_Tuple>(__tuple));
+  }
+
+  struct __zip_op_decrement
+  {
+    struct __op_decrement
+    {
+      template <class _Iter>
+      _CCCL_API constexpr void operator()(_Iter& __i) const noexcept(noexcept(--__i))
+      {
+        --__i;
+      }
+    };
+
+    template <class... _Types>
+    _CCCL_API constexpr void operator()(_Types&&... __tuple_elements) const
+      noexcept(noexcept((_CUDA_VSTD::invoke(__op_decrement{}, _CUDA_VSTD::forward<_Types>(__tuple_elements)), ...)))
+    {
+      (_CUDA_VSTD::invoke(__op_decrement{}, _CUDA_VSTD::forward<_Types>(__tuple_elements)), ...);
+    }
+  };
+
+  template <class _Tuple>
+  _CCCL_API static constexpr void __iter_op_decrement(_Tuple&& __tuple) noexcept(
+    noexcept(_CUDA_VSTD::apply(__zip_iter_functors::__zip_op_decrement{}, _CUDA_VSTD::forward<_Tuple>(__tuple))))
+  {
+    _CUDA_VSTD::apply(__zip_iter_functors::__zip_op_decrement{}, _CUDA_VSTD::forward<_Tuple>(__tuple));
+  }
+
+  template <class _Diff>
+  struct __zip_op_pe
+  {
+    _Diff __x;
+
+    struct __op_pe
+    {
+      _Diff __x;
+
+      template <class _Iter>
+      _CCCL_API constexpr void operator()(_Iter& __i) const
+        noexcept(noexcept(__i += _CUDA_VSTD::iter_difference_t<_Iter>(__x)))
+      {
+        __i += _CUDA_VSTD::iter_difference_t<_Iter>(__x);
+      }
+    };
+
+    template <class... _Types>
+    _CCCL_API constexpr void operator()(_Types&&... __tuple_elements) const
+      noexcept(noexcept((_CUDA_VSTD::invoke(__op_pe{__x}, _CUDA_VSTD::forward<_Types>(__tuple_elements)), ...)))
+    {
+      (_CUDA_VSTD::invoke(__op_pe{__x}, _CUDA_VSTD::forward<_Types>(__tuple_elements)), ...);
+    }
+  };
+
+  template <class _Diff, class _Tuple>
+  _CCCL_API static constexpr void __iter_op_pe(_Diff __x, _Tuple&& __tuple) noexcept(
+    noexcept(_CUDA_VSTD::apply(__zip_iter_functors::__zip_op_pe<_Diff>{__x}, _CUDA_VSTD::forward<_Tuple>(__tuple))))
+  {
+    _CUDA_VSTD::apply(__zip_iter_functors::__zip_op_pe<_Diff>{__x}, _CUDA_VSTD::forward<_Tuple>(__tuple));
+  }
+
+  template <class _Diff>
+  struct __zip_op_me
+  {
+    _Diff __x;
+
+    struct __op_me
+    {
+      _Diff __x;
+
+      template <class _Iter>
+      _CCCL_API constexpr void operator()(_Iter& __i) const
+        noexcept(noexcept(__i -= _CUDA_VSTD::iter_difference_t<_Iter>(__x)))
+      {
+        __i -= _CUDA_VSTD::iter_difference_t<_Iter>(__x);
+      }
+    };
+
+    template <class... _Types>
+    _CCCL_API constexpr void operator()(_Types&&... __tuple_elements) const
+      noexcept(noexcept((_CUDA_VSTD::invoke(__op_me{__x}, _CUDA_VSTD::forward<_Types>(__tuple_elements)), ...)))
+    {
+      (_CUDA_VSTD::invoke(__op_me{__x}, _CUDA_VSTD::forward<_Types>(__tuple_elements)), ...);
+    }
+  };
+
+  template <class _Diff, class _Tuple>
+  _CCCL_API static constexpr void __iter_op_me(_Diff __x, _Tuple&& __tuple) noexcept(
+    noexcept(_CUDA_VSTD::apply(__zip_iter_functors::__zip_op_me<_Diff>{__x}, _CUDA_VSTD::forward<_Tuple>(__tuple))))
+  {
+    _CUDA_VSTD::apply(__zip_iter_functors::__zip_op_me<_Diff>{__x}, _CUDA_VSTD::forward<_Tuple>(__tuple));
+  }
+
+  template <class _Diff>
+  struct __zip_op_index
+  {
+    _Diff __n;
+
+    struct __op_index
+    {
+      _Diff __n;
+
+      template <class _Iter>
+      _CCCL_API constexpr decltype(auto) operator()(_Iter& __i) const
+        noexcept(noexcept(__i[_CUDA_VSTD::iter_difference_t<_Iter>(__n)]))
+      {
+        return __i[_CUDA_VSTD::iter_difference_t<_Iter>(__n)];
+      }
+    };
+
+    template <class... _Types>
+    _CCCL_API constexpr auto operator()(_Types&&... __tuple_elements) const
+      noexcept(noexcept(__tuple_or_pair<_CUDA_VSTD::invoke_result_t<__zip_op_index::__op_index&, _Types>...>{
+        _CUDA_VSTD::invoke(__zip_op_index::__op_index{__n}, _CUDA_VSTD::forward<_Types>(__tuple_elements))...}))
+    {
+      return __tuple_or_pair<_CUDA_VSTD::invoke_result_t<__zip_op_index::__op_index&, _Types>...>{
+        _CUDA_VSTD::invoke(__zip_op_index::__op_index{__n}, _CUDA_VSTD::forward<_Types>(__tuple_elements))...};
+    }
+  };
+
+  template <class _Diff, class _Tuple>
+  _CCCL_API static constexpr auto __iter_op_index(_Diff __n, _Tuple&& __tuple) noexcept(
+    noexcept(_CUDA_VSTD::apply(__zip_iter_functors::__zip_op_index<_Diff>{__n}, _CUDA_VSTD::forward<_Tuple>(__tuple))))
+  {
+    return _CUDA_VSTD::apply(__zip_iter_functors::__zip_op_index<_Diff>{__n}, _CUDA_VSTD::forward<_Tuple>(__tuple));
+  }
+
+  struct __op_comp_abs
+  {
+    // abs in cstdlib is not constexpr
+    template <class _Diff>
+    _CCCL_API static constexpr _Diff __abs(_Diff __t) noexcept(noexcept(__t < 0 ? -__t : __t))
+    {
+      return __t < 0 ? -__t : __t;
+    }
+
+    template <class _Diff>
+    _CCCL_API constexpr bool operator()(const _Diff& __x, const _Diff& __y) const
+      noexcept(noexcept(__op_comp_abs::__abs(__x) < __op_comp_abs::__abs(__y)))
+    {
+      return __op_comp_abs::__abs(__x) < __op_comp_abs::__abs(__y);
+    }
+  };
+
+  template <class _Diff, class _Tuple1, class _Tuple2, size_t _Zero, size_t... _Indices>
+  _CCCL_API static constexpr _Diff
+  __iter_op_minus(const _Tuple1& __tuple1, const _Tuple2& __tuple2, _CUDA_VSTD::index_sequence<_Zero, _Indices...>) //
+    noexcept(noexcept(((_CUDA_VSTD::get<_Indices>(__tuple1) - _CUDA_VSTD::get<_Indices>(__tuple2)) && ...)))
+  {
+    const _Diff __first = _CUDA_VSTD::get<0>(__tuple1) - _CUDA_VSTD::get<0>(__tuple2);
+    if (__first == 0)
+    {
+      return __first;
+    }
+
+    const _Diff __temp[] = {__first, _CUDA_VSTD::get<_Indices>(__tuple1) - _CUDA_VSTD::get<_Indices>(__tuple2)...};
+    return *(_CUDA_VRANGES::min_element) (__temp, __op_comp_abs{});
+  }
+
+  template <class _Diff, class _Tuple1, class _Tuple2>
+  _CCCL_API static constexpr _Diff __iter_op_minus(const _Tuple1& __tuple1, const _Tuple2& __tuple2) noexcept(
+    noexcept(__zip_iter_functors::__iter_op_minus<_Diff>(
+      __tuple1,
+      __tuple2,
+      _CUDA_VSTD::make_index_sequence<_CUDA_VSTD::tuple_size_v<_CUDA_VSTD::remove_cvref_t<_Tuple1>>>())))
+  {
+    return __zip_iter_functors::__iter_op_minus<_Diff>(
+      __tuple1,
+      __tuple2,
+      _CUDA_VSTD::make_index_sequence<_CUDA_VSTD::tuple_size_v<_CUDA_VSTD::remove_cvref_t<_Tuple1>>>());
+  }
+
+  struct __zip_iter_move
+  {
+    template <class... _Types>
+    _CCCL_API constexpr __tuple_or_pair<_CUDA_VSTD::invoke_result_t<decltype(_CUDA_VRANGES::iter_move)&, _Types>...>
+    operator()(_Types&&... __tuple_elements) const
+      noexcept(noexcept(__tuple_or_pair<_CUDA_VSTD::invoke_result_t<decltype(_CUDA_VRANGES::iter_move)&, _Types>...>{
+        _CUDA_VSTD::invoke(_CUDA_VRANGES::iter_move, _CUDA_VSTD::forward<_Types>(__tuple_elements))...}))
+    {
+      return {_CUDA_VSTD::invoke(_CUDA_VRANGES::iter_move, _CUDA_VSTD::forward<_Types>(__tuple_elements))...};
+    }
+  };
+
+  template <class _Tuple>
+  _CCCL_API static constexpr auto __iter_move(_Tuple&& __tuple) noexcept(
+    noexcept(_CUDA_VSTD::apply(__zip_iter_move{}, _CUDA_VSTD::forward<_Tuple>(__tuple))))
+  {
+    return _CUDA_VSTD::apply(__zip_iter_move{}, _CUDA_VSTD::forward<_Tuple>(__tuple));
+  }
+
+  template <class _Tuple1, class _Tuple2, size_t... _Indices>
+  _CCCL_API static constexpr void
+  __iter_swap(_Tuple1&& __tuple1, _Tuple2&& __tuple2, _CUDA_VSTD::index_sequence<_Indices...>) noexcept(
+    _CUDA_VSTD::__all<noexcept(_CUDA_VRANGES::iter_swap(
+      _CUDA_VSTD::get<_Indices>(_CUDA_VSTD::declval<_Tuple1>()),
+      _CUDA_VSTD::get<_Indices>(_CUDA_VSTD::declval<_Tuple2>())))...>::value)
+  {
+    (_CUDA_VRANGES::iter_swap(_CUDA_VSTD::get<_Indices>(_CUDA_VSTD::forward<_Tuple1>(__tuple1)),
+                              _CUDA_VSTD::get<_Indices>(_CUDA_VSTD::forward<_Tuple2>(__tuple2))),
+     ...);
+  }
+
+  template <class _Tuple1, class _Tuple2>
+  _CCCL_API static constexpr void
+  __iter_swap(_Tuple1&& __tuple1, _Tuple2&& __tuple2) noexcept(noexcept(__zip_iter_functors::__iter_swap(
+    _CUDA_VSTD::forward<_Tuple1>(__tuple1),
+    _CUDA_VSTD::forward<_Tuple2>(__tuple2),
+    _CUDA_VSTD::make_index_sequence<_CUDA_VSTD::tuple_size<_CUDA_VSTD::remove_cvref_t<_Tuple1>>::value>())))
+  {
+    return __zip_iter_functors::__iter_swap(
+      _CUDA_VSTD::forward<_Tuple1>(__tuple1),
+      _CUDA_VSTD::forward<_Tuple2>(__tuple2),
+      _CUDA_VSTD::make_index_sequence<_CUDA_VSTD::tuple_size<_CUDA_VSTD::remove_cvref_t<_Tuple1>>::value>());
+  }
+};
+
+template <class... _Iterators>
+struct __zip_iter_constraints
+{
+  static constexpr bool __all_forward       = (_CUDA_VSTD::forward_iterator<_Iterators> && ...);
+  static constexpr bool __all_bidirectional = (_CUDA_VSTD::bidirectional_iterator<_Iterators> && ...);
+  static constexpr bool __all_random_access = (_CUDA_VSTD::random_access_iterator<_Iterators> && ...);
+
+  static constexpr bool __all_equality_comparable = (_CUDA_VSTD::equality_comparable<_Iterators> && ...);
+
+#if _LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
+  static constexpr bool __all_three_way_comparable = (_CUDA_VSTD::three_way_comparable<_Iterators> && ...);
+#endif // _LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
+
+  static constexpr bool __all_sized_sentinel = (_CUDA_VSTD::sized_sentinel_for<_Iterators, _Iterators> && ...);
+  static constexpr bool __all_nothrow_iter_movable =
+    (noexcept(_CUDA_VRANGES::iter_move(_CUDA_VSTD::declval<const _Iterators&>())) && ...)
+    && (_CUDA_VSTD::is_nothrow_move_constructible_v<_CUDA_VSTD::iter_rvalue_reference_t<_Iterators>> && ...);
+
+  static constexpr bool __all_indirectly_swappable = (_CUDA_VSTD::indirectly_swappable<_Iterators> && ...);
+
+  static constexpr bool __all_noexcept_swappable = (_CUDA_VSTD::__noexcept_swappable<_Iterators> && ...);
+};
+
+struct __zv_iter_category_base_none
+{};
+
+struct __zv_iter_category_base_tag
+{
+  using iterator_category = _CUDA_VSTD::input_iterator_tag;
+};
+
+template <class... _Iterators>
+using __zv_iter_category_base =
+  _CUDA_VSTD::conditional_t<__zip_iter_constraints<_Iterators...>::__all_forward,
+                            __zv_iter_category_base_tag,
+                            __zv_iter_category_base_none>;
+
+template <class... _Iterators>
+_CCCL_API constexpr auto __get_zip_view_iterator_tag()
+{
+  using _Constraints = __zip_iter_constraints<_Iterators...>;
+  if constexpr (_Constraints::__all_random_access)
+  {
+    return _CUDA_VSTD::random_access_iterator_tag();
+  }
+  else if constexpr (_Constraints::__all_bidirectional)
+  {
+    return _CUDA_VSTD::bidirectional_iterator_tag();
+  }
+  else if constexpr (_Constraints::__all_forward)
+  {
+    return _CUDA_VSTD::forward_iterator_tag();
+  }
+  else
+  {
+    return _CUDA_VSTD::input_iterator_tag();
+  }
+  _CCCL_UNREACHABLE();
+}
+
+template <class... _Iterators>
+class zip_iterator : public __zv_iter_category_base<_Iterators...>
+{
+  __tuple_or_pair<_Iterators...> __current_;
+
+  template <class...>
+  friend class zip_iterator;
+
+public:
+  _CCCL_API constexpr explicit zip_iterator(__tuple_or_pair<_Iterators...> __iters)
+      : __current_(_CUDA_VSTD::move(__iters))
+  {}
+
+  // We want to use the simpler `pair` if possible, but still want to be able to construct from a 3 element tuple
+  _CCCL_TEMPLATE(size_t _NumIterators = sizeof...(_Iterators))
+  _CCCL_REQUIRES((_NumIterators == 2))
+  _CCCL_API constexpr explicit zip_iterator(_CUDA_VSTD::tuple<_Iterators...> __iters)
+      : __current_(_CUDA_VSTD::get<0>(_CUDA_VSTD::move(__iters)), _CUDA_VSTD::get<1>(_CUDA_VSTD::move(__iters)))
+  {}
+
+  _CCCL_API constexpr explicit zip_iterator(_Iterators... __iters)
+      : __current_(_CUDA_VSTD::move(__iters)...)
+  {}
+
+  using iterator_concept = decltype(__get_zip_view_iterator_tag<_Iterators...>());
+  using value_type       = __tuple_or_pair<_CUDA_VSTD::iter_value_t<_Iterators>...>;
+  using difference_type  = _CUDA_VSTD::common_type_t<_CUDA_VSTD::iter_difference_t<_Iterators>...>;
+
+  _CCCL_HIDE_FROM_ABI zip_iterator() = default;
+
+  template <class... _OtherIters>
+  static constexpr bool __all_convertible =
+    (_CUDA_VSTD::convertible_to<_OtherIters, _Iterators> && ...)
+    && !(_CUDA_VSTD::is_same_v<_Iterators, _OtherIters> && ...);
+
+  _CCCL_TEMPLATE(class... _OtherIters)
+  _CCCL_REQUIRES((sizeof...(_OtherIters) == sizeof...(_Iterators)) _CCCL_AND __all_convertible<_OtherIters...>)
+  _CCCL_API constexpr zip_iterator(zip_iterator<_OtherIters...> __i)
+      : __current_(_CUDA_VSTD::move(__i.__current_))
+  {}
+
+  _CCCL_API constexpr auto operator*() const
+  {
+    return __zip_iter_functors::__iter_op_star(__current_);
+  }
+
+  _CCCL_API constexpr zip_iterator& operator++()
+  {
+    __zip_iter_functors::__iter_op_increment(__current_);
+    return *this;
+  }
+
+  _CCCL_API constexpr auto operator++(int)
+  {
+    if constexpr (__zip_iter_constraints<_Iterators...>::__all_forward)
+    {
+      auto __tmp = *this;
+      ++*this;
+      return __tmp;
+    }
+    else
+    {
+      ++*this;
+    }
+  }
+
+  _CCCL_TEMPLATE(class _Constraints = __zip_iter_constraints<_Iterators...>)
+  _CCCL_REQUIRES(_Constraints::__all_bidirectional)
+  _CCCL_API constexpr zip_iterator& operator--()
+  {
+    __zip_iter_functors::__iter_op_decrement(__current_);
+    return *this;
+  }
+
+  _CCCL_TEMPLATE(class _Constraints = __zip_iter_constraints<_Iterators...>)
+  _CCCL_REQUIRES(_Constraints::__all_bidirectional)
+  _CCCL_API constexpr zip_iterator operator--(int)
+  {
+    auto __tmp = *this;
+    --*this;
+    return __tmp;
+  }
+
+  _CCCL_TEMPLATE(class _Constraints = __zip_iter_constraints<_Iterators...>)
+  _CCCL_REQUIRES(_Constraints::__all_random_access)
+  _CCCL_API constexpr zip_iterator& operator+=(difference_type __x)
+  {
+    __zip_iter_functors::__iter_op_pe(__x, __current_);
+    return *this;
+  }
+
+  _CCCL_TEMPLATE(class _Constraints = __zip_iter_constraints<_Iterators...>)
+  _CCCL_REQUIRES(_Constraints::__all_random_access)
+  _CCCL_API constexpr zip_iterator& operator-=(difference_type __x)
+  {
+    __zip_iter_functors::__iter_op_me(__x, __current_);
+    return *this;
+  }
+
+  _CCCL_TEMPLATE(class _Constraints = __zip_iter_constraints<_Iterators...>)
+  _CCCL_REQUIRES(_Constraints::__all_random_access)
+  _CCCL_API constexpr auto operator[](difference_type __n) const
+  {
+    return __zip_iter_functors::__iter_op_index(__n, __current_);
+  }
+
+  template <class _Constraints = __zip_iter_constraints<_Iterators...>>
+  friend _CCCL_API constexpr auto operator==(const zip_iterator& __x, const zip_iterator& __y)
+    _CCCL_TRAILING_REQUIRES(bool)(_Constraints::__all_equality_comparable)
+  {
+    if constexpr (_Constraints::__all_bidirectional)
+    {
+      return __x.__current_ == __y.__current_;
+    }
+    else
+    {
+      return __zip_iter_functors::__iter_op_eq(__x.__current_, __y.__current_);
+    }
+    _CCCL_UNREACHABLE();
+  }
+
+#if _CCCL_STD_VER <= 2017
+  template <class _Constraints = __zip_iter_constraints<_Iterators...>>
+  friend _CCCL_API constexpr auto operator!=(const zip_iterator& __x, const zip_iterator& __y)
+    _CCCL_TRAILING_REQUIRES(bool)(_Constraints::__all_equality_comparable)
+  {
+    if constexpr (_Constraints::__all_bidirectional)
+    {
+      return __x.__current_ != __y.__current_;
+    }
+    else
+    {
+      return !__zip_iter_functors::__iter_op_eq(__x.__current_, __y.__current_);
+    }
+    _CCCL_UNREACHABLE();
+  }
+#endif // _CCCL_STD_VER <= 2017
+
+#if _LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
+  template <class _Constraints = __zip_iter_constraints<_Iterators...>>
+  friend _CCCL_API constexpr auto operator<=>(const zip_iterator& __x, const zip_iterator& __y)
+    _CCCL_TRAILING_REQUIRES(bool)(_Constraints::__all_random_access&& _Constraints::__all_three_way_comparable)
+  {
+    return __x.__current_ <=> __y.__current_;
+  }
+
+#else // ^^^ _LIBCUDACXX_HAS_SPACESHIP_OPERATOR() ^^^ / vvv !_LIBCUDACXX_HAS_SPACESHIP_OPERATOR() vvv
+
+  template <class _Constraints = __zip_iter_constraints<_Iterators...>>
+  friend _CCCL_API constexpr auto operator<(const zip_iterator& __x, const zip_iterator& __y)
+    _CCCL_TRAILING_REQUIRES(bool)(_Constraints::__all_random_access)
+  {
+    return __x.__current_ < __y.__current_;
+  }
+
+  template <class _Constraints = __zip_iter_constraints<_Iterators...>>
+  friend _CCCL_API constexpr auto operator>(const zip_iterator& __x, const zip_iterator& __y)
+    _CCCL_TRAILING_REQUIRES(bool)(_Constraints::__all_random_access)
+  {
+    return __y < __x;
+  }
+
+  template <class _Constraints = __zip_iter_constraints<_Iterators...>>
+  friend _CCCL_API constexpr auto operator<=(const zip_iterator& __x, const zip_iterator& __y)
+    _CCCL_TRAILING_REQUIRES(bool)(_Constraints::__all_random_access)
+  {
+    return !(__y < __x);
+  }
+
+  template <class _Constraints = __zip_iter_constraints<_Iterators...>>
+  friend _CCCL_API constexpr auto operator>=(const zip_iterator& __x, const zip_iterator& __y)
+    _CCCL_TRAILING_REQUIRES(bool)(_Constraints::__all_random_access)
+  {
+    return !(__x < __y);
+  }
+#endif // !_LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
+
+  template <class _Constraints = __zip_iter_constraints<_Iterators...>>
+  friend _CCCL_API constexpr auto operator+(const zip_iterator& __i, difference_type __n)
+    _CCCL_TRAILING_REQUIRES(zip_iterator)(_Constraints::__all_random_access)
+  {
+    auto __r = __i;
+    __r += __n;
+    return __r;
+  }
+
+  template <class _Constraints = __zip_iter_constraints<_Iterators...>>
+  friend _CCCL_API constexpr auto operator+(difference_type __n, const zip_iterator& __i)
+    _CCCL_TRAILING_REQUIRES(zip_iterator)(_Constraints::__all_random_access)
+  {
+    return __i + __n;
+  }
+
+  template <class _Constraints = __zip_iter_constraints<_Iterators...>>
+  friend _CCCL_API constexpr auto operator-(const zip_iterator& __i, difference_type __n)
+    _CCCL_TRAILING_REQUIRES(zip_iterator)(_Constraints::__all_random_access)
+  {
+    auto __r = __i;
+    __r -= __n;
+    return __r;
+  }
+
+  template <class _Constraints = __zip_iter_constraints<_Iterators...>>
+  friend _CCCL_API constexpr auto operator-(const zip_iterator& __x, const zip_iterator& __y)
+    _CCCL_TRAILING_REQUIRES(difference_type)(_Constraints::__all_sized_sentinel)
+  {
+    return __zip_iter_functors::__iter_op_minus<difference_type>(__x.__current_, __y.__current_);
+  }
+
+  // MSVC falls over its feet if this is not a template
+  template <class _Constraints = __zip_iter_constraints<_Iterators...>>
+  friend _CCCL_API constexpr auto iter_move(const zip_iterator& __i) noexcept(_Constraints::__all_nothrow_iter_movable)
+  {
+    return __zip_iter_functors::__iter_move(__i.__current_);
+  }
+
+  template <class _Constraints = __zip_iter_constraints<_Iterators...>>
+  friend _CCCL_API constexpr auto
+  iter_swap(const zip_iterator& __l, const zip_iterator& __r) noexcept(_Constraints::__all_noexcept_swappable)
+    _CCCL_TRAILING_REQUIRES(void)(_Constraints::__all_indirectly_swappable)
+  {
+    return __zip_iter_functors::__iter_swap(__l.__current_, __r.__current_);
+  }
+};
+
+template <class... _Iterators>
+_CCCL_HOST_DEVICE zip_iterator(_CUDA_VSTD::tuple<_Iterators...>) -> zip_iterator<_Iterators...>;
+
+template <class _Iterator1, class _Iterator2>
+_CCCL_HOST_DEVICE zip_iterator(_CUDA_VSTD::pair<_Iterator1, _Iterator2>) -> zip_iterator<_Iterator1, _Iterator2>;
+
+template <class... _Iterators>
+_CCCL_HOST_DEVICE zip_iterator(_Iterators...) -> zip_iterator<_Iterators...>;
+
+//! \p make_zip_iterator creates a \p zip_iterator from a \p tuple of iterators.
+//!
+//! \param t The \p tuple of iterators to copy.
+//! \return A newly created \p zip_iterator which zips the iterators encapsulated in \p t.
+template <typename... Iterators>
+_CCCL_API constexpr zip_iterator<Iterators...> make_zip_iterator(_CUDA_VSTD::tuple<Iterators...> t)
+{
+  return zip_iterator<Iterators...>{_CUDA_VSTD::move(t)};
+}
+
+//! \p make_zip_iterator creates a \p zip_iterator from iterators.
+//!
+//! \param its The iterators to copy.
+//! \return A newly created \p zip_iterator which zips the iterators.
+template <typename... Iterators>
+_CCCL_API constexpr zip_iterator<Iterators...> make_zip_iterator(Iterators... its)
+{
+  return zip_iterator<Iterators...>{_CUDA_VSTD::move(its)...};
+}
+
+_LIBCUDACXX_END_NAMESPACE_CUDA
+
+// GCC and MSVC2019 have issues determining _IsFancyPointer in C++17 because they fail to instantiate pointer_traits
+#if (_CCCL_COMPILER(GCC) || _CCCL_COMPILER(MSVC)) && _CCCL_STD_VER <= 2017
+_LIBCUDACXX_BEGIN_NAMESPACE_STD
+template <class... _Iterators>
+struct _IsFancyPointer<::cuda::zip_iterator<_Iterators...>> : false_type
+{};
+_LIBCUDACXX_END_NAMESPACE_STD
+#endif // _CCCL_COMPILER(MSVC) && _CCCL_STD_VER <= 2017
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA___ITERATOR_ZIP_ITERATOR_H

--- a/libcudacxx/include/cuda/functional
+++ b/libcudacxx/include/cuda/functional
@@ -25,6 +25,7 @@
 #include <cuda/__functional/maximum.h>
 #include <cuda/__functional/minimum.h>
 #include <cuda/__functional/proclaim_return_type.h>
+#include <cuda/__iterator/zip_function.h>
 #include <cuda/__memory/get_device_address.h>
 #include <cuda/std/functional>
 

--- a/libcudacxx/include/cuda/iterator
+++ b/libcudacxx/include/cuda/iterator
@@ -30,6 +30,7 @@
 #include <cuda/__iterator/transform_input_output_iterator.h>
 #include <cuda/__iterator/transform_iterator.h>
 #include <cuda/__iterator/transform_output_iterator.h>
+#include <cuda/__iterator/zip_function.h>
 #include <cuda/__iterator/zip_iterator.h>
 #include <cuda/std/iterator>
 

--- a/libcudacxx/test/libcudacxx/cuda/functional/zip_function/call.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/functional/zip_function/call.pass.cpp
@@ -1,0 +1,175 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/functional>
+#include <cuda/std/tuple>
+#include <cuda/std/utility>
+
+#include "test_macros.h"
+
+struct foo
+{};
+
+struct Immutable
+{
+  constexpr Immutable() = default;
+
+  __host__ __device__ constexpr int operator()(const int a, const double b, foo) const noexcept
+  {
+    return a + 41;
+  }
+  __host__ __device__ constexpr int operator()(const int a, const double) const
+  {
+    return a + 41;
+  }
+  __host__ __device__ constexpr int operator()(const int a) const noexcept
+  {
+    return a + 41;
+  }
+};
+
+struct Mutable
+{
+  constexpr Mutable() = default;
+
+  __host__ __device__ constexpr int operator()(const int a, const double b, foo)
+  {
+    return a + 41;
+  }
+  __host__ __device__ constexpr int operator()(const int a, const double) noexcept
+  {
+    return a + 41;
+  }
+  __host__ __device__ constexpr int operator()(const int a)
+  {
+    return a + 41;
+  }
+};
+
+struct Mixed
+{
+  constexpr Mixed() = default;
+
+  __host__ __device__ constexpr int operator()(const int a, const double b, foo) const noexcept
+  {
+    return a + 41;
+  }
+  __host__ __device__ constexpr int operator()(const int a, const double) const
+  {
+    return a + 41;
+  }
+  __host__ __device__ constexpr int operator()(const int a) const noexcept
+  {
+    return a + 41;
+  }
+
+  __host__ __device__ constexpr int operator()(const int a, const double b, foo)
+  {
+    return a + 41;
+  }
+  __host__ __device__ constexpr int operator()(const int a, const double) noexcept
+  {
+    return a + 41;
+  }
+  __host__ __device__ constexpr int operator()(const int a)
+  {
+    return a + 41;
+  }
+};
+
+template <bool IsNoexcept, class Fn, class Tuple>
+__host__ __device__ constexpr void test(Fn&& fun, Tuple&& tuple)
+{
+  static_assert(cuda::std::is_invocable_v<Fn, Tuple>);
+  static_assert(cuda::std::is_nothrow_invocable_v<Fn, Tuple> == IsNoexcept);
+  assert(cuda::std::forward<Fn>(fun)(cuda::std::forward<Tuple>(tuple)) == 42);
+}
+
+__host__ __device__ constexpr bool test()
+{
+  using cuda::zip_function;
+
+  cuda::std::tuple three_args{1, 3.14, foo{}};
+  cuda::std::pair two_args{1, 3.14};
+  cuda::std::tuple one_arg{1};
+  {
+    const zip_function<Immutable> fn{};
+    test<true>(fn, three_args);
+    test<false>(fn, two_args);
+    test<true>(fn, one_arg);
+
+    // Ensure we can also call the function with const arguments
+    test<true>(fn, cuda::std::as_const(three_args));
+    test<false>(fn, cuda::std::as_const(two_args));
+    test<true>(fn, cuda::std::as_const(one_arg));
+
+    // Ensure we can also call the function with prvalues
+    test<true>(fn, cuda::std::tuple{1, 3.14, foo{}});
+    test<false>(fn, cuda::std::pair{1, 3.14});
+    test<true>(fn, cuda::std::tuple{1});
+  }
+
+  {
+    zip_function<Mutable> fn{};
+    test<false>(fn, three_args);
+    test<true>(fn, two_args);
+    test<false>(fn, one_arg);
+
+    // Ensure we can also call the function with const arguments
+    test<false>(fn, cuda::std::as_const(three_args));
+    test<true>(fn, cuda::std::as_const(two_args));
+    test<false>(fn, cuda::std::as_const(one_arg));
+
+    // Ensure we can also call the function with prvalues
+    test<false>(fn, cuda::std::tuple{1, 3.14, foo{}});
+    test<true>(fn, cuda::std::pair{1, 3.14});
+    test<false>(fn, cuda::std::tuple{1});
+  }
+
+  { // Ensure that we properly dispatch to the const overload then possible
+    const zip_function<Mixed> const_fn{};
+    test<true>(const_fn, three_args);
+    test<false>(const_fn, two_args);
+    test<true>(const_fn, one_arg);
+
+    // Ensure we can also call the function with const arguments
+    test<true>(const_fn, cuda::std::as_const(three_args));
+    test<false>(const_fn, cuda::std::as_const(two_args));
+    test<true>(const_fn, cuda::std::as_const(one_arg));
+
+    // Ensure we can also call the function with prvalues
+    test<true>(const_fn, cuda::std::tuple{1, 3.14, foo{}});
+    test<false>(const_fn, cuda::std::pair{1, 3.14});
+    test<true>(const_fn, cuda::std::tuple{1});
+
+    zip_function<Mixed> fn{};
+    test<false>(fn, three_args);
+    test<true>(fn, two_args);
+    test<false>(fn, one_arg);
+
+    // Ensure we can also call the function with const arguments
+    test<false>(fn, cuda::std::as_const(three_args));
+    test<true>(fn, cuda::std::as_const(two_args));
+    test<false>(fn, cuda::std::as_const(one_arg));
+
+    // Ensure we can also call the function with prvalues
+    test<false>(fn, cuda::std::tuple{1, 3.14, foo{}});
+    test<true>(fn, cuda::std::pair{1, 3.14});
+    test<false>(fn, cuda::std::tuple{1});
+  }
+  return true;
+};
+
+int main(int, char**)
+{
+  assert(test());
+  static_assert(test());
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/functional/zip_function/constructor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/functional/zip_function/constructor.pass.cpp
@@ -1,0 +1,75 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/functional>
+#include <cuda/std/type_traits>
+
+#include "test_macros.h"
+
+struct Nothrow
+{
+  __host__ __device__ Nothrow() noexcept {}
+};
+
+struct NotDefaultable
+{
+  __host__ __device__ NotDefaultable() = delete;
+  __host__ __device__ NotDefaultable(int) noexcept {}
+};
+
+struct MaybeThrowingDefault
+{
+  __host__ __device__ MaybeThrowingDefault() noexcept(false) {}
+};
+
+struct MaybeThrowingCopy
+{
+  __host__ __device__ MaybeThrowingCopy(const MaybeThrowingCopy&) noexcept(false) {}
+};
+
+struct MaybeThrowingMove
+{
+  __host__ __device__ MaybeThrowingMove(MaybeThrowingCopy&&) noexcept(false) {}
+};
+
+template <class Fn>
+__host__ __device__ constexpr void test()
+{
+  using zip_function = cuda::zip_function<Fn>;
+  static_assert(cuda::std::is_default_constructible_v<zip_function> == cuda::std::is_default_constructible_v<Fn>);
+  static_assert(
+    cuda::std::is_nothrow_default_constructible_v<zip_function> == cuda::std::is_nothrow_default_constructible_v<Fn>);
+
+  static_assert(cuda::std::is_constructible_v<zip_function, Fn&&>);
+  static_assert(cuda::std::is_constructible_v<zip_function, const Fn&>);
+  static_assert(
+    cuda::std::is_nothrow_constructible_v<zip_function, const Fn&> == cuda::std::is_nothrow_copy_constructible_v<Fn>);
+  static_assert(
+    cuda::std::is_nothrow_constructible_v<zip_function, Fn&&> == cuda::std::is_nothrow_move_constructible_v<Fn>);
+
+  static_assert(cuda::std::is_copy_constructible_v<zip_function>);
+  static_assert(cuda::std::is_move_constructible_v<zip_function>);
+  static_assert(cuda::std::is_copy_assignable_v<zip_function>);
+  static_assert(cuda::std::is_move_assignable_v<zip_function>);
+}
+
+__host__ __device__ constexpr void test()
+{
+  test<Nothrow>();
+  test<NotDefaultable>();
+  test<MaybeThrowingDefault>();
+  test<MaybeThrowingCopy>();
+  test<MaybeThrowingMove>();
+}
+
+int main(int, char**)
+{
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/zip_iterator/arithmetic.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/zip_iterator/arithmetic.pass.cpp
@@ -1,0 +1,128 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES
+//
+//===----------------------------------------------------------------------===//
+
+// x += n;
+// x + n;
+// n + x;
+// x -= n;
+// x - n;
+// x - y;
+// All the arithmetic operators have the constraint `requires all-random-access<Const, Views...>;`,
+// except `operator-(x, y)` which instead has the constraint
+//    `requires (sized_sentinel_for<iterator_t<maybe-const<Const, Views>>,
+//                                  iterator_t<maybe-const<Const, Views>>> && ...);`
+
+#include <cuda/iterator>
+#include <cuda/std/concepts>
+#include <cuda/std/functional>
+
+#include "test_macros.h"
+#include "types.h"
+
+template <class T, class U>
+_CCCL_CONCEPT canPlusEqual = _CCCL_REQUIRES_EXPR((T, U), T& t, U& u)(t += u);
+
+template <class T, class U>
+_CCCL_CONCEPT canMinusEqual = _CCCL_REQUIRES_EXPR((T, U), T& t, U& u)(t -= u);
+
+__host__ __device__ constexpr bool test()
+{
+  int a[]    = {1, 2, 3, 4, 5};
+  double b[] = {4.1, 3.2, 4.3, 0.1, 0.2};
+
+  { // operator+(x, n) and operator+=
+    cuda::zip_iterator iter1{a, b};
+    using Iter = decltype(iter1);
+
+    const auto iter2 = iter1 + 3;
+    auto [x2, y2]    = *iter2;
+    assert(cuda::std::addressof(x2) == cuda::std::addressof(a[3]));
+    assert(cuda::std::addressof(y2) == cuda::std::addressof(b[3]));
+    static_assert(cuda::std::is_same_v<decltype(iter1 + 3), Iter>);
+
+    const auto iter3 = 3 + iter1;
+    auto [x3, y3]    = *iter3;
+    assert(cuda::std::addressof(x3) == cuda::std::addressof(a[3]));
+    assert(cuda::std::addressof(y3) == cuda::std::addressof(b[3]));
+    static_assert(cuda::std::is_same_v<decltype(3 + iter1), Iter>);
+
+    iter1 += 3;
+    assert(iter1 == iter2);
+    auto [x1, y1] = *iter2;
+    assert(cuda::std::addressof(x1) == cuda::std::addressof(a[3]));
+    assert(cuda::std::addressof(y1) == cuda::std::addressof(b[3]));
+    static_assert(cuda::std::is_same_v<decltype(iter1 += 3), Iter&>);
+
+    static_assert(canPlusEqual<Iter, intptr_t>);
+  }
+
+  { // operator-(x, n) and operator-=
+    cuda::zip_iterator iter1{a + 5, b + 5};
+    using Iter = decltype(iter1);
+
+    const auto iter2 = iter1 - 3;
+    auto [x2, y2]    = *iter2;
+    assert(cuda::std::addressof(x2) == cuda::std::addressof(a[2]));
+    assert(cuda::std::addressof(y2) == cuda::std::addressof(b[2]));
+    static_assert(cuda::std::is_same_v<decltype(iter1 - 3), Iter>);
+
+    iter1 -= 3;
+    assert(iter1 == iter2);
+    auto [x1, y1] = *iter2;
+    assert(cuda::std::addressof(x1) == cuda::std::addressof(a[2]));
+    assert(cuda::std::addressof(y1) == cuda::std::addressof(b[2]));
+    static_assert(cuda::std::is_same_v<decltype(iter1 -= 3), Iter&>);
+
+    static_assert(canMinusEqual<Iter, intptr_t>);
+  }
+
+  { // operator-(x, y)
+    cuda::zip_iterator iter1{a, b};
+    cuda::zip_iterator iter2{a + 5, b + 5};
+    using Iter = decltype(iter1);
+    assert(iter2 - iter1 == 5);
+    assert(iter1 - iter2 == -5);
+    static_assert(cuda::std::is_same_v<decltype(iter2 - iter1), cuda::std::iter_difference_t<Iter>>);
+  }
+
+  { // One of the iterators is not random access but sized
+    cuda::zip_iterator iter1{forward_sized_iterator<>{a}, b};
+    cuda::zip_iterator iter2{forward_sized_iterator<>{a + 5}, b + 5};
+    using Iter = decltype(iter1);
+    assert(iter2 - iter1 == 5);
+    assert(iter1 - iter2 == -5);
+
+    static_assert(!cuda::std::invocable<cuda::std::plus<>, Iter, intptr_t>);
+    static_assert(!cuda::std::invocable<cuda::std::plus<>, intptr_t, Iter>);
+    static_assert(!canPlusEqual<Iter, intptr_t>);
+    static_assert(!cuda::std::invocable<cuda::std::minus<>, Iter, intptr_t>);
+    static_assert(!canMinusEqual<Iter, intptr_t>);
+  }
+
+  { // One of the iterators is not random access and not sized
+    cuda::zip_iterator iter1{forward_iterator{a}, b};
+    using Iter = decltype(iter1);
+    static_assert(!cuda::std::invocable<cuda::std::plus<>, Iter, intptr_t>);
+    static_assert(!cuda::std::invocable<cuda::std::plus<>, intptr_t, Iter>);
+    static_assert(!canPlusEqual<Iter, intptr_t>);
+    static_assert(!cuda::std::invocable<cuda::std::minus<>, Iter, intptr_t>);
+    static_assert(!cuda::std::invocable<cuda::std::minus<>, Iter, Iter>);
+    static_assert(!canMinusEqual<Iter, intptr_t>);
+  }
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/zip_iterator/compare.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/zip_iterator/compare.pass.cpp
@@ -1,0 +1,144 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES
+//
+//===----------------------------------------------------------------------===//
+
+// friend constexpr bool operator==(const iterator& x, const iterator& y)
+//   requires (equality_comparable<iterator_t<maybe-const<Const, Views>>> && ...);
+// friend constexpr bool operator<(const iterator& x, const iterator& y)
+//   requires all-random-access<Const, Views...>;
+// friend constexpr bool operator>(const iterator& x, const iterator& y)
+//   requires all-random-access<Const, Views...>;
+// friend constexpr bool operator<=(const iterator& x, const iterator& y)
+//   requires all-random-access<Const, Views...>;
+// friend constexpr bool operator>=(const iterator& x, const iterator& y)
+//   requires all-random-access<Const, Views...>;
+// friend constexpr auto operator<=>(const iterator& x, const iterator& y)
+//   requires all-random-access<Const, Views...> &&
+//            (three_way_comparable<iterator_t<maybe-const<Const, Views>>> && ...);
+
+#include <cuda/iterator>
+#if _LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
+#  include <cuda/std/compare>
+#endif // !_LIBCUDACXX_HAS_NO_SPACESHIP_OPERATOR
+
+#include "test_iterators.h"
+#include "types.h"
+
+template <class Iter1, class Iter2>
+__host__ __device__ constexpr void compareOperatorTest(Iter1&& iter1, Iter2&& iter2)
+{
+  assert(!(iter1 < iter1));
+  assert(iter1 < iter2);
+  assert(!(iter2 < iter1));
+  assert(iter1 <= iter1);
+  assert(iter1 <= iter2);
+  assert(!(iter2 <= iter1));
+  assert(!(iter1 > iter1));
+  assert(!(iter1 > iter2));
+  assert(iter2 > iter1);
+  assert(iter1 >= iter1);
+  assert(!(iter1 >= iter2));
+  assert(iter2 >= iter1);
+  assert(iter1 == iter1);
+  assert(!(iter1 == iter2));
+  assert(iter2 == iter2);
+  assert(!(iter1 != iter1));
+  assert(iter1 != iter2);
+  assert(!(iter2 != iter2));
+}
+
+template <class Iter1, class Iter2>
+__host__ __device__ constexpr void inequalityOperatorsDoNotExistTest(Iter1&& iter1, Iter2&& iter2)
+{
+  static_assert(!cuda::std::is_invocable_v<cuda::std::less<>, Iter1, Iter2>);
+  static_assert(!cuda::std::is_invocable_v<cuda::std::less_equal<>, Iter1, Iter2>);
+  static_assert(!cuda::std::is_invocable_v<cuda::std::greater<>, Iter1, Iter2>);
+  static_assert(!cuda::std::is_invocable_v<cuda::std::greater_equal<>, Iter1, Iter2>);
+}
+
+__host__ __device__ constexpr bool test()
+{
+  int a[] = {1, 2, 3, 4};
+  int b[] = {5, 6, 7, 8, 9};
+
+#if TEST_HAS_SPACESHIP()
+  {
+    // Test a new-school iterator with operator<=>; the iterator should also have operator<=>.
+
+    using Iter = three_way_contiguous_iterator<int*>;
+    static_assert(cuda::std::three_way_comparable<Iter>);
+    static_assert(cuda::std::three_way_comparable<cuda::zip_iterator<Iter>>);
+
+    cuda::zip_iterator iter1{Iter(a), Iter(b + 4)};
+    cuda::zip_iterator iter2 = iter1 + 1;
+
+    compareOperatorTest(iter1, iter2);
+
+    assert((iter1 <=> iter2) == cuda::std::strong_ordering::less);
+    assert((iter1 <=> iter1) == cuda::std::strong_ordering::equal);
+    assert((iter2 <=> iter1) == cuda::std::strong_ordering::greater);
+  }
+#endif // TEST_HAS_SPACESHIP()
+
+  {
+    // Test an old-school iterator with no operator<=>; the transform iterator shouldn't have
+    // operator<=> either.
+    using Iter = random_access_iterator<int*>;
+#if TEST_HAS_SPACESHIP()
+    static_assert(!cuda::std::three_way_comparable<cuda::zip_iterator<Iter>>);
+#endif // TEST_HAS_SPACESHIP()
+
+    cuda::zip_iterator iter1{Iter(a), Iter(b + 4)};
+    cuda::zip_iterator iter2{Iter(a + 1), Iter(b + 5)};
+
+    compareOperatorTest(iter1, iter2);
+  }
+
+  {
+    using Iter = cpp17_input_iterator<int*>;
+
+    cuda::zip_iterator iter1{Iter(a), Iter(b + 4)};
+    cuda::zip_iterator iter2{Iter(a + 1), Iter(b + 5)};
+
+    assert(iter1 != iter2);
+    ++iter1;
+    assert(iter1 == iter2);
+
+    inequalityOperatorsDoNotExistTest(iter1, iter2);
+  }
+
+  {
+    // only < and == are needed
+    using Iter = LessThanIterator;
+
+    cuda::zip_iterator iter1{Iter(a), Iter(b + 4)};
+    cuda::zip_iterator iter2{Iter(a + 1), Iter(b + 5)};
+    static_assert(!cuda::std::invocable<cuda::std::equal_to<>, cuda::zip_iterator<Iter, Iter>>);
+    compareOperatorTest(iter1, iter2);
+  }
+
+  {
+    // underlying iterator does not support ==
+    using Iter = cpp20_input_iterator<int*>;
+
+    cuda::zip_iterator iter1{Iter(a), Iter(b + 4)};
+    cuda::zip_iterator iter2{Iter(a + 1), Iter(b + 5)};
+    static_assert(!cuda::std::invocable<cuda::std::equal_to<>, cuda::zip_iterator<Iter, Iter>>);
+    inequalityOperatorsDoNotExistTest(iter1, iter2);
+  }
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/zip_iterator/ctor.default.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/zip_iterator/ctor.default.pass.cpp
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES
+//
+//===----------------------------------------------------------------------===//
+
+// iterator() = default;
+
+#include <cuda/iterator>
+#include <cuda/std/tuple>
+
+#include "test_macros.h"
+#include "types.h"
+
+__host__ __device__ constexpr bool test()
+{
+  {
+    cuda::zip_iterator<PODIter> iter;
+    auto [x] = *iter;
+    assert(x == 0); // PODIter has to be initialised to have value 0
+  }
+
+  {
+    cuda::zip_iterator<PODIter> iter{};
+    auto [x] = *iter;
+    assert(x == 0); // PODIter has to be initialised to have value 0
+  }
+
+  static_assert(!cuda::std::is_default_constructible_v<cuda::zip_iterator<PODIter, IterNotDefaultConstructible>>);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/zip_iterator/ctor.other.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/zip_iterator/ctor.other.pass.cpp
@@ -1,0 +1,130 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES
+//
+//===----------------------------------------------------------------------===//
+
+// constexpr iterator(iterator<!Const> i)
+//       requires Const && (convertible_to<iterator_t<Views>,
+//                                         iterator_t<maybe-const<Const, Views>>> && ...);
+
+#include <cuda/iterator>
+#include <cuda/std/cassert>
+#include <cuda/std/tuple>
+
+#include "test_iterators.h"
+#include "test_macros.h"
+#include "types.h"
+
+__host__ __device__ constexpr bool test()
+{
+  int buffer[] = {0, 1, 2, 3, 4, 5, 6};
+
+  { // CTAD
+    { // single iterator
+      cuda::zip_iterator iter{buffer + 1};
+      static_assert(cuda::std::is_same_v<decltype(iter), cuda::zip_iterator<int*>>);
+      assert(cuda::std::get<0>(*iter) == *(buffer + 1));
+    }
+
+    { // one element tuple
+      cuda::zip_iterator iter{cuda::std::tuple{buffer + 1}};
+      static_assert(cuda::std::is_same_v<decltype(iter), cuda::zip_iterator<int*>>);
+      assert(cuda::std::get<0>(*iter) == *(buffer + 1));
+    }
+
+    { // two iterators
+      cuda::zip_iterator iter{buffer + 1, static_cast<const int*>(buffer + 3)};
+      static_assert(cuda::std::is_same_v<decltype(iter), cuda::zip_iterator<int*, const int*>>);
+      assert(cuda::std::get<0>(*iter) == *(buffer + 1));
+      assert(cuda::std::get<1>(*iter) == *(buffer + 3));
+    }
+
+    { // two element tuple
+      cuda::zip_iterator iter{cuda::std::tuple{buffer + 1, static_cast<const int*>(buffer + 3)}};
+      static_assert(cuda::std::is_same_v<decltype(iter), cuda::zip_iterator<int*, const int*>>);
+      assert(cuda::std::get<0>(*iter) == *(buffer + 1));
+      assert(cuda::std::get<1>(*iter) == *(buffer + 3));
+    }
+
+    { // pair
+      cuda::zip_iterator iter{cuda::std::pair{buffer + 1, static_cast<const int*>(buffer + 3)}};
+      static_assert(cuda::std::is_same_v<decltype(iter), cuda::zip_iterator<int*, const int*>>);
+      assert(cuda::std::get<0>(*iter) == *(buffer + 1));
+      assert(cuda::std::get<1>(*iter) == *(buffer + 3));
+    }
+
+    { // three iterators
+      cuda::zip_iterator iter{buffer + 1, static_cast<const int*>(buffer + 3), buffer};
+      static_assert(cuda::std::is_same_v<decltype(iter), cuda::zip_iterator<int*, const int*, int*>>);
+      assert(cuda::std::get<0>(*iter) == *(buffer + 1));
+      assert(cuda::std::get<1>(*iter) == *(buffer + 3));
+      assert(cuda::std::get<2>(*iter) == *(buffer));
+    }
+
+    { // three element tuple
+      cuda::zip_iterator iter{cuda::std::tuple{buffer + 1, static_cast<const int*>(buffer + 3), buffer}};
+      static_assert(cuda::std::is_same_v<decltype(iter), cuda::zip_iterator<int*, const int*, int*>>);
+      assert(cuda::std::get<0>(*iter) == *(buffer + 1));
+      assert(cuda::std::get<1>(*iter) == *(buffer + 3));
+      assert(cuda::std::get<2>(*iter) == *(buffer));
+    }
+  }
+
+  { // Explicit constructors
+    { // single iterator
+      cuda::zip_iterator<int*> iter{buffer + 1};
+      assert(cuda::std::get<0>(*iter) == *(buffer + 1));
+    }
+
+    { // one element tuple
+      cuda::zip_iterator<int*> iter{cuda::std::tuple{buffer + 1}};
+      assert(cuda::std::get<0>(*iter) == *(buffer + 1));
+    }
+
+    { // two iterators
+      cuda::zip_iterator<int*, const int*> iter{buffer + 1, buffer + 3};
+      assert(cuda::std::get<0>(*iter) == *(buffer + 1));
+      assert(cuda::std::get<1>(*iter) == *(buffer + 3));
+    }
+
+    { // two element tuple
+      cuda::zip_iterator<int*, const int*> iter{cuda::std::tuple{buffer + 1, buffer + 3}};
+      assert(cuda::std::get<0>(*iter) == *(buffer + 1));
+      assert(cuda::std::get<1>(*iter) == *(buffer + 3));
+    }
+
+    { // pair
+      cuda::zip_iterator<int*, const int*> iter{cuda::std::pair{buffer + 1, buffer + 3}};
+      assert(cuda::std::get<0>(*iter) == *(buffer + 1));
+      assert(cuda::std::get<1>(*iter) == *(buffer + 3));
+    }
+
+    { // three iterators
+      cuda::zip_iterator<int*, const int*, int*> iter{buffer + 1, buffer + 3, buffer};
+      assert(cuda::std::get<0>(*iter) == *(buffer + 1));
+      assert(cuda::std::get<1>(*iter) == *(buffer + 3));
+      assert(cuda::std::get<2>(*iter) == *(buffer));
+    }
+
+    { // three element tuple
+      cuda::zip_iterator<int*, const int*, int*> iter{cuda::std::tuple{buffer + 1, buffer + 3, buffer}};
+      assert(cuda::std::get<0>(*iter) == *(buffer + 1));
+      assert(cuda::std::get<1>(*iter) == *(buffer + 3));
+      assert(cuda::std::get<2>(*iter) == *(buffer));
+    }
+  }
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test(), "");
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/zip_iterator/decrement.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/zip_iterator/decrement.pass.cpp
@@ -1,0 +1,83 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES
+//
+//===----------------------------------------------------------------------===//
+
+// constexpr iterator& operator--() requires all-bidirectional<Const, Views...>;
+// constexpr iterator operator--(int) requires all-bidirectional<Const, Views...>;
+
+#include <cuda/iterator>
+#include <cuda/std/cassert>
+#include <cuda/std/tuple>
+
+#include "test_iterators.h"
+#include "test_macros.h"
+#include "types.h"
+
+template <class Iter>
+_CCCL_CONCEPT canDecrement = _CCCL_REQUIRES_EXPR((Iter), Iter iter)((--iter), (iter--));
+
+__host__ __device__ constexpr bool test()
+{
+  int a[]    = {1, 2, 3, 4};
+  double b[] = {4.1, 3.2, 4.3};
+
+  { // all random_access_iterator
+    cuda::zip_iterator iter{a + 3, random_access_iterator{b + 3}, cuda::counting_iterator{3}};
+    using Iter = decltype(iter);
+
+    static_assert(cuda::std::is_same_v<decltype(--iter), Iter&>);
+    auto& it_ref = --iter;
+    assert(cuda::std::addressof(it_ref) == cuda::std::addressof(iter));
+
+    assert(cuda::std::addressof(cuda::std::get<0>(*iter)) == cuda::std::addressof(a[2]));
+    assert(cuda::std::addressof(cuda::std::get<1>(*iter)) == cuda::std::addressof(b[2]));
+    assert(cuda::std::get<2>(*iter) == 2);
+
+    static_assert(cuda::std::is_same_v<decltype(iter--), Iter>);
+    iter--;
+    assert(cuda::std::addressof(cuda::std::get<0>(*iter)) == cuda::std::addressof(a[1]));
+    assert(cuda::std::addressof(cuda::std::get<1>(*iter)) == cuda::std::addressof(b[1]));
+    assert(cuda::std::get<2>(*iter) == 1);
+  }
+
+  { // all bidirectional_iterator
+    cuda::zip_iterator iter{a + 3, bidirectional_iterator{b + 3}, cuda::counting_iterator{3}};
+    using Iter = decltype(iter);
+
+    static_assert(cuda::std::is_same_v<decltype(--iter), Iter&>);
+    auto& it_ref = --iter;
+    assert(cuda::std::addressof(it_ref) == cuda::std::addressof(iter));
+
+    assert(cuda::std::addressof(cuda::std::get<0>(*iter)) == cuda::std::addressof(a[2]));
+    assert(cuda::std::addressof(cuda::std::get<1>(*iter)) == cuda::std::addressof(b[2]));
+    assert(cuda::std::get<2>(*iter) == 2);
+
+    static_assert(cuda::std::is_same_v<decltype(iter--), Iter>);
+    iter--;
+    assert(cuda::std::addressof(cuda::std::get<0>(*iter)) == cuda::std::addressof(a[1]));
+    assert(cuda::std::addressof(cuda::std::get<1>(*iter)) == cuda::std::addressof(b[1]));
+    assert(cuda::std::get<2>(*iter) == 1);
+  }
+
+  { // not all bidirectional_iterator
+    cuda::zip_iterator iter{a + 3, cpp17_input_iterator{b + 3}, cuda::counting_iterator{3}};
+    using Iter = decltype(iter);
+
+    static_assert(!canDecrement<Iter>);
+  }
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/zip_iterator/deref.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/zip_iterator/deref.pass.cpp
@@ -1,0 +1,74 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES
+//
+//===----------------------------------------------------------------------===//
+
+// constexpr auto operator*() const;
+
+#include <cuda/iterator>
+#include <cuda/std/cassert>
+#include <cuda/std/tuple>
+
+#include "test_iterators.h"
+#include "test_macros.h"
+#include "types.h"
+
+__host__ __device__ constexpr bool test()
+{
+  int a[]    = {1, 2, 3, 4};
+  double b[] = {4.1, 3.2, 4.3};
+
+  { // single iterator
+    cuda::zip_iterator iter{a};
+    assert(cuda::std::addressof(cuda::std::get<0>(*iter)) == cuda::std::addressof(a[0]));
+    static_assert(cuda::std::is_same_v<decltype(*iter), cuda::std::tuple<int&>>);
+  }
+
+  { // single iterator, operator* is const
+    const cuda::zip_iterator iter{a};
+    assert(cuda::std::addressof(cuda::std::get<0>(*iter)) == cuda::std::addressof(a[0]));
+    static_assert(cuda::std::is_same_v<decltype(*iter), cuda::std::tuple<int&>>);
+  }
+
+  { // two different iterators
+    cuda::zip_iterator iter{a, b};
+    auto [x, y] = *iter;
+    assert(cuda::std::addressof(x) == cuda::std::addressof(a[0]));
+    assert(cuda::std::addressof(y) == cuda::std::addressof(b[0]));
+    static_assert(cuda::std::is_same_v<decltype(*iter), cuda::std::pair<int&, double&>>);
+
+    x = 5;
+    y = 0.1;
+    assert(a[0] == 5);
+    assert(b[0] == 0.1);
+  }
+
+  { // iterator that generates prvalues
+    cuda::zip_iterator iter{a, b, cuda::counting_iterator{0}};
+    assert(cuda::std::addressof(cuda::std::get<0>(*iter)) == cuda::std::addressof(a[0]));
+    assert(cuda::std::addressof(cuda::std::get<1>(*iter)) == cuda::std::addressof(b[0]));
+    assert(cuda::std::get<2>(*iter) == 0);
+    static_assert(cuda::std::is_same_v<decltype(*iter), cuda::std::tuple<int&, double&, int>>);
+  }
+
+  { // const-correctness
+    cuda::zip_iterator iter{a, cuda::std::as_const(b)};
+    assert(cuda::std::addressof(cuda::std::get<0>(*iter)) == cuda::std::addressof(a[0]));
+    assert(cuda::std::addressof(cuda::std::get<1>(*iter)) == cuda::std::addressof(b[0]));
+    static_assert(cuda::std::is_same_v<decltype(*iter), cuda::std::pair<int&, const double&>>);
+  }
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/zip_iterator/increment.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/zip_iterator/increment.pass.cpp
@@ -1,0 +1,112 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES
+//
+//===----------------------------------------------------------------------===//
+
+// constexpr iterator& operator++();
+// constexpr void operator++(int);
+// constexpr iterator operator++(int) requires all_forward<Const, Views...>;
+
+#include <cuda/iterator>
+#include <cuda/std/cassert>
+#include <cuda/std/tuple>
+
+#include "test_iterators.h"
+#include "test_macros.h"
+#include "types.h"
+
+__host__ __device__ constexpr bool test()
+{
+  int a[]    = {1, 2, 3, 4};
+  double b[] = {4.1, 3.2, 4.3, 3.3};
+
+  { // all random_access_iterator
+    cuda::zip_iterator iter{a + 1, random_access_iterator{b + 1}, cuda::counting_iterator{1}};
+    using Iter = decltype(iter);
+
+    static_assert(cuda::std::is_same_v<decltype(++iter), Iter&>);
+    auto& it_ref = ++iter;
+    assert(cuda::std::addressof(it_ref) == cuda::std::addressof(iter));
+
+    assert(cuda::std::addressof(cuda::std::get<0>(*iter)) == cuda::std::addressof(a[2]));
+    assert(cuda::std::addressof(cuda::std::get<1>(*iter)) == cuda::std::addressof(b[2]));
+    assert(cuda::std::get<2>(*iter) == 2);
+
+    static_assert(cuda::std::is_same_v<decltype(iter++), Iter>);
+    iter++;
+    assert(cuda::std::addressof(cuda::std::get<0>(*iter)) == cuda::std::addressof(a[3]));
+    assert(cuda::std::addressof(cuda::std::get<1>(*iter)) == cuda::std::addressof(b[3]));
+    assert(cuda::std::get<2>(*iter) == 3);
+  }
+
+  { // all bidirectional_iterator
+    cuda::zip_iterator iter{a + 1, bidirectional_iterator{b + 1}, cuda::counting_iterator{1}};
+    using Iter = decltype(iter);
+
+    static_assert(cuda::std::is_same_v<decltype(++iter), Iter&>);
+    auto& it_ref = ++iter;
+    assert(cuda::std::addressof(it_ref) == cuda::std::addressof(iter));
+
+    assert(cuda::std::addressof(cuda::std::get<0>(*iter)) == cuda::std::addressof(a[2]));
+    assert(cuda::std::addressof(cuda::std::get<1>(*iter)) == cuda::std::addressof(b[2]));
+    assert(cuda::std::get<2>(*iter) == 2);
+
+    static_assert(cuda::std::is_same_v<decltype(iter++), Iter>);
+    iter++;
+    assert(cuda::std::addressof(cuda::std::get<0>(*iter)) == cuda::std::addressof(a[3]));
+    assert(cuda::std::addressof(cuda::std::get<1>(*iter)) == cuda::std::addressof(b[3]));
+    assert(cuda::std::get<2>(*iter) == 3);
+  }
+
+  { // all forward_iterator
+    cuda::zip_iterator iter{a + 1, forward_iterator{b + 1}, cuda::counting_iterator{1}};
+    using Iter = decltype(iter);
+
+    static_assert(cuda::std::is_same_v<decltype(++iter), Iter&>);
+    auto& it_ref = ++iter;
+    assert(cuda::std::addressof(it_ref) == cuda::std::addressof(iter));
+
+    assert(cuda::std::addressof(cuda::std::get<0>(*iter)) == cuda::std::addressof(a[2]));
+    assert(cuda::std::addressof(cuda::std::get<1>(*iter)) == cuda::std::addressof(b[2]));
+    assert(cuda::std::get<2>(*iter) == 2);
+
+    static_assert(cuda::std::is_same_v<decltype(iter++), Iter>);
+    iter++;
+    assert(cuda::std::addressof(cuda::std::get<0>(*iter)) == cuda::std::addressof(a[3]));
+    assert(cuda::std::addressof(cuda::std::get<1>(*iter)) == cuda::std::addressof(b[3]));
+    assert(cuda::std::get<2>(*iter) == 3);
+  }
+
+  { // all input_iterator
+    cuda::zip_iterator iter{a + 1, cpp20_input_iterator{b + 1}, cuda::counting_iterator{1}};
+    using Iter = decltype(iter);
+
+    static_assert(cuda::std::is_same_v<decltype(++iter), Iter&>);
+    auto& it_ref = ++iter;
+    assert(cuda::std::addressof(it_ref) == cuda::std::addressof(iter));
+
+    assert(cuda::std::addressof(cuda::std::get<0>(*iter)) == cuda::std::addressof(a[2]));
+    assert(cuda::std::addressof(cuda::std::get<1>(*iter)) == cuda::std::addressof(b[2]));
+    assert(cuda::std::get<2>(*iter) == 2);
+
+    static_assert(cuda::std::is_same_v<decltype(iter++), void>);
+    iter++;
+    assert(cuda::std::addressof(cuda::std::get<0>(*iter)) == cuda::std::addressof(a[3]));
+    assert(cuda::std::addressof(cuda::std::get<1>(*iter)) == cuda::std::addressof(b[3]));
+    assert(cuda::std::get<2>(*iter) == 3);
+  }
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/zip_iterator/iter_move.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/zip_iterator/iter_move.pass.cpp
@@ -1,0 +1,94 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES
+//
+//===----------------------------------------------------------------------===//
+
+// friend constexpr auto iter_move(const iterator& i) noexcept(see below);
+
+#include <cuda/iterator>
+#include <cuda/std/cassert>
+#include <cuda/std/iterator>
+#include <cuda/std/tuple>
+
+#include "test_iterators.h"
+#include "test_macros.h"
+#include "types.h"
+
+struct ThrowingMove
+{
+  __host__ __device__ constexpr ThrowingMove() noexcept {}
+  __host__ __device__ constexpr ThrowingMove(ThrowingMove&&) noexcept(false) {}
+};
+
+struct ToThrowingMove
+{
+  __host__ __device__ constexpr ThrowingMove operator()(int) const noexcept
+  {
+    return ThrowingMove{};
+  }
+};
+
+__host__ __device__ TEST_CONSTEXPR_CXX20 bool test()
+{
+  int a[]          = {1, 2, 3, 4};
+  const double b[] = {3.0, 4.0};
+
+  { // underlying iter_move noexcept
+    cuda::zip_iterator iter{a, b, cuda::counting_iterator{3L}};
+
+    assert(cuda::std::ranges::iter_move(iter) == cuda::std::make_tuple(1, 3.0, 3L));
+    static_assert(
+      cuda::std::is_same_v<decltype(cuda::std::ranges::iter_move(iter)), cuda::std::tuple<int&&, const double&&, long>>);
+    static_assert(noexcept(cuda::std::ranges::iter_move(iter)));
+  }
+
+  { // We need an iterator whose rvalue reference is potentially throwing on move construction
+    [[maybe_unused]] cuda::zip_iterator iter{cuda::transform_iterator{cuda::counting_iterator{0}, ToThrowingMove{}}};
+    static_assert(!noexcept(cuda::std::ranges::iter_move(iter)));
+  }
+
+  { // underlying iterators' iter_move are called through ranges::iter_move
+    int iter_move_called_times1 = 0;
+    int iter_move_called_times2 = 0;
+    int iter_swap_called_times1 = 0;
+    int iter_swap_called_times2 = 0;
+
+    using Iter = cuda::zip_iterator<adltest::iter_move_swap_iterator, adltest::iter_move_swap_iterator>;
+    Iter iter{{iter_move_called_times1, iter_swap_called_times1, 0},
+              {iter_move_called_times2, iter_swap_called_times2, 0}};
+    assert(iter_move_called_times1 == 0);
+    assert(iter_move_called_times2 == 0);
+    assert(iter_swap_called_times1 == 0);
+    assert(iter_swap_called_times2 == 0);
+    {
+      [[maybe_unused]] auto&& i = cuda::std::ranges::iter_move(iter);
+      assert(iter_move_called_times1 == 1);
+      assert(iter_move_called_times2 == 1);
+      assert(iter_swap_called_times1 == 0);
+      assert(iter_swap_called_times2 == 0);
+    }
+    {
+      [[maybe_unused]] auto&& i = cuda::std::ranges::iter_move(iter);
+      assert(iter_move_called_times1 == 2);
+      assert(iter_move_called_times2 == 2);
+      assert(iter_swap_called_times1 == 0);
+      assert(iter_swap_called_times2 == 0);
+    }
+  }
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+#if TEST_STD_VER >= 2020
+  static_assert(test());
+#endif // TEST_STD_VER >= 2020
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/zip_iterator/iter_swap.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/zip_iterator/iter_swap.pass.cpp
@@ -1,0 +1,112 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES
+//
+//===----------------------------------------------------------------------===//
+
+// friend constexpr void iter_swap(const iterator& l, const iterator& r) noexcept(see below)
+//   requires (indirectly_swappable<iterator_t<maybe-const<Const, Views>>> && ...);
+
+#include <cuda/iterator>
+#include <cuda/std/cassert>
+
+#include "test_iterators.h"
+#include "test_macros.h"
+#include "types.h"
+
+struct ThrowingMove
+{
+  __host__ __device__ constexpr ThrowingMove() noexcept {}
+  __host__ __device__ constexpr ThrowingMove(ThrowingMove&&) noexcept(false) {}
+  __host__ __device__ ThrowingMove& operator=(ThrowingMove&&) noexcept(false)
+  {
+    return *this;
+  }
+};
+
+struct ToThrowingMove
+{
+  __host__ __device__ constexpr ThrowingMove operator()(int) const noexcept
+  {
+    return ThrowingMove{};
+  }
+};
+
+__host__ __device__ TEST_CONSTEXPR_CXX20 bool test()
+{
+  int a[]    = {1, 2, 3, 4};
+  double b[] = {0.1, 0.2, 0.3};
+
+  {
+    cuda::zip_iterator iter1{a, b};
+    cuda::zip_iterator iter2{a + 1, b + 1};
+
+    cuda::std::ranges::iter_swap(iter1, iter2);
+
+    assert(a[0] == 2);
+    assert(a[1] == 1);
+    assert(b[0] == 0.2);
+    assert(b[1] == 0.1);
+
+    auto [x1, y1] = *iter1;
+    assert(cuda::std::addressof(x1) == cuda::std::addressof(a[0]));
+    assert(cuda::std::addressof(y1) == cuda::std::addressof(b[0]));
+
+    auto [x2, y2] = *iter2;
+    assert(cuda::std::addressof(x2) == cuda::std::addressof(a[1]));
+    assert(cuda::std::addressof(y2) == cuda::std::addressof(b[1]));
+
+    static_assert(noexcept(cuda::std::ranges::iter_swap(iter1, iter2)));
+  }
+
+  { // We need an iterator whose rvalue reference is potentially throwing on move construction
+    ThrowingMove throwing[3] = {ThrowingMove{}, ThrowingMove{}, ThrowingMove{}};
+    cuda::zip_iterator iter1{throwing};
+    [[maybe_unused]] cuda::zip_iterator iter2{throwing};
+    static_assert(!noexcept(cuda::std::ranges::iter_swap(iter1, iter2)));
+  }
+
+  { // underlying iterators iter_swap are called through ranges::iter_swap
+    int iter_move_called_times1 = 0;
+    int iter_move_called_times2 = 0;
+    int iter_swap_called_times1 = 0;
+    int iter_swap_called_times2 = 0;
+
+    using Iter = cuda::zip_iterator<adltest::iter_move_swap_iterator, adltest::iter_move_swap_iterator>;
+    Iter iter1{{iter_move_called_times1, iter_swap_called_times1, 0},
+               {iter_move_called_times2, iter_swap_called_times2, 0}};
+    Iter iter2 = cuda::std::ranges::next(iter1, 3);
+
+    assert(iter_move_called_times1 == 0);
+    assert(iter_move_called_times2 == 0);
+    assert(iter_swap_called_times1 == 0);
+    assert(iter_swap_called_times2 == 0);
+
+    cuda::std::ranges::iter_swap(iter1, iter2);
+    assert(iter_move_called_times1 == 0);
+    assert(iter_move_called_times2 == 0);
+    assert(iter_swap_called_times1 == 2);
+    assert(iter_swap_called_times2 == 2);
+
+    cuda::std::ranges::iter_swap(iter1, iter2);
+    assert(iter_move_called_times1 == 0);
+    assert(iter_move_called_times2 == 0);
+    assert(iter_swap_called_times1 == 4);
+    assert(iter_swap_called_times2 == 4);
+  }
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+#if TEST_STD_VER >= 2020
+  static_assert(test());
+#endif // TEST_STD_VER >= 2020
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/zip_iterator/member_types.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/zip_iterator/member_types.compile.pass.cpp
@@ -1,0 +1,128 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES
+//
+//===----------------------------------------------------------------------===//
+
+// Iterator traits and member typedefs in zip_view::<iterator>.
+
+#include <cuda/iterator>
+#include <cuda/std/tuple>
+
+#include "test_iterators.h"
+#include "test_macros.h"
+#include "types.h"
+
+template <class T>
+_CCCL_CONCEPT HasIterCategory = _CCCL_REQUIRES_EXPR((T))(typename(typename T::iterator_category));
+
+template <class T>
+struct DiffTypeIter
+{
+  using iterator_category = cuda::std::input_iterator_tag;
+  using value_type        = int;
+  using difference_type   = T;
+
+  __host__ __device__ int operator*() const;
+  __host__ __device__ DiffTypeIter& operator++();
+  __host__ __device__ void operator++(int);
+#if TEST_STD_VER >= 2020
+  __host__ __device__ friend constexpr bool operator==(DiffTypeIter, DiffTypeIter) = default;
+#else // ^^^ C++20 ^^^ / vvv C++17 vvv
+  __host__ __device__ friend constexpr bool operator==(const DiffTypeIter&, const DiffTypeIter&)
+  {
+    return true;
+  }
+  __host__ __device__ friend constexpr bool operator!=(const DiffTypeIter&, const DiffTypeIter&)
+  {
+    return false;
+  }
+#endif // TEST_STD_VER <=2017
+};
+
+struct Foo
+{};
+
+__host__ __device__ void test()
+{
+  { // Single iterator should have tuple value type
+    using Iter = cuda::zip_iterator<int*>;
+    static_assert(cuda::std::is_same_v<Iter::iterator_concept, cuda::std::random_access_iterator_tag>);
+    static_assert(cuda::std::is_same_v<Iter::iterator_category, cuda::std::input_iterator_tag>);
+    static_assert(cuda::std::is_same_v<Iter::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::is_same_v<Iter::value_type, cuda::std::tuple<int>>);
+    static_assert(HasIterCategory<Iter>);
+  }
+
+  { // Two iterator should have pair value type
+    using Iter = cuda::zip_iterator<int*, Foo*>;
+    static_assert(cuda::std::is_same_v<Iter::iterator_concept, cuda::std::random_access_iterator_tag>);
+    static_assert(cuda::std::is_same_v<Iter::iterator_category, cuda::std::input_iterator_tag>);
+    static_assert(cuda::std::is_same_v<Iter::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::is_same_v<Iter::value_type, cuda::std::pair<int, Foo>>);
+    static_assert(HasIterCategory<Iter>);
+  }
+
+  { // !=2 views should have tuple value_type
+    using Iter = cuda::zip_iterator<int*, Foo*, int*>;
+    static_assert(cuda::std::is_same_v<Iter::iterator_concept, cuda::std::random_access_iterator_tag>);
+    static_assert(cuda::std::is_same_v<Iter::iterator_category, cuda::std::input_iterator_tag>);
+    static_assert(cuda::std::is_same_v<Iter::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::is_same_v<Iter::value_type, cuda::std::tuple<int, Foo, int>>);
+    static_assert(HasIterCategory<Iter>);
+  }
+
+  { // If one iterator is not random access then the whole zip_iterator is not random access
+    using Iter = cuda::zip_iterator<int*, Foo*, bidirectional_iterator<int*>>;
+    static_assert(cuda::std::is_same_v<Iter::iterator_concept, cuda::std::bidirectional_iterator_tag>);
+    static_assert(cuda::std::is_same_v<Iter::iterator_category, cuda::std::input_iterator_tag>);
+    static_assert(cuda::std::is_same_v<Iter::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::is_same_v<Iter::value_type, cuda::std::tuple<int, Foo, int>>);
+    static_assert(HasIterCategory<Iter>);
+  }
+
+  { // If one iterator is not bidirectional_iterator then the whole zip_iterator is not bidirectional_iterator
+    using Iter = cuda::zip_iterator<forward_iterator<int*>, Foo*, bidirectional_iterator<int*>>;
+    static_assert(cuda::std::is_same_v<Iter::iterator_concept, cuda::std::forward_iterator_tag>);
+    static_assert(cuda::std::is_same_v<Iter::iterator_category, cuda::std::input_iterator_tag>);
+    static_assert(cuda::std::is_same_v<Iter::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::is_same_v<Iter::value_type, cuda::std::tuple<int, Foo, int>>);
+    static_assert(HasIterCategory<Iter>);
+  }
+
+  { // If one iterator is not forward_iterator then the whole zip_iterator is not forward_iterator
+    using Iter = cuda::zip_iterator<forward_iterator<int*>, cpp20_input_iterator<Foo*>, bidirectional_iterator<int*>>;
+    static_assert(cuda::std::is_same_v<Iter::iterator_concept, cuda::std::input_iterator_tag>);
+    static_assert(!HasIterCategory<Iter>);
+    static_assert(cuda::std::is_same_v<Iter::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::is_same_v<Iter::value_type, cuda::std::tuple<int, Foo, int>>);
+  }
+
+  { // nested iterator has the right value type
+    using Iter = cuda::zip_iterator<int*, cuda::zip_iterator<Foo*, int*>>;
+    static_assert(cuda::std::is_same_v<Iter::iterator_concept, cuda::std::random_access_iterator_tag>);
+    static_assert(cuda::std::is_same_v<Iter::iterator_category, cuda::std::input_iterator_tag>);
+    static_assert(cuda::std::is_same_v<Iter::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::is_same_v<Iter::value_type, cuda::std::pair<int, cuda::std::pair<Foo, int>>>);
+    static_assert(HasIterCategory<Iter>);
+  }
+
+  { // Takes the difference type from the base iterator
+    using Iter = cuda::zip_iterator<DiffTypeIter<intptr_t>>;
+    static_assert(cuda::std::is_same_v<Iter::difference_type, intptr_t>);
+  }
+
+  { // Difference type is the common type of the difference types
+    using Iter = cuda::zip_iterator<DiffTypeIter<intptr_t>, DiffTypeIter<cuda::std::ptrdiff_t>>;
+    static_assert(
+      cuda::std::is_same_v<Iter::difference_type, cuda::std::common_type_t<intptr_t, cuda::std::ptrdiff_t>>);
+  }
+}
+
+int main(int, char**)
+{
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/zip_iterator/subscript.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/zip_iterator/subscript.pass.cpp
@@ -1,0 +1,82 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES
+//
+//===----------------------------------------------------------------------===//
+
+// constexpr auto operator[](difference_type n) const requires
+//        all_random_access<Const, Views...>
+
+#include <cuda/iterator>
+#include <cuda/std/cassert>
+
+#include "test_iterators.h"
+#include "test_macros.h"
+#include "types.h"
+
+template <class Iter>
+_CCCL_CONCEPT canSubscript = _CCCL_REQUIRES_EXPR((Iter), Iter it)(it[0]);
+
+__host__ __device__ constexpr bool test()
+{
+  int a[]    = {1, 2, 3, 4};
+  double b[] = {4.1, 3.2, 4.3};
+
+  { // single iterator
+    cuda::zip_iterator iter{random_access_iterator{a}};
+    assert(cuda::std::addressof(cuda::std::get<0>(iter[0])) == cuda::std::addressof(a[0]));
+    static_assert(cuda::std::is_same_v<decltype(iter[0]), cuda::std::tuple<int&>>);
+  }
+
+  { // single iterator, operator* is const
+    const cuda::zip_iterator iter{a};
+    assert(cuda::std::addressof(cuda::std::get<0>(iter[0])) == cuda::std::addressof(a[0]));
+    static_assert(cuda::std::is_same_v<decltype(iter[0]), cuda::std::tuple<int&>>);
+  }
+
+  { // two different iterators
+    cuda::zip_iterator iter{a, b};
+    auto [x, y] = iter[0];
+    assert(cuda::std::addressof(x) == cuda::std::addressof(a[0]));
+    assert(cuda::std::addressof(y) == cuda::std::addressof(b[0]));
+    static_assert(cuda::std::is_same_v<decltype(iter[0]), cuda::std::pair<int&, double&>>);
+
+    x = 5;
+    y = 0.1;
+    assert(a[0] == 5);
+    assert(b[0] == 0.1);
+  }
+
+  { // iterator that generates prvalues
+    cuda::zip_iterator iter{a, b, cuda::counting_iterator{0}};
+    assert(cuda::std::addressof(cuda::std::get<0>(iter[0])) == cuda::std::addressof(a[0]));
+    assert(cuda::std::addressof(cuda::std::get<1>(iter[0])) == cuda::std::addressof(b[0]));
+    assert(cuda::std::get<2>(iter[0]) == 0);
+    static_assert(cuda::std::is_same_v<decltype(iter[0]), cuda::std::tuple<int&, double&, int>>);
+  }
+
+  { // const-correctness
+    cuda::zip_iterator iter{a, cuda::std::as_const(b)};
+    assert(cuda::std::addressof(cuda::std::get<0>(iter[0])) == cuda::std::addressof(a[0]));
+    assert(cuda::std::addressof(cuda::std::get<1>(iter[0])) == cuda::std::addressof(b[0]));
+    static_assert(cuda::std::is_same_v<decltype(iter[0]), cuda::std::pair<int&, const double&>>);
+  }
+
+  { // not all random_access_iterator
+    [[maybe_unused]] cuda::zip_iterator iter{a, forward_iterator{b}, cuda::counting_iterator{0}};
+    static_assert(!canSubscript<decltype(iter)>);
+  }
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test(), "");
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/zip_iterator/types.h
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/zip_iterator/types.h
@@ -1,0 +1,315 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TEST_CUDA_ITERATOR_ZIP_ITERATOR_H
+#define TEST_CUDA_ITERATOR_ZIP_ITERATOR_H
+
+#include <cuda/std/functional>
+
+#include "test_iterators.h"
+#include "test_macros.h"
+
+struct PODIter
+{
+  int i; // deliberately uninitialised
+
+  using iterator_category = cuda::std::random_access_iterator_tag;
+  using value_type        = int;
+  using difference_type   = intptr_t;
+
+  __host__ __device__ constexpr int operator*() const
+  {
+    return i;
+  }
+
+  __host__ __device__ constexpr PODIter& operator++()
+  {
+    return *this;
+  }
+  __host__ __device__ constexpr void operator++(int) {}
+
+#if TEST_STD_VER >= 2020
+  __host__ __device__ friend constexpr bool operator==(const PODIter&, const PODIter&) = default;
+#else // ^^^ C++20 ^^^ / vvv C++17 vvv
+  __host__ __device__ friend constexpr bool operator==(const PODIter& lhs, const PODIter& rhs)
+  {
+    return lhs.i == rhs.i;
+  }
+  __host__ __device__ friend constexpr bool operator!=(const PODIter& lhs, const PODIter& rhs)
+  {
+    return lhs.i != rhs.i;
+  }
+#endif // TEST_STD_VER <=2017
+};
+
+struct IterNotDefaultConstructible
+{
+  int i; // deliberately uninitialised
+
+  __host__ __device__ constexpr IterNotDefaultConstructible(const int val) noexcept
+      : i(val)
+  {}
+
+  using iterator_category = cuda::std::random_access_iterator_tag;
+  using value_type        = int;
+  using difference_type   = intptr_t;
+
+  __host__ __device__ constexpr int operator*() const
+  {
+    return i;
+  }
+
+  __host__ __device__ constexpr IterNotDefaultConstructible& operator++()
+  {
+    return *this;
+  }
+  __host__ __device__ constexpr void operator++(int) {}
+
+#if TEST_STD_VER >= 2020
+  __host__ __device__ friend constexpr bool
+  operator==(const IterNotDefaultConstructible&, const IterNotDefaultConstructible&) = default;
+#else // ^^^ C++20 ^^^ / vvv C++17 vvv
+  __host__ __device__ friend constexpr bool
+  operator==(const IterNotDefaultConstructible& lhs, const IterNotDefaultConstructible& rhs)
+  {
+    return lhs.i == rhs.i;
+  }
+  __host__ __device__ friend constexpr bool
+  operator!=(const IterNotDefaultConstructible& lhs, const IterNotDefaultConstructible& rhs)
+  {
+    return lhs.i != rhs.i;
+  }
+#endif // TEST_STD_VER <=2017
+};
+
+template <class Base = int*>
+struct forward_sized_iterator
+{
+  Base it_ = nullptr;
+
+  using iterator_category = cuda::std::forward_iterator_tag;
+  using value_type        = int;
+  using difference_type   = intptr_t;
+  using pointer           = Base;
+  using reference         = decltype(*Base{});
+
+  forward_sized_iterator() = default;
+  __host__ __device__ constexpr forward_sized_iterator(Base it)
+      : it_(it)
+  {}
+
+  __host__ __device__ constexpr reference operator*() const
+  {
+    return *it_;
+  }
+
+  __host__ __device__ constexpr forward_sized_iterator& operator++()
+  {
+    ++it_;
+    return *this;
+  }
+  __host__ __device__ constexpr forward_sized_iterator operator++(int)
+  {
+    return forward_sized_iterator(it_++);
+  }
+
+#if TEST_STD_VER >= 2020
+  __host__ __device__ friend constexpr bool
+  operator==(const forward_sized_iterator&, const forward_sized_iterator&) = default;
+#else // ^^^ C++20 ^^^ / vvv C++17 vvv
+  __host__ __device__ friend constexpr bool operator==(const forward_sized_iterator& x, const forward_sized_iterator& y)
+  {
+    return x.it_ == y.it_;
+  }
+  __host__ __device__ friend constexpr bool operator!=(const forward_sized_iterator& x, const forward_sized_iterator& y)
+  {
+    return x.it_ != y.it_;
+  }
+#endif // TEST_STD_VER <= 2017
+
+  __host__ __device__ friend constexpr difference_type
+  operator-(const forward_sized_iterator& x, const forward_sized_iterator& y)
+  {
+    return x.it_ - y.it_;
+  }
+};
+static_assert(cuda::std::forward_iterator<forward_sized_iterator<>>);
+static_assert(cuda::std::sized_sentinel_for<forward_sized_iterator<>, forward_sized_iterator<>>);
+
+namespace adltest
+{
+struct iter_move_swap_iterator
+{
+  cuda::std::reference_wrapper<int> iter_move_called_times;
+  cuda::std::reference_wrapper<int> iter_swap_called_times;
+  int i = 0;
+
+  using iterator_category = cuda::std::input_iterator_tag;
+  using value_type        = int;
+  using difference_type   = intptr_t;
+
+  __host__ __device__ TEST_CONSTEXPR_CXX20
+  iter_move_swap_iterator(int& move_called, int& swap_called, int val = 0) noexcept
+      : iter_move_called_times(move_called)
+      , iter_swap_called_times(swap_called)
+      , i(val)
+  {}
+
+  __host__ __device__ TEST_CONSTEXPR_CXX20 int operator*() const
+  {
+    return i;
+  }
+
+  __host__ __device__ TEST_CONSTEXPR_CXX20 iter_move_swap_iterator& operator++()
+  {
+    ++i;
+    return *this;
+  }
+  __host__ __device__ TEST_CONSTEXPR_CXX20 void operator++(int)
+  {
+    ++i;
+  }
+
+#if TEST_STD_VER >= 2020
+  __host__ __device__ friend TEST_CONSTEXPR_CXX20 bool
+  operator==(const iter_move_swap_iterator& x, cuda::std::default_sentinel_t)
+  {
+    return x.i == 5;
+  }
+#else // ^^^ C++20 ^^^ / vvv C++17 vvv
+  __host__ __device__ friend TEST_CONSTEXPR_CXX20 bool
+  operator==(const iter_move_swap_iterator& x, cuda::std::default_sentinel_t)
+  {
+    return x.i == 5;
+  }
+  __host__ __device__ friend TEST_CONSTEXPR_CXX20 bool
+  operator==(cuda::std::default_sentinel_t, const iter_move_swap_iterator& x)
+  {
+    return x.i == 5;
+  }
+  __host__ __device__ friend TEST_CONSTEXPR_CXX20 bool
+  operator!=(const iter_move_swap_iterator& x, cuda::std::default_sentinel_t)
+  {
+    return x.i != 5;
+  }
+  __host__ __device__ friend TEST_CONSTEXPR_CXX20 bool
+  operator!=(cuda::std::default_sentinel_t, const iter_move_swap_iterator& x)
+  {
+    return x.i != 5;
+  }
+#endif // TEST_STD_VER <= 2017
+
+  __host__ __device__ friend TEST_CONSTEXPR_CXX20 int iter_move(iter_move_swap_iterator const& it)
+  {
+    ++it.iter_move_called_times;
+    return it.i;
+  }
+  __host__ __device__ friend TEST_CONSTEXPR_CXX20 void
+  iter_swap(iter_move_swap_iterator const& x, iter_move_swap_iterator const& y)
+  {
+    ++x.iter_swap_called_times;
+    ++y.iter_swap_called_times;
+  }
+};
+
+} // namespace adltest
+
+// This is for testing that zip iterator never calls underlying iterator's >, >=, <=, !=.
+// The spec indicates that zip iterator's >= is negating zip iterator's < instead of calling underlying iterator's >=.
+// Declare all the operations >, >=, <= etc to make it satisfy random_access_iterator concept,
+// but not define them. If the zip iterator's >,>=, <=, etc isn't implemented in the way defined by the standard
+// but instead calling underlying iterator's >,>=,<=, we will get a linker error for the runtime tests and
+// non-constant expression for the compile time tests.
+struct LessThanIterator
+{
+  int* it_           = nullptr;
+  LessThanIterator() = default;
+  __host__ __device__ constexpr LessThanIterator(int* it)
+      : it_(it)
+  {}
+
+  using iterator_category = cuda::std::random_access_iterator_tag;
+  using value_type        = int;
+  using difference_type   = intptr_t;
+
+  __host__ __device__ constexpr int& operator*() const
+  {
+    return *it_;
+  }
+  __host__ __device__ constexpr int& operator[](difference_type n) const
+  {
+    return it_[n];
+  }
+  __host__ __device__ constexpr LessThanIterator& operator++()
+  {
+    ++it_;
+    return *this;
+  }
+  __host__ __device__ constexpr LessThanIterator& operator--()
+  {
+    --it_;
+    return *this;
+  }
+  __host__ __device__ constexpr LessThanIterator operator++(int)
+  {
+    return LessThanIterator(it_++);
+  }
+  __host__ __device__ constexpr LessThanIterator operator--(int)
+  {
+    return LessThanIterator(it_--);
+  }
+
+  __host__ __device__ constexpr LessThanIterator& operator+=(difference_type n)
+  {
+    it_ += n;
+    return *this;
+  }
+  __host__ __device__ constexpr LessThanIterator& operator-=(difference_type n)
+  {
+    it_ -= n;
+    return *this;
+  }
+
+  __host__ __device__ constexpr friend LessThanIterator operator+(LessThanIterator x, difference_type n)
+  {
+    x += n;
+    return x;
+  }
+  __host__ __device__ constexpr friend LessThanIterator operator+(difference_type n, LessThanIterator x)
+  {
+    x += n;
+    return x;
+  }
+  __host__ __device__ constexpr friend LessThanIterator operator-(LessThanIterator x, difference_type n)
+  {
+    x -= n;
+    return x;
+  }
+  __host__ __device__ constexpr friend difference_type operator-(LessThanIterator x, LessThanIterator y)
+  {
+    return x.it_ - y.it_;
+  }
+
+  __host__ __device__ constexpr friend bool operator==(LessThanIterator const& x, LessThanIterator const& y)
+  {
+    return x.it_ == y.it_;
+  }
+  __host__ __device__ friend bool operator!=(LessThanIterator const& x, LessThanIterator const& y);
+
+  __host__ __device__ constexpr friend bool operator<(LessThanIterator const& x, LessThanIterator const& y)
+  {
+    return x.it_ < y.it_;
+  }
+  __host__ __device__ friend bool operator<=(LessThanIterator const&, LessThanIterator const&);
+  __host__ __device__ friend bool operator>(LessThanIterator const&, LessThanIterator const&);
+  __host__ __device__ friend bool operator>=(LessThanIterator const&, LessThanIterator const&);
+};
+static_assert(cuda::std::random_access_iterator<LessThanIterator>);
+
+#endif // TEST_CUDA_ITERATOR_ZIP_ITERATOR_H

--- a/libcudacxx/test/support/test_iterators.h
+++ b/libcudacxx/test/support/test_iterators.h
@@ -1835,10 +1835,11 @@ struct ProxyIterator : ProxyIteratorBase<Base>
   // If operator* returns Proxy<Foo&>, iter_move will return Proxy<Foo&&>
   // Note cuda::std::move(*it) returns Proxy<Foo&>&&, which is not what we want as
   // it will likely result in a copy rather than a move
-  __host__ __device__ friend constexpr Proxy<cuda::std::iter_rvalue_reference_t<Base>>
-  iter_move(const ProxyIterator& p) noexcept
+  // MSVC falls over its feet without the template indirection
+  template <class B2 = Base>
+  __host__ __device__ friend constexpr auto iter_move(const ProxyIterator<B2>& p) noexcept
   {
-    return {cuda::std::ranges::iter_move(p.base_)};
+    return Proxy<cuda::std::iter_rvalue_reference_t<Base>>{cuda::std::ranges::iter_move(p.base_)};
   }
 
   // Specialization of iter_swap

--- a/thrust/testing/catch2_test_cuda_iterators.cu
+++ b/thrust/testing/catch2_test_cuda_iterators.cu
@@ -246,41 +246,30 @@ TEST_CASE("transform_iterator", "[iterators]")
   }
 }
 
-struct AddZipped
-{
-  template <class T>
-  [[nodiscard]] _CCCL_HOST_DEVICE constexpr T operator()(cuda::std::pair<T, T> val) const noexcept
-  {
-    return val.first + val.second;
-  }
-};
-
 TEST_CASE("zip_iterator", "[iterators]")
 {
+  cuda::zip_function<cuda::std::plus<void>> fun{};
   { // device system
     thrust::device_vector<int> vec{-1, -1, -1, -1};
-    auto iter = cuda::make_transform_iterator(
-      cuda::make_zip_iterator(cuda::counting_iterator{0}, cuda::counting_iterator{4}), AddZipped{});
+    auto iter = cuda::make_transform_iterator(cuda::make_zip_iterator(vec.begin(), cuda::counting_iterator{4}), fun);
     thrust::copy(iter, iter + 4, vec.begin());
-    thrust::device_vector<int> expected{4, 6, 8, 10};
+    thrust::device_vector<int> expected{3, 4, 5, 6};
     CHECK(thrust::equal(vec.begin(), vec.end(), expected.begin()));
   }
 
   { // host system
     thrust::host_vector<int> vec{-1, -1, -1, -1};
-    auto iter = cuda::make_transform_iterator(
-      cuda::make_zip_iterator(cuda::counting_iterator{0}, cuda::counting_iterator{4}), AddZipped{});
+    auto iter = cuda::make_transform_iterator(cuda::make_zip_iterator(vec.begin(), cuda::counting_iterator{4}), fun);
     thrust::copy(iter, iter + 4, vec.begin());
-    thrust::host_vector<int> expected{4, 6, 8, 10};
+    thrust::host_vector<int> expected{3, 4, 5, 6};
     CHECK(thrust::equal(vec.begin(), vec.end(), expected.begin()));
   }
 
   { // plain std::vector
     std::vector<int> vec{-1, -1, -1, -1};
-    auto iter = cuda::make_transform_iterator(
-      cuda::make_zip_iterator(cuda::counting_iterator{0}, cuda::counting_iterator{4}), AddZipped{});
+    auto iter = cuda::make_transform_iterator(cuda::make_zip_iterator(vec.begin(), cuda::counting_iterator{4}), fun);
     thrust::copy(iter, iter + 4, vec.begin());
-    std::vector<int> expected{4, 6, 8, 10};
+    std::vector<int> expected{3, 4, 5, 6};
     CHECK(thrust::equal(vec.begin(), vec.end(), expected.begin()));
   }
 }

--- a/thrust/thrust/iterator/iterator_traits.h
+++ b/thrust/thrust/iterator/iterator_traits.h
@@ -277,6 +277,17 @@ template <class Iter, class Fn>
 struct iterator_traversal<::cuda::transform_iterator<Iter, Fn>> : iterator_traversal<Iter>
 {};
 
+template <class... Iterators>
+struct iterator_system<::cuda::zip_iterator<Iterators...>>
+{
+  using type = detail::minimum_system_t<iterator_system_t<Iterators>...>;
+};
+template <class... Iterators>
+struct iterator_traversal<::cuda::zip_iterator<Iterators...>>
+{
+  using type = detail::minimum_type<iterator_traversal_t<Iterators>...>;
+};
+
 THRUST_NAMESPACE_END
 
 #include <thrust/iterator/detail/iterator_traversal_tags.h>


### PR DESCRIPTION
This ports `thrust::zip_iterator` to cuda

There are some notable differences that I want to highlight:

Following the approach taken by `std::ranges::zip_view` the template argument of `cuda::zip_iterator`  is a variadic set of iterators and not a `cuda::std::tuple`

That makes a lot of the machinery much simpler to handle and is generally the "modern" approach to writing this.

So this would not be a 1 to 1 drop in replacement. I also did not implement zip_function yet, so its global usefulness is still limited