### PR TITLE
cuda.cccl: Update dependencies to enable running on CUDA 13 driver

### DIFF
--- a/python/cuda_cccl/cuda/cccl/cooperative/experimental/warp/_warp_merge_sort.py
+++ b/python/cuda_cccl/cuda/cccl/cooperative/experimental/warp/_warp_merge_sort.py
@@ -28,12 +28,6 @@ def merge_sort_keys(
         are partitioned in a :ref:`blocked arrangement <flexible-data-arrangement>` across a warp of 32 threads
         where each thread owns 4 consecutive keys. We start by importing necessary modules:
 
-        .. literalinclude:: ../../python/cuda_cccl/tests/cooperative/test_warp_merge_sort_api.py
-            :language: python
-            :dedent:
-            :start-after: example-begin imports
-            :end-before: example-end imports
-
         Below is the code snippet that demonstrates the usage of the ``merge_sort_keys`` API:
 
         .. literalinclude:: ../../python/cuda_cccl/tests/cooperative/test_warp_merge_sort_api.py

--- a/python/cuda_cccl/cuda/cccl/parallel/experimental/_bindings.py
+++ b/python/cuda_cccl/cuda/cccl/parallel/experimental/_bindings.py
@@ -4,7 +4,7 @@
 # Preload `nvrtc` and `nvJitLink` before importing the Cython extension.
 # These shared libraries are indirect dependencies, pulled in via the direct
 # dependency `cccl.c.parallel`. To ensure reliable symbol resolution at
-# runtime, we explicitly load them first using `cuda.bindings.path_finder`.
+# runtime, we explicitly load them first using `cuda.path_finder`.
 #
 # Without this step, importing the Cython extension directly may fail or behave
 # inconsistently depending on environment setup and dynamic linker behavior.
@@ -12,13 +12,12 @@
 # `_bindings` is first imported across the codebase.
 #
 # See also:
-# https://github.com/NVIDIA/cuda-python/blob/main/cuda_bindings/cuda/bindings/_path_finder/README.md
+# https://github.com/NVIDIA/cuda-python/tree/main/cuda_pathfinder/cuda/pathfinder
 
-from cuda.bindings.path_finder import (  # type: ignore[import-not-found]
-    _load_nvidia_dynamic_library,
-)
+# type: ignore[import-not-found]
+from cuda.pathfinder import load_nvidia_dynamic_library
 
 for libname in ("nvrtc", "nvJitLink"):
-    _load_nvidia_dynamic_library(libname)
+    load_nvidia_dynamic_library(libname)
 
 from ._bindings_impl import *  # noqa: E402 F403

--- a/python/cuda_cccl/cuda/cccl/parallel/experimental/_bindings.py
+++ b/python/cuda_cccl/cuda/cccl/parallel/experimental/_bindings.py
@@ -15,9 +15,9 @@
 # https://github.com/NVIDIA/cuda-python/tree/main/cuda_pathfinder/cuda/pathfinder
 
 # type: ignore[import-not-found]
-from cuda.pathfinder import load_nvidia_dynamic_library
+from cuda.pathfinder import load_nvidia_dynamic_lib
 
 for libname in ("nvrtc", "nvJitLink"):
-    load_nvidia_dynamic_library(libname)
+    load_nvidia_dynamic_lib(libname)
 
 from ._bindings_impl import *  # noqa: E402 F403

--- a/python/cuda_cccl/pyproject.toml
+++ b/python/cuda_cccl/pyproject.toml
@@ -24,8 +24,7 @@ dependencies = [
   "cuda-core",
   "nvidia-cuda-nvrtc-cu12",
   "nvidia-nvjitlink-cu12",
-  "pynvjitlink-cu12>=0.2.4",
-  "numba-cuda",
+  "numba-cuda>=0.18.0",
 ]
 dynamic = ["version"]
 readme = { file = "README.md", content-type = "text/markdown" }

--- a/python/cuda_cccl/pyproject.toml
+++ b/python/cuda_cccl/pyproject.toml
@@ -19,7 +19,7 @@ requires-python = ">=3.9"
 dependencies = [
   "numba>=0.60.0",
   "numpy",
-  "cuda-python==12.9.0",
+  "cuda-bindings>=12.9.1,<13.0.0",
   "cuda-core",
   "nvidia-cuda-nvrtc-cu12",
   "nvidia-nvjitlink-cu12",

--- a/python/cuda_cccl/pyproject.toml
+++ b/python/cuda_cccl/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
   "nvidia-cuda-nvrtc-cu12",
   "nvidia-nvjitlink-cu12",
   "pynvjitlink-cu12>=0.2.4",
+  "numba-cuda",
 ]
 dynamic = ["version"]
 readme = { file = "README.md", content-type = "text/markdown" }

--- a/python/cuda_cccl/pyproject.toml
+++ b/python/cuda_cccl/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
   "numba>=0.60.0",
   "numpy",
   "cuda-bindings>=12.9.1,<13.0.0",
+  "cuda-pathfinder>=1.1.0",
   "cuda-core",
   "nvidia-cuda-nvrtc-cu12",
   "nvidia-nvjitlink-cu12",

--- a/python/cuda_cccl/tests/cooperative/examples/block/reduce.py
+++ b/python/cuda_cccl/tests/cooperative/examples/block/reduce.py
@@ -9,12 +9,11 @@ Block-level reduction examples demonstrating cooperative algorithms within a CUD
 import numba
 import numpy as np
 from numba import cuda
-from pynvjitlink import patch
 
 import cuda.cccl.cooperative.experimental as coop
 
-patch.patch_numba_linker(lto=True)
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
+numba.config.CUDA_ENABLE_PYNVJITLINK = 1
 
 
 def custom_reduce_example():

--- a/python/cuda_cccl/tests/cooperative/examples/block/reduce.py
+++ b/python/cuda_cccl/tests/cooperative/examples/block/reduce.py
@@ -13,7 +13,6 @@ from numba import cuda
 import cuda.cccl.cooperative.experimental as coop
 
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
-numba.config.CUDA_ENABLE_PYNVJITLINK = 1
 
 
 def custom_reduce_example():

--- a/python/cuda_cccl/tests/cooperative/examples/block/scan.py
+++ b/python/cuda_cccl/tests/cooperative/examples/block/scan.py
@@ -9,12 +9,11 @@ Block-level scan examples demonstrating cooperative prefix scan algorithms withi
 import numba
 import numpy as np
 from numba import cuda
-from pynvjitlink import patch
 
 import cuda.cccl.cooperative.experimental as coop
 
-patch.patch_numba_linker(lto=True)
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
+numba.config.CUDA_ENABLE_PYNVJITLINK = 1
 
 
 def exclusive_sum_multiple_items_example():

--- a/python/cuda_cccl/tests/cooperative/examples/block/scan.py
+++ b/python/cuda_cccl/tests/cooperative/examples/block/scan.py
@@ -13,7 +13,6 @@ from numba import cuda
 import cuda.cccl.cooperative.experimental as coop
 
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
-numba.config.CUDA_ENABLE_PYNVJITLINK = 1
 
 
 def exclusive_sum_multiple_items_example():

--- a/python/cuda_cccl/tests/cooperative/examples/warp/reduce.py
+++ b/python/cuda_cccl/tests/cooperative/examples/warp/reduce.py
@@ -13,7 +13,6 @@ from numba import cuda
 import cuda.cccl.cooperative.experimental as coop
 
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
-numba.config.CUDA_ENABLE_PYNVJITLINK = 1
 
 
 def custom_warp_reduce_example():

--- a/python/cuda_cccl/tests/cooperative/examples/warp/reduce.py
+++ b/python/cuda_cccl/tests/cooperative/examples/warp/reduce.py
@@ -9,12 +9,11 @@ Warp-level reduction examples demonstrating cooperative algorithms within a CUDA
 import numba
 import numpy as np
 from numba import cuda
-from pynvjitlink import patch
 
 import cuda.cccl.cooperative.experimental as coop
 
-patch.patch_numba_linker(lto=True)
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
+numba.config.CUDA_ENABLE_PYNVJITLINK = 1
 
 
 def custom_warp_reduce_example():

--- a/python/cuda_cccl/tests/cooperative/test_block_load.py
+++ b/python/cuda_cccl/tests/cooperative/test_block_load.py
@@ -9,11 +9,10 @@ import numba
 import pytest
 from helpers import NUMBA_TYPES_TO_NP, random_int, row_major_tid
 from numba import cuda, types
-from pynvjitlink import patch
 
 import cuda.cccl.cooperative.experimental as coop
 
-patch.patch_numba_linker(lto=True)
+numba.config.CUDA_ENABLE_PYNVJITLINK = 1
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
 
 

--- a/python/cuda_cccl/tests/cooperative/test_block_load.py
+++ b/python/cuda_cccl/tests/cooperative/test_block_load.py
@@ -12,7 +12,6 @@ from numba import cuda, types
 
 import cuda.cccl.cooperative.experimental as coop
 
-numba.config.CUDA_ENABLE_PYNVJITLINK = 1
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
 
 

--- a/python/cuda_cccl/tests/cooperative/test_block_load_store_api.py
+++ b/python/cuda_cccl/tests/cooperative/test_block_load_store_api.py
@@ -6,11 +6,10 @@
 import numba
 import numpy as np
 from numba import cuda
-from pynvjitlink import patch
 
 import cuda.cccl.cooperative.experimental as coop
 
-patch.patch_numba_linker(lto=True)
+numba.config.CUDA_ENABLE_PYNVJITLINK = 1
 # example-end imports
 
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0

--- a/python/cuda_cccl/tests/cooperative/test_block_load_store_api.py
+++ b/python/cuda_cccl/tests/cooperative/test_block_load_store_api.py
@@ -9,7 +9,6 @@ from numba import cuda
 
 import cuda.cccl.cooperative.experimental as coop
 
-numba.config.CUDA_ENABLE_PYNVJITLINK = 1
 # example-end imports
 
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0

--- a/python/cuda_cccl/tests/cooperative/test_block_merge_sort.py
+++ b/python/cuda_cccl/tests/cooperative/test_block_merge_sort.py
@@ -13,7 +13,6 @@ from numba import cuda, types
 
 import cuda.cccl.cooperative.experimental as coop
 
-numba.config.CUDA_ENABLE_PYNVJITLINK = 1
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
 
 

--- a/python/cuda_cccl/tests/cooperative/test_block_merge_sort.py
+++ b/python/cuda_cccl/tests/cooperative/test_block_merge_sort.py
@@ -10,11 +10,10 @@ import numpy as np
 import pytest
 from helpers import NUMBA_TYPES_TO_NP, random_int, row_major_tid
 from numba import cuda, types
-from pynvjitlink import patch
 
 import cuda.cccl.cooperative.experimental as coop
 
-patch.patch_numba_linker(lto=True)
+numba.config.CUDA_ENABLE_PYNVJITLINK = 1
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
 
 

--- a/python/cuda_cccl/tests/cooperative/test_block_merge_sort_api.py
+++ b/python/cuda_cccl/tests/cooperative/test_block_merge_sort_api.py
@@ -9,10 +9,6 @@ from numba import cuda
 import cuda.cccl.cooperative.experimental as coop
 
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
-# example-begin imports
-
-
-# example-end imports
 
 
 def test_block_merge_sort():

--- a/python/cuda_cccl/tests/cooperative/test_block_merge_sort_api.py
+++ b/python/cuda_cccl/tests/cooperative/test_block_merge_sort_api.py
@@ -8,7 +8,9 @@ from numba import cuda
 
 import cuda.cccl.cooperative.experimental as coop
 
+# example-begin imports
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
+# example-end imports
 
 
 def test_block_merge_sort():

--- a/python/cuda_cccl/tests/cooperative/test_block_merge_sort_api.py
+++ b/python/cuda_cccl/tests/cooperative/test_block_merge_sort_api.py
@@ -9,7 +9,6 @@ from numba import cuda
 import cuda.cccl.cooperative.experimental as coop
 
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
-numba.config.CUDA_ENABLE_PYNVJITLINK = 1
 # example-begin imports
 
 

--- a/python/cuda_cccl/tests/cooperative/test_block_merge_sort_api.py
+++ b/python/cuda_cccl/tests/cooperative/test_block_merge_sort_api.py
@@ -5,14 +5,14 @@
 import numba
 import numpy as np
 from numba import cuda
-from pynvjitlink import patch
 
 import cuda.cccl.cooperative.experimental as coop
 
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
-
+numba.config.CUDA_ENABLE_PYNVJITLINK = 1
 # example-begin imports
-patch.patch_numba_linker(lto=True)
+
+
 # example-end imports
 
 

--- a/python/cuda_cccl/tests/cooperative/test_block_radix_sort.py
+++ b/python/cuda_cccl/tests/cooperative/test_block_radix_sort.py
@@ -13,7 +13,6 @@ from numba import cuda, types
 import cuda.cccl.cooperative.experimental as coop
 
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
-numba.config.CUDA_ENABLE_PYNVJITLINK = 1
 
 
 @pytest.mark.parametrize("T", [types.int8, types.int16, types.uint32, types.uint64])

--- a/python/cuda_cccl/tests/cooperative/test_block_radix_sort.py
+++ b/python/cuda_cccl/tests/cooperative/test_block_radix_sort.py
@@ -9,12 +9,11 @@ import numba
 import pytest
 from helpers import NUMBA_TYPES_TO_NP, random_int, row_major_tid
 from numba import cuda, types
-from pynvjitlink import patch
 
 import cuda.cccl.cooperative.experimental as coop
 
-patch.patch_numba_linker(lto=True)
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
+numba.config.CUDA_ENABLE_PYNVJITLINK = 1
 
 
 @pytest.mark.parametrize("T", [types.int8, types.int16, types.uint32, types.uint64])

--- a/python/cuda_cccl/tests/cooperative/test_block_radix_sort_api.py
+++ b/python/cuda_cccl/tests/cooperative/test_block_radix_sort_api.py
@@ -9,9 +9,6 @@ from numba import cuda
 import cuda.cccl.cooperative.experimental as coop
 
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
-# example-begin imports
-
-# example-end imports
 
 
 def test_block_radix_sort():

--- a/python/cuda_cccl/tests/cooperative/test_block_radix_sort_api.py
+++ b/python/cuda_cccl/tests/cooperative/test_block_radix_sort_api.py
@@ -5,14 +5,14 @@
 import numba
 import numpy as np
 from numba import cuda
-from pynvjitlink import patch
 
 import cuda.cccl.cooperative.experimental as coop
 
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
+numba.config.CUDA_ENABLE_PYNVJITLINK = 1
 
 # example-begin imports
-patch.patch_numba_linker(lto=True)
+
 # example-end imports
 
 

--- a/python/cuda_cccl/tests/cooperative/test_block_radix_sort_api.py
+++ b/python/cuda_cccl/tests/cooperative/test_block_radix_sort_api.py
@@ -8,7 +8,9 @@ from numba import cuda
 
 import cuda.cccl.cooperative.experimental as coop
 
+# example-begin imports
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
+# example-end imports
 
 
 def test_block_radix_sort():

--- a/python/cuda_cccl/tests/cooperative/test_block_radix_sort_api.py
+++ b/python/cuda_cccl/tests/cooperative/test_block_radix_sort_api.py
@@ -9,8 +9,6 @@ from numba import cuda
 import cuda.cccl.cooperative.experimental as coop
 
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
-numba.config.CUDA_ENABLE_PYNVJITLINK = 1
-
 # example-begin imports
 
 # example-end imports

--- a/python/cuda_cccl/tests/cooperative/test_block_reduce.py
+++ b/python/cuda_cccl/tests/cooperative/test_block_reduce.py
@@ -16,14 +16,11 @@ from helpers import (
     row_major_tid,
 )
 from numba import cuda, types
-from pynvjitlink import patch
 
 import cuda.cccl.cooperative.experimental as coop
 
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
-
-
-patch.patch_numba_linker(lto=True)
+numba.config.CUDA_ENABLE_PYNVJITLINK = 1
 
 
 @pytest.mark.parametrize(

--- a/python/cuda_cccl/tests/cooperative/test_block_reduce.py
+++ b/python/cuda_cccl/tests/cooperative/test_block_reduce.py
@@ -20,7 +20,6 @@ from numba import cuda, types
 import cuda.cccl.cooperative.experimental as coop
 
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
-numba.config.CUDA_ENABLE_PYNVJITLINK = 1
 
 
 @pytest.mark.parametrize(

--- a/python/cuda_cccl/tests/cooperative/test_block_reduce_api.py
+++ b/python/cuda_cccl/tests/cooperative/test_block_reduce_api.py
@@ -9,7 +9,6 @@ from numba import cuda
 
 import cuda.cccl.cooperative.experimental as coop
 
-numba.config.CUDA_ENABLE_PYNVJITLINK = 1
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
 
 # example-end imports

--- a/python/cuda_cccl/tests/cooperative/test_block_reduce_api.py
+++ b/python/cuda_cccl/tests/cooperative/test_block_reduce_api.py
@@ -6,14 +6,13 @@
 import numba
 import numpy as np
 from numba import cuda
-from pynvjitlink import patch
 
 import cuda.cccl.cooperative.experimental as coop
 
-patch.patch_numba_linker(lto=True)
-# example-end imports
-
+numba.config.CUDA_ENABLE_PYNVJITLINK = 1
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
+
+# example-end imports
 
 
 def test_block_reduction():

--- a/python/cuda_cccl/tests/cooperative/test_block_scan.py
+++ b/python/cuda_cccl/tests/cooperative/test_block_scan.py
@@ -41,7 +41,6 @@ from cuda.cccl.cooperative.experimental.block._block_scan import (
 )
 
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
-numba.config.CUDA_ENABLE_PYNVJITLINK = 1
 
 
 class BlockPrefixCallbackOp:

--- a/python/cuda_cccl/tests/cooperative/test_block_scan.py
+++ b/python/cuda_cccl/tests/cooperative/test_block_scan.py
@@ -34,7 +34,6 @@ from numba.core.extending import (
     type_callable,
     typeof_impl,
 )
-from pynvjitlink import patch
 
 import cuda.cccl.cooperative.experimental as coop
 from cuda.cccl.cooperative.experimental.block._block_scan import (
@@ -42,9 +41,7 @@ from cuda.cccl.cooperative.experimental.block._block_scan import (
 )
 
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
-
-# Patching the Numba linker to enable LTO as needed.
-patch.patch_numba_linker(lto=True)
+numba.config.CUDA_ENABLE_PYNVJITLINK = 1
 
 
 class BlockPrefixCallbackOp:

--- a/python/cuda_cccl/tests/cooperative/test_block_scan_api.py
+++ b/python/cuda_cccl/tests/cooperative/test_block_scan_api.py
@@ -5,14 +5,12 @@
 import numba
 import numpy as np
 from numba import cuda
-from pynvjitlink import patch
 
 import cuda.cccl.cooperative.experimental as coop
 
-numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
-
 # example-begin imports
-patch.patch_numba_linker(lto=True)
+numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
+numba.config.CUDA_ENABLE_PYNVJITLINK = 1
 # example-end imports
 
 

--- a/python/cuda_cccl/tests/cooperative/test_block_scan_api.py
+++ b/python/cuda_cccl/tests/cooperative/test_block_scan_api.py
@@ -10,7 +10,6 @@ import cuda.cccl.cooperative.experimental as coop
 
 # example-begin imports
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
-numba.config.CUDA_ENABLE_PYNVJITLINK = 1
 # example-end imports
 
 

--- a/python/cuda_cccl/tests/cooperative/test_block_store.py
+++ b/python/cuda_cccl/tests/cooperative/test_block_store.py
@@ -9,11 +9,10 @@ import numba
 import pytest
 from helpers import NUMBA_TYPES_TO_NP, random_int, row_major_tid
 from numba import cuda, types
-from pynvjitlink import patch
 
 import cuda.cccl.cooperative.experimental as coop
 
-patch.patch_numba_linker(lto=True)
+numba.config.CUDA_ENABLE_PYNVJITLINK = 1
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
 
 

--- a/python/cuda_cccl/tests/cooperative/test_block_store.py
+++ b/python/cuda_cccl/tests/cooperative/test_block_store.py
@@ -12,7 +12,6 @@ from numba import cuda, types
 
 import cuda.cccl.cooperative.experimental as coop
 
-numba.config.CUDA_ENABLE_PYNVJITLINK = 1
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
 
 

--- a/python/cuda_cccl/tests/cooperative/test_warp_merge_sort.py
+++ b/python/cuda_cccl/tests/cooperative/test_warp_merge_sort.py
@@ -6,11 +6,10 @@ import numba
 import pytest
 from helpers import NUMBA_TYPES_TO_NP, random_int
 from numba import cuda, types
-from pynvjitlink import patch
 
 import cuda.cccl.cooperative.experimental as coop
 
-patch.patch_numba_linker(lto=True)
+numba.config.CUDA_ENABLE_PYNVJITLINK = 1
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
 
 

--- a/python/cuda_cccl/tests/cooperative/test_warp_merge_sort.py
+++ b/python/cuda_cccl/tests/cooperative/test_warp_merge_sort.py
@@ -9,7 +9,6 @@ from numba import cuda, types
 
 import cuda.cccl.cooperative.experimental as coop
 
-numba.config.CUDA_ENABLE_PYNVJITLINK = 1
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
 
 

--- a/python/cuda_cccl/tests/cooperative/test_warp_merge_sort_api.py
+++ b/python/cuda_cccl/tests/cooperative/test_warp_merge_sort_api.py
@@ -5,14 +5,11 @@
 import numba
 import numpy as np
 from numba import cuda
-from pynvjitlink import patch
 
 import cuda.cccl.cooperative.experimental as coop
 
-numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
-
 # example-begin imports
-patch.patch_numba_linker(lto=True)
+numba.config.CUDA_ENABLE_PYNVJITLINK = 1
 # example-end imports
 
 

--- a/python/cuda_cccl/tests/cooperative/test_warp_merge_sort_api.py
+++ b/python/cuda_cccl/tests/cooperative/test_warp_merge_sort_api.py
@@ -8,10 +8,6 @@ from numba import cuda
 
 import cuda.cccl.cooperative.experimental as coop
 
-# example-begin imports
-numba.config.CUDA_ENABLE_PYNVJITLINK = 1
-# example-end imports
-
 
 def test_warp_merge_sort():
     # example-begin merge-sort

--- a/python/cuda_cccl/tests/cooperative/test_warp_reduce.py
+++ b/python/cuda_cccl/tests/cooperative/test_warp_reduce.py
@@ -7,14 +7,11 @@ import numpy as np
 import pytest
 from helpers import NUMBA_TYPES_TO_NP, random_int
 from numba import cuda, types
-from pynvjitlink import patch
 
 import cuda.cccl.cooperative.experimental as coop
 
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
-
-
-patch.patch_numba_linker(lto=True)
+numba.config.CUDA_ENABLE_PYNVJITLINK = 1
 
 
 @pytest.mark.parametrize("T", [types.uint32, types.uint64])

--- a/python/cuda_cccl/tests/cooperative/test_warp_reduce.py
+++ b/python/cuda_cccl/tests/cooperative/test_warp_reduce.py
@@ -11,7 +11,6 @@ from numba import cuda, types
 import cuda.cccl.cooperative.experimental as coop
 
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
-numba.config.CUDA_ENABLE_PYNVJITLINK = 1
 
 
 @pytest.mark.parametrize("T", [types.uint32, types.uint64])

--- a/python/cuda_cccl/tests/cooperative/test_warp_reduce_api.py
+++ b/python/cuda_cccl/tests/cooperative/test_warp_reduce_api.py
@@ -8,7 +8,9 @@ from numba import cuda
 
 import cuda.cccl.cooperative.experimental as coop
 
+# example-begin imports
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
+# example-end imports
 
 
 def test_warp_reduction():

--- a/python/cuda_cccl/tests/cooperative/test_warp_reduce_api.py
+++ b/python/cuda_cccl/tests/cooperative/test_warp_reduce_api.py
@@ -5,14 +5,13 @@
 import numba
 import numpy as np
 from numba import cuda
-from pynvjitlink import patch
 
 import cuda.cccl.cooperative.experimental as coop
 
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
 
 # example-begin imports
-patch.patch_numba_linker(lto=True)
+numba.config.CUDA_ENABLE_PYNVJITLINK = 1
 # example-end imports
 
 

--- a/python/cuda_cccl/tests/cooperative/test_warp_reduce_api.py
+++ b/python/cuda_cccl/tests/cooperative/test_warp_reduce_api.py
@@ -10,10 +10,6 @@ import cuda.cccl.cooperative.experimental as coop
 
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
 
-# example-begin imports
-numba.config.CUDA_ENABLE_PYNVJITLINK = 1
-# example-end imports
-
 
 def test_warp_reduction():
     def op(a, b):

--- a/python/cuda_cccl/tests/cooperative/test_warp_scan.py
+++ b/python/cuda_cccl/tests/cooperative/test_warp_scan.py
@@ -7,14 +7,11 @@ import numpy as np
 import pytest
 from helpers import NUMBA_TYPES_TO_NP, random_int
 from numba import cuda, types
-from pynvjitlink import patch
 
 import cuda.cccl.cooperative.experimental as coop
 
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
-
-
-patch.patch_numba_linker(lto=True)
+numba.config.CUDA_ENABLE_PYNVJITLINK = 1
 
 
 @pytest.mark.parametrize("T", [types.uint32, types.uint64])

--- a/python/cuda_cccl/tests/cooperative/test_warp_scan.py
+++ b/python/cuda_cccl/tests/cooperative/test_warp_scan.py
@@ -11,7 +11,6 @@ from numba import cuda, types
 import cuda.cccl.cooperative.experimental as coop
 
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
-numba.config.CUDA_ENABLE_PYNVJITLINK = 1
 
 
 @pytest.mark.parametrize("T", [types.uint32, types.uint64])

--- a/python/cuda_cccl/tests/cooperative/test_warp_scan_api.py
+++ b/python/cuda_cccl/tests/cooperative/test_warp_scan_api.py
@@ -10,10 +10,6 @@ import cuda.cccl.cooperative.experimental as coop
 
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
 
-# example-begin imports
-numba.config.CUDA_ENABLE_PYNVJITLINK = 1
-# example-end imports
-
 
 def test_warp_exclusive_sum():
     # example-begin exclusive-sum

--- a/python/cuda_cccl/tests/cooperative/test_warp_scan_api.py
+++ b/python/cuda_cccl/tests/cooperative/test_warp_scan_api.py
@@ -5,14 +5,13 @@
 import numba
 import numpy as np
 from numba import cuda
-from pynvjitlink import patch
 
 import cuda.cccl.cooperative.experimental as coop
 
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
 
 # example-begin imports
-patch.patch_numba_linker(lto=True)
+numba.config.CUDA_ENABLE_PYNVJITLINK = 1
 # example-end imports
 
 

--- a/python/cuda_cccl/tests/cooperative/test_warp_scan_api.py
+++ b/python/cuda_cccl/tests/cooperative/test_warp_scan_api.py
@@ -8,7 +8,9 @@ from numba import cuda
 
 import cuda.cccl.cooperative.experimental as coop
 
+# example-begin imports
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
+# example-end imports
 
 
 def test_warp_exclusive_sum():


### PR DESCRIPTION
## Description

This PR should unblock CI.

CI is currently failing because our runners have been updated to have CUDA 13 drivers (580.x.y). To enable running with latest drivers, I had to update a few dependencies:

* start depending on `numba_cuda`, rather than the (now unmaintained) `cuda` target that ships with `numba`
* update our `cuda-bindings` dependency to >=12.9.1, as a bug in 12.9.0 prevented us from running on CUDA 13 driver
* while we're at it, start depending on `cuda.pathfinder`, rather than using `cuda.bindings.path_finder` - which will be removed shortly in favor of `cuda.pathfinder` 

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
