### PR TITLE
Fix some issues withe the calculation of `__fp_one`

### DIFF
--- a/libcudacxx/include/cuda/std/__floating_point/constants.h
+++ b/libcudacxx/include/cuda/std/__floating_point/constants.h
@@ -200,9 +200,9 @@ template <__fp_format _Fmt>
   }
   else
   {
-    constexpr __fp_storage_t<_Fmt> implicit_bit = __fp_storage_t<_Fmt>{1} << (__fp_mant_nbits_v<fmt> - 1);
+    constexpr __fp_storage_t<_Fmt> __implicit_bit = __fp_storage_t<_Fmt>{1} << (__fp_mant_nbits_v<_Fmt> - 1);
     return static_cast<__fp_storage_t<_Fmt>>(
-      (static_cast<__fp_storage_t<_Fmt>>(__fp_exp_bias_v<_Fmt>) << __fp_mant_nbits_v<_Fmt>) &implicit_bit);
+      (static_cast<__fp_storage_t<_Fmt>>(__fp_exp_bias_v<_Fmt>) << __fp_mant_nbits_v<_Fmt>) | __implicit_bit);
   }
 }
 

--- a/libcudacxx/include/cuda/std/__floating_point/constants.h
+++ b/libcudacxx/include/cuda/std/__floating_point/constants.h
@@ -200,10 +200,9 @@ template <__fp_format _Fmt>
   }
   else
   {
-    constexpr auto __implicit_bit =
-      static_cast<__fp_storage_t<_Fmt>>(__fp_storage_t<_Fmt>{1} << (__fp_mant_nbits_v<_Fmt> - 1));
     return static_cast<__fp_storage_t<_Fmt>>(
-      (static_cast<__fp_storage_t<_Fmt>>(__fp_exp_bias_v<_Fmt>) << __fp_mant_nbits_v<_Fmt>) | __implicit_bit);
+      (static_cast<__fp_storage_t<_Fmt>>(__fp_exp_bias_v<_Fmt>) << __fp_mant_nbits_v<_Fmt>)
+      | (static_cast<__fp_storage_t<_Fmt>>(__fp_storage_t<_Fmt>{1} << (__fp_mant_nbits_v<_Fmt> - 1))));
   }
 }
 

--- a/libcudacxx/include/cuda/std/__floating_point/constants.h
+++ b/libcudacxx/include/cuda/std/__floating_point/constants.h
@@ -193,7 +193,17 @@ template <class _Tp>
 template <__fp_format _Fmt>
 [[nodiscard]] _CCCL_API constexpr __fp_storage_t<_Fmt> __fp_one() noexcept
 {
-  return static_cast<__fp_storage_t<_Fmt>>(__fp_exp_bias_v<_Fmt> << __fp_mant_nbits_v<_Fmt>);
+  if constexpr (__fp_has_implicit_bit_v<_Fmt>)
+  {
+    return static_cast<__fp_storage_t<_Fmt>>(
+      static_cast<__fp_storage_t<_Fmt>>(__fp_exp_bias_v<_Fmt>) << __fp_mant_nbits_v<_Fmt>);
+  }
+  else
+  {
+    constexpr __fp_storage_t<_Fmt> implicit_bit = __fp_storage_t<_Fmt>{1} << (__fp_mant_nbits_v<fmt> - 1);
+    return static_cast<__fp_storage_t<_Fmt>>(
+      (static_cast<__fp_storage_t<_Fmt>>(__fp_exp_bias_v<_Fmt>) << __fp_mant_nbits_v<_Fmt>) &implicit_bit);
+  }
 }
 
 template <class _Tp>

--- a/libcudacxx/include/cuda/std/__floating_point/constants.h
+++ b/libcudacxx/include/cuda/std/__floating_point/constants.h
@@ -200,7 +200,8 @@ template <__fp_format _Fmt>
   }
   else
   {
-    constexpr __fp_storage_t<_Fmt> __implicit_bit = __fp_storage_t<_Fmt>{1} << (__fp_mant_nbits_v<_Fmt> - 1);
+    constexpr auto __implicit_bit =
+      static_cast<__fp_storage_t<_Fmt>>(__fp_storage_t<_Fmt>{1} << (__fp_mant_nbits_v<_Fmt> - 1));
     return static_cast<__fp_storage_t<_Fmt>>(
       (static_cast<__fp_storage_t<_Fmt>>(__fp_exp_bias_v<_Fmt>) << __fp_mant_nbits_v<_Fmt>) | __implicit_bit);
   }

--- a/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/constants.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/constants.pass.cpp
@@ -18,7 +18,7 @@
 #include "test_macros.h"
 
 template <class T>
-__host__ __device__ void test_fp_storage()
+__host__ __device__ void test_fp_storage(cuda::std::__fp_storage_of_t<T> expected_one)
 {
   constexpr auto fmt = cuda::std::__fp_format_of_v<T>;
 
@@ -79,49 +79,49 @@ __host__ __device__ void test_fp_storage()
   {
     const auto val = cuda::std::__fp_zero<T>();
     const auto ref = cuda::std::__fp_storage_of_t<T>(0);
+    assert(cuda::std::__fp_zero<cuda::std::__fp_format_of_v<T>>() == cuda::std::__fp_storage_of_t<T>(0));
     assert(cuda::std::memcmp(&val, &ref, sizeof(T)) == 0);
     assert(!cuda::std::signbit(val));
   }
 
   // test __fp_one for standard types only
-  if constexpr (cuda::std::__fp_is_native_type_v<T>)
   {
     const auto val = cuda::std::__fp_one<T>();
-    const auto ref = T{1};
-    assert(cuda::std::memcmp(&val, &ref, sizeof(T)) == 0);
+    assert(cuda::std::__fp_one<cuda::std::__fp_format_of_v<T>>() == expected_one);
+    assert(cuda::std::__fp_get_storage(val) == expected_one);
   }
 }
 
 int main(int, char**)
 {
-  test_fp_storage<float>();
-  test_fp_storage<double>();
+  test_fp_storage<float>(0x3f800000);
+  test_fp_storage<double>(0x3ff0000000000000);
 #if _CCCL_HAS_LONG_DOUBLE()
-  test_fp_storage<long double>();
+  test_fp_storage<long double>(0x3fff8000000000000000);
 #endif // _CCCL_HAS_LONG_DOUBLE()
 #if _CCCL_HAS_NVFP16()
-  test_fp_storage<__half>();
+  test_fp_storage<__half>(0x3c00);
 #endif // _CCCL_HAS_NVFP16()
 #if _CCCL_HAS_NVBF16()
-  test_fp_storage<__nv_bfloat16>();
+  test_fp_storage<__nv_bfloat16>(0x3f80);
 #endif // _CCCL_HAS_NVBF16()
 #if _CCCL_HAS_NVFP8_E4M3()
-  test_fp_storage<__nv_fp8_e4m3>();
+  test_fp_storage<__nv_fp8_e4m3>(0x38);
 #endif // _CCCL_HAS_NVFP8_E4M3()
 #if _CCCL_HAS_NVFP8_E5M2()
-  test_fp_storage<__nv_fp8_e5m2>();
+  test_fp_storage<__nv_fp8_e5m2>(0x3c);
 #endif // _CCCL_HAS_NVFP8_E5M2()
 #if _CCCL_HAS_NVFP8_E8M0()
-  test_fp_storage<__nv_fp8_e8m0>();
+  test_fp_storage<__nv_fp8_e8m0>(0x7f);
 #endif // _CCCL_HAS_NVFP8_E8M0()
 #if _CCCL_HAS_NVFP6_E2M3()
-  test_fp_storage<__nv_fp6_e2m3>();
+  test_fp_storage<__nv_fp6_e2m3>(0x8);
 #endif // _CCCL_HAS_NVFP6_E2M3()
 #if _CCCL_HAS_NVFP6_E3M2()
-  test_fp_storage<__nv_fp6_e3m2>();
+  test_fp_storage<__nv_fp6_e3m2>(0xc);
 #endif // _CCCL_HAS_NVFP6_E3M2()
 #if _CCCL_HAS_NVFP4_E2M1()
-  test_fp_storage<__nv_fp4_e2m1>();
+  test_fp_storage<__nv_fp4_e2m1>(0x2);
 #endif // _CCCL_HAS_NVFP4_E2M1()
 
   return 0;


### PR DESCRIPTION
The problem occured with floating point types without an implicit bit like `long double` which however takes a different code path.

The ther issue was that we did not properly cast the integer of the bias to the storage type, which could again could lead to issues with types that have more mantissa bits than `int`.

However, currently the only supported types that satisfy this are builtin types, which again take a different code path.

Still worth fixing though
